### PR TITLE
feat(llm): wire run() to real provider SDK and add e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,48 @@
-# Turborepo starter
+# OpenOmni
 
-This Turborepo starter is maintained by the Turborepo core team.
+Multi-agent task orchestration framework for LLM-powered autonomous agents.
 
-## Using this example
+## Architecture
 
-Run the following command:
-
-```sh
-npx create-turbo@latest
-```
-
-## What's inside?
-
-This Turborepo includes the following packages/apps:
-
-### Apps and Packages
-
-- `docs`: a [Next.js](https://nextjs.org/) app
-- `web`: another [Next.js](https://nextjs.org/) app
-- `@repo/ui`: a stub React component library shared by both `web` and `docs` applications
-- `@repo/eslint-config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
-
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
-
-### Build
-
-To build all apps and packages, run the following command:
+TypeScript monorepo powered by [Bun](https://bun.sh) and [Turborepo](https://turborepo.dev).
 
 ```
-cd my-turborepo
-
-# With [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation) installed (recommended)
-turbo build
-
-# Without [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation), use your package manager
-npx turbo build
-yarn dlx turbo build
-pnpm exec turbo build
+openomni/
+├── apps/cli/            # CLI entry point
+├── packages/
+│   ├── protocol/        # Shared Zod schemas (Message, Tool, Run, Events)
+│   ├── session/         # Session CRUD, pub/sub bus, storage adapters
+│   ├── llm/             # LLM abstraction (providers, OAuth, streaming, retry)
+│   └── agent/           # Core orchestration (task lifecycle, agent graph, triggers)
 ```
 
-You can build a specific package by using a [filter](https://turborepo.dev/docs/crafting-your-repository/running-tasks#using-filters):
+### Dependency Graph
 
 ```
-# With [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation) installed (recommended)
-turbo build --filter=docs
-
-# Without [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation), use your package manager
-npx turbo build --filter=docs
-yarn exec turbo build --filter=docs
-pnpm exec turbo build --filter=docs
+protocol  <-  session  <-  llm  <-  agent  <-  cli
 ```
 
-### Develop
+`protocol` is the leaf with zero internal dependencies. Each layer builds on the one before it.
 
-To develop all apps and packages, run the following command:
+## Getting Started
 
-```
-cd my-turborepo
+```bash
+# Install dependencies
+bun install
 
-# With [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation) installed (recommended)
-turbo dev
+# Build all packages
+bun run build
 
-# Without [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation), use your package manager
-npx turbo dev
-yarn exec turbo dev
-pnpm exec turbo dev
-```
+# Run tests
+bun test
 
-You can develop a specific package by using a [filter](https://turborepo.dev/docs/crafting-your-repository/running-tasks#using-filters):
+# Type check
+bun run check-types
 
-```
-# With [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation) installed (recommended)
-turbo dev --filter=web
-
-# Without [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation), use your package manager
-npx turbo dev --filter=web
-yarn exec turbo dev --filter=web
-pnpm exec turbo dev --filter=web
+# Format
+bun run format
 ```
 
-### Remote Caching
+## License
 
-> [!TIP]
-> Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
-
-Turborepo can use a technique known as [Remote Caching](https://turborepo.dev/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
-
-By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
-
-```
-cd my-turborepo
-
-# With [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation) installed (recommended)
-turbo login
-
-# Without [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation), use your package manager
-npx turbo login
-yarn exec turbo login
-pnpm exec turbo login
-```
-
-This will authenticate the Turborepo CLI with your [Vercel account](https://vercel.com/docs/concepts/personal-accounts/overview).
-
-Next, you can link your Turborepo to your Remote Cache by running the following command from the root of your Turborepo:
-
-```
-# With [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation) installed (recommended)
-turbo link
-
-# Without [global `turbo`](https://turborepo.dev/docs/getting-started/installation#global-installation), use your package manager
-npx turbo link
-yarn exec turbo link
-pnpm exec turbo link
-```
-
-## Useful Links
-
-Learn more about the power of Turborepo:
-
-- [Tasks](https://turborepo.dev/docs/crafting-your-repository/running-tasks)
-- [Caching](https://turborepo.dev/docs/crafting-your-repository/caching)
-- [Remote Caching](https://turborepo.dev/docs/core-concepts/remote-caching)
-- [Filtering](https://turborepo.dev/docs/crafting-your-repository/running-tasks#using-filters)
-- [Configuration Options](https://turborepo.dev/docs/reference/configuration)
-- [CLI Usage](https://turborepo.dev/docs/reference/command-line-reference)
+MIT

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -5,21 +5,31 @@ import type {
   RunOutcome,
   ToolCall,
 } from "@openomni/protocol";
+import type { CoreMessage } from "ai";
+import { streamText, jsonSchema } from "ai";
 import { Processor } from "./session/processor";
-import { Provider } from "./provider";
+import { toModelMessages } from "./session/convert";
+import { Provider, getLanguage } from "./provider";
+import { Auth } from "./auth/storage";
 
 /**
- * Input for the run() function
+ * Input for the run() function.
+ *
+ * When `model` is provided the function resolves auth credentials
+ * and calls the real provider SDK.  When omitted the Processor
+ * falls back to its default noop stream (useful for unit tests).
  */
 export interface RunInput {
   messages: Message.WithParts[];
   tools: ToolSpec[];
   system?: string;
   signal?: AbortSignal;
+  model?: Provider.Model;
+  providerOptions?: Record<string, unknown>;
 }
 
 export async function run(input: RunInput, sink: Sink): Promise<RunOutcome> {
-  const { messages, system = "", signal } = input;
+  const { messages, system = "", signal, model } = input;
 
   const abortController = signal ? undefined : new AbortController();
   const abortSignal = signal || abortController!.signal;
@@ -36,12 +46,17 @@ export async function run(input: RunInput, sink: Sink): Promise<RunOutcome> {
     role: "assistant",
     time: { created: Date.now() },
     parentID,
-    modelID: "default",
-    providerID: "default",
+    modelID: model?.id ?? "default",
+    providerID: model?.providerID ?? "default",
     agent: "default",
     path: { cwd: process.cwd(), root: process.cwd() },
     cost: 0,
-    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
   };
 
   const pendingToolCalls: ToolCall[] = [];
@@ -56,20 +71,106 @@ export async function run(input: RunInput, sink: Sink): Promise<RunOutcome> {
     onSnapshot: sink.onSnapshot,
   };
 
+  let createStream: Processor.ProcessorOptions["createStream"];
+
+  if (model) {
+    createStream = async (streamInput) => {
+      const auth = await Auth.get(model.providerID);
+      if (!auth) {
+        throw new Error(
+          `No authentication found for provider: ${model.providerID}. Run 'openomni auth login' first.`,
+        );
+      }
+
+      const languageModel = getLanguage(model, auth);
+
+      const normalizedMessages = toModelMessages(messages, model);
+
+      const systemMessages: CoreMessage[] = streamInput.system
+        ? [{ role: "system" as const, content: streamInput.system }]
+        : [];
+
+      const sdkTools: Record<
+        string,
+        { description?: string; parameters: unknown }
+      > = {};
+      for (const spec of input.tools) {
+        sdkTools[spec.name] = {
+          description: spec.description,
+          parameters: jsonSchema(spec.inputSchema),
+        };
+      }
+
+      const streamResult = streamText({
+        model: languageModel,
+        messages: [...systemMessages, ...normalizedMessages],
+        tools: sdkTools as Parameters<typeof streamText>[0]["tools"],
+        abortSignal: abortSignal,
+        ...(input.providerOptions ?? {}),
+      });
+
+      async function* adaptStream(): AsyncGenerator<{
+        type: string;
+        [key: string]: unknown;
+      }> {
+        let inText = false;
+
+        for await (const chunk of streamResult.fullStream) {
+          const event = chunk as { type: string; [key: string]: unknown };
+
+          if (event.type === "text-delta" && !inText) {
+            inText = true;
+            yield { type: "text-start" };
+          }
+
+          if (event.type !== "text-delta" && inText) {
+            inText = false;
+            yield { type: "text-end" };
+          }
+
+          if (event.type === "text-delta") {
+            yield { ...event, text: event.textDelta ?? event.text };
+          } else if (event.type === "reasoning") {
+            yield {
+              ...event,
+              type: "reasoning-delta",
+              text: event.textDelta ?? event.text,
+            };
+          } else {
+            yield event;
+          }
+        }
+
+        if (inText) {
+          yield { type: "text-end" };
+        }
+      }
+
+      return { fullStream: adaptStream() };
+    };
+  }
+
+  const resolvedModel = model ?? ({} as Provider.Model);
+
   const processor = Processor.create({
     assistantMessage,
     sessionID,
-    model: {} as Provider.Model,
+    model: resolvedModel,
     abort: abortSignal,
     sink: wrappedSink,
+    createStream,
   });
 
   try {
     const result = await processor.process({
       messages: messages.map((m) => m.info),
-      model: {} as Provider.Model,
+      model: resolvedModel,
       system,
     });
+
+    if (pendingToolCalls.length > 0) {
+      return { type: "await_tool", toolCalls: pendingToolCalls };
+    }
 
     switch (result) {
       case "stop":

--- a/packages/llm/test/e2e/llm-real.test.ts
+++ b/packages/llm/test/e2e/llm-real.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { run, type RunInput } from "../../src/run";
+import { Auth } from "../../src/auth/storage";
+import { listModels } from "../../src/provider/index";
+import type { Provider } from "../../src/provider/index";
+import type {
+  Sink,
+  Message,
+  ToolCall,
+  ToolResult,
+  RunSnapshot,
+} from "@openomni/protocol";
+
+let auth: Auth.Info | undefined;
+let model: Provider.Model | undefined;
+
+beforeAll(async () => {
+  auth = await Auth.get("anthropic");
+  if (!auth) return;
+
+  const models = await listModels(
+    "anthropic",
+    auth.type === "oauth" ? "oauth" : "api",
+  );
+  model = models.find((m) => m.id.includes("haiku")) ?? models[0];
+});
+
+function shouldSkip(): boolean {
+  return !auth || !model;
+}
+
+function createSink() {
+  const messages: Message.WithParts[] = [];
+  const toolCalls: ToolCall[] = [];
+  const toolResults: ToolResult[] = [];
+  const snapshots: RunSnapshot[] = [];
+
+  const sink: Sink = {
+    onMessage: (msg) => messages.push(msg),
+    onToolCall: (call) => toolCalls.push(call),
+    onToolResult: (result) => toolResults.push(result),
+    onSnapshot: (snapshot) => snapshots.push(snapshot),
+  };
+
+  return { sink, messages, toolCalls, toolResults, snapshots };
+}
+
+function makeUserMessage(
+  text: string,
+  sessionID = "test-session",
+): Message.WithParts {
+  const msgId = crypto.randomUUID();
+  return {
+    info: {
+      id: msgId,
+      sessionID,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "test",
+      model: { providerID: "anthropic", modelID: model?.id ?? "unknown" },
+    } as Message.Info,
+    parts: [
+      {
+        id: crypto.randomUUID(),
+        sessionID,
+        messageID: msgId,
+        type: "text" as const,
+        text,
+      },
+    ],
+  };
+}
+
+const weatherToolSpec = {
+  name: "get_weather",
+  description: "Get the current weather for a city",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      city: { type: "string", description: "City name" },
+    },
+    required: ["city"],
+  },
+};
+
+const calculateToolSpec = {
+  name: "calculate",
+  description: "Evaluate a math expression",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      expression: { type: "string", description: "Math expression" },
+    },
+    required: ["expression"],
+  },
+};
+
+describe("Real LLM e2e", () => {
+  it("sends a simple prompt and receives text response", async () => {
+    if (shouldSkip()) return;
+
+    const { sink, messages } = createSink();
+
+    const input: RunInput = {
+      messages: [makeUserMessage("Reply with exactly: PONG")],
+      tools: [],
+      system: "You are a test assistant. Follow instructions exactly.",
+      model: model!,
+    };
+
+    const outcome = await run(input, sink);
+
+    expect(outcome.type).toBe("stop");
+    expect(messages.length).toBeGreaterThan(0);
+
+    const lastMsg = messages[messages.length - 1];
+    const textParts = lastMsg.parts.filter((p) => p.type === "text");
+    expect(textParts.length).toBeGreaterThan(0);
+
+    const fullText = textParts.map((p) => ("text" in p ? p.text : "")).join("");
+    expect(fullText).toContain("PONG");
+  }, 30_000);
+
+  it("streams text incrementally via sink.onMessage", async () => {
+    if (shouldSkip()) return;
+
+    const { sink, messages } = createSink();
+
+    const input: RunInput = {
+      messages: [makeUserMessage("Write a haiku about testing software.")],
+      tools: [],
+      system: "You are a poet.",
+      model: model!,
+    };
+
+    const outcome = await run(input, sink);
+
+    expect(outcome.type).toBe("stop");
+    expect(messages.length).toBeGreaterThanOrEqual(2);
+
+    const lastMsg = messages[messages.length - 1];
+    const textParts = lastMsg.parts.filter((p) => p.type === "text");
+    const fullText = textParts.map((p) => ("text" in p ? p.text : "")).join("");
+    expect(fullText.length).toBeGreaterThan(10);
+  }, 30_000);
+
+  it("handles abort signal during real LLM call", async () => {
+    if (shouldSkip()) return;
+
+    const { sink } = createSink();
+    const abortController = new AbortController();
+
+    const input: RunInput = {
+      messages: [
+        makeUserMessage(
+          "Write a very long essay about the history of computing.",
+        ),
+      ],
+      tools: [],
+      model: model!,
+      signal: abortController.signal,
+    };
+
+    setTimeout(() => abortController.abort(), 500);
+
+    const outcome = await run(input, sink);
+
+    expect(["aborted", "error", "stop"]).toContain(outcome.type);
+  }, 15_000);
+
+  it("detects tool calls from LLM and returns await_tool", async () => {
+    if (shouldSkip()) return;
+
+    const { sink, toolCalls, messages } = createSink();
+
+    const input: RunInput = {
+      messages: [
+        makeUserMessage(
+          "What is the weather in Seoul? Use the get_weather tool.",
+        ),
+      ],
+      tools: [weatherToolSpec],
+      system:
+        "You have access to tools. When asked about weather, you MUST call the get_weather tool. Do not make up answers.",
+      model: model!,
+    };
+
+    const outcome = await run(input, sink);
+
+    expect(outcome.type).toBe("await_tool");
+    if (outcome.type === "await_tool") {
+      expect(outcome.toolCalls.length).toBeGreaterThan(0);
+      expect(outcome.toolCalls[0].tool).toBe("get_weather");
+      expect(outcome.toolCalls[0].input).toHaveProperty("city");
+    }
+
+    expect(toolCalls.length).toBeGreaterThan(0);
+    expect(toolCalls[0].tool).toBe("get_weather");
+
+    const toolParts = messages
+      .flatMap((m) => m.parts)
+      .filter((p) => p.type === "tool");
+    expect(toolParts.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("completes full tool loop: LLM calls tool, receives result, produces final text", async () => {
+    if (shouldSkip()) return;
+
+    const fakeWeather: Record<string, string> = {
+      seoul: "Sunny, 3°C",
+      tokyo: "Rainy, 7°C",
+    };
+
+    let turnCount = 0;
+    const maxTurns = 5;
+    let allMessages: Message.WithParts[] = [];
+    const conversationMessages = [
+      makeUserMessage(
+        "What is the weather in Seoul? Use the tool then tell me the result.",
+      ),
+    ];
+
+    let finalText = "";
+
+    while (turnCount < maxTurns) {
+      turnCount++;
+      const { sink, messages, toolCalls } = createSink();
+
+      const input: RunInput = {
+        messages: conversationMessages,
+        tools: [weatherToolSpec],
+        system:
+          "You have access to tools. Use get_weather to check weather. After receiving tool results, summarize them for the user.",
+        model: model!,
+      };
+
+      const outcome = await run(input, sink);
+      allMessages = [...allMessages, ...messages];
+
+      if (outcome.type === "stop") {
+        const lastMsg = messages[messages.length - 1];
+        const textParts = lastMsg?.parts.filter((p) => p.type === "text") ?? [];
+        finalText = textParts.map((p) => ("text" in p ? p.text : "")).join("");
+        break;
+      }
+
+      if (outcome.type === "await_tool") {
+        for (const call of outcome.toolCalls) {
+          const city = String(
+            (call.input as Record<string, unknown>).city ?? "",
+          ).toLowerCase();
+          const weather = fakeWeather[city] ?? `Clear, 20°C in ${city}`;
+
+          const toolResultMsg: Message.WithParts = {
+            info: {
+              id: crypto.randomUUID(),
+              sessionID: "test-session",
+              role: "assistant",
+              time: { created: Date.now() },
+              parentID: "",
+              modelID: model!.id,
+              providerID: model!.providerID,
+              agent: "test",
+              path: { cwd: process.cwd(), root: process.cwd() },
+              cost: 0,
+              tokens: {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+            } as Message.Info,
+            parts: [
+              {
+                id: crypto.randomUUID(),
+                sessionID: "test-session",
+                messageID: "",
+                type: "tool" as const,
+                callID: call.id,
+                tool: call.tool,
+                state: {
+                  status: "completed" as const,
+                  input: call.input,
+                  output: weather,
+                  title: call.tool,
+                  metadata: {},
+                  time: { start: Date.now(), end: Date.now() },
+                },
+              },
+            ],
+          };
+          conversationMessages.push(toolResultMsg);
+        }
+        continue;
+      }
+
+      break;
+    }
+
+    expect(turnCount).toBeLessThanOrEqual(maxTurns);
+    expect(finalText.length).toBeGreaterThan(0);
+    expect(
+      finalText.toLowerCase().includes("sunny") ||
+        finalText.toLowerCase().includes("3") ||
+        finalText.toLowerCase().includes("seoul"),
+    ).toBe(true);
+  }, 60_000);
+
+  it("detects multiple tool calls in a single response", async () => {
+    if (shouldSkip()) return;
+
+    const { sink, toolCalls } = createSink();
+
+    const input: RunInput = {
+      messages: [
+        makeUserMessage(
+          "What is the weather in Seoul and also calculate 7 * 8? Use both tools.",
+        ),
+      ],
+      tools: [weatherToolSpec, calculateToolSpec],
+      system:
+        "You have tools available. ALWAYS use get_weather for weather questions and calculate for math. Call BOTH tools now.",
+      model: model!,
+    };
+
+    const outcome = await run(input, sink);
+
+    expect(outcome.type).toBe("await_tool");
+    if (outcome.type === "await_tool") {
+      expect(outcome.toolCalls.length).toBeGreaterThanOrEqual(2);
+      const toolNames = outcome.toolCalls.map((tc) => tc.tool).sort();
+      expect(toolNames).toContain("get_weather");
+      expect(toolNames).toContain("calculate");
+    }
+  }, 30_000);
+});

--- a/packages/llm/test_import.ts
+++ b/packages/llm/test_import.ts
@@ -1,4 +1,0 @@
-import { Storage, Bus, BusEvent } from "@openomni/session";
-console.log("Storage:", typeof Storage);
-console.log("Bus:", typeof Bus);
-console.log("BusEvent:", typeof BusEvent);


### PR DESCRIPTION
## Summary

- Wire `run()` in `packages/llm/src/run.ts` to actual LLM providers (Anthropic/OpenAI) when a `model` is supplied
- Add 6 real-API e2e tests that call Anthropic via OAuth and exercise the full pipeline

## Changes

### `packages/llm/src/run.ts` — Glue Code
- Add `model` and `providerOptions` fields to `RunInput`
- When `model` is provided: `Auth.get()` → `getLanguage()` → `streamText()` pipeline
- `adaptStream` generator converts AI SDK v4 events to Processor format:
  - Injects `text-start`/`text-end` lifecycle events
  - Maps `textDelta` → `text` field for Processor compatibility
  - Maps `reasoning` → `reasoning-delta` for thinking models
- Convert `ToolSpec[]` → AI SDK tool format via `jsonSchema()`
- Return `await_tool` when `pendingToolCalls` is non-empty (fixes detection)
- Backward compatible: omitting `model` preserves existing noop behavior

### `packages/llm/test/e2e/llm-real.test.ts` — Real LLM Tests
1. Simple prompt → text response (verifies "PONG")
2. Incremental streaming via `sink.onMessage`
3. AbortSignal handling during live stream
4. Single tool call detection (`get_weather`)
5. Multiple tool calls in one response (`get_weather` + `calculate`)
6. Full tool loop: LLM calls tool → receives mock result → produces final text answer

All tests skip gracefully when no Anthropic auth is configured.

## Verification
- `tsc --noEmit`: ✅ passes
- Existing tests: 289 pass, 0 fail (2 pre-existing unhandled errors in `llm.test.ts`, unrelated)
- New e2e tests: 6 pass, 0 fail