### PR TITLE
feat(session): add session history persistence

### DIFF
--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -7,8 +7,8 @@ export {
   CachedStorageAdapter,
   ensureGitignore,
   initialize,
-  InitializeOptions,
 } from "./storage";
+export type { InitializeOptions } from "./storage";
 export { Session } from "./session";
 export { SessionStatus } from "./status";
 export { Snapshot, InMemorySnapshotProvider } from "./snapshot";

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,5 +1,14 @@
 export { Bus, BusEvent } from "./bus";
-export { Storage, InMemoryStorage, FileStorageAdapter } from "./storage";
+export {
+  Storage,
+  InMemoryStorage,
+  FileStorageAdapter,
+  FileLock,
+  CachedStorageAdapter,
+  ensureGitignore,
+  initialize,
+  InitializeOptions,
+} from "./storage";
 export { Session } from "./session";
 export { SessionStatus } from "./status";
 export { Snapshot, InMemorySnapshotProvider } from "./snapshot";

--- a/packages/session/src/session/index.ts
+++ b/packages/session/src/session/index.ts
@@ -161,6 +161,31 @@ export namespace Session {
 
   export function addMessage(sessionID: string, message: Message.Info): void {
     Storage.getAdapter().message.set(sessionID, message);
+
+    const session = Storage.getAdapter().session.get(sessionID);
+    if (!session) return;
+
+    const updated: Info = {
+      ...session,
+      messageCount: (session.messageCount ?? 0) + 1,
+      time: {
+        ...session.time,
+        updated: Date.now(),
+      },
+      ...(message.role === "assistant" && {
+        tokens: {
+          input: (session.tokens?.input ?? 0) + message.tokens.input,
+          output: (session.tokens?.output ?? 0) + message.tokens.output,
+          total:
+            (session.tokens?.total ?? 0) +
+            message.tokens.input +
+            message.tokens.output,
+        },
+      }),
+    };
+
+    Storage.getAdapter().session.set(sessionID, updated);
+    Bus.publish(Event.Updated, { info: updated });
   }
 
   export function getMessages(sessionID: string): Message.Info[] {

--- a/packages/session/src/session/index.ts
+++ b/packages/session/src/session/index.ts
@@ -173,14 +173,13 @@ export namespace Session {
         updated: Date.now(),
       },
       ...(message.role === "assistant" && {
-        tokens: {
-          input: (session.tokens?.input ?? 0) + message.tokens.input,
-          output: (session.tokens?.output ?? 0) + message.tokens.output,
-          total:
-            (session.tokens?.total ?? 0) +
-            message.tokens.input +
-            message.tokens.output,
-        },
+        tokens: (() => {
+          const input =
+            (session.tokens?.input ?? 0) + message.tokens.input;
+          const output =
+            (session.tokens?.output ?? 0) + message.tokens.output;
+          return { input, output, total: input + output };
+        })(),
       }),
     };
 

--- a/packages/session/src/session/info.ts
+++ b/packages/session/src/session/info.ts
@@ -10,8 +10,25 @@ export const SessionInfo = z.object({
   time: z.object({
     created: z.number(),
     updated: z.number(),
+    archived: z.number().optional(),
   }),
   expiresAt: z.number().optional(),
+  agent: z
+    .object({
+      id: z.string(),
+      name: z.string().optional(),
+    })
+    .optional(),
+  tokens: z
+    .object({
+      input: z.number(),
+      output: z.number(),
+      total: z.number(),
+    })
+    .optional(),
+  messageCount: z.number().optional(),
+  summary: z.string().optional(),
+  projectId: z.string().optional(),
 });
 
 export type SessionInfo = z.infer<typeof SessionInfo>;

--- a/packages/session/src/storage/cache.ts
+++ b/packages/session/src/storage/cache.ts
@@ -1,0 +1,129 @@
+import { Message } from "@openomni/protocol";
+import { SessionInfo } from "../session/info";
+import { Storage } from "./storage";
+
+export class CachedStorageAdapter implements Storage.Adapter {
+  private sessionCache = new Map<string, SessionInfo>();
+  private sessionListCache: SessionInfo[] | null = null;
+  private messageCache = new Map<string, Message.Info[]>();
+  private partCache = new Map<string, Message.Part[]>();
+
+  constructor(
+    private readonly underlying: Storage.Adapter & { clear?: () => void },
+  ) {}
+
+  session = {
+    get: (id: string): SessionInfo | undefined => {
+      const cached = this.sessionCache.get(id);
+      if (cached !== undefined) return cached;
+
+      const result = this.underlying.session.get(id);
+      if (result !== undefined) this.sessionCache.set(id, result);
+      return result;
+    },
+
+    set: (id: string, info: SessionInfo): void => {
+      this.underlying.session.set(id, info);
+      this.sessionCache.set(id, info);
+      this.sessionListCache = null;
+    },
+
+    list: (): SessionInfo[] => {
+      if (this.sessionListCache !== null) return this.sessionListCache;
+
+      const result = this.underlying.session.list();
+      this.sessionListCache = result;
+      return result;
+    },
+
+    remove: (id: string): boolean => {
+      const result = this.underlying.session.remove(id);
+      this.sessionCache.delete(id);
+      this.sessionListCache = null;
+      return result;
+    },
+  };
+
+  message = {
+    get: (sessionID: string, messageID: string): Message.Info | undefined => {
+      const msgs = this.message.list(sessionID);
+      return msgs.find((m) => m.id === messageID);
+    },
+
+    set: (sessionID: string, message: Message.Info): void => {
+      this.underlying.message.set(sessionID, message);
+
+      const cached = this.messageCache.get(sessionID);
+      if (cached !== undefined) {
+        const idx = cached.findIndex((m) => m.id === message.id);
+        if (idx >= 0) cached[idx] = message;
+        else cached.push(message);
+      } else {
+        this.messageCache.delete(sessionID);
+      }
+    },
+
+    list: (sessionID: string): Message.Info[] => {
+      const cached = this.messageCache.get(sessionID);
+      if (cached !== undefined) return cached;
+
+      const result = this.underlying.message.list(sessionID);
+      this.messageCache.set(sessionID, result);
+      return result;
+    },
+
+    remove: (sessionID: string, messageID: string): boolean => {
+      const result = this.underlying.message.remove(sessionID, messageID);
+      this.messageCache.delete(sessionID);
+      return result;
+    },
+  };
+
+  part = {
+    get: (messageID: string, partID: string): Message.Part | undefined => {
+      const pts = this.part.list(messageID);
+      return pts.find((p) => p.id === partID);
+    },
+
+    set: (messageID: string, part: Message.Part): void => {
+      this.underlying.part.set(messageID, part);
+
+      const cached = this.partCache.get(messageID);
+      if (cached !== undefined) {
+        const idx = cached.findIndex((p) => p.id === part.id);
+        if (idx >= 0) cached[idx] = part;
+        else cached.push(part);
+      } else {
+        this.partCache.delete(messageID);
+      }
+    },
+
+    list: (messageID: string): Message.Part[] => {
+      const cached = this.partCache.get(messageID);
+      if (cached !== undefined) return cached;
+
+      const result = this.underlying.part.list(messageID);
+      this.partCache.set(messageID, result);
+      return result;
+    },
+
+    remove: (messageID: string, partID: string): boolean => {
+      const result = this.underlying.part.remove(messageID, partID);
+      this.partCache.delete(messageID);
+      return result;
+    },
+  };
+
+  clear(): void {
+    this.sessionCache.clear();
+    this.sessionListCache = null;
+    this.messageCache.clear();
+    this.partCache.clear();
+    if (
+      "clear" in this.underlying &&
+      typeof this.underlying.clear === "function"
+    ) {
+      this.underlying.clear();
+    }
+  }
+}

--- a/packages/session/src/storage/file-storage.ts
+++ b/packages/session/src/storage/file-storage.ts
@@ -12,17 +12,23 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { Message } from "@openomni/protocol";
 import { SessionInfo } from "../session/info";
+import { FileLock } from "./lock";
 import { Storage } from "./storage";
 
 export class FileStorageAdapter implements Storage.Adapter {
   private readonly sessionsDir: string;
   private readonly messagesDir: string;
   private readonly partsDir: string;
+  private readonly lockPath?: string;
 
-  constructor(private readonly baseDir: string) {
+  constructor(
+    private readonly baseDir: string,
+    lockDir?: string,
+  ) {
     this.sessionsDir = join(baseDir, "sessions");
     this.messagesDir = join(baseDir, "messages");
     this.partsDir = join(baseDir, "parts");
+    this.lockPath = lockDir ? join(lockDir, "write.lock") : undefined;
 
     mkdirSync(this.sessionsDir, { recursive: true });
     mkdirSync(this.messagesDir, { recursive: true });
@@ -30,22 +36,51 @@ export class FileStorageAdapter implements Storage.Adapter {
   }
 
   private atomicWrite(filePath: string, data: unknown): void {
-    const dir = join(filePath, "..");
-    mkdirSync(dir, { recursive: true });
-    const tmpPath = `${filePath}.${randomUUID()}.tmp`;
-    try {
-      writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8");
-      renameSync(tmpPath, filePath);
-    } catch (err) {
+    const write = (): void => {
+      const dir = join(filePath, "..");
+      mkdirSync(dir, { recursive: true });
+      const tmpPath = `${filePath}.${randomUUID()}.tmp`;
       try {
-        unlinkSync(tmpPath);
-      } catch (_cleanupErr: unknown) {
-        // tmp file cleanup is best-effort; original write error is rethrown below
+        // Note: fsync is intentionally omitted - this is a dev tool where crash safety is acceptable
+        writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+        renameSync(tmpPath, filePath);
+      } catch (err) {
+        try {
+          unlinkSync(tmpPath);
+        } catch (_cleanupErr: unknown) {
+          // tmp file cleanup is best-effort; original write error is rethrown below
+        }
+        throw new Error(
+          `FileStorageAdapter: failed to write ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
-      throw new Error(
-        `FileStorageAdapter: failed to write ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+    };
+
+    if (this.lockPath) {
+      FileLock.withLock(this.lockPath, write);
+      return;
     }
+
+    write();
+  }
+
+  private getPartStartTime(part: Message.Part): number | undefined {
+    if (
+      (part.type === "text" || part.type === "reasoning") &&
+      part.time?.start !== undefined
+    ) {
+      return part.time.start;
+    }
+
+    if (
+      part.type === "tool" &&
+      part.state.status !== "pending" &&
+      part.state.time?.start !== undefined
+    ) {
+      return part.state.time.start;
+    }
+
+    return undefined;
   }
 
   private readJSON<T>(filePath: string): T | undefined {
@@ -146,6 +181,9 @@ export class FileStorageAdapter implements Storage.Adapter {
         const msg = this.readJSON<Message.Info>(join(dir, file));
         if (msg) results.push(msg);
       }
+      results.sort(
+        (a, b) => a.time.created - b.time.created || a.id.localeCompare(b.id),
+      );
       return results;
     },
 
@@ -189,6 +227,19 @@ export class FileStorageAdapter implements Storage.Adapter {
         const pt = this.readJSON<Message.Part>(join(dir, file));
         if (pt) results.push(pt);
       }
+      results.sort((a, b) => {
+        const aStart = this.getPartStartTime(a);
+        const bStart = this.getPartStartTime(b);
+
+        if (aStart !== undefined && bStart !== undefined) {
+          return aStart - bStart || a.id.localeCompare(b.id);
+        }
+
+        if (aStart !== undefined) return -1;
+        if (bStart !== undefined) return 1;
+
+        return a.id.localeCompare(b.id);
+      });
       return results;
     },
 

--- a/packages/session/src/storage/gitignore.ts
+++ b/packages/session/src/storage/gitignore.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function ensureGitignore(dir: string, pattern: string): void {
+  const gitignorePath = join(dir, ".gitignore");
+
+  let content = "";
+  try {
+    content = readFileSync(gitignorePath, "utf-8");
+  } catch (err: unknown) {
+    if (
+      !(
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      )
+    ) {
+      throw err;
+    }
+  }
+
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const lines = content.split(eol);
+
+  const trimmedPattern = pattern.trim();
+  const patternExists = lines.some((line) => line.trim() === trimmedPattern);
+
+  if (patternExists) {
+    return;
+  }
+
+  let newContent = content;
+  if (
+    content.length > 0 &&
+    !content.endsWith("\n") &&
+    !content.endsWith("\r\n")
+  ) {
+    newContent += eol;
+  }
+  newContent += pattern + eol;
+
+  writeFileSync(gitignorePath, newContent, "utf-8");
+}

--- a/packages/session/src/storage/index.ts
+++ b/packages/session/src/storage/index.ts
@@ -3,4 +3,5 @@ export { FileStorageAdapter } from "./file-storage";
 export { FileLock } from "./lock";
 export { CachedStorageAdapter } from "./cache";
 export { ensureGitignore } from "./gitignore";
-export { initialize, InitializeOptions } from "./initialize";
+export { initialize } from "./initialize";
+export type { InitializeOptions } from "./initialize";

--- a/packages/session/src/storage/index.ts
+++ b/packages/session/src/storage/index.ts
@@ -1,2 +1,6 @@
 export { Storage, InMemoryStorage } from "./storage";
 export { FileStorageAdapter } from "./file-storage";
+export { FileLock } from "./lock";
+export { CachedStorageAdapter } from "./cache";
+export { ensureGitignore } from "./gitignore";
+export { initialize, InitializeOptions } from "./initialize";

--- a/packages/session/src/storage/initialize.ts
+++ b/packages/session/src/storage/initialize.ts
@@ -14,11 +14,14 @@ export interface InitializeOptions {
 export function initialize(options: InitializeOptions = {}): void {
   const dir = options.dir ?? ".openomni";
   const cwd = options.cwd ?? process.cwd();
+  const lock = options.lock !== false;
   const fullPath = join(cwd, dir);
 
   mkdirSync(fullPath, { recursive: true });
 
-  const fileAdapter = new FileStorageAdapter(fullPath);
+  const lockDir = lock ? join(fullPath, ".lock") : undefined;
+  if (lockDir) mkdirSync(lockDir, { recursive: true });
+  const fileAdapter = new FileStorageAdapter(fullPath, lockDir);
   const cachedAdapter = new CachedStorageAdapter(fileAdapter);
 
   Storage.configure(cachedAdapter);

--- a/packages/session/src/storage/initialize.ts
+++ b/packages/session/src/storage/initialize.ts
@@ -1,0 +1,34 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Storage } from "./storage";
+import { FileStorageAdapter } from "./file-storage";
+import { CachedStorageAdapter } from "./cache";
+import { ensureGitignore } from "./gitignore";
+
+export interface InitializeOptions {
+  dir?: string;
+  cwd?: string;
+  lock?: boolean;
+}
+
+export function initialize(options: InitializeOptions = {}): void {
+  const dir = options.dir ?? ".openomni";
+  const cwd = options.cwd ?? process.cwd();
+  const fullPath = join(cwd, dir);
+
+  mkdirSync(fullPath, { recursive: true });
+
+  const fileAdapter = new FileStorageAdapter(fullPath);
+  const cachedAdapter = new CachedStorageAdapter(fileAdapter);
+
+  Storage.configure(cachedAdapter);
+  ensureGitignore(cwd, dir + "/");
+}
+
+declare module "./storage" {
+  namespace Storage {
+    function initialize(options?: InitializeOptions): void;
+  }
+}
+
+(Storage as Record<string, unknown>).initialize = initialize;

--- a/packages/session/src/storage/lock.ts
+++ b/packages/session/src/storage/lock.ts
@@ -2,6 +2,7 @@ import {
   mkdirSync,
   writeFileSync,
   readFileSync,
+  statSync,
   existsSync,
   rmSync,
 } from "node:fs";
@@ -44,11 +45,18 @@ function readLockInfo(lockPath: string): LockInfo | null {
 
 function isStale(lockPath: string, staleMs: number): boolean {
   const info = readLockInfo(lockPath);
-  // If info.json is missing or unreadable, treat the lock as active (not stale).
-  // Returning true here would cause a race: between mkdirSync and writeLockInfo,
-  // a concurrent process could see the lock as stale and force-remove it.
-  if (!info) return false;
-  return info.timestamp + staleMs < Date.now();
+  if (info) {
+    return info.timestamp + staleMs < Date.now();
+  }
+  // info.json missing or unreadable — fall back to directory mtime.
+  // A freshly-created lock dir has a recent mtime (not stale → no race).
+  // A crash-orphaned lock dir will age past staleMs (stale → self-healing).
+  try {
+    const mtime = statSync(lockPath).mtimeMs;
+    return mtime + staleMs < Date.now();
+  } catch {
+    return false;
+  }
 }
 
 function forceRemoveLock(lockPath: string): void {

--- a/packages/session/src/storage/lock.ts
+++ b/packages/session/src/storage/lock.ts
@@ -1,0 +1,128 @@
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+
+interface LockOptions {
+  staleMs?: number;
+  timeoutMs?: number;
+  pollMs?: number;
+}
+
+interface LockInfo {
+  pid: number;
+  timestamp: number;
+}
+
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_POLL_MS = 50;
+
+function syncSleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function readLockInfo(lockPath: string): LockInfo | null {
+  try {
+    const raw = readFileSync(join(lockPath, "info.json"), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed.pid === "number" &&
+      typeof parsed.timestamp === "number"
+    ) {
+      return parsed as LockInfo;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isStale(lockPath: string, staleMs: number): boolean {
+  const info = readLockInfo(lockPath);
+  if (!info) return true;
+  return info.timestamp + staleMs < Date.now();
+}
+
+function forceRemoveLock(lockPath: string): void {
+  try {
+    rmSync(lockPath, { recursive: true, force: true });
+  } catch {}
+}
+
+function writeLockInfo(lockPath: string): void {
+  const info: LockInfo = { pid: process.pid, timestamp: Date.now() };
+  writeFileSync(join(lockPath, "info.json"), JSON.stringify(info), "utf-8");
+}
+
+export namespace FileLock {
+  export function acquire(lockPath: string, options?: LockOptions): void {
+    const staleMs = options?.staleMs ?? DEFAULT_STALE_MS;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const pollMs = options?.pollMs ?? DEFAULT_POLL_MS;
+    const startTime = Date.now();
+
+    while (true) {
+      try {
+        mkdirSync(lockPath);
+        writeLockInfo(lockPath);
+        return;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "EEXIST"
+        ) {
+          if (isStale(lockPath, staleMs)) {
+            forceRemoveLock(lockPath);
+            continue;
+          }
+
+          if (Date.now() - startTime > timeoutMs) {
+            throw new Error(
+              `FileLock: timeout acquiring lock after ${timeoutMs}ms: ${lockPath}`,
+            );
+          }
+
+          syncSleep(pollMs);
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  export function release(lockPath: string): void {
+    try {
+      rmSync(lockPath, { recursive: true, force: true });
+    } catch {}
+  }
+
+  export function withLock<T>(
+    lockPath: string,
+    fn: () => T,
+    options?: LockOptions,
+  ): T {
+    acquire(lockPath, options);
+    try {
+      return fn();
+    } finally {
+      try {
+        release(lockPath);
+      } catch {}
+    }
+  }
+
+  export function isLocked(
+    lockPath: string,
+    options?: Pick<LockOptions, "staleMs">,
+  ): boolean {
+    if (!existsSync(lockPath)) return false;
+    const staleMs = options?.staleMs ?? DEFAULT_STALE_MS;
+    return !isStale(lockPath, staleMs);
+  }
+}

--- a/packages/session/src/storage/lock.ts
+++ b/packages/session/src/storage/lock.ts
@@ -44,7 +44,10 @@ function readLockInfo(lockPath: string): LockInfo | null {
 
 function isStale(lockPath: string, staleMs: number): boolean {
   const info = readLockInfo(lockPath);
-  if (!info) return true;
+  // If info.json is missing or unreadable, treat the lock as active (not stale).
+  // Returning true here would cause a race: between mkdirSync and writeLockInfo,
+  // a concurrent process could see the lock as stale and force-remove it.
+  if (!info) return false;
   return info.timestamp + staleMs < Date.now();
 }
 

--- a/packages/session/test/file-storage.test.ts
+++ b/packages/session/test/file-storage.test.ts
@@ -27,6 +27,17 @@ function makeUserMessage(sessionID: string, messageID: string): Message.Info {
   };
 }
 
+function makeUserMessageAt(
+  sessionID: string,
+  messageID: string,
+  created: number,
+): Message.Info {
+  return {
+    ...makeUserMessage(sessionID, messageID),
+    time: { created },
+  };
+}
+
 function makeTextPart(
   sessionID: string,
   messageID: string,
@@ -136,6 +147,31 @@ describe("FileStorageAdapter", () => {
     test("should return false when removing non-existent message", () => {
       expect(adapter.message.remove("s1", "nonexistent")).toBe(false);
     });
+
+    test("should list messages ordered by created time ascending", () => {
+      const messages: Message.Info[] = [
+        makeUserMessageAt("s1", "a-msg", 50),
+        makeUserMessageAt("s1", "b-msg", 40),
+        makeUserMessageAt("s1", "c-msg", 30),
+        makeUserMessageAt("s1", "d-msg", 20),
+        makeUserMessageAt("s1", "e-msg", 10),
+      ];
+
+      adapter.message.set("s1", messages[2]);
+      adapter.message.set("s1", messages[4]);
+      adapter.message.set("s1", messages[0]);
+      adapter.message.set("s1", messages[3]);
+      adapter.message.set("s1", messages[1]);
+
+      const listed = adapter.message.list("s1");
+      expect(listed.map((message) => message.id)).toEqual([
+        "e-msg",
+        "d-msg",
+        "c-msg",
+        "b-msg",
+        "a-msg",
+      ]);
+    });
   });
 
   describe("part", () => {
@@ -172,6 +208,89 @@ describe("FileStorageAdapter", () => {
 
     test("should return false when removing non-existent part", () => {
       expect(adapter.part.remove("m1", "nonexistent")).toBe(false);
+    });
+
+    test("should list parts by time start and fallback to stable id order", () => {
+      const parts: Message.Part[] = [
+        {
+          id: "x-tool-error-30",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "tool",
+          callID: "call-1",
+          tool: "tool-1",
+          state: {
+            status: "error",
+            input: {},
+            error: "failed",
+            time: { start: 30, end: 31 },
+          },
+        },
+        {
+          id: "z-tool-running-10",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "tool",
+          callID: "call-2",
+          tool: "tool-2",
+          state: {
+            status: "running",
+            input: {},
+            time: { start: 10 },
+          },
+        },
+        {
+          id: "y-text-20",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "text",
+          text: "text at 20",
+          time: { start: 20 },
+        },
+        {
+          id: "w-reasoning-20",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "reasoning",
+          text: "reasoning at 20",
+          time: { start: 20 },
+        },
+        {
+          id: "a-tool-pending",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "tool",
+          callID: "call-3",
+          tool: "tool-3",
+          state: {
+            status: "pending",
+            input: {},
+          },
+        },
+        {
+          id: "b-step-start",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "step-start",
+        },
+      ];
+
+      adapter.part.set("m1", parts[0]);
+      adapter.part.set("m1", parts[5]);
+      adapter.part.set("m1", parts[2]);
+      adapter.part.set("m1", parts[4]);
+      adapter.part.set("m1", parts[1]);
+      adapter.part.set("m1", parts[3]);
+
+      const listed = adapter.part.list("m1");
+      expect(listed.map((part) => part.id)).toEqual([
+        "z-tool-running-10",
+        "w-reasoning-20",
+        "y-text-20",
+        "x-tool-error-30",
+        "a-tool-pending",
+        "b-step-start",
+      ]);
     });
   });
 

--- a/packages/session/test/session/info.test.ts
+++ b/packages/session/test/session/info.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { SessionInfo } from "../../src/session/info";
+
+describe("SessionInfo schema", () => {
+  test("parses old format (backward compatibility)", () => {
+    const oldFormat = {
+      id: "session-1",
+      title: "My Session",
+      model: { providerID: "anthropic", modelID: "claude-3-sonnet" },
+      time: { created: 1000, updated: 2000 },
+    };
+
+    const result = SessionInfo.safeParse(oldFormat);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("session-1");
+      expect(result.data.title).toBe("My Session");
+      expect(result.data.agent).toBeUndefined();
+      expect(result.data.tokens).toBeUndefined();
+      expect(result.data.messageCount).toBeUndefined();
+      expect(result.data.summary).toBeUndefined();
+      expect(result.data.projectId).toBeUndefined();
+      expect(result.data.time.archived).toBeUndefined();
+    }
+  });
+
+  test("parses full format with all new fields", () => {
+    const fullFormat = {
+      id: "session-2",
+      title: "Full Session",
+      model: { providerID: "openai", modelID: "gpt-4" },
+      time: {
+        created: 1000,
+        updated: 2000,
+        archived: 3000,
+      },
+      expiresAt: 4000,
+      agent: { id: "agent-1", name: "Research Agent" },
+      tokens: { input: 100, output: 50, total: 150 },
+      messageCount: 5,
+      summary: "Session summary text",
+      projectId: "proj-123",
+    };
+
+    const result = SessionInfo.safeParse(fullFormat);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("session-2");
+      expect(result.data.agent?.id).toBe("agent-1");
+      expect(result.data.agent?.name).toBe("Research Agent");
+      expect(result.data.tokens?.input).toBe(100);
+      expect(result.data.tokens?.output).toBe(50);
+      expect(result.data.tokens?.total).toBe(150);
+      expect(result.data.messageCount).toBe(5);
+      expect(result.data.summary).toBe("Session summary text");
+      expect(result.data.projectId).toBe("proj-123");
+      expect(result.data.time.archived).toBe(3000);
+    }
+  });
+
+  test("parses partial format with some new fields", () => {
+    const partialFormat = {
+      id: "session-3",
+      title: "Partial Session",
+      model: { providerID: "anthropic", modelID: "claude-3-opus" },
+      time: { created: 1000, updated: 2000 },
+      agent: { id: "agent-2" },
+      messageCount: 3,
+    };
+
+    const result = SessionInfo.safeParse(partialFormat);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agent?.id).toBe("agent-2");
+      expect(result.data.agent?.name).toBeUndefined();
+      expect(result.data.messageCount).toBe(3);
+      expect(result.data.tokens).toBeUndefined();
+      expect(result.data.summary).toBeUndefined();
+      expect(result.data.projectId).toBeUndefined();
+    }
+  });
+
+  test("infers correct TypeScript types", () => {
+    const session: SessionInfo = {
+      id: "session-4",
+      title: "Type Test",
+      model: { providerID: "test", modelID: "test-model" },
+      time: { created: 1000, updated: 2000 },
+    };
+
+    expect(session.id).toBe("session-4");
+    expect(session.agent).toBeUndefined();
+    expect(session.tokens).toBeUndefined();
+  });
+
+  test("validates agent object structure", () => {
+    const invalidAgent = {
+      id: "session-5",
+      title: "Invalid Agent",
+      model: { providerID: "test", modelID: "test-model" },
+      time: { created: 1000, updated: 2000 },
+      agent: { id: 123 },
+    };
+
+    const result = SessionInfo.safeParse(invalidAgent);
+    expect(result.success).toBe(false);
+  });
+
+  test("validates tokens object structure", () => {
+    const invalidTokens = {
+      id: "session-6",
+      title: "Invalid Tokens",
+      model: { providerID: "test", modelID: "test-model" },
+      time: { created: 1000, updated: 2000 },
+      tokens: { input: "100", output: 50, total: 150 },
+    };
+
+    const result = SessionInfo.safeParse(invalidTokens);
+    expect(result.success).toBe(false);
+  });
+
+  test("allows expiresAt with new fields", () => {
+    const withExpiry = {
+      id: "session-7",
+      title: "With Expiry",
+      model: { providerID: "test", modelID: "test-model" },
+      time: { created: 1000, updated: 2000 },
+      expiresAt: 5000,
+      agent: { id: "agent-3" },
+      tokens: { input: 10, output: 5, total: 15 },
+    };
+
+    const result = SessionInfo.safeParse(withExpiry);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.expiresAt).toBe(5000);
+      expect(result.data.agent?.id).toBe("agent-3");
+    }
+  });
+});

--- a/packages/session/test/session/metadata-hooks.test.ts
+++ b/packages/session/test/session/metadata-hooks.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Message } from "@openomni/protocol";
+import { Session } from "../../src/session";
+import { Storage } from "../../src/storage/storage";
+
+function makeUserMessage(
+  sessionID: string,
+  overrides?: Partial<Message.UserMessage>,
+): Message.UserMessage {
+  return {
+    id: crypto.randomUUID(),
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test-agent",
+    model: { providerID: "test", modelID: "test-model" },
+    ...overrides,
+  };
+}
+
+function makeAssistantMessage(
+  sessionID: string,
+  tokens: { input: number; output: number },
+  overrides?: Partial<Message.AssistantMessage>,
+): Message.AssistantMessage {
+  return {
+    id: crypto.randomUUID(),
+    sessionID,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "parent-1",
+    modelID: "test-model",
+    providerID: "test",
+    agent: "test-agent",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: {
+      input: tokens.input,
+      output: tokens.output,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    ...overrides,
+  };
+}
+
+describe("Session.addMessage metadata hooks", () => {
+  beforeEach(() => {
+    Storage.reset();
+  });
+
+  describe("messageCount", () => {
+    test("increments messageCount from undefined to 1 on first message", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      expect(session.messageCount).toBeUndefined();
+
+      Session.addMessage(session.id, makeUserMessage(session.id));
+
+      const updated = Session.get(session.id)!;
+      expect(updated.messageCount).toBe(1);
+    });
+
+    test("increments messageCount from 1 to 2 on second message", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      Session.addMessage(session.id, makeUserMessage(session.id));
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 10, output: 5 }),
+      );
+
+      const updated = Session.get(session.id)!;
+      expect(updated.messageCount).toBe(2);
+    });
+
+    test("increments for both user and assistant messages", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      Session.addMessage(session.id, makeUserMessage(session.id));
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 10, output: 5 }),
+      );
+      Session.addMessage(session.id, makeUserMessage(session.id));
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 20, output: 10 }),
+      );
+
+      const updated = Session.get(session.id)!;
+      expect(updated.messageCount).toBe(4);
+    });
+  });
+
+  describe("tokens accumulation", () => {
+    test("does NOT update tokens for user messages", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      Session.addMessage(session.id, makeUserMessage(session.id));
+
+      const updated = Session.get(session.id)!;
+      expect(updated.tokens).toBeUndefined();
+    });
+
+    test("accumulates tokens from assistant message when session has no initial tokens", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 100, output: 50 }),
+      );
+
+      const updated = Session.get(session.id)!;
+      expect(updated.tokens).toEqual({
+        input: 100,
+        output: 50,
+        total: 150,
+      });
+    });
+
+    test("accumulates tokens across multiple assistant messages", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 100, output: 50 }),
+      );
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 200, output: 80 }),
+      );
+
+      const updated = Session.get(session.id)!;
+      expect(updated.tokens).toEqual({
+        input: 300,
+        output: 130,
+        total: 430,
+      });
+    });
+
+    test("user messages between assistants do not affect tokens", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 100, output: 50 }),
+      );
+      Session.addMessage(session.id, makeUserMessage(session.id));
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 200, output: 80 }),
+      );
+
+      const updated = Session.get(session.id)!;
+      expect(updated.tokens).toEqual({
+        input: 300,
+        output: 130,
+        total: 430,
+      });
+    });
+  });
+
+  describe("time.updated", () => {
+    test("updates time.updated when message is added", () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+
+      const originalUpdated = session.time.updated;
+
+      const before = Date.now();
+      Session.addMessage(session.id, makeUserMessage(session.id));
+      const after = Date.now();
+
+      const updated = Session.get(session.id)!;
+      expect(updated.time.updated).toBeGreaterThanOrEqual(before);
+      expect(updated.time.updated).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("does not throw when session does not exist", () => {
+      const msg = makeUserMessage("nonexistent-session");
+      expect(() =>
+        Session.addMessage("nonexistent-session", msg),
+      ).not.toThrow();
+    });
+
+    test("preserves other session fields when updating metadata", () => {
+      const session = Session.create({
+        title: "Original Title",
+        model: { providerID: "test", modelID: "test-model" },
+        ttlMs: 60000,
+      });
+
+      Session.addMessage(
+        session.id,
+        makeAssistantMessage(session.id, { input: 50, output: 25 }),
+      );
+
+      const updated = Session.get(session.id)!;
+      expect(updated.title).toBe("Original Title");
+      expect(updated.model).toEqual({
+        providerID: "test",
+        modelID: "test-model",
+      });
+      expect(updated.expiresAt).toBeDefined();
+    });
+  });
+});

--- a/packages/session/test/session/metadata-hooks.test.ts
+++ b/packages/session/test/session/metadata-hooks.test.ts
@@ -196,6 +196,7 @@ describe("Session.addMessage metadata hooks", () => {
       const after = Date.now();
 
       const updated = Session.get(session.id)!;
+      expect(updated.time.updated).toBeGreaterThanOrEqual(originalUpdated);
       expect(updated.time.updated).toBeGreaterThanOrEqual(before);
       expect(updated.time.updated).toBeLessThanOrEqual(after);
     });

--- a/packages/session/test/storage/cache.test.ts
+++ b/packages/session/test/storage/cache.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test, beforeEach, spyOn } from "bun:test";
+import type { Message } from "@openomni/protocol";
+import { InMemoryStorage } from "../../src/storage/storage";
+import { CachedStorageAdapter } from "../../src/storage/cache";
+import { Session } from "../../src/session";
+
+function makeSession(id: string): Session.Info {
+  return {
+    id,
+    title: `Session ${id}`,
+    model: { providerID: "test", modelID: "test-model" },
+    time: { created: Date.now(), updated: Date.now() },
+  };
+}
+
+function makeUserMessage(sessionID: string, messageID: string): Message.Info {
+  return {
+    id: messageID,
+    sessionID,
+    role: "user" as const,
+    time: { created: Date.now() },
+    agent: "test-agent",
+    model: { providerID: "test", modelID: "test-model" },
+  };
+}
+
+function makeTextPart(
+  sessionID: string,
+  messageID: string,
+  partID: string,
+): Message.Part {
+  return {
+    id: partID,
+    sessionID,
+    messageID,
+    type: "text" as const,
+    text: `Part ${partID} content`,
+  };
+}
+
+describe("CachedStorageAdapter", () => {
+  let underlying: InMemoryStorage;
+  let cached: CachedStorageAdapter;
+
+  beforeEach(() => {
+    underlying = new InMemoryStorage();
+    cached = new CachedStorageAdapter(underlying);
+  });
+
+  describe("session", () => {
+    test("get: first call hits underlying, second call hits cache", () => {
+      const session = makeSession("s1");
+      underlying.session.set("s1", session);
+
+      const getSpy = spyOn(underlying.session, "get");
+
+      const result1 = cached.session.get("s1");
+      expect(result1).toEqual(session);
+      expect(getSpy).toHaveBeenCalledTimes(1);
+
+      const result2 = cached.session.get("s1");
+      expect(result2).toEqual(session);
+      expect(getSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("set: write-through writes to underlying", () => {
+      const session = makeSession("s1");
+      cached.session.set("s1", session);
+
+      const fromUnderlying = underlying.session.get("s1");
+      expect(fromUnderlying).toEqual(session);
+
+      const getSpy = spyOn(underlying.session, "get");
+      const fromCache = cached.session.get("s1");
+      expect(fromCache).toEqual(session);
+      expect(getSpy).toHaveBeenCalledTimes(0);
+    });
+
+    test("remove: invalidates cache", () => {
+      const session = makeSession("s1");
+      cached.session.set("s1", session);
+
+      expect(cached.session.remove("s1")).toBe(true);
+      expect(cached.session.get("s1")).toBeUndefined();
+    });
+
+    test("remove: returns false for non-existent session", () => {
+      expect(cached.session.remove("nonexistent")).toBe(false);
+    });
+
+    test("list: first call loads all, second call from cache", () => {
+      underlying.session.set("s1", makeSession("s1"));
+      underlying.session.set("s2", makeSession("s2"));
+
+      const listSpy = spyOn(underlying.session, "list");
+
+      const result1 = cached.session.list();
+      expect(result1).toHaveLength(2);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+
+      const result2 = cached.session.list();
+      expect(result2).toHaveLength(2);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("set: invalidates session list cache", () => {
+      underlying.session.set("s1", makeSession("s1"));
+
+      cached.session.list();
+      const listSpy = spyOn(underlying.session, "list");
+
+      cached.session.set("s2", makeSession("s2"));
+
+      const result = cached.session.list();
+      expect(result).toHaveLength(2);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("remove: invalidates session list cache", () => {
+      cached.session.set("s1", makeSession("s1"));
+      cached.session.set("s2", makeSession("s2"));
+
+      cached.session.list();
+      const listSpy = spyOn(underlying.session, "list");
+
+      cached.session.remove("s1");
+
+      cached.session.list();
+      expect(listSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("get: returns undefined for non-existent session and caches miss", () => {
+      const getSpy = spyOn(underlying.session, "get");
+
+      expect(cached.session.get("nope")).toBeUndefined();
+      expect(getSpy).toHaveBeenCalledTimes(1);
+
+      expect(cached.session.get("nope")).toBeUndefined();
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("message", () => {
+    test("list: first call hits underlying, second call hits cache", () => {
+      const msg = makeUserMessage("s1", "m1");
+      underlying.message.set("s1", msg);
+
+      const listSpy = spyOn(underlying.message, "list");
+
+      const result1 = cached.message.list("s1");
+      expect(result1).toHaveLength(1);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+
+      const result2 = cached.message.list("s1");
+      expect(result2).toHaveLength(1);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("get: finds message from cached list", () => {
+      const msg = makeUserMessage("s1", "m1");
+      underlying.message.set("s1", msg);
+
+      const result = cached.message.get("s1", "m1");
+      expect(result).toEqual(msg);
+    });
+
+    test("get: returns undefined for non-existent message", () => {
+      expect(cached.message.get("s1", "nope")).toBeUndefined();
+    });
+
+    test("set: upsert - set message twice returns single updated message", () => {
+      const msg1 = makeUserMessage("s1", "m1");
+      cached.message.set("s1", msg1);
+
+      const msg2 = { ...msg1, agent: "updated-agent" };
+      cached.message.set("s1", msg2);
+
+      const list = cached.message.list("s1");
+      expect(list).toHaveLength(1);
+      expect(list[0]!.agent).toBe("updated-agent");
+
+      const underlyingList = underlying.message.list("s1");
+      expect(underlyingList).toHaveLength(1);
+      expect(underlyingList[0]!.agent).toBe("updated-agent");
+    });
+
+    test("set: invalidates cache when list not yet cached", () => {
+      underlying.message.set("s1", makeUserMessage("s1", "m1"));
+
+      const msg2 = makeUserMessage("s1", "m2");
+      cached.message.set("s1", msg2);
+
+      const list = cached.message.list("s1");
+      expect(list).toHaveLength(2);
+    });
+
+    test("remove: invalidates list cache", () => {
+      cached.message.set("s1", makeUserMessage("s1", "m1"));
+      cached.message.set("s1", makeUserMessage("s1", "m2"));
+
+      expect(cached.message.list("s1")).toHaveLength(2);
+
+      cached.message.remove("s1", "m1");
+
+      const list = cached.message.list("s1");
+      expect(list).toHaveLength(1);
+      expect(list[0]!.id).toBe("m2");
+    });
+
+    test("remove: returns false for non-existent message", () => {
+      expect(cached.message.remove("s1", "nope")).toBe(false);
+    });
+  });
+
+  describe("part", () => {
+    test("list: first call hits underlying, second call hits cache", () => {
+      const part = makeTextPart("s1", "m1", "p1");
+      underlying.part.set("m1", part);
+
+      const listSpy = spyOn(underlying.part, "list");
+
+      const result1 = cached.part.list("m1");
+      expect(result1).toHaveLength(1);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+
+      const result2 = cached.part.list("m1");
+      expect(result2).toHaveLength(1);
+      expect(listSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("get: finds part from cached list", () => {
+      const part = makeTextPart("s1", "m1", "p1");
+      underlying.part.set("m1", part);
+
+      const result = cached.part.get("m1", "p1");
+      expect(result).toEqual(part);
+    });
+
+    test("get: returns undefined for non-existent part", () => {
+      expect(cached.part.get("m1", "nope")).toBeUndefined();
+    });
+
+    test("set: upsert - set part twice returns single updated part", () => {
+      const part1 = makeTextPart("s1", "m1", "p1");
+      cached.part.set("m1", part1);
+
+      const part2 = { ...part1, text: "updated content" } as Message.Part;
+      cached.part.set("m1", part2);
+
+      const list = cached.part.list("m1");
+      expect(list).toHaveLength(1);
+      expect((list[0] as { text: string }).text).toBe("updated content");
+    });
+
+    test("remove: invalidates cache entry", () => {
+      cached.part.set("m1", makeTextPart("s1", "m1", "p1"));
+      cached.part.set("m1", makeTextPart("s1", "m1", "p2"));
+
+      expect(cached.part.list("m1")).toHaveLength(2);
+
+      cached.part.remove("m1", "p1");
+
+      const list = cached.part.list("m1");
+      expect(list).toHaveLength(1);
+      expect(list[0]!.id).toBe("p2");
+    });
+
+    test("remove: returns false for non-existent part", () => {
+      expect(cached.part.remove("m1", "nope")).toBe(false);
+    });
+  });
+
+  describe("clear", () => {
+    test("resets all caches", () => {
+      cached.session.set("s1", makeSession("s1"));
+      cached.message.set("s1", makeUserMessage("s1", "m1"));
+      cached.part.set("m1", makeTextPart("s1", "m1", "p1"));
+
+      cached.session.list();
+      cached.message.list("s1");
+      cached.part.list("m1");
+
+      cached.clear();
+
+      expect(cached.session.get("s1")).toBeUndefined();
+      expect(cached.message.list("s1")).toHaveLength(0);
+      expect(cached.part.list("m1")).toHaveLength(0);
+      expect(cached.session.list()).toHaveLength(0);
+    });
+
+    test("calls underlying clear if available", () => {
+      const clearSpy = spyOn(underlying, "clear");
+      cached.clear();
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("works when underlying has no clear method", () => {
+      const noClearAdapter: CachedStorageAdapter = new CachedStorageAdapter({
+        session: underlying.session,
+        message: underlying.message,
+        part: underlying.part,
+      });
+
+      expect(() => noClearAdapter.clear()).not.toThrow();
+    });
+  });
+});

--- a/packages/session/test/storage/gitignore.test.ts
+++ b/packages/session/test/storage/gitignore.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureGitignore } from "../../src/storage/gitignore";
+
+describe("ensureGitignore", () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("creates .gitignore when file doesn't exist", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const pattern = "node_modules/";
+
+    ensureGitignore(tempDir, pattern);
+
+    const gitignorePath = join(tempDir, ".gitignore");
+    const content = readFileSync(gitignorePath, "utf-8");
+    expect(content).toBe("node_modules/\n");
+  });
+
+  test("appends to existing .gitignore that lacks pattern", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const gitignorePath = join(tempDir, ".gitignore");
+    writeFileSync(gitignorePath, "dist/\n", "utf-8");
+
+    ensureGitignore(tempDir, "node_modules/");
+
+    const content = readFileSync(gitignorePath, "utf-8");
+    expect(content).toBe("dist/\nnode_modules/\n");
+  });
+
+  test("is idempotent: calling twice doesn't duplicate pattern", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const pattern = "node_modules/";
+
+    ensureGitignore(tempDir, pattern);
+    ensureGitignore(tempDir, pattern);
+
+    const gitignorePath = join(tempDir, ".gitignore");
+    const content = readFileSync(gitignorePath, "utf-8");
+    expect(content).toBe("node_modules/\n");
+  });
+
+  test("handles .gitignore with existing entries + no trailing newline", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const gitignorePath = join(tempDir, ".gitignore");
+    writeFileSync(gitignorePath, "dist/", "utf-8"); // No trailing newline
+
+    ensureGitignore(tempDir, "node_modules/");
+
+    const content = readFileSync(gitignorePath, "utf-8");
+    expect(content).toBe("dist/\nnode_modules/\n");
+  });
+
+  test("preserves CRLF line endings: input with \\r\\n → output also uses \\r\\n", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const gitignorePath = join(tempDir, ".gitignore");
+    writeFileSync(gitignorePath, "dist/\r\n", "utf-8");
+
+    ensureGitignore(tempDir, "node_modules/");
+
+    const content = readFileSync(gitignorePath, "utf-8");
+    expect(content).toBe("dist/\r\nnode_modules/\r\n");
+  });
+
+  test("pattern not added if already present (case-sensitive exact match after trim)", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const gitignorePath = join(tempDir, ".gitignore");
+    writeFileSync(gitignorePath, "  node_modules/  \n", "utf-8");
+
+    ensureGitignore(tempDir, "node_modules/");
+
+    const gitignorePath2 = join(tempDir, ".gitignore");
+    const content = readFileSync(gitignorePath2, "utf-8");
+    expect(content).toBe("  node_modules/  \n");
+  });
+
+  test("works with .gitignore that has comments and blank lines", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gitignore-test-"));
+    const gitignorePath = join(tempDir, ".gitignore");
+    writeFileSync(gitignorePath, "# Comment\ndist/\n\n", "utf-8");
+
+    ensureGitignore(tempDir, "node_modules/");
+
+    const content = readFileSync(gitignorePath, "utf-8");
+    expect(content).toBe("# Comment\ndist/\n\nnode_modules/\n");
+  });
+});

--- a/packages/session/test/storage/initialize.test.ts
+++ b/packages/session/test/storage/initialize.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Storage, InMemoryStorage } from "../../src/storage/storage";
+import { CachedStorageAdapter } from "../../src/storage/cache";
+import { FileStorageAdapter } from "../../src/storage/file-storage";
+import { initialize } from "../../src/storage/initialize";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "openomni-init-test-"));
+  Storage.reset();
+});
+
+afterEach(() => {
+  Storage.reset();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("Storage.initialize", () => {
+  test("creates storage directory", () => {
+    initialize({ cwd: tmpDir });
+    expect(existsSync(join(tmpDir, ".openomni"))).toBe(true);
+  });
+
+  test("creates subdirectories for file storage", () => {
+    initialize({ cwd: tmpDir });
+    const base = join(tmpDir, ".openomni");
+    expect(existsSync(join(base, "sessions"))).toBe(true);
+    expect(existsSync(join(base, "messages"))).toBe(true);
+    expect(existsSync(join(base, "parts"))).toBe(true);
+  });
+
+  test("configures adapter as CachedStorageAdapter", () => {
+    initialize({ cwd: tmpDir });
+    expect(Storage.getAdapter()).toBeInstanceOf(CachedStorageAdapter);
+  });
+
+  test("adapter is not InMemoryStorage after initialize", () => {
+    initialize({ cwd: tmpDir });
+    expect(Storage.getAdapter()).not.toBeInstanceOf(InMemoryStorage);
+  });
+
+  test("sessions persist to disk", () => {
+    initialize({ cwd: tmpDir });
+
+    const session = {
+      id: "s1",
+      title: "Persisted",
+      model: { providerID: "test", modelID: "test-model" },
+      time: { created: Date.now(), updated: Date.now() },
+    };
+    Storage.getAdapter().session.set("s1", session);
+
+    const verifyAdapter = new FileStorageAdapter(join(tmpDir, ".openomni"));
+    const recovered = verifyAdapter.session.get("s1");
+    expect(recovered).toBeDefined();
+    expect(recovered?.title).toBe("Persisted");
+  });
+
+  test("updates .gitignore with storage directory pattern", () => {
+    initialize({ cwd: tmpDir });
+    const content = readFileSync(join(tmpDir, ".gitignore"), "utf-8");
+    expect(content).toContain(".openomni/");
+  });
+
+  test("is idempotent — no error on second call", () => {
+    initialize({ cwd: tmpDir });
+    expect(() => initialize({ cwd: tmpDir })).not.toThrow();
+  });
+
+  test("is idempotent — no duplicate gitignore entries", () => {
+    initialize({ cwd: tmpDir });
+    initialize({ cwd: tmpDir });
+    const content = readFileSync(join(tmpDir, ".gitignore"), "utf-8");
+    const matches = content
+      .split("\n")
+      .filter((line) => line.trim() === ".openomni/");
+    expect(matches).toHaveLength(1);
+  });
+
+  test("custom dir option works", () => {
+    initialize({ dir: ".custom-data", cwd: tmpDir });
+    expect(existsSync(join(tmpDir, ".custom-data"))).toBe(true);
+    const content = readFileSync(join(tmpDir, ".gitignore"), "utf-8");
+    expect(content).toContain(".custom-data/");
+  });
+
+  test("defaults dir to .openomni when not specified", () => {
+    initialize({ cwd: tmpDir });
+    expect(existsSync(join(tmpDir, ".openomni"))).toBe(true);
+  });
+
+  test("Storage.initialize is callable on the namespace", () => {
+    expect(typeof Storage.initialize).toBe("function");
+    Storage.initialize({ cwd: tmpDir });
+    expect(Storage.getAdapter()).toBeInstanceOf(CachedStorageAdapter);
+  });
+});

--- a/packages/session/test/storage/lock.test.ts
+++ b/packages/session/test/storage/lock.test.ts
@@ -46,21 +46,26 @@ describe("FileLock.acquire", () => {
     FileLock.release(lockPath);
   });
 
-  test("overrides lock with missing info.json as stale", () => {
+  test("treats lock with missing info.json as active (not stale)", () => {
     mkdirSync(lockPath);
+    // No info.json — could be a freshly acquired lock between mkdirSync and writeLockInfo.
+    // Must NOT treat as stale to avoid race condition.
+    expect(() =>
+      FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
+    ).toThrow(/timeout/i);
 
-    FileLock.acquire(lockPath);
-    expect(existsSync(join(lockPath, "info.json"))).toBe(true);
-    FileLock.release(lockPath);
+    rmSync(lockPath, { recursive: true, force: true });
   });
 
-  test("overrides lock with invalid info.json as stale", () => {
+  test("treats lock with invalid info.json as active (not stale)", () => {
     mkdirSync(lockPath);
     writeFileSync(join(lockPath, "info.json"), "NOT_JSON");
+    // Unreadable info.json — safer to assume lock is active.
+    expect(() =>
+      FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
+    ).toThrow(/timeout/i);
 
-    FileLock.acquire(lockPath);
-    expect(existsSync(join(lockPath, "info.json"))).toBe(true);
-    FileLock.release(lockPath);
+    rmSync(lockPath, { recursive: true, force: true });
   });
 
   test("throws on timeout when lock is held by active process", () => {

--- a/packages/session/test/storage/lock.test.ts
+++ b/packages/session/test/storage/lock.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { FileLock } from "../../src/storage/lock";
+
+let tempDir: string;
+let lockPath: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "filelock-test-"));
+  lockPath = join(tempDir, "test.lock");
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("FileLock.acquire", () => {
+  test("succeeds when no lock exists and creates lock directory", () => {
+    FileLock.acquire(lockPath);
+    expect(existsSync(lockPath)).toBe(true);
+    const info = JSON.parse(readFileSync(join(lockPath, "info.json"), "utf-8"));
+    expect(info.pid).toBe(process.pid);
+    expect(typeof info.timestamp).toBe("number");
+    FileLock.release(lockPath);
+  });
+
+  test("overrides stale lock", () => {
+    mkdirSync(lockPath);
+    writeFileSync(
+      join(lockPath, "info.json"),
+      JSON.stringify({ pid: 99999, timestamp: Date.now() - 60_000 }),
+    );
+
+    FileLock.acquire(lockPath);
+    const info = JSON.parse(readFileSync(join(lockPath, "info.json"), "utf-8"));
+    expect(info.pid).toBe(process.pid);
+    FileLock.release(lockPath);
+  });
+
+  test("overrides lock with missing info.json as stale", () => {
+    mkdirSync(lockPath);
+
+    FileLock.acquire(lockPath);
+    expect(existsSync(join(lockPath, "info.json"))).toBe(true);
+    FileLock.release(lockPath);
+  });
+
+  test("overrides lock with invalid info.json as stale", () => {
+    mkdirSync(lockPath);
+    writeFileSync(join(lockPath, "info.json"), "NOT_JSON");
+
+    FileLock.acquire(lockPath);
+    expect(existsSync(join(lockPath, "info.json"))).toBe(true);
+    FileLock.release(lockPath);
+  });
+
+  test("throws on timeout when lock is held by active process", () => {
+    mkdirSync(lockPath);
+    writeFileSync(
+      join(lockPath, "info.json"),
+      JSON.stringify({ pid: process.pid, timestamp: Date.now() }),
+    );
+
+    expect(() =>
+      FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
+    ).toThrow(/timeout/i);
+
+    rmSync(lockPath, { recursive: true, force: true });
+  });
+});
+
+describe("FileLock.release", () => {
+  test("removes lock directory recursively", () => {
+    FileLock.acquire(lockPath);
+    expect(existsSync(lockPath)).toBe(true);
+
+    FileLock.release(lockPath);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("does not throw when lock does not exist", () => {
+    expect(() => FileLock.release(lockPath)).not.toThrow();
+  });
+});
+
+describe("FileLock.withLock", () => {
+  test("runs fn and returns its value", () => {
+    const result = FileLock.withLock(lockPath, () => 42);
+    expect(result).toBe(42);
+  });
+
+  test("auto-releases on success", () => {
+    FileLock.withLock(lockPath, () => {});
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test("auto-releases on error and re-throws", () => {
+    const err = new Error("boom");
+    expect(() =>
+      FileLock.withLock(lockPath, () => {
+        throw err;
+      }),
+    ).toThrow("boom");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});
+
+describe("FileLock.isLocked", () => {
+  test("returns false when no lock exists", () => {
+    expect(FileLock.isLocked(lockPath)).toBe(false);
+  });
+
+  test("returns true when lock is held", () => {
+    FileLock.acquire(lockPath);
+    expect(FileLock.isLocked(lockPath)).toBe(true);
+    FileLock.release(lockPath);
+  });
+
+  test("returns false when lock is stale", () => {
+    mkdirSync(lockPath);
+    writeFileSync(
+      join(lockPath, "info.json"),
+      JSON.stringify({ pid: 99999, timestamp: Date.now() - 60_000 }),
+    );
+    expect(FileLock.isLocked(lockPath)).toBe(false);
+  });
+});

--- a/packages/session/test/storage/lock.test.ts
+++ b/packages/session/test/storage/lock.test.ts
@@ -46,10 +46,10 @@ describe("FileLock.acquire", () => {
     FileLock.release(lockPath);
   });
 
-  test("treats lock with missing info.json as active (not stale)", () => {
+  test("treats fresh lock with missing info.json as active (mtime is recent)", () => {
     mkdirSync(lockPath);
     // No info.json — could be a freshly acquired lock between mkdirSync and writeLockInfo.
-    // Must NOT treat as stale to avoid race condition.
+    // Directory mtime is recent, so it should NOT be considered stale.
     expect(() =>
       FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
     ).toThrow(/timeout/i);
@@ -57,15 +57,25 @@ describe("FileLock.acquire", () => {
     rmSync(lockPath, { recursive: true, force: true });
   });
 
-  test("treats lock with invalid info.json as active (not stale)", () => {
+  test("treats lock with invalid info.json as active when mtime is recent", () => {
     mkdirSync(lockPath);
     writeFileSync(join(lockPath, "info.json"), "NOT_JSON");
-    // Unreadable info.json — safer to assume lock is active.
+    // Unreadable info.json, but directory mtime is recent → not stale.
     expect(() =>
       FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
     ).toThrow(/timeout/i);
 
     rmSync(lockPath, { recursive: true, force: true });
+  });
+
+  test("reclaims crash-orphaned lock with missing info.json after staleMs", () => {
+    mkdirSync(lockPath);
+    // Simulate a crash-orphaned lock: no info.json, staleMs=0 so any age is stale.
+    // The directory mtime is "now", but with staleMs=0 even that is considered stale.
+    FileLock.acquire(lockPath, { staleMs: 0 });
+    const info = JSON.parse(readFileSync(join(lockPath, "info.json"), "utf-8"));
+    expect(info.pid).toBe(process.pid);
+    FileLock.release(lockPath);
   });
 
   test("throws on timeout when lock is held by active process", () => {


### PR DESCRIPTION
## Summary

- Add `Storage.initialize()` one-call bootstrap for persistent file-based session storage to `.openomni/`
- Add write-through cache layer (`CachedStorageAdapter`) to eliminate hot-path disk I/O during LLM streaming
- Add file-based locking (`FileLock`, mkdir pattern) for concurrent write safety with stale detection
- Add message ordering by `time.created` and stable part ordering in `FileStorageAdapter`
- Extend `SessionInfo` schema with optional metadata fields (agent, tokens, messageCount, summary, projectId, archived)
- Add automatic session metadata updates (messageCount increment, token accumulation) on `Session.addMessage()`
- Add `.gitignore` auto-management utility

## Details

### New files
| File | Purpose |
|------|---------|
| `storage/lock.ts` | `FileLock` — POSIX mkdir-based atomic locking with stale detection (30s), timeout (10s), sync polling via `Atomics.wait()` |
| `storage/cache.ts` | `CachedStorageAdapter` — Write-through cache wrapping any `Storage.Adapter`. Map-based caches for session/message/part with write-through invalidation |
| `storage/gitignore.ts` | `ensureGitignore()` — Read-modify-write `.gitignore` management. CRLF-aware, idempotent, exact line matching |
| `storage/initialize.ts` | `Storage.initialize()` — Creates `.openomni/` dirs, wires FileStorageAdapter → CachedStorageAdapter → Storage.configure(), updates .gitignore |

### Modified files
| File | Change |
|------|--------|
| `storage/file-storage.ts` | Message sorting (`time.created` asc), part sorting (time-aware stable), `lockDir` constructor param, `FileLock.withLock()` on all writes |
| `session/info.ts` | 6 optional fields: `agent`, `tokens`, `messageCount`, `summary`, `projectId`, `time.archived` |
| `session/index.ts` | `addMessage()` auto-updates messageCount, tokens (assistant only), time.updated |
| `storage/index.ts`, `src/index.ts` | Barrel exports for all new modules |

### Test coverage
147 tests, 0 failures (session package). 1,239 tests, 0 failures (full monorepo).

### Design decisions
- **Sync API preserved** — No async conversion, leverages Bun's fast sync I/O
- **fsync omitted** — Acceptable for dev tool; documented in code comment
- **No session pruning** — Sessions accumulate forever (by design)
- **No migration needed** — All new fields are optional → backward compatible
- **External cache wrapping** — CachedStorageAdapter applied in `initialize()`, not internal to FileStorageAdapter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent on-disk session history in .openomni/ with caching and file locking for fast, safe writes. Extends session metadata and auto-updates so message counts and token totals stay accurate; initialize storage once with Storage.initialize() (defaults to .openomni/, locking on).

- **New Features**
  - Storage.initialize() sets up .openomni/, wraps FileStorage → CachedStorage, and adds .openomni/ to .gitignore.
  - Write-through CachedStorageAdapter to avoid hot-path disk I/O during streaming.
  - FileLock (mkdir-based) for concurrent write safety with stale lock detection.
  - FileStorageAdapter orders messages by created time and parts by start time with stable fallback; all writes are lock-guarded.
  - SessionInfo gains optional fields: agent, tokens, messageCount, summary, projectId, time.archived.
  - Session.addMessage() auto-updates messageCount, assistant token totals, and time.updated.

- **Bug Fixes**
  - When lock info.json is missing or invalid, use directory mtime as the stale check fallback so fresh locks remain active and crash-orphaned locks are reclaimed after staleMs.
  - tokens.total is derived from computed input+output during Session.addMessage to avoid drift.

<sup>Written for commit d0cf278dd85c4a31d062e986ec50836583009449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

