### PR TITLE
chore: add PR template and CI workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+<!-- What does this PR do? Keep it concise (1-3 sentences). -->
+
+## Changes
+
+<!-- List the key changes. Use bullet points. -->
+
+-
+
+## Type
+
+<!-- Check the one that applies. -->
+
+- [ ] `feat` - New feature
+- [ ] `fix` - Bug fix
+- [ ] `refactor` - Code restructuring (no behavior change)
+- [ ] `test` - Adding or updating tests
+- [ ] `docs` - Documentation only
+- [ ] `chore` - Build, CI, tooling, dependencies
+- [ ] `perf` - Performance improvement
+
+## Affected Packages
+
+<!-- Check all that apply. -->
+
+- [ ] `protocol`
+- [ ] `session`
+- [ ] `llm`
+- [ ] `agent`
+- [ ] `cli`
+
+## Checklist
+
+- [ ] `bun run check-types` passes
+- [ ] `bun run build` passes
+- [ ] Tests added/updated for changes
+- [ ] No `as any`, `@ts-ignore`, or `@ts-expect-error` added

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
         run: bun run build
 
       - name: Test
-        run: bun test
+        run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Type Check & Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run check-types
+
+      - name: Build
+        run: bun run build
+
+      - name: Test
+        run: bun test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types"
+    "check-types": "turbo run check-types",
+    "test": "turbo run test"
   },
   "devDependencies": {
     "prettier": "^3.7.4",


### PR DESCRIPTION
## Summary

Add GitHub PR template and CI workflow for automated quality checks on pull requests.

## Changes

- **PR template** (`.github/pull_request_template.md`): Structured form with summary, changes, type, affected packages, and checklist sections
- **CI workflow** (`.github/workflows/ci.yml`): Runs `check-types`, `build`, and `test` on every PR to `main` and push to `main`. Uses Bun 1.3.6, concurrency groups, and 10min timeout.

## Type

- [x] `chore` - Build, CI, tooling, dependencies

## Affected Packages

N/A — repo-level configuration only.

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run build` passes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PR template and a CI workflow that runs type check, build, and tests on PRs and pushes to main. Tests now run through Turbo for consistent monorepo execution.

- **New Features**
  - PR template with sections for summary, changes, type, affected packages, and a checklist.
  - CI on PRs and pushes to main runs: check-types, build, test (Bun 1.3.6) with tests routed through Turbo.
  - Concurrency by ref and a 10-minute timeout to avoid stuck jobs.

<sup>Written for commit 3be361f9ca61eafa78a8df32757c4ed7bf78bcc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

