### PR TITLE
feat(openomni): IngressEngine — session management and mode routing pipeline

### DIFF
--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -429,3 +429,88 @@ interface DAGStructure {
 - Do NOT import from `src/legacy/` directly — use the package barrel (`@openomni/openomni`).
 - For the pure ChatAgent primitive (stateless, no session), use `@openomni/agent` instead.
 - Plan Mode and Team Mode are V1 implementations — sequential, in-memory, no persistence.
+
+---
+
+## INGRESS ENGINE (Phase 3)
+
+### Architecture
+
+`IngressEngine.ingest(event)` is a **stateless pipeline** that validates, resolves sessions, projects events, and routes to the appropriate agent based on mode.
+
+```
+InboundEvent
+  └─→ IngressEngine.ingest()
+        ├─→ InboundEventSchema.parse() — Zod validation (original event preserved)
+        ├─→ IngressSessionResolver.resolve() — SurfaceKey-based session lookup/create
+        ├─→ IngressEventProjector.project() — UserMessage + TextPart stored in session
+        └─→ switch(event.mode):
+              ├─→ "plan"   → IngressHandlers.handlePlan()   → PlanAgent.generate()
+              ├─→ "team"   → IngressHandlers.handleTeam()   → TeamOrchestrator.execute()
+              └─→ "direct" → IngressHandlers.handleDirect() → ChatAgent.run()
+```
+
+### IngressEngine API
+
+```typescript
+namespace IngressEngine {
+  // Test cleanup only — clears SurfaceKey + Session state
+  function reset(): void;
+
+  // Main entry point — fully stateless
+  async function ingest(event: InboundEvent): Promise<IngressResult>;
+}
+```
+
+### InboundEvent Schema (from `@openomni/protocol`)
+
+```typescript
+// Discriminated union by mode
+type InboundEvent =
+  | { mode: "plan";   surface: string; workspace?: string; channel?: string; payload: unknown; agent: AgentDef }
+  | { mode: "team";   surface: string; workspace?: string; channel?: string; payload: unknown; agents: { reviewer: AgentDef; executor: AgentDef } }
+  | { mode: "direct"; surface: string; workspace?: string; channel?: string; payload: unknown; agent: AgentDef };
+
+type AgentDef = {
+  model: { provider: string; id: string };
+  systemPrompt?: string;
+  tools?: Tool.Spec[];
+  budget?: { maxTurns?: number };
+  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>; // TS-only, not in Zod schema
+};
+```
+
+### IngressResult (from `@openomni/protocol`)
+
+```typescript
+type IngressResult =
+  | { mode: "plan";   sessionId: string; result: PlanResult }
+  | { mode: "team";   sessionId: string; result: TeamOrchestrator.TeamResult }
+  | { mode: "direct"; sessionId: string; result: { output: string; finishReason: string } };
+```
+
+### Session Lifecycle
+
+Single session spans the full plan→re-plan→execute lifecycle:
+- Same `surface` + `workspace` + `channel` → same session (via SurfaceKey)
+- Re-plan: second `mode: "plan"` call on same session includes previous Plan + user feedback in goal
+- Team execution: `mode: "team"` extracts latest Plan from session, executes it
+
+### Key Modules
+
+| Module | File | Responsibility |
+|--------|------|----------------|
+| `IngressEngine` | `src/ingress/engine.ts` | Top-level stateless pipeline |
+| `IngressSessionResolver` | `src/ingress/session-resolver.ts` | SurfaceKey → session lookup/create |
+| `IngressEventProjector` | `src/ingress/event-projector.ts` | InboundEvent → UserMessage + TextPart |
+| `SessionBridge` | `src/ingress/session-bridge.ts` | Session↔agent input/output conversion |
+| `IngressHandlers` | `src/ingress/handlers.ts` | Mode-specific handler functions |
+
+### Architectural Decisions
+
+- **Stateless**: No `configure()` — all info comes from InboundEvent. Agent definitions provided by caller (CLI/CUI layer).
+- **toolExecutor preserved**: Zod parse is validation-only; original event object used in pipeline to preserve function fields.
+- **Plan stored in session**: As TextPart with `__OPENOMNI_PLAN__` prefix for extraction.
+- **Re-plan via conversation**: No dedicated API — session history provides context for LLM re-generation.
+- **No auto mode**: V1 requires explicit mode selection.
+- **No rework**: Post-execution result modification is V2.

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -1,0 +1,39 @@
+import {
+  InboundEventSchema,
+  type InboundEvent,
+  type IngressResult,
+} from "@openomni/protocol";
+import { Bus, Storage, SurfaceKey } from "@openomni/session";
+import { IngressEventProjector } from "./event-projector";
+import { IngressHandlers } from "./handlers";
+import { IngressSessionResolver } from "./session-resolver";
+
+export namespace IngressEngine {
+  export function reset(): void {
+    SurfaceKey.clear();
+    Storage.reset();
+    Bus.reset();
+  }
+
+  export async function ingest(event: InboundEvent): Promise<IngressResult> {
+    InboundEventSchema.parse(event);
+
+    const agentModel =
+      event.mode === "team" ? event.agents.executor.model : event.agent.model;
+    const { session } = IngressSessionResolver.resolve(event, {
+      providerID: agentModel.provider,
+      modelID: agentModel.id,
+    });
+
+    IngressEventProjector.project(event, session.id);
+
+    switch (event.mode) {
+      case "plan":
+        return IngressHandlers.handlePlan({ sessionId: session.id, event });
+      case "team":
+        return IngressHandlers.handleTeam({ sessionId: session.id, event });
+      case "direct":
+        return IngressHandlers.handleDirect({ sessionId: session.id, event });
+    }
+  }
+}

--- a/packages/openomni/src/ingress/event-projector.ts
+++ b/packages/openomni/src/ingress/event-projector.ts
@@ -32,7 +32,7 @@ export namespace IngressEventProjector {
       return (event.payload as Record<string, unknown>).text as string;
     }
 
-    return JSON.stringify(event.payload);
+    return JSON.stringify(event.payload) ?? "";
   }
 
   /**

--- a/packages/openomni/src/ingress/event-projector.ts
+++ b/packages/openomni/src/ingress/event-projector.ts
@@ -1,0 +1,72 @@
+import { InboundEvent, Message } from "@openomni/protocol";
+import { Session } from "@openomni/session";
+
+// ============================================================
+// IngressEventProjector
+// ============================================================
+
+/**
+ * IngressEventProjector converts an InboundEvent into a UserMessage + TextPart
+ * and stores both in the session.
+ *
+ * This fixes the legacy EventProjector bug where text payload was never stored.
+ */
+export namespace IngressEventProjector {
+  /**
+   * Extract text payload from an InboundEvent.
+   * - If payload is a string → return it directly
+   * - If payload is an object with a `text` field (string) → return that field
+   * - Otherwise → JSON.stringify the payload
+   */
+  function extractTextPayload(event: InboundEvent): string {
+    if (typeof event.payload === "string") {
+      return event.payload;
+    }
+
+    if (
+      typeof event.payload === "object" &&
+      event.payload !== null &&
+      "text" in event.payload &&
+      typeof (event.payload as Record<string, unknown>).text === "string"
+    ) {
+      return (event.payload as Record<string, unknown>).text as string;
+    }
+
+    return JSON.stringify(event.payload);
+  }
+
+  /**
+   * Project an InboundEvent into a session as a UserMessage + TextPart.
+   * @param event - The inbound event to project
+   * @param sessionId - The session ID to add the message to
+   */
+  export function project(event: InboundEvent, sessionId: string): void {
+    // Create UserMessage
+    const message: Message.UserMessage = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      role: "user",
+      time: {
+        created: Date.now(),
+      },
+      agent: event.surface,
+      model: undefined as any, // Will be set by caller if needed
+    };
+
+    // Store UserMessage
+    Session.addMessage(sessionId, message);
+
+    // Create TextPart with extracted text payload
+    const textPayload = extractTextPayload(event);
+    const part: Message.TextPart = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      messageID: message.id,
+      type: "text",
+      text: textPayload,
+    };
+
+    // Store TextPart
+    Session.addPart(message.id, part);
+  }
+}

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -46,6 +46,7 @@ export namespace IngressHandlers {
         systemPrompt: ctx.event.agents.executor.systemPrompt,
         tools: ctx.event.agents.executor.tools,
         toolExecutor: ctx.event.agents.executor.toolExecutor,
+        budget: ctx.event.agents.executor.budget,
       },
       teammates: new Map(),
     };
@@ -57,7 +58,14 @@ export namespace IngressHandlers {
       ctx.event.agents.reviewer.model,
     );
 
-    return { mode: "team", sessionId: ctx.sessionId, result };
+    return {
+      mode: "team",
+      sessionId: ctx.sessionId,
+      result: {
+        ...result,
+        results: Object.fromEntries(result.results),
+      },
+    };
   }
 
   export async function handleDirect(

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -1,0 +1,105 @@
+import { ChatAgent } from "@openomni/agent";
+import type { InboundEvent, IngressResult } from "@openomni/protocol";
+import { SessionBridge } from "./session-bridge";
+import { PlanAgent } from "../plan/plan-agent";
+import { TeamOrchestrator } from "../team/team-orchestrator";
+
+export namespace IngressHandlers {
+  export interface HandlerContext {
+    sessionId: string;
+    event: InboundEvent;
+  }
+
+  export async function handlePlan(
+    ctx: HandlerContext,
+  ): Promise<Extract<IngressResult, { mode: "plan" }>> {
+    if (ctx.event.mode !== "plan") {
+      throw new Error("handlePlan requires plan mode event");
+    }
+
+    const goal = SessionBridge.buildPlanGoal(ctx.sessionId);
+    const result = await PlanAgent.generate(goal, {
+      model: ctx.event.agent.model,
+      systemPrompt: ctx.event.agent.systemPrompt,
+      budget: ctx.event.agent.budget,
+    });
+
+    SessionBridge.storePlanResult(ctx.sessionId, result, ctx.event.agent.model);
+
+    return { mode: "plan", sessionId: ctx.sessionId, result };
+  }
+
+  export async function handleTeam(
+    ctx: HandlerContext,
+  ): Promise<Extract<IngressResult, { mode: "team" }>> {
+    if (ctx.event.mode !== "team") {
+      throw new Error("handleTeam requires team mode event");
+    }
+
+    const plan = SessionBridge.extractPlan(ctx.sessionId);
+    const orchestratorConfig: TeamOrchestrator.OrchestratorConfig = {
+      reviewModel: ctx.event.agents.reviewer.model,
+      reviewSystemPrompt: ctx.event.agents.reviewer.systemPrompt,
+      defaultTeammateConfig: {
+        agentId: "executor",
+        model: ctx.event.agents.executor.model,
+        systemPrompt: ctx.event.agents.executor.systemPrompt,
+        tools: ctx.event.agents.executor.tools,
+        toolExecutor: ctx.event.agents.executor.toolExecutor,
+      },
+      teammates: new Map(),
+    };
+
+    const result = await TeamOrchestrator.execute(plan, orchestratorConfig);
+    SessionBridge.storeTeamResult(
+      ctx.sessionId,
+      result,
+      ctx.event.agents.reviewer.model,
+    );
+
+    return { mode: "team", sessionId: ctx.sessionId, result };
+  }
+
+  export async function handleDirect(
+    ctx: HandlerContext,
+  ): Promise<Extract<IngressResult, { mode: "direct" }>> {
+    if (ctx.event.mode !== "direct") {
+      throw new Error("handleDirect requires direct mode event");
+    }
+
+    const messages = SessionBridge.buildDirectMessages(ctx.sessionId).filter(
+      (
+        message,
+      ): message is
+        | { role: "user"; content: string }
+        | {
+            role: "assistant";
+            content: string;
+          } => message.role === "user" || message.role === "assistant",
+    );
+    const agent = ChatAgent.create({
+      model: ctx.event.agent.model,
+      systemPrompt: ctx.event.agent.systemPrompt,
+      tools: ctx.event.agent.tools,
+      budget: ctx.event.agent.budget,
+      toolExecutor: ctx.event.agent.toolExecutor,
+    });
+    const runResult = await agent.run({ messages });
+    const output = runResult.text;
+
+    SessionBridge.storeDirectResult(
+      ctx.sessionId,
+      output,
+      ctx.event.agent.model,
+    );
+
+    return {
+      mode: "direct",
+      sessionId: ctx.sessionId,
+      result: {
+        output,
+        finishReason: runResult.finishReason,
+      },
+    };
+  }
+}

--- a/packages/openomni/src/ingress/index.ts
+++ b/packages/openomni/src/ingress/index.ts
@@ -1,0 +1,5 @@
+export { IngressEngine } from "./engine.js";
+export { IngressSessionResolver } from "./session-resolver.js";
+export { IngressEventProjector } from "./event-projector.js";
+export { SessionBridge } from "./session-bridge.js";
+export { IngressHandlers } from "./handlers.js";

--- a/packages/openomni/src/ingress/session-bridge.ts
+++ b/packages/openomni/src/ingress/session-bridge.ts
@@ -70,6 +70,7 @@ export namespace SessionBridge {
     // Scan for the last plan in session
     let lastPlanJson: string | undefined;
     for (const message of messages) {
+      if (message.role !== "assistant") continue;
       const parts = Session.getParts(message.id);
       for (const part of parts) {
         if (part.type === "text" && part.text.startsWith(PLAN_PREFIX)) {
@@ -110,6 +111,7 @@ export namespace SessionBridge {
 
     let lastPlanText: string | undefined;
     for (const message of messages) {
+      if (message.role !== "assistant") continue;
       const parts = Session.getParts(message.id);
       for (const part of parts) {
         if (part.type === "text" && part.text.startsWith(PLAN_PREFIX)) {
@@ -140,7 +142,7 @@ export namespace SessionBridge {
     for (const message of messages) {
       const parts = Session.getParts(message.id);
       for (const part of parts) {
-        if (part.type === "text") {
+        if (part.type === "text" && !part.text.startsWith(PLAN_PREFIX)) {
           result.push({ role: message.role, content: part.text });
         }
       }

--- a/packages/openomni/src/ingress/session-bridge.ts
+++ b/packages/openomni/src/ingress/session-bridge.ts
@@ -1,0 +1,221 @@
+import { Message, PlanSchema } from "@openomni/protocol";
+import type { Plan, PlanResult } from "@openomni/protocol";
+import { Session } from "@openomni/session";
+import type { TeamOrchestrator } from "../team/team-orchestrator";
+
+const PLAN_PREFIX = "__OPENOMNI_PLAN__";
+
+/**
+ * Normalize Plan payload from JSON round-trip.
+ * JSON.stringify converts Date → string, so we convert it back.
+ * Duplicated from plan-agent.ts (private function) to avoid modifying that module.
+ */
+function normalizePlanPayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  if (typeof candidate.createdAt !== "string") {
+    return payload;
+  }
+
+  const parsedDate = new Date(candidate.createdAt);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return payload;
+  }
+
+  return { ...candidate, createdAt: parsedDate };
+}
+
+function createAssistantMessage(
+  sessionId: string,
+  model: { provider: string; id: string },
+): Message.AssistantMessage {
+  return {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "",
+    modelID: model.id,
+    providerID: model.provider,
+    agent: "session-bridge",
+    path: { cwd: process.cwd(), root: process.cwd() },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+/**
+ * SessionBridge — converts between session messages and agent inputs/outputs.
+ *
+ * Handles Plan storage/extraction using the `__OPENOMNI_PLAN__` prefix convention,
+ * and message format conversion for direct/plan/team modes.
+ */
+export namespace SessionBridge {
+  /**
+   * Build a goal string for PlanAgent from session messages.
+   * - If no previous Plan exists: returns the latest user message text.
+   * - If a previous Plan exists: returns "Previous plan:\n{plan}\n\nUser feedback:\n{latest user text}".
+   */
+  export function buildPlanGoal(sessionId: string): string {
+    const messages = Session.getMessages(sessionId);
+
+    // Scan for the last plan in session
+    let lastPlanJson: string | undefined;
+    for (const message of messages) {
+      const parts = Session.getParts(message.id);
+      for (const part of parts) {
+        if (part.type === "text" && part.text.startsWith(PLAN_PREFIX)) {
+          lastPlanJson = part.text.slice(PLAN_PREFIX.length);
+        }
+      }
+    }
+
+    // Get the latest user message text
+    let latestUserText = "";
+    for (const message of messages) {
+      if (message.role === "user") {
+        const parts = Session.getParts(message.id);
+        for (const part of parts) {
+          if (part.type === "text") {
+            latestUserText = part.text;
+          }
+        }
+      }
+    }
+
+    if (!lastPlanJson) {
+      return latestUserText;
+    }
+
+    return `Previous plan:\n${lastPlanJson}\n\nUser feedback:\n${latestUserText}`;
+  }
+
+  /**
+   * Extract the latest Plan from session messages.
+   * Scans all TextParts for the `__OPENOMNI_PLAN__` prefix, takes the last one,
+   * parses and validates via PlanSchema with Date normalization.
+   *
+   * @throws Error if no plan found in session
+   */
+  export function extractPlan(sessionId: string): Plan {
+    const messages = Session.getMessages(sessionId);
+
+    let lastPlanText: string | undefined;
+    for (const message of messages) {
+      const parts = Session.getParts(message.id);
+      for (const part of parts) {
+        if (part.type === "text" && part.text.startsWith(PLAN_PREFIX)) {
+          lastPlanText = part.text.slice(PLAN_PREFIX.length);
+        }
+      }
+    }
+
+    if (!lastPlanText) {
+      throw new Error("No plan found in session");
+    }
+
+    const parsed = JSON.parse(lastPlanText);
+    const normalized = normalizePlanPayload(parsed);
+    return PlanSchema.parse(normalized);
+  }
+
+  /**
+   * Build a simple message array for ChatAgent.run() from session messages.
+   * Each message with a TextPart becomes { role, content }.
+   */
+  export function buildDirectMessages(
+    sessionId: string,
+  ): Array<{ role: string; content: string }> {
+    const messages = Session.getMessages(sessionId);
+    const result: Array<{ role: string; content: string }> = [];
+
+    for (const message of messages) {
+      const parts = Session.getParts(message.id);
+      for (const part of parts) {
+        if (part.type === "text") {
+          result.push({ role: message.role, content: part.text });
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Store a PlanResult in the session as an AssistantMessage + TextPart
+   * with the `__OPENOMNI_PLAN__` prefix for later extraction.
+   */
+  export function storePlanResult(
+    sessionId: string,
+    result: PlanResult,
+    model: { provider: string; id: string },
+  ): void {
+    const message = createAssistantMessage(sessionId, model);
+    Session.addMessage(sessionId, message);
+
+    const part: Message.TextPart = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      messageID: message.id,
+      type: "text",
+      text: PLAN_PREFIX + JSON.stringify(result.plan),
+    };
+    Session.addPart(message.id, part);
+  }
+
+  /**
+   * Store a TeamResult in the session as an AssistantMessage + TextPart.
+   * Converts Map fields to plain objects for JSON serialization.
+   */
+  export function storeTeamResult(
+    sessionId: string,
+    result: TeamOrchestrator.TeamResult,
+    model: { provider: string; id: string },
+  ): void {
+    const message = createAssistantMessage(sessionId, model);
+    Session.addMessage(sessionId, message);
+
+    const serializable = {
+      ...result,
+      results: Object.fromEntries(result.results),
+    };
+
+    const part: Message.TextPart = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      messageID: message.id,
+      type: "text",
+      text: JSON.stringify(serializable),
+    };
+    Session.addPart(message.id, part);
+  }
+
+  /**
+   * Store a direct agent text output in the session as an AssistantMessage + TextPart.
+   */
+  export function storeDirectResult(
+    sessionId: string,
+    output: string,
+    model: { provider: string; id: string },
+  ): void {
+    const message = createAssistantMessage(sessionId, model);
+    Session.addMessage(sessionId, message);
+
+    const part: Message.TextPart = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      messageID: message.id,
+      type: "text",
+      text: output,
+    };
+    Session.addPart(message.id, part);
+  }
+}

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -1,0 +1,82 @@
+import { Session, SurfaceKey } from "@openomni/session";
+
+// Minimal event shape needed for session resolution.
+// Full InboundEvent type from @openomni/protocol will be used
+// in T5/T6 when wiring everything together.
+interface ResolvableEvent {
+  surface: string;
+  workspace?: string;
+  channel?: string;
+}
+
+// Default model config when creating new sessions
+export interface ModelConfig {
+  providerID: string;
+  modelID: string;
+}
+
+export namespace IngressSessionResolver {
+  export interface ResolveResult {
+    session: Session.Info;
+    isNew: boolean;
+  }
+
+  /**
+   * Build a SurfaceKey from event origin fields.
+   * Format: "surface:workspace:channel" (omit undefined parts)
+   * Examples:
+   *   {surface: "tui", workspace: "/project"} → "tui:/project"
+   *   {surface: "slack", workspace: "team-a", channel: "C123"} → "slack:team-a:C123"
+   *   {surface: "tui"} → "tui" (single element, no ":" — will fail SurfaceKey.create validation)
+   *
+   * For single-surface keys, we use the raw string directly since SurfaceKey.create()
+   * requires at least 2 parts to include a ":" separator.
+   */
+  export function extractSurfaceKey(event: ResolvableEvent): string {
+    const parts = [event.surface, event.workspace, event.channel].filter(
+      (p): p is string => p !== undefined && p !== "",
+    );
+
+    // If only surface, return it directly (no ":" separator)
+    if (parts.length === 1) {
+      return parts[0];
+    }
+
+    // Multiple parts: use SurfaceKey.create() which validates ":" presence
+    return SurfaceKey.create(parts);
+  }
+
+  /**
+   * Resolve a session for the given event.
+   * Looks up the SurfaceKey in the SurfaceKey registry.
+   * If found and session exists → reuse it.
+   * If found but session missing (stale) → create new + re-register.
+   * If not found → create new + register.
+   */
+  export function resolve(
+    event: ResolvableEvent,
+    defaultModel: ModelConfig = {
+      providerID: "anthropic",
+      modelID: "claude-3-5-sonnet-20241022",
+    },
+  ): ResolveResult {
+    const surfaceKey = extractSurfaceKey(event);
+    const existingSessionId = SurfaceKey.lookup(surfaceKey);
+
+    if (existingSessionId) {
+      const existing = Session.get(existingSessionId);
+      if (existing) {
+        return { session: existing, isNew: false };
+      }
+      // Stale entry — session was deleted, create new
+    }
+
+    // Create new session and register
+    const session = Session.create({
+      title: `Session from ${event.surface}`,
+      model: defaultModel,
+    });
+    SurfaceKey.register(surfaceKey, session.id);
+    return { session, isNew: true };
+  }
+}

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -23,26 +23,20 @@ export namespace IngressSessionResolver {
 
   /**
    * Build a SurfaceKey from event origin fields.
-   * Format: "surface:workspace:channel" (omit undefined parts)
+   * Format: "surface:workspace:channel" (always 3 positional parts).
+   * Missing workspace/channel are represented as empty strings to prevent collisions.
    * Examples:
-   *   {surface: "tui", workspace: "/project"} → "tui:/project"
    *   {surface: "slack", workspace: "team-a", channel: "C123"} → "slack:team-a:C123"
-   *   {surface: "tui"} → "tui" (single element, no ":" — will fail SurfaceKey.create validation)
-   *
-   * For single-surface keys, we use the raw string directly since SurfaceKey.create()
-   * requires at least 2 parts to include a ":" separator.
+   *   {surface: "tui", workspace: "/project"} → "tui:/project:"
+   *   {surface: "tui"} → "tui::"
+   *   {surface: "slack", channel: "C123"} → "slack::C123"
    */
   export function extractSurfaceKey(event: ResolvableEvent): string {
-    const parts = [event.surface, event.workspace, event.channel].filter(
-      (p): p is string => p !== undefined && p !== "",
-    );
-
-    // If only surface, return it directly (no ":" separator)
-    if (parts.length === 1) {
-      return parts[0];
-    }
-
-    // Multiple parts: use SurfaceKey.create() which validates ":" presence
+    const parts = [
+      event.surface,
+      event.workspace ?? "",
+      event.channel ?? "",
+    ];
     return SurfaceKey.create(parts);
   }
 

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -1,0 +1,276 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Message, Run, Sink } from "@openomni/protocol";
+import type { InboundEvent } from "@openomni/protocol";
+
+const responseQueue: string[] = [];
+
+type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
+
+let mockRunFn: MockLlmFn = async (_input: unknown, sink: Sink) => {
+  const text = responseQueue.shift() ?? "{}";
+  sink.onMessage(createAssistantMessage(text));
+  return { type: "stop" } as Run.Outcome;
+};
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
+}));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+}));
+
+let IngressEngine: typeof import("../../src/ingress/engine").IngressEngine;
+
+beforeAll(async () => {
+  ({ IngressEngine } = await import("../../src/ingress/engine"));
+});
+
+beforeEach(() => {
+  responseQueue.length = 0;
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
+  mockRunFn = async (_input: unknown, sink: Sink) => {
+    const text = responseQueue.shift() ?? "{}";
+    sink.onMessage(createAssistantMessage(text));
+    return { type: "stop" } as Run.Outcome;
+  };
+  IngressEngine.reset();
+});
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "engine-test";
+  const now = Date.now();
+
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 1,
+      output: 1,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+
+  return { info, parts: [textPart] };
+}
+
+function enqueuePlan(goal: string): void {
+  responseQueue.push(
+    JSON.stringify({
+      planId: crypto.randomUUID(),
+      goal,
+      steps: [
+        {
+          stepId: "s1",
+          description: "Execute step",
+          expectedOutput: "done",
+          dependsOn: [],
+        },
+      ],
+      createdAt: new Date().toISOString(),
+      version: 1,
+    }),
+  );
+}
+
+describe("IngressEngine", () => {
+  it("ingest() with plan mode returns plan result", async () => {
+    enqueuePlan("Create delivery plan");
+
+    const event: InboundEvent = {
+      id: "event-plan-1",
+      surface: "tui",
+      workspace: "/repo",
+      mode: "plan",
+      payload: "Create delivery plan",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const result = await IngressEngine.ingest(event);
+
+    expect(result.mode).toBe("plan");
+    if (result.mode !== "plan") {
+      throw new Error("Expected plan mode result");
+    }
+    expect(result.sessionId).toBeString();
+    expect(result.result.plan.goal).toBe("Create delivery plan");
+  });
+
+  it("ingest() with team mode returns team result", async () => {
+    enqueuePlan("Execute release checks");
+    responseQueue.push("executor output");
+    responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+    const planEvent: InboundEvent = {
+      id: "event-team-plan",
+      surface: "tui",
+      workspace: "/repo",
+      mode: "plan",
+      payload: "Execute release checks",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const planResult = await IngressEngine.ingest(planEvent);
+
+    const teamEvent: InboundEvent = {
+      id: "event-team-run",
+      surface: "tui",
+      workspace: "/repo",
+      mode: "team",
+      payload: "run",
+      agents: {
+        reviewer: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+        executor: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      },
+    };
+
+    const result = await IngressEngine.ingest(teamEvent);
+
+    expect(planResult.sessionId).toBe(result.sessionId);
+    expect(result.mode).toBe("team");
+    if (result.mode !== "team") {
+      throw new Error("Expected team mode result");
+    }
+    expect(result.result.status).toBe("completed");
+    expect(result.result.completedSteps).toEqual(["s1"]);
+  });
+
+  it("ingest() with direct mode returns direct result", async () => {
+    responseQueue.push("direct response");
+
+    const event: InboundEvent = {
+      id: "event-direct-1",
+      surface: "slack",
+      workspace: "team-a",
+      channel: "C1",
+      mode: "direct",
+      payload: "hello",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const result = await IngressEngine.ingest(event);
+
+    expect(result.mode).toBe("direct");
+    if (result.mode !== "direct") {
+      throw new Error("Expected direct mode result");
+    }
+    expect(result.result.output).toBe("direct response");
+    expect(result.result.finishReason).toBe("stop");
+  });
+
+  it("ingest() with invalid event throws", async () => {
+    await expect(
+      IngressEngine.ingest({
+        id: "invalid-1",
+        surface: "tui",
+        payload: "hello",
+      } as unknown as InboundEvent),
+    ).rejects.toThrow();
+  });
+
+  it("reuses session for same surface key across calls", async () => {
+    enqueuePlan("First plan");
+    enqueuePlan("Second plan");
+
+    const eventA: InboundEvent = {
+      id: "event-reuse-1",
+      surface: "tui",
+      workspace: "/repo",
+      channel: "main",
+      mode: "plan",
+      payload: "First plan",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const eventB: InboundEvent = {
+      id: "event-reuse-2",
+      surface: "tui",
+      workspace: "/repo",
+      channel: "main",
+      mode: "plan",
+      payload: "Second plan",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const first = await IngressEngine.ingest(eventA);
+    const second = await IngressEngine.ingest(eventB);
+
+    expect(first.sessionId).toBe(second.sessionId);
+  });
+
+  it("reset() clears session mapping state", async () => {
+    enqueuePlan("Plan before reset");
+    enqueuePlan("Plan after reset");
+
+    const event: InboundEvent = {
+      id: "event-reset-1",
+      surface: "tui",
+      workspace: "/repo",
+      mode: "plan",
+      payload: "Plan before reset",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const first = await IngressEngine.ingest(event);
+    IngressEngine.reset();
+
+    const second = await IngressEngine.ingest({
+      ...event,
+      id: "event-reset-2",
+      payload: "Plan after reset",
+    });
+
+    expect(first.sessionId).not.toBe(second.sessionId);
+  });
+});

--- a/packages/openomni/test/ingress/event-projector.test.ts
+++ b/packages/openomni/test/ingress/event-projector.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InboundEvent, Message } from "@openomni/protocol";
+import { Session, Storage } from "@openomni/session";
+import { IngressEventProjector } from "../../src/ingress/event-projector";
+
+describe("IngressEventProjector", () => {
+  let sessionId: string;
+
+  beforeEach(() => {
+    Storage.reset();
+    sessionId = Session.create({
+      title: "Test Session",
+      model: { providerID: "anthropic", modelID: "claude-3-haiku" },
+    }).id;
+  });
+
+  it("should store TextPart with string payload verbatim", () => {
+    const event: InboundEvent = {
+      id: "event-1",
+      surface: "slack",
+      mode: "direct",
+      payload: "Hello, world!",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku" },
+      },
+    };
+
+    IngressEventProjector.project(event, sessionId);
+
+    const messages = Session.getMessages(sessionId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+
+    const parts = Session.getParts(messages[0].id);
+    expect(parts).toHaveLength(1);
+    expect(parts[0].type).toBe("text");
+    expect((parts[0] as Message.TextPart).text).toBe("Hello, world!");
+  });
+
+  it("should extract text field from object payload", () => {
+    const event: InboundEvent = {
+      id: "event-2",
+      surface: "discord",
+      mode: "direct",
+      payload: { text: "Message from Discord", author: "user123" },
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku" },
+      },
+    };
+
+    IngressEventProjector.project(event, sessionId);
+
+    const messages = Session.getMessages(sessionId);
+    const parts = Session.getParts(messages[0].id);
+    expect((parts[0] as Message.TextPart).text).toBe("Message from Discord");
+  });
+
+  it("should JSON.stringify object payload without text field", () => {
+    const payload = { type: "reaction", emoji: "👍", count: 5 };
+    const event: InboundEvent = {
+      id: "event-3",
+      surface: "telegram",
+      mode: "direct",
+      payload,
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku" },
+      },
+    };
+
+    IngressEventProjector.project(event, sessionId);
+
+    const messages = Session.getMessages(sessionId);
+    const parts = Session.getParts(messages[0].id);
+    expect((parts[0] as Message.TextPart).text).toBe(JSON.stringify(payload));
+  });
+
+  it("should set UserMessage.agent to event.surface", () => {
+    const event: InboundEvent = {
+      id: "event-4",
+      surface: "whatsapp",
+      mode: "direct",
+      payload: "Test message",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku" },
+      },
+    };
+
+    IngressEventProjector.project(event, sessionId);
+
+    const messages = Session.getMessages(sessionId);
+    expect((messages[0] as Message.UserMessage).agent).toBe("whatsapp");
+    expect(messages[0].role).toBe("user");
+  });
+
+  it("should store both UserMessage and TextPart in session", () => {
+    const event: InboundEvent = {
+      id: "event-5",
+      surface: "email",
+      mode: "direct",
+      payload: "Email body content",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku" },
+      },
+    };
+
+    IngressEventProjector.project(event, sessionId);
+
+    // Verify UserMessage is stored
+    const messages = Session.getMessages(sessionId);
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message.role).toBe("user");
+    expect(message.sessionID).toBe(sessionId);
+
+    // Verify TextPart is stored with correct references
+    const parts = Session.getParts(message.id);
+    expect(parts).toHaveLength(1);
+    const part = parts[0] as Message.TextPart;
+    expect(part.type).toBe("text");
+    expect(part.messageID).toBe(message.id);
+    expect(part.sessionID).toBe(sessionId);
+    expect(part.text).toBe("Email body content");
+  });
+});

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -1,0 +1,416 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+import { Message } from "@openomni/protocol";
+import type { InboundEvent, Plan } from "@openomni/protocol";
+import { Bus, Session, Storage, SurfaceKey } from "@openomni/session";
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
+}));
+
+const mockLlmRun = mock(async () => ({ type: "stop" as const }));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: mockLlmRun,
+}));
+
+let IngressHandlers: typeof import("../../src/ingress/handlers").IngressHandlers;
+let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;
+let TeamOrchestrator: typeof import("../../src/team/team-orchestrator").TeamOrchestrator;
+let ChatAgent: typeof import("@openomni/agent").ChatAgent;
+let SessionBridge: typeof import("../../src/ingress/session-bridge").SessionBridge;
+
+const originalFns: {
+  planGenerate?: typeof import("../../src/plan/plan-agent").PlanAgent.generate;
+  teamExecute?: typeof import("../../src/team/team-orchestrator").TeamOrchestrator.execute;
+  chatCreate?: typeof import("@openomni/agent").ChatAgent.create;
+  buildPlanGoal?: typeof import("../../src/ingress/session-bridge").SessionBridge.buildPlanGoal;
+  storePlanResult?: typeof import("../../src/ingress/session-bridge").SessionBridge.storePlanResult;
+  storeTeamResult?: typeof import("../../src/ingress/session-bridge").SessionBridge.storeTeamResult;
+  storeDirectResult?: typeof import("../../src/ingress/session-bridge").SessionBridge.storeDirectResult;
+} = {};
+
+beforeAll(async () => {
+  ({ IngressHandlers } = await import("../../src/ingress/handlers"));
+  ({ PlanAgent } = await import("../../src/plan/plan-agent"));
+  ({ TeamOrchestrator } = await import("../../src/team/team-orchestrator"));
+  ({ ChatAgent } = await import("@openomni/agent"));
+  ({ SessionBridge } = await import("../../src/ingress/session-bridge"));
+
+  originalFns.planGenerate = PlanAgent.generate;
+  originalFns.teamExecute = TeamOrchestrator.execute;
+  originalFns.chatCreate = ChatAgent.create;
+  originalFns.buildPlanGoal = SessionBridge.buildPlanGoal;
+  originalFns.storePlanResult = SessionBridge.storePlanResult;
+  originalFns.storeTeamResult = SessionBridge.storeTeamResult;
+  originalFns.storeDirectResult = SessionBridge.storeDirectResult;
+});
+
+beforeEach(() => {
+  SurfaceKey.clear();
+  Storage.reset();
+  Bus.reset();
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
+  mockLlmRun.mockClear();
+});
+
+afterEach(() => {
+  if (originalFns.planGenerate) PlanAgent.generate = originalFns.planGenerate;
+  if (originalFns.teamExecute)
+    TeamOrchestrator.execute = originalFns.teamExecute;
+  if (originalFns.chatCreate) ChatAgent.create = originalFns.chatCreate;
+  if (originalFns.buildPlanGoal)
+    SessionBridge.buildPlanGoal = originalFns.buildPlanGoal;
+  if (originalFns.storePlanResult) {
+    SessionBridge.storePlanResult = originalFns.storePlanResult;
+  }
+  if (originalFns.storeTeamResult) {
+    SessionBridge.storeTeamResult = originalFns.storeTeamResult;
+  }
+  if (originalFns.storeDirectResult) {
+    SessionBridge.storeDirectResult = originalFns.storeDirectResult;
+  }
+});
+
+function createSession(): string {
+  return Session.create({
+    title: "Handlers Test Session",
+    model: { providerID: "anthropic", modelID: "claude-3-haiku-20240307" },
+  }).id;
+}
+
+function addTextMessage(
+  sessionId: string,
+  role: "user" | "assistant",
+  text: string,
+): void {
+  if (role === "user") {
+    const message: Message.UserMessage = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "test-user",
+      model: { providerID: "anthropic", modelID: "claude-3-haiku-20240307" },
+    };
+    Session.addMessage(sessionId, message);
+    const part: Message.TextPart = {
+      id: crypto.randomUUID(),
+      sessionID: sessionId,
+      messageID: message.id,
+      type: "text",
+      text,
+    };
+    Session.addPart(message.id, part);
+    return;
+  }
+
+  const message: Message.AssistantMessage = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "test-assistant",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+  Session.addMessage(sessionId, message);
+  const part: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    messageID: message.id,
+    type: "text",
+    text,
+  };
+  Session.addPart(message.id, part);
+}
+
+function createPlan(): Plan {
+  return {
+    planId: "plan-handlers-1",
+    goal: "Deliver ingress handlers",
+    steps: [
+      {
+        stepId: "s1",
+        description: "Create handlers",
+        expectedOutput: "handlers.ts",
+        dependsOn: [],
+      },
+    ],
+    createdAt: new Date("2026-03-08T00:00:00.000Z"),
+    version: 1,
+  };
+}
+
+describe("IngressHandlers", () => {
+  it("handlePlan returns mode=plan with PlanResult", async () => {
+    const sessionId = createSession();
+    addTextMessage(sessionId, "user", "Plan this work");
+
+    const plan = createPlan();
+    const generateMock = mock(async () => ({ plan }));
+    PlanAgent.generate = generateMock;
+
+    const event: InboundEvent = {
+      id: "event-plan-1",
+      surface: "tui",
+      mode: "plan",
+      payload: "payload",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+    };
+
+    const result = await IngressHandlers.handlePlan({ sessionId, event });
+
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    expect(result.mode).toBe("plan");
+    expect(result.sessionId).toBe(sessionId);
+    expect(result.result.plan.planId).toBe(plan.planId);
+  });
+
+  it("handlePlan builds goal and stores plan result", async () => {
+    const sessionId = createSession();
+    const buildPlanGoalMock = mock(() => "goal-from-session");
+    const plan = createPlan();
+    const planResult = { plan };
+    const generateMock = mock(async () => planResult);
+    const storePlanResultMock = mock(() => {});
+
+    SessionBridge.buildPlanGoal = buildPlanGoalMock;
+    PlanAgent.generate = generateMock;
+    SessionBridge.storePlanResult = storePlanResultMock;
+
+    const event: InboundEvent = {
+      id: "event-plan-2",
+      surface: "tui",
+      mode: "plan",
+      payload: "payload",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        systemPrompt: "planner system",
+        budget: { maxTurns: 2 },
+      },
+    };
+
+    await IngressHandlers.handlePlan({ sessionId, event });
+
+    expect(buildPlanGoalMock).toHaveBeenCalledWith(sessionId);
+    expect(generateMock).toHaveBeenCalledWith("goal-from-session", {
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      systemPrompt: "planner system",
+      budget: { maxTurns: 2 },
+    });
+    expect(storePlanResultMock).toHaveBeenCalledWith(
+      sessionId,
+      planResult,
+      event.agent.model,
+    );
+  });
+
+  it("handleTeam executes extracted plan and returns team result", async () => {
+    const sessionId = createSession();
+    const reviewerModel = {
+      provider: "anthropic",
+      id: "claude-3-haiku-20240307",
+    };
+    const executorModel = {
+      provider: "anthropic",
+      id: "claude-3-haiku-20240307",
+    };
+    const plan = createPlan();
+    SessionBridge.storePlanResult(sessionId, { plan }, reviewerModel);
+
+    const teamResult: import("../../src/team/team-orchestrator").TeamOrchestrator.TeamResult =
+      {
+        status: "completed",
+        completedSteps: ["s1"],
+        failedSteps: [],
+        skippedSteps: [],
+        results: new Map([["s1", "done"]]),
+      };
+
+    const executeMock = mock(async () => teamResult);
+    const storeTeamResultMock = mock(() => {});
+    TeamOrchestrator.execute = executeMock;
+    SessionBridge.storeTeamResult = storeTeamResultMock;
+
+    const event: InboundEvent = {
+      id: "event-team-1",
+      surface: "tui",
+      mode: "team",
+      payload: "payload",
+      agents: {
+        reviewer: {
+          model: reviewerModel,
+          systemPrompt: "review prompt",
+        },
+        executor: {
+          model: executorModel,
+          systemPrompt: "execute prompt",
+          tools: [],
+        },
+      },
+    };
+
+    const result = await IngressHandlers.handleTeam({ sessionId, event });
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(executeMock).toHaveBeenCalledWith(
+      plan,
+      expect.objectContaining({
+        reviewModel: reviewerModel,
+        reviewSystemPrompt: "review prompt",
+        defaultTeammateConfig: expect.objectContaining({
+          agentId: "executor",
+          model: executorModel,
+          systemPrompt: "execute prompt",
+          tools: [],
+        }),
+      }),
+    );
+    expect(storeTeamResultMock).toHaveBeenCalledWith(
+      sessionId,
+      teamResult,
+      reviewerModel,
+    );
+    expect(result.mode).toBe("team");
+    expect(result.result).toBe(teamResult);
+  });
+
+  it("handleTeam throws when no plan exists in session", async () => {
+    const sessionId = createSession();
+    const executeMock = mock(async () => {
+      throw new Error("should not be called");
+    });
+    TeamOrchestrator.execute = executeMock;
+
+    const event: InboundEvent = {
+      id: "event-team-2",
+      surface: "tui",
+      mode: "team",
+      payload: "payload",
+      agents: {
+        reviewer: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+        executor: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      },
+    };
+
+    await expect(
+      IngressHandlers.handleTeam({ sessionId, event }),
+    ).rejects.toThrow(/No plan found in session/);
+    expect(executeMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("handleDirect runs ChatAgent with session messages and stores output", async () => {
+    const sessionId = createSession();
+    addTextMessage(sessionId, "user", "hello");
+    addTextMessage(sessionId, "assistant", "hi");
+    addTextMessage(sessionId, "user", "summarize");
+
+    const runMock = mock(async ({ messages }: { messages: unknown[] }) => ({
+      text: "direct output",
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      finishReason: "stop" as const,
+      received: messages,
+    }));
+    const createMock = mock(() => ({
+      run: runMock,
+      async *stream() {
+        return;
+      },
+    }));
+    const storeDirectResultMock = mock(() => {});
+
+    ChatAgent.create = createMock as unknown as typeof ChatAgent.create;
+    SessionBridge.storeDirectResult = storeDirectResultMock;
+
+    const toolExecutor = async () => ({
+      id: crypto.randomUUID(),
+      toolCallId: "tool-call-1",
+      output: "ok",
+      isError: false,
+    });
+    const event: InboundEvent = {
+      id: "event-direct-1",
+      surface: "tui",
+      mode: "direct",
+      payload: "payload",
+      agent: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        systemPrompt: "direct system",
+        tools: [],
+        budget: { maxTurns: 3 },
+        toolExecutor,
+      },
+    };
+
+    const result = await IngressHandlers.handleDirect({ sessionId, event });
+
+    expect(createMock).toHaveBeenCalledWith({
+      model: event.agent.model,
+      systemPrompt: "direct system",
+      tools: [],
+      budget: { maxTurns: 3 },
+      toolExecutor,
+    });
+    expect(runMock).toHaveBeenCalledWith({
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "summarize" },
+      ],
+    });
+    expect(storeDirectResultMock).toHaveBeenCalledWith(
+      sessionId,
+      "direct output",
+      event.agent.model,
+    );
+    expect(result).toEqual({
+      mode: "direct",
+      sessionId,
+      result: {
+        output: "direct output",
+        finishReason: "stop",
+      },
+    });
+  });
+});

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -308,7 +308,10 @@ describe("IngressHandlers", () => {
       reviewerModel,
     );
     expect(result.mode).toBe("team");
-    expect(result.result).toBe(teamResult);
+    expect(result.result).toEqual({
+      ...teamResult,
+      results: Object.fromEntries(teamResult.results),
+    });
   });
 
   it("handleTeam throws when no plan exists in session", async () => {

--- a/packages/openomni/test/ingress/integration.test.ts
+++ b/packages/openomni/test/ingress/integration.test.ts
@@ -1,0 +1,347 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { InboundEvent, Message, Run, Sink } from "@openomni/protocol";
+import { ZodError } from "zod";
+
+const responseQueue: string[] = [];
+const llmInputs: unknown[] = [];
+
+type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
+
+let mockRunFn: MockLlmFn = async (_input: unknown, sink: Sink) => {
+  const text = responseQueue.shift() ?? "{}";
+  sink.onMessage(createAssistantMessage(text));
+  return { type: "stop" } as Run.Outcome;
+};
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-3-haiku-20240307",
+  providerID: "anthropic",
+}));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: unknown, sink: Sink) => {
+    llmInputs.push(input);
+    return mockRunFn(input, sink);
+  },
+}));
+
+let IngressEngine: typeof import("../../src/ingress/engine").IngressEngine;
+let SessionBridge: typeof import("../../src/ingress/session-bridge").SessionBridge;
+
+beforeAll(async () => {
+  ({ IngressEngine } = await import("../../src/ingress/engine"));
+  ({ SessionBridge } = await import("../../src/ingress/session-bridge"));
+});
+
+beforeEach(() => {
+  responseQueue.length = 0;
+  llmInputs.length = 0;
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
+  mockRunFn = async (_input: unknown, sink: Sink) => {
+    const text = responseQueue.shift() ?? "{}";
+    sink.onMessage(createAssistantMessage(text));
+    return { type: "stop" } as Run.Outcome;
+  };
+  IngressEngine.reset();
+});
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "integration-test";
+  const now = Date.now();
+
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-3-haiku-20240307",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 1,
+      output: 1,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+
+  return { info, parts: [textPart] };
+}
+
+function enqueuePlan(planId: string, goal: string, stepId: string): void {
+  responseQueue.push(
+    JSON.stringify({
+      planId,
+      goal,
+      steps: [
+        {
+          stepId,
+          description: `Do ${stepId}`,
+          expectedOutput: `${stepId} done`,
+          dependsOn: [],
+        },
+      ],
+      createdAt: "2024-01-01T00:00:00.000Z",
+      version: 1,
+    }),
+  );
+}
+
+function extractTextMessages(
+  input: unknown,
+): Array<{ role: string; content: string }> {
+  if (!input || typeof input !== "object") {
+    return [];
+  }
+
+  const candidate = input as {
+    messages?: Array<{
+      info?: { role?: string };
+      parts?: Array<{ type?: string; text?: string }>;
+    }>;
+  };
+  const messages = candidate.messages ?? [];
+
+  return messages.flatMap((message) => {
+    const role = message.info?.role;
+    if (typeof role !== "string") {
+      return [];
+    }
+
+    return (message.parts ?? [])
+      .filter(
+        (part): part is { type: "text"; text: string } =>
+          part.type === "text" && typeof part.text === "string",
+      )
+      .map((part) => ({ role, content: part.text }));
+  });
+}
+
+describe("IngressEngine integration pipeline", () => {
+  describe("plan -> re-plan -> team lifecycle", () => {
+    it("reuses session and executes latest stored plan", async () => {
+      enqueuePlan("plan-1", "Build a REST API", "step-1");
+      enqueuePlan("plan-2", "Add auth to step 2", "step-2");
+      responseQueue.push("executor output");
+      responseQueue.push(JSON.stringify({ decision: "accept" }));
+
+      const first = await IngressEngine.ingest({
+        id: "evt-plan-1",
+        mode: "plan",
+        surface: "tui",
+        workspace: "/project",
+        payload: "Build a REST API",
+        agent: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      });
+
+      expect(first.mode).toBe("plan");
+      if (first.mode !== "plan") {
+        throw new Error("Expected plan mode result");
+      }
+      const firstStoredPlan = SessionBridge.extractPlan(first.sessionId);
+      expect(firstStoredPlan.goal).toBe("Build a REST API");
+
+      const second = await IngressEngine.ingest({
+        id: "evt-plan-2",
+        mode: "plan",
+        surface: "tui",
+        workspace: "/project",
+        payload: "Add auth to step 2",
+        agent: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      });
+
+      expect(second.mode).toBe("plan");
+      if (second.mode !== "plan") {
+        throw new Error("Expected plan mode result");
+      }
+
+      const replanInput = llmInputs[1];
+      const replanMessages = extractTextMessages(replanInput);
+      const replanGoal = replanMessages
+        .map((message) => message.content)
+        .join("\n");
+      expect(replanGoal).toContain("Previous plan:");
+      expect(replanGoal).toContain("Build a REST API");
+      expect(replanGoal).toContain("User feedback:");
+      expect(replanGoal).toContain("Add auth to step 2");
+
+      const team = await IngressEngine.ingest({
+        id: "evt-team-1",
+        mode: "team",
+        surface: "tui",
+        workspace: "/project",
+        payload: "execute",
+        agents: {
+          reviewer: {
+            model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+          },
+          executor: {
+            model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+          },
+        },
+      });
+
+      expect(team.mode).toBe("team");
+      if (team.mode !== "team") {
+        throw new Error("Expected team mode result");
+      }
+      expect(team.result.status).toBe("completed");
+      expect(team.result.completedSteps).toEqual(["step-2"]);
+
+      expect(first.sessionId).toBe(second.sessionId);
+      expect(second.sessionId).toBe(team.sessionId);
+    });
+  });
+
+  describe("direct mode conversation history", () => {
+    it("sends accumulated user history on second turn", async () => {
+      responseQueue.push("Hi there");
+      responseQueue.push("Sure, what do you need?");
+
+      const first = await IngressEngine.ingest({
+        id: "evt-direct-1",
+        mode: "direct",
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+        payload: "Hello",
+        agent: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      });
+
+      const second = await IngressEngine.ingest({
+        id: "evt-direct-2",
+        mode: "direct",
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+        payload: "Follow up",
+        agent: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      });
+
+      const secondInput = llmInputs[1];
+      const secondMessages = extractTextMessages(secondInput);
+      const secondUserMessages = secondMessages.filter(
+        (message) => message.role === "user",
+      );
+
+      expect(secondUserMessages).toHaveLength(2);
+      expect(secondUserMessages[0]?.content).toBe("Hello");
+      expect(secondUserMessages[1]?.content).toBe("Follow up");
+      expect(first.sessionId).toBe(second.sessionId);
+    });
+  });
+
+  describe("session isolation", () => {
+    it("does not leak plan context across different surface keys", async () => {
+      enqueuePlan("plan-a", "Plan A", "step-a");
+      enqueuePlan("plan-b", "Plan B", "step-b");
+
+      const first = await IngressEngine.ingest({
+        id: "evt-isolation-a",
+        mode: "plan",
+        surface: "tui",
+        workspace: "/project-a",
+        payload: "Plan A",
+        agent: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      });
+
+      const second = await IngressEngine.ingest({
+        id: "evt-isolation-b",
+        mode: "plan",
+        surface: "tui",
+        workspace: "/project-b",
+        payload: "Plan B",
+        agent: {
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        },
+      });
+
+      expect(first.sessionId).not.toBe(second.sessionId);
+      const planA = SessionBridge.extractPlan(first.sessionId);
+      const planB = SessionBridge.extractPlan(second.sessionId);
+      expect(planA.goal).toBe("Plan A");
+      expect(planB.goal).toBe("Plan B");
+
+      const replanInputForProjectB = llmInputs[1];
+      const replanMessagesForProjectB = extractTextMessages(
+        replanInputForProjectB,
+      )
+        .map((message) => message.content)
+        .join("\n");
+      expect(replanMessagesForProjectB).not.toContain("Previous plan:");
+      expect(replanMessagesForProjectB).toContain("Plan B");
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws when team mode runs without stored plan", async () => {
+      await expect(
+        IngressEngine.ingest({
+          id: "evt-no-plan-team",
+          mode: "team",
+          surface: "tui",
+          workspace: "/project",
+          payload: "execute",
+          agents: {
+            reviewer: {
+              model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+            },
+            executor: {
+              model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+            },
+          },
+        }),
+      ).rejects.toThrow(/No plan/);
+    });
+
+    it("throws zod error when mode is missing", async () => {
+      const invalidEvent = {
+        id: "evt-invalid-no-mode",
+        surface: "tui",
+        payload: "hello",
+      };
+
+      await expect(
+        IngressEngine.ingest(invalidEvent as unknown as InboundEvent),
+      ).rejects.toBeInstanceOf(ZodError);
+    });
+  });
+});

--- a/packages/openomni/test/ingress/session-bridge.test.ts
+++ b/packages/openomni/test/ingress/session-bridge.test.ts
@@ -134,6 +134,21 @@ describe("SessionBridge", () => {
         /No plan found in session/,
       );
     });
+
+    it("should ignore plan prefix in user messages (spoofing prevention)", () => {
+      const fakePlan = JSON.stringify({
+        planId: "fake",
+        goal: "hacked",
+        steps: [],
+        createdAt: new Date().toISOString(),
+        version: 1,
+      });
+      addUserMessage(sessionId, `__OPENOMNI_PLAN__${fakePlan}`);
+
+      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(
+        /No plan found in session/,
+      );
+    });
   });
 
   describe("buildPlanGoal", () => {
@@ -184,6 +199,20 @@ describe("SessionBridge", () => {
     it("should return empty array for session with no messages", () => {
       const messages = SessionBridge.buildDirectMessages(sessionId);
       expect(messages).toHaveLength(0);
+    });
+
+    it("should exclude __OPENOMNI_PLAN__ parts from direct messages", () => {
+      addUserMessage(sessionId, "Hello");
+      // Simulate a plan stored as assistant message
+      const plan = JSON.stringify({ planId: "p1", goal: "test", steps: [], createdAt: new Date(), version: 1 });
+      addAssistantMessage(sessionId, `__OPENOMNI_PLAN__${plan}`);
+      addUserMessage(sessionId, "Continue chat");
+
+      const messages = SessionBridge.buildDirectMessages(sessionId);
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({ role: "user", content: "Hello" });
+      expect(messages[1]).toEqual({ role: "user", content: "Continue chat" });
     });
   });
 

--- a/packages/openomni/test/ingress/session-bridge.test.ts
+++ b/packages/openomni/test/ingress/session-bridge.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { Message } from "@openomni/protocol";
+import type { Plan, PlanResult } from "@openomni/protocol";
+import { Session, Storage } from "@openomni/session";
+import { SessionBridge } from "../../src/ingress/session-bridge";
+import type { TeamOrchestrator } from "../../src/team/team-orchestrator";
+
+const TEST_MODEL = { provider: "anthropic", id: "claude-3-haiku" };
+
+function createTestSession(): string {
+  return Session.create({
+    title: "Test Session",
+    model: { providerID: "anthropic", modelID: "claude-3-haiku" },
+  }).id;
+}
+
+function addUserMessage(sessionId: string, text: string): void {
+  const message: Message.UserMessage = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test",
+    model: { providerID: "anthropic", modelID: "claude-3-haiku" },
+  };
+  Session.addMessage(sessionId, message);
+
+  const part: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    messageID: message.id,
+    type: "text",
+    text,
+  };
+  Session.addPart(message.id, part);
+}
+
+function addAssistantMessage(sessionId: string, text: string): void {
+  const message: Message.AssistantMessage = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "",
+    modelID: "claude-3-haiku",
+    providerID: "anthropic",
+    agent: "test",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+  Session.addMessage(sessionId, message);
+
+  const part: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    messageID: message.id,
+    type: "text",
+    text,
+  };
+  Session.addPart(message.id, part);
+}
+
+function createTestPlan(): Plan {
+  return {
+    planId: "plan-1",
+    goal: "Build an API",
+    steps: [
+      {
+        stepId: "s1",
+        description: "Design routes",
+        expectedOutput: "Route map",
+        dependsOn: [],
+      },
+      {
+        stepId: "s2",
+        description: "Implement handlers",
+        expectedOutput: "Working endpoints",
+        dependsOn: ["s1"],
+      },
+    ],
+    createdAt: new Date("2025-01-15T10:00:00Z"),
+    version: 1,
+  };
+}
+
+describe("SessionBridge", () => {
+  let sessionId: string;
+
+  beforeEach(() => {
+    Storage.reset();
+    sessionId = createTestSession();
+  });
+
+  describe("storePlanResult + extractPlan round-trip", () => {
+    it("should store and extract Plan with createdAt as Date", () => {
+      const plan = createTestPlan();
+      const planResult: PlanResult = { plan };
+
+      SessionBridge.storePlanResult(sessionId, planResult, TEST_MODEL);
+
+      const extracted = SessionBridge.extractPlan(sessionId);
+
+      expect(extracted.planId).toBe(plan.planId);
+      expect(extracted.goal).toBe(plan.goal);
+      expect(extracted.steps).toHaveLength(2);
+      expect(extracted.steps[0].stepId).toBe("s1");
+      expect(extracted.steps[1].dependsOn).toEqual(["s1"]);
+      expect(extracted.createdAt).toBeInstanceOf(Date);
+      expect(extracted.createdAt.toISOString()).toBe(
+        plan.createdAt.toISOString(),
+      );
+      expect(extracted.version).toBe(1);
+    });
+  });
+
+  describe("extractPlan", () => {
+    it("should throw Error with 'No plan' when session is empty", () => {
+      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(
+        /No plan found in session/,
+      );
+    });
+
+    it("should throw Error with 'No plan' when session has only user messages", () => {
+      addUserMessage(sessionId, "Hello");
+      addUserMessage(sessionId, "Build me something");
+
+      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(
+        /No plan found in session/,
+      );
+    });
+  });
+
+  describe("buildPlanGoal", () => {
+    it("should return latest user message text when no plan exists", () => {
+      addUserMessage(sessionId, "Build me an API gateway");
+
+      const goal = SessionBridge.buildPlanGoal(sessionId);
+
+      expect(goal).toBe("Build me an API gateway");
+    });
+
+    it("should include 'Previous plan:' and 'User feedback:' when plan + feedback exist", () => {
+      // First user message
+      addUserMessage(sessionId, "Build me an API");
+
+      // Store a plan result (simulates PlanAgent output)
+      const plan = createTestPlan();
+      SessionBridge.storePlanResult(sessionId, { plan }, TEST_MODEL);
+
+      // User sends feedback
+      addUserMessage(sessionId, "Add authentication to the plan");
+
+      const goal = SessionBridge.buildPlanGoal(sessionId);
+
+      expect(goal).toContain("Previous plan:");
+      expect(goal).toContain("User feedback:");
+      expect(goal).toContain("Add authentication to the plan");
+      expect(goal).toContain(plan.planId);
+    });
+  });
+
+  describe("buildDirectMessages", () => {
+    it("should return messages in chronological order with correct roles", () => {
+      addUserMessage(sessionId, "Hello");
+      addAssistantMessage(sessionId, "Hi there!");
+      addUserMessage(sessionId, "How are you?");
+      addAssistantMessage(sessionId, "I'm good!");
+
+      const messages = SessionBridge.buildDirectMessages(sessionId);
+
+      expect(messages).toHaveLength(4);
+      expect(messages[0]).toEqual({ role: "user", content: "Hello" });
+      expect(messages[1]).toEqual({ role: "assistant", content: "Hi there!" });
+      expect(messages[2]).toEqual({ role: "user", content: "How are you?" });
+      expect(messages[3]).toEqual({ role: "assistant", content: "I'm good!" });
+    });
+
+    it("should return empty array for session with no messages", () => {
+      const messages = SessionBridge.buildDirectMessages(sessionId);
+      expect(messages).toHaveLength(0);
+    });
+  });
+
+  describe("storeTeamResult", () => {
+    it("should store TeamResult as JSON in session", () => {
+      const teamResult: TeamOrchestrator.TeamResult = {
+        status: "completed",
+        completedSteps: ["s1", "s2"],
+        failedSteps: [],
+        skippedSteps: [],
+        results: new Map([
+          ["s1", "Route map created"],
+          ["s2", "Handlers implemented"],
+        ]),
+      };
+
+      SessionBridge.storeTeamResult(sessionId, teamResult, TEST_MODEL);
+
+      const messages = Session.getMessages(sessionId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe("assistant");
+
+      const parts = Session.getParts(messages[0].id);
+      expect(parts).toHaveLength(1);
+      expect(parts[0].type).toBe("text");
+
+      const stored = JSON.parse((parts[0] as Message.TextPart).text);
+      expect(stored.status).toBe("completed");
+      expect(stored.completedSteps).toEqual(["s1", "s2"]);
+      expect(stored.results.s1).toBe("Route map created");
+      expect(stored.results.s2).toBe("Handlers implemented");
+    });
+  });
+
+  describe("storeDirectResult", () => {
+    it("should store output string as TextPart in session", () => {
+      const output = "Here is the API documentation you requested.";
+
+      SessionBridge.storeDirectResult(sessionId, output, TEST_MODEL);
+
+      const messages = Session.getMessages(sessionId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe("assistant");
+
+      const parts = Session.getParts(messages[0].id);
+      expect(parts).toHaveLength(1);
+      expect(parts[0].type).toBe("text");
+      expect((parts[0] as Message.TextPart).text).toBe(output);
+    });
+  });
+});

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { SurfaceKey, Storage, Session } from "@openomni/session";
 import { IngressSessionResolver } from "../../src/ingress/session-resolver";
-import { SurfaceKey, Storage } from "@openomni/session";
-import { IngressSessionResolver } from "../../src/ingress/session-resolver";
 
 describe("IngressSessionResolver", () => {
   beforeEach(() => {
@@ -27,7 +25,7 @@ describe("IngressSessionResolver", () => {
         workspace: "/Users/ino/Develop/OpenOmni",
       };
       const key = IngressSessionResolver.extractSurfaceKey(event);
-      expect(key).toBe("tui:/Users/ino/Develop/OpenOmni");
+      expect(key).toBe("tui:/Users/ino/Develop/OpenOmni:");
     });
 
     it("builds key from surface only", () => {
@@ -35,7 +33,7 @@ describe("IngressSessionResolver", () => {
         surface: "tui",
       };
       const key = IngressSessionResolver.extractSurfaceKey(event);
-      expect(key).toBe("tui");
+      expect(key).toBe("tui::");
     });
 
     it("filters out undefined and empty string parts", () => {
@@ -45,7 +43,7 @@ describe("IngressSessionResolver", () => {
         channel: "C123",
       };
       const key = IngressSessionResolver.extractSurfaceKey(event);
-      expect(key).toBe("slack:C123");
+      expect(key).toBe("slack::C123");
     });
 
     it("handles all undefined optional fields", () => {
@@ -55,7 +53,7 @@ describe("IngressSessionResolver", () => {
         channel: undefined,
       };
       const key = IngressSessionResolver.extractSurfaceKey(event);
-      expect(key).toBe("telegram");
+      expect(key).toBe("telegram::");
     });
   });
 

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { SurfaceKey, Storage, Session } from "@openomni/session";
+import { IngressSessionResolver } from "../../src/ingress/session-resolver";
+import { SurfaceKey, Storage } from "@openomni/session";
+import { IngressSessionResolver } from "../../src/ingress/session-resolver";
+
+describe("IngressSessionResolver", () => {
+  beforeEach(() => {
+    SurfaceKey.clear();
+    Storage.reset();
+  });
+
+  describe("extractSurfaceKey", () => {
+    it("builds key from surface + workspace + channel", () => {
+      const event = {
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+      };
+      const key = IngressSessionResolver.extractSurfaceKey(event);
+      expect(key).toBe("slack:team-a:C123");
+    });
+
+    it("builds key from surface + workspace (no channel)", () => {
+      const event = {
+        surface: "tui",
+        workspace: "/Users/ino/Develop/OpenOmni",
+      };
+      const key = IngressSessionResolver.extractSurfaceKey(event);
+      expect(key).toBe("tui:/Users/ino/Develop/OpenOmni");
+    });
+
+    it("builds key from surface only", () => {
+      const event = {
+        surface: "tui",
+      };
+      const key = IngressSessionResolver.extractSurfaceKey(event);
+      expect(key).toBe("tui");
+    });
+
+    it("filters out undefined and empty string parts", () => {
+      const event = {
+        surface: "slack",
+        workspace: "",
+        channel: "C123",
+      };
+      const key = IngressSessionResolver.extractSurfaceKey(event);
+      expect(key).toBe("slack:C123");
+    });
+
+    it("handles all undefined optional fields", () => {
+      const event = {
+        surface: "telegram",
+        workspace: undefined,
+        channel: undefined,
+      };
+      const key = IngressSessionResolver.extractSurfaceKey(event);
+      expect(key).toBe("telegram");
+    });
+  });
+
+  describe("resolve", () => {
+    it("creates new session for new surface key", () => {
+      const event = {
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+      };
+      const result = IngressSessionResolver.resolve(event);
+
+      expect(result.isNew).toBe(true);
+      expect(result.session.id).toBeDefined();
+      expect(result.session.title).toBe("Session from slack");
+      expect(result.session.model.providerID).toBe("anthropic");
+      expect(result.session.model.modelID).toBe("claude-3-5-sonnet-20241022");
+    });
+
+    it("reuses same session for same surface key on second call", () => {
+      const event = {
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+      };
+
+      const result1 = IngressSessionResolver.resolve(event);
+      const result2 = IngressSessionResolver.resolve(event);
+
+      expect(result1.isNew).toBe(true);
+      expect(result2.isNew).toBe(false);
+      expect(result1.session.id).toBe(result2.session.id);
+    });
+
+    it("creates different sessions for different surface keys", () => {
+      const event1 = {
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+      };
+      const event2 = {
+        surface: "slack",
+        workspace: "team-b",
+        channel: "C456",
+      };
+
+      const result1 = IngressSessionResolver.resolve(event1);
+      const result2 = IngressSessionResolver.resolve(event2);
+
+      expect(result1.session.id).not.toBe(result2.session.id);
+      expect(result1.isNew).toBe(true);
+      expect(result2.isNew).toBe(true);
+    });
+
+    it("creates new session if existing session was deleted (stale key)", () => {
+      const event = {
+        surface: "tui",
+        workspace: "/project",
+      };
+
+      // First resolve: creates new session
+      const result1 = IngressSessionResolver.resolve(event);
+      const sessionId1 = result1.session.id;
+      expect(result1.isNew).toBe(true);
+
+      // Delete the session
+      Session.remove(sessionId1);
+      // Second resolve: should create new session (stale key)
+      const result2 = IngressSessionResolver.resolve(event);
+      const sessionId2 = result2.session.id;
+
+      expect(result2.isNew).toBe(true);
+      expect(sessionId1).not.toBe(sessionId2);
+    });
+
+    it("uses custom model config when provided", () => {
+      const event = {
+        surface: "telegram",
+        workspace: "bot-123",
+      };
+      const customModel = {
+        providerID: "openai",
+        modelID: "gpt-4",
+      };
+
+      const result = IngressSessionResolver.resolve(event, customModel);
+
+      expect(result.session.model.providerID).toBe("openai");
+      expect(result.session.model.modelID).toBe("gpt-4");
+    });
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -8,3 +8,4 @@ export * from "./event/index.js";
 export * from "./notification/index.js";
 export * from "./plan/index.js";
 export * from "./team/index.js";
+export * from "./ingress/index.js";

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -68,7 +68,7 @@ export type TeamResult = {
   failedSteps: string[];
   skippedSteps: string[];
   stallReason?: string;
-  results: Map<string, string>;
+  results: Record<string, string>;
 };
 
 // DirectResult

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import { Tool } from "../tool/index.js";
+import { PlanResult } from "../plan/index.js";
+
+// AgentDef — agent configuration passed in by callers (CLI/CUI layer)
+export const AgentDefSchema = z.object({
+  model: z.object({ provider: z.string(), id: z.string() }),
+  systemPrompt: z.string().optional(),
+  tools: z.array(Tool.Spec).optional(),
+  budget: z.object({ maxTurns: z.number().optional() }).optional(),
+});
+// IMPORTANT: toolExecutor is a runtime callback, NOT in Zod schema.
+// The TypeScript type extends the schema:
+export type AgentDef = z.infer<typeof AgentDefSchema> & {
+  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+};
+
+// InboundEvent — discriminated union by mode
+const InboundEventBase = {
+  id: z.string(),
+  surface: z.string(),
+  channel: z.string().optional(),
+  workspace: z.string().optional(),
+  userId: z.string().optional(),
+  payload: z.unknown(),
+  meta: z.record(z.unknown()).optional(),
+};
+
+export const PlanEventSchema = z.object({
+  ...InboundEventBase,
+  mode: z.literal("plan"),
+  agent: AgentDefSchema,
+});
+export type PlanEvent = z.infer<typeof PlanEventSchema> & { agent: AgentDef };
+
+export const TeamEventSchema = z.object({
+  ...InboundEventBase,
+  mode: z.literal("team"),
+  agents: z.object({
+    reviewer: AgentDefSchema,
+    executor: AgentDefSchema,
+  }),
+});
+export type TeamEvent = z.infer<typeof TeamEventSchema> & {
+  agents: { reviewer: AgentDef; executor: AgentDef };
+};
+
+export const DirectEventSchema = z.object({
+  ...InboundEventBase,
+  mode: z.literal("direct"),
+  agent: AgentDefSchema,
+});
+export type DirectEvent = z.infer<typeof DirectEventSchema> & {
+  agent: AgentDef;
+};
+
+export const InboundEventSchema = z.discriminatedUnion("mode", [
+  PlanEventSchema,
+  TeamEventSchema,
+  DirectEventSchema,
+]);
+export type InboundEvent = PlanEvent | TeamEvent | DirectEvent;
+
+// TeamResult — mirrors TeamOrchestrator.TeamResult (plain TS type, NOT Zod)
+export type TeamResult = {
+  status: "completed" | "stalled" | "failed";
+  completedSteps: string[];
+  failedSteps: string[];
+  skippedSteps: string[];
+  stallReason?: string;
+  results: Map<string, string>;
+};
+
+// DirectResult
+export type DirectResult = {
+  output: string;
+  finishReason: string;
+};
+
+// IngressResult — discriminated union return type from IngressEngine.ingest()
+export type IngressResult =
+  | { mode: "plan"; sessionId: string; result: PlanResult }
+  | { mode: "team"; sessionId: string; result: TeamResult }
+  | { mode: "direct"; sessionId: string; result: DirectResult };

--- a/packages/protocol/test/ingress.test.ts
+++ b/packages/protocol/test/ingress.test.ts
@@ -1,0 +1,312 @@
+import { describe, test, expect } from "bun:test";
+import {
+  AgentDefSchema,
+  PlanEventSchema,
+  TeamEventSchema,
+  DirectEventSchema,
+  InboundEventSchema,
+} from "../src/ingress/index.js";
+
+describe("AgentDef", () => {
+  test("should parse agent with only model required", () => {
+    const agent = AgentDefSchema.parse({
+      model: {
+        provider: "anthropic",
+        id: "claude-3-5-sonnet",
+      },
+    });
+    expect(agent.model.provider).toBe("anthropic");
+    expect(agent.model.id).toBe("claude-3-5-sonnet");
+    expect(agent.systemPrompt).toBeUndefined();
+    expect(agent.tools).toBeUndefined();
+    expect(agent.budget).toBeUndefined();
+  });
+
+  test("should parse agent with optional fields", () => {
+    const agent = AgentDefSchema.parse({
+      model: {
+        provider: "openai",
+        id: "gpt-4",
+      },
+      systemPrompt: "You are a helpful assistant",
+      tools: [
+        {
+          name: "bash",
+          description: "Execute bash commands",
+          inputSchema: { command: { type: "string" } },
+        },
+      ],
+      budget: {
+        maxTurns: 10,
+      },
+    });
+    expect(agent.systemPrompt).toBe("You are a helpful assistant");
+    expect(agent.tools).toHaveLength(1);
+    expect(agent.tools?.[0].name).toBe("bash");
+    expect(agent.budget?.maxTurns).toBe(10);
+  });
+});
+
+describe("PlanEvent", () => {
+  test("should parse valid plan event with agent", () => {
+    const event = PlanEventSchema.parse({
+      id: "event-1",
+      surface: "cli",
+      mode: "plan",
+      payload: { goal: "Build API" },
+      agent: {
+        model: {
+          provider: "anthropic",
+          id: "claude-3-5-sonnet",
+        },
+      },
+    });
+    expect(event.mode).toBe("plan");
+    expect(event.id).toBe("event-1");
+    expect(event.surface).toBe("cli");
+    expect(event.agent.model.provider).toBe("anthropic");
+  });
+
+  test("should parse plan event with optional fields", () => {
+    const event = PlanEventSchema.parse({
+      id: "event-2",
+      surface: "api",
+      channel: "webhook",
+      workspace: "workspace-1",
+      userId: "user-123",
+      mode: "plan",
+      payload: { goal: "Deploy service" },
+      meta: { source: "github" },
+      agent: {
+        model: {
+          provider: "openai",
+          id: "gpt-4",
+        },
+        systemPrompt: "You are a planning agent",
+      },
+    });
+    expect(event.channel).toBe("webhook");
+    expect(event.workspace).toBe("workspace-1");
+    expect(event.userId).toBe("user-123");
+    expect(event.meta?.source).toBe("github");
+  });
+
+  test("should reject plan event missing mode", () => {
+    expect(() =>
+      PlanEventSchema.parse({
+        id: "event-1",
+        surface: "cli",
+        payload: { goal: "Build API" },
+        agent: {
+          model: {
+            provider: "anthropic",
+            id: "claude-3-5-sonnet",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("should reject plan event missing agent", () => {
+    expect(() =>
+      PlanEventSchema.parse({
+        id: "event-1",
+        surface: "cli",
+        mode: "plan",
+        payload: { goal: "Build API" },
+      }),
+    ).toThrow();
+  });
+
+  test("should reject plan event missing surface", () => {
+    expect(() =>
+      PlanEventSchema.parse({
+        id: "event-1",
+        mode: "plan",
+        payload: { goal: "Build API" },
+        agent: {
+          model: {
+            provider: "anthropic",
+            id: "claude-3-5-sonnet",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("TeamEvent", () => {
+  test("should parse valid team event with reviewer and executor agents", () => {
+    const event = TeamEventSchema.parse({
+      id: "event-1",
+      surface: "cli",
+      mode: "team",
+      payload: { goal: "Build and review API" },
+      agents: {
+        reviewer: {
+          model: {
+            provider: "anthropic",
+            id: "claude-3-5-sonnet",
+          },
+        },
+        executor: {
+          model: {
+            provider: "openai",
+            id: "gpt-4",
+          },
+        },
+      },
+    });
+    expect(event.mode).toBe("team");
+    expect(event.agents.reviewer.model.provider).toBe("anthropic");
+    expect(event.agents.executor.model.provider).toBe("openai");
+  });
+
+  test("should reject team event missing agents.reviewer", () => {
+    expect(() =>
+      TeamEventSchema.parse({
+        id: "event-1",
+        surface: "cli",
+        mode: "team",
+        payload: { goal: "Build and review API" },
+        agents: {
+          executor: {
+            model: {
+              provider: "openai",
+              id: "gpt-4",
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("should reject team event missing agents.executor", () => {
+    expect(() =>
+      TeamEventSchema.parse({
+        id: "event-1",
+        surface: "cli",
+        mode: "team",
+        payload: { goal: "Build and review API" },
+        agents: {
+          reviewer: {
+            model: {
+              provider: "anthropic",
+              id: "claude-3-5-sonnet",
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("DirectEvent", () => {
+  test("should parse valid direct event with agent", () => {
+    const event = DirectEventSchema.parse({
+      id: "event-1",
+      surface: "cli",
+      mode: "direct",
+      payload: { query: "What is 2+2?" },
+      agent: {
+        model: {
+          provider: "anthropic",
+          id: "claude-3-5-sonnet",
+        },
+      },
+    });
+    expect(event.mode).toBe("direct");
+    expect(event.agent.model.id).toBe("claude-3-5-sonnet");
+  });
+});
+
+describe("InboundEvent (discriminated union)", () => {
+  test("should parse plan event via discriminated union", () => {
+    const event = InboundEventSchema.parse({
+      id: "event-1",
+      surface: "cli",
+      mode: "plan",
+      payload: { goal: "Build API" },
+      agent: {
+        model: {
+          provider: "anthropic",
+          id: "claude-3-5-sonnet",
+        },
+      },
+    });
+    expect(event.mode).toBe("plan");
+  });
+
+  test("should parse team event via discriminated union", () => {
+    const event = InboundEventSchema.parse({
+      id: "event-1",
+      surface: "cli",
+      mode: "team",
+      payload: { goal: "Build and review API" },
+      agents: {
+        reviewer: {
+          model: {
+            provider: "anthropic",
+            id: "claude-3-5-sonnet",
+          },
+        },
+        executor: {
+          model: {
+            provider: "openai",
+            id: "gpt-4",
+          },
+        },
+      },
+    });
+    expect(event.mode).toBe("team");
+  });
+
+  test("should parse direct event via discriminated union", () => {
+    const event = InboundEventSchema.parse({
+      id: "event-1",
+      surface: "cli",
+      mode: "direct",
+      payload: { query: "What is 2+2?" },
+      agent: {
+        model: {
+          provider: "anthropic",
+          id: "claude-3-5-sonnet",
+        },
+      },
+    });
+    expect(event.mode).toBe("direct");
+  });
+
+  test("should reject invalid mode value", () => {
+    expect(() =>
+      InboundEventSchema.parse({
+        id: "event-1",
+        surface: "cli",
+        mode: "auto",
+        payload: { goal: "Build API" },
+        agent: {
+          model: {
+            provider: "anthropic",
+            id: "claude-3-5-sonnet",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("should reject missing id", () => {
+    expect(() =>
+      InboundEventSchema.parse({
+        surface: "cli",
+        mode: "plan",
+        payload: { goal: "Build API" },
+        agent: {
+          model: {
+            provider: "anthropic",
+            id: "claude-3-5-sonnet",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add **IngressEngine** — stateless pipeline: validate → resolve session → project event → route by mode
- Add **IngressSessionResolver** — SurfaceKey-based session lookup/create (same surface = same session)
- Add **IngressEventProjector** — stores UserMessage + TextPart in session (fixes legacy TextPart bug)
- Add **SessionBridge** — session ↔ agent input/output conversion, Plan store/extract via `__OPENOMNI_PLAN__` prefix
- Add **IngressHandlers** — plan/team/direct mode dispatch to PlanAgent, TeamOrchestrator, ChatAgent
- Add **Protocol schemas** — `InboundEvent` (discriminated union by mode), `AgentDef`, `IngressResult`

## Architecture

```
InboundEvent
  → IngressEngine.ingest()
    → Zod validation (original event preserved for toolExecutor)
    → IngressSessionResolver.resolve() — SurfaceKey → session
    → IngressEventProjector.project() — store message in session
    → switch(event.mode):
        "plan"   → IngressHandlers.handlePlan()   → PlanAgent.generate()
        "team"   → IngressHandlers.handleTeam()   → TeamOrchestrator.execute()
        "direct" → IngressHandlers.handleDirect() → ChatAgent.run()
    → IngressResult
```

**Key design**: Fully stateless — no `configure()`. All info (agents, mode, surface) comes from InboundEvent. Single session spans the full plan→re-plan→execute lifecycle.

## Depends on

⚠️ Stacked on #29 (`feat/plan-team-mode`). Merge that first.

## Packages changed

- `packages/protocol` — InboundEvent, AgentDef, IngressResult schemas
- `packages/openomni` — IngressEngine, SessionResolver, EventProjector, SessionBridge, Handlers

## Tests

56 tests across 7 test files:
- `session-resolver.test.ts` (10), `event-projector.test.ts` (5)
- `session-bridge.test.ts` (9), `handlers.test.ts` (5)
- `engine.test.ts` (6), `integration.test.ts` (5)
- `ingress.test.ts` (16, protocol)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `IngressEngine`, a stateless ingestion pipeline that validates events, resolves a session by surface, records the message, and routes to plan/team/direct handlers. Unifies the session lifecycle across plan → re-plan → execute with no global configure.

- **New Features**
  - Stateless pipeline: validate → resolve session (SurfaceKey) → project event → route by mode.
  - Session management: reuse/create sessions from surface/workspace/channel; default model comes from the event’s agent; `IngressEngine.reset()` for tests.
  - Event storage: always store inbound text as UserMessage + TextPart (fixes legacy TextPart bug).
  - Bridging: convert session history to Plan goals and chat messages; store plans with `__OPENOMNI_PLAN__`; persist team/direct outputs.
  - Mode handlers: Plan → PlanAgent.generate, Team → TeamOrchestrator.execute, Direct → ChatAgent.run; preserves `toolExecutor`.
  - Protocol: add `InboundEvent`, `AgentDef`, and `IngressResult` in `@openomni/protocol`.

<sup>Written for commit b47074ccfcca2a63508f6cb9a53f939d9a9aa911. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

