### PR TITLE
feat(cli): add serve command with telegram, github, and discord adapters

### DIFF
--- a/apps/cli/bin/openomni.mjs
+++ b/apps/cli/bin/openomni.mjs
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 import "../src/index.ts";

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "check-types": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.50",

--- a/apps/cli/src/adapter/discord.ts
+++ b/apps/cli/src/adapter/discord.ts
@@ -1,0 +1,506 @@
+import { SurfaceKey } from "@openomni/session";
+import { Dedupe } from "../serve/dedupe";
+import { sleep, splitText, fetchWithRetry } from "../serve/utils";
+import { evaluateTriggers, normalizeContent } from "../serve/trigger";
+import type { Adapter } from "./types";
+
+// ---------------------------------------------------------------------------
+// Discord Gateway opcodes & intents
+// ---------------------------------------------------------------------------
+
+const GatewayOp = {
+  DISPATCH: 0,
+  HEARTBEAT: 1,
+  IDENTIFY: 2,
+  RESUME: 6,
+  RECONNECT: 7,
+  INVALID_SESSION: 9,
+  HELLO: 10,
+  HEARTBEAT_ACK: 11,
+} as const;
+
+const Intents = {
+  GUILDS: 1 << 0,
+  GUILD_MESSAGES: 1 << 9,
+  DIRECT_MESSAGES: 1 << 12,
+  MESSAGE_CONTENT: 1 << 15,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Discord API types (minimal subset)
+// ---------------------------------------------------------------------------
+
+interface DiscordUser {
+  id: string;
+  username: string;
+  bot?: boolean;
+}
+
+interface DiscordMessage {
+  id: string;
+  channel_id: string;
+  guild_id?: string;
+  author: DiscordUser;
+  content: string;
+  mentions?: DiscordUser[];
+}
+
+interface GatewayPayload {
+  op: number;
+  d: unknown;
+  s: number | null;
+  t: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class DiscordAdapter implements Adapter.Surface {
+  readonly id = "discord";
+  readonly capabilities: Adapter.Capabilities = {
+    streaming: false,
+    media: { send: false, receive: false },
+    commands: false,
+    threads: true,
+  };
+
+  private readonly baseUrl = "https://discord.com/api/v10";
+  private readonly dedupe = new Dedupe();
+  private ws: WebSocket | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private sequence: number | null = null;
+  private sessionId: string | null = null;
+  private resumeUrl: string | null = null;
+  private botId = "";
+  private botUsername = "";
+  private running = false;
+  private handler: Adapter.MessageHandler | null = null;
+  private ackReceived = true;
+  private reconnectAttempt = 0;
+  private readonly maxBackoff = 60_000;
+  private readonly FATAL_CLOSE_CODES = new Set([
+    4004, 4010, 4011, 4012, 4013, 4014,
+  ]);
+
+  constructor(
+    private readonly token: string,
+    readonly config: Adapter.Config,
+  ) {}
+
+  onMessage(handler: Adapter.MessageHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (!this.handler) {
+      throw new Error(
+        "[discord] No message handler registered. Call onMessage() before start().",
+      );
+    }
+
+    this.running = true;
+    await this.connect();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.stopHeartbeat();
+    if (this.ws) {
+      this.ws.close(1000);
+      this.ws = null;
+    }
+    console.log("[discord] Bot stopped");
+  }
+
+  async send(
+    surfaceKey: string,
+    message: Adapter.OutboundMessage,
+  ): Promise<void> {
+    const parsed = SurfaceKey.parse(surfaceKey);
+    let channelId = parsed.id!;
+
+    if (parsed.kind === "dm") {
+      const dmChannel = (await this.api("/users/@me/channels", {
+        recipient_id: parsed.id!,
+      })) as { id: string };
+      channelId = dmChannel.id;
+    }
+
+    await this.sendOutbound(channelId, message);
+  }
+
+  // -- Gateway connection ---------------------------------------------------
+
+  private async connect(): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/gateway/bot`, {
+      headers: { Authorization: `Bot ${this.token}` },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Discord gateway fetch failed (${res.status}): ${body}`);
+    }
+
+    const { url } = (await res.json()) as { url: string };
+    const wsUrl = `${url}?v=10&encoding=json`;
+
+    await this.openSocket(wsUrl);
+  }
+
+  private async resume(): Promise<void> {
+    if (!this.resumeUrl || !this.sessionId) {
+      return this.connect();
+    }
+    await this.openSocket(this.resumeUrl);
+  }
+
+  private openSocket(url: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(url);
+      this.ws = ws;
+
+      let resolved = false;
+
+      ws.addEventListener("message", (event) => {
+        const payload = JSON.parse(String(event.data)) as GatewayPayload;
+        const ready = this.handleGateway(payload);
+        if (ready && !resolved) {
+          resolved = true;
+          resolve();
+        }
+      });
+
+      ws.addEventListener("close", async (event) => {
+        this.stopHeartbeat();
+        if (!resolved) {
+          resolved = true;
+          reject(new Error(`WebSocket closed before ready: ${event.code}`));
+          return;
+        }
+
+        const code = event.code;
+        if (this.FATAL_CLOSE_CODES.has(code)) {
+          this.running = false;
+          console.error(
+            `[discord] Fatal close code (${code}), stopping reconnect attempts`,
+          );
+          return;
+        }
+
+        if (this.running) {
+          this.reconnectAttempt++;
+          const backoffMs = this.calculateBackoff();
+          console.log(
+            `[discord] Connection closed (${code}), reconnecting in ${Math.round(backoffMs)}ms...`,
+          );
+          await sleep(backoffMs);
+          if (this.running) this.resume().catch(console.error);
+        }
+      });
+
+      ws.addEventListener("error", (err) => {
+        console.error("[discord] WebSocket error:", err);
+      });
+    });
+  }
+
+  // -- Gateway event handling -----------------------------------------------
+
+  private handleGateway(payload: GatewayPayload): boolean {
+    if (payload.s !== null) {
+      this.sequence = payload.s;
+    }
+
+    switch (payload.op) {
+      case GatewayOp.HELLO: {
+        const d = payload.d as { heartbeat_interval: number };
+        this.startHeartbeat(d.heartbeat_interval);
+
+        if (this.sessionId && this.sequence !== null) {
+          this.sendGateway({
+            op: GatewayOp.RESUME,
+            d: {
+              token: this.token,
+              session_id: this.sessionId,
+              seq: this.sequence,
+            },
+          });
+        } else {
+          this.identify();
+        }
+        return false;
+      }
+
+      case GatewayOp.HEARTBEAT_ACK:
+        this.ackReceived = true;
+        return false;
+
+      case GatewayOp.RECONNECT:
+        console.log("[discord] Server requested reconnect");
+        this.ws?.close(4000);
+        return false;
+
+      case GatewayOp.INVALID_SESSION: {
+        const resumable = payload.d as boolean;
+        console.log(`[discord] Invalid session (resumable: ${resumable})`);
+        if (!resumable) {
+          this.sessionId = null;
+          this.sequence = null;
+        }
+        this.ws?.close(4000);
+        return false;
+      }
+
+      case GatewayOp.DISPATCH:
+        try {
+          return this.handleDispatch(payload.t!, payload.d);
+        } catch (err) {
+          console.error("[discord] Error handling dispatch:", err);
+          return false;
+        }
+
+      default:
+        return false;
+    }
+  }
+
+  private handleDispatch(event: string, data: unknown): boolean {
+    switch (event) {
+      case "READY": {
+        const d = data as {
+          session_id: string;
+          resume_gateway_url: string;
+          user: DiscordUser;
+        };
+        this.sessionId = d.session_id;
+        this.resumeUrl = `${d.resume_gateway_url}?v=10&encoding=json`;
+        this.botId = d.user.id;
+        this.botUsername = d.user.username;
+        this.reconnectAttempt = 0;
+        console.log(
+          `[discord] Bot started: @${this.botUsername} (${this.botId})`,
+        );
+        return true;
+      }
+
+      case "RESUMED":
+        this.reconnectAttempt = 0;
+        console.log("[discord] Session resumed");
+        return true;
+
+      case "MESSAGE_CREATE": {
+        const message = data as DiscordMessage;
+        if (message.author.bot) return false;
+        if (!message.content) return false;
+
+        // Dedupe
+        if (this.dedupe.isDuplicate(message.id)) return false;
+
+        // Build trigger context and evaluate
+        const isDM = !message.guild_id;
+        const mentioned =
+          message.mentions?.some((u) => u.id === this.botId) ?? false;
+
+        const ctx: Adapter.TriggerContext = {
+          event: "message",
+          mentioned,
+          channelId: message.channel_id,
+          senderId: message.author.id,
+          isDM,
+          text: message.content,
+        };
+
+        if (!evaluateTriggers(this.config.triggers, ctx)) return false;
+
+        this.handleIncoming(message, mentioned).catch((err) => {
+          console.error("[discord] Error handling message:", err);
+        });
+        return false;
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  // -- Message handling -----------------------------------------------------
+
+  private async handleIncoming(
+    message: DiscordMessage,
+    mentioned: boolean,
+  ): Promise<void> {
+    const channelId = message.channel_id;
+    const isDM = !message.guild_id;
+
+    // Strip @mention from content for cleaner LLM input
+    let content = message.content;
+    if (mentioned && !isDM) {
+      content = content
+        .replace(new RegExp(`<@!?${this.botId}>\\s*`), "")
+        .trim();
+    }
+
+    // Strip prefix via normalizeContent (no botUsername — Discord uses ID-based mentions)
+    content = normalizeContent(content, this.config.triggers);
+    if (!content) return;
+
+    const surfaceKey = SurfaceKey.fromChannel({
+      surface: "discord",
+      namespace: this.botId,
+      kind: isDM ? "dm" : "channel",
+      id: isDM ? message.author.id : channelId,
+    });
+
+    console.log(
+      `[discord] ${isDM ? "dm" : channelId}: ${content.slice(0, 80)}`,
+    );
+
+    // Typing indicator (repeat every 8s until done)
+    this.sendTyping(channelId);
+    const typingInterval = setInterval(() => {
+      this.sendTyping(channelId);
+    }, 8000);
+
+    try {
+      const inbound: Adapter.InboundMessage = {
+        id: message.id,
+        surfaceKey,
+        text: content,
+        sender: {
+          id: message.author.id,
+          name: message.author.username,
+        },
+        raw: message,
+      };
+
+      const outbound = await this.getHandler()(inbound);
+      if (outbound) await this.sendOutbound(channelId, outbound);
+    } catch (err) {
+      console.error(`[discord] Error in ${channelId}:`, err);
+      await this.sendOutbound(channelId, {
+        text: "Sorry, an error occurred.",
+      });
+    } finally {
+      clearInterval(typingInterval);
+    }
+  }
+
+  private getHandler(): Adapter.MessageHandler {
+    if (!this.handler) {
+      throw new Error(
+        `[${this.id}] No handler registered. Call onMessage() before processing.`,
+      );
+    }
+    return this.handler;
+  }
+
+  private async sendOutbound(
+    channelId: string,
+    message: Adapter.OutboundMessage,
+  ): Promise<void> {
+    if (message.text) {
+      const chunks = splitText(message.text, 2000);
+      for (const chunk of chunks) {
+        await this.api(`/channels/${channelId}/messages`, {
+          content: chunk,
+        });
+      }
+    }
+    // TODO: handle message.media when capabilities.media.send is enabled
+  }
+
+  private sendTyping(channelId: string): void {
+    fetch(`${this.baseUrl}/channels/${channelId}/typing`, {
+      method: "POST",
+      headers: { Authorization: `Bot ${this.token}` },
+    }).catch((e) => console.error("[discord] typing indicator error:", e));
+  }
+
+  // -- Discord REST helper --------------------------------------------------
+
+  private async api(
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<unknown> {
+    const res = await fetchWithRetry(
+      `${this.baseUrl}${path}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bot ${this.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      },
+      {
+        parseRetryAfter: (data) => {
+          const r = data as { retry_after?: number };
+          return r.retry_after ?? 5;
+        },
+        label: `discord${path}`,
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Discord API ${path} failed (${res.status}): ${text}`);
+    }
+
+    return res.json();
+  }
+
+  // -- Gateway helpers ------------------------------------------------------
+
+  private calculateBackoff(): number {
+    return (
+      Math.min(1000 * 2 ** this.reconnectAttempt, this.maxBackoff) +
+      Math.random() * 1000
+    );
+  }
+
+  private identify(): void {
+    this.sendGateway({
+      op: GatewayOp.IDENTIFY,
+      d: {
+        token: this.token,
+        intents:
+          Intents.GUILDS |
+          Intents.GUILD_MESSAGES |
+          Intents.DIRECT_MESSAGES |
+          Intents.MESSAGE_CONTENT,
+        properties: {
+          os: "linux",
+          browser: "openomni",
+          device: "openomni",
+        },
+      },
+    });
+  }
+
+  private startHeartbeat(intervalMs: number): void {
+    this.stopHeartbeat();
+    this.ackReceived = true;
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.ackReceived) {
+        this.ws?.close();
+        return;
+      }
+      this.sendGateway({ op: GatewayOp.HEARTBEAT, d: this.sequence });
+      this.ackReceived = false;
+    }, intervalMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private sendGateway(payload: Record<string, unknown>): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+    }
+  }
+}

--- a/apps/cli/src/adapter/github.ts
+++ b/apps/cli/src/adapter/github.ts
@@ -1,0 +1,365 @@
+import { timingSafeEqual } from "node:crypto";
+import { SurfaceKey } from "@openomni/session";
+import { Dedupe } from "../serve/dedupe";
+import { evaluateTriggers, normalizeContent } from "../serve/trigger";
+import { fetchWithRetry } from "../serve/utils";
+import type { Adapter } from "./types";
+
+// ---------------------------------------------------------------------------
+// GitHub webhook payload types (minimal subset)
+// ---------------------------------------------------------------------------
+
+interface GitHubUser {
+  login: string;
+  type: string;
+}
+
+interface GitHubLabel {
+  name: string;
+}
+
+interface GitHubRepository {
+  full_name: string;
+  owner: { login: string };
+  name: string;
+}
+
+interface GitHubIssueCommentPayload {
+  action: string;
+  issue: {
+    number: number;
+    title: string;
+    body?: string;
+    pull_request?: unknown;
+    labels?: GitHubLabel[];
+    user: GitHubUser;
+  };
+  comment: {
+    id: number;
+    body: string;
+    user: GitHubUser;
+  };
+  repository: GitHubRepository;
+}
+
+interface GitHubIssuesPayload {
+  action: string;
+  issue: {
+    number: number;
+    title: string;
+    body?: string;
+    pull_request?: unknown;
+    labels?: GitHubLabel[];
+    user: GitHubUser;
+  };
+  repository: GitHubRepository;
+}
+
+/** Normalized content extracted from any supported GitHub event. */
+interface GitHubEventContent {
+  text: string;
+  sender: string;
+  senderType: string;
+  repo: string;
+  issueNumber: number;
+  issueKind: "issue" | "pr";
+  labels: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class GitHubAdapter implements Adapter.Surface {
+  readonly id = "github";
+  readonly capabilities: Adapter.Capabilities = {
+    streaming: false,
+    media: { send: false, receive: false },
+    commands: false,
+    threads: true,
+  };
+
+  private readonly dedupe = new Dedupe();
+  private handler: Adapter.MessageHandler | null = null;
+
+  constructor(
+    private readonly secret: string,
+    readonly config: Adapter.Config,
+    private readonly githubToken?: string,
+    private readonly botUsername?: string,
+  ) {}
+
+  onMessage(handler: Adapter.MessageHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (!this.handler) {
+      throw new Error(
+        "[github] No message handler registered. Call onMessage() before start().",
+      );
+    }
+    console.log("[github] Webhook handler ready");
+  }
+
+  stop(): void {
+    // Webhook-based — no persistent connection to tear down
+  }
+
+  async send(
+    surfaceKey: string,
+    message: Adapter.OutboundMessage,
+  ): Promise<void> {
+    const parsed = SurfaceKey.parse(surfaceKey);
+    const repo = parsed.namespace;
+    const issueNumber = parseInt(parsed.id!.split("-")[1]);
+
+    if (message.text && this.githubToken) {
+      await this.postComment(repo, issueNumber, message.text);
+    }
+    // TODO: handle message.media when capabilities.media.send is enabled
+  }
+
+  /**
+   * Handle an incoming GitHub webhook request.
+   * Verifies signature, deduplicates, evaluates triggers, routes the event.
+   */
+  async handleWebhook(request: Request): Promise<Response> {
+    // 1. Verify signature
+    const signature = request.headers.get("x-hub-signature-256");
+    if (!signature) {
+      return new Response("Missing signature", { status: 401 });
+    }
+
+    const body = await request.text();
+    const valid = await this.verifySignature(body, signature);
+    if (!valid) {
+      return new Response("Invalid signature", { status: 401 });
+    }
+
+    // 2. Dedupe by delivery ID
+    const deliveryId = request.headers.get("x-github-delivery");
+    if (deliveryId && this.dedupe.isDuplicate(deliveryId)) {
+      return new Response("Already processed", { status: 200 });
+    }
+
+    // 3. Extract content from event
+    const event = request.headers.get("x-github-event");
+    const payload = JSON.parse(body);
+    const eventKey = `${event}.${payload.action}`;
+
+    console.log(`[github] Event: ${eventKey}`);
+
+    const content = this.extractContent(event!, payload);
+    if (!content) {
+      return new Response("Unsupported event", { status: 200 });
+    }
+
+    // 4. Evaluate triggers
+    const ctx: Adapter.TriggerContext = {
+      event: eventKey,
+      mentioned: this.checkMention(content.text),
+      senderId: content.sender,
+      channelId: `${content.issueKind}-${content.issueNumber}`,
+      labels: content.labels,
+      text: content.text,
+    };
+
+    if (!evaluateTriggers(this.config.triggers, ctx)) {
+      return new Response("Filtered", { status: 200 });
+    }
+
+    // 5. Process
+    const surfaceKey = SurfaceKey.fromChannel({
+      surface: "github",
+      namespace: content.repo,
+      kind: "channel",
+      id: `${content.issueKind}-${content.issueNumber}`,
+    });
+
+    this.processEvent(content, eventKey).catch((err) => {
+      console.error(
+        `[github] async processing failed (event=${eventKey}, surface=${surfaceKey}):`,
+        err,
+      );
+    });
+
+    return new Response("OK", { status: 200 });
+  }
+
+  // -- Content extraction ---------------------------------------------------
+
+  /**
+   * Extract normalized content from a webhook payload.
+   * Returns null for unsupported event types or bot-authored events.
+   */
+  private extractContent(
+    event: string,
+    payload: Record<string, unknown>,
+  ): GitHubEventContent | null {
+    switch (event) {
+      case "issue_comment": {
+        const p = payload as unknown as GitHubIssueCommentPayload;
+        if (p.action !== "created") return null;
+        if (p.comment.user.type === "Bot") return null;
+        return {
+          text: p.comment.body,
+          sender: p.comment.user.login,
+          senderType: p.comment.user.type,
+          repo: p.repository.full_name,
+          issueNumber: p.issue.number,
+          issueKind: p.issue.pull_request ? "pr" : "issue",
+          labels: p.issue.labels?.map((l) => l.name) ?? [],
+        };
+      }
+
+      case "issues": {
+        const p = payload as unknown as GitHubIssuesPayload;
+        if (p.action !== "opened") return null;
+        if (p.issue.user.type === "Bot") return null;
+        return {
+          text: p.issue.body ?? p.issue.title,
+          sender: p.issue.user.login,
+          senderType: p.issue.user.type,
+          repo: p.repository.full_name,
+          issueNumber: p.issue.number,
+          issueKind: p.issue.pull_request ? "pr" : "issue",
+          labels: p.issue.labels?.map((l) => l.name) ?? [],
+        };
+      }
+
+      default:
+        return null;
+    }
+  }
+
+  // -- Event processing -----------------------------------------------------
+
+  private async processEvent(
+    content: GitHubEventContent,
+    eventKey: string,
+  ): Promise<void> {
+    const surfaceKey = SurfaceKey.fromChannel({
+      surface: "github",
+      namespace: content.repo,
+      kind: "channel",
+      id: `${content.issueKind}-${content.issueNumber}`,
+    });
+
+    console.log(
+      `[github] ${content.repo}#${content.issueNumber} (${eventKey}): ${content.text.slice(0, 80)}`,
+    );
+
+    const normalizedText = normalizeContent(
+      content.text,
+      this.config.triggers,
+      this.botUsername,
+    );
+
+    try {
+      const inbound: Adapter.InboundMessage = {
+        id: `${eventKey}-${content.issueNumber}-${Date.now()}`,
+        surfaceKey,
+        text: normalizedText,
+        sender: {
+          id: content.sender,
+          name: content.sender,
+        },
+        threadId: `${content.issueKind}-${content.issueNumber}`,
+        raw: content,
+      };
+
+      const outbound = await this.getHandler()(inbound);
+
+      if (outbound?.text && this.githubToken) {
+        await this.postComment(
+          content.repo,
+          content.issueNumber,
+          outbound.text,
+        );
+      } else if (outbound?.text) {
+        console.log(
+          `[github] Response (no token, not posted):\n${outbound.text}`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `[github] Error in ${content.repo}#${content.issueNumber}:`,
+        err,
+      );
+    }
+  }
+
+  private getHandler(): Adapter.MessageHandler {
+    if (!this.handler) {
+      throw new Error(
+        `[${this.id}] No handler registered. Call onMessage() before processing.`,
+      );
+    }
+    return this.handler;
+  }
+
+  // -- Mention detection ----------------------------------------------------
+
+  private checkMention(text: string): boolean {
+    if (!this.botUsername) return false;
+    return text.includes(`@${this.botUsername}`);
+  }
+
+  // -- GitHub API -----------------------------------------------------------
+
+  private async postComment(
+    repo: string,
+    issueNumber: number,
+    body: string,
+  ): Promise<void> {
+    const url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`;
+
+    const response = await fetchWithRetry(
+      url,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.githubToken}`,
+          Accept: "application/vnd.github.v3+json",
+          "Content-Type": "application/json",
+          "User-Agent": "openomni-cli",
+        },
+        body: JSON.stringify({ body }),
+      },
+      { label: "github/postComment" },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API failed (${response.status}): ${text}`);
+    }
+
+    console.log(`[github] Posted comment to ${repo}#${issueNumber}`);
+  }
+
+  // -- Signature verification -----------------------------------------------
+
+  private async verifySignature(
+    payload: string,
+    signature: string,
+  ): Promise<boolean> {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(this.secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+
+    const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+    const digest = `sha256=${Array.from(new Uint8Array(sig))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")}`;
+
+    // Constant-time comparison to prevent timing attacks
+    if (signature.length !== digest.length) return false;
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+  }
+}

--- a/apps/cli/src/adapter/telegram.ts
+++ b/apps/cli/src/adapter/telegram.ts
@@ -1,0 +1,290 @@
+import { SurfaceKey } from "@openomni/session";
+import { Dedupe } from "../serve/dedupe";
+import { sleep, splitText, fetchWithRetry } from "../serve/utils";
+import { evaluateTriggers, normalizeContent } from "../serve/trigger";
+import type { Adapter } from "./types";
+
+// ---------------------------------------------------------------------------
+// Telegram Bot API types (minimal subset)
+// ---------------------------------------------------------------------------
+
+interface TelegramUser {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  username?: string;
+}
+
+interface TelegramChat {
+  id: number;
+  type: "private" | "group" | "supergroup" | "channel";
+  title?: string;
+  first_name?: string;
+  username?: string;
+}
+
+interface TelegramMessage {
+  message_id: number;
+  from?: TelegramUser;
+  chat: TelegramChat;
+  date: number;
+  text?: string;
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+interface TelegramResponse<T> {
+  ok: boolean;
+  result: T;
+  description?: string;
+  error_code?: number;
+  parameters?: { retry_after?: number };
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class TelegramAdapter implements Adapter.Surface {
+  readonly id = "telegram";
+  readonly capabilities: Adapter.Capabilities = {
+    streaming: false,
+    media: { send: false, receive: false },
+    commands: false,
+    threads: false,
+  };
+
+  private readonly baseUrl: string;
+  private readonly dedupe = new Dedupe();
+  private offset = 0;
+  private running = false;
+  private botId = "";
+  private botUsername = "";
+  private pollController: AbortController | null = null;
+  private handler: Adapter.MessageHandler | null = null;
+
+  constructor(
+    token: string,
+    readonly config: Adapter.Config,
+  ) {
+    this.baseUrl = `https://api.telegram.org/bot${token}`;
+  }
+
+  onMessage(handler: Adapter.MessageHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (!this.handler) {
+      throw new Error(
+        "[telegram] No message handler registered. Call onMessage() before start().",
+      );
+    }
+
+    const me = await this.api<TelegramUser>("getMe");
+    this.botId = String(me.id);
+    this.botUsername = me.username ?? "";
+    console.log(
+      `[telegram] Bot started: @${me.username ?? me.first_name} (${me.id})`,
+    );
+
+    this.running = true;
+    this.poll();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.pollController?.abort();
+    console.log("[telegram] Bot stopped");
+  }
+
+  async send(
+    surfaceKey: string,
+    message: Adapter.OutboundMessage,
+  ): Promise<void> {
+    const parsed = SurfaceKey.parse(surfaceKey);
+    const chatId = parsed.id!;
+    await this.sendOutbound(chatId, message);
+  }
+
+  // -- Long polling loop ----------------------------------------------------
+
+  private async poll(): Promise<void> {
+    while (this.running) {
+      try {
+        this.pollController = new AbortController();
+        const updates = await this.api<TelegramUpdate[]>(
+          "getUpdates",
+          {
+            offset: this.offset,
+            timeout: 30,
+            allowed_updates: ["message"],
+          },
+          this.pollController.signal,
+        );
+
+        for (const update of updates) {
+          this.offset = update.update_id + 1;
+
+          if (update.message?.text) {
+            if (this.dedupe.isDuplicate(String(update.update_id))) continue;
+
+            this.handleUpdate(update.message).catch((err) => {
+              console.error("[telegram] Error handling message:", err);
+            });
+          }
+        }
+      } catch (err) {
+        if (!this.running) break;
+        console.error("[telegram] Poll error:", err);
+        await sleep(5000);
+      }
+    }
+  }
+
+  // -- Message handling -----------------------------------------------------
+
+  private async handleUpdate(message: TelegramMessage): Promise<void> {
+    const text = message.text;
+    if (!text) return;
+
+    const userId = message.from?.id;
+    const chatId = String(message.chat.id);
+    const isDM = message.chat.type === "private";
+
+    // Check for @mention in text
+    const mentioned =
+      this.botUsername !== "" && text.includes(`@${this.botUsername}`);
+
+    // Build trigger context and evaluate
+    const ctx: Adapter.TriggerContext = {
+      event: "message",
+      mentioned,
+      channelId: chatId,
+      senderId: String(userId ?? 0),
+      isDM,
+      text,
+    };
+
+    if (!evaluateTriggers(this.config.triggers, ctx)) return;
+
+    // Strip prefix if a prefix rule matched
+    const content = normalizeContent(
+      text,
+      this.config.triggers,
+      this.botUsername,
+    );
+    if (!content) return;
+
+    const surfaceKey = SurfaceKey.fromChannel({
+      surface: "telegram",
+      namespace: this.botId,
+      kind: "chat",
+      id: chatId,
+    });
+
+    console.log(`[telegram] ${chatId}: ${content.slice(0, 80)}`);
+
+    // Typing indicator (repeat every 4s until done)
+    const typingInterval = setInterval(() => {
+      this.api("sendChatAction", { chat_id: chatId, action: "typing" }).catch(
+        (e) => console.error("[telegram] typing indicator error:", e),
+      );
+    }, 4000);
+    this.api("sendChatAction", { chat_id: chatId, action: "typing" }).catch(
+      (e) => console.error("[telegram] typing indicator error:", e),
+    );
+
+    try {
+      const inbound: Adapter.InboundMessage = {
+        id: String(message.message_id),
+        surfaceKey,
+        text: content,
+        sender: {
+          id: String(userId ?? 0),
+          name: message.from?.username ?? message.from?.first_name,
+        },
+        raw: message,
+      };
+
+      const outbound = await this.getHandler()(inbound);
+      if (outbound) await this.sendOutbound(chatId, outbound);
+    } catch (err) {
+      console.error(`[telegram] Error in chat ${chatId}:`, err);
+      await this.sendOutbound(chatId, { text: "Sorry, an error occurred." });
+    } finally {
+      clearInterval(typingInterval);
+    }
+  }
+
+  private getHandler(): Adapter.MessageHandler {
+    if (!this.handler) {
+      throw new Error(
+        `[${this.id}] No handler registered. Call onMessage() before processing.`,
+      );
+    }
+    return this.handler;
+  }
+
+  private async sendOutbound(
+    chatId: string,
+    message: Adapter.OutboundMessage,
+  ): Promise<void> {
+    if (message.text) {
+      const chunks = splitText(message.text, 4096);
+      for (const chunk of chunks) {
+        await this.api("sendMessage", {
+          chat_id: chatId,
+          text: chunk,
+        });
+      }
+    }
+    // TODO: handle message.media when capabilities.media.send is enabled
+  }
+
+  // -- Telegram API helper --------------------------------------------------
+
+  private async api<T>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const url = `${this.baseUrl}/${method}`;
+
+    const response = await fetchWithRetry(
+      url,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params ?? {}),
+        signal,
+      },
+      {
+        parseRetryAfter: (body) => {
+          const r = body as { parameters?: { retry_after?: number } };
+          return r.parameters?.retry_after ?? 5;
+        },
+        label: `telegram/${method}`,
+      },
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(
+        `Telegram API ${method} failed (${response.status}): ${body}`,
+      );
+    }
+
+    const body = (await response.json()) as TelegramResponse<T>;
+    if (!body.ok) {
+      throw new Error(
+        `Telegram API ${method}: ${body.description ?? "Unknown error"}`,
+      );
+    }
+
+    return body.result;
+  }
+}

--- a/apps/cli/src/adapter/types.ts
+++ b/apps/cli/src/adapter/types.ts
@@ -1,0 +1,250 @@
+/**
+ * Adapter — common contract for all surface adapters.
+ *
+ * Adapters are transport layers bridging external platforms (Telegram, Discord,
+ * GitHub, TUI, etc.) with the OpenOmni conversation handler. Each adapter
+ * declares its capabilities, and the orchestration layer adjusts behavior
+ * accordingly.
+ */
+export namespace Adapter {
+  // ── Capabilities ──────────────────────────────────────────────
+
+  /** Declares what a surface adapter supports. */
+  export interface Capabilities {
+    /** Adapter can deliver streamed response chunks incrementally. */
+    streaming: boolean;
+    /** Media support per direction. */
+    media: {
+      send: boolean;
+      receive: boolean;
+    };
+    /** Supports platform-native command registration (e.g. Telegram /commands). */
+    commands: boolean;
+    /** Supports threaded conversations. */
+    threads: boolean;
+  }
+
+  // ── Trigger Rules ──────────────────────────────────────────
+
+  /**
+   * Composable trigger rules. All rules in a config must pass (AND logic)
+   * for the adapter to invoke the message handler.
+   * Empty array = always trigger (no filtering).
+   */
+  export type TriggerRule =
+    /** Match specific platform events (e.g. "message", "issue_comment.created"). */
+    | { type: "event"; events: string[] }
+    /** Require @mention of the bot. DMs implicitly pass. */
+    | { type: "mention" }
+    /** Require message to start with a prefix (stripped before handler). */
+    | { type: "prefix"; value: string }
+    /** Match specific labels (e.g. GitHub issue labels). */
+    | { type: "label"; values: string[] }
+    /** Restrict to specific channels or chats. */
+    | { type: "channel"; ids: string[] }
+    /** Filter by sender identity. */
+    | { type: "sender"; allow?: string[]; deny?: string[] };
+
+  /**
+   * Context constructed by the adapter from a platform event.
+   * Passed to the trigger evaluation engine.
+   */
+  export interface TriggerContext {
+    /** Platform event identifier (e.g. "message", "issue_comment.created"). */
+    event: string;
+    /** Was the bot explicitly mentioned? */
+    mentioned: boolean;
+    /** Channel or chat identifier. */
+    channelId?: string;
+    /** Sender identifier. */
+    senderId: string;
+    /** Associated labels (e.g. GitHub issue labels). */
+    labels?: string[];
+    /** Is this a direct message? DMs bypass mention rules. */
+    isDM?: boolean;
+    /** Message text content. */
+    text: string;
+  }
+
+  // ── Delivery Policy ───────────────────────────────────────────
+
+  /**
+   * Controls which messages from a multi-step agent run are delivered.
+   * - `"all"` — every intermediate message (reasoning steps, tool calls)
+   * - `"final"` — only the final assistant response
+   *
+   * TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
+   */
+  export type DeliveryPolicy = "all" | "final";
+
+  // ── Media ─────────────────────────────────────────────────────
+
+  /** A media attachment for inbound or outbound messages. */
+  export interface MediaAttachment {
+    kind: "image" | "file" | "audio" | "video";
+    /** Remote URL. Preferred when the platform accepts URLs directly. */
+    url?: string;
+    /** Raw binary data. Used when URL is not available. */
+    data?: Uint8Array;
+    mimeType?: string;
+    filename?: string;
+  }
+
+  // ── Messages ──────────────────────────────────────────────────
+
+  /** Inbound message: platform → agent. */
+  export interface InboundMessage {
+    /** Platform-specific message identifier. */
+    id: string;
+    /** Resolved SurfaceKey for session routing. */
+    surfaceKey: string;
+    /** Message text content. */
+    text: string;
+    /** Sender identity. */
+    sender: {
+      id: string;
+      name?: string;
+    };
+    /** Attached media (images, files, etc.). */
+    media?: MediaAttachment[];
+    /** ID of the message being replied to. */
+    replyToId?: string;
+    /** Thread identifier. */
+    threadId?: string;
+    /** Raw platform payload for escape-hatch access. */
+    raw?: unknown;
+  }
+
+  /** Outbound message: agent → platform. */
+  export interface OutboundMessage {
+    text?: string;
+    media?: MediaAttachment[];
+    replyToId?: string;
+    threadId?: string;
+  }
+
+  // ── Commands ──────────────────────────────────────────────────
+
+  /** A platform command definition (e.g. /help, /status). */
+  export interface Command {
+    name: string;
+    description: string;
+    options?: Array<{
+      name: string;
+      description: string;
+      required?: boolean;
+    }>;
+  }
+
+  /** Context passed to a command handler. */
+  export interface CommandContext {
+    command: string;
+    args: Record<string, string>;
+    message: InboundMessage;
+  }
+
+  // ── Handlers ──────────────────────────────────────────────────
+
+  /**
+   * Handles an inbound message and returns an optional response.
+   * Returning `null` means no response should be sent.
+   */
+  export type MessageHandler = (
+    message: InboundMessage,
+  ) => Promise<OutboundMessage | null>;
+
+  /** Handles a platform command invocation. */
+  export type CommandHandler = (
+    ctx: CommandContext,
+  ) => Promise<OutboundMessage | null>;
+
+  /**
+   * Streaming sink for adapters that support incremental delivery.
+   * The orchestration layer writes chunks; the adapter flushes them
+   * to the platform in real time.
+   */
+  export interface StreamSink {
+    /** Append a text chunk. */
+    write(text: string): void;
+    /** Attach media (forces flush of any buffered text). */
+    attach(media: MediaAttachment): void;
+    /** Signal that the response is complete. */
+    end(): void;
+    /** Signal an error. */
+    error(err: Error): void;
+  }
+
+  /**
+   * Streaming handler — used instead of MessageHandler when the adapter
+   * supports incremental delivery.
+   */
+  export type StreamingHandler = (
+    message: InboundMessage,
+    sink: StreamSink,
+  ) => Promise<void>;
+
+  // ── Config ────────────────────────────────────────────────────
+
+  /** Shared adapter configuration. */
+  export interface Config {
+    /** Composable trigger rules. AND logic — all must pass. Empty = always. */
+    triggers: TriggerRule[];
+    /** Which messages from a multi-step run to deliver. */
+    deliveryPolicy: DeliveryPolicy;
+  }
+
+  // ── Surface Interface ─────────────────────────────────────────
+
+  /**
+   * A surface adapter — bridges a platform with the OpenOmni agent.
+   *
+   * Adapters declare capabilities and accept configuration. The orchestration
+   * layer wires handlers based on capabilities (e.g. streaming handler for
+   * streaming-capable adapters, standard handler for others).
+   */
+  export interface Surface {
+    /** Unique adapter identifier (e.g. "telegram", "discord", "github"). */
+    readonly id: string;
+    /** What this adapter supports. */
+    readonly capabilities: Capabilities;
+    /** How this adapter should behave. */
+    readonly config: Config;
+
+    // ── Lifecycle ──
+
+    /** Start listening for platform events. */
+    start(): Promise<void>;
+    /** Stop listening and release resources. */
+    stop(): void;
+
+    // ── Inbound ──
+
+    /**
+     * Register a handler for incoming messages.
+     * The adapter applies trigger and user filtering before invoking.
+     */
+    onMessage(handler: MessageHandler): void;
+
+    /**
+     * Register a streaming handler (optional).
+     * When set on a streaming-capable adapter, called instead of the
+     * regular message handler.
+     */
+    onStreamingMessage?(handler: StreamingHandler): void;
+
+    // ── Outbound ──
+
+    /**
+     * Send a message to a specific surface.
+     * Used for proactive messages or orchestration-managed delivery.
+     */
+    send(surfaceKey: string, message: OutboundMessage): Promise<void>;
+
+    // ── Commands (optional) ──
+
+    /** Register commands with the platform. */
+    registerCommands?(commands: Command[]): Promise<void>;
+    /** Register a handler for command invocations. */
+    onCommand?(handler: CommandHandler): void;
+  }
+}

--- a/apps/cli/src/cmd/config.ts
+++ b/apps/cli/src/cmd/config.ts
@@ -1,0 +1,217 @@
+import type { CommandModule } from "yargs";
+import * as prompts from "@clack/prompts";
+import { Config } from "../config";
+
+function cancel(): never {
+  prompts.cancel("Operation cancelled.");
+  process.exit(0);
+}
+
+async function promptUsers(): Promise<string[] | undefined> {
+  const input = await prompts.text({
+    message: "Allowed user IDs (comma-separated, empty for all)",
+    placeholder: "Leave empty to allow everyone",
+    defaultValue: "",
+  });
+  if (prompts.isCancel(input)) cancel();
+
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+  return trimmed.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// config add
+// ---------------------------------------------------------------------------
+
+const ConfigAddCommand: CommandModule = {
+  command: "add",
+  describe: "Configure an adapter",
+  handler: async () => {
+    prompts.intro("Configure adapter");
+
+    const adapter = await prompts.select({
+      message: "Select adapter",
+      options: [
+        { label: "Telegram", value: "telegram", hint: "Bot token" },
+        {
+          label: "GitHub",
+          value: "github",
+          hint: "Webhook secret + API token",
+        },
+        { label: "Discord", value: "discord", hint: "Bot token" },
+      ],
+    });
+    if (prompts.isCancel(adapter)) cancel();
+
+    switch (adapter) {
+      case "telegram": {
+        const token = await prompts.password({
+          message: "Enter Telegram bot token",
+          validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+        });
+        if (prompts.isCancel(token)) cancel();
+
+        const allowedUsers = await promptUsers();
+        Config.setAdapter("telegram", {
+          token,
+          ...(allowedUsers && { allowedUsers }),
+        });
+        prompts.log.success("Telegram bot token saved");
+        break;
+      }
+
+      case "github": {
+        const secret = await prompts.password({
+          message: "Enter GitHub webhook secret",
+          validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+        });
+        if (prompts.isCancel(secret)) cancel();
+
+        const wantToken = await prompts.confirm({
+          message: "Add GitHub API token? (for posting comments)",
+        });
+        if (prompts.isCancel(wantToken)) cancel();
+
+        let token: string | undefined;
+        if (wantToken) {
+          const t = await prompts.password({
+            message: "Enter GitHub API token",
+            validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+          });
+          if (prompts.isCancel(t)) cancel();
+          token = t;
+        }
+
+        const allowedUsers = await promptUsers();
+        Config.setAdapter("github", {
+          secret,
+          ...(token && { token }),
+          ...(allowedUsers && { allowedUsers }),
+        });
+        prompts.log.success("GitHub credentials saved");
+        break;
+      }
+
+      case "discord": {
+        const token = await prompts.password({
+          message: "Enter Discord bot token",
+          validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+        });
+        if (prompts.isCancel(token)) cancel();
+
+        const allowedUsers = await promptUsers();
+        Config.setAdapter("discord", {
+          token,
+          ...(allowedUsers && { allowedUsers }),
+        });
+        prompts.log.success("Discord bot token saved");
+        break;
+      }
+    }
+
+    prompts.outro("Done");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// config list
+// ---------------------------------------------------------------------------
+
+const ConfigListCommand: CommandModule = {
+  command: "list",
+  aliases: ["ls"],
+  describe: "List configured adapters",
+  handler: async () => {
+    const config = Config.load();
+    const entries: string[] = [];
+
+    if (config.telegram) {
+      let line = `telegram — token: ${Config.mask(config.telegram.token)}`;
+      if (config.telegram.allowedUsers?.length) {
+        line += ` (${config.telegram.allowedUsers.length} allowed user(s))`;
+      }
+      entries.push(line);
+    }
+    if (config.github) {
+      let line = `github  — secret: ${Config.mask(config.github.secret)}`;
+      if (config.github.token) {
+        line += `, token: ${Config.mask(config.github.token)}`;
+      }
+      if (config.github.allowedUsers?.length) {
+        line += ` (${config.github.allowedUsers.length} allowed user(s))`;
+      }
+      entries.push(line);
+    }
+    if (config.discord) {
+      let line = `discord — token: ${Config.mask(config.discord.token)}`;
+      if (config.discord.allowedUsers?.length) {
+        line += ` (${config.discord.allowedUsers.length} allowed user(s))`;
+      }
+      entries.push(line);
+    }
+
+    if (entries.length === 0) {
+      prompts.log.info("No adapters configured. Run 'openomni config add'.");
+      return;
+    }
+
+    prompts.intro("Configured adapters");
+    for (const entry of entries) {
+      prompts.log.info(entry);
+    }
+    prompts.outro(
+      `${entries.length} adapter${entries.length === 1 ? "" : "s"}`,
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// config remove
+// ---------------------------------------------------------------------------
+
+const ConfigRemoveCommand: CommandModule = {
+  command: "remove",
+  aliases: ["rm"],
+  describe: "Remove an adapter configuration",
+  handler: async () => {
+    const config = Config.load();
+    const adapters: Array<{ label: string; value: string }> = [];
+
+    if (config.telegram) adapters.push({ label: "Telegram", value: "telegram" });
+    if (config.github) adapters.push({ label: "GitHub", value: "github" });
+    if (config.discord) adapters.push({ label: "Discord", value: "discord" });
+
+    if (adapters.length === 0) {
+      prompts.log.info("No adapters configured.");
+      return;
+    }
+
+    prompts.intro("Remove adapter");
+
+    const selected = await prompts.select({
+      message: "Select adapter to remove",
+      options: adapters,
+    });
+    if (prompts.isCancel(selected)) cancel();
+
+    Config.removeAdapter(selected as keyof Config.Adapters);
+    prompts.outro(`${selected} configuration removed`);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// config (parent)
+// ---------------------------------------------------------------------------
+
+export const ConfigCommand: CommandModule = {
+  command: "config",
+  describe: "Manage adapter configurations",
+  builder: (yargs) =>
+    yargs
+      .command(ConfigAddCommand)
+      .command(ConfigListCommand)
+      .command(ConfigRemoveCommand)
+      .demandCommand(1, "Run a subcommand. Try --help for usage."),
+  handler: () => {},
+};

--- a/apps/cli/src/cmd/serve.ts
+++ b/apps/cli/src/cmd/serve.ts
@@ -1,0 +1,265 @@
+import type { CommandModule } from "yargs";
+import { Auth, Provider } from "@openomni/llm";
+import { Config } from "../config";
+import { SurfaceStore } from "../serve/surface-store";
+import { TelegramAdapter } from "../adapter/telegram";
+import { GitHubAdapter } from "../adapter/github";
+import { DiscordAdapter } from "../adapter/discord";
+import {
+  createMessageHandler,
+  type ConversationConfig,
+} from "../serve/conversation";
+import type { Adapter } from "../adapter/types";
+
+type ServeArgs = {
+  port: number;
+  host: string;
+  "telegram-token"?: string;
+  "github-secret"?: string;
+  "github-token"?: string;
+  "discord-token"?: string;
+  provider?: string;
+  model?: string;
+  system?: string;
+};
+
+async function resolveModel(
+  requestedProviderID?: string,
+  requestedModelID?: string,
+): Promise<Provider.Model> {
+  const credentials = await Auth.all();
+  const entries = Object.entries(credentials);
+
+  if (entries.length === 0) {
+    console.error("No credentials found. Run 'openomni auth login' first.");
+    process.exit(1);
+  }
+
+  const providerID = requestedProviderID ?? entries[0][0];
+  const auth = credentials[providerID];
+
+  if (!auth) {
+    console.error(`No credentials found for '${providerID}'.`);
+    process.exit(1);
+  }
+
+  const models = await Provider.listModels(providerID, auth.type);
+
+  if (models.length === 0) {
+    console.error(`No models found for provider '${providerID}'.`);
+    process.exit(1);
+  }
+
+  if (requestedModelID) {
+    const model = models.find((m) => m.id === requestedModelID);
+    if (!model) {
+      console.error(
+        `Model '${requestedModelID}' not found for '${providerID}'.`,
+      );
+      process.exit(1);
+    }
+    return model;
+  }
+
+  return models[0];
+}
+
+export const ServeCommand: CommandModule<object, ServeArgs> = {
+  command: "serve",
+  describe: "Start the OpenOmni server",
+  builder: (yargs) =>
+    yargs
+      .option("port", {
+        type: "number",
+        default: 3000,
+        describe: "HTTP server port",
+      })
+      .option("host", {
+        type: "string",
+        default: "127.0.0.1",
+        describe: "HTTP server bind address",
+      })
+      .option("telegram-token", {
+        type: "string",
+        describe: "Telegram bot token",
+      })
+      .option("github-secret", {
+        type: "string",
+        describe: "GitHub webhook secret",
+      })
+      .option("github-token", {
+        type: "string",
+        describe: "GitHub API token for posting comments",
+      })
+      .option("discord-token", {
+        type: "string",
+        describe: "Discord bot token",
+      })
+      .option("provider", {
+        alias: "p",
+        type: "string",
+        describe: "LLM provider ID",
+      })
+      .option("model", {
+        alias: "m",
+        type: "string",
+        describe: "Model ID",
+      })
+      .option("system", {
+        alias: "s",
+        type: "string",
+        describe: "System prompt",
+      }),
+  handler: async (argv) => {
+    // Secure sensitive files on boot
+    Config.secureAll();
+
+    // Restore surface key mappings from disk
+    SurfaceStore.initialize();
+
+    const model = await resolveModel(argv.provider, argv.model);
+    console.log(`Using model: ${model.providerID}/${model.id}`);
+
+    const conversationConfig: ConversationConfig = {
+      model,
+      system: argv.system,
+    };
+
+    // Shared message handler for all adapters
+    const handler = createMessageHandler(conversationConfig);
+
+    // -- Resolve adapter credentials: CLI args > env > config file --------
+
+    const adapterConfig = Config.load();
+
+    const telegramToken =
+      argv["telegram-token"] ??
+      process.env.OPENOMNI_TELEGRAM_TOKEN ??
+      adapterConfig.telegram?.token;
+
+    const githubSecret =
+      argv["github-secret"] ??
+      process.env.OPENOMNI_GITHUB_SECRET ??
+      adapterConfig.github?.secret;
+
+    const githubToken =
+      argv["github-token"] ??
+      process.env.OPENOMNI_GITHUB_TOKEN ??
+      adapterConfig.github?.token;
+
+    const discordToken =
+      argv["discord-token"] ??
+      process.env.OPENOMNI_DISCORD_TOKEN ??
+      adapterConfig.discord?.token;
+
+    // -- Start adapters ---------------------------------------------------
+
+    const adapters: Adapter.Surface[] = [];
+
+    if (telegramToken) {
+      const telegramAllowed = adapterConfig.telegram?.allowedUsers;
+      const telegram = new TelegramAdapter(telegramToken, {
+        triggers: [
+          ...(telegramAllowed
+            ? [{ type: "sender" as const, allow: telegramAllowed }]
+            : []),
+        ],
+        // TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
+        deliveryPolicy: "final",
+      });
+      telegram.onMessage(handler);
+      await telegram.start();
+      adapters.push(telegram);
+    }
+
+    let github: GitHubAdapter | undefined;
+    if (githubSecret) {
+      const githubAllowed = adapterConfig.github?.allowedUsers;
+      github = new GitHubAdapter(
+        githubSecret,
+        {
+          triggers: [
+            {
+              type: "event",
+              events: ["issue_comment.created", "issues.opened"],
+            },
+            ...(githubAllowed
+              ? [{ type: "sender" as const, allow: githubAllowed }]
+              : []),
+          ],
+          // TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
+          deliveryPolicy: "final",
+        },
+        githubToken,
+        adapterConfig.github?.botUsername,
+      );
+      github.onMessage(handler);
+      await github.start();
+      adapters.push(github);
+    }
+
+    if (discordToken) {
+      const discordAllowed = adapterConfig.discord?.allowedUsers;
+      const discord = new DiscordAdapter(discordToken, {
+        triggers: [
+          { type: "mention" },
+          ...(discordAllowed
+            ? [{ type: "sender" as const, allow: discordAllowed }]
+            : []),
+        ],
+        // TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
+        deliveryPolicy: "final",
+      });
+      discord.onMessage(handler);
+      await discord.start();
+      adapters.push(discord);
+    }
+
+    if (adapters.length === 0) {
+      console.log(
+        "No adapters configured. Run 'openomni config add' or pass tokens via CLI args.",
+      );
+      console.log("Server will start but won't process any messages.");
+    }
+
+    // -- HTTP server ------------------------------------------------------
+
+    const server = Bun.serve({
+      port: argv.port,
+      hostname: argv.host,
+      fetch: async (request) => {
+        const url = new URL(request.url);
+
+        if (url.pathname === "/health") {
+          return new Response("OK");
+        }
+
+        if (
+          url.pathname === "/github/webhook" &&
+          github &&
+          request.method === "POST"
+        ) {
+          return github.handleWebhook(request);
+        }
+
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    console.log(`Server listening on http://${argv.host}:${server.port}`);
+
+    // -- Graceful shutdown ------------------------------------------------
+
+    const shutdown = () => {
+      console.log("\nShutting down...");
+      for (const adapter of adapters) {
+        adapter.stop();
+      }
+      server.stop();
+      process.exit(0);
+    };
+
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  },
+};

--- a/apps/cli/src/config/index.ts
+++ b/apps/cli/src/config/index.ts
@@ -1,0 +1,135 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  chmodSync,
+} from "node:fs";
+import { z } from "zod";
+
+const CONFIG_PATH = join(homedir(), ".openomni", "config.json");
+
+const AdaptersSchema = z
+  .object({
+    telegram: z
+      .object({
+        token: z.string(),
+        allowedUsers: z.string().array().optional(),
+      })
+      .optional(),
+    github: z
+      .object({
+        secret: z.string(),
+        token: z.string().optional(),
+        botUsername: z.string().optional(),
+        allowedUsers: z.string().array().optional(),
+      })
+      .optional(),
+    discord: z
+      .object({
+        token: z.string(),
+        allowedUsers: z.string().array().optional(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export namespace Config {
+  export interface TelegramConfig {
+    token: string;
+    allowedUsers?: string[];
+  }
+
+  export interface GitHubConfig {
+    secret: string;
+    token?: string;
+    botUsername?: string;
+    allowedUsers?: string[];
+  }
+
+  export interface DiscordConfig {
+    token: string;
+    allowedUsers?: string[];
+  }
+
+  export interface Adapters {
+    telegram?: TelegramConfig;
+    github?: GitHubConfig;
+    discord?: DiscordConfig;
+  }
+
+  export function load(): Adapters {
+    if (!existsSync(CONFIG_PATH)) return {};
+    try {
+      const parsed = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+      const result = AdaptersSchema.safeParse(parsed);
+      if (!result.success) {
+        console.warn(
+          "[config] invalid config.json, ignoring:",
+          result.error.message,
+        );
+        return {};
+      }
+      return result.data;
+    } catch (err) {
+      console.warn(
+        "[config] failed to read config.json:",
+        err instanceof Error ? err.message : err,
+      );
+      return {};
+    }
+  }
+
+  export function save(config: Adapters): void {
+    const dir = join(homedir(), ".openomni");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", {
+      mode: 0o600,
+    });
+    secureFile(CONFIG_PATH);
+  }
+
+  export function setAdapter<K extends keyof Adapters>(
+    adapter: K,
+    value: NonNullable<Adapters[K]>,
+  ): void {
+    const config = load();
+    config[adapter] = value;
+    save(config);
+  }
+
+  export function removeAdapter(adapter: keyof Adapters): boolean {
+    const config = load();
+    if (!(adapter in config)) return false;
+    delete config[adapter];
+    save(config);
+    return true;
+  }
+
+  /** Mask a secret for display: show last 4 chars only. */
+  export function mask(value: string): string {
+    if (value.length <= 4) return "••••";
+    return "••••" + value.slice(-4);
+  }
+
+  /** Secure sensitive files to owner-only read/write (0600). */
+  export function secureFile(filePath: string): void {
+    try {
+      chmodSync(filePath, 0o600);
+    } catch {
+      // chmod may not be supported (e.g., Windows) — best-effort
+    }
+  }
+
+  /** Secure all sensitive files in ~/.openomni/ on boot. */
+  export function secureAll(): void {
+    const dir = join(homedir(), ".openomni");
+    const sensitiveFiles = ["config.json", "auth.json"];
+    for (const file of sensitiveFiles) {
+      const path = join(dir, file);
+      if (existsSync(path)) secureFile(path);
+    }
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,10 +1,22 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { ModelsDev } from "@openomni/llm";
+import { FileTaskStore, TaskStorage } from "@openomni/openomni";
+import { Storage } from "@openomni/session";
 import pkg from "../package.json";
 import { AuthCommand } from "./cmd/auth";
-import { ModelsDev } from "@openomni/llm";
+import { ConfigCommand } from "./cmd/config";
+import { ServeCommand } from "./cmd/serve";
 
 ModelsDev.init();
+Storage.initialize({ cwd: homedir() });
+
+const taskDir = join(homedir(), ".openomni", "tasks");
+mkdirSync(taskDir, { recursive: true });
+TaskStorage.configure(new FileTaskStore(taskDir));
 
 await yargs(hideBin(process.argv))
   .scriptName("openomni")
@@ -13,6 +25,8 @@ await yargs(hideBin(process.argv))
   .version("version", "Show version number", pkg.version)
   .alias("version", "v")
   .command(AuthCommand)
+  .command(ConfigCommand)
+  .command(ServeCommand)
   .demandCommand(1, "Run a command. Try --help for usage.")
   .strict()
   .parseAsync();

--- a/apps/cli/src/serve/conversation.ts
+++ b/apps/cli/src/serve/conversation.ts
@@ -1,0 +1,175 @@
+import { Session } from "@openomni/session";
+import { run, Provider } from "@openomni/llm";
+import { Message, type Sink } from "@openomni/protocol";
+import { SurfaceStore } from "./surface-store";
+import type { Adapter } from "../adapter/types";
+
+export interface ConversationConfig {
+  model: Provider.Model;
+  system?: string;
+}
+
+const LLM_TIMEOUT_MS = 120_000; // 2 minutes
+
+// ---------------------------------------------------------------------------
+// Message handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a message handler that routes inbound messages through the
+ * conversation pipeline: session resolution -> LLM -> response.
+ *
+ * Each handler instance maintains its own per-surface serialization queue
+ * to prevent history race conditions.
+ */
+export function createMessageHandler(
+  config: ConversationConfig,
+): Adapter.MessageHandler {
+  const queues = new Map<string, Promise<unknown>>();
+
+  return async (message) => {
+    // TODO: respect Adapter.Config.deliveryPolicy - currently always delivers final response only
+    const prev = queues.get(message.surfaceKey) ?? Promise.resolve();
+    const current = prev.then(() =>
+      processMessage(message.surfaceKey, message.text, config),
+    );
+    const tail = current.catch(() => {});
+    queues.set(message.surfaceKey, tail);
+
+    // Cleanup: remove queue entry when no more messages are pending
+    tail.then(() => {
+      if (queues.get(message.surfaceKey) === tail)
+        queues.delete(message.surfaceKey);
+    });
+
+    const text = await current;
+    return text ? { text } : null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Message processing (runs inside per-surface queue)
+// ---------------------------------------------------------------------------
+
+function createUserMessage(
+  sessionID: string,
+  model: Provider.Model,
+  text: string,
+): Message.WithParts {
+  const messageID = `msg-${crypto.randomUUID()}`;
+
+  return {
+    info: {
+      id: messageID,
+      sessionID,
+      role: "user" as const,
+      time: { created: Date.now() },
+      agent: "serve",
+      model: { providerID: model.providerID, modelID: model.id },
+    },
+    parts: [
+      {
+        id: `part-${crypto.randomUUID()}`,
+        sessionID,
+        messageID,
+        type: "text" as const,
+        text,
+      },
+    ],
+  };
+}
+
+function loadHistory(sessionID: string): Message.WithParts[] {
+  const messages = Session.getMessages(sessionID);
+  return messages.map((info) => ({
+    info,
+    parts: Session.getParts(info.id),
+  }));
+}
+
+async function processMessage(
+  surfaceKey: string,
+  text: string,
+  config: ConversationConfig,
+): Promise<string> {
+  // 1. Resolve or create session
+  let sessionId = SurfaceStore.lookup(surfaceKey);
+
+  if (!sessionId) {
+    const session = Session.create({
+      title: surfaceKey,
+      model: { providerID: config.model.providerID, modelID: config.model.id },
+    });
+    sessionId = session.id;
+    SurfaceStore.register(surfaceKey, sessionId);
+  }
+
+  // 2. Create and persist user message
+  const userMessage = createUserMessage(sessionId, config.model, text);
+  Session.addMessage(sessionId, userMessage.info);
+  for (const part of userMessage.parts) {
+    Session.addPart(userMessage.info.id, part);
+  }
+
+  // 3. Load full conversation history
+  const history = loadHistory(sessionId);
+
+  // 4. Call LLM with timeout
+  let assistantMessage: Message.WithParts | undefined;
+
+  const sink: Sink = {
+    onMessage(message) {
+      assistantMessage = message;
+    },
+    onToolCall() {},
+    onToolResult() {},
+    onSnapshot() {},
+  };
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+
+  let outcome;
+  try {
+    outcome = await run(
+      {
+        messages: history,
+        tools: [],
+        model: config.model,
+        system: config.system,
+        signal: controller.signal,
+      },
+      sink,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  // 5. Persist assistant response and extract text
+  let responseText = "";
+
+  if (assistantMessage) {
+    Session.addMessage(sessionId, assistantMessage.info);
+    for (const part of assistantMessage.parts) {
+      Session.addPart(assistantMessage.info.id, part);
+    }
+
+    responseText = assistantMessage.parts
+      .filter((p): p is Message.TextPart => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+  }
+
+  if (outcome.type === "error") {
+    const msg = outcome.error?.message ?? "Unknown error";
+    console.error(`[conversation] LLM error: ${msg}`);
+    return `Error: ${msg}`;
+  }
+
+  if (outcome.type === "aborted") {
+    console.error("[conversation] LLM call timed out");
+    return "Sorry, the request timed out. Please try again.";
+  }
+
+  return responseText || "(no response)";
+}

--- a/apps/cli/src/serve/dedupe.ts
+++ b/apps/cli/src/serve/dedupe.ts
@@ -1,0 +1,51 @@
+/**
+ * Time-windowed message deduplication.
+ *
+ * Tracks seen message/event IDs and rejects duplicates within the
+ * configured time window. Used by adapters to handle platform retries
+ * (Telegram re-delivery, Discord RESUME replays, GitHub webhook resends).
+ */
+export class Dedupe {
+  private readonly seen = new Map<string, number>();
+  private readonly maxAge: number;
+  private readonly maxSize: number;
+  private ops = 0;
+
+  constructor(maxAge = 5 * 60_000, maxSize = 10_000) {
+    this.maxAge = maxAge;
+    this.maxSize = maxSize;
+  }
+
+  /** Returns true if this ID was already seen (skip processing). */
+  isDuplicate(id: string): boolean {
+    // Prune every 100 operations to amortize cost
+    if (++this.ops >= 100) {
+      this.ops = 0;
+      this.prune();
+    }
+
+    const existing = this.seen.get(id);
+    if (existing !== undefined) {
+      // Allow re-processing if the previous entry has expired
+      if (Date.now() - existing > this.maxAge) {
+        this.seen.set(id, Date.now());
+        return false;
+      }
+      return true;
+    }
+    this.seen.set(id, Date.now());
+    return false;
+  }
+
+  private prune(): void {
+    const cutoff = Date.now() - this.maxAge;
+    for (const [id, time] of this.seen) {
+      if (time < cutoff) this.seen.delete(id);
+    }
+
+    while (this.seen.size > this.maxSize) {
+      const oldest = this.seen.keys().next().value;
+      if (oldest !== undefined) this.seen.delete(oldest);
+    }
+  }
+}

--- a/apps/cli/src/serve/surface-store.ts
+++ b/apps/cli/src/serve/surface-store.ts
@@ -1,0 +1,84 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { SurfaceKey, Session } from "@openomni/session";
+
+const STORE_PATH = join(homedir(), ".openomni", "surface-keys.json");
+
+/**
+ * Persistent wrapper around in-memory SurfaceKey.
+ *
+ * On boot, restores surfaceKey->sessionId mappings from disk into the
+ * in-memory index (validating each session still exists). On register,
+ * writes through to both memory and disk.
+ */
+export namespace SurfaceStore {
+  export function initialize(): void {
+    const mappings = load();
+    let restored = 0;
+
+    for (const [key, sessionId] of Object.entries(mappings)) {
+      const session = Session.get(sessionId);
+      if (session) {
+        SurfaceKey.register(key, sessionId);
+        restored++;
+      }
+    }
+
+    // Save cleaned mappings (remove stale entries)
+    if (restored < Object.keys(mappings).length) {
+      const cleaned: Record<string, string> = {};
+      for (const [key, sessionId] of Object.entries(mappings)) {
+        if (Session.get(sessionId)) {
+          cleaned[key] = sessionId;
+        }
+      }
+      save(cleaned);
+    }
+
+    if (restored > 0) {
+      console.log(`[surface] Restored ${restored} surface key mapping(s)`);
+    }
+  }
+
+  export function register(key: string, sessionId: string): void {
+    SurfaceKey.register(key, sessionId);
+    const mappings = load();
+    mappings[key] = sessionId;
+    save(mappings);
+  }
+
+  export function lookup(key: string): string | undefined {
+    return SurfaceKey.lookup(key);
+  }
+
+  function load(): Record<string, string> {
+    if (!existsSync(STORE_PATH)) return {};
+    try {
+      return JSON.parse(readFileSync(STORE_PATH, "utf-8"));
+    } catch {
+      return {};
+    }
+  }
+
+  function save(mappings: Record<string, string>): void {
+    const tmpPath = STORE_PATH + ".tmp";
+    try {
+      mkdirSync(join(homedir(), ".openomni"), { recursive: true });
+      writeFileSync(tmpPath, JSON.stringify(mappings, null, 2) + "\n");
+      renameSync(tmpPath, STORE_PATH);
+    } catch (err) {
+      try {
+        unlinkSync(tmpPath);
+      } catch {}
+      throw err;
+    }
+  }
+}

--- a/apps/cli/src/serve/trigger.ts
+++ b/apps/cli/src/serve/trigger.ts
@@ -1,0 +1,84 @@
+import type { Adapter } from "../adapter/types";
+
+/**
+ * Evaluate all trigger rules against a context.
+ * Returns true if the message should be processed.
+ *
+ * - Empty rules array = always pass (no filtering).
+ * - AND logic: every rule must pass.
+ */
+export function evaluateTriggers(
+  rules: Adapter.TriggerRule[],
+  ctx: Adapter.TriggerContext,
+): boolean {
+  if (rules.length === 0) return true;
+  return rules.every((rule) => evaluateRule(rule, ctx));
+}
+
+function evaluateRule(
+  rule: Adapter.TriggerRule,
+  ctx: Adapter.TriggerContext,
+): boolean {
+  switch (rule.type) {
+    case "event":
+      return rule.events.includes(ctx.event);
+
+    case "mention":
+      // DMs always pass the mention check
+      return ctx.isDM === true || ctx.mentioned;
+
+    case "prefix":
+      return ctx.text.startsWith(rule.value);
+
+    case "label":
+      if (!ctx.labels || ctx.labels.length === 0) return false;
+      return rule.values.some((v) => ctx.labels!.includes(v));
+
+    case "channel":
+      if (!ctx.channelId) return ctx.isDM === true;
+      return rule.ids.includes(ctx.channelId);
+
+    case "sender":
+      if (rule.deny?.includes(ctx.senderId)) return false;
+      if (rule.allow && rule.allow.length > 0) {
+        return rule.allow.includes(ctx.senderId);
+      }
+      return true;
+  }
+}
+
+/**
+ * Strip trigger-related prefixes from message text.
+ * Call after trigger evaluation passes.
+ */
+export function stripTriggerPrefix(
+  text: string,
+  rules: Adapter.TriggerRule[],
+): string {
+  const prefix = rules.find(
+    (r): r is Extract<Adapter.TriggerRule, { type: "prefix" }> =>
+      r.type === "prefix",
+  );
+  if (prefix) {
+    return text.slice(prefix.value.length).trim();
+  }
+  return text;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function normalizeContent(
+  text: string,
+  rules: Adapter.TriggerRule[],
+  botUsername?: string,
+): string {
+  let result = stripTriggerPrefix(text, rules);
+  if (botUsername) {
+    result = result
+      .replace(new RegExp(`@${escapeRegex(botUsername)}\\s*`, "g"), "")
+      .trim();
+  }
+  return result;
+}

--- a/apps/cli/src/serve/utils.ts
+++ b/apps/cli/src/serve/utils.ts
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// Shared adapter utilities
+// ---------------------------------------------------------------------------
+
+/** Promise-based sleep. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Split text into chunks respecting a max length, preferring line boundaries.
+ * Falls back to hard-split when no suitable newline is found.
+ */
+export function splitText(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+
+    let splitAt = remaining.lastIndexOf("\n", maxLength);
+    if (splitAt < maxLength / 2) {
+      splitAt = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+
+  return chunks;
+}
+
+const MAX_API_RETRIES = 3;
+
+/**
+ * Fetch with automatic 429 retry and bounded retries.
+ * Throws after MAX_API_RETRIES consecutive rate-limit responses.
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  options?: {
+    /** Extract retry-after seconds from the 429 response body. Default: 5s. */
+    parseRetryAfter?: (body: unknown) => number;
+    retries?: number;
+    label?: string;
+  },
+): Promise<Response> {
+  const retries = options?.retries ?? 0;
+  const label = options?.label ?? url;
+
+  const response = await fetch(url, init);
+
+  if (response.status === 429) {
+    if (retries >= MAX_API_RETRIES) {
+      throw new Error(
+        `${label}: rate limited after ${MAX_API_RETRIES} retries`,
+      );
+    }
+
+    let retryAfter = 5;
+    if (options?.parseRetryAfter) {
+      try {
+        const body = await response.json();
+        retryAfter = options.parseRetryAfter(body);
+      } catch {
+        // fallback to default
+      }
+    }
+
+    console.warn(
+      `[${label}] Rate limited, retrying in ${retryAfter}s (${retries + 1}/${MAX_API_RETRIES})`,
+    );
+    await sleep(retryAfter * 1000);
+
+    return fetchWithRetry(url, init, {
+      ...options,
+      retries: retries + 1,
+    });
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Summary

- Add multi-platform adapter system (`serve` command) with Telegram, GitHub, and Discord support
- Add `config` command for persistent adapter credential storage
- Port adapter code from prototype branch with quality and security improvements applied

## Architecture

```
apps/cli/src/
├── adapter/                  # Platform adapters only
│   ├── types.ts              # Adapter.Surface interface, TriggerRule, InboundMessage
│   ├── telegram.ts           # Long polling + sendMessage API
│   ├── github.ts             # Webhook + HMAC-SHA256 signature verification
│   └── discord.ts            # Gateway WebSocket + heartbeat + reconnect
├── serve/                    # Shared serve utilities
│   ├── conversation.ts       # Message handler factory: surfaceKey → session → LLM → response
│   ├── dedupe.ts             # Message deduplication (TTL + LRU eviction)
│   ├── surface-store.ts      # Persistent surface key ↔ session mapping
│   ├── trigger.ts            # Composable TriggerRule evaluation engine
│   └── utils.ts              # fetchWithRetry, splitText, sleep
├── cmd/
│   ├── serve.ts              # serve command — boots adapters + HTTP server
│   └── config.ts             # config add|remove|list — credential management
└── config/
    └── index.ts              # ~/.openomni/config.json persistence + Zod validation
```

## Quality improvements over prototype

| Issue | Fix |
|---|---|
| GitHub API calls had no retry | `fetchWithRetry()` with backoff |
| Typing indicator errors silently swallowed | Logged with adapter context |
| Config loading had no schema validation | Zod `safeParse()` with warning on invalid |
| Dedupe eviction was random order | LRU (oldest-first via Map insertion order) |
| GitHub processEvent errors lacked context | Logs event type + surface key on failure |
| Expired IDs still blocked in dedupe | Expiry check on lookup before rejection |
| Config JSON parse error silently swallowed | Now logs parse error before returning defaults |
| Config file briefly world-readable (TOCTOU) | `writeFileSync` with `mode: 0o600` from creation |
| Discord double reconnect on INVALID_SESSION | Removed `setTimeout` block, close handler manages reconnection |
| GitHub API missing User-Agent header (403) | Added `User-Agent: openomni-cli` header |
| Shebang used node but project requires Bun | Updated to `#!/usr/bin/env bun` |

## Usage

```bash
openomni serve --telegram-token TOKEN
openomni serve --github-secret SECRET --github-token TOKEN
openomni serve --discord-token TOKEN
openomni serve -p anthropic -m claude-sonnet-4-20250514
openomni config add     # interactive credential setup
openomni config list    # show configured adapters
```

## Notes

- Ported from `feat/cli-prototype` branch — adapter code only, no architectural changes
- `apps/cli` is not in workspace scope, so tsc type checking is not included in `turbo check-types` (pre-existing)
- All package-level type checks pass (5/5)