### PR TITLE
fix(llm): remove flaky upper-bound assertion in Retry.sleep test

### DIFF
--- a/packages/llm/test/session/retry.test.ts
+++ b/packages/llm/test/session/retry.test.ts
@@ -28,7 +28,6 @@ describe("Retry", () => {
       await Retry.sleep(100, controller.signal);
       const elapsed = Date.now() - start;
       expect(elapsed).toBeGreaterThanOrEqual(100);
-      expect(elapsed).toBeLessThan(200);
     });
 
     test("respects AbortSignal and throws AbortError", async () => {


### PR DESCRIPTION
## Summary

- Remove flaky `expect(elapsed).toBeLessThan(200)` assertion from `Retry.sleep` test that fails on GitHub Actions due to CI runner scheduling latency

Closes #23

## Details

The test `Retry > sleep(ms, abortSignal) > resolves after specified milliseconds` asserts that a 100ms sleep completes within 200ms. This is unreliable on GitHub Actions runners where scheduling latency can push wall-clock time beyond 200ms.

The lower-bound assertion (`toBeGreaterThanOrEqual(100)`) is kept — it validates sleep waits at least the specified duration. The upper bound adds no meaningful coverage since the other two tests already verify abort signal and timeout cleanup behavior.

**Failed CI runs (same test):**
- PR #21 merge: https://github.com/INONONO66/openomni/actions/runs/22625892563
- PR #22 merge: https://github.com/INONONO66/openomni/actions/runs/22627734926

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove flaky upper-bound timing assertion in Retry.sleep test to stop CI failures on GitHub Actions caused by scheduler jitter. Keeps the lower-bound check to ensure sleep waits at least the requested duration.

<sup>Written for commit 95c3862aea710f39d6c69db801e0c88755634700. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

