### PR TITLE
feat: session isolation infrastructure (key encoding, disk persistence, agent discovery)

### DIFF
--- a/packages/agent/src/agent/discovery.ts
+++ b/packages/agent/src/agent/discovery.ts
@@ -1,0 +1,262 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import {
+  AgentDefinitionSchema,
+  BuiltinAgentRegistry,
+  type AgentDefinition,
+} from "./registry";
+
+export interface AgentLoadResult {
+  file: string;
+  success: boolean;
+  agent?: AgentDefinition;
+  error?: string;
+}
+
+export interface AgentDiscoveryOptions {
+  allowOverride?: boolean;
+  strict?: boolean;
+}
+
+/**
+ * Extracts YAML frontmatter (between `---` delimiters) and markdown body.
+ * Supports: scalars, booleans, numbers, inline arrays `[a, b]`,
+ * block arrays (`- item`), and one-level nested objects.
+ */
+export function parseFrontmatter(content: string): {
+  data: Record<string, unknown>;
+  body: string;
+} {
+  const lines = content.split("\n");
+
+  if (lines[0]?.trim() !== "---") {
+    throw new Error("Missing frontmatter: file must start with ---");
+  }
+
+  let closingIndex = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]?.trim() === "---") {
+      closingIndex = i;
+      break;
+    }
+  }
+
+  if (closingIndex === -1) {
+    throw new Error("Missing frontmatter: no closing --- found");
+  }
+
+  const yamlLines = lines.slice(1, closingIndex);
+  const body = lines
+    .slice(closingIndex + 1)
+    .join("\n")
+    .trim();
+  const data = parseSimpleYaml(yamlLines);
+
+  return { data, body };
+}
+
+/**
+ * Minimal YAML parser for frontmatter. Handles flat key-value pairs,
+ * inline arrays `[a, b]`, block arrays (`- item`), and single-level
+ * nested objects (e.g., `permissions:` / `model:`).
+ */
+function parseSimpleYaml(lines: string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      i++;
+      continue;
+    }
+
+    const topMatch = line.match(/^(\w[\w.-]*)\s*:\s*(.*)/);
+    if (!topMatch) {
+      i++;
+      continue;
+    }
+
+    const key = topMatch[1]!;
+    const rawValue = topMatch[2]!.trim();
+
+    if (rawValue === "") {
+      const nested: string[] = [];
+      let j = i + 1;
+      while (j < lines.length) {
+        const nextLine = lines[j]!;
+        if (nextLine.trim() === "" || nextLine.trim().startsWith("#")) {
+          j++;
+          continue;
+        }
+        if (nextLine.startsWith("  ")) {
+          nested.push(nextLine);
+          j++;
+        } else {
+          break;
+        }
+      }
+
+      if (nested.length > 0) {
+        const isBlockArray = nested.every(
+          (l) => l.trim().startsWith("- ") || l.trim() === "",
+        );
+
+        if (isBlockArray) {
+          result[key] = nested
+            .filter((l) => l.trim().startsWith("- "))
+            .map((l) => parseScalar(l.trim().slice(2).trim()));
+        } else {
+          const obj: Record<string, unknown> = {};
+          for (const nl of nested) {
+            const nestedMatch = nl.match(/^\s+(\w[\w.-]*)\s*:\s*(.*)/);
+            if (nestedMatch) {
+              obj[nestedMatch[1]!] = parseScalar(nestedMatch[2]!.trim());
+            }
+          }
+          result[key] = obj;
+        }
+        i = j;
+        continue;
+      }
+    }
+
+    result[key] = parseValue(rawValue);
+    i++;
+  }
+
+  return result;
+}
+
+function parseValue(raw: string): unknown {
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    const inner = raw.slice(1, -1).trim();
+    if (inner === "") return [];
+    return inner.split(",").map((s) => parseScalar(s.trim()));
+  }
+
+  return parseScalar(raw);
+}
+
+function parseScalar(raw: string): unknown {
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    return raw.slice(1, -1);
+  }
+
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "null" || raw === "~") return null;
+
+  const num = Number(raw);
+  if (raw !== "" && !isNaN(num)) return num;
+
+  return raw;
+}
+
+/**
+ * File-based agent discovery. Loads agent definitions from `*.md` files
+ * where YAML frontmatter provides the definition and the markdown body
+ * extends the systemPrompt. Validates all definitions with Zod.
+ */
+export namespace AgentDiscovery {
+  export function load(
+    dir: string,
+    options: AgentDiscoveryOptions = {},
+  ): AgentLoadResult[] {
+    const { allowOverride = false, strict = false } = options;
+    const results: AgentLoadResult[] = [];
+
+    if (!existsSync(dir)) {
+      if (strict) {
+        throw new Error(`Agent discovery directory does not exist: ${dir}`);
+      }
+      return results;
+    }
+
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch (err: unknown) {
+      if (strict) throw err;
+      return results;
+    }
+
+    const mdFiles = entries.filter((f) => extname(f) === ".md").sort();
+
+    for (const file of mdFiles) {
+      const result = loadFile(join(dir, file), { allowOverride, strict });
+      results.push(result);
+    }
+
+    return results;
+  }
+
+  export function loadFile(
+    filePath: string,
+    options: AgentDiscoveryOptions = {},
+  ): AgentLoadResult {
+    const { allowOverride = false, strict = false } = options;
+    const file = filePath;
+
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      const { data, body } = parseFrontmatter(content);
+
+      if (body && typeof data.systemPrompt === "string") {
+        data.systemPrompt = data.systemPrompt + "\n\n" + body;
+      } else if (body && !data.systemPrompt) {
+        data.systemPrompt = body;
+      }
+
+      const validated = AgentDefinitionSchema.parse(data);
+
+      if (BuiltinAgentRegistry.has(validated.name)) {
+        if (!allowOverride) {
+          const msg = `Agent "${validated.name}" already exists and allowOverride is not set`;
+          if (strict) throw new Error(msg);
+          return { file, success: false, error: msg };
+        }
+        return overrideAgent(validated, file);
+      }
+
+      BuiltinAgentRegistry.define(validated);
+
+      return { file, success: true, agent: validated };
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : "Unknown error loading agent file";
+      if (strict) throw err;
+      return { file, success: false, error: msg };
+    }
+  }
+
+  /**
+   * Atomically replaces an existing agent by clearing and re-registering all agents.
+   * Required because BuiltinAgentRegistry.define() throws on duplicate names.
+   */
+  function overrideAgent(
+    definition: AgentDefinition,
+    file: string,
+  ): AgentLoadResult {
+    const existing = BuiltinAgentRegistry.list();
+    BuiltinAgentRegistry.clear();
+
+    for (const agent of existing) {
+      if (agent.name === definition.name) {
+        BuiltinAgentRegistry.define(definition);
+      } else {
+        BuiltinAgentRegistry.define(agent);
+      }
+    }
+
+    if (!BuiltinAgentRegistry.has(definition.name)) {
+      BuiltinAgentRegistry.define(definition);
+    }
+
+    return { file, success: true, agent: definition };
+  }
+}

--- a/packages/agent/src/agent/file-registry-storage.ts
+++ b/packages/agent/src/agent/file-registry-storage.ts
@@ -1,0 +1,118 @@
+import {
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { AgentProfile } from "./profile";
+import type { AgentRegistryStore } from "./profile";
+import { AgentProfileSchema } from "./profile";
+
+export class FileAgentRegistryStore implements AgentRegistryStore {
+  private profiles = new Map<string, AgentProfile>();
+  private readonly dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+    mkdirSync(dir, { recursive: true });
+    this.loadFromDisk();
+  }
+
+  get(id: string): AgentProfile | undefined {
+    return this.profiles.get(id);
+  }
+
+  set(id: string, profile: AgentProfile): void {
+    this.profiles.set(id, profile);
+    this.flushProfile(id, profile);
+  }
+
+  list(): AgentProfile[] {
+    return Array.from(this.profiles.values());
+  }
+
+  remove(id: string): boolean {
+    const deleted = this.profiles.delete(id);
+    if (deleted) {
+      const target = join(this.dir, `${this.encodeFilename(id)}.json`);
+      try {
+        unlinkSync(target);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      }
+    }
+    return deleted;
+  }
+
+  has(id: string): boolean {
+    return this.profiles.has(id);
+  }
+
+  clear(): void {
+    for (const id of this.profiles.keys()) {
+      const target = join(this.dir, `${this.encodeFilename(id)}.json`);
+      try {
+        unlinkSync(target);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      }
+    }
+    this.profiles.clear();
+  }
+
+  size(): number {
+    return this.profiles.size;
+  }
+
+  private loadFromDisk(): void {
+    if (!existsSync(this.dir)) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(this.dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+      const filePath = join(this.dir, entry);
+      try {
+        const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+        const profile = AgentProfileSchema.parse(raw);
+        this.profiles.set(profile.id, profile);
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  private flushProfile(id: string, profile: AgentProfile): void {
+    this.atomicWrite(
+      `${this.encodeFilename(id)}.json`,
+      JSON.stringify(profile, null, 2),
+    );
+  }
+
+  private atomicWrite(filename: string, data: string): void {
+    const target = join(this.dir, filename);
+    const tmp = target + ".tmp";
+    try {
+      writeFileSync(tmp, data, "utf-8");
+      renameSync(tmp, target);
+    } catch (err) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* noop */
+      }
+      throw err;
+    }
+  }
+
+  private encodeFilename(id: string): string {
+    return encodeURIComponent(id);
+  }
+}

--- a/packages/agent/src/agent/index.ts
+++ b/packages/agent/src/agent/index.ts
@@ -14,9 +14,13 @@ export {
   AgentRuntimeSchema,
   type AgentRuntime,
   AgentRegistry,
+  InMemoryAgentRegistryStore,
+  type AgentRegistryStore,
   createAgentIdentity,
   createAgentRuntime,
 } from "./profile";
+
+export { FileAgentRegistryStore } from "./file-registry-storage";
 
 export {
   AgentMessenger,

--- a/packages/agent/src/agent/index.ts
+++ b/packages/agent/src/agent/index.ts
@@ -34,3 +34,10 @@ export {
   AgentDefinitionSchema,
   type AgentDefinition,
 } from "./registry";
+
+export {
+  AgentDiscovery,
+  parseFrontmatter,
+  type AgentLoadResult,
+  type AgentDiscoveryOptions,
+} from "./discovery";

--- a/packages/agent/src/agent/profile.ts
+++ b/packages/agent/src/agent/profile.ts
@@ -127,12 +127,69 @@ export const AgentRuntimeSchema = z.object({
 
 export type AgentRuntime = z.infer<typeof AgentRuntimeSchema>;
 
-/**
- * Agent Registry - In-memory registry for agent profiles
- * Manages registration, lookup, and lifecycle of agent profiles
- */
+export interface AgentRegistryStore {
+  get(id: string): AgentProfile | undefined;
+  set(id: string, profile: AgentProfile): void;
+  list(): AgentProfile[];
+  remove(id: string): boolean;
+  has(id: string): boolean;
+  clear(): void;
+  size(): number;
+}
+
+export class InMemoryAgentRegistryStore implements AgentRegistryStore {
+  private profiles = new Map<string, AgentProfile>();
+
+  get(id: string): AgentProfile | undefined {
+    return this.profiles.get(id);
+  }
+
+  set(id: string, profile: AgentProfile): void {
+    this.profiles.set(id, profile);
+  }
+
+  list(): AgentProfile[] {
+    return Array.from(this.profiles.values());
+  }
+
+  remove(id: string): boolean {
+    return this.profiles.delete(id);
+  }
+
+  has(id: string): boolean {
+    return this.profiles.has(id);
+  }
+
+  clear(): void {
+    this.profiles.clear();
+  }
+
+  size(): number {
+    return this.profiles.size;
+  }
+}
+
 export class AgentRegistry {
-  private profiles: Map<string, AgentProfile> = new Map();
+  private static defaultStore: AgentRegistryStore | undefined;
+
+  static configure(store: AgentRegistryStore): void {
+    AgentRegistry.defaultStore = store;
+  }
+
+  static getStore(): AgentRegistryStore | undefined {
+    return AgentRegistry.defaultStore;
+  }
+
+  static reset(): void {
+    AgentRegistry.defaultStore = undefined;
+  }
+
+  private store: AgentRegistryStore;
+
+  constructor(store?: AgentRegistryStore) {
+    this.store =
+      store ?? AgentRegistry.defaultStore ?? new InMemoryAgentRegistryStore();
+  }
 
   /**
    * Register a new agent profile
@@ -140,11 +197,11 @@ export class AgentRegistry {
    * @throws Error if profile with same ID already exists
    */
   set(profile: AgentProfile): void {
-    if (this.profiles.has(profile.id)) {
+    if (this.store.has(profile.id)) {
       throw new Error(`Agent profile with id "${profile.id}" already exists`);
     }
     const validated = AgentProfileSchema.parse(profile);
-    this.profiles.set(validated.id, validated);
+    this.store.set(validated.id, validated);
   }
 
   /**
@@ -153,7 +210,7 @@ export class AgentRegistry {
    * @returns The agent profile or undefined if not found
    */
   get(id: string): AgentProfile | undefined {
-    return this.profiles.get(id);
+    return this.store.get(id);
   }
 
   /**
@@ -161,7 +218,7 @@ export class AgentRegistry {
    * @returns Array of all registered profiles
    */
   list(): AgentProfile[] {
-    return Array.from(this.profiles.values());
+    return this.store.list();
   }
 
   /**
@@ -170,7 +227,7 @@ export class AgentRegistry {
    * @returns true if profile was removed, false if not found
    */
   remove(id: string): boolean {
-    return this.profiles.delete(id);
+    return this.store.remove(id);
   }
 
   /**
@@ -179,21 +236,21 @@ export class AgentRegistry {
    * @returns true if profile exists
    */
   has(id: string): boolean {
-    return this.profiles.has(id);
+    return this.store.has(id);
   }
 
   /**
    * Clear all registered profiles
    */
   clear(): void {
-    this.profiles.clear();
+    this.store.clear();
   }
 
   /**
    * Get the count of registered profiles
    */
   size(): number {
-    return this.profiles.size;
+    return this.store.size();
   }
 }
 

--- a/packages/agent/src/ingress/session-resolver.ts
+++ b/packages/agent/src/ingress/session-resolver.ts
@@ -10,7 +10,22 @@ export namespace SessionResolver {
     isNew: boolean;
   }
 
-  function extractSurfaceKey(source: EventEnvelope["source"]): string {
+  export function extractSurfaceKey(
+    source: EventEnvelope["source"],
+    meta?: Record<string, unknown>,
+  ): string {
+    const channelKind = meta?.channelKind as string | undefined;
+    const channelId = meta?.channelId as string | undefined;
+    const threadId = meta?.threadId as string | undefined;
+
+    if (source.id && channelKind && channelId) {
+      const parts = [source.type, source.id, channelKind, channelId];
+      if (threadId) {
+        parts.push("thread", threadId);
+      }
+      return parts.join(":");
+    }
+
     if (source.id) {
       return `${source.type}:${source.id}`;
     }
@@ -25,7 +40,7 @@ export namespace SessionResolver {
     },
     projector: EventProjector = DefaultEventProjector,
   ): ResolveResult {
-    const surfaceKey = extractSurfaceKey(event.source);
+    const surfaceKey = extractSurfaceKey(event.source, event.meta);
     const existingSessionId = SurfaceKey.lookup(surfaceKey);
 
     let session: Session.Info;

--- a/packages/agent/src/task/file-task-storage.ts
+++ b/packages/agent/src/task/file-task-storage.ts
@@ -1,0 +1,307 @@
+import {
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { TaskStore, TaskListFilter, RunListOptions } from "./storage";
+import type { Task, TaskRun } from "./types";
+
+export class FileTaskStore implements TaskStore {
+  private tasks = new Map<string, Task.Info>();
+  private runs = new Map<string, TaskRun>();
+  private taskRuns = new Map<string, string[]>(); // taskId -> runId[]
+  private idempotencyIndex = new Map<string, string>(); // idempotencyKey -> runId
+  private statusIndex = new Map<TaskRun["status"], Set<string>>(); // status -> Set<runId>
+
+  private readonly dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+    mkdirSync(dir, { recursive: true });
+    this.loadFromDisk();
+  }
+
+  // ===========================================================
+  // task sub-object
+  // ===========================================================
+
+  task = {
+    get: (id: string): Task.Info | undefined => {
+      return this.tasks.get(id);
+    },
+    set: (id: string, info: Task.Info): void => {
+      this.tasks.set(id, info);
+      this.flushTasks();
+    },
+    list: (filter?: TaskListFilter): Task.Info[] => {
+      let tasks = Array.from(this.tasks.values());
+
+      if (!filter) return tasks;
+
+      if (filter.status) {
+        const statuses = Array.isArray(filter.status)
+          ? filter.status
+          : [filter.status];
+        tasks = tasks.filter((t) => statuses.includes(t.status));
+      }
+
+      if (filter.ownerId) {
+        tasks = tasks.filter((t) => t.owner.id === filter.ownerId);
+      }
+
+      if (filter.assignedAgentId) {
+        tasks = tasks.filter(
+          (t) => t.assignedAgentId === filter.assignedAgentId,
+        );
+      }
+
+      if (filter.tags && filter.tags.length > 0) {
+        tasks = tasks.filter((t) =>
+          filter.tags!.every((tag) => t.tags?.includes(tag)),
+        );
+      }
+
+      return tasks;
+    },
+    remove: (id: string): boolean => {
+      const runIds = this.taskRuns.get(id);
+      if (runIds) {
+        for (const runId of runIds) {
+          const run = this.runs.get(runId);
+          if (run) {
+            this.statusIndex.get(run.status)?.delete(runId);
+            this.idempotencyIndex.delete(run.idempotencyKey);
+            this.runs.delete(runId);
+          }
+        }
+        this.taskRuns.delete(id);
+      }
+
+      const deleted = this.tasks.delete(id);
+      this.flushAll();
+      return deleted;
+    },
+  };
+
+  // ===========================================================
+  // run sub-object
+  // ===========================================================
+
+  run = {
+    get: (runId: string): TaskRun | undefined => {
+      return this.runs.get(runId);
+    },
+    set: (taskId: string, run: TaskRun): void => {
+      const existingRun = this.runs.get(run.runId);
+
+      if (existingRun && existingRun.status !== run.status) {
+        this.statusIndex.get(existingRun.status)?.delete(run.runId);
+      }
+
+      if (!this.statusIndex.has(run.status)) {
+        this.statusIndex.set(run.status, new Set());
+      }
+      this.statusIndex.get(run.status)!.add(run.runId);
+
+      this.idempotencyIndex.set(run.idempotencyKey, run.runId);
+      this.runs.set(run.runId, run);
+
+      const runIds = this.taskRuns.get(taskId) ?? [];
+      if (!runIds.includes(run.runId)) {
+        runIds.push(run.runId);
+        this.taskRuns.set(taskId, runIds);
+      }
+
+      this.flushRuns();
+      this.flushTaskRuns();
+      this.flushIdempotencyIndex();
+      this.flushStatusIndex();
+    },
+    list: (taskId: string, opts?: RunListOptions): TaskRun[] => {
+      const runIds = this.taskRuns.get(taskId) ?? [];
+      let runs = runIds
+        .map((id) => this.runs.get(id))
+        .filter((r): r is TaskRun => r !== undefined);
+
+      if (opts?.sortBy) {
+        const sortBy = opts.sortBy;
+        const sortOrder = opts.sortOrder ?? "desc";
+        runs.sort((a, b) => {
+          const aVal = a[sortBy] ?? 0;
+          const bVal = b[sortBy] ?? 0;
+          return sortOrder === "asc" ? aVal - bVal : bVal - aVal;
+        });
+      }
+
+      if (opts?.offset !== undefined || opts?.limit !== undefined) {
+        const offset = opts.offset ?? 0;
+        const limit = opts.limit ?? runs.length;
+        runs = runs.slice(offset, offset + limit);
+      }
+
+      return runs;
+    },
+    listByStatus: (status: TaskRun["status"][]): TaskRun[] => {
+      const runIds = new Set<string>();
+      for (const s of status) {
+        const ids = this.statusIndex.get(s);
+        if (ids) {
+          for (const id of ids) {
+            runIds.add(id);
+          }
+        }
+      }
+      return Array.from(runIds)
+        .map((id) => this.runs.get(id))
+        .filter((r): r is TaskRun => r !== undefined);
+    },
+    remove: (runId: string): boolean => {
+      const run = this.runs.get(runId);
+      if (!run) return false;
+
+      this.statusIndex.get(run.status)?.delete(runId);
+      this.idempotencyIndex.delete(run.idempotencyKey);
+
+      const runIds = this.taskRuns.get(run.taskId);
+      if (runIds) {
+        const idx = runIds.indexOf(runId);
+        if (idx >= 0) {
+          runIds.splice(idx, 1);
+        }
+      }
+
+      const deleted = this.runs.delete(runId);
+      this.flushRuns();
+      this.flushTaskRuns();
+      this.flushIdempotencyIndex();
+      this.flushStatusIndex();
+      return deleted;
+    },
+    getByIdempotencyKey: (key: string): TaskRun | undefined => {
+      const runId = this.idempotencyIndex.get(key);
+      return runId ? this.runs.get(runId) : undefined;
+    },
+  };
+
+  // ===========================================================
+  // Disk I/O — load
+  // ===========================================================
+
+  private loadFromDisk(): void {
+    this.tasks = this.readMapFile<Task.Info>("tasks.json");
+    this.runs = this.readMapFile<TaskRun>("runs.json");
+    this.taskRuns = this.readMapFile<string[]>("taskRuns.json");
+    this.idempotencyIndex = this.readMapFile<string>("idempotencyIndex.json");
+    this.loadStatusIndex();
+  }
+
+  private loadStatusIndex(): void {
+    const path = join(this.dir, "statusIndex.json");
+    if (!existsSync(path)) return;
+    try {
+      const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<
+        string,
+        string[]
+      >;
+      this.statusIndex = new Map();
+      for (const [status, ids] of Object.entries(raw)) {
+        this.statusIndex.set(status as TaskRun["status"], new Set(ids));
+      }
+    } catch {
+      this.rebuildStatusIndex();
+    }
+  }
+
+  private rebuildStatusIndex(): void {
+    this.statusIndex = new Map();
+    for (const run of this.runs.values()) {
+      if (!this.statusIndex.has(run.status)) {
+        this.statusIndex.set(run.status, new Set());
+      }
+      this.statusIndex.get(run.status)!.add(run.runId);
+    }
+  }
+
+  private readMapFile<V>(filename: string): Map<string, V> {
+    const path = join(this.dir, filename);
+    if (!existsSync(path)) return new Map();
+    try {
+      const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, V>;
+      return new Map(Object.entries(raw));
+    } catch {
+      return new Map();
+    }
+  }
+
+  // ===========================================================
+  // Disk I/O — flush (atomic write: tmp → rename)
+  // ===========================================================
+
+  private atomicWrite(filename: string, data: string): void {
+    const target = join(this.dir, filename);
+    const tmp = target + ".tmp";
+    try {
+      writeFileSync(tmp, data, "utf-8");
+      renameSync(tmp, target);
+    } catch (err) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* noop */
+      }
+      throw err;
+    }
+  }
+
+  private flushMap<V>(filename: string, map: Map<string, V>): void {
+    this.atomicWrite(
+      filename,
+      JSON.stringify(Object.fromEntries(map), null, 2),
+    );
+  }
+
+  private flushTasks(): void {
+    this.flushMap("tasks.json", this.tasks);
+  }
+
+  private flushRuns(): void {
+    this.flushMap("runs.json", this.runs);
+  }
+
+  private flushTaskRuns(): void {
+    this.flushMap("taskRuns.json", this.taskRuns);
+  }
+
+  private flushIdempotencyIndex(): void {
+    this.flushMap("idempotencyIndex.json", this.idempotencyIndex);
+  }
+
+  private flushStatusIndex(): void {
+    const obj: Record<string, string[]> = {};
+    for (const [status, ids] of this.statusIndex) {
+      obj[status] = Array.from(ids);
+    }
+    this.atomicWrite("statusIndex.json", JSON.stringify(obj, null, 2));
+  }
+
+  private flushAll(): void {
+    this.flushTasks();
+    this.flushRuns();
+    this.flushTaskRuns();
+    this.flushIdempotencyIndex();
+    this.flushStatusIndex();
+  }
+
+  clear(): void {
+    this.tasks.clear();
+    this.runs.clear();
+    this.taskRuns.clear();
+    this.idempotencyIndex.clear();
+    this.statusIndex.clear();
+    this.flushAll();
+  }
+}

--- a/packages/agent/src/task/index.ts
+++ b/packages/agent/src/task/index.ts
@@ -3,6 +3,7 @@ export { TaskManager } from "./manager";
 export type { TriggerError, TriggerResult } from "./manager";
 export { TaskStorage, InMemoryTaskStore } from "./storage";
 export type { TaskStore } from "./storage";
+export { FileTaskStore } from "./file-task-storage";
 export { TaskStateMachine } from "./state-machine";
 export type { Checkpoint } from "./checkpoint";
 export { CheckpointManager } from "./checkpoint";

--- a/packages/agent/test/agent/discovery.test.ts
+++ b/packages/agent/test/agent/discovery.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { join } from "node:path";
+import { AgentDiscovery, parseFrontmatter } from "../../src/agent/discovery";
+import { BuiltinAgentRegistry } from "../../src/agent/registry";
+
+const FIXTURES_DIR = join(import.meta.dir, "../fixtures/agents");
+
+beforeEach(() => {
+  BuiltinAgentRegistry.clear();
+});
+
+describe("parseFrontmatter", () => {
+  it("extracts YAML data and markdown body", () => {
+    const content = `---
+name: "test"
+description: "desc"
+---
+
+# Body content`;
+
+    const { data, body } = parseFrontmatter(content);
+    expect(data.name).toBe("test");
+    expect(data.description).toBe("desc");
+    expect(body).toBe("# Body content");
+  });
+
+  it("throws when frontmatter opening delimiter is missing", () => {
+    expect(() => parseFrontmatter("no frontmatter")).toThrow(
+      "Missing frontmatter: file must start with ---",
+    );
+  });
+
+  it("throws when frontmatter closing delimiter is missing", () => {
+    expect(() => parseFrontmatter("---\nname: test\n")).toThrow(
+      "Missing frontmatter: no closing --- found",
+    );
+  });
+
+  it("parses nested objects", () => {
+    const content = `---
+permissions:
+  read: true
+  write: false
+---`;
+
+    const { data } = parseFrontmatter(content);
+    expect(data.permissions).toEqual({ read: true, write: false });
+  });
+
+  it("parses inline arrays", () => {
+    const content = `---
+tools: [read, grep, glob]
+---`;
+
+    const { data } = parseFrontmatter(content);
+    expect(data.tools).toEqual(["read", "grep", "glob"]);
+  });
+
+  it("parses block arrays", () => {
+    const content = `---
+tools:
+  - read
+  - grep
+  - glob
+---`;
+
+    const { data } = parseFrontmatter(content);
+    expect(data.tools).toEqual(["read", "grep", "glob"]);
+  });
+
+  it("parses quoted strings", () => {
+    const content = `---
+name: "my-agent"
+description: 'single quoted'
+---`;
+
+    const { data } = parseFrontmatter(content);
+    expect(data.name).toBe("my-agent");
+    expect(data.description).toBe("single quoted");
+  });
+
+  it("parses numbers", () => {
+    const content = `---
+maxTurns: 25
+---`;
+
+    const { data } = parseFrontmatter(content);
+    expect(data.maxTurns).toBe(25);
+  });
+});
+
+describe("AgentDiscovery.load", () => {
+  it("loads valid worker agent from .md file", () => {
+    const results = AgentDiscovery.load(FIXTURES_DIR);
+    const worker = results.find((r) => r.agent?.name === "code-analyzer");
+
+    expect(worker).toBeDefined();
+    expect(worker!.success).toBe(true);
+    expect(worker!.agent!.name).toBe("code-analyzer");
+    expect(worker!.agent!.tools).toEqual(["read", "grep", "glob"]);
+    expect(worker!.agent!.permissions.read).toBe(true);
+    expect(worker!.agent!.permissions.write).toBe(false);
+    expect(worker!.agent!.maxTurns).toBe(15);
+  });
+
+  it("loads valid supervisor agent from .md file", () => {
+    const results = AgentDiscovery.load(FIXTURES_DIR);
+    const supervisor = results.find(
+      (r) => r.agent?.name === "conversation-supervisor",
+    );
+
+    expect(supervisor).toBeDefined();
+    expect(supervisor!.success).toBe(true);
+    expect(supervisor!.agent!.name).toBe("conversation-supervisor");
+    expect(supervisor!.agent!.permissions.lsp).toBe(true);
+    expect(supervisor!.agent!.maxTurns).toBe(50);
+  });
+
+  it("appends markdown body to systemPrompt", () => {
+    const results = AgentDiscovery.load(FIXTURES_DIR);
+    const worker = results.find((r) => r.agent?.name === "code-analyzer");
+
+    expect(worker!.agent!.systemPrompt).toContain(
+      "You are a code analysis agent.",
+    );
+    expect(worker!.agent!.systemPrompt).toContain("Extended Instructions");
+    expect(worker!.agent!.systemPrompt).toContain("anti-patterns");
+  });
+
+  it("rejects invalid frontmatter with Zod validation failure", () => {
+    const results = AgentDiscovery.load(FIXTURES_DIR);
+    const invalid = results.find((r) => r.file.includes("invalid.md"));
+
+    expect(invalid).toBeDefined();
+    expect(invalid!.success).toBe(false);
+    expect(invalid!.error).toBeDefined();
+  });
+
+  it("registers loaded agents in BuiltinAgentRegistry", () => {
+    AgentDiscovery.load(FIXTURES_DIR);
+
+    expect(BuiltinAgentRegistry.has("code-analyzer")).toBe(true);
+    expect(BuiltinAgentRegistry.has("conversation-supervisor")).toBe(true);
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    const results = AgentDiscovery.load("/non/existent/path");
+    expect(results).toEqual([]);
+  });
+
+  it("throws in strict mode for non-existent directory", () => {
+    expect(() =>
+      AgentDiscovery.load("/non/existent/path", { strict: true }),
+    ).toThrow("Agent discovery directory does not exist");
+  });
+});
+
+describe("AgentDiscovery override protection", () => {
+  it("rejects when agent name conflicts and no override flag", () => {
+    BuiltinAgentRegistry.define({
+      name: "code-analyzer",
+      description: "existing agent",
+      systemPrompt: "existing",
+      tools: ["read"],
+      permissions: {
+        read: true,
+        write: false,
+        bash: false,
+        lsp: false,
+        grep: false,
+        glob: false,
+      },
+    });
+
+    const results = AgentDiscovery.load(FIXTURES_DIR);
+    const worker = results.find((r) => r.file.includes("valid-worker.md"));
+
+    expect(worker!.success).toBe(false);
+    expect(worker!.error).toContain("already exists");
+    expect(worker!.error).toContain("allowOverride is not set");
+  });
+
+  it("allows override when allowOverride flag is set", () => {
+    BuiltinAgentRegistry.define({
+      name: "code-analyzer",
+      description: "existing agent",
+      systemPrompt: "existing",
+      tools: ["read"],
+      permissions: {
+        read: true,
+        write: false,
+        bash: false,
+        lsp: false,
+        grep: false,
+        glob: false,
+      },
+    });
+
+    const results = AgentDiscovery.load(FIXTURES_DIR, {
+      allowOverride: true,
+    });
+    const worker = results.find((r) => r.file.includes("valid-worker.md"));
+
+    expect(worker!.success).toBe(true);
+    expect(worker!.agent!.description).toBe(
+      "Analyzes codebases for patterns and issues",
+    );
+
+    const registered = BuiltinAgentRegistry.get("code-analyzer");
+    expect(registered!.description).toBe(
+      "Analyzes codebases for patterns and issues",
+    );
+  });
+
+  it("throws in strict mode when agent name conflicts without override", () => {
+    BuiltinAgentRegistry.define({
+      name: "code-analyzer",
+      description: "existing",
+      systemPrompt: "existing",
+      tools: [],
+      permissions: {
+        read: false,
+        write: false,
+        bash: false,
+        lsp: false,
+        grep: false,
+        glob: false,
+      },
+    });
+
+    expect(() =>
+      AgentDiscovery.loadFile(join(FIXTURES_DIR, "valid-worker.md"), {
+        strict: true,
+      }),
+    ).toThrow("already exists");
+  });
+});
+
+describe("AgentDiscovery.loadFile", () => {
+  it("loads a single agent file", () => {
+    const result = AgentDiscovery.loadFile(
+      join(FIXTURES_DIR, "valid-worker.md"),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.agent!.name).toBe("code-analyzer");
+  });
+
+  it("returns failure for invalid file", () => {
+    const result = AgentDiscovery.loadFile(join(FIXTURES_DIR, "invalid.md"));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+});

--- a/packages/agent/test/agent/file-registry-storage.test.ts
+++ b/packages/agent/test/agent/file-registry-storage.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { FileAgentRegistryStore } from "../../src/agent/file-registry-storage";
+import { AgentRegistry, type AgentProfile } from "../../src/agent/profile";
+
+function makeProfile(id: string, name?: string): AgentProfile {
+  return { id, name: name ?? `Agent ${id}` };
+}
+
+describe("FileAgentRegistryStore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "file-agent-registry-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("set and get profile", () => {
+    const store = new FileAgentRegistryStore(dir);
+    const profile = makeProfile("a1", "Alpha");
+
+    store.set("a1", profile);
+
+    expect(store.get("a1")).toEqual(profile);
+  });
+
+  test("list returns all profiles", () => {
+    const store = new FileAgentRegistryStore(dir);
+
+    store.set("a1", makeProfile("a1"));
+    store.set("a2", makeProfile("a2"));
+
+    const profiles = store.list();
+    expect(profiles).toHaveLength(2);
+    expect(profiles.map((p) => p.id).sort()).toEqual(["a1", "a2"]);
+  });
+
+  test("remove deletes profile and file", () => {
+    const store = new FileAgentRegistryStore(dir);
+    store.set("a1", makeProfile("a1"));
+
+    expect(store.remove("a1")).toBe(true);
+    expect(store.get("a1")).toBeUndefined();
+    expect(store.has("a1")).toBe(false);
+    expect(existsSync(join(dir, "a1.json"))).toBe(false);
+  });
+
+  test("remove returns false for non-existent", () => {
+    const store = new FileAgentRegistryStore(dir);
+    expect(store.remove("nope")).toBe(false);
+  });
+
+  test("has returns correct values", () => {
+    const store = new FileAgentRegistryStore(dir);
+    store.set("a1", makeProfile("a1"));
+
+    expect(store.has("a1")).toBe(true);
+    expect(store.has("nope")).toBe(false);
+  });
+
+  test("size returns profile count", () => {
+    const store = new FileAgentRegistryStore(dir);
+
+    expect(store.size()).toBe(0);
+    store.set("a1", makeProfile("a1"));
+    expect(store.size()).toBe(1);
+    store.set("a2", makeProfile("a2"));
+    expect(store.size()).toBe(2);
+  });
+
+  test("clear removes all profiles and files", () => {
+    const store = new FileAgentRegistryStore(dir);
+    store.set("a1", makeProfile("a1"));
+    store.set("a2", makeProfile("a2"));
+
+    store.clear();
+
+    expect(store.size()).toBe(0);
+    expect(store.list()).toEqual([]);
+    expect(existsSync(join(dir, "a1.json"))).toBe(false);
+    expect(existsSync(join(dir, "a2.json"))).toBe(false);
+  });
+
+  test("persists to disk and recovers on reload", () => {
+    const store1 = new FileAgentRegistryStore(dir);
+    store1.set("a1", makeProfile("a1", "Alpha"));
+    store1.set("a2", makeProfile("a2", "Beta"));
+
+    const store2 = new FileAgentRegistryStore(dir);
+
+    expect(store2.size()).toBe(2);
+    expect(store2.get("a1")?.name).toBe("Alpha");
+    expect(store2.get("a2")?.name).toBe("Beta");
+  });
+
+  test("survives removal then reload", () => {
+    const store1 = new FileAgentRegistryStore(dir);
+    store1.set("a1", makeProfile("a1"));
+    store1.set("a2", makeProfile("a2"));
+    store1.remove("a1");
+
+    const store2 = new FileAgentRegistryStore(dir);
+    expect(store2.size()).toBe(1);
+    expect(store2.has("a1")).toBe(false);
+    expect(store2.has("a2")).toBe(true);
+  });
+
+  test("handles profiles with special characters in id", () => {
+    const store = new FileAgentRegistryStore(dir);
+    const profile = makeProfile("ns:agent:v1.0", "Namespaced Agent");
+
+    store.set("ns:agent:v1.0", profile);
+
+    const reloaded = new FileAgentRegistryStore(dir);
+    expect(reloaded.get("ns:agent:v1.0")?.name).toBe("Namespaced Agent");
+  });
+
+  test("profiles with full schema fields persist correctly", () => {
+    const store = new FileAgentRegistryStore(dir);
+    const profile: AgentProfile = {
+      id: "full",
+      name: "Full Agent",
+      role: "orchestrator",
+      systemPrompt: "You are an orchestrator.",
+      skills: ["reasoning", "coding"],
+      tools: ["calculator", "search"],
+      policy: {
+        tools: ["calculator"],
+        dataScopes: [{ type: "files", allow: "read", roots: ["/data"] }],
+        capabilities: ["delegate"],
+      },
+    };
+
+    store.set("full", profile);
+    const reloaded = new FileAgentRegistryStore(dir);
+
+    expect(reloaded.get("full")).toEqual(profile);
+  });
+});
+
+describe("AgentRegistry storage adapter integration", () => {
+  afterEach(() => {
+    AgentRegistry.reset();
+  });
+
+  test("default store is undefined (each instance creates its own)", () => {
+    expect(AgentRegistry.getStore()).toBeUndefined();
+  });
+
+  test("configure() swaps the global store", () => {
+    const dir = mkdtempSync(join(tmpdir(), "registry-configure-"));
+    try {
+      const fileStore = new FileAgentRegistryStore(dir);
+      AgentRegistry.configure(fileStore);
+
+      expect(AgentRegistry.getStore()).toBe(fileStore);
+    } finally {
+      AgentRegistry.reset();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("new AgentRegistry() uses configured global store", () => {
+    const dir = mkdtempSync(join(tmpdir(), "registry-global-"));
+    try {
+      const fileStore = new FileAgentRegistryStore(dir);
+      AgentRegistry.configure(fileStore);
+
+      const registry = new AgentRegistry();
+      registry.set(makeProfile("a1"));
+
+      expect(fileStore.get("a1")).toBeDefined();
+    } finally {
+      AgentRegistry.reset();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("AgentRegistry constructor accepts explicit store override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "registry-override-"));
+    try {
+      const fileStore = new FileAgentRegistryStore(dir);
+      const registry = new AgentRegistry(fileStore);
+
+      registry.set(makeProfile("a1"));
+      expect(fileStore.get("a1")).toBeDefined();
+
+      expect(AgentRegistry.getStore()).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reset() clears configured store", () => {
+    const dir = mkdtempSync(join(tmpdir(), "registry-reset-"));
+    try {
+      AgentRegistry.configure(new FileAgentRegistryStore(dir));
+      AgentRegistry.reset();
+
+      expect(AgentRegistry.getStore()).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("register → restart adapter → lookup recovers", () => {
+    const dir = mkdtempSync(join(tmpdir(), "registry-restart-"));
+    try {
+      const store1 = new FileAgentRegistryStore(dir);
+      const registry1 = new AgentRegistry(store1);
+      registry1.set(makeProfile("persistent-agent", "Persistent"));
+
+      const store2 = new FileAgentRegistryStore(dir);
+      const registry2 = new AgentRegistry(store2);
+
+      expect(registry2.get("persistent-agent")?.name).toBe("Persistent");
+      expect(registry2.size()).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent/test/fixtures/agents/invalid.md
+++ b/packages/agent/test/fixtures/agents/invalid.md
@@ -1,0 +1,9 @@
+---
+name: "broken-agent"
+description: 123
+tools: "not-an-array"
+permissions:
+  read: "yes"
+---
+
+This agent has invalid frontmatter and should fail Zod validation.

--- a/packages/agent/test/fixtures/agents/valid-supervisor.md
+++ b/packages/agent/test/fixtures/agents/valid-supervisor.md
@@ -1,0 +1,23 @@
+---
+name: "conversation-supervisor"
+description: "Supervises user-facing conversations and orchestrates sub-agents"
+systemPrompt: "You are a conversation supervisor."
+tools: ["read", "write", "bash", "grep", "glob"]
+permissions:
+  read: true
+  write: true
+  bash: true
+  lsp: true
+  grep: true
+  glob: true
+maxTurns: 50
+---
+
+# Supervisor Protocol
+
+You manage conversations by:
+
+1. Gathering requirements from the user
+2. Creating execution plans
+3. Delegating tasks to worker agents
+4. Reviewing and approving results

--- a/packages/agent/test/fixtures/agents/valid-worker.md
+++ b/packages/agent/test/fixtures/agents/valid-worker.md
@@ -1,0 +1,19 @@
+---
+name: "code-analyzer"
+description: "Analyzes codebases for patterns and issues"
+systemPrompt: "You are a code analysis agent."
+tools: ["read", "grep", "glob"]
+permissions:
+  read: true
+  write: false
+  bash: false
+  lsp: false
+  grep: true
+  glob: true
+maxTurns: 15
+---
+
+# Extended Instructions
+
+You should focus on identifying anti-patterns and suggesting improvements.
+Always provide concrete examples when reporting issues.

--- a/packages/agent/test/task/file-task-storage.test.ts
+++ b/packages/agent/test/task/file-task-storage.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { FileTaskStore } from "../../src/task/file-task-storage";
+import { TaskStorage, InMemoryTaskStore } from "../../src/task/storage";
+import type { Task, TaskRun } from "../../src/task/types";
+
+function makeTask(id: string, overrides?: Partial<Task.Info>): Task.Info {
+  return {
+    id,
+    title: `Task ${id}`,
+    owner: { type: "user", id: "user-1" },
+    status: "idle",
+    triggers: [],
+    policy: {},
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeRun(
+  runId: string,
+  taskId: string,
+  overrides?: Partial<TaskRun>,
+): TaskRun {
+  return {
+    runId,
+    taskId,
+    sessionKey: `task:${taskId}:run:${runId}`,
+    status: "scheduled",
+    trigger: { id: "trigger-1", type: "manual" },
+    idempotencyKey: `idem-${runId}`,
+    attempt: 1,
+    scheduledAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("FileTaskStore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "file-task-store-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("basic task operations", () => {
+    test("set and get task", () => {
+      const store = new FileTaskStore(dir);
+      const task = makeTask("task-1");
+
+      store.task.set("task-1", task);
+      expect(store.task.get("task-1")).toEqual(task);
+    });
+
+    test("get returns undefined for non-existent task", () => {
+      const store = new FileTaskStore(dir);
+      expect(store.task.get("non-existent")).toBeUndefined();
+    });
+
+    test("list returns all tasks", () => {
+      const store = new FileTaskStore(dir);
+      store.task.set("task-1", makeTask("task-1"));
+      store.task.set("task-2", makeTask("task-2", { status: "running" }));
+
+      expect(store.task.list()).toHaveLength(2);
+    });
+
+    test("list filters by status", () => {
+      const store = new FileTaskStore(dir);
+      store.task.set("task-1", makeTask("task-1", { status: "idle" }));
+      store.task.set("task-2", makeTask("task-2", { status: "running" }));
+
+      expect(store.task.list({ status: "idle" })).toHaveLength(1);
+      expect(store.task.list({ status: ["running"] })).toHaveLength(1);
+    });
+
+    test("remove deletes task and associated runs", () => {
+      const store = new FileTaskStore(dir);
+      store.task.set("task-1", makeTask("task-1"));
+      store.run.set("task-1", makeRun("run-1", "task-1"));
+
+      expect(store.task.remove("task-1")).toBe(true);
+      expect(store.task.get("task-1")).toBeUndefined();
+      expect(store.run.get("run-1")).toBeUndefined();
+    });
+  });
+
+  describe("basic run operations", () => {
+    test("set and get run", () => {
+      const store = new FileTaskStore(dir);
+      const run = makeRun("run-1", "task-1");
+
+      store.run.set("task-1", run);
+      expect(store.run.get("run-1")).toEqual(run);
+    });
+
+    test("listByStatus returns matching runs", () => {
+      const store = new FileTaskStore(dir);
+      store.run.set(
+        "task-1",
+        makeRun("run-1", "task-1", { status: "scheduled" }),
+      );
+      store.run.set(
+        "task-1",
+        makeRun("run-2", "task-1", { status: "running" }),
+      );
+      store.run.set(
+        "task-2",
+        makeRun("run-3", "task-2", { status: "scheduled" }),
+      );
+
+      const scheduled = store.run.listByStatus(["scheduled"]);
+      expect(scheduled).toHaveLength(2);
+      expect(scheduled.map((r) => r.runId).sort()).toEqual(["run-1", "run-3"]);
+    });
+
+    test("getByIdempotencyKey returns run", () => {
+      const store = new FileTaskStore(dir);
+      const run = makeRun("run-1", "task-1", { idempotencyKey: "my-key" });
+
+      store.run.set("task-1", run);
+      expect(store.run.getByIdempotencyKey("my-key")).toEqual(run);
+    });
+
+    test("status index updates on status change", () => {
+      const store = new FileTaskStore(dir);
+      const run = makeRun("run-1", "task-1", { status: "scheduled" });
+      store.run.set("task-1", run);
+
+      expect(store.run.listByStatus(["scheduled"])).toHaveLength(1);
+
+      store.run.set("task-1", { ...run, status: "running" });
+
+      expect(store.run.listByStatus(["scheduled"])).toHaveLength(0);
+      expect(store.run.listByStatus(["running"])).toHaveLength(1);
+    });
+
+    test("remove deletes run and updates indexes", () => {
+      const store = new FileTaskStore(dir);
+      store.run.set("task-1", makeRun("run-1", "task-1"));
+
+      expect(store.run.remove("run-1")).toBe(true);
+      expect(store.run.get("run-1")).toBeUndefined();
+      expect(store.run.listByStatus(["scheduled"])).toHaveLength(0);
+      expect(store.run.getByIdempotencyKey("idem-run-1")).toBeUndefined();
+    });
+
+    test("list with sort and pagination", () => {
+      const store = new FileTaskStore(dir);
+      const now = Date.now();
+
+      for (let i = 0; i < 5; i++) {
+        store.run.set(
+          "task-1",
+          makeRun(`run-${i}`, "task-1", { scheduledAt: now + i }),
+        );
+      }
+
+      const page = store.run.list("task-1", {
+        sortBy: "scheduledAt",
+        sortOrder: "asc",
+        limit: 2,
+        offset: 1,
+      });
+
+      expect(page).toHaveLength(2);
+      expect(page[0].runId).toBe("run-1");
+      expect(page[1].runId).toBe("run-2");
+    });
+  });
+
+  describe("persistence across restart", () => {
+    test("write task → restart → read task", () => {
+      const task = makeTask("task-1");
+
+      const store1 = new FileTaskStore(dir);
+      store1.task.set("task-1", task);
+
+      const store2 = new FileTaskStore(dir);
+      expect(store2.task.get("task-1")).toEqual(task);
+      expect(store2.task.list()).toHaveLength(1);
+    });
+
+    test("write run → restart → read run", () => {
+      const run = makeRun("run-1", "task-1");
+
+      const store1 = new FileTaskStore(dir);
+      store1.run.set("task-1", run);
+
+      const store2 = new FileTaskStore(dir);
+      expect(store2.run.get("run-1")).toEqual(run);
+    });
+
+    test("write run with idempotency key → restart → lookup by idempotency key", () => {
+      const run = makeRun("run-1", "task-1", {
+        idempotencyKey: "unique-key-123",
+      });
+
+      const store1 = new FileTaskStore(dir);
+      store1.run.set("task-1", run);
+
+      const store2 = new FileTaskStore(dir);
+      const found = store2.run.getByIdempotencyKey("unique-key-123");
+      expect(found).toEqual(run);
+    });
+
+    test("write run → change status → restart → listByStatus", () => {
+      const store1 = new FileTaskStore(dir);
+      const run = makeRun("run-1", "task-1", { status: "scheduled" });
+      store1.run.set("task-1", run);
+      store1.run.set("task-1", { ...run, status: "running" });
+
+      const store2 = new FileTaskStore(dir);
+      expect(store2.run.listByStatus(["scheduled"])).toHaveLength(0);
+      expect(store2.run.listByStatus(["running"])).toHaveLength(1);
+      expect(store2.run.listByStatus(["running"])[0].runId).toBe("run-1");
+    });
+
+    test("multiple tasks and runs survive restart", () => {
+      const store1 = new FileTaskStore(dir);
+      store1.task.set("task-1", makeTask("task-1"));
+      store1.task.set("task-2", makeTask("task-2"));
+      store1.run.set("task-1", makeRun("run-1", "task-1", { status: "done" }));
+      store1.run.set(
+        "task-1",
+        makeRun("run-2", "task-1", { status: "running" }),
+      );
+      store1.run.set(
+        "task-2",
+        makeRun("run-3", "task-2", { status: "scheduled" }),
+      );
+
+      const store2 = new FileTaskStore(dir);
+      expect(store2.task.list()).toHaveLength(2);
+      expect(store2.run.list("task-1")).toHaveLength(2);
+      expect(store2.run.list("task-2")).toHaveLength(1);
+      expect(store2.run.listByStatus(["done"])).toHaveLength(1);
+      expect(store2.run.listByStatus(["running"])).toHaveLength(1);
+      expect(store2.run.listByStatus(["scheduled"])).toHaveLength(1);
+    });
+
+    test("remove persists across restart", () => {
+      const store1 = new FileTaskStore(dir);
+      store1.task.set("task-1", makeTask("task-1"));
+      store1.run.set("task-1", makeRun("run-1", "task-1"));
+      store1.task.remove("task-1");
+
+      const store2 = new FileTaskStore(dir);
+      expect(store2.task.get("task-1")).toBeUndefined();
+      expect(store2.run.get("run-1")).toBeUndefined();
+      expect(store2.task.list()).toHaveLength(0);
+    });
+  });
+
+  describe("clear", () => {
+    test("clear removes all data from memory and disk", () => {
+      const store1 = new FileTaskStore(dir);
+      store1.task.set("task-1", makeTask("task-1"));
+      store1.run.set("task-1", makeRun("run-1", "task-1"));
+      store1.clear();
+
+      expect(store1.task.list()).toHaveLength(0);
+      expect(store1.run.listByStatus(["scheduled"])).toHaveLength(0);
+
+      const store2 = new FileTaskStore(dir);
+      expect(store2.task.list()).toHaveLength(0);
+      expect(store2.run.listByStatus(["scheduled"])).toHaveLength(0);
+    });
+  });
+
+  describe("TaskStorage.configure integration", () => {
+    test("configure accepts FileTaskStore", () => {
+      const store = new FileTaskStore(dir);
+      TaskStorage.configure(store);
+
+      const adapter = TaskStorage.getAdapter();
+      expect(adapter).toBe(store);
+    });
+  });
+
+  describe("InMemoryTaskStore remains default", () => {
+    test("default adapter is InMemoryTaskStore", () => {
+      TaskStorage.reset();
+      const adapter = TaskStorage.getAdapter();
+      expect(adapter).toBeInstanceOf(InMemoryTaskStore);
+    });
+  });
+});

--- a/packages/session/src/file-storage.ts
+++ b/packages/session/src/file-storage.ts
@@ -1,0 +1,223 @@
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+  renameSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { Message } from "@openomni/protocol";
+import { Session } from "./session";
+import type { StorageAdapter } from "./storage";
+
+export class FileStorageAdapter implements StorageAdapter {
+  private readonly sessionsDir: string;
+  private readonly messagesDir: string;
+  private readonly partsDir: string;
+
+  constructor(private readonly baseDir: string) {
+    this.sessionsDir = join(baseDir, "sessions");
+    this.messagesDir = join(baseDir, "messages");
+    this.partsDir = join(baseDir, "parts");
+
+    mkdirSync(this.sessionsDir, { recursive: true });
+    mkdirSync(this.messagesDir, { recursive: true });
+    mkdirSync(this.partsDir, { recursive: true });
+  }
+
+  private atomicWrite(filePath: string, data: unknown): void {
+    const dir = join(filePath, "..");
+    mkdirSync(dir, { recursive: true });
+    const tmpPath = `${filePath}.${randomUUID()}.tmp`;
+    try {
+      writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+      renameSync(tmpPath, filePath);
+    } catch (err) {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        /* noop */
+      }
+      throw new Error(
+        `FileStorageAdapter: failed to write ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private readJSON<T>(filePath: string): T | undefined {
+    try {
+      const raw = readFileSync(filePath, "utf-8");
+      return JSON.parse(raw) as T;
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return undefined;
+      }
+      throw new Error(
+        `FileStorageAdapter: failed to read ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private listDir(dir: string): string[] {
+    try {
+      return readdirSync(dir);
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return [];
+      }
+      throw new Error(
+        `FileStorageAdapter: failed to list ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  session = {
+    get: (id: string): Session.Info | undefined => {
+      return this.readJSON<Session.Info>(join(this.sessionsDir, `${id}.json`));
+    },
+
+    set: (id: string, info: Session.Info): void => {
+      this.atomicWrite(join(this.sessionsDir, `${id}.json`), info);
+    },
+
+    list: (): Session.Info[] => {
+      const files = this.listDir(this.sessionsDir);
+      const results: Session.Info[] = [];
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        const info = this.readJSON<Session.Info>(join(this.sessionsDir, file));
+        if (info) results.push(info);
+      }
+      return results;
+    },
+
+    remove: (id: string): boolean => {
+      const filePath = join(this.sessionsDir, `${id}.json`);
+      try {
+        unlinkSync(filePath);
+        return true;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          return false;
+        }
+        throw new Error(
+          `FileStorageAdapter: failed to remove session ${id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    },
+  };
+
+  message = {
+    get: (sessionID: string, messageID: string): Message.Info | undefined => {
+      return this.readJSON<Message.Info>(
+        join(this.messagesDir, sessionID, `${messageID}.json`),
+      );
+    },
+
+    set: (sessionID: string, message: Message.Info): void => {
+      this.atomicWrite(
+        join(this.messagesDir, sessionID, `${message.id}.json`),
+        message,
+      );
+    },
+
+    list: (sessionID: string): Message.Info[] => {
+      const dir = join(this.messagesDir, sessionID);
+      const files = this.listDir(dir);
+      const results: Message.Info[] = [];
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        const msg = this.readJSON<Message.Info>(join(dir, file));
+        if (msg) results.push(msg);
+      }
+      return results;
+    },
+
+    remove: (sessionID: string, messageID: string): boolean => {
+      const filePath = join(this.messagesDir, sessionID, `${messageID}.json`);
+      try {
+        unlinkSync(filePath);
+        return true;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          return false;
+        }
+        throw new Error(
+          `FileStorageAdapter: failed to remove message ${messageID}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    },
+  };
+
+  part = {
+    get: (messageID: string, partID: string): Message.Part | undefined => {
+      return this.readJSON<Message.Part>(
+        join(this.partsDir, messageID, `${partID}.json`),
+      );
+    },
+
+    set: (messageID: string, part: Message.Part): void => {
+      this.atomicWrite(join(this.partsDir, messageID, `${part.id}.json`), part);
+    },
+
+    list: (messageID: string): Message.Part[] => {
+      const dir = join(this.partsDir, messageID);
+      const files = this.listDir(dir);
+      const results: Message.Part[] = [];
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        const pt = this.readJSON<Message.Part>(join(dir, file));
+        if (pt) results.push(pt);
+      }
+      return results;
+    },
+
+    remove: (messageID: string, partID: string): boolean => {
+      const filePath = join(this.partsDir, messageID, `${partID}.json`);
+      try {
+        unlinkSync(filePath);
+        return true;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          return false;
+        }
+        throw new Error(
+          `FileStorageAdapter: failed to remove part ${partID}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    },
+  };
+
+  clear(): void {
+    if (existsSync(this.baseDir)) {
+      rmSync(this.baseDir, { recursive: true, force: true });
+    }
+    mkdirSync(this.sessionsDir, { recursive: true });
+    mkdirSync(this.messagesDir, { recursive: true });
+    mkdirSync(this.partsDir, { recursive: true });
+  }
+}

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,6 +1,7 @@
 export { Bus, BusEvent } from "./bus";
 export { Storage, InMemoryStorage } from "./storage";
 export type { StorageAdapter } from "./storage";
+export { FileStorageAdapter } from "./file-storage";
 export { Session } from "./session";
 export { SessionStatus } from "./status";
 export { Snapshot, InMemorySnapshotProvider } from "./snapshot";

--- a/packages/session/src/surface-key.ts
+++ b/packages/session/src/surface-key.ts
@@ -3,13 +3,42 @@
  * Provides bidirectional lookup for routing events to sessions.
  *
  * Key format: `<surface-type>:<surface-specific-path>`
- * Examples:
- *   - slack:workspaceA:channel:C123:thread:171000
- *   - tui:/Users/ino/Develop/OpenOmni
- *   - telegram:botId:chat:chatId
+ *
+ * Channel/peer kind encoding:
+ *   - DM:      slack:workspaceA:dm:U123
+ *   - Group:   slack:workspaceA:group:C123
+ *   - Thread:  slack:workspaceA:group:C123:thread:171000
+ *   - Channel: slack:workspaceA:channel:C123
+ *   - TUI:     tui:/Users/ino/Develop/OpenOmni
+ *   - Chat:    telegram:botId:chat:chatId
+ *
+ * The `ChannelKind` type defines recognized channel/peer kinds.
+ * Use `SurfaceKey.fromChannel()` for structured creation with explicit kind.
  */
 
 export namespace SurfaceKey {
+  /**
+   * Recognized channel/peer kinds for explicit key encoding.
+   * - dm: Direct message (1:1 peer conversation)
+   * - group: Group/multi-party channel
+   * - channel: Generic named channel (backward compat)
+   * - thread: Thread within a channel/group
+   * - chat: Generic chat (e.g., telegram)
+   */
+  export type ChannelKind = "dm" | "group" | "channel" | "thread" | "chat";
+
+  export interface ChannelDescriptor {
+    /** Surface type (e.g., "slack", "telegram", "tui") */
+    surface: string;
+    /** Namespace/workspace/bot identifier */
+    namespace: string;
+    /** Channel/peer kind */
+    kind: ChannelKind;
+    /** Channel/peer identifier */
+    id: string;
+    /** Optional thread identifier (creates a sub-key under the channel) */
+    threadId?: string;
+  }
   // Forward index: surfaceKey → sessionId
   const keyToSession = new Map<string, string>();
 
@@ -46,11 +75,60 @@ export namespace SurfaceKey {
     return key;
   }
 
-  /**
-   * Look up the session ID for a given surfaceKey.
-   * @param key - The surfaceKey to look up
-   * @returns Session ID if found, undefined otherwise
-   */
+  const KNOWN_KINDS: ReadonlySet<string> = new Set<ChannelKind>([
+    "dm",
+    "group",
+    "channel",
+    "thread",
+    "chat",
+  ]);
+
+  export function fromChannel(descriptor: ChannelDescriptor): string {
+    const parts = [
+      descriptor.surface,
+      descriptor.namespace,
+      descriptor.kind,
+      descriptor.id,
+    ];
+    if (descriptor.threadId) {
+      parts.push("thread", descriptor.threadId);
+    }
+    return create(parts);
+  }
+
+  export interface ParsedKey {
+    surface: string;
+    namespace: string;
+    kind: ChannelKind | undefined;
+    id: string | undefined;
+    threadId: string | undefined;
+  }
+
+  export function parse(key: string): ParsedKey {
+    const segments = key.split(":");
+    const surface = segments[0] ?? "";
+    const namespace = segments[1] ?? "";
+
+    let kind: ChannelKind | undefined;
+    let id: string | undefined;
+    let threadId: string | undefined;
+
+    for (let i = 2; i < segments.length; i++) {
+      const seg = segments[i];
+      if (KNOWN_KINDS.has(seg)) {
+        if (seg === "thread") {
+          threadId = segments[i + 1];
+          i++;
+        } else {
+          kind = seg as ChannelKind;
+          id = segments[i + 1];
+          i++;
+        }
+      }
+    }
+
+    return { surface, namespace, kind, id, threadId };
+  }
   export function lookup(key: string): string | undefined {
     return keyToSession.get(key);
   }

--- a/packages/session/test/file-storage.test.ts
+++ b/packages/session/test/file-storage.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Message } from "@openomni/protocol";
+import { FileStorageAdapter } from "../src/file-storage";
+import { Storage, InMemoryStorage } from "../src/storage";
+import { Session } from "../src/session";
+
+function makeSession(id: string): Session.Info {
+  return {
+    id,
+    title: `Session ${id}`,
+    model: { providerID: "test", modelID: "test-model" },
+    time: { created: Date.now(), updated: Date.now() },
+  };
+}
+
+function makeUserMessage(sessionID: string, messageID: string): Message.Info {
+  return {
+    id: messageID,
+    sessionID,
+    role: "user" as const,
+    time: { created: Date.now() },
+    agent: "test-agent",
+    model: { providerID: "test", modelID: "test-model" },
+  };
+}
+
+function makeTextPart(
+  sessionID: string,
+  messageID: string,
+  partID: string,
+): Message.Part {
+  return {
+    id: partID,
+    sessionID,
+    messageID,
+    type: "text" as const,
+    text: `Part ${partID} content`,
+  };
+}
+
+describe("FileStorageAdapter", () => {
+  let dir: string;
+  let adapter: FileStorageAdapter;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "openomni-test-"));
+    adapter = new FileStorageAdapter(dir);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("session", () => {
+    it("should set and get a session", () => {
+      const session = makeSession("s1");
+      adapter.session.set("s1", session);
+
+      const retrieved = adapter.session.get("s1");
+      expect(retrieved).toEqual(session);
+    });
+
+    it("should return undefined for non-existent session", () => {
+      expect(adapter.session.get("nonexistent")).toBeUndefined();
+    });
+
+    it("should list all sessions", () => {
+      adapter.session.set("s1", makeSession("s1"));
+      adapter.session.set("s2", makeSession("s2"));
+
+      const sessions = adapter.session.list();
+      expect(sessions).toHaveLength(2);
+      expect(sessions.map((s) => s.id).sort()).toEqual(["s1", "s2"]);
+    });
+
+    it("should remove a session", () => {
+      adapter.session.set("s1", makeSession("s1"));
+      expect(adapter.session.remove("s1")).toBe(true);
+      expect(adapter.session.get("s1")).toBeUndefined();
+    });
+
+    it("should return false when removing non-existent session", () => {
+      expect(adapter.session.remove("nonexistent")).toBe(false);
+    });
+
+    it("should overwrite existing session on set", () => {
+      const session = makeSession("s1");
+      adapter.session.set("s1", session);
+
+      const updated = { ...session, title: "Updated Title" };
+      adapter.session.set("s1", updated);
+
+      expect(adapter.session.get("s1")?.title).toBe("Updated Title");
+    });
+  });
+
+  describe("message", () => {
+    it("should set and get a message", () => {
+      const msg = makeUserMessage("s1", "m1");
+      adapter.message.set("s1", msg);
+
+      const retrieved = adapter.message.get("s1", "m1");
+      expect(retrieved).toEqual(msg);
+    });
+
+    it("should return undefined for non-existent message", () => {
+      expect(adapter.message.get("s1", "nonexistent")).toBeUndefined();
+    });
+
+    it("should list messages for a session", () => {
+      adapter.message.set("s1", makeUserMessage("s1", "m1"));
+      adapter.message.set("s1", makeUserMessage("s1", "m2"));
+      adapter.message.set("s2", makeUserMessage("s2", "m3"));
+
+      const s1Messages = adapter.message.list("s1");
+      expect(s1Messages).toHaveLength(2);
+      expect(s1Messages.map((m) => m.id).sort()).toEqual(["m1", "m2"]);
+
+      const s2Messages = adapter.message.list("s2");
+      expect(s2Messages).toHaveLength(1);
+    });
+
+    it("should return empty array for session with no messages", () => {
+      expect(adapter.message.list("empty")).toEqual([]);
+    });
+
+    it("should remove a message", () => {
+      adapter.message.set("s1", makeUserMessage("s1", "m1"));
+      expect(adapter.message.remove("s1", "m1")).toBe(true);
+      expect(adapter.message.get("s1", "m1")).toBeUndefined();
+    });
+
+    it("should return false when removing non-existent message", () => {
+      expect(adapter.message.remove("s1", "nonexistent")).toBe(false);
+    });
+  });
+
+  describe("part", () => {
+    it("should set and get a part", () => {
+      const part = makeTextPart("s1", "m1", "p1");
+      adapter.part.set("m1", part);
+
+      const retrieved = adapter.part.get("m1", "p1");
+      expect(retrieved).toEqual(part);
+    });
+
+    it("should return undefined for non-existent part", () => {
+      expect(adapter.part.get("m1", "nonexistent")).toBeUndefined();
+    });
+
+    it("should list parts for a message", () => {
+      adapter.part.set("m1", makeTextPart("s1", "m1", "p1"));
+      adapter.part.set("m1", makeTextPart("s1", "m1", "p2"));
+
+      const parts = adapter.part.list("m1");
+      expect(parts).toHaveLength(2);
+      expect(parts.map((p) => p.id).sort()).toEqual(["p1", "p2"]);
+    });
+
+    it("should return empty array for message with no parts", () => {
+      expect(adapter.part.list("empty")).toEqual([]);
+    });
+
+    it("should remove a part", () => {
+      adapter.part.set("m1", makeTextPart("s1", "m1", "p1"));
+      expect(adapter.part.remove("m1", "p1")).toBe(true);
+      expect(adapter.part.get("m1", "p1")).toBeUndefined();
+    });
+
+    it("should return false when removing non-existent part", () => {
+      expect(adapter.part.remove("m1", "nonexistent")).toBe(false);
+    });
+  });
+
+  describe("persistence across adapter instances", () => {
+    it("should recover session after creating new adapter", () => {
+      const session = makeSession("s1");
+      adapter.session.set("s1", session);
+
+      const newAdapter = new FileStorageAdapter(dir);
+      expect(newAdapter.session.get("s1")).toEqual(session);
+    });
+
+    it("should recover messages after creating new adapter", () => {
+      const msg = makeUserMessage("s1", "m1");
+      adapter.message.set("s1", msg);
+
+      const newAdapter = new FileStorageAdapter(dir);
+      expect(newAdapter.message.get("s1", "m1")).toEqual(msg);
+      expect(newAdapter.message.list("s1")).toHaveLength(1);
+    });
+
+    it("should recover parts after creating new adapter", () => {
+      const part = makeTextPart("s1", "m1", "p1");
+      adapter.part.set("m1", part);
+
+      const newAdapter = new FileStorageAdapter(dir);
+      expect(newAdapter.part.get("m1", "p1")).toEqual(part);
+      expect(newAdapter.part.list("m1")).toHaveLength(1);
+    });
+
+    it("should recover full session graph after restart", () => {
+      const session = makeSession("s1");
+      const msg = makeUserMessage("s1", "m1");
+      const part = makeTextPart("s1", "m1", "p1");
+
+      adapter.session.set("s1", session);
+      adapter.message.set("s1", msg);
+      adapter.part.set("m1", part);
+
+      const newAdapter = new FileStorageAdapter(dir);
+      expect(newAdapter.session.get("s1")).toEqual(session);
+      expect(newAdapter.message.list("s1")).toHaveLength(1);
+      expect(newAdapter.part.list("m1")).toHaveLength(1);
+    });
+  });
+
+  describe("clear", () => {
+    it("should remove all data and recreate directory structure", () => {
+      adapter.session.set("s1", makeSession("s1"));
+      adapter.message.set("s1", makeUserMessage("s1", "m1"));
+      adapter.part.set("m1", makeTextPart("s1", "m1", "p1"));
+
+      adapter.clear();
+
+      expect(adapter.session.list()).toEqual([]);
+      expect(adapter.message.list("s1")).toEqual([]);
+      expect(adapter.part.list("m1")).toEqual([]);
+    });
+  });
+});
+
+describe("Storage.configure with FileStorageAdapter", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "openomni-test-"));
+    Storage.reset();
+  });
+
+  afterEach(() => {
+    Storage.reset();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("should use InMemoryStorage by default", () => {
+    expect(Storage.getAdapter()).toBeInstanceOf(InMemoryStorage);
+  });
+
+  it("should accept FileStorageAdapter via Storage.configure", () => {
+    const fileAdapter = new FileStorageAdapter(dir);
+    Storage.configure(fileAdapter);
+
+    expect(Storage.getAdapter()).toBe(fileAdapter);
+  });
+
+  it("should persist via Session API with FileStorageAdapter", () => {
+    Storage.configure(new FileStorageAdapter(dir));
+
+    const session = Session.create({
+      title: "Persisted Session",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+
+    Storage.configure(new FileStorageAdapter(dir));
+
+    const recovered = Session.get(session.id);
+    expect(recovered).toBeDefined();
+    expect(recovered?.title).toBe("Persisted Session");
+  });
+
+  it("should restore to InMemoryStorage on Storage.reset", () => {
+    Storage.configure(new FileStorageAdapter(dir));
+    Storage.reset();
+
+    expect(Storage.getAdapter()).toBeInstanceOf(InMemoryStorage);
+  });
+});

--- a/packages/session/test/surface-key.test.ts
+++ b/packages/session/test/surface-key.test.ts
@@ -189,6 +189,219 @@ describe("SurfaceKey", () => {
     });
   });
 
+  describe("fromChannel", () => {
+    it("creates a DM key", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "dm",
+        id: "U123",
+      });
+      expect(key).toBe("slack:workspaceA:dm:U123");
+    });
+
+    it("creates a group key", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "group",
+        id: "C456",
+      });
+      expect(key).toBe("slack:workspaceA:group:C456");
+    });
+
+    it("creates a thread key under a group", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "group",
+        id: "C456",
+        threadId: "171000",
+      });
+      expect(key).toBe("slack:workspaceA:group:C456:thread:171000");
+    });
+
+    it("creates a channel key (backward compat kind)", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "channel",
+        id: "C789",
+      });
+      expect(key).toBe("slack:workspaceA:channel:C789");
+    });
+
+    it("creates a telegram chat key", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "telegram",
+        namespace: "bot123",
+        kind: "chat",
+        id: "chat456",
+      });
+      expect(key).toBe("telegram:bot123:chat:chat456");
+    });
+  });
+
+  describe("parse", () => {
+    it("parses a DM key", () => {
+      const parsed = SurfaceKey.parse("slack:workspaceA:dm:U123");
+      expect(parsed.surface).toBe("slack");
+      expect(parsed.namespace).toBe("workspaceA");
+      expect(parsed.kind).toBe("dm");
+      expect(parsed.id).toBe("U123");
+      expect(parsed.threadId).toBeUndefined();
+    });
+
+    it("parses a group key", () => {
+      const parsed = SurfaceKey.parse("slack:workspaceA:group:C456");
+      expect(parsed.kind).toBe("group");
+      expect(parsed.id).toBe("C456");
+    });
+
+    it("parses a thread key", () => {
+      const parsed = SurfaceKey.parse(
+        "slack:workspaceA:group:C456:thread:171000",
+      );
+      expect(parsed.kind).toBe("group");
+      expect(parsed.id).toBe("C456");
+      expect(parsed.threadId).toBe("171000");
+    });
+
+    it("parses a chat key", () => {
+      const parsed = SurfaceKey.parse("telegram:bot123:chat:chat456");
+      expect(parsed.kind).toBe("chat");
+      expect(parsed.id).toBe("chat456");
+    });
+
+    it("parses a legacy key without known kind", () => {
+      const parsed = SurfaceKey.parse("tui:/Users/ino/Develop/OpenOmni");
+      expect(parsed.surface).toBe("tui");
+      expect(parsed.namespace).toBe("/Users/ino/Develop/OpenOmni");
+      expect(parsed.kind).toBeUndefined();
+      expect(parsed.id).toBeUndefined();
+    });
+  });
+
+  describe("DM vs group vs thread distinction", () => {
+    it("produces distinct keys for DM and group in same workspace", () => {
+      const dmKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "dm",
+        id: "U001",
+      });
+      const groupKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+      });
+      expect(dmKey).not.toBe(groupKey);
+      expect(dmKey).toContain(":dm:");
+      expect(groupKey).toContain(":group:");
+    });
+
+    it("produces distinct keys for group and thread in same channel", () => {
+      const groupKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+      });
+      const threadKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+        threadId: "171000",
+      });
+      expect(groupKey).not.toBe(threadKey);
+      expect(threadKey).toContain(":thread:");
+      expect(groupKey).not.toContain(":thread:");
+    });
+
+    it("routes DM and group to different sessions", () => {
+      const dmKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "dm",
+        id: "U001",
+      });
+      const groupKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+      });
+
+      SurfaceKey.register(dmKey, "session-dm");
+      SurfaceKey.register(groupKey, "session-group");
+
+      expect(SurfaceKey.lookup(dmKey)).toBe("session-dm");
+      expect(SurfaceKey.lookup(groupKey)).toBe("session-group");
+    });
+
+    it("routes thread separately from parent channel", () => {
+      const channelKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+      });
+      const threadKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+        threadId: "171000",
+      });
+
+      SurfaceKey.register(channelKey, "session-channel");
+      SurfaceKey.register(threadKey, "session-thread");
+
+      expect(SurfaceKey.lookup(channelKey)).toBe("session-channel");
+      expect(SurfaceKey.lookup(threadKey)).toBe("session-thread");
+    });
+
+    it("roundtrips fromChannel → parse correctly", () => {
+      const descriptor: SurfaceKey.ChannelDescriptor = {
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+        threadId: "171000",
+      };
+      const key = SurfaceKey.fromChannel(descriptor);
+      const parsed = SurfaceKey.parse(key);
+
+      expect(parsed.surface).toBe(descriptor.surface);
+      expect(parsed.namespace).toBe(descriptor.namespace);
+      expect(parsed.kind).toBe(descriptor.kind);
+      expect(parsed.id).toBe(descriptor.id);
+      expect(parsed.threadId).toBe(descriptor.threadId);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    it("existing create() API still works unchanged", () => {
+      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123"]);
+      expect(key).toBe("slack:workspaceA:channel:C123");
+    });
+
+    it("existing keys without explicit kind still register/lookup", () => {
+      const legacyKey = "tui:/Users/ino/Develop/OpenOmni";
+      SurfaceKey.register(legacyKey, "session-tui");
+      expect(SurfaceKey.lookup(legacyKey)).toBe("session-tui");
+    });
+
+    it("parse handles legacy keys gracefully", () => {
+      const parsed = SurfaceKey.parse("myservice:some-id");
+      expect(parsed.surface).toBe("myservice");
+      expect(parsed.namespace).toBe("some-id");
+      expect(parsed.kind).toBeUndefined();
+    });
+  });
+
   describe("clear", () => {
     it("clears all mappings", () => {
       const sessionId = "session-123";


### PR DESCRIPTION
## Summary

- Add channel/peer kind encoding to surface keys for DM/group/thread distinction
- Implement disk-backed storage adapters for session, task, and agent registry
- Add file-based agent discovery from markdown files with YAML frontmatter

## Changes

### Session Key Encoding (`packages/session`)
- `ChannelKind` type (`dm | group | channel | thread | chat`) and `ChannelDescriptor` interface
- `SurfaceKey.fromChannel()` for structured key creation
- `SurfaceKey.parse()` for key decomposition
- `extractSurfaceKey()` updated to support `meta.channelKind/channelId/threadId`
- Backward compatible with existing key format

### Disk-Backed Storage Adapters
- **`FileStorageAdapter`** (`packages/session`) — JSON persistence for sessions, messages, parts
- **`FileTaskStore`** (`packages/agent`) — JSON persistence with secondary indexes (idempotency, status)
- **`FileAgentRegistryStore`** (`packages/agent`) — JSON persistence per agent profile
- All adapters use atomic writes (temp file → rename) for crash safety
- In-memory adapters remain the defaults

### Agent Discovery (`packages/agent`)
- `AgentDiscovery.load(dir)` reads `*.md` files with YAML frontmatter
- Minimal YAML parser (no external dependencies)
- Markdown body appended to `systemPrompt`
- Zod validation mandatory — no bypass possible
- Override protection via explicit `allowOverride` flag
- Supports both worker and supervisor agent definitions

## Testing

```
bun test --cwd packages/session  → 73 pass, 0 fail
bun test --cwd packages/agent   → 704 pass, 0 fail
tsc --noEmit                     → clean
```

## Commits (5 atomic)

1. `feat(session,agent): add channel/peer kind encoding to surface key`
2. `feat(session): add file-based disk storage adapter`
3. `feat(agent): add file-based disk task storage adapter`
4. `feat(agent): add storage adapter pattern to agent registry`
5. `feat(agent): add file-based agent discovery from markdown files`