### PR TITLE
fix(ci): improve CI pipeline speed and reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-types:
-    name: Type Check
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -26,22 +26,14 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
+      - run: bunx turbo run build --filter=@openomni/protocol
       - run: bun run check-types
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.6"
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - run: bun install --frozen-lockfile
-      - run: bun run build
-      - run: bun run test
+      - name: Test (session)
+        run: bun test
+        working-directory: packages/session
+      - name: Test (llm)
+        run: bun test
+        working-directory: packages/llm
+      - name: Test (agent)
+        run: bun test --preload ./test/force-exit.ts
+        working-directory: packages/agent

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "tsc",
+    "check-types": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/agent/src/trigger/watcher.ts
+++ b/packages/agent/src/trigger/watcher.ts
@@ -6,6 +6,8 @@ export interface WatcherConfig {
   recursive: boolean;
   includePatterns: string[];
   excludePatterns: string[];
+  /** Keep the process alive while watching. Defaults to true. Set false in tests. */
+  persistent?: boolean;
 }
 
 export interface Watcher {
@@ -42,7 +44,10 @@ class FilesystemWatcher implements Watcher {
 
     const watcher = watch(
       path,
-      { recursive: this.config.recursive },
+      {
+        recursive: this.config.recursive,
+        persistent: this.config.persistent ?? true,
+      },
       (eventType, filename) => {
         const resolvedPath = filename ? join(path, filename.toString()) : path;
         this.handleEvent(resolvedPath, eventType);

--- a/packages/agent/test/force-exit.ts
+++ b/packages/agent/test/force-exit.ts
@@ -1,0 +1,10 @@
+// Force exit after 10s if bun test hangs (bun 1.3.6 Linux event loop bug)
+const forceExitTimer = setTimeout(() => {
+  const handles = (process as any)._getActiveHandles?.() ?? [];
+  console.log(
+    "[DEBUG] Force exit triggered. Active handles:",
+    handles.map((h: any) => `${h?.constructor?.name ?? typeof h}`),
+  );
+  process.exit(process.exitCode ?? 0);
+}, 10_000);
+forceExitTimer.unref();

--- a/packages/agent/test/tools/subagent-announce.test.ts
+++ b/packages/agent/test/tools/subagent-announce.test.ts
@@ -98,7 +98,7 @@ describe("Subagent Completion Announce", () => {
 
       expect(result.isError).toBe(false);
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(capturedEnvelopes.length).toBe(1);
       const announce = capturedEnvelopes[0];
@@ -128,7 +128,7 @@ describe("Subagent Completion Announce", () => {
 
       expect(result.isError).toBe(false);
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(capturedEnvelopes.length).toBe(1);
       const payload = capturedEnvelopes[0].payload as Record<string, unknown>;
@@ -149,7 +149,7 @@ describe("Subagent Completion Announce", () => {
 
       expect(result.isError).toBe(true);
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(capturedEnvelopes.length).toBe(1);
       const payload = capturedEnvelopes[0].payload as Record<string, unknown>;
@@ -168,7 +168,7 @@ describe("Subagent Completion Announce", () => {
 
       expect(result.isError).toBe(false);
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(capturedEnvelopes.length).toBe(0);
     });
@@ -204,7 +204,7 @@ describe("Subagent Completion Announce", () => {
       expect(result.isError).toBe(false);
       expect(result.output).toContain("Subagent completed the task");
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(capturedEnvelopes.length).toBe(0);
     });
@@ -222,7 +222,7 @@ describe("Subagent Completion Announce", () => {
         baseContext({ parentSessionId: "parent-session-6" }),
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(consoleSpy).toHaveBeenCalledWith(
         "Announce failed (non-fatal):",
@@ -241,7 +241,7 @@ describe("Subagent Completion Announce", () => {
         baseContext({ parentSessionId: "parent-session-7" }),
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      await new Promise((r) => setTimeout(r, 5));
 
       expect(capturedEnvelopes.length).toBe(1);
       const envelope = capturedEnvelopes[0];

--- a/packages/agent/test/tools/subagent.test.ts
+++ b/packages/agent/test/tools/subagent.test.ts
@@ -219,7 +219,7 @@ describe("Subagent", () => {
 
       const hangingLLM = {
         run: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 5000));
+          await new Promise((resolve) => setTimeout(resolve, 200));
           return { type: "stop" as const };
         },
       };

--- a/packages/agent/test/trigger/deadline-drift.test.ts
+++ b/packages/agent/test/trigger/deadline-drift.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { Scheduler } from "../../src/trigger/scheduler";
 import { Task } from "../../src/task/types";
-import { TaskManager } from "../../src/task/manager";
 import { IngressEngine } from "../../src/ingress/engine";
 
 describe("Scheduler - Deadline Drift Warning", () => {
@@ -9,11 +8,13 @@ describe("Scheduler - Deadline Drift Warning", () => {
   let consoleWarnSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
+    Scheduler.clear();
     originalDateNow = Date.now;
     consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    Scheduler.clear();
     Date.now = originalDateNow;
     consoleWarnSpy.mockRestore();
   });
@@ -29,9 +30,7 @@ describe("Scheduler - Deadline Drift Warning", () => {
     const baseTime = 1000000000000;
     Date.now = () => baseTime;
 
-    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue(
-      undefined,
-    );
+    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue([]);
 
     Scheduler.registerTrigger(taskId, trigger);
 
@@ -63,9 +62,7 @@ describe("Scheduler - Deadline Drift Warning", () => {
     const baseTime = 1000000000000;
     Date.now = () => baseTime;
 
-    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue(
-      undefined,
-    );
+    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue([]);
 
     Scheduler.registerTrigger(taskId, trigger);
 
@@ -92,9 +89,7 @@ describe("Scheduler - Deadline Drift Warning", () => {
     const baseTime = 1000000000000;
     Date.now = () => baseTime;
 
-    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue(
-      undefined,
-    );
+    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue([]);
 
     Scheduler.registerTrigger(taskId, trigger);
 
@@ -123,9 +118,7 @@ describe("Scheduler - Deadline Drift Warning", () => {
       at: Date.now() + 10000,
     };
 
-    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue(
-      undefined,
-    );
+    const ingestSpy = spyOn(IngressEngine, "ingest").mockResolvedValue([]);
 
     await Scheduler.fire(taskId, trigger);
 

--- a/packages/agent/test/trigger/watcher.test.ts
+++ b/packages/agent/test/trigger/watcher.test.ts
@@ -14,6 +14,7 @@ const baseConfig: WatcherConfig = {
   recursive: false,
   includePatterns: [],
   excludePatterns: [],
+  persistent: false,
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -5,6 +5,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/llm/test/session/retry.test.ts
+++ b/packages/llm/test/session/retry.test.ts
@@ -456,7 +456,7 @@ describe("Retry", () => {
       };
 
       try {
-        await Retry.withRetry(fn, { maxAttempts: 2 });
+        await Retry.withRetry(fn, { maxAttempts: 2, initialDelay: 10 });
         expect.unreachable("Should have thrown RetryError");
       } catch (e) {
         expect(RetryError.isInstance(e)).toBe(true);
@@ -485,14 +485,13 @@ describe("Retry", () => {
 
       const result = await Retry.withRetry(fn, {
         maxAttempts: 3,
-        initialDelay: 10,
+        initialDelay: 50,
       });
       const elapsed = Date.now() - start;
 
       expect(result).toBe("success");
       expect(callCount).toBe(2);
-      // Should have waited at least 10ms (first retry delay)
-      expect(elapsed).toBeGreaterThanOrEqual(10);
+      expect(elapsed).toBeGreaterThanOrEqual(40);
     });
 
     test("throws non-APIError immediately", async () => {
@@ -528,7 +527,10 @@ describe("Retry", () => {
         return "success";
       };
 
-      const result = await Retry.withRetry(fn, { maxAttempts: 3 });
+      const result = await Retry.withRetry(fn, {
+        maxAttempts: 3,
+        initialDelay: 10,
+      });
       expect(result).toBe("success");
       expect(callCount).toBe(2);
     });

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "check-types": "tsc --noEmit",
     "dev": "tsc --watch"
   },
   "dependencies": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -5,6 +5,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -9,12 +9,8 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
-    "check-types": {
-      "dependsOn": ["^check-types"]
-    },
-    "test": {
-      "dependsOn": ["^test"]
-    },
+    "check-types": {},
+    "test": {},
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary

CI pipeline was hanging for 5+ minutes due to bun test runner not exiting on Linux. Total CI time reduced from **5min+ (timeout)** to **~34 seconds**.

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- Merge 2 jobs into 1 single job
- Build only `@openomni/protocol` instead of full monorepo build
- Run `bun test` directly per package instead of through turbo (avoids turbo output buffering)
- Add force-exit preload for agent tests to work around bun 1.3.6 Linux event loop bug

### Turbo (`turbo.json`)
- Remove `dependsOn` from `test` and `check-types` tasks to enable parallel execution

### Package Scripts
- Add `"check-types": "tsc --noEmit"` to all 4 packages (was silently no-op before)

### Test Performance
- Reduce retry test `initialDelay` from 2000ms default to 10ms
- Reduce subagent test timeouts from 5000ms to 200ms
- Reduce subagent-announce test delays from 50ms to 5ms
- Clear scheduler timers properly in deadline-drift tests

### Bun Linux Hang Fix
- Add `persistent` option to `WatcherConfig` (default `true`, tests use `false`)
- Add `force-exit.ts` preload that terminates bun after 10s if event loop hangs
- Root cause: bun 1.3.6 event loop on Linux doesn't exit after tests complete (active handles report empty, confirmed via `process._getActiveHandles()`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI from 5+ minutes (hang) to ~34 seconds and fixes Bun’s Linux test runner exit. Consolidates to one job, builds only protocol, runs tests per package, trims test delays, and adds type checks.

- **Performance**
  - Merge CI into one job; build only @openomni/protocol.
  - Run bun test per package (no turbo buffering); parallelize turbo tasks by removing dependsOn.
  - Add check-types (tsc --noEmit) to all packages and run in CI.
  - Shorten retry delays and subagent timeouts in llm/agent tests.

- **Bug Fixes**
  - Work around Bun 1.3.6 Linux event loop hang with a force-exit preload for agent tests.
  - Add persistent option to WatcherConfig; set persistent: false in tests.
  - Clear Scheduler state in deadline-drift tests to prevent lingering handles.

<sup>Written for commit e9d2d35064fb1362d83fe5ff9fb82f7f73df8e9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

