### PR TITLE
feat(openomni): Plan Mode + Team Mode — multi-agent execution pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ protocol  ←  session  ←  llm  ←  agent (pure ReAct)  ←  openomni (orches
 | Provider SDK wiring          | `packages/llm/src/provider/provider.ts`               | `getSDK()` function                                                  |
 | Model catalog                | `packages/llm/src/model/`                             | Fetches from models.dev                                              |
 | ChatAgent (stateless ReAct) | `packages/agent/src/chat-agent.ts`                    | create(), run(), stream() stub                                       |
+| Plan Mode (PlanAgent)        | `packages/openomni/src/plan/`                         | PlanAgent.generate(goal, config) → PlanResult; LLM-based, no exec   |
+| Team Mode (TeamOrchestrator) | `packages/openomni/src/team/`                         | TeamOrchestrator.execute(plan, config) → TeamResult; deterministic   |
+| DAG utilities                | `packages/openomni/src/dag/`                          | Pure functions: build, validateAcyclic, getReady, complete           |
+| Plan/Team schemas            | `packages/protocol/src/plan/` + `src/team/`           | Plan, PlanStep, PlanResult; Team.StepState, StallReason, 10 events  |
 | Agent profile/graph          | `packages/openomni/src/legacy/agent/`                 | Graph validation, routing, messaging                                 |
 | Task lifecycle               | `packages/openomni/src/legacy/task/`                  | State machine, manager, checkpoint, recovery                         |
 | Orchestration loop           | `packages/openomni/src/legacy/`                       | Envelope → Router → Dispatcher → Supervisor                          |
@@ -107,3 +111,5 @@ openomni agent --mode orchestrated   # full pipeline
 - `@ai-sdk/anthropic` and `@ai-sdk/openai` are the two bundled providers. New providers via `@ai-sdk/openai-compatible` fallback.
 - `packages/agent` is now a pure ChatAgent primitive — stateless, no session dependency. Use `@openomni/agent` for the ReAct loop.
 - `packages/openomni` contains all legacy orchestration code (moved as-is from packages/agent in Phase 1). Use `@openomni/openomni` for RunWorker, TaskManager, IngressEngine, etc.
+- **Plan Mode** (`PlanAgent`) and **Team Mode** (`TeamOrchestrator`) are now implemented in `packages/openomni/src/plan/` and `packages/openomni/src/team/`. Plan Mode generates a structured `Plan` via LLM; Team Mode executes it with a deterministic dispatch loop (LLM used only in ReviewLoop).
+- Plan/Team protocol types live in `packages/protocol/src/plan/` and `packages/protocol/src/team/` — 4 Plan schemas + 4 Team types + 10 BusEvents.

--- a/packages/agent/src/chat-agent.ts
+++ b/packages/agent/src/chat-agent.ts
@@ -134,7 +134,26 @@ function toMessagesWithParts(
 async function executeTools(
   calls: Tool.Call[],
   _specs: Tool.Spec[],
+  config?: ChatAgentConfig,
 ): Promise<Tool.Result[]> {
+  if (config?.toolExecutor) {
+    const results: Tool.Result[] = [];
+    for (const call of calls) {
+      try {
+        const result = await config.toolExecutor(call);
+        results.push(result);
+      } catch (error) {
+        results.push({
+          id: crypto.randomUUID(),
+          toolCallId: call.id,
+          output: error instanceof Error ? error.message : String(error),
+          isError: true,
+        });
+      }
+    }
+    return results;
+  }
+
   return calls.map((call) => ({
     id: crypto.randomUUID(),
     toolCallId: call.id,
@@ -326,6 +345,7 @@ export namespace ChatAgent {
               const toolResults = await executeTools(
                 outcome.toolCalls,
                 config.tools ?? [],
+                config,
               );
               const elapsed = Date.now() - toolStart;
               const perToolMs =

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -31,6 +31,7 @@ export interface ChatAgentConfig {
   };
   budget?: AgentBudget;
   onStepFinish?: (step: AgentStep) => void | Promise<void>;
+  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
   signal?: AbortSignal;
 }
 

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -254,3 +254,107 @@ describe("ChatAgent", () => {
     expect(content.includes(forbiddenImport)).toBe(false);
   });
 });
+
+  it("uses toolExecutor when provided to execute tool calls", async () => {
+    let callCount = 0;
+    mockRunFn = async (_input, sink): Promise<Run.Outcome> => {
+      callCount += 1;
+      if (callCount === 1) {
+        const call = createToolCall("call-1", "custom_tool");
+        sink.onToolCall(call);
+        return createToolCallOutcome([call]);
+      }
+
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const toolExecutorCalls: Tool.Call[] = [];
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      toolExecutor: async (call) => {
+        toolExecutorCalls.push(call);
+        return {
+          id: crypto.randomUUID(),
+          toolCallId: call.id,
+          output: "real result from executor",
+          isError: false,
+        };
+      },
+    });
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: "Use a tool" }],
+    });
+
+    expect(toolExecutorCalls).toHaveLength(1);
+    expect(toolExecutorCalls[0]?.tool).toBe("custom_tool");
+    expect(result.steps.some((step) => step.type === "tool-call")).toBe(true);
+    const toolStep = result.steps.find((step) => step.type === "tool-call");
+    expect(toolStep?.toolResults?.[0]?.output).toBe("real result from executor");
+  });
+
+  it("handles toolExecutor errors by setting isError: true", async () => {
+    let callCount = 0;
+    mockRunFn = async (_input, sink): Promise<Run.Outcome> => {
+      callCount += 1;
+      if (callCount === 1) {
+        const call = createToolCall("call-1", "failing_tool");
+        sink.onToolCall(call);
+        return createToolCallOutcome([call]);
+      }
+
+      sink.onMessage(createAssistantMessage("handled error"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      toolExecutor: async (call) => {
+        throw new Error("Tool execution failed: database connection lost");
+      },
+    });
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: "Use a tool" }],
+    });
+
+    const toolStep = result.steps.find((step) => step.type === "tool-call");
+    expect(toolStep?.toolResults).toHaveLength(1);
+    expect(toolStep?.toolResults?.[0]?.isError).toBe(true);
+    expect(toolStep?.toolResults?.[0]?.output).toContain(
+      "Tool execution failed",
+    );
+  });
+
+  it("preserves stub behavior when toolExecutor is not provided", async () => {
+    let callCount = 0;
+    mockRunFn = async (_input, sink): Promise<Run.Outcome> => {
+      callCount += 1;
+      if (callCount === 1) {
+        const call = createToolCall("call-1", "stub_tool");
+        sink.onToolCall(call);
+        return createToolCallOutcome([call]);
+      }
+
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      // No toolExecutor provided
+    });
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: "Use a tool" }],
+    });
+
+    const toolStep = result.steps.find((step) => step.type === "tool-call");
+    expect(toolStep?.toolResults).toHaveLength(1);
+    expect(toolStep?.toolResults?.[0]?.output).toContain(
+      "Tool 'stub_tool' executed (no executor configured)",
+    );
+    expect(toolStep?.toolResults?.[0]?.isError).toBe(false);
+  });
+

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -1,12 +1,23 @@
 # packages/openomni
 
-Orchestration package. Contains all legacy agent code migrated from `packages/agent` in Phase 1 of the agent architecture redesign.
+Orchestration package. Contains legacy agent code (Phase 1 migration) plus the new Plan Mode and Team Mode architecture.
 
 ## STRUCTURE
 
 ```
 src/
-├── index.ts          # Public API — re-exports all legacy modules
+├── index.ts          # Public API — re-exports all modules
+├── dag/              # DAG utilities (pure functions)
+│   └── index.ts      # DAG.build, DAG.validateAcyclic, DAG.getReady, DAG.complete
+├── plan/             # Plan Mode — LLM-based plan generation
+│   └── plan-agent.ts # PlanAgent.generate(goal, config) → PlanResult
+├── team/             # Team Mode — deterministic step dispatch
+│   ├── index.ts      # Team module barrel
+│   ├── team-orchestrator.ts  # TeamOrchestrator.execute(plan, config) → TeamResult
+│   ├── teammate.ts   # Teammate.execute(input, config) → ExecuteResult
+│   ├── review-loop.ts        # ReviewLoop.review() — LLM accept/reject
+│   ├── stall-detector.ts     # StallDetector.check() — stall detection
+│   └── run-ledger.ts         # RunLedger.create() — in-memory step state
 └── legacy/           # All 10 domains migrated as-is from packages/agent
     ├── index.ts      # Legacy barrel — re-exports all 10 domains
     ├── agent/        # Agent identity, registry, messaging
@@ -23,18 +34,20 @@ src/
 
 ## MIGRATION STATUS
 
-**Phase 1 (current)**: Code moved as-is from `packages/agent`. No refactoring.
-**Phase 2 (future)**: Add Plan/Team/Router/Memory layers. Refactor legacy code.
+**Phase 1 (complete)**: Code moved as-is from `packages/agent`. No refactoring.
+**Phase 2 (complete)**: Plan Mode (`src/plan/`) and Team Mode (`src/team/`) implemented.
 
 ## USAGE
 
 ```typescript
 import { RunWorker, TaskManager, IngressEngine } from "@openomni/openomni";
+import { PlanAgent } from "@openomni/openomni";
+import { TeamOrchestrator } from "@openomni/openomni";
 ```
 
-All exports from the legacy agent code are available via `@openomni/openomni`.
-
 ## KEY EXPORTS
+
+### Legacy (Phase 1)
 
 - **RunWorker** — LLM/tool loop execution primitive
 - **TaskManager** — Task lifecycle management
@@ -43,9 +56,376 @@ All exports from the legacy agent code are available via `@openomni/openomni`.
 - **ExecutionSupervisor** — DAG execution engine
 - **BuiltinAgentRegistry** — Agent registry and lookup
 
+### Plan Mode (Phase 2)
+
+- **PlanAgent** — LLM-based plan generation (does NOT execute)
+- **DAG** — Pure DAG utilities (build, validate, schedule)
+
+### Team Mode (Phase 2)
+
+- **TeamOrchestrator** — Deterministic step dispatch loop
+- **Teammate** — Wraps ChatAgent for step execution
+- **ReviewLoop** — LLM-based accept/reject for step results
+- **StallDetector** — Detects consecutive rejections, no progress, unsatisfiable deps
+- **RunLedger** — In-memory step state tracking
+
+---
+
+## PLAN MODE
+
+### Architecture
+
+`PlanAgent.generate(goal, config)` calls an LLM to produce a structured `Plan` with steps and DAG dependencies. It does **not** execute the plan — that is Team Mode's job.
+
+```
+goal (string)
+  └─→ PlanAgent.generate()
+        └─→ ChatAgent (LLM call)
+              └─→ JSON parse + Zod validate
+                    └─→ PlanResult { plan }
+```
+
+### PlanAgent API
+
+```typescript
+namespace PlanAgent {
+  interface GenerateConfig {
+    model: { provider: string; id: string };
+    systemPrompt?: string; // Override default planning prompt
+    reviewPrompt?: string; // Appended to system prompt
+    budget?: AgentBudget;
+  }
+
+  async function generate(
+    goal: string,
+    config: GenerateConfig,
+  ): Promise<PlanResult>;
+}
+```
+
+**Usage example:**
+
+```typescript
+import { PlanAgent } from "@openomni/openomni";
+
+const result = await PlanAgent.generate(
+  "Build a REST API for user management",
+  {
+    model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
+  },
+);
+
+console.log(result.plan.steps); // PlanStep[]
+```
+
+### Plan Schema (from `@openomni/protocol`)
+
+```typescript
+type PlanStep = {
+  stepId: string;
+  description: string;
+  expectedOutput: string;
+  dependsOn: string[]; // stepIds this step depends on
+  suggestedAgent?: string; // hint for TeamOrchestrator teammate routing
+  guardrail?: string; // acceptance criteria for ReviewLoop
+  tools?: Tool.Spec[];
+};
+
+type Plan = {
+  planId: string;
+  goal: string;
+  steps: PlanStep[];
+  createdAt: Date;
+  version: number;
+};
+
+type PlanResult = {
+  plan: Plan;
+  reviewNotes?: string;
+};
+```
+
+---
+
+## TEAM MODE
+
+### Architecture
+
+`TeamOrchestrator.execute(plan, config)` is a **deterministic dispatch loop** — the Lead is NOT LLM-based. LLM is used ONLY in `ReviewLoop` for accept/reject decisions.
+
+```
+Plan
+  └─→ TeamOrchestrator.execute()
+        ├─→ DAG.build() + DAG.validateAcyclic()
+        ├─→ RunLedger.create()
+        └─→ dispatch loop:
+              ├─→ DAG.getReady() → ready steps
+              ├─→ Teammate.execute() → step output
+              ├─→ ReviewLoop.review() → accept | reject
+              │     ├─→ accept: ledger.transition("succeeded"), DAG.complete()
+              │     └─→ reject: retry or fail, skipDependents()
+              ├─→ StallDetector.check() → stall detection
+              └─→ Bus.publish() → fire-and-forget events
+```
+
+### TeamOrchestrator API
+
+```typescript
+namespace TeamOrchestrator {
+  interface OrchestratorConfig {
+    reviewModel: { provider: string; id: string };
+    reviewSystemPrompt?: string;
+    teammates: Map<string, Teammate.TeammateConfig>; // keyed by agentId
+    defaultTeammateConfig: Teammate.TeammateConfig;
+    stallConfig?: StallDetector.StallConfig;
+    maxAttemptsPerStep?: number; // default: 3
+  }
+
+  interface TeamResult {
+    status: "completed" | "stalled" | "failed";
+    completedSteps: string[];
+    failedSteps: string[];
+    skippedSteps: string[];
+    stallReason?: Team.StallReason;
+    results: Map<string, string>; // stepId → output text
+  }
+
+  async function execute(
+    plan: Plan,
+    config: OrchestratorConfig,
+  ): Promise<TeamResult>;
+}
+```
+
+**Usage example:**
+
+```typescript
+import { PlanAgent, TeamOrchestrator } from "@openomni/openomni";
+
+// 1. Generate plan
+const { plan } = await PlanAgent.generate("Build a REST API", {
+  model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
+});
+
+// 2. Execute plan
+const result = await TeamOrchestrator.execute(plan, {
+  reviewModel: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
+  teammates: new Map(),
+  defaultTeammateConfig: {
+    agentId: "default",
+    model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
+  },
+});
+
+console.log(result.status); // "completed" | "stalled" | "failed"
+console.log(result.completedSteps); // string[]
+console.log(result.results); // Map<stepId, output>
+```
+
+### Teammate API
+
+```typescript
+namespace Teammate {
+  interface TeammateConfig {
+    agentId: string;
+    model: { provider: string; id: string };
+    systemPrompt?: string;
+    tools?: Tool.Spec[];
+    budget?: ChatAgentConfig["budget"];
+    toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  }
+
+  interface ExecuteInput {
+    step: PlanStep;
+    context?: string; // Output from dependency steps
+    handoffDocument?: string; // Handoff from previous failed attempt
+  }
+
+  interface ExecuteResult {
+    agentId: string;
+    stepId: string;
+    output: string;
+    usage: TokenUsage;
+    finishReason: string;
+  }
+
+  async function execute(
+    input: ExecuteInput,
+    config: TeammateConfig,
+  ): Promise<ExecuteResult>;
+}
+```
+
+**Key constraint**: Each `execute()` call creates a **fresh ChatAgent instance** — no cross-step state.
+
+### ReviewLoop API
+
+```typescript
+namespace ReviewLoop {
+  interface ReviewConfig {
+    model: { provider: string; id: string };
+    systemPrompt?: string;
+    budget?: AgentBudget;
+  }
+
+  interface ReviewInput {
+    step: PlanStep;
+    result: string;
+    agentId: string;
+    attemptNumber: number;
+  }
+
+  interface ReviewOutput {
+    decision: "accept" | "reject";
+    feedback?: string;
+    handoffDocument?: string;
+  }
+
+  async function review(
+    input: ReviewInput,
+    config: ReviewConfig,
+  ): Promise<ReviewOutput>;
+  function shouldHandoff(attemptNumber: number, maxAttempts: number): boolean;
+  async function generateHandoff(
+    input: ReviewInput,
+    rejectionFeedback: string,
+    config: ReviewConfig,
+  ): Promise<string>;
+}
+```
+
+**Key constraint**: ReviewLoop is the **only place LLM is used** in Team Mode execution. The orchestrator dispatch loop itself is deterministic.
+
+### StallDetector API
+
+```typescript
+namespace StallDetector {
+  interface StallConfig {
+    maxConsecutiveRejections: number; // default: 3
+    maxNoProgressTurns: number; // default: 5
+  }
+
+  interface StallResult {
+    stalled: boolean;
+    reason?: Team.StallReason; // "consecutive_rejections" | "no_progress" | "unsatisfiable_deps"
+    details?: string;
+    stalledStepId?: string;
+  }
+
+  function check(
+    ledger: RunLedgerInstance,
+    dag: DAGStructure,
+    config: StallConfig,
+    noProgressTurns: number,
+  ): StallResult;
+  function checkConsecutiveRejections(
+    ledger: RunLedgerInstance,
+    config: StallConfig,
+  ): StallResult;
+  function checkNoProgress(
+    ledger: RunLedgerInstance,
+    dag: DAGStructure,
+    config: StallConfig,
+    noProgressTurns: number,
+  ): StallResult;
+  function checkUnsatisfiableDeps(
+    ledger: RunLedgerInstance,
+    dag: DAGStructure,
+  ): StallResult;
+}
+```
+
+**Priority order**: `consecutive_rejections` > `unsatisfiable_deps` > `no_progress`.
+
+### RunLedger API
+
+```typescript
+// Factory function — returns RunLedgerInstance
+namespace RunLedger {
+  function create(steps: PlanStep[]): RunLedgerInstance;
+}
+
+interface RunLedgerInstance {
+  transition(stepId: string, state: Team.StepState): void;
+  recordAttempt(stepId: string): void;
+  recordRejection(stepId: string): void;
+  resetRejectionStreak(stepId: string): void;
+  getState(): Map<string, RunLedgerEntry>;
+  getStepState(stepId: string): RunLedgerEntry | undefined;
+  getRunning(): RunLedgerEntry[];
+  getCompleted(): RunLedgerEntry[];
+}
+```
+
+**Valid transitions**: `ready → running → succeeded | failed`. `skipped` is a special case (any state → skipped).
+
+---
+
+## DAG UTILITIES
+
+Pure functions for DAG build, validation, and scheduling. No mutation of inputs.
+
+```typescript
+namespace DAG {
+  function build(steps: PlanStep[]): DAGStructure;
+  function validateAcyclic(
+    dag: DAGStructure,
+  ): { valid: true } | { valid: false; cycle: string[] };
+  function getReady(dag: DAGStructure, completed: Set<string>): string[];
+  function complete(
+    dag: DAGStructure,
+    stepId: string,
+    completed: Set<string>,
+  ): { newlyReady: string[] };
+}
+
+interface DAGStructure {
+  nodes: Set<string>;
+  edges: Map<string, Set<string>>; // stepId → deps
+  reverseEdges: Map<string, Set<string>>; // stepId → dependents
+  pendingDeps: Map<string, number>; // stepId → initial dep count
+}
+```
+
+**Algorithm**: Kahn's algorithm for cycle detection. `getReady()` derives readiness from `completed` set (pure, no mutation).
+
+---
+
+## TEAM EVENTS (fire-and-forget)
+
+`TeamOrchestrator` publishes 9 `Bus` events during execution. All are **fire-and-forget** (`void Bus.publish(...)`) — errors do NOT propagate to the orchestrator.
+
+| Event                | When published                               | Payload                                                     |
+| -------------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| `plan.created`       | After DAG validation, before loop            | `planId, goal, stepCount`                                   |
+| `step.assigned`      | When step assigned to teammate               | `planId, stepId, agentId`                                   |
+| `step.started`       | Before `Teammate.execute()`                  | `planId, stepId, agentId, attempt`                          |
+| `review.decision`    | After `ReviewLoop.review()`                  | `planId, stepId, decision, feedback?`                       |
+| `step.completed`     | When review accepts                          | `planId, stepId, result`                                    |
+| `step.failed`        | Max attempts reached or execution throws     | `planId, stepId, error`                                     |
+| `step.handoff`       | When `ReviewLoop.shouldHandoff()` is true    | `planId, stepId, from, to, handoffDocument`                 |
+| `stall.detected`     | When `StallDetector.check()` returns stalled | `planId, reason, details`                                   |
+| `execution.complete` | At end of `execute()`                        | `planId, status, completedSteps, failedSteps, skippedSteps` |
+
+---
+
+## ARCHITECTURAL DECISIONS
+
+- **Deterministic Lead**: `TeamOrchestrator` dispatch loop is pure logic — no LLM calls. Only `ReviewLoop` uses LLM.
+- **LLM only in ReviewLoop**: Keeps orchestration predictable and testable. ReviewLoop is the single LLM boundary.
+- **Fire-and-forget events**: Bus events are observability hooks, not control flow. Errors in publishing don't affect execution.
+- **No persistence**: `RunLedger` is in-memory only. No checkpointing or recovery in V1.
+- **No concurrency**: Sequential step dispatch in V1. Steps execute one at a time even if multiple are ready.
+- **No dynamic step insertion**: Plan is fixed at `execute()` call time. No mid-execution replanning.
+- **No peer messaging**: Teammates don't communicate directly. Context flows via `results` map through `buildContext()`.
+- **Fresh agent per step**: `Teammate.execute()` creates a new `ChatAgent` instance per call — no cross-step session state.
+
+---
+
 ## NOTES
 
 - This package depends on `@openomni/agent` for ChatAgent (the pure ReAct primitive).
 - Legacy code in `src/legacy/` was moved as-is — it still uses `@openomni/session` internally.
 - Do NOT import from `src/legacy/` directly — use the package barrel (`@openomni/openomni`).
 - For the pure ChatAgent primitive (stateless, no session), use `@openomni/agent` instead.
+- Plan Mode and Team Mode are V1 implementations — sequential, in-memory, no persistence.

--- a/packages/openomni/src/dag/index.ts
+++ b/packages/openomni/src/dag/index.ts
@@ -1,0 +1,222 @@
+import type { PlanStep } from "@openomni/protocol";
+
+export interface DAGStructure {
+  nodes: Set<string>;
+  edges: Map<string, Set<string>>;
+  reverseEdges: Map<string, Set<string>>;
+  pendingDeps: Map<string, number>;
+}
+
+type AcyclicResult = { valid: true } | { valid: false; cycle: string[] };
+
+export namespace DAG {
+  export function build(steps: PlanStep[]): DAGStructure {
+    const nodes = new Set<string>();
+    const edges = new Map<string, Set<string>>();
+    const reverseEdges = new Map<string, Set<string>>();
+    const pendingDeps = new Map<string, number>();
+
+    for (const step of steps) {
+      if (nodes.has(step.stepId)) {
+        throw new Error(`Duplicate step id: ${step.stepId}`);
+      }
+
+      nodes.add(step.stepId);
+      edges.set(step.stepId, new Set(step.dependsOn));
+      reverseEdges.set(step.stepId, new Set());
+      pendingDeps.set(step.stepId, step.dependsOn.length);
+    }
+
+    for (const step of steps) {
+      for (const dependencyId of step.dependsOn) {
+        if (!nodes.has(dependencyId)) {
+          throw new Error(
+            `Step "${step.stepId}" depends on unknown step "${dependencyId}"`,
+          );
+        }
+
+        const dependents = reverseEdges.get(dependencyId);
+        if (!dependents) {
+          continue;
+        }
+
+        dependents.add(step.stepId);
+      }
+    }
+
+    return {
+      nodes,
+      edges,
+      reverseEdges,
+      pendingDeps,
+    };
+  }
+
+  export function validateAcyclic(dag: DAGStructure): AcyclicResult {
+    const inDegree = new Map<string, number>(dag.pendingDeps.entries());
+    const queue: string[] = [];
+
+    for (const nodeId of dag.nodes) {
+      const degree = inDegree.get(nodeId) ?? 0;
+      if (degree === 0) {
+        queue.push(nodeId);
+      }
+    }
+
+    let visited = 0;
+
+    while (queue.length > 0) {
+      const nodeId = queue.shift();
+      if (!nodeId) {
+        continue;
+      }
+
+      visited += 1;
+      const dependents = dag.reverseEdges.get(nodeId) ?? new Set<string>();
+      for (const dependentId of dependents) {
+        const degree = inDegree.get(dependentId);
+        if (degree === undefined) {
+          continue;
+        }
+
+        const nextDegree = degree - 1;
+        inDegree.set(dependentId, nextDegree);
+        if (nextDegree === 0) {
+          queue.push(dependentId);
+        }
+      }
+    }
+
+    if (visited === dag.nodes.size) {
+      return { valid: true };
+    }
+
+    const remaining = new Set<string>();
+    for (const [nodeId, degree] of inDegree.entries()) {
+      if (degree > 0) {
+        remaining.add(nodeId);
+      }
+    }
+
+    return {
+      valid: false,
+      cycle: findCycle(remaining, dag.reverseEdges),
+    };
+  }
+
+  export function getReady(
+    dag: DAGStructure,
+    completed: Set<string>,
+  ): string[] {
+    const ready: string[] = [];
+    for (const nodeId of dag.nodes) {
+      if (completed.has(nodeId)) {
+        continue;
+      }
+
+      const dependencies = dag.edges.get(nodeId) ?? new Set<string>();
+      let allResolved = true;
+      for (const depId of dependencies) {
+        if (!completed.has(depId)) {
+          allResolved = false;
+          break;
+        }
+      }
+
+      if (allResolved) {
+        ready.push(nodeId);
+      }
+    }
+
+    return ready;
+  }
+
+  export function complete(
+    dag: DAGStructure,
+    stepId: string,
+    completed: Set<string>,
+  ): { newlyReady: string[] } {
+    if (!dag.nodes.has(stepId) || completed.has(stepId)) {
+      return { newlyReady: [] };
+    }
+
+    const completedWithStep = new Set<string>(completed);
+    completedWithStep.add(stepId);
+
+    const newlyReady: string[] = [];
+    const dependents = dag.reverseEdges.get(stepId) ?? new Set<string>();
+    for (const dependentId of dependents) {
+      if (completedWithStep.has(dependentId)) {
+        continue;
+      }
+
+      const dependencies = dag.edges.get(dependentId) ?? new Set<string>();
+      let allResolved = true;
+      for (const dependencyId of dependencies) {
+        if (!completedWithStep.has(dependencyId)) {
+          allResolved = false;
+          break;
+        }
+      }
+
+      if (allResolved) {
+        newlyReady.push(dependentId);
+      }
+    }
+
+    return { newlyReady };
+  }
+}
+
+function findCycle(
+  nodes: Set<string>,
+  adjacency: Map<string, Set<string>>,
+): string[] {
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (nodeId: string): string[] | undefined => {
+    visiting.add(nodeId);
+    stack.push(nodeId);
+
+    const neighbors = adjacency.get(nodeId) ?? new Set<string>();
+    for (const neighborId of neighbors) {
+      if (!nodes.has(neighborId)) {
+        continue;
+      }
+
+      if (visiting.has(neighborId)) {
+        const start = stack.indexOf(neighborId);
+        const cycle = stack.slice(start);
+        cycle.push(neighborId);
+        return cycle;
+      }
+
+      if (!visited.has(neighborId)) {
+        const found = visit(neighborId);
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    visiting.delete(nodeId);
+    visited.add(nodeId);
+    stack.pop();
+    return undefined;
+  };
+
+  for (const nodeId of nodes) {
+    if (visited.has(nodeId)) {
+      continue;
+    }
+
+    const cycle = visit(nodeId);
+    if (cycle) {
+      return cycle;
+    }
+  }
+
+  return [];
+}

--- a/packages/openomni/src/plan/plan-agent.ts
+++ b/packages/openomni/src/plan/plan-agent.ts
@@ -15,7 +15,7 @@ Output ONLY valid JSON matching this schema:
       "dependsOn": ["<stepId>", ...],
       "suggestedAgent": "<optional agent hint>",
       "guardrail": "<optional acceptance criteria>",
-      "tools": ["<optional tool names>"]
+      "tools": [{ "name": "<tool-name>", "description": "<what it does>", "inputSchema": { "type": "object", "properties": {} } }]
     }
   ],
   "createdAt": "<ISO date string>",

--- a/packages/openomni/src/plan/plan-agent.ts
+++ b/packages/openomni/src/plan/plan-agent.ts
@@ -1,0 +1,96 @@
+import { ChatAgent, type AgentBudget } from "@openomni/agent";
+import { PlanSchema, type PlanResult } from "@openomni/protocol";
+
+export const DEFAULT_SYSTEM_PROMPT = `You are a planning agent. Given a goal, produce a structured execution plan as JSON.
+
+Output ONLY valid JSON matching this schema:
+{
+  "planId": "<uuid>",
+  "goal": "<the goal>",
+  "steps": [
+    {
+      "stepId": "<unique-id>",
+      "description": "<what to do>",
+      "expectedOutput": "<what success looks like>",
+      "dependsOn": ["<stepId>", ...],
+      "suggestedAgent": "<optional agent hint>",
+      "guardrail": "<optional acceptance criteria>",
+      "tools": ["<optional tool names>"]
+    }
+  ],
+  "createdAt": "<ISO date string>",
+  "version": 1
+}
+
+Rules:
+- stepId must be unique across all steps
+- dependsOn must reference valid stepIds
+- Steps with no dependencies have dependsOn: []
+- Minimize dependencies - only add when truly sequential`;
+
+function normalizePlanPayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  if (typeof candidate.createdAt !== "string") {
+    return payload;
+  }
+
+  const parsedDate = new Date(candidate.createdAt);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return payload;
+  }
+
+  return { ...candidate, createdAt: parsedDate };
+}
+
+function parsePlan(text: string): PlanResult["plan"] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse plan JSON: ${reason}`);
+  }
+
+  const result = PlanSchema.safeParse(normalizePlanPayload(parsed));
+  if (!result.success) {
+    throw new Error(`Failed to validate plan: ${result.error.message}`);
+  }
+
+  return result.data;
+}
+
+export namespace PlanAgent {
+  export interface GenerateConfig {
+    model: { provider: string; id: string };
+    systemPrompt?: string;
+    reviewPrompt?: string;
+    budget?: AgentBudget;
+  }
+
+  export async function generate(
+    goal: string,
+    config: GenerateConfig,
+  ): Promise<PlanResult> {
+    const promptParts = [config.systemPrompt ?? DEFAULT_SYSTEM_PROMPT];
+    if (config.reviewPrompt) {
+      promptParts.push(config.reviewPrompt);
+    }
+
+    const agent = ChatAgent.create({
+      model: config.model,
+      systemPrompt: promptParts.join("\n\n"),
+      budget: config.budget,
+    });
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: goal }],
+    });
+
+    const plan = parsePlan(result.text);
+    return { plan };
+  }
+}

--- a/packages/openomni/src/team/index.ts
+++ b/packages/openomni/src/team/index.ts
@@ -1,0 +1,1 @@
+export { Teammate } from "./teammate.js";

--- a/packages/openomni/src/team/review-loop.ts
+++ b/packages/openomni/src/team/review-loop.ts
@@ -7,6 +7,10 @@ export const DEFAULT_REVIEW_PROMPT =
   'Always respond with valid JSON containing a "decision" field ' +
   '("accept" or "reject") and an optional "feedback" field.';
 
+export const DEFAULT_HANDOFF_PROMPT =
+  "You are an expert at analyzing failed task executions and creating handoff documents. " +
+  "Summarize what was attempted, why it failed, and what should be tried differently. " +
+  "Respond with a clear, concise handoff document in plain text.";
 export namespace ReviewLoop {
   export interface ReviewConfig {
     model: { provider: string; id: string };
@@ -88,7 +92,7 @@ export namespace ReviewLoop {
     attemptNumber: number,
     maxAttempts: number,
   ): boolean {
-    return attemptNumber >= maxAttempts;
+    return attemptNumber >= maxAttempts - 1;
   }
 
   export async function generateHandoff(
@@ -98,7 +102,7 @@ export namespace ReviewLoop {
   ): Promise<string> {
     const agent = ChatAgent.create({
       model: config.model,
-      systemPrompt: config.systemPrompt ?? DEFAULT_REVIEW_PROMPT,
+      systemPrompt: DEFAULT_HANDOFF_PROMPT,
       budget: config.budget,
     });
 

--- a/packages/openomni/src/team/review-loop.ts
+++ b/packages/openomni/src/team/review-loop.ts
@@ -1,0 +1,131 @@
+import { ChatAgent } from "@openomni/agent";
+import type { AgentBudget } from "@openomni/agent";
+import type { PlanStep } from "@openomni/protocol";
+
+export const DEFAULT_REVIEW_PROMPT =
+  "You are a strict code reviewer evaluating task execution results. " +
+  'Always respond with valid JSON containing a "decision" field ' +
+  '("accept" or "reject") and an optional "feedback" field.';
+
+export namespace ReviewLoop {
+  export interface ReviewConfig {
+    model: { provider: string; id: string };
+    systemPrompt?: string;
+    budget?: AgentBudget;
+  }
+
+  export interface ReviewInput {
+    step: PlanStep;
+    result: string;
+    agentId: string;
+    attemptNumber: number;
+  }
+
+  export interface ReviewOutput {
+    decision: "accept" | "reject";
+    feedback?: string;
+    handoffDocument?: string;
+  }
+
+  function buildReviewPrompt(input: ReviewInput): string {
+    return [
+      "You are reviewing the output of a task execution.",
+      "",
+      `Step: ${input.step.description}`,
+      `Expected Output: ${input.step.expectedOutput}`,
+      `Guardrail: ${input.step.guardrail ?? "None specified"}`,
+      "",
+      `Agent: ${input.agentId}`,
+      `Attempt: ${input.attemptNumber}`,
+      "",
+      "Result produced:",
+      input.result,
+      "",
+      "Evaluate whether this result meets the expected output and guardrail criteria.",
+      "",
+      "Respond with ONLY valid JSON:",
+      "{",
+      '  "decision": "accept" | "reject",',
+      '  "feedback": "<optional explanation>"',
+      "}",
+    ].join("\n");
+  }
+
+  export async function review(
+    input: ReviewInput,
+    config: ReviewConfig,
+  ): Promise<ReviewOutput> {
+    const agent = ChatAgent.create({
+      model: config.model,
+      systemPrompt: config.systemPrompt ?? DEFAULT_REVIEW_PROMPT,
+      budget: config.budget,
+    });
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: buildReviewPrompt(input) }],
+    });
+
+    let parsed: { decision: string; feedback?: string };
+    try {
+      parsed = JSON.parse(result.text);
+    } catch {
+      throw new Error(
+        `Failed to parse review response as JSON: ${result.text}`,
+      );
+    }
+
+    if (parsed.decision !== "accept" && parsed.decision !== "reject") {
+      throw new Error(`Invalid review decision: ${parsed.decision}`);
+    }
+
+    return {
+      decision: parsed.decision as "accept" | "reject",
+      feedback: parsed.feedback,
+    };
+  }
+
+  export function shouldHandoff(
+    attemptNumber: number,
+    maxAttempts: number,
+  ): boolean {
+    return attemptNumber >= maxAttempts;
+  }
+
+  export async function generateHandoff(
+    input: ReviewInput,
+    rejectionFeedback: string,
+    config: ReviewConfig,
+  ): Promise<string> {
+    const agent = ChatAgent.create({
+      model: config.model,
+      systemPrompt: config.systemPrompt ?? DEFAULT_REVIEW_PROMPT,
+      budget: config.budget,
+    });
+
+    const prompt = [
+      "Generate a handoff document for the following failed task execution.",
+      "",
+      `Step: ${input.step.description}`,
+      `Expected Output: ${input.step.expectedOutput}`,
+      `Agent: ${input.agentId}`,
+      `Attempt: ${input.attemptNumber}`,
+      "",
+      "Result produced:",
+      input.result,
+      "",
+      "Rejection feedback:",
+      rejectionFeedback,
+      "",
+      "Create a concise handoff document that summarizes:",
+      "1. What was attempted",
+      "2. Why it was rejected",
+      "3. What the next agent should try differently",
+    ].join("\n");
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    return result.text;
+  }
+}

--- a/packages/openomni/src/team/run-ledger.ts
+++ b/packages/openomni/src/team/run-ledger.ts
@@ -1,0 +1,144 @@
+import type { PlanStep } from "@openomni/protocol";
+import type { Team } from "@openomni/protocol";
+
+type StepState = Team.StepState;
+
+interface RunLedgerEntry {
+  stepId: string;
+  state: StepState;
+  attempts: number;
+  rejectionStreak: number;
+  totalRejections: number;
+  startedAt?: Date;
+  completedAt?: Date;
+}
+
+const VALID_TRANSITIONS: Record<StepState, StepState[]> = {
+  ready: ["running"],
+  running: ["succeeded", "failed"],
+  succeeded: [],
+  failed: [],
+  skipped: [],
+};
+
+const COMPLETED_STATES: StepState[] = ["succeeded", "failed", "skipped"];
+
+function cloneEntry(entry: RunLedgerEntry): RunLedgerEntry {
+  return { ...entry };
+}
+
+function getEntryOrThrow(
+  entries: Map<string, RunLedgerEntry>,
+  stepId: string,
+): RunLedgerEntry {
+  const entry = entries.get(stepId);
+  if (!entry) {
+    throw new Error(`Step not found: "${stepId}"`);
+  }
+  return entry;
+}
+
+export interface RunLedgerInstance {
+  transition(stepId: string, state: StepState): void;
+  recordAttempt(stepId: string): void;
+  recordRejection(stepId: string): void;
+  resetRejectionStreak(stepId: string): void;
+  getState(): Map<string, RunLedgerEntry>;
+  getStepState(stepId: string): RunLedgerEntry | undefined;
+  getRunning(): RunLedgerEntry[];
+  getCompleted(): RunLedgerEntry[];
+}
+
+export namespace RunLedger {
+  export function create(steps: PlanStep[]): RunLedgerInstance {
+    const entries = new Map<string, RunLedgerEntry>();
+
+    for (const step of steps) {
+      entries.set(step.stepId, {
+        stepId: step.stepId,
+        state: "ready",
+        attempts: 0,
+        rejectionStreak: 0,
+        totalRejections: 0,
+      });
+    }
+
+    return {
+      transition(stepId: string, targetState: StepState): void {
+        const entry = getEntryOrThrow(entries, stepId);
+
+        if (targetState === "skipped") {
+          entry.state = "skipped";
+          entry.completedAt = new Date();
+          return;
+        }
+
+        const allowed = VALID_TRANSITIONS[entry.state];
+        if (!allowed.includes(targetState)) {
+          throw new Error(
+            `Invalid transition: "${entry.state}" → "${targetState}" for step "${stepId}"`,
+          );
+        }
+
+        entry.state = targetState;
+
+        if (targetState === "running") {
+          entry.startedAt = new Date();
+        }
+
+        if (targetState === "succeeded" || targetState === "failed") {
+          entry.completedAt = new Date();
+        }
+      },
+
+      recordAttempt(stepId: string): void {
+        const entry = getEntryOrThrow(entries, stepId);
+        entry.attempts++;
+      },
+
+      recordRejection(stepId: string): void {
+        const entry = getEntryOrThrow(entries, stepId);
+        entry.rejectionStreak++;
+        entry.totalRejections++;
+      },
+
+      resetRejectionStreak(stepId: string): void {
+        const entry = getEntryOrThrow(entries, stepId);
+        entry.rejectionStreak = 0;
+      },
+
+      getState(): Map<string, RunLedgerEntry> {
+        const copy = new Map<string, RunLedgerEntry>();
+        for (const [id, entry] of entries) {
+          copy.set(id, cloneEntry(entry));
+        }
+        return copy;
+      },
+
+      getStepState(stepId: string): RunLedgerEntry | undefined {
+        const entry = entries.get(stepId);
+        return entry ? cloneEntry(entry) : undefined;
+      },
+
+      getRunning(): RunLedgerEntry[] {
+        const result: RunLedgerEntry[] = [];
+        for (const entry of entries.values()) {
+          if (entry.state === "running") {
+            result.push(cloneEntry(entry));
+          }
+        }
+        return result;
+      },
+
+      getCompleted(): RunLedgerEntry[] {
+        const result: RunLedgerEntry[] = [];
+        for (const entry of entries.values()) {
+          if (COMPLETED_STATES.includes(entry.state)) {
+            result.push(cloneEntry(entry));
+          }
+        }
+        return result;
+      },
+    };
+  }
+}

--- a/packages/openomni/src/team/run-ledger.ts
+++ b/packages/openomni/src/team/run-ledger.ts
@@ -24,7 +24,13 @@ const VALID_TRANSITIONS: Record<StepState, StepState[]> = {
 const COMPLETED_STATES: StepState[] = ["succeeded", "failed", "skipped"];
 
 function cloneEntry(entry: RunLedgerEntry): RunLedgerEntry {
-  return { ...entry };
+  return {
+    ...entry,
+    startedAt: entry.startedAt ? new Date(entry.startedAt.getTime()) : undefined,
+    completedAt: entry.completedAt
+      ? new Date(entry.completedAt.getTime())
+      : undefined,
+  };
 }
 
 function getEntryOrThrow(

--- a/packages/openomni/src/team/stall-detector.ts
+++ b/packages/openomni/src/team/stall-detector.ts
@@ -1,0 +1,110 @@
+import type { Team } from "@openomni/protocol";
+import type { RunLedgerInstance } from "./run-ledger";
+import type { DAGStructure } from "../dag/index";
+
+const NOT_STALLED: StallDetector.StallResult = { stalled: false };
+
+const TERMINAL_STATES: Team.StepState[] = ["succeeded", "failed", "skipped"];
+const FAILED_STATES: Team.StepState[] = ["failed", "skipped"];
+
+export namespace StallDetector {
+  export interface StallConfig {
+    maxConsecutiveRejections: number;
+    maxNoProgressTurns: number;
+  }
+
+  export interface StallResult {
+    stalled: boolean;
+    reason?: Team.StallReason;
+    details?: string;
+    stalledStepId?: string;
+  }
+
+  export function checkConsecutiveRejections(
+    ledger: RunLedgerInstance,
+    config: StallConfig,
+  ): StallResult {
+    for (const [, entry] of ledger.getState()) {
+      if (entry.rejectionStreak >= config.maxConsecutiveRejections) {
+        return {
+          stalled: true,
+          reason: "consecutive_rejections",
+          details: `Step "${entry.stepId}" rejected ${entry.rejectionStreak} consecutive times (limit: ${config.maxConsecutiveRejections})`,
+          stalledStepId: entry.stepId,
+        };
+      }
+    }
+    return NOT_STALLED;
+  }
+
+  export function checkNoProgress(
+    ledger: RunLedgerInstance,
+    _dag: DAGStructure,
+    config: StallConfig,
+    noProgressTurns: number,
+  ): StallResult {
+    if (noProgressTurns < config.maxNoProgressTurns) {
+      return NOT_STALLED;
+    }
+
+    if (ledger.getRunning().length > 0) {
+      return NOT_STALLED;
+    }
+
+    return {
+      stalled: true,
+      reason: "no_progress",
+      details: `No progress for ${noProgressTurns} turns (limit: ${config.maxNoProgressTurns}) and no steps running`,
+    };
+  }
+
+  export function checkUnsatisfiableDeps(
+    ledger: RunLedgerInstance,
+    dag: DAGStructure,
+  ): StallResult {
+    const state = ledger.getState();
+
+    for (const [stepId, entry] of state) {
+      if (TERMINAL_STATES.includes(entry.state) || entry.state === "running") {
+        continue;
+      }
+
+      const deps = dag.edges.get(stepId);
+      if (!deps || deps.size === 0) {
+        continue;
+      }
+
+      for (const depId of deps) {
+        const depEntry = state.get(depId);
+        if (depEntry && FAILED_STATES.includes(depEntry.state)) {
+          return {
+            stalled: true,
+            reason: "unsatisfiable_deps",
+            details: `Step "${stepId}" depends on "${depId}" which is "${depEntry.state}"`,
+            stalledStepId: stepId,
+          };
+        }
+      }
+    }
+
+    return NOT_STALLED;
+  }
+
+  export function check(
+    ledger: RunLedgerInstance,
+    dag: DAGStructure,
+    config: StallConfig,
+    noProgressTurns: number,
+  ): StallResult {
+    const rejections = checkConsecutiveRejections(ledger, config);
+    if (rejections.stalled) return rejections;
+
+    const unsatisfiable = checkUnsatisfiableDeps(ledger, dag);
+    if (unsatisfiable.stalled) return unsatisfiable;
+
+    const noProgress = checkNoProgress(ledger, dag, config, noProgressTurns);
+    if (noProgress.stalled) return noProgress;
+
+    return NOT_STALLED;
+  }
+}

--- a/packages/openomni/src/team/stall-detector.ts
+++ b/packages/openomni/src/team/stall-detector.ts
@@ -25,6 +25,9 @@ export namespace StallDetector {
     config: StallConfig,
   ): StallResult {
     for (const [, entry] of ledger.getState()) {
+      if (TERMINAL_STATES.includes(entry.state)) {
+        continue;
+      }
       if (entry.rejectionStreak >= config.maxConsecutiveRejections) {
         return {
           stalled: true,

--- a/packages/openomni/src/team/team-orchestrator.ts
+++ b/packages/openomni/src/team/team-orchestrator.ts
@@ -198,6 +198,7 @@ export namespace TeamOrchestrator {
           if (attempts >= maxAttemptsPerStep) {
             ledger.transition(stepId, "failed");
             failed.add(stepId);
+            ledger.resetRejectionStreak(stepId);
 
             // Publish step.failed event (fire-and-forget)
             void Bus.publish(Team.Events.StepFailed, {

--- a/packages/openomni/src/team/team-orchestrator.ts
+++ b/packages/openomni/src/team/team-orchestrator.ts
@@ -1,0 +1,343 @@
+import type { Plan, PlanStep, Team } from "@openomni/protocol";
+import { DAG } from "../dag/index";
+import { RunLedger } from "./run-ledger";
+import { StallDetector } from "./stall-detector";
+import { ReviewLoop } from "./review-loop";
+import { Teammate } from "./teammate";
+
+const DEFAULT_STALL_CONFIG: StallDetector.StallConfig = {
+  maxConsecutiveRejections: 3,
+  maxNoProgressTurns: 5,
+};
+
+export namespace TeamOrchestrator {
+  export interface OrchestratorConfig {
+    reviewModel: { provider: string; id: string };
+    reviewSystemPrompt?: string;
+    teammates: Map<string, Teammate.TeammateConfig>;
+    defaultTeammateConfig: Teammate.TeammateConfig;
+    stallConfig?: StallDetector.StallConfig;
+    maxAttemptsPerStep?: number;
+  }
+
+  export interface TeamResult {
+    status: "completed" | "stalled" | "failed";
+    completedSteps: string[];
+    failedSteps: string[];
+    skippedSteps: string[];
+    stallReason?: Team.StallReason;
+    results: Map<string, string>;
+  }
+
+  export async function execute(
+    plan: Plan,
+    config: OrchestratorConfig,
+  ): Promise<TeamResult> {
+    if (plan.steps.length === 0) {
+      return {
+        status: "completed",
+        completedSteps: [],
+        failedSteps: [],
+        skippedSteps: [],
+        results: new Map<string, string>(),
+      };
+    }
+
+    const dag = DAG.build(plan.steps);
+    const acyclic = DAG.validateAcyclic(dag);
+    if (!acyclic.valid) {
+      const cycleText =
+        acyclic.cycle.length > 0 ? `: ${acyclic.cycle.join(" -> ")}` : "";
+      throw new Error(`Plan contains cycle${cycleText}`);
+    }
+
+    const ledger = RunLedger.create(plan.steps);
+    const completed = new Set<string>();
+    const failed = new Set<string>();
+    const skipped = new Set<string>();
+    const results = new Map<string, string>();
+    const pendingRetry = new Map<string, { handoffDocument?: string }>();
+    const stepById = new Map(plan.steps.map((step) => [step.stepId, step]));
+
+    const maxAttemptsPerStep = config.maxAttemptsPerStep ?? 3;
+    const stallConfig = config.stallConfig ?? DEFAULT_STALL_CONFIG;
+    let noProgressTurns = 0;
+
+    while (true) {
+      let progressed = false;
+
+      const readyFromDag = DAG.getReady(dag, completed);
+      const readySteps = readyFromDag.filter((stepId) => {
+        if (failed.has(stepId) || skipped.has(stepId)) {
+          return false;
+        }
+
+        const state = ledger.getStepState(stepId)?.state;
+        return state === "ready" || pendingRetry.has(stepId);
+      });
+
+      for (const stepId of readySteps) {
+        if (failed.has(stepId) || skipped.has(stepId)) {
+          continue;
+        }
+
+        const step = stepById.get(stepId);
+        const current = ledger.getStepState(stepId);
+        if (!step || !current) {
+          continue;
+        }
+
+        const retryMeta = pendingRetry.get(stepId);
+        pendingRetry.delete(stepId);
+
+        if (current.state === "ready") {
+          ledger.transition(stepId, "running");
+        }
+
+        ledger.recordAttempt(stepId);
+        const attemptNumber = ledger.getStepState(stepId)?.attempts ?? 1;
+        const teammateConfig = resolveTeammate(step, config);
+
+        try {
+          const execution = await Teammate.execute(
+            {
+              step,
+              context: buildContext(step, results),
+              handoffDocument: retryMeta?.handoffDocument,
+            },
+            teammateConfig,
+          );
+
+          const review = await ReviewLoop.review(
+            {
+              step,
+              result: execution.output,
+              agentId: execution.agentId,
+              attemptNumber,
+            },
+            {
+              model: config.reviewModel,
+              systemPrompt: config.reviewSystemPrompt,
+            },
+          );
+
+          if (review.decision === "accept") {
+            ledger.transition(stepId, "succeeded");
+            ledger.resetRejectionStreak(stepId);
+            completed.add(stepId);
+            results.set(stepId, execution.output);
+            DAG.complete(dag, stepId, completed);
+            progressed = true;
+            continue;
+          }
+
+          ledger.recordRejection(stepId);
+          const attempts =
+            ledger.getStepState(stepId)?.attempts ?? attemptNumber;
+
+          if (attempts >= maxAttemptsPerStep) {
+            ledger.transition(stepId, "failed");
+            failed.add(stepId);
+            skipDependents(
+              stepId,
+              dag,
+              ledger,
+              failed,
+              skipped,
+              completed,
+              pendingRetry,
+            );
+            progressed = true;
+            continue;
+          }
+
+          let handoffDocument = retryMeta?.handoffDocument;
+          if (review.feedback) {
+            handoffDocument = review.feedback;
+          }
+
+          if (
+            ReviewLoop.shouldHandoff(attempts, maxAttemptsPerStep) &&
+            review.feedback
+          ) {
+            handoffDocument = await ReviewLoop.generateHandoff(
+              {
+                step,
+                result: execution.output,
+                agentId: execution.agentId,
+                attemptNumber: attempts,
+              },
+              review.feedback,
+              {
+                model: config.reviewModel,
+                systemPrompt: config.reviewSystemPrompt,
+              },
+            );
+          }
+
+          pendingRetry.set(stepId, { handoffDocument });
+        } catch {
+          ledger.transition(stepId, "failed");
+          failed.add(stepId);
+          skipDependents(
+            stepId,
+            dag,
+            ledger,
+            failed,
+            skipped,
+            completed,
+            pendingRetry,
+          );
+          progressed = true;
+        }
+      }
+
+      const stall = StallDetector.check(
+        ledger,
+        dag,
+        stallConfig,
+        noProgressTurns,
+      );
+      if (stall.stalled) {
+        return buildResult(
+          plan.steps,
+          ledger,
+          results,
+          "stalled",
+          stall.reason,
+        );
+      }
+
+      if (isExecutionFinished(plan.steps, ledger)) {
+        break;
+      }
+
+      if (progressed) {
+        noProgressTurns = 0;
+      } else {
+        noProgressTurns += 1;
+      }
+    }
+
+    const final = buildResult(plan.steps, ledger, results);
+    if (final.failedSteps.length > 0) {
+      return { ...final, status: "failed" };
+    }
+
+    return final;
+  }
+}
+
+function resolveTeammate(
+  step: PlanStep,
+  config: TeamOrchestrator.OrchestratorConfig,
+): Teammate.TeammateConfig {
+  if (step.suggestedAgent && config.teammates.has(step.suggestedAgent)) {
+    return (
+      config.teammates.get(step.suggestedAgent) ?? config.defaultTeammateConfig
+    );
+  }
+
+  return config.defaultTeammateConfig;
+}
+
+function buildContext(
+  step: PlanStep,
+  results: Map<string, string>,
+): string | undefined {
+  if (step.dependsOn.length === 0) {
+    return undefined;
+  }
+
+  const contextBlocks: string[] = [];
+  for (const dependencyId of step.dependsOn) {
+    const text = results.get(dependencyId);
+    if (!text) {
+      continue;
+    }
+
+    contextBlocks.push(`[${dependencyId}]\n${text}`);
+  }
+
+  if (contextBlocks.length === 0) {
+    return undefined;
+  }
+
+  return contextBlocks.join("\n\n");
+}
+
+function skipDependents(
+  failedStepId: string,
+  dag: ReturnType<typeof DAG.build>,
+  ledger: ReturnType<typeof RunLedger.create>,
+  failed: Set<string>,
+  skipped: Set<string>,
+  completed: Set<string>,
+  pendingRetry: Map<string, { handoffDocument?: string }>,
+): void {
+  const queue = [...(dag.reverseEdges.get(failedStepId) ?? new Set<string>())];
+
+  while (queue.length > 0) {
+    const stepId = queue.shift();
+    if (!stepId) {
+      continue;
+    }
+
+    if (failed.has(stepId) || skipped.has(stepId) || completed.has(stepId)) {
+      continue;
+    }
+
+    const state = ledger.getStepState(stepId);
+    if (!state || state.state === "succeeded") {
+      continue;
+    }
+
+    ledger.transition(stepId, "skipped");
+    skipped.add(stepId);
+    pendingRetry.delete(stepId);
+
+    const descendants = dag.reverseEdges.get(stepId);
+    if (descendants) {
+      queue.push(...descendants);
+    }
+  }
+}
+
+function isExecutionFinished(
+  steps: PlanStep[],
+  ledger: ReturnType<typeof RunLedger.create>,
+): boolean {
+  return ledger.getCompleted().length === steps.length;
+}
+
+function buildResult(
+  steps: PlanStep[],
+  ledger: ReturnType<typeof RunLedger.create>,
+  results: Map<string, string>,
+  status: TeamOrchestrator.TeamResult["status"] = "completed",
+  stallReason?: Team.StallReason,
+): TeamOrchestrator.TeamResult {
+  const completedSteps: string[] = [];
+  const failedSteps: string[] = [];
+  const skippedSteps: string[] = [];
+
+  for (const step of steps) {
+    const state = ledger.getStepState(step.stepId)?.state;
+    if (state === "succeeded") {
+      completedSteps.push(step.stepId);
+    } else if (state === "failed") {
+      failedSteps.push(step.stepId);
+    } else if (state === "skipped") {
+      skippedSteps.push(step.stepId);
+    }
+  }
+
+  return {
+    status,
+    completedSteps,
+    failedSteps,
+    skippedSteps,
+    stallReason,
+    results,
+  };
+}

--- a/packages/openomni/src/team/team-orchestrator.ts
+++ b/packages/openomni/src/team/team-orchestrator.ts
@@ -1,9 +1,12 @@
-import type { Plan, PlanStep, Team } from "@openomni/protocol";
+import type { Plan, PlanStep } from "@openomni/protocol";
+import { Team } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import { DAG } from "../dag/index";
 import { RunLedger } from "./run-ledger";
 import { StallDetector } from "./stall-detector";
 import { ReviewLoop } from "./review-loop";
 import { Teammate } from "./teammate";
+
 
 const DEFAULT_STALL_CONFIG: StallDetector.StallConfig = {
   maxConsecutiveRejections: 3,
@@ -50,6 +53,17 @@ export namespace TeamOrchestrator {
         acyclic.cycle.length > 0 ? `: ${acyclic.cycle.join(" -> ")}` : "";
       throw new Error(`Plan contains cycle${cycleText}`);
     }
+
+    // Publish plan.created event (fire-and-forget)
+    void Bus.publish(Team.Events.PlanCreated, {
+      traceId: crypto.randomUUID(),
+      time: Date.now(),
+      payload: {
+        planId: plan.planId,
+        goal: plan.goal,
+        stepCount: plan.steps.length,
+      },
+    });
 
     const ledger = RunLedger.create(plan.steps);
     const completed = new Set<string>();
@@ -98,6 +112,29 @@ export namespace TeamOrchestrator {
         const attemptNumber = ledger.getStepState(stepId)?.attempts ?? 1;
         const teammateConfig = resolveTeammate(step, config);
 
+        // Publish step.assigned event (fire-and-forget)
+        void Bus.publish(Team.Events.StepAssigned, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          payload: {
+            planId: plan.planId,
+            stepId,
+            agentId: teammateConfig.agentId,
+          },
+        });
+
+        // Publish step.started event (fire-and-forget)
+        void Bus.publish(Team.Events.StepStarted, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          payload: {
+            planId: plan.planId,
+            stepId,
+            agentId: teammateConfig.agentId,
+            attempt: attemptNumber,
+          },
+        });
+
         try {
           const execution = await Teammate.execute(
             {
@@ -121,12 +158,35 @@ export namespace TeamOrchestrator {
             },
           );
 
+          // Publish review.decision event (fire-and-forget)
+          void Bus.publish(Team.Events.ReviewDecision, {
+            traceId: crypto.randomUUID(),
+            time: Date.now(),
+            payload: {
+              planId: plan.planId,
+              stepId,
+              decision: review.decision,
+              feedback: review.feedback,
+            },
+          });
+
           if (review.decision === "accept") {
             ledger.transition(stepId, "succeeded");
             ledger.resetRejectionStreak(stepId);
             completed.add(stepId);
             results.set(stepId, execution.output);
             DAG.complete(dag, stepId, completed);
+
+            // Publish step.completed event (fire-and-forget)
+            void Bus.publish(Team.Events.StepCompleted, {
+              traceId: crypto.randomUUID(),
+              time: Date.now(),
+              payload: {
+                planId: plan.planId,
+                stepId,
+                result: execution.output,
+              },
+            });
             progressed = true;
             continue;
           }
@@ -138,6 +198,17 @@ export namespace TeamOrchestrator {
           if (attempts >= maxAttemptsPerStep) {
             ledger.transition(stepId, "failed");
             failed.add(stepId);
+
+            // Publish step.failed event (fire-and-forget)
+            void Bus.publish(Team.Events.StepFailed, {
+              traceId: crypto.randomUUID(),
+              time: Date.now(),
+              payload: {
+                planId: plan.planId,
+                stepId,
+                error: `Max attempts (${maxAttemptsPerStep}) reached`,
+              },
+            });
             skipDependents(
               stepId,
               dag,
@@ -173,12 +244,36 @@ export namespace TeamOrchestrator {
                 systemPrompt: config.reviewSystemPrompt,
               },
             );
+
+            // Publish step.handoff event (fire-and-forget)
+            void Bus.publish(Team.Events.StepHandoff, {
+              traceId: crypto.randomUUID(),
+              time: Date.now(),
+              payload: {
+                planId: plan.planId,
+                stepId,
+                from: execution.agentId,
+                to: execution.agentId,
+                handoffDocument,
+              },
+            });
           }
 
           pendingRetry.set(stepId, { handoffDocument });
         } catch {
           ledger.transition(stepId, "failed");
           failed.add(stepId);
+
+          // Publish step.failed event (fire-and-forget)
+          void Bus.publish(Team.Events.StepFailed, {
+            traceId: crypto.randomUUID(),
+            time: Date.now(),
+            payload: {
+              planId: plan.planId,
+              stepId,
+              error: "Execution error",
+            },
+          });
           skipDependents(
             stepId,
             dag,
@@ -198,7 +293,18 @@ export namespace TeamOrchestrator {
         stallConfig,
         noProgressTurns,
       );
-      if (stall.stalled) {
+      if (stall.stalled && stall.reason) {
+        // Publish stall.detected event (fire-and-forget)
+        void Bus.publish(Team.Events.StallDetected, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          payload: {
+            planId: plan.planId,
+            reason: stall.reason,
+            details: `Stall detected: ${stall.reason}`,
+          },
+        });
+
         return buildResult(
           plan.steps,
           ledger,
@@ -220,6 +326,20 @@ export namespace TeamOrchestrator {
     }
 
     const final = buildResult(plan.steps, ledger, results);
+
+    // Publish execution.complete event (fire-and-forget)
+    void Bus.publish(Team.Events.ExecutionComplete, {
+      traceId: crypto.randomUUID(),
+      time: Date.now(),
+      payload: {
+        planId: plan.planId,
+        status: final.status,
+        completedSteps: final.completedSteps.length,
+        failedSteps: final.failedSteps.length,
+        skippedSteps: final.skippedSteps.length,
+      },
+    });
+
     if (final.failedSteps.length > 0) {
       return { ...final, status: "failed" };
     }

--- a/packages/openomni/src/team/team-orchestrator.ts
+++ b/packages/openomni/src/team/team-orchestrator.ts
@@ -13,6 +13,14 @@ const DEFAULT_STALL_CONFIG: StallDetector.StallConfig = {
   maxNoProgressTurns: 5,
 };
 
+/** Publish a bus event, swallowing any synchronous errors. */
+function safePublish<T>(...args: Parameters<typeof Bus.publish<T>>): void {
+  try {
+    Bus.publish(...args);
+  } catch {
+    // fire-and-forget: event errors must never crash the orchestrator
+  }
+}
 export namespace TeamOrchestrator {
   export interface OrchestratorConfig {
     reviewModel: { provider: string; id: string };
@@ -55,7 +63,7 @@ export namespace TeamOrchestrator {
     }
 
     // Publish plan.created event (fire-and-forget)
-    void Bus.publish(Team.Events.PlanCreated, {
+    safePublish(Team.Events.PlanCreated, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       payload: {
@@ -113,7 +121,7 @@ export namespace TeamOrchestrator {
         const teammateConfig = resolveTeammate(step, config);
 
         // Publish step.assigned event (fire-and-forget)
-        void Bus.publish(Team.Events.StepAssigned, {
+        safePublish(Team.Events.StepAssigned, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           payload: {
@@ -124,7 +132,7 @@ export namespace TeamOrchestrator {
         });
 
         // Publish step.started event (fire-and-forget)
-        void Bus.publish(Team.Events.StepStarted, {
+        safePublish(Team.Events.StepStarted, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           payload: {
@@ -159,7 +167,7 @@ export namespace TeamOrchestrator {
           );
 
           // Publish review.decision event (fire-and-forget)
-          void Bus.publish(Team.Events.ReviewDecision, {
+          safePublish(Team.Events.ReviewDecision, {
             traceId: crypto.randomUUID(),
             time: Date.now(),
             payload: {
@@ -178,7 +186,7 @@ export namespace TeamOrchestrator {
             DAG.complete(dag, stepId, completed);
 
             // Publish step.completed event (fire-and-forget)
-            void Bus.publish(Team.Events.StepCompleted, {
+            safePublish(Team.Events.StepCompleted, {
               traceId: crypto.randomUUID(),
               time: Date.now(),
               payload: {
@@ -201,7 +209,7 @@ export namespace TeamOrchestrator {
             ledger.resetRejectionStreak(stepId);
 
             // Publish step.failed event (fire-and-forget)
-            void Bus.publish(Team.Events.StepFailed, {
+            safePublish(Team.Events.StepFailed, {
               traceId: crypto.randomUUID(),
               time: Date.now(),
               payload: {
@@ -247,7 +255,7 @@ export namespace TeamOrchestrator {
             );
 
             // Publish step.handoff event (fire-and-forget)
-            void Bus.publish(Team.Events.StepHandoff, {
+            safePublish(Team.Events.StepHandoff, {
               traceId: crypto.randomUUID(),
               time: Date.now(),
               payload: {
@@ -266,7 +274,7 @@ export namespace TeamOrchestrator {
           failed.add(stepId);
 
           // Publish step.failed event (fire-and-forget)
-          void Bus.publish(Team.Events.StepFailed, {
+          safePublish(Team.Events.StepFailed, {
             traceId: crypto.randomUUID(),
             time: Date.now(),
             payload: {
@@ -296,7 +304,7 @@ export namespace TeamOrchestrator {
       );
       if (stall.stalled && stall.reason) {
         // Publish stall.detected event (fire-and-forget)
-        void Bus.publish(Team.Events.StallDetected, {
+        safePublish(Team.Events.StallDetected, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           payload: {
@@ -329,7 +337,7 @@ export namespace TeamOrchestrator {
     const final = buildResult(plan.steps, ledger, results);
 
     // Publish execution.complete event (fire-and-forget)
-    void Bus.publish(Team.Events.ExecutionComplete, {
+    safePublish(Team.Events.ExecutionComplete, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       payload: {

--- a/packages/openomni/src/team/teammate.ts
+++ b/packages/openomni/src/team/teammate.ts
@@ -59,6 +59,28 @@ export namespace Teammate {
   }
 
   /**
+   * Merge config-level and step-level tools, deduplicating by name.
+   * Step tools take precedence over config tools with the same name.
+   */
+  function mergeTools(
+    configTools?: Tool.Spec[],
+    stepTools?: Tool.Spec[],
+  ): Tool.Spec[] | undefined {
+    if (!configTools && !stepTools) return undefined;
+    if (!configTools) return stepTools;
+    if (!stepTools) return configTools;
+
+    const merged = new Map<string, Tool.Spec>();
+    for (const tool of configTools) {
+      merged.set(tool.name, tool);
+    }
+    for (const tool of stepTools) {
+      merged.set(tool.name, tool);
+    }
+    return [...merged.values()];
+  }
+
+  /**
    * Execute a single step using a fresh ChatAgent instance
    * Each call creates a NEW ChatAgent (no cross-step state)
    */
@@ -70,7 +92,7 @@ export namespace Teammate {
     const agentConfig: ChatAgentConfig = {
       model: config.model,
       systemPrompt: config.systemPrompt,
-      tools: config.tools,
+      tools: mergeTools(config.tools, input.step.tools),
       budget: config.budget,
       toolExecutor: config.toolExecutor,
     };

--- a/packages/openomni/src/team/teammate.ts
+++ b/packages/openomni/src/team/teammate.ts
@@ -1,0 +1,98 @@
+import { ChatAgent } from "@openomni/agent";
+import type { ChatAgentConfig, AgentResult, TokenUsage } from "@openomni/agent";
+import type { PlanStep, Tool } from "@openomni/protocol";
+
+/**
+ * Teammate namespace — wraps ChatAgent for step execution
+ * Each execute() call creates a fresh ChatAgent instance (no cross-step state)
+ */
+export namespace Teammate {
+  /**
+   * Configuration for Teammate execution
+   */
+  export interface TeammateConfig {
+    agentId: string;
+    model: { provider: string; id: string };
+    systemPrompt?: string;
+    tools?: Tool.Spec[];
+    budget?: ChatAgentConfig["budget"];
+    toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  }
+
+  /**
+   * Input to Teammate.execute()
+   */
+  export interface ExecuteInput {
+    step: PlanStep;
+    context?: string; // Optional context from previous steps
+    handoffDocument?: string; // Optional handoff from previous attempt
+  }
+
+  /**
+   * Result of Teammate.execute()
+   */
+  export interface ExecuteResult {
+    agentId: string;
+    stepId: string;
+    output: string;
+    usage: TokenUsage;
+    finishReason: string;
+  }
+
+  /**
+   * Build user message from ExecuteInput
+   */
+  function buildUserMessage(input: ExecuteInput): string {
+    const { step, context, handoffDocument } = input;
+
+    let message = `Execute the following task:\n\nTask: ${step.description}\nExpected Output: ${step.expectedOutput}`;
+
+    if (context) {
+      message += `\n\nContext from previous steps:\n${context}`;
+    }
+
+    if (handoffDocument) {
+      message += `\n\nHandoff from previous attempt:\n${handoffDocument}`;
+    }
+
+    return message;
+  }
+
+  /**
+   * Execute a single step using a fresh ChatAgent instance
+   * Each call creates a NEW ChatAgent (no cross-step state)
+   */
+  export async function execute(
+    input: ExecuteInput,
+    config: TeammateConfig,
+  ): Promise<ExecuteResult> {
+    // Build ChatAgent config
+    const agentConfig: ChatAgentConfig = {
+      model: config.model,
+      systemPrompt: config.systemPrompt,
+      tools: config.tools,
+      budget: config.budget,
+      toolExecutor: config.toolExecutor,
+    };
+
+    // Create fresh ChatAgent instance
+    const agent = ChatAgent.create(agentConfig);
+
+    // Build user message
+    const userMessage = buildUserMessage(input);
+
+    // Run agent
+    const result: AgentResult = await agent.run({
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    // Return ExecuteResult
+    return {
+      agentId: config.agentId,
+      stepId: input.step.stepId,
+      output: result.text,
+      usage: result.usage,
+      finishReason: result.finishReason,
+    };
+  }
+}

--- a/packages/openomni/test/dag/dag.test.ts
+++ b/packages/openomni/test/dag/dag.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import type { PlanStep } from "@openomni/protocol";
+import { DAG } from "../../src/dag";
+
+function step(stepId: string, dependsOn: string[] = []): PlanStep {
+  return {
+    stepId,
+    description: `Step ${stepId}`,
+    expectedOutput: `Output ${stepId}`,
+    dependsOn,
+  };
+}
+
+describe("DAG", () => {
+  it("builds empty DAG and getReady returns empty", () => {
+    const dag = DAG.build([]);
+
+    expect(dag.nodes.size).toBe(0);
+    expect(dag.edges.size).toBe(0);
+    expect(dag.reverseEdges.size).toBe(0);
+    expect(dag.pendingDeps.size).toBe(0);
+    expect(DAG.getReady(dag, new Set())).toEqual([]);
+  });
+
+  it("returns single step as ready when there are no dependencies", () => {
+    const dag = DAG.build([step("A")]);
+
+    expect(DAG.getReady(dag, new Set())).toEqual(["A"]);
+  });
+
+  it("unblocks linear chain A -> B -> C", () => {
+    const dag = DAG.build([step("A"), step("B", ["A"]), step("C", ["B"])]);
+    const completed = new Set<string>();
+
+    expect(DAG.getReady(dag, completed)).toEqual(["A"]);
+
+    expect(DAG.complete(dag, "A", completed)).toEqual({ newlyReady: ["B"] });
+    const completedAfterA = new Set<string>([...completed, "A"]);
+    expect(DAG.complete(dag, "B", completedAfterA)).toEqual({
+      newlyReady: ["C"],
+    });
+  });
+
+  it("returns all independent steps as ready", () => {
+    const dag = DAG.build([step("A"), step("B"), step("C")]);
+
+    expect(DAG.getReady(dag, new Set())).toEqual(["A", "B", "C"]);
+  });
+
+  it("unblocks diamond DAG only after both prerequisites complete", () => {
+    const dag = DAG.build([
+      step("A"),
+      step("B", ["A"]),
+      step("C", ["A"]),
+      step("D", ["B", "C"]),
+    ]);
+    const completed = new Set<string>();
+
+    expect(DAG.getReady(dag, completed)).toEqual(["A"]);
+    expect(DAG.complete(dag, "A", completed)).toEqual({
+      newlyReady: ["B", "C"],
+    });
+
+    const completedWithA = new Set<string>(["A"]);
+    expect(DAG.complete(dag, "B", completedWithA)).toEqual({ newlyReady: [] });
+
+    const completedWithAB = new Set<string>(["A", "B"]);
+    expect(DAG.complete(dag, "C", completedWithAB)).toEqual({
+      newlyReady: ["D"],
+    });
+  });
+
+  it("detects cycle A -> B -> C -> A", () => {
+    const dag = DAG.build([
+      step("A", ["C"]),
+      step("B", ["A"]),
+      step("C", ["B"]),
+    ]);
+
+    expect(DAG.validateAcyclic(dag)).toEqual({
+      valid: false,
+      cycle: ["A", "B", "C", "A"],
+    });
+  });
+
+  it("detects self cycle A -> A", () => {
+    const dag = DAG.build([step("A", ["A"])]);
+    const result = DAG.validateAcyclic(dag);
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.cycle.length).toBeGreaterThanOrEqual(2);
+      expect(result.cycle[0]).toBe("A");
+      expect(result.cycle[result.cycle.length - 1]).toBe("A");
+    }
+  });
+
+  it("does not mutate completed input set in complete", () => {
+    const dag = DAG.build([step("A"), step("B", ["A"])]);
+    const completed = new Set<string>();
+
+    const result = DAG.complete(dag, "A", completed);
+
+    expect(completed.size).toBe(0);
+    expect(result).toEqual({ newlyReady: ["B"] });
+  });
+
+  it("does not mutate DAGStructure in getReady", () => {
+    const dag = DAG.build([step("A"), step("B", ["A"])]);
+    const nodesBefore = [...dag.nodes];
+    const edgesBefore = [...dag.edges.entries()].map(([id, deps]) => [
+      id,
+      [...deps],
+    ]);
+    const reverseEdgesBefore = [...dag.reverseEdges.entries()].map(
+      ([id, deps]) => [id, [...deps]],
+    );
+    const pendingBefore = [...dag.pendingDeps.entries()];
+
+    DAG.getReady(dag, new Set());
+
+    expect([...dag.nodes]).toEqual(nodesBefore);
+    expect(
+      [...dag.edges.entries()].map(([id, deps]) => [id, [...deps]]),
+    ).toEqual(edgesBefore);
+    expect(
+      [...dag.reverseEdges.entries()].map(([id, deps]) => [id, [...deps]]),
+    ).toEqual(reverseEdgesBefore);
+    expect([...dag.pendingDeps.entries()]).toEqual(pendingBefore);
+  });
+});

--- a/packages/openomni/test/integration/plan-to-team.test.ts
+++ b/packages/openomni/test/integration/plan-to-team.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as SessionModule from "@openomni/session";
 import type { Message, Run, Sink } from "@openomni/protocol";
 
 const responseQueue: string[] = [];
@@ -42,7 +43,8 @@ mock.module("@openomni/llm", () => ({
 }));
 
 mock.module("@openomni/session", () => ({
-  Bus: { publish: mockBusPublish },
+  ...SessionModule,
+  Bus: { ...SessionModule.Bus, publish: mockBusPublish },
 }));
 
 let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;

--- a/packages/openomni/test/integration/plan-to-team.test.ts
+++ b/packages/openomni/test/integration/plan-to-team.test.ts
@@ -1,0 +1,238 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Message, Run, Sink } from "@openomni/protocol";
+
+const responseQueue: string[] = [];
+const llmInputs: unknown[] = [];
+
+type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
+
+let mockRunFn: MockLlmFn = async (_input: unknown, sink: Sink) => {
+  const text = responseQueue.shift() ?? "{}";
+  sink.onMessage(createAssistantMessage(text));
+  return { type: "stop" } as Run.Outcome;
+};
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
+}));
+
+const mockBusPublish = mock(() => {});
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: unknown, sink: Sink) => {
+    llmInputs.push(input);
+    return mockRunFn(input, sink);
+  },
+}));
+
+mock.module("@openomni/session", () => ({
+  Bus: { publish: mockBusPublish },
+}));
+
+let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;
+let TeamOrchestrator: typeof import("../../src/team/team-orchestrator").TeamOrchestrator;
+
+beforeAll(async () => {
+  ({ PlanAgent } = await import("../../src/plan/plan-agent"));
+  ({ TeamOrchestrator } = await import("../../src/team/team-orchestrator"));
+});
+
+beforeEach(() => {
+  responseQueue.length = 0;
+  llmInputs.length = 0;
+  mockBusPublish.mockClear();
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
+  mockRunFn = async (_input: unknown, sink: Sink) => {
+    const text = responseQueue.shift() ?? "{}";
+    sink.onMessage(createAssistantMessage(text));
+    return { type: "stop" } as Run.Outcome;
+  };
+});
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "integration-test";
+  const now = Date.now();
+
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+
+  return { info, parts: [textPart] };
+}
+
+function enqueuePlan(
+  goal: string,
+  steps: Array<{ stepId: string; dependsOn: string[] }>,
+) {
+  responseQueue.push(
+    JSON.stringify({
+      planId: "plan-integration",
+      goal,
+      steps: steps.map((step) => ({
+        stepId: step.stepId,
+        description: `Do ${step.stepId}`,
+        expectedOutput: `Output ${step.stepId}`,
+        dependsOn: step.dependsOn,
+      })),
+      createdAt: new Date().toISOString(),
+      version: 1,
+    }),
+  );
+}
+
+function makeConfig(): import("../../src/team/team-orchestrator").TeamOrchestrator.OrchestratorConfig {
+  return {
+    reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    teammates: new Map(),
+    defaultTeammateConfig: {
+      agentId: "default-agent",
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    },
+    maxAttemptsPerStep: 3,
+  };
+}
+
+function extractUserText(input: unknown): string {
+  if (!input || typeof input !== "object") {
+    return "";
+  }
+
+  const candidate = input as {
+    messages?: Array<{ parts?: Array<{ type?: string; text?: string }> }>;
+  };
+
+  const messages = candidate.messages ?? [];
+  return messages
+    .flatMap((message) => message.parts ?? [])
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text as string)
+    .join("\n");
+}
+
+describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
+  it("completes two-step dependent plan end-to-end", async () => {
+    const goal = "Build and validate release package";
+
+    enqueuePlan(goal, [
+      { stepId: "s1", dependsOn: [] },
+      { stepId: "s2", dependsOn: ["s1"] },
+    ]);
+    responseQueue.push("Step 1 completed");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+    responseQueue.push("Step 2 completed");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const planResult = await PlanAgent.generate(goal, {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+    const result = await TeamOrchestrator.execute(
+      planResult.plan,
+      makeConfig(),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual(["s1", "s2"]);
+    expect(result.failedSteps).toEqual([]);
+    expect(result.skippedSteps).toEqual([]);
+  });
+
+  it("completes one-step plan end-to-end", async () => {
+    const goal = "Run one verification";
+
+    enqueuePlan(goal, [{ stepId: "s1", dependsOn: [] }]);
+    responseQueue.push("Single step completed");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const planResult = await PlanAgent.generate(goal, {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+    const result = await TeamOrchestrator.execute(
+      planResult.plan,
+      makeConfig(),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual(["s1"]);
+    expect(result.failedSteps).toEqual([]);
+    expect(result.skippedSteps).toEqual([]);
+  });
+
+  it("retries once after rejection and then succeeds", async () => {
+    const goal = "Retry rejected step";
+
+    enqueuePlan(goal, [{ stepId: "s1", dependsOn: [] }]);
+    responseQueue.push("Step output attempt 1");
+    responseQueue.push(
+      JSON.stringify({ decision: "reject", feedback: "Need fixes" }),
+    );
+    responseQueue.push("Step output attempt 2");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const planResult = await PlanAgent.generate(goal, {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+    const result = await TeamOrchestrator.execute(
+      planResult.plan,
+      makeConfig(),
+    );
+
+    const executionCalls = llmInputs
+      .map((input) => extractUserText(input))
+      .filter((text) => text.includes("Execute the following task:"));
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual(["s1"]);
+    expect(executionCalls).toHaveLength(2);
+  });
+
+  it("throws when plan output is invalid JSON", async () => {
+    responseQueue.push("{ invalid json");
+
+    return expect(
+      PlanAgent.generate("Generate broken plan", {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      }),
+    ).rejects.toThrow(/Failed to parse plan/);
+  });
+});

--- a/packages/openomni/test/plan/plan-agent.test.ts
+++ b/packages/openomni/test/plan/plan-agent.test.ts
@@ -1,33 +1,37 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Message, Run, Sink } from "@openomni/protocol";
 
-type MockAgentResult = {
-  text: string;
-  steps: [];
-  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
-  finishReason: "stop";
-};
+// --- Mock setup (must be before dynamic import) ---
 
-const mockRun = mock(
-  async (): Promise<MockAgentResult> => ({
-    text: "{}",
-    steps: [],
-    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-    finishReason: "stop",
-  }),
-);
+type MockLlmFn = (input: any, sink: Sink) => Promise<Run.Outcome>;
 
-const mockCreate = mock(() => ({
-  run: mockRun,
-  stream: async function* () {
-    return;
+let mockRunFn: MockLlmFn = async () => ({ type: "stop" });
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
   },
 }));
 
-mock.module("@openomni/agent", () => ({
-  ChatAgent: {
-    create: mockCreate,
-  },
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
 }));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: any, sink: Sink) => mockRunFn(input, sink),
+}));
+
+// --- Dynamic import after mock ---
 
 let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;
 
@@ -35,17 +39,59 @@ beforeAll(async () => {
   ({ PlanAgent } = await import("../../src/plan/plan-agent"));
 });
 
+// --- Helpers ---
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "plan-test";
+  const now = Date.now();
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+  return { info, parts: [textPart] };
+}
+
+function setupMockResponse(text: string) {
+  mockRunFn = async (_input: any, sink: Sink) => {
+    sink.onMessage(createAssistantMessage(text));
+    return { type: "stop" } as Run.Outcome;
+  };
+}
+
 beforeEach(() => {
-  mockRun.mockClear();
-  mockCreate.mockClear();
+  mockRunFn = async () => ({ type: "stop" }) as Run.Outcome;
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
 });
 
 describe("PlanAgent.generate", () => {
   it("returns PlanResult when LLM returns valid plan JSON", async () => {
     const goal = "Build API gateway";
     const now = new Date().toISOString();
-    mockRun.mockResolvedValueOnce({
-      text: JSON.stringify({
+    setupMockResponse(
+      JSON.stringify({
         planId: "plan-1",
         goal,
         steps: [
@@ -59,10 +105,7 @@ describe("PlanAgent.generate", () => {
         createdAt: now,
         version: 1,
       }),
-      steps: [],
-      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      finishReason: "stop",
-    });
+    );
 
     const result = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -72,17 +115,10 @@ describe("PlanAgent.generate", () => {
     expect(result.plan.goal).toBe(goal);
     expect(result.plan.steps).toHaveLength(1);
     expect(result.plan.createdAt).toBeInstanceOf(Date);
-    expect(mockCreate).toHaveBeenCalledTimes(1);
-    expect(mockRun).toHaveBeenCalledTimes(1);
   });
 
   it("throws when LLM output is not valid JSON", async () => {
-    mockRun.mockResolvedValueOnce({
-      text: "not-json",
-      steps: [],
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      finishReason: "stop",
-    });
+    setupMockResponse("not-json");
 
     return expect(
       PlanAgent.generate("Write docs", {
@@ -92,8 +128,8 @@ describe("PlanAgent.generate", () => {
   });
 
   it("throws when JSON fails Plan schema validation", async () => {
-    mockRun.mockResolvedValueOnce({
-      text: JSON.stringify({
+    setupMockResponse(
+      JSON.stringify({
         planId: "plan-2",
         goal: "Ship feature",
         steps: [
@@ -106,10 +142,7 @@ describe("PlanAgent.generate", () => {
         createdAt: new Date().toISOString(),
         version: 1,
       }),
-      steps: [],
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      finishReason: "stop",
-    });
+    );
 
     return expect(
       PlanAgent.generate("Ship feature", {
@@ -120,18 +153,15 @@ describe("PlanAgent.generate", () => {
 
   it("ensures generated plan goal matches input goal", async () => {
     const goal = "Migrate billing service";
-    mockRun.mockResolvedValueOnce({
-      text: JSON.stringify({
+    setupMockResponse(
+      JSON.stringify({
         planId: "plan-3",
         goal,
         steps: [],
         createdAt: new Date().toISOString(),
         version: 1,
       }),
-      steps: [],
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      finishReason: "stop",
-    });
+    );
 
     const result = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -141,8 +171,8 @@ describe("PlanAgent.generate", () => {
   });
 
   it("parses steps with dependsOn links", async () => {
-    mockRun.mockResolvedValueOnce({
-      text: JSON.stringify({
+    setupMockResponse(
+      JSON.stringify({
         planId: "plan-4",
         goal: "Deploy app",
         steps: [
@@ -162,10 +192,7 @@ describe("PlanAgent.generate", () => {
         createdAt: new Date().toISOString(),
         version: 1,
       }),
-      steps: [],
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      finishReason: "stop",
-    });
+    );
 
     const result = await PlanAgent.generate("Deploy app", {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -175,18 +202,15 @@ describe("PlanAgent.generate", () => {
   });
 
   it("accepts empty steps array as a valid plan", async () => {
-    mockRun.mockResolvedValueOnce({
-      text: JSON.stringify({
+    setupMockResponse(
+      JSON.stringify({
         planId: "plan-empty",
         goal: "Simple goal",
         steps: [],
         createdAt: new Date().toISOString(),
         version: 1,
       }),
-      steps: [],
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      finishReason: "stop",
-    });
+    );
 
     const result = await PlanAgent.generate("Simple goal", {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },

--- a/packages/openomni/test/plan/plan-agent.test.ts
+++ b/packages/openomni/test/plan/plan-agent.test.ts
@@ -1,0 +1,197 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+type MockAgentResult = {
+  text: string;
+  steps: [];
+  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+  finishReason: "stop";
+};
+
+const mockRun = mock(
+  async (): Promise<MockAgentResult> => ({
+    text: "{}",
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    finishReason: "stop",
+  }),
+);
+
+const mockCreate = mock(() => ({
+  run: mockRun,
+  stream: async function* () {
+    return;
+  },
+}));
+
+mock.module("@openomni/agent", () => ({
+  ChatAgent: {
+    create: mockCreate,
+  },
+}));
+
+let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;
+
+beforeAll(async () => {
+  ({ PlanAgent } = await import("../../src/plan/plan-agent"));
+});
+
+beforeEach(() => {
+  mockRun.mockClear();
+  mockCreate.mockClear();
+});
+
+describe("PlanAgent.generate", () => {
+  it("returns PlanResult when LLM returns valid plan JSON", async () => {
+    const goal = "Build API gateway";
+    const now = new Date().toISOString();
+    mockRun.mockResolvedValueOnce({
+      text: JSON.stringify({
+        planId: "plan-1",
+        goal,
+        steps: [
+          {
+            stepId: "s1",
+            description: "Design routes",
+            expectedOutput: "Route map",
+            dependsOn: [],
+          },
+        ],
+        createdAt: now,
+        version: 1,
+      }),
+      steps: [],
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      finishReason: "stop",
+    });
+
+    const result = await PlanAgent.generate(goal, {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+
+    expect(result.plan.planId).toBe("plan-1");
+    expect(result.plan.goal).toBe(goal);
+    expect(result.plan.steps).toHaveLength(1);
+    expect(result.plan.createdAt).toBeInstanceOf(Date);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when LLM output is not valid JSON", async () => {
+    mockRun.mockResolvedValueOnce({
+      text: "not-json",
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop",
+    });
+
+    return expect(
+      PlanAgent.generate("Write docs", {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      }),
+    ).rejects.toThrow(/Failed to parse plan/);
+  });
+
+  it("throws when JSON fails Plan schema validation", async () => {
+    mockRun.mockResolvedValueOnce({
+      text: JSON.stringify({
+        planId: "plan-2",
+        goal: "Ship feature",
+        steps: [
+          {
+            stepId: "s1",
+            expectedOutput: "Done",
+            dependsOn: [],
+          },
+        ],
+        createdAt: new Date().toISOString(),
+        version: 1,
+      }),
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop",
+    });
+
+    return expect(
+      PlanAgent.generate("Ship feature", {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("ensures generated plan goal matches input goal", async () => {
+    const goal = "Migrate billing service";
+    mockRun.mockResolvedValueOnce({
+      text: JSON.stringify({
+        planId: "plan-3",
+        goal,
+        steps: [],
+        createdAt: new Date().toISOString(),
+        version: 1,
+      }),
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop",
+    });
+
+    const result = await PlanAgent.generate(goal, {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+
+    expect(result.plan.goal).toBe(goal);
+  });
+
+  it("parses steps with dependsOn links", async () => {
+    mockRun.mockResolvedValueOnce({
+      text: JSON.stringify({
+        planId: "plan-4",
+        goal: "Deploy app",
+        steps: [
+          {
+            stepId: "s1",
+            description: "Build",
+            expectedOutput: "Artifact",
+            dependsOn: [],
+          },
+          {
+            stepId: "s2",
+            description: "Deploy",
+            expectedOutput: "Running service",
+            dependsOn: ["s1"],
+          },
+        ],
+        createdAt: new Date().toISOString(),
+        version: 1,
+      }),
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop",
+    });
+
+    const result = await PlanAgent.generate("Deploy app", {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+
+    expect(result.plan.steps[1]?.dependsOn).toEqual(["s1"]);
+  });
+
+  it("accepts empty steps array as a valid plan", async () => {
+    mockRun.mockResolvedValueOnce({
+      text: JSON.stringify({
+        planId: "plan-empty",
+        goal: "Simple goal",
+        steps: [],
+        createdAt: new Date().toISOString(),
+        version: 1,
+      }),
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop",
+    });
+
+    const result = await PlanAgent.generate("Simple goal", {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+
+    expect(result.plan.steps).toEqual([]);
+  });
+});

--- a/packages/openomni/test/team/event-stream.test.ts
+++ b/packages/openomni/test/team/event-stream.test.ts
@@ -243,21 +243,30 @@ describe("TeamOrchestrator event stream", () => {
     });
   });
 
-  it("publishes events synchronously without awaiting (fire-and-forget pattern)", async () => {
-    // Bus.publish is synchronous (returns void), and the orchestrator
-    // calls it with `void Bus.publish(...)` to signal fire-and-forget intent.
-    // This test verifies that events are published and execution completes.
-    responseQueue.push("step output");
-    responseQueue.push(JSON.stringify({ decision: "accept" }));
+  it("completes execution even when Bus.publish throws (fire-and-forget)", async () => {
+    // Replace Bus.publish with a throwing implementation to verify
+    // that safePublish() in team-orchestrator catches the error.
+    const { Bus } = await import("@openomni/session");
+    const originalPublish = Bus.publish;
+    let throwCount = 0;
+    Bus.publish = ((..._args: unknown[]) => {
+      throwCount++;
+      throw new Error("Bus.publish sync error");
+    }) as typeof Bus.publish;
 
-    const plan = makePlan([makeStep("s1")]);
-    const result = await TeamOrchestrator.execute(plan, makeConfig());
+    try {
+      responseQueue.push("step output");
+      responseQueue.push(JSON.stringify({ decision: "accept" }));
 
-    // Execution completed successfully
-    expect(result.status).toBe("completed");
-    // Events were published during execution
-    expect(publishedEvents.length).toBeGreaterThan(0);
-    // Verify specific event ordering: plan.created should come first
-    expect(publishedEvents[0]?.eventName).toBe("plan.created");
+      const plan = makePlan([makeStep("s1")]);
+      const result = await TeamOrchestrator.execute(plan, makeConfig());
+
+      // Execution MUST complete despite Bus.publish throwing
+      expect(result.status).toBe("completed");
+      // safePublish was called (and caught the throws)
+      expect(throwCount).toBeGreaterThan(0);
+    } finally {
+      Bus.publish = originalPublish;
+    }
   });
 });

--- a/packages/openomni/test/team/event-stream.test.ts
+++ b/packages/openomni/test/team/event-stream.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AgentResult } from "@openomni/agent";
+import type { Plan, PlanStep, Team } from "@openomni/protocol";
+import type { Teammate } from "../../src/team/teammate";
+
+const responseQueue: string[] = [];
+const publishedEvents: Array<{ eventName: string; data: unknown }> = [];
+
+// Mock Bus.publish to capture events
+mock.module("@openomni/session", () => ({
+  Bus: {
+    publish: (event: { name: string }, data: unknown) => {
+      publishedEvents.push({ eventName: event.name, data });
+    },
+    subscribe: () => () => {},
+    reset: () => {},
+  },
+}));
+
+// Mock ChatAgent for deterministic responses
+mock.module("@openomni/agent", () => ({
+  ChatAgent: {
+    create: () => ({
+      run: async () => {
+        const text = responseQueue.shift() ?? "{}";
+        return {
+          text,
+          steps: [],
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+          },
+          finishReason: "stop",
+        } as AgentResult;
+      },
+    }),
+  },
+}));
+
+const { TeamOrchestrator } = await import("../../src/team/team-orchestrator");
+
+beforeEach(() => {
+  responseQueue.length = 0;
+  publishedEvents.length = 0;
+});
+
+function makeStep(
+  stepId: string,
+  dependsOn: string[] = [],
+  suggestedAgent?: string,
+): PlanStep {
+  return {
+    stepId,
+    description: `${stepId} task`,
+    expectedOutput: `${stepId} output`,
+    dependsOn,
+    suggestedAgent,
+  };
+}
+
+function makePlan(steps: PlanStep[]): Plan {
+  return {
+    planId: "plan-1",
+    goal: "execute plan",
+    steps,
+    createdAt: new Date(),
+    version: 1,
+  };
+}
+
+const defaultTeammateConfig: Teammate.TeammateConfig = {
+  agentId: "default-agent",
+  model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+};
+
+function makeConfig(overrides?: {
+  teammates?: Map<string, Teammate.TeammateConfig>;
+  maxAttemptsPerStep?: number;
+}) {
+  return {
+    reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    teammates:
+      overrides?.teammates ?? new Map<string, Teammate.TeammateConfig>(),
+    defaultTeammateConfig,
+    maxAttemptsPerStep: overrides?.maxAttemptsPerStep,
+  };
+}
+
+describe("TeamOrchestrator event stream", () => {
+  it("publishes plan.created when execute() starts", async () => {
+    responseQueue.push("step output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    await TeamOrchestrator.execute(plan, makeConfig());
+
+    const planCreatedEvent = publishedEvents.find(
+      (e) => e.eventName === "plan.created",
+    );
+    expect(planCreatedEvent).toBeDefined();
+    expect(planCreatedEvent?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        goal: "execute plan",
+        stepCount: 1,
+      },
+    });
+  });
+
+  it("publishes step.assigned for each step", async () => {
+    responseQueue.push("s1 output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+    responseQueue.push("s2 output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1"), makeStep("s2")]);
+    await TeamOrchestrator.execute(plan, makeConfig());
+
+    const assignedEvents = publishedEvents.filter(
+      (e) => e.eventName === "step.assigned",
+    );
+    expect(assignedEvents.length).toBe(2);
+    expect(assignedEvents[0]?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        stepId: "s1",
+        agentId: "default-agent",
+      },
+    });
+    expect(assignedEvents[1]?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        stepId: "s2",
+        agentId: "default-agent",
+      },
+    });
+  });
+
+  it("publishes step.started before Teammate.execute()", async () => {
+    responseQueue.push("step output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    await TeamOrchestrator.execute(plan, makeConfig());
+
+    const startedEvent = publishedEvents.find(
+      (e) => e.eventName === "step.started",
+    );
+    expect(startedEvent).toBeDefined();
+    expect(startedEvent?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        stepId: "s1",
+        agentId: "default-agent",
+        attempt: 1,
+      },
+    });
+  });
+
+  it("publishes step.completed when step is accepted", async () => {
+    responseQueue.push("step output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    await TeamOrchestrator.execute(plan, makeConfig());
+
+    const completedEvent = publishedEvents.find(
+      (e) => e.eventName === "step.completed",
+    );
+    expect(completedEvent).toBeDefined();
+    expect(completedEvent?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        stepId: "s1",
+        result: "step output",
+      },
+    });
+  });
+
+  it("publishes review.decision after each review", async () => {
+    responseQueue.push("s1 output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    await TeamOrchestrator.execute(plan, makeConfig());
+
+    const decisionEvent = publishedEvents.find(
+      (e) => e.eventName === "review.decision",
+    );
+    expect(decisionEvent).toBeDefined();
+    expect(decisionEvent?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        stepId: "s1",
+        decision: "accept",
+      },
+    });
+  });
+
+  it("publishes step.failed when max attempts reached", async () => {
+    responseQueue.push("attempt 1");
+    responseQueue.push(JSON.stringify({ decision: "reject" }));
+    responseQueue.push("attempt 2");
+    responseQueue.push(JSON.stringify({ decision: "reject" }));
+    responseQueue.push("attempt 3");
+    responseQueue.push(JSON.stringify({ decision: "reject" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    await TeamOrchestrator.execute(plan, makeConfig({ maxAttemptsPerStep: 3 }));
+
+    const failedEvent = publishedEvents.find(
+      (e) => e.eventName === "step.failed",
+    );
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        stepId: "s1",
+      },
+    });
+  });
+
+  it("publishes execution.complete when done", async () => {
+    responseQueue.push("step output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    await TeamOrchestrator.execute(plan, makeConfig());
+
+    const completeEvent = publishedEvents.find(
+      (e) => e.eventName === "execution.complete",
+    );
+    expect(completeEvent).toBeDefined();
+    expect(completeEvent?.data).toMatchObject({
+      payload: {
+        planId: "plan-1",
+        status: "completed",
+        completedSteps: 1,
+        failedSteps: 0,
+        skippedSteps: 0,
+      },
+    });
+  });
+
+  it("publishes events as fire-and-forget (no await)", async () => {
+    // This test verifies that Bus.publish errors don't propagate
+    // by checking that execution completes even if publish throws
+    responseQueue.push("step output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    const result = await TeamOrchestrator.execute(plan, makeConfig());
+
+    // If events were awaited and threw, execution would fail
+    // Since we got a result, events were fire-and-forget
+    expect(result.status).toBe("completed");
+    expect(publishedEvents.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/openomni/test/team/event-stream.test.ts
+++ b/packages/openomni/test/team/event-stream.test.ts
@@ -243,18 +243,21 @@ describe("TeamOrchestrator event stream", () => {
     });
   });
 
-  it("publishes events as fire-and-forget (no await)", async () => {
-    // This test verifies that Bus.publish errors don't propagate
-    // by checking that execution completes even if publish throws
+  it("publishes events synchronously without awaiting (fire-and-forget pattern)", async () => {
+    // Bus.publish is synchronous (returns void), and the orchestrator
+    // calls it with `void Bus.publish(...)` to signal fire-and-forget intent.
+    // This test verifies that events are published and execution completes.
     responseQueue.push("step output");
     responseQueue.push(JSON.stringify({ decision: "accept" }));
 
     const plan = makePlan([makeStep("s1")]);
     const result = await TeamOrchestrator.execute(plan, makeConfig());
 
-    // If events were awaited and threw, execution would fail
-    // Since we got a result, events were fire-and-forget
+    // Execution completed successfully
     expect(result.status).toBe("completed");
+    // Events were published during execution
     expect(publishedEvents.length).toBeGreaterThan(0);
+    // Verify specific event ordering: plan.created should come first
+    expect(publishedEvents[0]?.eventName).toBe("plan.created");
   });
 });

--- a/packages/openomni/test/team/review-loop.test.ts
+++ b/packages/openomni/test/team/review-loop.test.ts
@@ -1,0 +1,207 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { PlanStep } from "@openomni/protocol";
+import type { Message, Run, Sink } from "@openomni/protocol";
+
+// --- Mock setup (must be before dynamic import) ---
+
+type MockLlmFn = (input: any, sink: Sink) => Promise<Run.Outcome>;
+
+let mockRunFn: MockLlmFn = async () => ({ type: "stop" });
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
+}));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: any, sink: Sink) => mockRunFn(input, sink),
+}));
+
+// --- Dynamic import after mock ---
+
+let ReviewLoop: typeof import("../../src/team/review-loop").ReviewLoop;
+
+beforeAll(async () => {
+  ({ ReviewLoop } = await import("../../src/team/review-loop"));
+});
+
+// --- Helpers ---
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "review-test";
+  const now = Date.now();
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+  return { info, parts: [textPart] };
+}
+
+function setupMockResponse(text: string) {
+  mockRunFn = async (_input: any, sink: Sink) => {
+    sink.onMessage(createAssistantMessage(text));
+    return { type: "stop" } as Run.Outcome;
+  };
+}
+
+// --- Fixtures ---
+
+const defaultConfig = {
+  model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+};
+
+const defaultStep: PlanStep = {
+  stepId: "step-1",
+  description: "Implement the login feature",
+  expectedOutput: "A working login page with email/password fields",
+  dependsOn: [],
+};
+
+const defaultInput = {
+  step: defaultStep,
+  result: "Created login page with email and password fields.",
+  agentId: "agent-coder",
+  attemptNumber: 1,
+};
+
+// --- Tests ---
+
+describe("ReviewLoop", () => {
+  beforeEach(() => {
+    mockRunFn = async () => ({ type: "stop" }) as Run.Outcome;
+    mockModelsGet.mockClear();
+    mockProviderFromModelsDevModel.mockClear();
+  });
+
+  describe("review", () => {
+    it("returns accept decision when LLM accepts", async () => {
+      setupMockResponse(JSON.stringify({ decision: "accept" }));
+
+      const output = await ReviewLoop.review(defaultInput, defaultConfig);
+
+      expect(output.decision).toBe("accept");
+      expect(output.feedback).toBeUndefined();
+    });
+
+    it("returns reject decision with feedback", async () => {
+      setupMockResponse(
+        JSON.stringify({
+          decision: "reject",
+          feedback: "Missing error handling",
+        }),
+      );
+
+      const output = await ReviewLoop.review(defaultInput, defaultConfig);
+
+      expect(output.decision).toBe("reject");
+      expect(output.feedback).toBe("Missing error handling");
+    });
+
+    it("throws when LLM returns invalid JSON", async () => {
+      setupMockResponse("This is definitely not JSON");
+
+      await expect(
+        ReviewLoop.review(defaultInput, defaultConfig),
+      ).rejects.toThrow(/failed to parse/i);
+    });
+
+    it("includes guardrail in review prompt when step has guardrail", async () => {
+      let capturedInput: any;
+      mockRunFn = async (input: any, sink: Sink) => {
+        capturedInput = input;
+        sink.onMessage(
+          createAssistantMessage(JSON.stringify({ decision: "accept" })),
+        );
+        return { type: "stop" } as Run.Outcome;
+      };
+
+      const stepWithGuardrail: PlanStep = {
+        ...defaultStep,
+        guardrail: "Must not expose user passwords in logs",
+      };
+
+      await ReviewLoop.review(
+        { ...defaultInput, step: stepWithGuardrail },
+        defaultConfig,
+      );
+
+      // The user message (first in messages array) should contain the guardrail
+      const messages = capturedInput.messages as Message.WithParts[];
+      const userMsg = messages[0];
+      const textPart = userMsg.parts.find(
+        (p: Message.Part) => p.type === "text",
+      ) as Message.TextPart | undefined;
+      expect(textPart?.text).toContain(
+        "Must not expose user passwords in logs",
+      );
+    });
+  });
+
+  describe("shouldHandoff", () => {
+    it("returns true when at max attempts", () => {
+      expect(ReviewLoop.shouldHandoff(3, 3)).toBe(true);
+    });
+
+    it("returns false when not at max attempts", () => {
+      expect(ReviewLoop.shouldHandoff(2, 3)).toBe(false);
+    });
+
+    it("returns false on first attempt", () => {
+      expect(ReviewLoop.shouldHandoff(1, 3)).toBe(false);
+    });
+  });
+
+  describe("generateHandoff", () => {
+    it("returns a non-empty handoff document", async () => {
+      setupMockResponse(
+        "## Handoff Document\n\nThe login feature was rejected because...",
+      );
+
+      const handoff = await ReviewLoop.generateHandoff(
+        defaultInput,
+        "Missing error handling for invalid credentials",
+        defaultConfig,
+      );
+
+      expect(handoff).toBeTruthy();
+      expect(handoff.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/openomni/test/team/review-loop.test.ts
+++ b/packages/openomni/test/team/review-loop.test.ts
@@ -179,12 +179,23 @@ describe("ReviewLoop", () => {
       expect(ReviewLoop.shouldHandoff(3, 3)).toBe(true);
     });
 
-    it("returns false when not at max attempts", () => {
-      expect(ReviewLoop.shouldHandoff(2, 3)).toBe(false);
+    it("returns true at penultimate attempt (handoff before final retry)", () => {
+      // Fix for off-by-one: handoff triggers at maxAttempts - 1
+      // so the final retry gets a handoff document
+      expect(ReviewLoop.shouldHandoff(2, 3)).toBe(true);
     });
 
-    it("returns false on first attempt", () => {
+    it("returns false when well below max attempts", () => {
       expect(ReviewLoop.shouldHandoff(1, 3)).toBe(false);
+    });
+
+    it("returns true on first attempt with max=2 (penultimate = first)", () => {
+      // With max=2, attempt 1 is the penultimate, so handoff triggers
+      expect(ReviewLoop.shouldHandoff(1, 2)).toBe(true);
+    });
+
+    it("returns true on first attempt with max=1 (immediate handoff)", () => {
+      expect(ReviewLoop.shouldHandoff(1, 1)).toBe(true);
     });
   });
 

--- a/packages/openomni/test/team/run-ledger.test.ts
+++ b/packages/openomni/test/team/run-ledger.test.ts
@@ -122,6 +122,21 @@ describe("RunLedger", () => {
     expect(ledger.getStepState("step-1")!.attempts).toBe(0);
   });
 
+  it("returns deep-copied Date fields that cannot mutate internal state", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    ledger.transition("step-1", "running");
+
+    const entry = ledger.getStepState("step-1")!;
+    const originalTime = entry.startedAt!.getTime();
+
+    // Mutate the returned Date
+    entry.startedAt!.setTime(0);
+
+    // Internal state should be unchanged
+    const fresh = ledger.getStepState("step-1")!;
+    expect(fresh.startedAt!.getTime()).toBe(originalTime);
+  });
+
   it("getRunning returns only running steps", () => {
     const ledger = RunLedger.create(makeSteps(["s1", "s2", "s3"]));
     ledger.transition("s1", "running");

--- a/packages/openomni/test/team/run-ledger.test.ts
+++ b/packages/openomni/test/team/run-ledger.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "bun:test";
+import type { PlanStep } from "@openomni/protocol";
+import { RunLedger } from "../../src/team/run-ledger";
+
+function makeSteps(ids: string[]): PlanStep[] {
+  return ids.map((stepId) => ({
+    stepId,
+    description: `Step ${stepId}`,
+    expectedOutput: `Output of ${stepId}`,
+    dependsOn: [],
+  }));
+}
+
+describe("RunLedger", () => {
+  it("initializes all steps as ready with zero counters", () => {
+    const ledger = RunLedger.create(makeSteps(["s1", "s2", "s3"]));
+    const state = ledger.getState();
+
+    expect(state.size).toBe(3);
+    for (const [, entry] of state) {
+      expect(entry.state).toBe("ready");
+      expect(entry.attempts).toBe(0);
+      expect(entry.rejectionStreak).toBe(0);
+      expect(entry.totalRejections).toBe(0);
+      expect(entry.startedAt).toBeUndefined();
+      expect(entry.completedAt).toBeUndefined();
+    }
+  });
+
+  it("transitions from ready to running", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    ledger.transition("step-1", "running");
+
+    const entry = ledger.getStepState("step-1")!;
+    expect(entry.state).toBe("running");
+    expect(entry.startedAt).toBeInstanceOf(Date);
+  });
+
+  it("transitions from running to succeeded with completedAt", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    ledger.transition("step-1", "running");
+    ledger.transition("step-1", "succeeded");
+
+    const entry = ledger.getStepState("step-1")!;
+    expect(entry.state).toBe("succeeded");
+    expect(entry.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("throws when transitioning ready → succeeded (must run first)", () => {
+    const ledger = RunLedger.create(makeSteps(["step-2"]));
+    expect(() => ledger.transition("step-2", "succeeded")).toThrow(
+      /invalid.*transition/i,
+    );
+  });
+
+  it("throws when transitioning succeeded → running", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    ledger.transition("step-1", "running");
+    ledger.transition("step-1", "succeeded");
+
+    expect(() => ledger.transition("step-1", "running")).toThrow(
+      /invalid.*transition/i,
+    );
+  });
+
+  it("increments attempts on recordAttempt", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+
+    ledger.recordAttempt("step-1");
+    expect(ledger.getStepState("step-1")!.attempts).toBe(1);
+
+    ledger.recordAttempt("step-1");
+    expect(ledger.getStepState("step-1")!.attempts).toBe(2);
+  });
+
+  it("increments rejectionStreak and totalRejections on recordRejection", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+
+    ledger.recordRejection("step-1");
+    const entry1 = ledger.getStepState("step-1")!;
+    expect(entry1.rejectionStreak).toBe(1);
+    expect(entry1.totalRejections).toBe(1);
+
+    ledger.recordRejection("step-1");
+    const entry2 = ledger.getStepState("step-1")!;
+    expect(entry2.rejectionStreak).toBe(2);
+    expect(entry2.totalRejections).toBe(2);
+  });
+
+  it("resets rejectionStreak without affecting totalRejections", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+
+    ledger.recordRejection("step-1");
+    ledger.recordRejection("step-1");
+    ledger.recordRejection("step-1");
+    ledger.resetRejectionStreak("step-1");
+
+    const entry = ledger.getStepState("step-1")!;
+    expect(entry.rejectionStreak).toBe(0);
+    expect(entry.totalRejections).toBe(3);
+  });
+
+  it("returns a deep copy from getState that does not affect internal state", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    const copy = ledger.getState();
+
+    copy.delete("step-1");
+    expect(copy.size).toBe(0);
+
+    const fresh = ledger.getState();
+    expect(fresh.size).toBe(1);
+    expect(fresh.get("step-1")!.state).toBe("ready");
+  });
+
+  it("returns deep-copied entries that cannot mutate internal state", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    const copy = ledger.getState();
+    const entry = copy.get("step-1")!;
+
+    (entry as any).attempts = 999;
+
+    expect(ledger.getStepState("step-1")!.attempts).toBe(0);
+  });
+
+  it("getRunning returns only running steps", () => {
+    const ledger = RunLedger.create(makeSteps(["s1", "s2", "s3"]));
+    ledger.transition("s1", "running");
+    ledger.transition("s2", "running");
+
+    const running = ledger.getRunning();
+    expect(running).toHaveLength(2);
+    expect(running.map((e) => e.stepId).sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("getCompleted returns succeeded, failed, and skipped steps", () => {
+    const ledger = RunLedger.create(makeSteps(["s1", "s2", "s3", "s4"]));
+
+    ledger.transition("s1", "running");
+    ledger.transition("s1", "succeeded");
+
+    ledger.transition("s2", "running");
+    ledger.transition("s2", "failed");
+
+    ledger.transition("s3", "skipped");
+
+    const completed = ledger.getCompleted();
+    expect(completed).toHaveLength(3);
+    expect(completed.map((e) => e.stepId).sort()).toEqual(["s1", "s2", "s3"]);
+  });
+
+  it("throws step not found for non-existent step", () => {
+    const ledger = RunLedger.create(makeSteps(["s1"]));
+    expect(() => ledger.transition("nope", "running")).toThrow(
+      /step not found/i,
+    );
+  });
+
+  it("allows transition to skipped from any state", () => {
+    const steps = makeSteps([
+      "ready-s",
+      "running-s",
+      "succeeded-s",
+      "failed-s",
+    ]);
+    const ledger = RunLedger.create(steps);
+
+    ledger.transition("running-s", "running");
+    ledger.transition("succeeded-s", "running");
+    ledger.transition("succeeded-s", "succeeded");
+    ledger.transition("failed-s", "running");
+    ledger.transition("failed-s", "failed");
+
+    ledger.transition("ready-s", "skipped");
+    ledger.transition("running-s", "skipped");
+    ledger.transition("succeeded-s", "skipped");
+    ledger.transition("failed-s", "skipped");
+
+    for (const id of ["ready-s", "running-s", "succeeded-s", "failed-s"]) {
+      expect(ledger.getStepState(id)!.state).toBe("skipped");
+    }
+  });
+
+  it("transitions from running to failed", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    ledger.transition("step-1", "running");
+    ledger.transition("step-1", "failed");
+
+    const entry = ledger.getStepState("step-1")!;
+    expect(entry.state).toBe("failed");
+    expect(entry.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("throws when transitioning failed → running", () => {
+    const ledger = RunLedger.create(makeSteps(["step-1"]));
+    ledger.transition("step-1", "running");
+    ledger.transition("step-1", "failed");
+
+    expect(() => ledger.transition("step-1", "running")).toThrow(
+      /invalid.*transition/i,
+    );
+  });
+
+  it("getStepState returns undefined for unknown step", () => {
+    const ledger = RunLedger.create(makeSteps(["s1"]));
+    expect(ledger.getStepState("nope")).toBeUndefined();
+  });
+
+  it("throws on recordAttempt for unknown step", () => {
+    const ledger = RunLedger.create(makeSteps(["s1"]));
+    expect(() => ledger.recordAttempt("nope")).toThrow(/step not found/i);
+  });
+
+  it("throws on recordRejection for unknown step", () => {
+    const ledger = RunLedger.create(makeSteps(["s1"]));
+    expect(() => ledger.recordRejection("nope")).toThrow(/step not found/i);
+  });
+
+  it("throws on resetRejectionStreak for unknown step", () => {
+    const ledger = RunLedger.create(makeSteps(["s1"]));
+    expect(() => ledger.resetRejectionStreak("nope")).toThrow(
+      /step not found/i,
+    );
+  });
+});

--- a/packages/openomni/test/team/stall-detector.test.ts
+++ b/packages/openomni/test/team/stall-detector.test.ts
@@ -54,6 +54,28 @@ describe("StallDetector", () => {
     });
   });
 
+    it("ignores terminal (failed/succeeded/skipped) steps when checking rejections", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+
+      // Step A: failed with high rejection streak
+      ledger.transition("A", "running");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+      ledger.transition("A", "failed");
+
+      // Step B: running with no rejections
+      ledger.transition("B", "running");
+
+      // Should NOT detect stall — A is terminal and should be filtered
+      const result = StallDetector.checkConsecutiveRejections(
+        ledger,
+        DEFAULT_CONFIG,
+      );
+      expect(result.stalled).toBe(false);
+    });
+
   describe("checkNoProgress", () => {
     it("detects stall when noProgressTurns >= max and no running steps", () => {
       const steps = [makeStep("A"), makeStep("B")];
@@ -162,11 +184,11 @@ describe("StallDetector", () => {
       const ledger = RunLedger.create(steps);
       const dag = DAG.build(steps);
 
+      // Step A is running with 3 rejections (not terminal)
       ledger.transition("A", "running");
       ledger.recordRejection("A");
       ledger.recordRejection("A");
       ledger.recordRejection("A");
-      ledger.transition("A", "failed");
       const result = StallDetector.check(ledger, dag, DEFAULT_CONFIG, 5);
       expect(result.stalled).toBe(true);
       expect(result.reason).toBe("consecutive_rejections");

--- a/packages/openomni/test/team/stall-detector.test.ts
+++ b/packages/openomni/test/team/stall-detector.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "bun:test";
+import type { PlanStep } from "@openomni/protocol";
+import { RunLedger } from "../../src/team/run-ledger";
+import { DAG } from "../../src/dag/index";
+import { StallDetector } from "../../src/team/stall-detector";
+
+function makeStep(id: string, deps: string[] = []): PlanStep {
+  return {
+    stepId: id,
+    description: `Step ${id}`,
+    expectedOutput: `Output of ${id}`,
+    dependsOn: deps,
+  };
+}
+
+const DEFAULT_CONFIG: StallDetector.StallConfig = {
+  maxConsecutiveRejections: 3,
+  maxNoProgressTurns: 5,
+};
+
+describe("StallDetector", () => {
+  describe("checkConsecutiveRejections", () => {
+    it("detects stall when rejectionStreak >= max", () => {
+      const steps = [makeStep("A")];
+      const ledger = RunLedger.create(steps);
+
+      ledger.transition("A", "running");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+
+      const result = StallDetector.checkConsecutiveRejections(
+        ledger,
+        DEFAULT_CONFIG,
+      );
+      expect(result.stalled).toBe(true);
+      expect(result.reason).toBe("consecutive_rejections");
+      expect(result.stalledStepId).toBe("A");
+    });
+
+    it("returns no stall when rejectionStreak < max", () => {
+      const steps = [makeStep("A")];
+      const ledger = RunLedger.create(steps);
+
+      ledger.transition("A", "running");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+
+      const result = StallDetector.checkConsecutiveRejections(
+        ledger,
+        DEFAULT_CONFIG,
+      );
+      expect(result.stalled).toBe(false);
+    });
+  });
+
+  describe("checkNoProgress", () => {
+    it("detects stall when noProgressTurns >= max and no running steps", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+
+      const result = StallDetector.checkNoProgress(
+        ledger,
+        dag,
+        DEFAULT_CONFIG,
+        5,
+      );
+      expect(result.stalled).toBe(true);
+      expect(result.reason).toBe("no_progress");
+    });
+
+    it("returns no stall when noProgressTurns >= max but steps are running", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      ledger.transition("A", "running");
+
+      const result = StallDetector.checkNoProgress(
+        ledger,
+        dag,
+        DEFAULT_CONFIG,
+        5,
+      );
+      expect(result.stalled).toBe(false);
+    });
+
+    it("returns no stall when noProgressTurns < max", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      const result = StallDetector.checkNoProgress(
+        ledger,
+        dag,
+        DEFAULT_CONFIG,
+        3,
+      );
+      expect(result.stalled).toBe(false);
+    });
+  });
+
+  describe("checkUnsatisfiableDeps", () => {
+    it("detects stall when all deps are failed/skipped", () => {
+      const steps = [makeStep("A"), makeStep("B", ["A"])];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      ledger.transition("A", "running");
+      ledger.transition("A", "failed");
+
+      const result = StallDetector.checkUnsatisfiableDeps(ledger, dag);
+      expect(result.stalled).toBe(true);
+      expect(result.reason).toBe("unsatisfiable_deps");
+      expect(result.stalledStepId).toBe("B");
+    });
+
+    it("returns no stall when step has no deps", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      const result = StallDetector.checkUnsatisfiableDeps(ledger, dag);
+      expect(result.stalled).toBe(false);
+    });
+
+    it("detects stall when some deps succeeded and some failed", () => {
+      const steps = [makeStep("A"), makeStep("B"), makeStep("C", ["A", "B"])];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      ledger.transition("A", "running");
+      ledger.transition("A", "succeeded");
+      ledger.transition("B", "running");
+      ledger.transition("B", "failed");
+
+      const result = StallDetector.checkUnsatisfiableDeps(ledger, dag);
+      expect(result.stalled).toBe(true);
+      expect(result.reason).toBe("unsatisfiable_deps");
+      expect(result.stalledStepId).toBe("C");
+    });
+  });
+
+  describe("check", () => {
+    it("returns no stall when all steps running normally", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      ledger.transition("A", "running");
+      ledger.transition("B", "running");
+
+      const result = StallDetector.check(ledger, dag, DEFAULT_CONFIG, 0);
+      expect(result.stalled).toBe(false);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it("consecutive_rejections takes priority over no_progress", () => {
+      const steps = [makeStep("A"), makeStep("B")];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      ledger.transition("A", "running");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+      ledger.recordRejection("A");
+      ledger.transition("A", "failed");
+      const result = StallDetector.check(ledger, dag, DEFAULT_CONFIG, 5);
+      expect(result.stalled).toBe(true);
+      expect(result.reason).toBe("consecutive_rejections");
+    });
+
+    it("returns no stall when everything is fine", () => {
+      const steps = [makeStep("A"), makeStep("B", ["A"])];
+      const ledger = RunLedger.create(steps);
+      const dag = DAG.build(steps);
+
+      ledger.transition("A", "running");
+
+      const result = StallDetector.check(ledger, dag, DEFAULT_CONFIG, 0);
+      expect(result.stalled).toBe(false);
+    });
+  });
+});

--- a/packages/openomni/test/team/team-orchestrator.test.ts
+++ b/packages/openomni/test/team/team-orchestrator.test.ts
@@ -1,0 +1,280 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Message, Plan, PlanStep, Run, Sink } from "@openomni/protocol";
+import type { Teammate } from "../../src/team/teammate";
+
+type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
+
+let mockRunFn: MockLlmFn = async () => ({ type: "stop" });
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
+}));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+}));
+
+let TeamOrchestrator: typeof import("../../src/team/team-orchestrator").TeamOrchestrator;
+
+const responseQueue: string[] = [];
+const executedTasks: string[] = [];
+
+beforeAll(async () => {
+  ({ TeamOrchestrator } = await import("../../src/team/team-orchestrator"));
+});
+
+beforeEach(() => {
+  responseQueue.length = 0;
+  executedTasks.length = 0;
+
+  mockRunFn = async (input: unknown, sink: Sink) => {
+    const messageInput = input as {
+      messages?: Message.WithParts[];
+    };
+
+    const text =
+      messageInput.messages?.[0]?.parts
+        ?.filter((part): part is Message.TextPart => part.type === "text")
+        .map((part) => part.text)
+        .join("\n") ?? "";
+
+    if (text.includes("Execute the following task:")) {
+      const matchedTask = text.match(/Task:\s*(.+)/);
+      if (matchedTask?.[1]) {
+        executedTasks.push(matchedTask[1].trim());
+      }
+    }
+
+    const responseText = responseQueue.shift() ?? "{}";
+    sink.onMessage(createAssistantMessage(responseText));
+    return { type: "stop" };
+  };
+});
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "team-orchestrator-test";
+  const now = Date.now();
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 10,
+      output: 5,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+
+  return { info, parts: [textPart] };
+}
+
+function makeStep(
+  stepId: string,
+  dependsOn: string[] = [],
+  suggestedAgent?: string,
+): PlanStep {
+  return {
+    stepId,
+    description: `${stepId} task`,
+    expectedOutput: `${stepId} output`,
+    dependsOn,
+    suggestedAgent,
+  };
+}
+
+function makePlan(steps: PlanStep[]): Plan {
+  return {
+    planId: "plan-1",
+    goal: "execute plan",
+    steps,
+    createdAt: new Date(),
+    version: 1,
+  };
+}
+
+const defaultTeammateConfig: Teammate.TeammateConfig = {
+  agentId: "default-agent",
+  model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+};
+
+function makeConfig(overrides?: {
+  teammates?: Map<string, Teammate.TeammateConfig>;
+  maxAttemptsPerStep?: number;
+  stallConfig?: {
+    maxConsecutiveRejections: number;
+    maxNoProgressTurns: number;
+  };
+}) {
+  return {
+    reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    teammates:
+      overrides?.teammates ?? new Map<string, Teammate.TeammateConfig>(),
+    defaultTeammateConfig,
+    maxAttemptsPerStep: overrides?.maxAttemptsPerStep,
+    stallConfig: overrides?.stallConfig,
+  };
+}
+
+describe("TeamOrchestrator.execute", () => {
+  it("completes a single accepted step", async () => {
+    responseQueue.push("single-step output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    const result = await TeamOrchestrator.execute(plan, makeConfig());
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual(["s1"]);
+    expect(result.failedSteps).toEqual([]);
+    expect(result.skippedSteps).toEqual([]);
+    expect(result.results.get("s1")).toBe("single-step output");
+  });
+
+  it("runs dependent steps in order", async () => {
+    responseQueue.push("s1 output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+    responseQueue.push("s2 output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1"), makeStep("s2", ["s1"])]);
+    const result = await TeamOrchestrator.execute(plan, makeConfig());
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual(["s1", "s2"]);
+    expect(executedTasks).toEqual(["s1 task", "s2 task"]);
+  });
+
+  it("retries once after rejection and then succeeds", async () => {
+    responseQueue.push("first attempt output");
+    responseQueue.push(
+      JSON.stringify({ decision: "reject", feedback: "needs improvement" }),
+    );
+    responseQueue.push("second attempt output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const plan = makePlan([makeStep("s1")]);
+    const result = await TeamOrchestrator.execute(
+      plan,
+      makeConfig({ maxAttemptsPerStep: 3 }),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual(["s1"]);
+    expect(result.results.get("s1")).toBe("second attempt output");
+    expect(executedTasks.filter((task) => task === "s1 task")).toHaveLength(2);
+  });
+
+  it("fails when max attempts are exhausted", async () => {
+    responseQueue.push("attempt 1 output");
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "bad" }));
+    responseQueue.push("attempt 2 output");
+    responseQueue.push(
+      JSON.stringify({ decision: "reject", feedback: "still bad" }),
+    );
+
+    const plan = makePlan([makeStep("s1")]);
+    const result = await TeamOrchestrator.execute(
+      plan,
+      makeConfig({ maxAttemptsPerStep: 2 }),
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.failedSteps).toEqual(["s1"]);
+    expect(result.completedSteps).toEqual([]);
+  });
+
+  it("skips dependents when a prerequisite step fails", async () => {
+    responseQueue.push("attempt output");
+    responseQueue.push(
+      JSON.stringify({ decision: "reject", feedback: "fatal" }),
+    );
+
+    const plan = makePlan([makeStep("s1"), makeStep("s2", ["s1"])]);
+    const result = await TeamOrchestrator.execute(
+      plan,
+      makeConfig({ maxAttemptsPerStep: 1 }),
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.failedSteps).toEqual(["s1"]);
+    expect(result.skippedSteps).toEqual(["s2"]);
+  });
+
+  it("returns stalled when consecutive rejection threshold is hit", async () => {
+    responseQueue.push("attempt 1 output");
+    responseQueue.push(
+      JSON.stringify({ decision: "reject", feedback: "nope" }),
+    );
+    responseQueue.push("attempt 2 output");
+    responseQueue.push(
+      JSON.stringify({ decision: "reject", feedback: "still nope" }),
+    );
+
+    const plan = makePlan([makeStep("s1")]);
+    const result = await TeamOrchestrator.execute(
+      plan,
+      makeConfig({
+        maxAttemptsPerStep: 10,
+        stallConfig: {
+          maxConsecutiveRejections: 2,
+          maxNoProgressTurns: 100,
+        },
+      }),
+    );
+
+    expect(result.status).toBe("stalled");
+    expect(result.stallReason).toBe("consecutive_rejections");
+  });
+
+  it("throws on cyclic DAG", async () => {
+    const plan = makePlan([makeStep("s1", ["s2"]), makeStep("s2", ["s1"])]);
+
+    return expect(TeamOrchestrator.execute(plan, makeConfig())).rejects.toThrow(
+      /cycle/i,
+    );
+  });
+
+  it("completes an empty plan", async () => {
+    const plan = makePlan([]);
+    const result = await TeamOrchestrator.execute(plan, makeConfig());
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toEqual([]);
+    expect(result.failedSteps).toEqual([]);
+    expect(result.skippedSteps).toEqual([]);
+    expect(result.results.size).toBe(0);
+  });
+});

--- a/packages/openomni/test/team/team-orchestrator.test.ts
+++ b/packages/openomni/test/team/team-orchestrator.test.ts
@@ -1,105 +1,47 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { Message, Plan, PlanStep, Run, Sink } from "@openomni/protocol";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AgentResult } from "@openomni/agent";
+import type { Plan, PlanStep } from "@openomni/protocol";
 import type { Teammate } from "../../src/team/teammate";
-
-type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
-
-let mockRunFn: MockLlmFn = async () => ({ type: "stop" });
-
-const mockModelsGet = mock(async () => ({
-  anthropic: {
-    id: "anthropic",
-    name: "Anthropic",
-    models: {
-      "claude-3-haiku-20240307": {
-        id: "claude-3-haiku-20240307",
-        name: "Claude 3 Haiku",
-      },
-    },
-  },
-}));
-
-const mockProviderFromModelsDevModel = mock(() => ({
-  id: "claude-3-haiku-20240307",
-  providerID: "anthropic",
-}));
-
-mock.module("@openomni/llm", () => ({
-  ModelsDev: { get: mockModelsGet },
-  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
-  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
-}));
-
-let TeamOrchestrator: typeof import("../../src/team/team-orchestrator").TeamOrchestrator;
 
 const responseQueue: string[] = [];
 const executedTasks: string[] = [];
 
-beforeAll(async () => {
-  ({ TeamOrchestrator } = await import("../../src/team/team-orchestrator"));
-});
+mock.module("@openomni/agent", () => ({
+  ChatAgent: {
+    create: () => ({
+      run: async (input: {
+        messages: Array<{ role: string; content: string }>;
+      }) => {
+        const userPrompt = input.messages[0]?.content ?? "";
+        if (userPrompt.includes("Execute the following task:")) {
+          const matchedTask = userPrompt.match(/Task:\s*(.+)/);
+          if (matchedTask?.[1]) {
+            executedTasks.push(matchedTask[1].trim());
+          }
+        }
+
+        const text = responseQueue.shift() ?? "{}";
+        return {
+          text,
+          steps: [],
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+          },
+          finishReason: "stop",
+        } as AgentResult;
+      },
+    }),
+  },
+}));
+
+const { TeamOrchestrator } = await import("../../src/team/team-orchestrator");
 
 beforeEach(() => {
   responseQueue.length = 0;
   executedTasks.length = 0;
-
-  mockRunFn = async (input: unknown, sink: Sink) => {
-    const messageInput = input as {
-      messages?: Message.WithParts[];
-    };
-
-    const text =
-      messageInput.messages?.[0]?.parts
-        ?.filter((part): part is Message.TextPart => part.type === "text")
-        .map((part) => part.text)
-        .join("\n") ?? "";
-
-    if (text.includes("Execute the following task:")) {
-      const matchedTask = text.match(/Task:\s*(.+)/);
-      if (matchedTask?.[1]) {
-        executedTasks.push(matchedTask[1].trim());
-      }
-    }
-
-    const responseText = responseQueue.shift() ?? "{}";
-    sink.onMessage(createAssistantMessage(responseText));
-    return { type: "stop" };
-  };
 });
-
-function createAssistantMessage(text: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "team-orchestrator-test";
-  const now = Date.now();
-  const info: Message.AssistantMessage = {
-    id,
-    sessionID,
-    role: "assistant",
-    time: { created: now },
-    parentID: "",
-    modelID: "claude-3-haiku-20240307",
-    providerID: "anthropic",
-    agent: "chat-agent",
-    path: { cwd: "", root: "" },
-    cost: 0,
-    tokens: {
-      input: 10,
-      output: 5,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-  };
-
-  const textPart: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID,
-    messageID: id,
-    type: "text",
-    text,
-  };
-
-  return { info, parts: [textPart] };
-}
 
 function makeStep(
   stepId: string,

--- a/packages/openomni/test/team/teammate.test.ts
+++ b/packages/openomni/test/team/teammate.test.ts
@@ -4,6 +4,7 @@ import type { AgentResult, TokenUsage } from "@openomni/agent";
 import { Teammate } from "../../src/team/teammate";
 
 // Mock ChatAgent module
+const mockChatAgentConfigs: unknown[] = [];
 const mockChatAgentInstances: Array<{
   run: (input: unknown) => Promise<AgentResult>;
 }> = [];
@@ -11,6 +12,7 @@ const mockChatAgentInstances: Array<{
 mock.module("@openomni/agent", () => ({
   ChatAgent: {
     create: (config: unknown) => {
+      mockChatAgentConfigs.push(config);
       const instance = {
         run: mock(async (input: unknown): Promise<AgentResult> => {
           return {
@@ -33,6 +35,7 @@ mock.module("@openomni/agent", () => ({
 
 describe("Teammate", () => {
   beforeEach(() => {
+    mockChatAgentConfigs.length = 0;
     mockChatAgentInstances.length = 0;
   });
 
@@ -163,9 +166,10 @@ describe("Teammate", () => {
 
       await Teammate.execute({ step }, config);
 
-      // Verify ChatAgent.create was called with toolExecutor in config
-      // This is verified by checking that the instance was created
-      expect(mockChatAgentInstances.length).toBe(1);
+      // Verify ChatAgent.create was called with toolExecutor
+      expect(mockChatAgentConfigs.length).toBe(1);
+      const passedConfig = mockChatAgentConfigs[0] as Record<string, unknown>;
+      expect(passedConfig.toolExecutor).toBe(mockToolExecutor);
     });
 
     it("should return result.output matching AgentResult.text", async () => {
@@ -229,8 +233,10 @@ describe("Teammate", () => {
 
       await Teammate.execute({ step }, config);
 
-      // Verify ChatAgent.create was called
-      expect(mockChatAgentInstances.length).toBe(1);
+      // Verify ChatAgent.create was called with correct systemPrompt
+      expect(mockChatAgentConfigs.length).toBe(1);
+      const passedConfig = mockChatAgentConfigs[0] as Record<string, unknown>;
+      expect(passedConfig.systemPrompt).toBe("You are a helpful assistant");
     });
 
     it("should pass tools to ChatAgent config when provided", async () => {
@@ -260,7 +266,9 @@ describe("Teammate", () => {
 
       await Teammate.execute({ step }, config);
 
-      expect(mockChatAgentInstances.length).toBe(1);
+      expect(mockChatAgentConfigs.length).toBe(1);
+      const passedConfig = mockChatAgentConfigs[0] as Record<string, unknown>;
+      expect(passedConfig.tools).toEqual(tools);
     });
 
     it("should pass budget to ChatAgent config when provided", async () => {
@@ -280,7 +288,78 @@ describe("Teammate", () => {
 
       await Teammate.execute({ step }, config);
 
-      expect(mockChatAgentInstances.length).toBe(1);
+      expect(mockChatAgentConfigs.length).toBe(1);
+      const passedConfig = mockChatAgentConfigs[0] as Record<string, unknown>;
+      expect(passedConfig.budget).toEqual(budget);
+    });
+
+    it("should merge config tools with step-level tools", async () => {
+      const configTool: Tool.Spec = {
+        name: "config-tool",
+        description: "Tool from config",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      };
+      const stepTool: Tool.Spec = {
+        name: "step-tool",
+        description: "Tool from step",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      };
+
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+        dependsOn: [],
+        tools: [stepTool],
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        tools: [configTool],
+      };
+
+      await Teammate.execute({ step }, config);
+
+      expect(mockChatAgentConfigs.length).toBe(1);
+      const passedConfig = mockChatAgentConfigs[0] as Record<string, unknown>;
+      const tools = passedConfig.tools as Tool.Spec[];
+      expect(tools).toHaveLength(2);
+      expect(tools.map((t) => t.name).sort()).toEqual(["config-tool", "step-tool"]);
+    });
+
+    it("step tools override config tools with same name", async () => {
+      const configTool: Tool.Spec = {
+        name: "shared-tool",
+        description: "From config",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      };
+      const stepTool: Tool.Spec = {
+        name: "shared-tool",
+        description: "From step (override)",
+        inputSchema: { type: "object", properties: {}, required: [] },
+      };
+
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+        dependsOn: [],
+        tools: [stepTool],
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        tools: [configTool],
+      };
+
+      await Teammate.execute({ step }, config);
+
+      const passedConfig = mockChatAgentConfigs[0] as Record<string, unknown>;
+      const tools = passedConfig.tools as Tool.Spec[];
+      expect(tools).toHaveLength(1);
+      expect(tools[0].description).toBe("From step (override)");
     });
   });
 });

--- a/packages/openomni/test/team/teammate.test.ts
+++ b/packages/openomni/test/team/teammate.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { PlanStep, Tool } from "@openomni/protocol";
+import type { AgentResult, TokenUsage } from "@openomni/agent";
+import { Teammate } from "../../src/team/teammate";
+
+// Mock ChatAgent module
+const mockChatAgentInstances: Array<{
+  run: (input: unknown) => Promise<AgentResult>;
+}> = [];
+
+mock.module("@openomni/agent", () => ({
+  ChatAgent: {
+    create: (config: unknown) => {
+      const instance = {
+        run: mock(async (input: unknown): Promise<AgentResult> => {
+          return {
+            text: "Mock agent output",
+            steps: [],
+            usage: {
+              inputTokens: 10,
+              outputTokens: 20,
+              totalTokens: 30,
+            },
+            finishReason: "stop",
+          };
+        }),
+      };
+      mockChatAgentInstances.push(instance);
+      return instance;
+    },
+  },
+}));
+
+describe("Teammate", () => {
+  beforeEach(() => {
+    mockChatAgentInstances.length = 0;
+  });
+
+  describe("execute()", () => {
+    it("should return ExecuteResult with correct agentId and stepId", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      };
+
+      const result = await Teammate.execute({ step }, config);
+
+      expect(result.agentId).toBe("agent-1");
+      expect(result.stepId).toBe("step-1");
+      expect(result.output).toBe("Mock agent output");
+      expect(result.usage).toEqual({
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      });
+      expect(result.finishReason).toBe("stop");
+    });
+
+    it("should create fresh ChatAgent per call (no shared state)", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      };
+
+      // First call
+      await Teammate.execute({ step }, config);
+      const firstInstanceCount = mockChatAgentInstances.length;
+
+      // Second call
+      await Teammate.execute({ step }, config);
+      const secondInstanceCount = mockChatAgentInstances.length;
+
+      // Should have created 2 separate instances
+      expect(secondInstanceCount).toBe(firstInstanceCount + 1);
+    });
+
+    it("should include context in user message when provided", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      };
+
+      const context = "Previous step output: some data";
+
+      await Teammate.execute({ step, context }, config);
+
+      // Verify the ChatAgent.run was called with context in message
+      const instance = mockChatAgentInstances[0];
+      expect(instance.run).toHaveBeenCalled();
+
+      const callArgs = instance.run.mock.calls[0];
+      const input = callArgs[0] as { messages: Array<{ content: string }> };
+
+      // Check that context is in the user message
+      const userMessage = input.messages[0];
+      expect(userMessage.content).toContain("Context from previous steps:");
+      expect(userMessage.content).toContain(context);
+    });
+
+    it("should include handoffDocument in user message when provided", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      };
+
+      const handoffDocument =
+        "Previous attempt notes: try a different approach";
+
+      await Teammate.execute({ step, handoffDocument }, config);
+
+      const instance = mockChatAgentInstances[0];
+      const callArgs = instance.run.mock.calls[0];
+      const input = callArgs[0] as { messages: Array<{ content: string }> };
+
+      const userMessage = input.messages[0];
+      expect(userMessage.content).toContain("Handoff from previous attempt:");
+      expect(userMessage.content).toContain(handoffDocument);
+    });
+
+    it("should pass toolExecutor to ChatAgent config when provided", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const mockToolExecutor = mock(async (call: Tool.Call) => ({
+        id: "result-1",
+        toolCallId: call.id,
+        output: "Tool result",
+        isError: false,
+      }));
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        toolExecutor: mockToolExecutor,
+      };
+
+      await Teammate.execute({ step }, config);
+
+      // Verify ChatAgent.create was called with toolExecutor in config
+      // This is verified by checking that the instance was created
+      expect(mockChatAgentInstances.length).toBe(1);
+    });
+
+    it("should return result.output matching AgentResult.text", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      };
+
+      const result = await Teammate.execute({ step }, config);
+
+      // The output should match the text from AgentResult
+      expect(result.output).toBe("Mock agent output");
+    });
+
+    it("should build user message with task description and expected output", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Analyze the data",
+        expectedOutput: "A summary of findings",
+      };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      };
+
+      await Teammate.execute({ step }, config);
+
+      const instance = mockChatAgentInstances[0];
+      const callArgs = instance.run.mock.calls[0];
+      const input = callArgs[0] as { messages: Array<{ content: string }> };
+
+      const userMessage = input.messages[0];
+      expect(userMessage.content).toContain("Execute the following task:");
+      expect(userMessage.content).toContain("Task: Analyze the data");
+      expect(userMessage.content).toContain(
+        "Expected Output: A summary of findings",
+      );
+    });
+
+    it("should pass systemPrompt to ChatAgent config when provided", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const systemPrompt = "You are a helpful assistant";
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        systemPrompt,
+      };
+
+      await Teammate.execute({ step }, config);
+
+      // Verify ChatAgent.create was called
+      expect(mockChatAgentInstances.length).toBe(1);
+    });
+
+    it("should pass tools to ChatAgent config when provided", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const tools: Tool.Spec[] = [
+        {
+          name: "test-tool",
+          description: "A test tool",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            required: [],
+          },
+        },
+      ];
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        tools,
+      };
+
+      await Teammate.execute({ step }, config);
+
+      expect(mockChatAgentInstances.length).toBe(1);
+    });
+
+    it("should pass budget to ChatAgent config when provided", async () => {
+      const step: PlanStep = {
+        stepId: "step-1",
+        description: "Test step",
+        expectedOutput: "Expected result",
+      };
+
+      const budget = { maxTurns: 5, maxToolCalls: 10 };
+
+      const config: Teammate.TeammateConfig = {
+        agentId: "agent-1",
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        budget,
+      };
+
+      await Teammate.execute({ step }, config);
+
+      expect(mockChatAgentInstances.length).toBe(1);
+    });
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -7,3 +7,4 @@ export * from "./bus/index.js";
 export * from "./event/index.js";
 export * from "./notification/index.js";
 export * from "./plan/index.js";
+export * from "./team/index.js";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -6,3 +6,4 @@ export * from "./sink/index.js";
 export * from "./bus/index.js";
 export * from "./event/index.js";
 export * from "./notification/index.js";
+export * from "./plan/index.js";

--- a/packages/protocol/src/plan/index.ts
+++ b/packages/protocol/src/plan/index.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { Tool } from "../tool/index.js";
+
+export const PlanStepSchema = z.object({
+  stepId: z.string(),
+  description: z.string(),
+  expectedOutput: z.string(),
+  dependsOn: z.array(z.string()).default([]),
+  suggestedAgent: z.string().optional(),
+  guardrail: z.string().optional(),
+  tools: z.array(Tool.Spec).optional(),
+});
+
+export type PlanStep = z.infer<typeof PlanStepSchema>;
+
+export const PlanSchema = z
+  .object({
+    planId: z.string(),
+    goal: z.string(),
+    steps: z.array(PlanStepSchema),
+    createdAt: z.date(),
+    version: z.number().int().default(1),
+  })
+  .superRefine((data, ctx) => {
+    // Check for duplicate step IDs
+    const stepIds = data.steps.map((s) => s.stepId);
+    const uniqueIds = new Set(stepIds);
+    if (stepIds.length !== uniqueIds.size) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Step IDs must be unique",
+        path: ["steps"],
+      });
+    }
+
+    // Check that all dependencies reference existing steps
+    const stepIdSet = new Set(stepIds);
+    for (const step of data.steps) {
+      for (const dep of step.dependsOn) {
+        if (!stepIdSet.has(dep)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Step "${step.stepId}" depends on non-existent step "${dep}"`,
+            path: ["steps"],
+          });
+        }
+      }
+    }
+  });
+
+export type Plan = z.infer<typeof PlanSchema>;
+
+export const PlanConfigSchema = z.object({
+  model: z.object({
+    provider: z.string(),
+    id: z.string(),
+  }),
+  systemPrompt: z.string().optional(),
+  reviewPrompt: z.string().optional(),
+});
+
+export type PlanConfig = z.infer<typeof PlanConfigSchema>;
+
+export const PlanResultSchema = z.object({
+  plan: PlanSchema,
+  reviewNotes: z.string().optional(),
+});
+
+export type PlanResult = z.infer<typeof PlanResultSchema>;

--- a/packages/protocol/src/team/index.ts
+++ b/packages/protocol/src/team/index.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+import { BusEvent } from "../bus/index.js";
+
+/**
+ * Base event schema with correlation fields
+ * All team events must include these fields for tracing and correlation
+ */
+const BaseEvent = z.object({
+  traceId: z.string(),
+  runId: z.string().optional(),
+  taskId: z.string().optional(),
+  sessionId: z.string().optional(),
+  time: z.number(),
+});
+
+export namespace Team {
+  /**
+   * Step execution state enum
+   */
+  export const StepState = z.enum([
+    "ready",
+    "running",
+    "succeeded",
+    "failed",
+    "skipped",
+  ]);
+  export type StepState = z.infer<typeof StepState>;
+
+  /**
+   * RunLedgerEntry tracks the execution state of a single step
+   */
+  export const RunLedgerEntry = z.object({
+    stepId: z.string(),
+    state: StepState,
+    assignedAgent: z.string().optional(),
+    attempts: z.number().int().min(0).default(0),
+    rejectionStreak: z.number().int().min(0).default(0),
+    totalRejections: z.number().int().min(0).default(0),
+    error: z.string().optional(),
+    result: z.string().optional(),
+    startedAt: z.date().optional(),
+    completedAt: z.date().optional(),
+  });
+  export type RunLedgerEntry = z.infer<typeof RunLedgerEntry>;
+
+  /**
+   * Stall reason enum for execution stalls
+   */
+  export const StallReason = z.enum([
+    "consecutive_rejections",
+    "no_progress",
+    "unsatisfiable_deps",
+  ]);
+  export type StallReason = z.infer<typeof StallReason>;
+
+  /**
+   * ReviewDecision for step review outcomes
+   */
+  export const ReviewDecision = z.object({
+    decision: z.enum(["accept", "reject"]),
+    feedback: z.string().optional(),
+  });
+  export type ReviewDecision = z.infer<typeof ReviewDecision>;
+
+  /**
+   * Team Events namespace
+   */
+  export namespace Events {
+    /**
+     * plan.created - Emitted when a new plan is created
+     */
+    export const PlanCreated = BusEvent.define(
+      "plan.created",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          goal: z.string(),
+          stepCount: z.number().int(),
+        }),
+      }),
+    );
+
+    /**
+     * step.assigned - Emitted when a step is assigned to an agent
+     */
+    export const StepAssigned = BusEvent.define(
+      "step.assigned",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          stepId: z.string(),
+          agentId: z.string(),
+        }),
+      }),
+    );
+
+    /**
+     * step.started - Emitted when a step execution starts
+     */
+    export const StepStarted = BusEvent.define(
+      "step.started",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          stepId: z.string(),
+          agentId: z.string(),
+          attempt: z.number().int(),
+        }),
+      }),
+    );
+
+    /**
+     * step.completed - Emitted when a step completes successfully
+     */
+    export const StepCompleted = BusEvent.define(
+      "step.completed",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          stepId: z.string(),
+          result: z.string(),
+        }),
+      }),
+    );
+
+    /**
+     * step.failed - Emitted when a step fails
+     */
+    export const StepFailed = BusEvent.define(
+      "step.failed",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          stepId: z.string(),
+          error: z.string(),
+        }),
+      }),
+    );
+
+    /**
+     * review.decision - Emitted when a step review decision is made
+     */
+    export const ReviewDecision = BusEvent.define(
+      "review.decision",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          stepId: z.string(),
+          decision: z.enum(["accept", "reject"]),
+          feedback: z.string().optional(),
+        }),
+      }),
+    );
+
+    /**
+     * step.handoff - Emitted when a step is handed off between agents
+     */
+    export const StepHandoff = BusEvent.define(
+      "step.handoff",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          stepId: z.string(),
+          from: z.string(),
+          to: z.string(),
+          handoffDocument: z.string(),
+        }),
+      }),
+    );
+
+    /**
+     * stall.detected - Emitted when execution stall is detected
+     */
+    export const StallDetected = BusEvent.define(
+      "stall.detected",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          reason: StallReason,
+          details: z.string(),
+        }),
+      }),
+    );
+
+    /**
+     * replan.requested - Emitted when replanning is requested
+     */
+    export const ReplanRequested = BusEvent.define(
+      "replan.requested",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          reason: z.string(),
+        }),
+      }),
+    );
+
+    /**
+     * execution.complete - Emitted when execution completes
+     */
+    export const ExecutionComplete = BusEvent.define(
+      "execution.complete",
+      BaseEvent.extend({
+        payload: z.object({
+          planId: z.string(),
+          status: z.string(),
+          completedSteps: z.number().int(),
+          failedSteps: z.number().int(),
+          skippedSteps: z.number().int(),
+        }),
+      }),
+    );
+  }
+}

--- a/packages/protocol/src/team/index.ts
+++ b/packages/protocol/src/team/index.ts
@@ -104,7 +104,7 @@ export namespace Team {
           planId: z.string(),
           stepId: z.string(),
           agentId: z.string(),
-          attempt: z.number().int(),
+          attempt: z.number().int().min(1),
         }),
       }),
     );
@@ -204,9 +204,9 @@ export namespace Team {
         payload: z.object({
           planId: z.string(),
           status: z.string(),
-          completedSteps: z.number().int(),
-          failedSteps: z.number().int(),
-          skippedSteps: z.number().int(),
+          completedSteps: z.number().int().min(0),
+          failedSteps: z.number().int().min(0),
+          skippedSteps: z.number().int().min(0),
         }),
       }),
     );

--- a/packages/protocol/test/plan.test.ts
+++ b/packages/protocol/test/plan.test.ts
@@ -1,0 +1,263 @@
+import { describe, test, expect } from "bun:test";
+import {
+  PlanStepSchema,
+  PlanSchema,
+  PlanConfigSchema,
+  PlanResultSchema,
+} from "../src/plan/index.js";
+
+describe("PlanStep", () => {
+  test("should parse valid step with required fields", () => {
+    const step = PlanStepSchema.parse({
+      stepId: "step-1",
+      description: "Initialize project",
+      expectedOutput: "Project initialized",
+      dependsOn: [],
+    });
+    expect(step.stepId).toBe("step-1");
+    expect(step.description).toBe("Initialize project");
+    expect(step.expectedOutput).toBe("Project initialized");
+    expect(step.dependsOn).toEqual([]);
+  });
+
+  test("should parse step with optional fields", () => {
+    const step = PlanStepSchema.parse({
+      stepId: "step-2",
+      description: "Build API",
+      expectedOutput: "API built",
+      dependsOn: ["step-1"],
+      suggestedAgent: "backend-agent",
+      guardrail: "Ensure all endpoints are documented",
+      tools: [
+        {
+          name: "npm",
+          description: "Node package manager",
+          inputSchema: { command: { type: "string" } },
+        },
+      ],
+    });
+    expect(step.stepId).toBe("step-2");
+    expect(step.suggestedAgent).toBe("backend-agent");
+    expect(step.guardrail).toBe("Ensure all endpoints are documented");
+    expect(step.tools).toHaveLength(1);
+    expect(step.tools?.[0].name).toBe("npm");
+  });
+
+  test("should default dependsOn to empty array", () => {
+    const step = PlanStepSchema.parse({
+      stepId: "step-1",
+      description: "Test",
+      expectedOutput: "Done",
+    });
+    expect(step.dependsOn).toEqual([]);
+  });
+
+  test("should reject missing required fields", () => {
+    expect(() =>
+      PlanStepSchema.parse({
+        stepId: "step-1",
+        description: "Test",
+        // missing expectedOutput
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Plan", () => {
+  test("should parse valid plan with empty steps", () => {
+    const now = new Date();
+    const plan = PlanSchema.parse({
+      planId: "plan-1",
+      goal: "Build a web application",
+      steps: [],
+      createdAt: now,
+      version: 1,
+    });
+    expect(plan.planId).toBe("plan-1");
+    expect(plan.goal).toBe("Build a web application");
+    expect(plan.steps).toEqual([]);
+    expect(plan.version).toBe(1);
+  });
+
+  test("should parse valid plan with steps and dependencies", () => {
+    const now = new Date();
+    const plan = PlanSchema.parse({
+      planId: "plan-1",
+      goal: "Build API",
+      steps: [
+        {
+          stepId: "A",
+          description: "Setup database",
+          expectedOutput: "Database ready",
+          dependsOn: [],
+        },
+        {
+          stepId: "B",
+          description: "Create API endpoints",
+          expectedOutput: "Endpoints created",
+          dependsOn: ["A"],
+        },
+      ],
+      createdAt: now,
+      version: 1,
+    });
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[1].dependsOn).toEqual(["A"]);
+  });
+
+  test("should default version to 1", () => {
+    const now = new Date();
+    const plan = PlanSchema.parse({
+      planId: "plan-1",
+      goal: "Test",
+      steps: [],
+      createdAt: now,
+    });
+    expect(plan.version).toBe(1);
+  });
+
+  test("should reject plan with duplicate step IDs", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "plan-1",
+        goal: "Build API",
+        steps: [
+          {
+            stepId: "A",
+            description: "Step A",
+            expectedOutput: "Output A",
+            dependsOn: [],
+          },
+          {
+            stepId: "A",
+            description: "Step A duplicate",
+            expectedOutput: "Output A",
+            dependsOn: [],
+          },
+        ],
+        createdAt: now,
+        version: 1,
+      }),
+    ).toThrow();
+  });
+
+  test("should reject plan with dependency on non-existent step", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "plan-1",
+        goal: "Build API",
+        steps: [
+          {
+            stepId: "A",
+            description: "Step A",
+            expectedOutput: "Output A",
+            dependsOn: ["Z"],
+          },
+        ],
+        createdAt: now,
+        version: 1,
+      }),
+    ).toThrow();
+  });
+
+  test("should reject missing required fields", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "plan-1",
+        // missing goal
+        steps: [],
+        createdAt: now,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("PlanConfig", () => {
+  test("should parse valid config with required fields", () => {
+    const config = PlanConfigSchema.parse({
+      model: {
+        provider: "anthropic",
+        id: "claude-3-5-sonnet",
+      },
+    });
+    expect(config.model.provider).toBe("anthropic");
+    expect(config.model.id).toBe("claude-3-5-sonnet");
+  });
+
+  test("should parse config with optional prompts", () => {
+    const config = PlanConfigSchema.parse({
+      model: {
+        provider: "openai",
+        id: "gpt-4",
+      },
+      systemPrompt: "You are a helpful assistant",
+      reviewPrompt: "Review the plan for completeness",
+    });
+    expect(config.systemPrompt).toBe("You are a helpful assistant");
+    expect(config.reviewPrompt).toBe("Review the plan for completeness");
+  });
+
+  test("should reject missing model", () => {
+    expect(() =>
+      PlanConfigSchema.parse({
+        // missing model
+      }),
+    ).toThrow();
+  });
+
+  test("should reject missing model provider", () => {
+    expect(() =>
+      PlanConfigSchema.parse({
+        model: {
+          // missing provider
+          id: "claude-3-5-sonnet",
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("PlanResult", () => {
+  test("should parse valid result with plan only", () => {
+    const now = new Date();
+    const plan = {
+      planId: "plan-1",
+      goal: "Build API",
+      steps: [],
+      createdAt: now,
+      version: 1,
+    };
+    const result = PlanResultSchema.parse({
+      plan,
+    });
+    expect(result.plan.planId).toBe("plan-1");
+    expect(result.reviewNotes).toBeUndefined();
+  });
+
+  test("should parse result with review notes", () => {
+    const now = new Date();
+    const plan = {
+      planId: "plan-1",
+      goal: "Build API",
+      steps: [],
+      createdAt: now,
+      version: 1,
+    };
+    const result = PlanResultSchema.parse({
+      plan,
+      reviewNotes: "Plan looks good, ready for execution",
+    });
+    expect(result.reviewNotes).toBe("Plan looks good, ready for execution");
+  });
+
+  test("should reject missing plan", () => {
+    expect(() =>
+      PlanResultSchema.parse({
+        // missing plan
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/protocol/test/team.test.ts
+++ b/packages/protocol/test/team.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from "bun:test";
+import { z } from "zod";
+import { Team, BusEvent } from "../src/index.js";
+
+describe("Team Protocol Types", () => {
+  describe("StepState", () => {
+    it("should validate valid step states", () => {
+      const validStates = [
+        "ready",
+        "running",
+        "succeeded",
+        "failed",
+        "skipped",
+      ];
+      validStates.forEach((state) => {
+        expect(() => Team.StepState.parse(state)).not.toThrow();
+      });
+    });
+
+    it("should reject invalid step states", () => {
+      expect(() => Team.StepState.parse("invalid")).toThrow();
+    });
+  });
+
+  describe("RunLedgerEntry", () => {
+    it("should create a valid RunLedgerEntry with required fields", () => {
+      const entry = Team.RunLedgerEntry.parse({
+        stepId: "step-1",
+        state: "ready",
+      });
+      expect(entry.stepId).toBe("step-1");
+      expect(entry.state).toBe("ready");
+      expect(entry.attempts).toBe(0);
+      expect(entry.rejectionStreak).toBe(0);
+      expect(entry.totalRejections).toBe(0);
+    });
+
+    it("should create a valid RunLedgerEntry with all fields", () => {
+      const now = new Date();
+      const entry = Team.RunLedgerEntry.parse({
+        stepId: "step-1",
+        state: "succeeded",
+        assignedAgent: "agent-1",
+        attempts: 3,
+        rejectionStreak: 1,
+        totalRejections: 2,
+        error: "some error",
+        result: "some result",
+        startedAt: now,
+        completedAt: now,
+      });
+      expect(entry.stepId).toBe("step-1");
+      expect(entry.state).toBe("succeeded");
+      expect(entry.assignedAgent).toBe("agent-1");
+      expect(entry.attempts).toBe(3);
+      expect(entry.rejectionStreak).toBe(1);
+      expect(entry.totalRejections).toBe(2);
+      expect(entry.error).toBe("some error");
+      expect(entry.result).toBe("some result");
+      expect(entry.startedAt).toEqual(now);
+      expect(entry.completedAt).toEqual(now);
+    });
+
+    it("should reject invalid state in RunLedgerEntry", () => {
+      expect(() =>
+        Team.RunLedgerEntry.parse({
+          stepId: "step-1",
+          state: "invalid",
+        }),
+      ).toThrow();
+    });
+
+    it("should reject negative attempts", () => {
+      expect(() =>
+        Team.RunLedgerEntry.parse({
+          stepId: "step-1",
+          state: "ready",
+          attempts: -1,
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("StallReason", () => {
+    it("should validate valid stall reasons", () => {
+      const validReasons = [
+        "consecutive_rejections",
+        "no_progress",
+        "unsatisfiable_deps",
+      ];
+      validReasons.forEach((reason) => {
+        expect(() => Team.StallReason.parse(reason)).not.toThrow();
+      });
+    });
+
+    it("should reject invalid stall reasons", () => {
+      expect(() => Team.StallReason.parse("invalid_reason")).toThrow();
+    });
+  });
+
+  describe("ReviewDecision", () => {
+    it("should create a valid ReviewDecision with accept", () => {
+      const decision = Team.ReviewDecision.parse({
+        decision: "accept",
+      });
+      expect(decision.decision).toBe("accept");
+      expect(decision.feedback).toBeUndefined();
+    });
+
+    it("should create a valid ReviewDecision with reject and feedback", () => {
+      const decision = Team.ReviewDecision.parse({
+        decision: "reject",
+        feedback: "needs improvement",
+      });
+      expect(decision.decision).toBe("reject");
+      expect(decision.feedback).toBe("needs improvement");
+    });
+
+    it("should reject invalid decision", () => {
+      expect(() =>
+        Team.ReviewDecision.parse({
+          decision: "invalid",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("Team Events", () => {
+    it("should have plan.created event", () => {
+      expect(Team.Events.PlanCreated).toBeDefined();
+      expect(Team.Events.PlanCreated.name).toBe("plan.created");
+    });
+
+    it("should have step.assigned event", () => {
+      expect(Team.Events.StepAssigned).toBeDefined();
+      expect(Team.Events.StepAssigned.name).toBe("step.assigned");
+    });
+
+    it("should have step.started event", () => {
+      expect(Team.Events.StepStarted).toBeDefined();
+      expect(Team.Events.StepStarted.name).toBe("step.started");
+    });
+
+    it("should have step.completed event", () => {
+      expect(Team.Events.StepCompleted).toBeDefined();
+      expect(Team.Events.StepCompleted.name).toBe("step.completed");
+    });
+
+    it("should have step.failed event", () => {
+      expect(Team.Events.StepFailed).toBeDefined();
+      expect(Team.Events.StepFailed.name).toBe("step.failed");
+    });
+
+    it("should have review.decision event", () => {
+      expect(Team.Events.ReviewDecision).toBeDefined();
+      expect(Team.Events.ReviewDecision.name).toBe("review.decision");
+    });
+
+    it("should have step.handoff event", () => {
+      expect(Team.Events.StepHandoff).toBeDefined();
+      expect(Team.Events.StepHandoff.name).toBe("step.handoff");
+    });
+
+    it("should have stall.detected event", () => {
+      expect(Team.Events.StallDetected).toBeDefined();
+      expect(Team.Events.StallDetected.name).toBe("stall.detected");
+    });
+
+    it("should have replan.requested event", () => {
+      expect(Team.Events.ReplanRequested).toBeDefined();
+      expect(Team.Events.ReplanRequested.name).toBe("replan.requested");
+    });
+
+    it("should have execution.complete event", () => {
+      expect(Team.Events.ExecutionComplete).toBeDefined();
+      expect(Team.Events.ExecutionComplete.name).toBe("execution.complete");
+    });
+
+    it("should validate plan.created event payload", () => {
+      const eventDescriptor = Team.Events.PlanCreated;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          goal: "test goal",
+          stepCount: 5,
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate step.assigned event payload", () => {
+      const eventDescriptor = Team.Events.StepAssigned;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          stepId: "step-1",
+          agentId: "agent-1",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate step.started event payload", () => {
+      const eventDescriptor = Team.Events.StepStarted;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          stepId: "step-1",
+          agentId: "agent-1",
+          attempt: 1,
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate step.completed event payload", () => {
+      const eventDescriptor = Team.Events.StepCompleted;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          stepId: "step-1",
+          result: "step result",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate step.failed event payload", () => {
+      const eventDescriptor = Team.Events.StepFailed;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          stepId: "step-1",
+          error: "step error",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate review.decision event payload", () => {
+      const eventDescriptor = Team.Events.ReviewDecision;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          stepId: "step-1",
+          decision: "accept",
+          feedback: "looks good",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate step.handoff event payload", () => {
+      const eventDescriptor = Team.Events.StepHandoff;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          stepId: "step-1",
+          from: "agent-1",
+          to: "agent-2",
+          handoffDocument: "handoff info",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate stall.detected event payload", () => {
+      const eventDescriptor = Team.Events.StallDetected;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          reason: "consecutive_rejections",
+          details: "too many rejections",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate replan.requested event payload", () => {
+      const eventDescriptor = Team.Events.ReplanRequested;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          reason: "stall detected",
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    it("should validate execution.complete event payload", () => {
+      const eventDescriptor = Team.Events.ExecutionComplete;
+      const payload = {
+        traceId: "trace-1",
+        time: Date.now(),
+        payload: {
+          planId: "plan-1",
+          status: "completed",
+          completedSteps: 5,
+          failedSteps: 0,
+          skippedSteps: 0,
+        },
+      };
+      expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add **Plan Mode** (`PlanAgent.generate()`) — LLM-based structured plan generation with step DAG dependencies
- Add **Team Mode** (`TeamOrchestrator.execute()`) — deterministic dispatch loop with Teammate execution, ReviewLoop accept/reject, and StallDetector
- Add **DAG utilities** — pure functions for build, validate, schedule, complete
- Add **Protocol schemas** — `Plan`, `PlanStep`, `PlanResult`, `Team.StepState`, `Team.StallReason`, `RunLedgerEntry`, 10 BusEvents

## Architecture

```
Goal (string)
  → PlanAgent.generate() → Plan { steps[], DAG deps }
    → TeamOrchestrator.execute()
        ├→ DAG.getReady() → ready steps
        ├→ Teammate.execute() → step output (ChatAgent wrapper)
        ├→ ReviewLoop.review() → accept | reject (only LLM boundary)
        ├→ StallDetector.check() → stall detection
        └→ Bus.publish() → fire-and-forget events
```

**Key design**: TeamOrchestrator dispatch loop is fully deterministic — LLM is used ONLY in ReviewLoop for accept/reject decisions.

## Packages changed

- `packages/protocol` — Plan, Team, RunLedger schemas + 10 BusEvents
- `packages/agent` — `toolExecutor` callback added to ChatAgent config
- `packages/openomni` — PlanAgent, TeamOrchestrator, Teammate, ReviewLoop, StallDetector, RunLedger, DAG

## Tests

84 tests across 10 test files:
- `plan-agent.test.ts`, `teammate.test.ts`, `review-loop.test.ts`
- `run-ledger.test.ts`, `stall-detector.test.ts`, `team-orchestrator.test.ts`
- `event-stream.test.ts`, `dag.test.ts`
- `plan.test.ts`, `team.test.ts` (protocol)
- `plan-to-team.test.ts` (integration)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Plan Mode and Team Mode for structured multi‑agent runs. Generates a step DAG from a goal and executes it deterministically with review gating, stall detection, and event emission.

- **New Features**
  - Plan Mode: `PlanAgent.generate(goal, config)` returns a normalized `Plan` with a step DAG.
  - Team Mode: `TeamOrchestrator.execute(plan, config)` dispatches ready steps to `Teammate`, gates results via `ReviewLoop`, detects stalls, and publishes bus events.
  - DAG utilities: pure functions to build, validate, schedule, and complete steps.
  - Protocol: new `Plan`, `PlanStep`, `Team.StepState`, `Team.StallReason`, `RunLedgerEntry`, plus 10 bus events in `@openomni/protocol`.
  - Agent: optional `toolExecutor` in `@openomni/agent` `ChatAgent` config for custom tool call execution.

- **Migration**
  - Generate a plan with `PlanAgent.generate(goal)` and execute it via `TeamOrchestrator.execute(plan, { reviewModel, teammates, ... })`.
  - Configure teammate models (and optional `toolExecutor`) in `teammates`; existing `ChatAgent` usage remains unchanged.

<sup>Written for commit 7919032c709e2bbf0e21fe3b959678f06e517548. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

