### PR TITLE
chore: CI infrastructure for AI self-development

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,15 @@
+extends:
+  - "@commitlint/config-conventional"
+rules:
+  type-enum:
+    - 2
+    - always
+    - [feat, fix, refactor, test, docs, chore, perf]
+  scope-enum:
+    - 1
+    - always
+    - [protocol, session, llm, agent, openomni, cli]
+  header-max-length:
+    - 2
+    - always
+    - 72

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format migration: prettier → biome
+04578df79917ad8f2147aa03eaca0d35e9ca7bf7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: CI
+  static:
+    name: Static Analysis (${{ matrix.task }})
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        task: [lint, check-types]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.6"
@@ -27,9 +32,46 @@ jobs:
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bunx turbo run build --filter=@openomni/protocol
-      - run: bun run check-types
-      - name: Check dependency rules
-        run: bun run script/check-deps.ts
+      - run: bunx turbo run ${{ matrix.task }}
+
+  deps:
+    name: Dependency Rules
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - run: bun run script/check-deps.ts
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [static, deps]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - run: bunx turbo run build --filter=@openomni/protocol
       - name: Test (session)
         run: bun test
         working-directory: packages/session
@@ -45,3 +87,9 @@ jobs:
       - name: Test (openomni)
         run: bun run test:ci
         working-directory: packages/openomni
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage
+          path: packages/*/coverage/
+          if-no-files-found: ignore

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "build": "tsc",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "lint": "bunx biome check ./src"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.50",

--- a/apps/cli/src/adapter/discord.ts
+++ b/apps/cli/src/adapter/discord.ts
@@ -79,9 +79,7 @@ export class DiscordAdapter implements Adapter.Surface {
   private ackReceived = true;
   private reconnectAttempt = 0;
   private readonly maxBackoff = 60_000;
-  private readonly FATAL_CLOSE_CODES = new Set([
-    4004, 4010, 4011, 4012, 4013, 4014,
-  ]);
+  private readonly FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 
   constructor(
     private readonly token: string,
@@ -94,9 +92,7 @@ export class DiscordAdapter implements Adapter.Surface {
 
   async start(): Promise<void> {
     if (!this.handler) {
-      throw new Error(
-        "[discord] No message handler registered. Call onMessage() before start().",
-      );
+      throw new Error("[discord] No message handler registered. Call onMessage() before start().");
     }
 
     this.running = true;
@@ -113,10 +109,7 @@ export class DiscordAdapter implements Adapter.Surface {
     console.log("[discord] Bot stopped");
   }
 
-  async send(
-    surfaceKey: string,
-    message: Adapter.OutboundMessage,
-  ): Promise<void> {
+  async send(surfaceKey: string, message: Adapter.OutboundMessage): Promise<void> {
     const parsed = SurfaceKey.parse(surfaceKey);
     let channelId = parsed.id!;
 
@@ -182,9 +175,7 @@ export class DiscordAdapter implements Adapter.Surface {
         const code = event.code;
         if (this.FATAL_CLOSE_CODES.has(code)) {
           this.running = false;
-          console.error(
-            `[discord] Fatal close code (${code}), stopping reconnect attempts`,
-          );
+          console.error(`[discord] Fatal close code (${code}), stopping reconnect attempts`);
           return;
         }
 
@@ -278,9 +269,7 @@ export class DiscordAdapter implements Adapter.Surface {
         this.botId = d.user.id;
         this.botUsername = d.user.username;
         this.reconnectAttempt = 0;
-        console.log(
-          `[discord] Bot started: @${this.botUsername} (${this.botId})`,
-        );
+        console.log(`[discord] Bot started: @${this.botUsername} (${this.botId})`);
         return true;
       }
 
@@ -299,8 +288,7 @@ export class DiscordAdapter implements Adapter.Surface {
 
         // Build trigger context and evaluate
         const isDM = !message.guild_id;
-        const mentioned =
-          message.mentions?.some((u) => u.id === this.botId) ?? false;
+        const mentioned = message.mentions?.some((u) => u.id === this.botId) ?? false;
 
         const ctx: Adapter.TriggerContext = {
           event: "message",
@@ -326,19 +314,14 @@ export class DiscordAdapter implements Adapter.Surface {
 
   // -- Message handling -----------------------------------------------------
 
-  private async handleIncoming(
-    message: DiscordMessage,
-    mentioned: boolean,
-  ): Promise<void> {
+  private async handleIncoming(message: DiscordMessage, mentioned: boolean): Promise<void> {
     const channelId = message.channel_id;
     const isDM = !message.guild_id;
 
     // Strip @mention from content for cleaner LLM input
     let content = message.content;
     if (mentioned && !isDM) {
-      content = content
-        .replace(new RegExp(`<@!?${this.botId}>\\s*`), "")
-        .trim();
+      content = content.replace(new RegExp(`<@!?${this.botId}>\\s*`), "").trim();
     }
 
     // Strip prefix via normalizeContent (no botUsername — Discord uses ID-based mentions)
@@ -352,9 +335,7 @@ export class DiscordAdapter implements Adapter.Surface {
       id: isDM ? message.author.id : channelId,
     });
 
-    console.log(
-      `[discord] ${isDM ? "dm" : channelId}: ${content.slice(0, 80)}`,
-    );
+    console.log(`[discord] ${isDM ? "dm" : channelId}: ${content.slice(0, 80)}`);
 
     // Typing indicator (repeat every 8s until done)
     this.sendTyping(channelId);
@@ -388,17 +369,12 @@ export class DiscordAdapter implements Adapter.Surface {
 
   private getHandler(): Adapter.MessageHandler {
     if (!this.handler) {
-      throw new Error(
-        `[${this.id}] No handler registered. Call onMessage() before processing.`,
-      );
+      throw new Error(`[${this.id}] No handler registered. Call onMessage() before processing.`);
     }
     return this.handler;
   }
 
-  private async sendOutbound(
-    channelId: string,
-    message: Adapter.OutboundMessage,
-  ): Promise<void> {
+  private async sendOutbound(channelId: string, message: Adapter.OutboundMessage): Promise<void> {
     if (message.text) {
       const chunks = splitText(message.text, 2000);
       for (const chunk of chunks) {
@@ -419,10 +395,7 @@ export class DiscordAdapter implements Adapter.Surface {
 
   // -- Discord REST helper --------------------------------------------------
 
-  private async api(
-    path: string,
-    body: Record<string, unknown>,
-  ): Promise<unknown> {
+  private async api(path: string, body: Record<string, unknown>): Promise<unknown> {
     const res = await fetchWithRetry(
       `${this.baseUrl}${path}`,
       {
@@ -453,10 +426,7 @@ export class DiscordAdapter implements Adapter.Surface {
   // -- Gateway helpers ------------------------------------------------------
 
   private calculateBackoff(): number {
-    return (
-      Math.min(1000 * 2 ** this.reconnectAttempt, this.maxBackoff) +
-      Math.random() * 1000
-    );
+    return Math.min(1000 * 2 ** this.reconnectAttempt, this.maxBackoff) + Math.random() * 1000;
   }
 
   private identify(): void {

--- a/apps/cli/src/adapter/github.ts
+++ b/apps/cli/src/adapter/github.ts
@@ -95,9 +95,7 @@ export class GitHubAdapter implements Adapter.Surface {
 
   async start(): Promise<void> {
     if (!this.handler) {
-      throw new Error(
-        "[github] No message handler registered. Call onMessage() before start().",
-      );
+      throw new Error("[github] No message handler registered. Call onMessage() before start().");
     }
     console.log("[github] Webhook handler ready");
   }
@@ -106,10 +104,7 @@ export class GitHubAdapter implements Adapter.Surface {
     // Webhook-based — no persistent connection to tear down
   }
 
-  async send(
-    surfaceKey: string,
-    message: Adapter.OutboundMessage,
-  ): Promise<void> {
+  async send(surfaceKey: string, message: Adapter.OutboundMessage): Promise<void> {
     const parsed = SurfaceKey.parse(surfaceKey);
     const repo = parsed.namespace;
     const issueNumber = parseInt(parsed.id!.split("-")[1]);
@@ -235,10 +230,7 @@ export class GitHubAdapter implements Adapter.Surface {
 
   // -- Event processing -----------------------------------------------------
 
-  private async processEvent(
-    content: GitHubEventContent,
-    eventKey: string,
-  ): Promise<void> {
+  private async processEvent(content: GitHubEventContent, eventKey: string): Promise<void> {
     const surfaceKey = SurfaceKey.fromChannel({
       surface: "github",
       namespace: content.repo,
@@ -250,11 +242,7 @@ export class GitHubAdapter implements Adapter.Surface {
       `[github] ${content.repo}#${content.issueNumber} (${eventKey}): ${content.text.slice(0, 80)}`,
     );
 
-    const normalizedText = normalizeContent(
-      content.text,
-      this.config.triggers,
-      this.botUsername,
-    );
+    const normalizedText = normalizeContent(content.text, this.config.triggers, this.botUsername);
 
     try {
       const inbound: Adapter.InboundMessage = {
@@ -272,29 +260,18 @@ export class GitHubAdapter implements Adapter.Surface {
       const outbound = await this.getHandler()(inbound);
 
       if (outbound?.text && this.githubToken) {
-        await this.postComment(
-          content.repo,
-          content.issueNumber,
-          outbound.text,
-        );
+        await this.postComment(content.repo, content.issueNumber, outbound.text);
       } else if (outbound?.text) {
-        console.log(
-          `[github] Response (no token, not posted):\n${outbound.text}`,
-        );
+        console.log(`[github] Response (no token, not posted):\n${outbound.text}`);
       }
     } catch (err) {
-      console.error(
-        `[github] Error in ${content.repo}#${content.issueNumber}:`,
-        err,
-      );
+      console.error(`[github] Error in ${content.repo}#${content.issueNumber}:`, err);
     }
   }
 
   private getHandler(): Adapter.MessageHandler {
     if (!this.handler) {
-      throw new Error(
-        `[${this.id}] No handler registered. Call onMessage() before processing.`,
-      );
+      throw new Error(`[${this.id}] No handler registered. Call onMessage() before processing.`);
     }
     return this.handler;
   }
@@ -308,11 +285,7 @@ export class GitHubAdapter implements Adapter.Surface {
 
   // -- GitHub API -----------------------------------------------------------
 
-  private async postComment(
-    repo: string,
-    issueNumber: number,
-    body: string,
-  ): Promise<void> {
+  private async postComment(repo: string, issueNumber: number, body: string): Promise<void> {
     const url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`;
 
     const response = await fetchWithRetry(
@@ -340,10 +313,7 @@ export class GitHubAdapter implements Adapter.Surface {
 
   // -- Signature verification -----------------------------------------------
 
-  private async verifySignature(
-    payload: string,
-    signature: string,
-  ): Promise<boolean> {
+  private async verifySignature(payload: string, signature: string): Promise<boolean> {
     const encoder = new TextEncoder();
     const key = await crypto.subtle.importKey(
       "raw",

--- a/apps/cli/src/adapter/telegram.ts
+++ b/apps/cli/src/adapter/telegram.ts
@@ -79,17 +79,13 @@ export class TelegramAdapter implements Adapter.Surface {
 
   async start(): Promise<void> {
     if (!this.handler) {
-      throw new Error(
-        "[telegram] No message handler registered. Call onMessage() before start().",
-      );
+      throw new Error("[telegram] No message handler registered. Call onMessage() before start().");
     }
 
     const me = await this.api<TelegramUser>("getMe");
     this.botId = String(me.id);
     this.botUsername = me.username ?? "";
-    console.log(
-      `[telegram] Bot started: @${me.username ?? me.first_name} (${me.id})`,
-    );
+    console.log(`[telegram] Bot started: @${me.username ?? me.first_name} (${me.id})`);
 
     this.running = true;
     this.poll();
@@ -101,10 +97,7 @@ export class TelegramAdapter implements Adapter.Surface {
     console.log("[telegram] Bot stopped");
   }
 
-  async send(
-    surfaceKey: string,
-    message: Adapter.OutboundMessage,
-  ): Promise<void> {
+  async send(surfaceKey: string, message: Adapter.OutboundMessage): Promise<void> {
     const parsed = SurfaceKey.parse(surfaceKey);
     const chatId = parsed.id!;
     await this.sendOutbound(chatId, message);
@@ -156,8 +149,7 @@ export class TelegramAdapter implements Adapter.Surface {
     const isDM = message.chat.type === "private";
 
     // Check for @mention in text
-    const mentioned =
-      this.botUsername !== "" && text.includes(`@${this.botUsername}`);
+    const mentioned = this.botUsername !== "" && text.includes(`@${this.botUsername}`);
 
     // Build trigger context and evaluate
     const ctx: Adapter.TriggerContext = {
@@ -172,11 +164,7 @@ export class TelegramAdapter implements Adapter.Surface {
     if (!evaluateTriggers(this.config.triggers, ctx)) return;
 
     // Strip prefix if a prefix rule matched
-    const content = normalizeContent(
-      text,
-      this.config.triggers,
-      this.botUsername,
-    );
+    const content = normalizeContent(text, this.config.triggers, this.botUsername);
     if (!content) return;
 
     const surfaceKey = SurfaceKey.fromChannel({
@@ -190,12 +178,12 @@ export class TelegramAdapter implements Adapter.Surface {
 
     // Typing indicator (repeat every 4s until done)
     const typingInterval = setInterval(() => {
-      this.api("sendChatAction", { chat_id: chatId, action: "typing" }).catch(
-        (e) => console.error("[telegram] typing indicator error:", e),
+      this.api("sendChatAction", { chat_id: chatId, action: "typing" }).catch((e) =>
+        console.error("[telegram] typing indicator error:", e),
       );
     }, 4000);
-    this.api("sendChatAction", { chat_id: chatId, action: "typing" }).catch(
-      (e) => console.error("[telegram] typing indicator error:", e),
+    this.api("sendChatAction", { chat_id: chatId, action: "typing" }).catch((e) =>
+      console.error("[telegram] typing indicator error:", e),
     );
 
     try {
@@ -222,17 +210,12 @@ export class TelegramAdapter implements Adapter.Surface {
 
   private getHandler(): Adapter.MessageHandler {
     if (!this.handler) {
-      throw new Error(
-        `[${this.id}] No handler registered. Call onMessage() before processing.`,
-      );
+      throw new Error(`[${this.id}] No handler registered. Call onMessage() before processing.`);
     }
     return this.handler;
   }
 
-  private async sendOutbound(
-    chatId: string,
-    message: Adapter.OutboundMessage,
-  ): Promise<void> {
+  private async sendOutbound(chatId: string, message: Adapter.OutboundMessage): Promise<void> {
     if (message.text) {
       const chunks = splitText(message.text, 4096);
       for (const chunk of chunks) {
@@ -273,16 +256,12 @@ export class TelegramAdapter implements Adapter.Surface {
 
     if (!response.ok) {
       const body = await response.text();
-      throw new Error(
-        `Telegram API ${method} failed (${response.status}): ${body}`,
-      );
+      throw new Error(`Telegram API ${method} failed (${response.status}): ${body}`);
     }
 
     const body = (await response.json()) as TelegramResponse<T>;
     if (!body.ok) {
-      throw new Error(
-        `Telegram API ${method}: ${body.description ?? "Unknown error"}`,
-      );
+      throw new Error(`Telegram API ${method}: ${body.description ?? "Unknown error"}`);
     }
 
     return body.result;

--- a/apps/cli/src/adapter/types.ts
+++ b/apps/cli/src/adapter/types.ts
@@ -149,14 +149,10 @@ export namespace Adapter {
    * Handles an inbound message and returns an optional response.
    * Returning `null` means no response should be sent.
    */
-  export type MessageHandler = (
-    message: InboundMessage,
-  ) => Promise<OutboundMessage | null>;
+  export type MessageHandler = (message: InboundMessage) => Promise<OutboundMessage | null>;
 
   /** Handles a platform command invocation. */
-  export type CommandHandler = (
-    ctx: CommandContext,
-  ) => Promise<OutboundMessage | null>;
+  export type CommandHandler = (ctx: CommandContext) => Promise<OutboundMessage | null>;
 
   /**
    * Streaming sink for adapters that support incremental delivery.
@@ -178,10 +174,7 @@ export namespace Adapter {
    * Streaming handler — used instead of MessageHandler when the adapter
    * supports incremental delivery.
    */
-  export type StreamingHandler = (
-    message: InboundMessage,
-    sink: StreamSink,
-  ) => Promise<void>;
+  export type StreamingHandler = (message: InboundMessage, sink: StreamSink) => Promise<void>;
 
   // ── Config ────────────────────────────────────────────────────
 

--- a/apps/cli/src/cmd/auth.ts
+++ b/apps/cli/src/cmd/auth.ts
@@ -1,9 +1,6 @@
 import type { CommandModule } from "yargs";
 import * as prompts from "@clack/prompts";
-import {
-  getAuthProviders,
-  type AuthCallbacks,
-} from "@openomni/llm/src/auth/registry";
+import { getAuthProviders, type AuthCallbacks } from "@openomni/llm/src/auth/registry";
 import { Auth } from "@openomni/llm/src/auth/storage";
 
 function cancel(): never {
@@ -76,10 +73,7 @@ const AuthLoginCommand: CommandModule = {
     if (providerID === "other") {
       const customId = await prompts.text({
         message: "Enter provider id",
-        validate: (v) =>
-          v && v.match(/^[0-9a-z-]+$/)
-            ? undefined
-            : "a-z, 0-9 and hyphens only",
+        validate: (v) => (v && v.match(/^[0-9a-z-]+$/) ? undefined : "a-z, 0-9 and hyphens only"),
       });
       if (prompts.isCancel(customId)) cancel();
 
@@ -160,9 +154,7 @@ const AuthListCommand: CommandModule = {
     for (const [key, value] of entries) {
       prompts.log.info(`${key} — ${value.type}`);
     }
-    prompts.outro(
-      `${entries.length} credential${entries.length === 1 ? "" : "s"}`,
-    );
+    prompts.outro(`${entries.length} credential${entries.length === 1 ? "" : "s"}`);
   },
 };
 

--- a/apps/cli/src/cmd/config.ts
+++ b/apps/cli/src/cmd/config.ts
@@ -17,7 +17,10 @@ async function promptUsers(): Promise<string[] | undefined> {
 
   const trimmed = input.trim();
   if (!trimmed) return undefined;
-  return trimmed.split(",").map((s) => s.trim()).filter(Boolean);
+  return trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 // ---------------------------------------------------------------------------
@@ -160,9 +163,7 @@ const ConfigListCommand: CommandModule = {
     for (const entry of entries) {
       prompts.log.info(entry);
     }
-    prompts.outro(
-      `${entries.length} adapter${entries.length === 1 ? "" : "s"}`,
-    );
+    prompts.outro(`${entries.length} adapter${entries.length === 1 ? "" : "s"}`);
   },
 };
 

--- a/apps/cli/src/cmd/serve.ts
+++ b/apps/cli/src/cmd/serve.ts
@@ -5,10 +5,7 @@ import { SurfaceStore } from "../serve/surface-store";
 import { TelegramAdapter } from "../adapter/telegram";
 import { GitHubAdapter } from "../adapter/github";
 import { DiscordAdapter } from "../adapter/discord";
-import {
-  createMessageHandler,
-  type ConversationConfig,
-} from "../serve/conversation";
+import { createMessageHandler, type ConversationConfig } from "../serve/conversation";
 import type { Adapter } from "../adapter/types";
 
 type ServeArgs = {
@@ -53,9 +50,7 @@ async function resolveModel(
   if (requestedModelID) {
     const model = models.find((m) => m.id === requestedModelID);
     if (!model) {
-      console.error(
-        `Model '${requestedModelID}' not found for '${providerID}'.`,
-      );
+      console.error(`Model '${requestedModelID}' not found for '${providerID}'.`);
       process.exit(1);
     }
     return model;
@@ -138,19 +133,13 @@ export const ServeCommand: CommandModule<object, ServeArgs> = {
       adapterConfig.telegram?.token;
 
     const githubSecret =
-      argv["github-secret"] ??
-      process.env.OPENOMNI_GITHUB_SECRET ??
-      adapterConfig.github?.secret;
+      argv["github-secret"] ?? process.env.OPENOMNI_GITHUB_SECRET ?? adapterConfig.github?.secret;
 
     const githubToken =
-      argv["github-token"] ??
-      process.env.OPENOMNI_GITHUB_TOKEN ??
-      adapterConfig.github?.token;
+      argv["github-token"] ?? process.env.OPENOMNI_GITHUB_TOKEN ?? adapterConfig.github?.token;
 
     const discordToken =
-      argv["discord-token"] ??
-      process.env.OPENOMNI_DISCORD_TOKEN ??
-      adapterConfig.discord?.token;
+      argv["discord-token"] ?? process.env.OPENOMNI_DISCORD_TOKEN ?? adapterConfig.discord?.token;
 
     // -- Start adapters ---------------------------------------------------
 
@@ -160,9 +149,7 @@ export const ServeCommand: CommandModule<object, ServeArgs> = {
       const telegramAllowed = adapterConfig.telegram?.allowedUsers;
       const telegram = new TelegramAdapter(telegramToken, {
         triggers: [
-          ...(telegramAllowed
-            ? [{ type: "sender" as const, allow: telegramAllowed }]
-            : []),
+          ...(telegramAllowed ? [{ type: "sender" as const, allow: telegramAllowed }] : []),
         ],
         // TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
         deliveryPolicy: "final",
@@ -183,9 +170,7 @@ export const ServeCommand: CommandModule<object, ServeArgs> = {
               type: "event",
               events: ["issue_comment.created", "issues.opened"],
             },
-            ...(githubAllowed
-              ? [{ type: "sender" as const, allow: githubAllowed }]
-              : []),
+            ...(githubAllowed ? [{ type: "sender" as const, allow: githubAllowed }] : []),
           ],
           // TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
           deliveryPolicy: "final",
@@ -203,9 +188,7 @@ export const ServeCommand: CommandModule<object, ServeArgs> = {
       const discord = new DiscordAdapter(discordToken, {
         triggers: [
           { type: "mention" },
-          ...(discordAllowed
-            ? [{ type: "sender" as const, allow: discordAllowed }]
-            : []),
+          ...(discordAllowed ? [{ type: "sender" as const, allow: discordAllowed }] : []),
         ],
         // TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
         deliveryPolicy: "final",
@@ -216,9 +199,7 @@ export const ServeCommand: CommandModule<object, ServeArgs> = {
     }
 
     if (adapters.length === 0) {
-      console.log(
-        "No adapters configured. Run 'openomni config add' or pass tokens via CLI args.",
-      );
+      console.log("No adapters configured. Run 'openomni config add' or pass tokens via CLI args.");
       console.log("Server will start but won't process any messages.");
     }
 
@@ -234,11 +215,7 @@ export const ServeCommand: CommandModule<object, ServeArgs> = {
           return new Response("OK");
         }
 
-        if (
-          url.pathname === "/github/webhook" &&
-          github &&
-          request.method === "POST"
-        ) {
+        if (url.pathname === "/github/webhook" && github && request.method === "POST") {
           return github.handleWebhook(request);
         }
 

--- a/apps/cli/src/config/index.ts
+++ b/apps/cli/src/config/index.ts
@@ -1,12 +1,6 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
-import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  existsSync,
-  chmodSync,
-} from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
 import { z } from "zod";
 
 const CONFIG_PATH = join(homedir(), ".openomni", "config.json");
@@ -66,10 +60,7 @@ export namespace Config {
       const parsed = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
       const result = AdaptersSchema.safeParse(parsed);
       if (!result.success) {
-        console.warn(
-          "[config] invalid config.json, ignoring:",
-          result.error.message,
-        );
+        console.warn("[config] invalid config.json, ignoring:", result.error.message);
         return {};
       }
       return result.data;

--- a/apps/cli/src/serve/conversation.ts
+++ b/apps/cli/src/serve/conversation.ts
@@ -22,24 +22,19 @@ const LLM_TIMEOUT_MS = 120_000; // 2 minutes
  * Each handler instance maintains its own per-surface serialization queue
  * to prevent history race conditions.
  */
-export function createMessageHandler(
-  config: ConversationConfig,
-): Adapter.MessageHandler {
+export function createMessageHandler(config: ConversationConfig): Adapter.MessageHandler {
   const queues = new Map<string, Promise<unknown>>();
 
   return async (message) => {
     // TODO: respect Adapter.Config.deliveryPolicy - currently always delivers final response only
     const prev = queues.get(message.surfaceKey) ?? Promise.resolve();
-    const current = prev.then(() =>
-      processMessage(message.surfaceKey, message.text, config),
-    );
+    const current = prev.then(() => processMessage(message.surfaceKey, message.text, config));
     const tail = current.catch(() => {});
     queues.set(message.surfaceKey, tail);
 
     // Cleanup: remove queue entry when no more messages are pending
     tail.then(() => {
-      if (queues.get(message.surfaceKey) === tail)
-        queues.delete(message.surfaceKey);
+      if (queues.get(message.surfaceKey) === tail) queues.delete(message.surfaceKey);
     });
 
     const text = await current;

--- a/apps/cli/src/serve/trigger.ts
+++ b/apps/cli/src/serve/trigger.ts
@@ -15,10 +15,7 @@ export function evaluateTriggers(
   return rules.every((rule) => evaluateRule(rule, ctx));
 }
 
-function evaluateRule(
-  rule: Adapter.TriggerRule,
-  ctx: Adapter.TriggerContext,
-): boolean {
+function evaluateRule(rule: Adapter.TriggerRule, ctx: Adapter.TriggerContext): boolean {
   switch (rule.type) {
     case "event":
       return rule.events.includes(ctx.event);
@@ -51,13 +48,9 @@ function evaluateRule(
  * Strip trigger-related prefixes from message text.
  * Call after trigger evaluation passes.
  */
-export function stripTriggerPrefix(
-  text: string,
-  rules: Adapter.TriggerRule[],
-): string {
+export function stripTriggerPrefix(text: string, rules: Adapter.TriggerRule[]): string {
   const prefix = rules.find(
-    (r): r is Extract<Adapter.TriggerRule, { type: "prefix" }> =>
-      r.type === "prefix",
+    (r): r is Extract<Adapter.TriggerRule, { type: "prefix" }> => r.type === "prefix",
   );
   if (prefix) {
     return text.slice(prefix.value.length).trim();
@@ -76,9 +69,7 @@ export function normalizeContent(
 ): string {
   let result = stripTriggerPrefix(text, rules);
   if (botUsername) {
-    result = result
-      .replace(new RegExp(`@${escapeRegex(botUsername)}\\s*`, "g"), "")
-      .trim();
+    result = result.replace(new RegExp(`@${escapeRegex(botUsername)}\\s*`, "g"), "").trim();
   }
   return result;
 }

--- a/apps/cli/src/serve/utils.ts
+++ b/apps/cli/src/serve/utils.ts
@@ -58,9 +58,7 @@ export async function fetchWithRetry(
 
   if (response.status === 429) {
     if (retries >= MAX_API_RETRIES) {
-      throw new Error(
-        `${label}: rate limited after ${MAX_API_RETRIES} retries`,
-      );
+      throw new Error(`${label}: rate limited after ${MAX_API_RETRIES} retries`);
     }
 
     let retryAfter = 5;

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,24 @@
     "indentWidth": 2,
     "lineWidth": 100
   },
-  "linter": { "enabled": false },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn",
+        "useYield": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noEmptyBlockStatements": "warn",
+        "noImplicitAnyLet": "warn",
+        "noAssignInExpressions": "warn",
+        "noFallthroughSwitchClause": "warn"
+      }
+    }
+  },
   "files": {
     "includes": [
       "**",

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "assist": { "enabled": false },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": { "enabled": false },
+  "files": {
+    "includes": [
+      "**",
+      "!**/dist/**",
+      "!**/node_modules/**",
+      "!**/.turbo/**",
+      "!bun.lock",
+      "!**/*.lock"
+    ]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,10 @@
     "": {
       "name": "OpenOmni",
       "devDependencies": {
-        "prettier": "^3.7.4",
+        "@biomejs/biome": "2.0.0",
+        "@commitlint/cli": "^20.5.0",
+        "@commitlint/config-conventional": "^20.5.0",
+        "lefthook": "^2.1.4",
         "turbo": "^2.8.1",
         "typescript": "5.9.2",
       },
@@ -111,9 +114,67 @@
 
     "@ai-sdk/ui-utils": ["@ai-sdk/ui-utils@1.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.0.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.0.0", "@biomejs/cli-darwin-x64": "2.0.0", "@biomejs/cli-linux-arm64": "2.0.0", "@biomejs/cli-linux-arm64-musl": "2.0.0", "@biomejs/cli-linux-x64": "2.0.0", "@biomejs/cli-linux-x64-musl": "2.0.0", "@biomejs/cli-win32-arm64": "2.0.0", "@biomejs/cli-win32-x64": "2.0.0" }, "bin": { "biome": "bin/biome" } }, "sha512-BlUoXEOI/UQTDEj/pVfnkMo8SrZw3oOWBDrXYFT43V7HTkIUDkBRY53IC5Jx1QkZbaB+0ai1wJIfYwp9+qaJTQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QvqWYtFFhhxdf8jMAdJzXW+Frc7X8XsnHQLY+TBM1fnT1TfeV/v9vsFI5L2J7GH6qN1+QEEJ19jHibCY2Ypplw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-5JFhls1EfmuIH4QGFPlNpxJQFC6ic3X1ltcoLN+eSRRIPr6H/lUS1ttuD0Fj7rPgPhZqopK/jfH8UVj/1hIsQw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-BAH4QVi06TzAbVchXdJPsL0Z/P87jOfes15rI+p3EX9/EGTfIjaQ9lBVlHunxcmoptaA5y1Hdb9UYojIhmnjIw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bxsz8ki8+b3PytMnS5SgrGV+mbAWwIxI3ydChb/d1rURlJTMdxTTq5LTebUnlsUWAX6OvJuFeiVq9Gjn1YbCyA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-09PcOGYTtkopWRm6mZ/B6Mr6UHdkniUgIG/jLBv+2J8Z61ezRE+xQmpi3yNgUrFIAU4lPA9atg7mhvE/5Bo7Wg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tiQ0ABxMJb9I6GlfNp0ulrTiQSFacJRJO8245FFwE3ty3bfsfxlU/miblzDIi+qNrgGsLq5wIZcVYGp4c+HXZA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vrTtuGu91xNTEQ5ZcMJBZuDlqr32DWU1r14UfePIGndF//s2WUAmer4FmgoPgruo76rprk37e8S2A2c0psXdxw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2USVQ0hklNsph/KIR72ZdeptyXNnQ3JdzPn3NbjI4Sna34CnxeiYAaZcZzXPDl5PYNFBivV4xmvT3Z3rTmyDBg=="],
+
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
+
+    "@commitlint/cli": ["@commitlint/cli@20.5.0", "", { "dependencies": { "@commitlint/format": "^20.5.0", "@commitlint/lint": "^20.5.0", "@commitlint/load": "^20.5.0", "@commitlint/read": "^20.5.0", "@commitlint/types": "^20.5.0", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ=="],
+
+    "@commitlint/config-conventional": ["@commitlint/config-conventional@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "conventional-changelog-conventionalcommits": "^9.2.0" } }, "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA=="],
+
+    "@commitlint/config-validator": ["@commitlint/config-validator@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "ajv": "^8.11.0" } }, "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw=="],
+
+    "@commitlint/ensure": ["@commitlint/ensure@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "lodash.camelcase": "^4.3.0", "lodash.kebabcase": "^4.1.1", "lodash.snakecase": "^4.1.1", "lodash.startcase": "^4.4.0", "lodash.upperfirst": "^4.3.1" } }, "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw=="],
+
+    "@commitlint/execute-rule": ["@commitlint/execute-rule@20.0.0", "", {}, "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw=="],
+
+    "@commitlint/format": ["@commitlint/format@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "picocolors": "^1.1.1" } }, "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q=="],
+
+    "@commitlint/is-ignored": ["@commitlint/is-ignored@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "semver": "^7.6.0" } }, "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg=="],
+
+    "@commitlint/lint": ["@commitlint/lint@20.5.0", "", { "dependencies": { "@commitlint/is-ignored": "^20.5.0", "@commitlint/parse": "^20.5.0", "@commitlint/rules": "^20.5.0", "@commitlint/types": "^20.5.0" } }, "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA=="],
+
+    "@commitlint/load": ["@commitlint/load@20.5.0", "", { "dependencies": { "@commitlint/config-validator": "^20.5.0", "@commitlint/execute-rule": "^20.0.0", "@commitlint/resolve-extends": "^20.5.0", "@commitlint/types": "^20.5.0", "cosmiconfig": "^9.0.1", "cosmiconfig-typescript-loader": "^6.1.0", "is-plain-obj": "^4.1.0", "lodash.mergewith": "^4.6.2", "picocolors": "^1.1.1" } }, "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw=="],
+
+    "@commitlint/message": ["@commitlint/message@20.4.3", "", {}, "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ=="],
+
+    "@commitlint/parse": ["@commitlint/parse@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "conventional-changelog-angular": "^8.2.0", "conventional-commits-parser": "^6.3.0" } }, "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA=="],
+
+    "@commitlint/read": ["@commitlint/read@20.5.0", "", { "dependencies": { "@commitlint/top-level": "^20.4.3", "@commitlint/types": "^20.5.0", "git-raw-commits": "^5.0.0", "minimist": "^1.2.8", "tinyexec": "^1.0.0" } }, "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w=="],
+
+    "@commitlint/resolve-extends": ["@commitlint/resolve-extends@20.5.0", "", { "dependencies": { "@commitlint/config-validator": "^20.5.0", "@commitlint/types": "^20.5.0", "global-directory": "^4.0.1", "import-meta-resolve": "^4.0.0", "lodash.mergewith": "^4.6.2", "resolve-from": "^5.0.0" } }, "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg=="],
+
+    "@commitlint/rules": ["@commitlint/rules@20.5.0", "", { "dependencies": { "@commitlint/ensure": "^20.5.0", "@commitlint/message": "^20.4.3", "@commitlint/to-lines": "^20.0.0", "@commitlint/types": "^20.5.0" } }, "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ=="],
+
+    "@commitlint/to-lines": ["@commitlint/to-lines@20.0.0", "", {}, "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw=="],
+
+    "@commitlint/top-level": ["@commitlint/top-level@20.4.3", "", { "dependencies": { "escalade": "^3.2.0" } }, "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ=="],
+
+    "@commitlint/types": ["@commitlint/types@20.5.0", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA=="],
+
+    "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.6.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.3.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
@@ -132,6 +193,10 @@
     "@openomni/session": ["@openomni/session@workspace:packages/session"],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
+
+    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -155,6 +220,10 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
@@ -165,19 +234,37 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
+
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "conventional-changelog-angular": ["conventional-changelog-angular@8.3.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA=="],
+
+    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA=="],
+
+    "conventional-commits-parser": ["conventional-commits-parser@6.3.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -189,6 +276,8 @@
 
     "diff-match-patch": ["diff-match-patch@1.0.5", "", {}, "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="],
 
+    "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -196,6 +285,10 @@
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -237,6 +330,10 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
+
+    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -249,17 +346,39 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
@@ -269,15 +388,55 @@
 
     "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
 
+    "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BUAAE9+rUrjr39a+wH/1zHmGrDdwUQ2Yq/z6BQbM/yUb9qtXBRcQ5eOXxApqWW177VhGBpX31aqIlfAZ5Q7wzw=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-K1ncIMEe84fe+ss1hQNO7rIvqiKy2TJvTFpkypvqFodT7mJXZn7GLKYTIXdIuyPAYthRa9DwFnx5uMoHwD2F1Q=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-PVUhjOhVN71YaYsVdQyNbFZ4a2jFB2Tg5hKrrn9kaWpx64aLz/XivLjwr8sEuTaP1GRlEWBpW6Bhrcsyo39qFw=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ZWV9o/LeyWNEBoVO+BhLqxH3rGTba05nkm5NvMjEFSj7LbUNUDbQmupZwtHl1OMGJO66eZP0CalzRfUH6GhBxQ=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iWN0pGnTjrIvNIcSI1vQBJXUbybTqJ5CLMniPA0olabMXQfPDrdMKVQe+mgdwHK+E3/Y0H0ZNL3lnOj6Sk6szA=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-96bTBE/JdYgqWYAJDh+/e/0MaxJ25XTOAk7iy/fKoZ1ugf6S0W9bEFbnCFNooXOcxNVTan5xWKfcjJmPIKtsJA=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-oYUoK6AIJNEr9lUSpIMj6g7sWzotvtc3ryw7yoOyQM6uqmEduw73URV/qGoUcm4nqqmR93ZalZwR2r3Gd61zvw=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/Dv9Jcm68y9cggr1PhyUhOabBGP9+hzQPoiyOhKks7y9qrJl79A8XfG6LHekSuYc2VpiSu5wdnnrE1cj2nfTg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-hSww7z+QX4YMnw2lK7DMrs3+w7NtxksuMKOkCKGyxUAC/0m1LAICo0ZbtdDtZ7agxRQQQ/SEbzFRhU5ysNcbjA=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-eE68LwnogxwcPgGsbVGPGxmghyMGmU9SdGwcc+uhGnUxPz1jL89oECMWJNc36zjVK24umNeDAzB5KA3lw1MuWw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.kebabcase": ["lodash.kebabcase@4.1.1", "", {}, "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="],
+
+    "lodash.mergewith": ["lodash.mergewith@4.6.2", "", {}, "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="],
+
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
+    "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
+
+    "lodash.upperfirst": ["lodash.upperfirst@4.3.1", "", {}, "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -293,15 +452,19 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
-    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -313,13 +476,19 @@
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -350,6 +519,8 @@
     "swr": ["swr@2.3.8", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w=="],
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
+
+    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
@@ -407,9 +578,13 @@
 
     "@ai-sdk/ui-utils/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
 
+    "@commitlint/cli/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "@ai-sdk/openai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@1.1.2", "", {}, "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="],
 
@@ -419,6 +594,26 @@
 
     "@ai-sdk/ui-utils/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "@commitlint/cli/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@commitlint/cli/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@commitlint/cli/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
     "ai/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "@commitlint/cli/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@commitlint/cli/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@commitlint/cli/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@commitlint/cli/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@commitlint/cli/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@commitlint/cli/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@commitlint/cli/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+coverage = true
+coverageReporter = ["text", "lcov"]
+coverageDir = "./coverage"
+coverageSkipTestFiles = true

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -2,6 +2,14 @@
 
 > Invariants that MUST hold across all packages. Violations should be caught by linting or CI.
 
+## Enforcement Notes
+
+- `§1 Package Boundaries` + `§2 Dependency Direction`: enforced by `script/check-deps.ts` and the pre-push hook.
+- `§5 Error Handling` (no `as any`, no empty catch): enforced by Biome lint rules (warn-level) and `script/check-deps.ts`.
+- `§6 Testing`: coverage is reported via `bunfig.toml` (`text` + `lcov`), with no threshold yet.
+- Commit format: enforced by commitlint via `.commitlintrc.yml`.
+- Format + lint: enforced by Biome (`biome.json`) and Lefthook pre-commit.
+
 ## 1. Package Boundaries
 
 - Cross-package imports go through `index.ts` barrel only.

--- a/docs/quality-score.md
+++ b/docs/quality-score.md
@@ -2,16 +2,16 @@
 
 > Per-package quality assessment. Updated periodically to track progress.
 
-Last updated: 2026-03-09
+Last updated: 2026-03-27
 
-| Package  | Tests                  | Types                      | API Stability           | Docs                              | Overall |
-| -------- | ---------------------- | -------------------------- | ----------------------- | --------------------------------- | ------- |
-| protocol | ⭐⭐⭐ (4 test files)  | ⭐⭐⭐ (strict, no any)    | ⭐⭐⭐ (stable schemas) | ⭐⭐⭐ (AGENTS.md 48L)            | **A-**  |
-| session  | ⭐⭐⭐ (10 test files) | ⭐⭐⭐ (strict)            | ⭐⭐⭐ (stable)         | ⭐⭐⭐ (AGENTS.md 47L)            | **A-**  |
-| llm      | ⭐⭐⭐ (19 test files) | ⭐⭐ (noEmit)              | ⭐⭐ (evolving)         | ⭐⭐⭐ (AGENTS.md 52L)            | **B+**  |
-| agent    | ⭐⭐ (2 test files)    | ⭐⭐⭐ (strict)            | ⭐⭐ (stream() stub)    | ⭐⭐⭐ (AGENTS.md 95L)            | **B**   |
-| openomni | ⭐⭐⭐ (67 test files) | ⭐⭐ (legacy has some any) | ⭐⭐ (legacy + new)     | ⭐⭐⭐ (AGENTS.md 72L + docs/) | **B**   |
-| cli      | ⭐ (0 test files)      | ⭐⭐ (strict)              | ⭐ (demo/hardcoded)     | ⭐⭐ (AGENTS.md 37L)              | **C**   |
+| Package  | Tests                  | Lint         | Types                      | API Stability           | Docs                           | Overall |
+| -------- | ---------------------- | ------------ | -------------------------- | ----------------------- | ------------------------------ | ------- |
+| protocol | ⭐⭐⭐ (4 test files)  | ⭐⭐ (Biome) | ⭐⭐⭐ (strict, no any)    | ⭐⭐⭐ (stable schemas) | ⭐⭐⭐ (AGENTS.md 48L)         | **A-**  |
+| session  | ⭐⭐⭐ (10 test files) | ⭐⭐ (Biome) | ⭐⭐⭐ (strict)            | ⭐⭐⭐ (stable)         | ⭐⭐⭐ (AGENTS.md 47L)         | **A-**  |
+| llm      | ⭐⭐⭐ (19 test files) | ⭐⭐ (Biome) | ⭐⭐ (noEmit)              | ⭐⭐ (evolving)         | ⭐⭐⭐ (AGENTS.md 52L)         | **B+**  |
+| agent    | ⭐⭐ (2 test files)    | ⭐⭐ (Biome) | ⭐⭐⭐ (strict)            | ⭐⭐ (stream() stub)    | ⭐⭐⭐ (AGENTS.md 95L)         | **B**   |
+| openomni | ⭐⭐⭐ (67 test files) | ⭐⭐ (Biome) | ⭐⭐ (legacy has some any) | ⭐⭐ (legacy + new)     | ⭐⭐⭐ (AGENTS.md 72L + docs/) | **B**   |
+| cli      | ⭐ (0 test files)      | ⭐⭐ (Biome) | ⭐⭐ (strict)              | ⭐ (demo/hardcoded)     | ⭐⭐ (AGENTS.md 37L)           | **C**   |
 
 ## Rating Criteria
 
@@ -19,6 +19,8 @@ Last updated: 2026-03-09
 - **Types**: ⭐ any/ignore present, ⭐⭐ mostly strict, ⭐⭐⭐ fully strict
 - **API Stability**: ⭐ unstable/stub, ⭐⭐ evolving, ⭐⭐⭐ stable
 - **Docs**: ⭐ none, ⭐⭐ outdated/oversized, ⭐⭐⭐ concise and current
+- **Lint**: ⭐ none, ⭐⭐ Biome configured, ⭐⭐⭐ package-level guardrails fully green
+- Coverage reporting: enabled via `bunfig.toml` (`text` + `lcov`), thresholds not enforced yet
 
 ## Known Tech Debt
 
@@ -26,4 +28,4 @@ Last updated: 2026-03-09
 - CLI has zero test files
 - openomni legacy code has broader `any` usage than other packages
 - agent `stream()` is a stub (Phase 2 planned)
-- No ESLint configuration across the repo
+- Biome configured (replaces ESLint + Prettier)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,19 @@
+pre-commit:
+  parallel: true
+  commands:
+    biome-check:
+      glob: "*.{ts,tsx,js,jsx,json,css}"
+      run: bunx biome check --write --no-errors-on-unmatched {staged_files}
+      stage_fixed: true
+
+pre-push:
+  commands:
+    type-check:
+      run: bun run check-types
+    dep-check:
+      run: bun run script/check-deps.ts
+
+commit-msg:
+  commands:
+    commitlint:
+      run: bunx commitlint --edit {1}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
-    "lint": "turbo run lint",
-    "format": "biome format --write .",
+    "lint": "bunx biome check .",
+    "lint:fix": "bunx biome check --write .",
+    "format": "bunx biome format --write .",
     "check-types": "turbo run check-types",
     "test": "turbo run test"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "prepare": "lefthook install",
     "lint": "bunx biome check .",
     "lint:fix": "bunx biome check --write .",
     "format": "bunx biome format --write .",
@@ -12,6 +13,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
+    "lefthook": "^2.1.4",
     "turbo": "^2.8.1",
     "typescript": "5.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format": "biome format --write .",
     "check-types": "turbo run check-types",
     "test": "turbo run test"
   },
   "devDependencies": {
-    "prettier": "^3.7.4",
+    "@biomejs/biome": "2.0.0",
     "turbo": "^2.8.1",
     "typescript": "5.9.2"
   },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "check-types": "tsc --noEmit",
+    "lint": "bunx biome check ./src",
     "test": "bun test",
     "test:ci": "bun test"
   },

--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -22,10 +22,7 @@ export function createBudgetState(): BudgetState {
   };
 }
 
-export function checkBudget(
-  state: BudgetState,
-  budget?: AgentBudget,
-): "ok" | "exceeded" {
+export function checkBudget(state: BudgetState, budget?: AgentBudget): "ok" | "exceeded" {
   const maxWallTimeMs = budget?.maxWallTimeMs ?? 5 * 60 * 1000;
   const maxTurns = budget?.maxTurns ?? 24;
   const maxToolCalls = budget?.maxToolCalls ?? 40;
@@ -37,23 +34,16 @@ export function checkBudget(
   if (state.toolCalls >= maxToolCalls) return "exceeded";
   if (state.toolRuntimeMs >= maxToolRuntimeMs) return "exceeded";
 
-  if (
-    budget?.maxInputTokens !== undefined &&
-    state.totalInputTokens >= budget.maxInputTokens
-  )
+  if (budget?.maxInputTokens !== undefined && state.totalInputTokens >= budget.maxInputTokens)
     return "exceeded";
-  if (
-    budget?.maxOutputTokens !== undefined &&
-    state.totalOutputTokens >= budget.maxOutputTokens
-  )
+  if (budget?.maxOutputTokens !== undefined && state.totalOutputTokens >= budget.maxOutputTokens)
     return "exceeded";
   if (
     budget?.maxTotalTokens !== undefined &&
     state.totalInputTokens + state.totalOutputTokens >= budget.maxTotalTokens
   )
     return "exceeded";
-  if (budget?.maxCost !== undefined && state.totalCost >= budget.maxCost)
-    return "exceeded";
+  if (budget?.maxCost !== undefined && state.totalCost >= budget.maxCost) return "exceeded";
 
   return "ok";
 }
@@ -62,10 +52,7 @@ export function recordTurn(state: BudgetState): BudgetState {
   return { ...state, turns: state.turns + 1 };
 }
 
-export function recordToolCall(
-  state: BudgetState,
-  durationMs: number,
-): BudgetState {
+export function recordToolCall(state: BudgetState, durationMs: number): BudgetState {
   return {
     ...state,
     toolCalls: state.toolCalls + 1,

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,18 +1,6 @@
-import {
-  ModelsDev,
-  Provider,
-  run as llmRun,
-  TokenTracker,
-  type RunInput,
-} from "@openomni/llm";
+import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
 import type { Message, Sink, Tool } from "@openomni/protocol";
-import type {
-  ChatAgentConfig,
-  ChatAgentInput,
-  AgentResult,
-  AgentStep,
-  TokenUsage,
-} from "./types";
+import type { ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, TokenUsage } from "./types";
 import {
   createBudgetState,
   checkBudget,
@@ -64,9 +52,7 @@ async function resolveProviderModel(model: {
 
   const rawModel = providerData.models?.[model.id];
   if (!rawModel) {
-    throw new Error(
-      `Model not found: ${model.id} for provider ${model.provider}`,
-    );
+    throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
   }
 
   return Provider.fromModelsDevModel(providerData, rawModel as ModelsDev.Model);
@@ -94,10 +80,7 @@ function createUserMessage(content: string): Message.WithParts {
   return { info, parts: [textPart] };
 }
 
-function createAssistantMessage(
-  content: string,
-  parentID: string,
-): Message.WithParts {
+function createAssistantMessage(content: string, parentID: string): Message.WithParts {
   const id = crypto.randomUUID();
   const sessionID = "chat-agent";
   const now = Date.now();
@@ -148,9 +131,7 @@ function prependContextMessage(
   return [createUserMessage(contextText), ...messages];
 }
 
-function toMessagesWithParts(
-  messages: ChatAgentInput["messages"],
-): Message.WithParts[] {
+function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.WithParts[] {
   const output: Message.WithParts[] = [];
 
   for (const message of messages) {
@@ -205,9 +186,7 @@ function buildAssistantMessageWithTools(
   const sessionID = "chat-agent";
   const now = Date.now();
 
-  const resultByCallId = new Map(
-    toolResults.map((result) => [result.toolCallId, result]),
-  );
+  const resultByCallId = new Map(toolResults.map((result) => [result.toolCallId, result]));
   const parts: Message.ToolPart[] = toolCalls.map((call) => {
     const result = resultByCallId.get(call.id);
     const start = now;
@@ -301,8 +280,7 @@ export namespace ChatAgent {
                 const trackingSink: Sink = {
                   onMessage: (message) => {
                     if (message.info.role === "assistant") {
-                      const tokens = (message.info as Message.AssistantMessage)
-                        .tokens;
+                      const tokens = (message.info as Message.AssistantMessage).tokens;
                       totalUsage.inputTokens += tokens.input;
                       totalUsage.outputTokens += tokens.output;
                       totalUsage.totalTokens += tokens.input + tokens.output;
@@ -319,14 +297,10 @@ export namespace ChatAgent {
                         tokens.output,
                         cost.totalCost,
                       );
-                      totalUsage.totalCost =
-                        (totalUsage.totalCost ?? 0) + cost.totalCost;
+                      totalUsage.totalCost = (totalUsage.totalCost ?? 0) + cost.totalCost;
                     }
                     const text = message.parts
-                      .filter(
-                        (part): part is Message.TextPart =>
-                          part.type === "text",
-                      )
+                      .filter((part): part is Message.TextPart => part.type === "text")
                       .map((part) => part.text)
                       .join("");
                     if (text) {
@@ -346,8 +320,7 @@ export namespace ChatAgent {
                       steps,
                       usage: totalUsage,
                       finishReason: "max-steps",
-                      compactionCount:
-                        compactionCount > 0 ? compactionCount : undefined,
+                      compactionCount: compactionCount > 0 ? compactionCount : undefined,
                     };
                   }
 
@@ -361,8 +334,7 @@ export namespace ChatAgent {
                   if (config.memory) {
                     const lastUserText = getLastUserMessageText(messages);
                     if (lastUserText) {
-                      const memoryResults =
-                        await config.memory.retrieve(lastUserText);
+                      const memoryResults = await config.memory.retrieve(lastUserText);
                       if (memoryResults.length > 0) {
                         effectiveMessages = prependContextMessage(
                           messages,
@@ -398,8 +370,7 @@ export namespace ChatAgent {
                       steps,
                       usage: totalUsage,
                       finishReason: "stop",
-                      compactionCount:
-                        compactionCount > 0 ? compactionCount : undefined,
+                      compactionCount: compactionCount > 0 ? compactionCount : undefined,
                     };
                   }
 
@@ -444,10 +415,7 @@ export namespace ChatAgent {
                     await config.onStepFinish(toolStep);
                   }
 
-                  const parentID =
-                    messages.length > 0
-                      ? messages[messages.length - 1].info.id
-                      : "";
+                  const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
                   const assistantWithTools = buildAssistantMessageWithTools(
                     outcome.toolCalls,
                     toolResults,
@@ -457,18 +425,9 @@ export namespace ChatAgent {
 
                   if (config.compaction) {
                     const totalTokens =
-                      budgetState.totalInputTokens +
-                      budgetState.totalOutputTokens;
-                    if (
-                      InMemoryCompactor.shouldCompact(
-                        totalTokens,
-                        config.compaction,
-                      )
-                    ) {
-                      const result = await InMemoryCompactor.compact(
-                        messages,
-                        config.compaction,
-                      );
+                      budgetState.totalInputTokens + budgetState.totalOutputTokens;
+                    if (InMemoryCompactor.shouldCompact(totalTokens, config.compaction)) {
+                      const result = await InMemoryCompactor.compact(messages, config.compaction);
                       if (result.compacted) {
                         messages = result.messages;
                         compactionCount += 1;
@@ -477,8 +436,7 @@ export namespace ChatAgent {
                   }
                 }
               } catch (error) {
-                lastError =
-                  error instanceof Error ? error.message : String(error);
+                lastError = error instanceof Error ? error.message : String(error);
                 const retryReason = classifyRetryReason(lastError);
 
                 if (shouldRetry(retryPolicy, retryReason, attempt)) {
@@ -500,10 +458,7 @@ export namespace ChatAgent {
           },
         );
       },
-      async *stream(
-        input: ChatAgentInput,
-        sink?: Sink,
-      ): AsyncIterable<AgentEvent> {
+      async *stream(input: ChatAgentInput, sink?: Sink): AsyncIterable<AgentEvent> {
         yield* streamAgent(input, config, sink);
       },
     };

--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -17,13 +17,9 @@ const DEFAULT_THRESHOLD_RATIO = 0.8;
 const DEFAULT_PROTECT_RECENT = 6;
 
 export namespace InMemoryCompactor {
-  export function shouldCompact(
-    totalTokens: number,
-    options: CompactionOptions,
-  ): boolean {
+  export function shouldCompact(totalTokens: number, options: CompactionOptions): boolean {
     const threshold =
-      options.contextWindowTokens *
-      (options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO);
+      options.contextWindowTokens * (options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO);
     return totalTokens >= threshold;
   }
 
@@ -31,8 +27,7 @@ export namespace InMemoryCompactor {
     messages: Message.WithParts[],
     options: CompactionOptions,
   ): Promise<CompactionResult> {
-    const protectRecent =
-      options.protectRecentMessages ?? DEFAULT_PROTECT_RECENT;
+    const protectRecent = options.protectRecentMessages ?? DEFAULT_PROTECT_RECENT;
 
     if (messages.length <= protectRecent) {
       return { messages, compacted: false, removedCount: 0 };

--- a/packages/agent/src/core/execution/parallel-tools.ts
+++ b/packages/agent/src/core/execution/parallel-tools.ts
@@ -56,9 +56,7 @@ export namespace ParallelToolExecutor {
     executor: (call: Tool.Call) => Promise<Tool.Result>,
     options?: ParallelExecutorOptions,
   ): Promise<Tool.Result[]> {
-    return Promise.all(
-      toolCalls.map((call) => executeSingle(call, executor, options)),
-    );
+    return Promise.all(toolCalls.map((call) => executeSingle(call, executor, options)));
   }
 
   async function executeSafeParallel(
@@ -88,17 +86,13 @@ export namespace ParallelToolExecutor {
 
     // Execute safe tools in parallel
     const safeResults = await Promise.all(
-      safeIndices.map((idx) =>
-        executeSingle(toolCalls[idx], executor, options),
-      ),
+      safeIndices.map((idx) => executeSingle(toolCalls[idx], executor, options)),
     );
 
     // Execute unsafe tools sequentially
     const unsafeResults: Tool.Result[] = [];
     for (const idx of unsafeIndices) {
-      unsafeResults.push(
-        await executeSingle(toolCalls[idx], executor, options),
-      );
+      unsafeResults.push(await executeSingle(toolCalls[idx], executor, options));
     }
 
     // Reconstruct results in original order
@@ -152,11 +146,7 @@ export namespace ParallelToolExecutor {
   }
 }
 
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  toolName: string,
-): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, ms: number, toolName: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
       reject(new Error(`Tool '${toolName}' timed out after ${ms}ms`));

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -1,9 +1,4 @@
-import {
-  ModelsDev,
-  Provider,
-  run as llmRun,
-  type RunInput,
-} from "@openomni/llm";
+import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
 import type { Message, Sink, Tool } from "@openomni/protocol";
 import type {
   AgentEvent,
@@ -13,12 +8,7 @@ import type {
   ChatAgentInput,
   TokenUsage,
 } from "../types";
-import {
-  createBudgetState,
-  checkBudget,
-  recordTurn,
-  recordToolCall,
-} from "../budget";
+import { createBudgetState, checkBudget, recordTurn, recordToolCall } from "../budget";
 import {
   DEFAULT_RETRY_POLICY,
   calculateBackoffMs,
@@ -65,10 +55,7 @@ function createUserMessage(content: string): Message.WithParts {
   };
 }
 
-function createAssistantMessage(
-  content: string,
-  parentID: string,
-): Message.WithParts {
+function createAssistantMessage(content: string, parentID: string): Message.WithParts {
   const id = crypto.randomUUID();
   const sessionID = "stream-engine";
   const now = Date.now();
@@ -99,9 +86,7 @@ function createAssistantMessage(
   };
 }
 
-function toMessagesWithParts(
-  messages: ChatAgentInput["messages"],
-): Message.WithParts[] {
+function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.WithParts[] {
   const output: Message.WithParts[] = [];
   for (const message of messages) {
     const parentID = output.length > 0 ? output[output.length - 1].info.id : "";
@@ -181,10 +166,7 @@ export async function* streamAgent(
               totalUsage.totalTokens += tokens.input + tokens.output;
             }
             const text = message.parts
-              .filter(
-                (part: Message.Part): part is Message.TextPart =>
-                  part.type === "text",
-              )
+              .filter((part: Message.Part): part is Message.TextPart => part.type === "text")
               .map((part: Message.TextPart) => part.text)
               .join("");
             if (text) lastAssistantText = text;
@@ -198,8 +180,7 @@ export async function* streamAgent(
         const outcome = await llmRun(runInput, trackingSink);
 
         if (outcome.type === "stop") {
-          if (lastAssistantText)
-            yield { type: "text_chunk", text: lastAssistantText };
+          if (lastAssistantText) yield { type: "text_chunk", text: lastAssistantText };
           yield { type: "turn_complete", turnIndex, usage: turnUsage };
 
           const step: AgentStep = { type: "text", content: lastAssistantText };
@@ -262,9 +243,7 @@ export async function* streamAgent(
 
         const elapsed = Date.now() - toolStart;
         const perToolMs =
-          toolResults.length > 0
-            ? Math.max(1, Math.ceil(elapsed / toolResults.length))
-            : elapsed;
+          toolResults.length > 0 ? Math.max(1, Math.ceil(elapsed / toolResults.length)) : elapsed;
         for (let i = 0; i < toolResults.length; i++) {
           budgetState = recordToolCall(budgetState, perToolMs);
         }
@@ -281,12 +260,8 @@ export async function* streamAgent(
         steps.push(toolStep);
         if (config.onStepFinish) await config.onStepFinish(toolStep);
 
-        const parentID =
-          messages.length > 0 ? messages[messages.length - 1].info.id : "";
-        messages = [
-          ...messages,
-          createAssistantMessage(lastAssistantText, parentID),
-        ];
+        const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
+        messages = [...messages, createAssistantMessage(lastAssistantText, parentID)];
       }
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -54,11 +54,7 @@ export namespace ToolExecutor {
   }
 }
 
-function withTimeout<T>(
-  promise: Promise<T>,
-  ms: number,
-  toolName: string,
-): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, ms: number, toolName: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
       reject(new Error(`Tool '${toolName}' timed out after ${ms}ms`));

--- a/packages/agent/src/core/memory.ts
+++ b/packages/agent/src/core/memory.ts
@@ -13,11 +13,7 @@ export interface MemoryResult {
 }
 
 export interface Memory {
-  store(
-    key: string,
-    content: string,
-    metadata?: Record<string, unknown>,
-  ): Promise<void>;
+  store(key: string, content: string, metadata?: Record<string, unknown>): Promise<void>;
   retrieve(
     query: string,
     options?: { limit?: number; threshold?: number },
@@ -51,11 +47,7 @@ function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
 export class InMemoryMemory implements Memory {
   private entries: MemoryEntry[] = [];
 
-  async store(
-    key: string,
-    content: string,
-    metadata?: Record<string, unknown>,
-  ): Promise<void> {
+  async store(key: string, content: string, metadata?: Record<string, unknown>): Promise<void> {
     this.entries.push({
       key,
       content,

--- a/packages/agent/src/core/retry.ts
+++ b/packages/agent/src/core/retry.ts
@@ -1,10 +1,6 @@
 import type { Run } from "@openomni/protocol";
 
-export type RetryReason =
-  | "timeout"
-  | "tool_error"
-  | "transient_error"
-  | "validation_error";
+export type RetryReason = "timeout" | "tool_error" | "transient_error" | "validation_error";
 
 export const DEFAULT_RETRY_POLICY: Run.RetryPolicy = {
   maxAttempts: 1,
@@ -12,13 +8,9 @@ export const DEFAULT_RETRY_POLICY: Run.RetryPolicy = {
   retryOn: ["timeout", "tool_error", "transient_error"],
 };
 
-export function calculateBackoffMs(
-  policy: Run.RetryPolicy,
-  attempt: number,
-): number {
+export function calculateBackoffMs(policy: Run.RetryPolicy, attempt: number): number {
   const rawDelay =
-    policy.backoffMs.initial *
-    Math.pow(policy.backoffMs.multiplier, Math.max(0, attempt - 1));
+    policy.backoffMs.initial * Math.pow(policy.backoffMs.multiplier, Math.max(0, attempt - 1));
   return Math.min(rawDelay, policy.backoffMs.max);
 }
 
@@ -55,7 +47,5 @@ export function shouldRetry(
 }
 
 export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) =>
-    setTimeout(resolve, Math.max(0, Math.floor(ms))),
-  );
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, Math.floor(ms))));
 }

--- a/packages/agent/src/core/telemetry.ts
+++ b/packages/agent/src/core/telemetry.ts
@@ -60,10 +60,7 @@ export namespace Telemetry {
   }
 
   export function counter(name: string): {
-    add: (
-      value: number,
-      attributes?: Record<string, string | number | boolean>,
-    ) => void;
+    add: (value: number, attributes?: Record<string, string | number | boolean>) => void;
   } {
     if (!_config.enabled || !_meter) {
       return { add: () => {} };
@@ -75,10 +72,7 @@ export namespace Telemetry {
   }
 
   export function histogram(name: string): {
-    record: (
-      value: number,
-      attributes?: Record<string, string | number | boolean>,
-    ) => void;
+    record: (value: number, attributes?: Record<string, string | number | boolean>) => void;
   } {
     if (!_config.enabled || !_meter) {
       return { record: () => {} };

--- a/packages/agent/src/core/tool-guard.ts
+++ b/packages/agent/src/core/tool-guard.ts
@@ -6,8 +6,7 @@ export namespace ToolGuard {
     permission: Guardrail.ToolPermission,
   ): "allow" | "deny" | "require_approval" {
     if (permission.denylist?.includes(toolName)) return "deny";
-    if (permission.requireApproval?.includes(toolName))
-      return "require_approval";
+    if (permission.requireApproval?.includes(toolName)) return "require_approval";
     if (permission.allowlist !== undefined) {
       if (permission.allowlist.length === 0) return "deny";
       if (permission.allowlist.includes("*")) return "allow";

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -43,9 +43,7 @@ export interface ChatAgentConfig {
 }
 
 export interface ChatAgentInput {
-  messages: Array<
-    { role: "user"; content: string } | { role: "assistant"; content: string }
-  >;
+  messages: Array<{ role: "user"; content: string } | { role: "assistant"; content: string }>;
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -76,8 +76,7 @@ function createTransport(config: McpServerConfig) {
       return new SSEClientTransport(new URL(config.url));
     }
     case "streamable-http": {
-      if (!config.url)
-        throw new Error("streamable-http transport requires url");
+      if (!config.url) throw new Error("streamable-http transport requires url");
       return new StreamableHTTPClientTransport(new URL(config.url));
     }
     default:

--- a/packages/agent/src/runtime/mcp/convert.ts
+++ b/packages/agent/src/runtime/mcp/convert.ts
@@ -11,10 +11,7 @@ interface McpToolResult {
   isError?: boolean;
 }
 
-export function convertMcpTool(
-  mcpTool: McpTool,
-  serverName?: string,
-): Tool.Spec {
+export function convertMcpTool(mcpTool: McpTool, serverName?: string): Tool.Spec {
   const toolName = serverName ? `${serverName}.${mcpTool.name}` : mcpTool.name;
   return {
     name: toolName,
@@ -23,10 +20,7 @@ export function convertMcpTool(
   };
 }
 
-export function convertMcpResult(
-  mcpResult: McpToolResult,
-  toolCallId: string,
-): Tool.Result {
+export function convertMcpResult(mcpResult: McpToolResult, toolCallId: string): Tool.Result {
   const text = mcpResult.content
     .filter((c) => c.type === "text")
     .map((c) => c.text ?? "")

--- a/packages/agent/src/runtime/messenger/history.ts
+++ b/packages/agent/src/runtime/messenger/history.ts
@@ -16,30 +16,21 @@ export interface HistoryResult {
   hasMore: boolean;
 }
 
-export function queryHistory(
-  agentId: string,
-  options: HistoryQueryOptions = {},
-): HistoryResult {
+export function queryHistory(agentId: string, options: HistoryQueryOptions = {}): HistoryResult {
   const { limit = 50, offset = 0 } = options;
   const all = AgentMessenger.getLog();
 
   const visible = all.filter((msg) => {
     if (msg.persistencePolicy === "asker_only") {
-      if (msg.fromAgentId !== agentId && msg.toAgentId !== agentId)
-        return false;
-      if (msg.toAgentId === agentId && msg.fromAgentId !== agentId)
-        return false;
+      if (msg.fromAgentId !== agentId && msg.toAgentId !== agentId) return false;
+      if (msg.toAgentId === agentId && msg.fromAgentId !== agentId) return false;
     } else {
-      if (msg.fromAgentId !== agentId && msg.toAgentId !== agentId)
-        return false;
+      if (msg.fromAgentId !== agentId && msg.toAgentId !== agentId) return false;
     }
 
     if (options.schemaRef && msg.schemaRef !== options.schemaRef) return false;
     if (options.traceId && msg.traceId !== options.traceId) return false;
-    if (
-      options.correlationId !== undefined &&
-      msg.correlationId !== options.correlationId
-    )
+    if (options.correlationId !== undefined && msg.correlationId !== options.correlationId)
       return false;
     if (options.timeRange?.from) {
       const sentAt = new Date(msg.sentAt).getTime();

--- a/packages/agent/src/runtime/messenger/instance-registry.ts
+++ b/packages/agent/src/runtime/messenger/instance-registry.ts
@@ -37,10 +37,7 @@ export namespace InstanceRegistry {
     return Array.from(store.values()).filter((i) => i.agentId === agentId);
   }
 
-  export function updateStatus(
-    instanceId: string,
-    status: InstanceStatus,
-  ): void {
+  export function updateStatus(instanceId: string, status: InstanceStatus): void {
     const instance = store.get(instanceId);
     if (!instance) throw new Error(`Instance '${instanceId}' not registered`);
     store.set(instanceId, { ...instance, status });

--- a/packages/agent/src/runtime/messenger/messenger.ts
+++ b/packages/agent/src/runtime/messenger/messenger.ts
@@ -3,11 +3,7 @@ import type { Transport } from "./transport";
 
 const messageLog: Messenger.MessageEnvelope[] = [];
 
-function matchesPattern(
-  pattern: Messenger.AllowPattern,
-  from: string,
-  to: string,
-): boolean {
+function matchesPattern(pattern: Messenger.AllowPattern, from: string, to: string): boolean {
   const fromMatch = pattern.from === "*" || pattern.from === from;
   const toMatch = pattern.to === "*" || pattern.to === to;
   return fromMatch && toMatch;
@@ -34,41 +30,24 @@ export interface RequestOptions {
 export namespace AgentMessenger {
   export interface Instance {
     send(envelope: Messenger.MessageEnvelope): Promise<void>;
-    subscribe(
-      agentId: string,
-      handler: (env: Messenger.MessageEnvelope) => void,
-    ): () => void;
+    subscribe(agentId: string, handler: (env: Messenger.MessageEnvelope) => void): () => void;
     request(
       envelope: Messenger.MessageEnvelope,
       options: RequestOptions,
     ): Promise<Messenger.MessageEnvelope>;
   }
 
-  export function create(
-    transport: Transport,
-    options?: AgentMessengerOptions,
-  ): Instance {
+  export function create(transport: Transport, options?: AgentMessengerOptions): Instance {
     return {
       async send(envelope: Messenger.MessageEnvelope): Promise<void> {
-        if (
-          !isAuthorized(
-            options?.allowPatterns,
-            envelope.fromAgentId,
-            envelope.toAgentId,
-          )
-        ) {
-          throw new Error(
-            `Authorization denied: ${envelope.fromAgentId} → ${envelope.toAgentId}`,
-          );
+        if (!isAuthorized(options?.allowPatterns, envelope.fromAgentId, envelope.toAgentId)) {
+          throw new Error(`Authorization denied: ${envelope.fromAgentId} → ${envelope.toAgentId}`);
         }
         messageLog.push(envelope);
         await transport.send(envelope);
       },
 
-      subscribe(
-        agentId: string,
-        handler: (env: Messenger.MessageEnvelope) => void,
-      ): () => void {
+      subscribe(agentId: string, handler: (env: Messenger.MessageEnvelope) => void): () => void {
         return transport.subscribe(agentId, handler);
       },
 
@@ -81,21 +60,16 @@ export namespace AgentMessenger {
         return new Promise<Messenger.MessageEnvelope>((resolve, reject) => {
           const timer = setTimeout(() => {
             unsub();
-            reject(
-              new Error(`Request timed out after ${reqOptions.timeout}ms`),
-            );
+            reject(new Error(`Request timed out after ${reqOptions.timeout}ms`));
           }, reqOptions.timeout);
 
-          const unsub = transport.subscribe(
-            envelope.fromAgentId,
-            (response) => {
-              if (response.correlationId === correlationId) {
-                clearTimeout(timer);
-                unsub();
-                resolve(response);
-              }
-            },
-          );
+          const unsub = transport.subscribe(envelope.fromAgentId, (response) => {
+            if (response.correlationId === correlationId) {
+              clearTimeout(timer);
+              unsub();
+              resolve(response);
+            }
+          });
 
           if (reqOptions.signal) {
             reqOptions.signal.addEventListener("abort", () => {

--- a/packages/agent/src/runtime/messenger/transport.ts
+++ b/packages/agent/src/runtime/messenger/transport.ts
@@ -3,10 +3,7 @@ import type { Messenger } from "@openomni/protocol";
 
 export interface Transport {
   send(envelope: Messenger.MessageEnvelope): Promise<void>;
-  subscribe(
-    agentId: string,
-    handler: (env: Messenger.MessageEnvelope) => void,
-  ): () => void;
+  subscribe(agentId: string, handler: (env: Messenger.MessageEnvelope) => void): () => void;
 }
 
 const messengerEvent = BusEvent.define<Messenger.MessageEnvelope>(
@@ -20,10 +17,7 @@ export class BusTransport implements Transport {
     Bus.publish(messengerEvent, envelope);
   }
 
-  subscribe(
-    agentId: string,
-    handler: (env: Messenger.MessageEnvelope) => void,
-  ): () => void {
+  subscribe(agentId: string, handler: (env: Messenger.MessageEnvelope) => void): () => void {
     return Bus.subscribe(messengerEvent, (env) => {
       if (env.toAgentId === agentId) {
         handler(env);

--- a/packages/agent/src/runtime/registry/registry.ts
+++ b/packages/agent/src/runtime/registry/registry.ts
@@ -19,10 +19,7 @@ export namespace AgentRegistry {
     return Array.from(store.values());
   }
 
-  export function override(
-    name: string,
-    partial: Partial<AgentProfile.Definition>,
-  ): void {
+  export function override(name: string, partial: Partial<AgentProfile.Definition>): void {
     const existing = store.get(name);
     if (!existing) throw new Error(`Agent '${name}' not registered`);
     store.set(name, { ...existing, ...partial });

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -78,9 +78,7 @@ export namespace SubagentTool {
         };
       }
 
-      const childAbort = ctx?.parentAbort
-        ? AbortSignal.any([ctx.parentAbort])
-        : undefined;
+      const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
 
       try {
         const childAgent = ChatAgent.create({
@@ -89,9 +87,7 @@ export namespace SubagentTool {
             id: "claude-3-haiku-20240307",
           },
           systemPrompt: definition.systemPrompt,
-          budget: definition.maxTurns
-            ? { maxTurns: definition.maxTurns }
-            : undefined,
+          budget: definition.maxTurns ? { maxTurns: definition.maxTurns } : undefined,
           permissions: definition.permissions,
           signal: childAbort,
         });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -250,10 +250,7 @@ describe("ChatAgent", () => {
 
   it("keeps ChatAgent source free of session package dependency", async () => {
     const forbiddenImport = "@openomni/" + "session";
-    const content = await readFile(
-      new URL("../src/core/chat-agent.ts", import.meta.url),
-      "utf8",
-    );
+    const content = await readFile(new URL("../src/core/chat-agent.ts", import.meta.url), "utf8");
 
     expect(content.includes(forbiddenImport)).toBe(false);
   });

--- a/packages/agent/test/core/budget-tokens.test.ts
+++ b/packages/agent/test/core/budget-tokens.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-  createBudgetState,
-  checkBudget,
-  recordTokenUsage,
-} from "../../src/core/budget";
+import { createBudgetState, checkBudget, recordTokenUsage } from "../../src/core/budget";
 
 describe("BudgetState token tracking", () => {
   it("starts with zero token counts", () => {

--- a/packages/agent/test/core/delegation.test.ts
+++ b/packages/agent/test/core/delegation.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { checkDelegation } from "../../src/core/delegation";
 import type { DelegationContext } from "../../src/core/delegation";
 
-const makeContext = (
-  overrides: Partial<DelegationContext> = {},
-): DelegationContext => ({
+const makeContext = (overrides: Partial<DelegationContext> = {}): DelegationContext => ({
   depth: 0,
   maxDepth: 3,
   visitedAgents: new Set(),

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -52,21 +52,15 @@ function makeAssistantMessage(text: string): Message.WithParts {
 describe("InMemoryCompactor", () => {
   describe("shouldCompact", () => {
     it("returns false when tokens are below threshold", () => {
-      expect(
-        InMemoryCompactor.shouldCompact(700, { contextWindowTokens: 1000 }),
-      ).toBe(false);
+      expect(InMemoryCompactor.shouldCompact(700, { contextWindowTokens: 1000 })).toBe(false);
     });
 
     it("returns true when tokens reach 80% threshold", () => {
-      expect(
-        InMemoryCompactor.shouldCompact(800, { contextWindowTokens: 1000 }),
-      ).toBe(true);
+      expect(InMemoryCompactor.shouldCompact(800, { contextWindowTokens: 1000 })).toBe(true);
     });
 
     it("returns true when tokens exceed threshold", () => {
-      expect(
-        InMemoryCompactor.shouldCompact(900, { contextWindowTokens: 1000 }),
-      ).toBe(true);
+      expect(InMemoryCompactor.shouldCompact(900, { contextWindowTokens: 1000 })).toBe(true);
     });
 
     it("respects custom thresholdRatio", () => {
@@ -99,9 +93,7 @@ describe("InMemoryCompactor", () => {
 
     it("removes oldest non-system messages beyond protectRecent", async () => {
       const messages = Array.from({ length: 10 }, (_, i) =>
-        i % 2 === 0
-          ? makeUserMessage(`user ${i}`)
-          : makeAssistantMessage(`assistant ${i}`),
+        i % 2 === 0 ? makeUserMessage(`user ${i}`) : makeAssistantMessage(`assistant ${i}`),
       );
       const result = await InMemoryCompactor.compact(messages, {
         contextWindowTokens: 1000,
@@ -130,9 +122,7 @@ describe("InMemoryCompactor", () => {
       expect(result.compacted).toBe(true);
       expect(result.messages).toHaveLength(6);
       const texts = result.messages.flatMap((m) =>
-        m.parts
-          .filter((p): p is Message.TextPart => p.type === "text")
-          .map((p) => p.text),
+        m.parts.filter((p): p is Message.TextPart => p.type === "text").map((p) => p.text),
       );
       expect(texts).toContain("recent-3");
       expect(texts).not.toContain("old-1");
@@ -140,9 +130,7 @@ describe("InMemoryCompactor", () => {
 
     it("inserts summary message when onSummarize is provided", async () => {
       const messages = Array.from({ length: 8 }, (_, i) =>
-        i % 2 === 0
-          ? makeUserMessage(`user ${i}`)
-          : makeAssistantMessage(`assistant ${i}`),
+        i % 2 === 0 ? makeUserMessage(`user ${i}`) : makeAssistantMessage(`assistant ${i}`),
       );
       const result = await InMemoryCompactor.compact(messages, {
         contextWindowTokens: 1000,
@@ -151,21 +139,13 @@ describe("InMemoryCompactor", () => {
       });
       expect(result.compacted).toBe(true);
       const allTexts = result.messages.flatMap((m) =>
-        m.parts
-          .filter((p): p is Message.TextPart => p.type === "text")
-          .map((p) => p.text),
+        m.parts.filter((p): p is Message.TextPart => p.type === "text").map((p) => p.text),
       );
-      expect(
-        allTexts.some((t) => t.includes("Summary of removed messages")),
-      ).toBe(true);
+      expect(allTexts.some((t) => t.includes("Summary of removed messages"))).toBe(true);
     });
 
     it("does not compact when non-system messages are within protectRecent", async () => {
-      const messages = [
-        makeUserMessage("a"),
-        makeAssistantMessage("b"),
-        makeUserMessage("c"),
-      ];
+      const messages = [makeUserMessage("a"), makeAssistantMessage("b"), makeUserMessage("c")];
       const result = await InMemoryCompactor.compact(messages, {
         contextWindowTokens: 1000,
         protectRecentMessages: 6,

--- a/packages/agent/test/core/execution/parallel-tools.test.ts
+++ b/packages/agent/test/core/execution/parallel-tools.test.ts
@@ -31,11 +31,7 @@ describe("ParallelToolExecutor", () => {
   describe("mode: off", () => {
     it("executes all tools sequentially regardless of safe flag", async () => {
       const calls = [makeCall("a"), makeCall("b"), makeCall("c")];
-      const specs = [
-        makeSpec("a", true),
-        makeSpec("b", true),
-        makeSpec("c", true),
-      ];
+      const specs = [makeSpec("a", true), makeSpec("b", true), makeSpec("c", true)];
       const order: string[] = [];
       const executor = async (call: Tool.Call): Promise<Tool.Result> => {
         order.push(call.tool);
@@ -56,11 +52,7 @@ describe("ParallelToolExecutor", () => {
 
   describe("mode: safe-only", () => {
     it("runs safe tools in parallel and unsafe tools sequentially", async () => {
-      const calls = [
-        makeCall("safe-a"),
-        makeCall("unsafe-b"),
-        makeCall("safe-c"),
-      ];
+      const calls = [makeCall("safe-a"), makeCall("unsafe-b"), makeCall("safe-c")];
       const specs = [
         makeSpec("safe-a", true),
         makeSpec("unsafe-b", false),
@@ -79,31 +71,21 @@ describe("ParallelToolExecutor", () => {
       };
 
       const start = Date.now();
-      const results = await ParallelToolExecutor.execute(
-        calls,
-        specs,
-        executor,
-        { mode: "safe-only" },
-      );
+      const results = await ParallelToolExecutor.execute(calls, specs, executor, {
+        mode: "safe-only",
+      });
       const elapsed = Date.now() - start;
 
       expect(results).toHaveLength(3);
       expect(elapsed).toBeLessThan(150);
       expect(startTimes["safe-a"]).toBeDefined();
       expect(startTimes["safe-c"]).toBeDefined();
-      const safeTimeDiff = Math.abs(
-        startTimes["safe-a"] - startTimes["safe-c"],
-      );
+      const safeTimeDiff = Math.abs(startTimes["safe-a"] - startTimes["safe-c"]);
       expect(safeTimeDiff).toBeLessThan(20);
     });
 
     it("preserves original call order in results", async () => {
-      const calls = [
-        makeCall("a"),
-        makeCall("b"),
-        makeCall("c"),
-        makeCall("d"),
-      ];
+      const calls = [makeCall("a"), makeCall("b"), makeCall("c"), makeCall("d")];
       const specs = [
         makeSpec("a", true),
         makeSpec("b", false),
@@ -112,12 +94,9 @@ describe("ParallelToolExecutor", () => {
       ];
       const executor = makeExecutor(0, { a: "ra", b: "rb", c: "rc", d: "rd" });
 
-      const results = await ParallelToolExecutor.execute(
-        calls,
-        specs,
-        executor,
-        { mode: "safe-only" },
-      );
+      const results = await ParallelToolExecutor.execute(calls, specs, executor, {
+        mode: "safe-only",
+      });
 
       expect(results[0].output).toBe("ra");
       expect(results[1].output).toBe("rb");
@@ -139,12 +118,9 @@ describe("ParallelToolExecutor", () => {
         };
       };
 
-      const results = await ParallelToolExecutor.execute(
-        calls,
-        specs,
-        executor,
-        { mode: "safe-only" },
-      );
+      const results = await ParallelToolExecutor.execute(calls, specs, executor, {
+        mode: "safe-only",
+      });
       expect(results).toHaveLength(1);
       expect(order).toEqual(["unknown"]);
     });
@@ -153,11 +129,7 @@ describe("ParallelToolExecutor", () => {
   describe("mode: all", () => {
     it("runs all tools in parallel including unsafe ones", async () => {
       const calls = [makeCall("a"), makeCall("b"), makeCall("c")];
-      const specs = [
-        makeSpec("a", false),
-        makeSpec("b", false),
-        makeSpec("c", false),
-      ];
+      const specs = [makeSpec("a", false), makeSpec("b", false), makeSpec("c", false)];
       const startTimes: number[] = [];
       const executor = async (call: Tool.Call): Promise<Tool.Result> => {
         startTimes.push(Date.now());
@@ -185,18 +157,12 @@ describe("ParallelToolExecutor", () => {
       const calls = [makeCall("blocked"), makeCall("allowed")];
       const specs = [makeSpec("blocked"), makeSpec("allowed")];
       const executor = makeExecutor();
-      const guard = (name: string) =>
-        name === "blocked" ? ("deny" as const) : ("allow" as const);
+      const guard = (name: string) => (name === "blocked" ? ("deny" as const) : ("allow" as const));
 
-      const results = await ParallelToolExecutor.execute(
-        calls,
-        specs,
-        executor,
-        {
-          mode: "safe-only",
-          guard,
-        },
-      );
+      const results = await ParallelToolExecutor.execute(calls, specs, executor, {
+        mode: "safe-only",
+        guard,
+      });
 
       expect(results[0].isError).toBe(true);
       expect(results[0].output).toContain("Permission denied");
@@ -209,15 +175,10 @@ describe("ParallelToolExecutor", () => {
       const executor = makeExecutor();
       const guard = () => "require_approval" as const;
 
-      const results = await ParallelToolExecutor.execute(
-        calls,
-        specs,
-        executor,
-        {
-          mode: "safe-only",
-          guard,
-        },
-      );
+      const results = await ParallelToolExecutor.execute(calls, specs, executor, {
+        mode: "safe-only",
+        guard,
+      });
 
       expect(results[0].isError).toBe(true);
       expect(results[0].output).toContain("Approval required");
@@ -232,12 +193,9 @@ describe("ParallelToolExecutor", () => {
         throw new Error("executor failed");
       };
 
-      const results = await ParallelToolExecutor.execute(
-        calls,
-        specs,
-        executor,
-        { mode: "safe-only" },
-      );
+      const results = await ParallelToolExecutor.execute(calls, specs, executor, {
+        mode: "safe-only",
+      });
       expect(results[0].isError).toBe(true);
       expect(results[0].output).toBe("executor failed");
     });

--- a/packages/agent/test/core/execution/tool-executor.test.ts
+++ b/packages/agent/test/core/execution/tool-executor.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { ToolExecutor } from "../../../src/core/execution/tool-executor";
 import type { Tool } from "@openomni/protocol";
 
-function makeCall(
-  tool: string,
-  input: Record<string, unknown> = {},
-): Tool.Call {
+function makeCall(tool: string, input: Record<string, unknown> = {}): Tool.Call {
   return { id: crypto.randomUUID(), tool, input };
 }
 
@@ -71,11 +68,7 @@ describe("ToolExecutor.executeSequential", () => {
 
   it("guard deny returns error result without calling executor", async () => {
     const executorCalled: string[] = [];
-    const calls = [
-      makeCall("tool-a"),
-      makeCall("forbidden"),
-      makeCall("tool-b"),
-    ];
+    const calls = [makeCall("tool-a"), makeCall("forbidden"), makeCall("tool-b")];
     const executor = async (call: Tool.Call): Promise<Tool.Result> => {
       executorCalled.push(call.tool);
       return {

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -101,9 +101,7 @@ describe("ChatAgent.stream()", () => {
     mockRunFn = async (_input, sink) => {
       callCount++;
       if (callCount === 1) {
-        return createToolCallOutcome([
-          { id: "call-1", tool: "test_tool", input: { q: "test" } },
-        ]);
+        return createToolCallOutcome([{ id: "call-1", tool: "test_tool", input: { q: "test" } }]);
       }
       sink.onMessage({
         info: {

--- a/packages/agent/test/core/tool-guard.test.ts
+++ b/packages/agent/test/core/tool-guard.test.ts
@@ -7,15 +7,11 @@ describe("ToolGuard.check", () => {
   });
 
   it("denies tool on denylist", () => {
-    expect(
-      ToolGuard.check("dangerous_tool", { denylist: ["dangerous_tool"] }),
-    ).toBe("deny");
+    expect(ToolGuard.check("dangerous_tool", { denylist: ["dangerous_tool"] })).toBe("deny");
   });
 
   it("allows tool not on denylist", () => {
-    expect(ToolGuard.check("safe_tool", { denylist: ["dangerous_tool"] })).toBe(
-      "allow",
-    );
+    expect(ToolGuard.check("safe_tool", { denylist: ["dangerous_tool"] })).toBe("allow");
   });
 
   it("denies all tools when allowlist is empty array", () => {
@@ -27,27 +23,19 @@ describe("ToolGuard.check", () => {
   });
 
   it("allows tool explicitly in allowlist", () => {
-    expect(
-      ToolGuard.check("allowed_tool", { allowlist: ["allowed_tool"] }),
-    ).toBe("allow");
+    expect(ToolGuard.check("allowed_tool", { allowlist: ["allowed_tool"] })).toBe("allow");
   });
 
   it("denies tool not in allowlist", () => {
-    expect(ToolGuard.check("other_tool", { allowlist: ["allowed_tool"] })).toBe(
-      "deny",
-    );
+    expect(ToolGuard.check("other_tool", { allowlist: ["allowed_tool"] })).toBe("deny");
   });
 
   it("allows tool matching prefix wildcard mcp.*", () => {
-    expect(ToolGuard.check("mcp.search", { allowlist: ["mcp.*"] })).toBe(
-      "allow",
-    );
+    expect(ToolGuard.check("mcp.search", { allowlist: ["mcp.*"] })).toBe("allow");
   });
 
   it("denies tool not matching prefix wildcard", () => {
-    expect(ToolGuard.check("other.search", { allowlist: ["mcp.*"] })).toBe(
-      "deny",
-    );
+    expect(ToolGuard.check("other.search", { allowlist: ["mcp.*"] })).toBe("deny");
   });
 
   it("returns require_approval for tool in requireApproval list", () => {

--- a/packages/agent/test/runtime/mcp/convert.test.ts
+++ b/packages/agent/test/runtime/mcp/convert.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-  convertMcpTool,
-  convertMcpResult,
-} from "../../../src/runtime/mcp/convert";
+import { convertMcpTool, convertMcpResult } from "../../../src/runtime/mcp/convert";
 
 describe("convertMcpTool", () => {
   it("converts basic MCP tool to Tool.Spec", () => {
@@ -23,10 +20,7 @@ describe("convertMcpTool", () => {
   });
 
   it("namespaces tool name with server name", () => {
-    const spec = convertMcpTool(
-      { name: "read", description: "Read" },
-      "fs-server",
-    );
+    const spec = convertMcpTool({ name: "read", description: "Read" }, "fs-server");
     expect(spec.name).toBe("fs-server.read");
   });
 

--- a/packages/agent/test/runtime/messenger/instance-registry.test.ts
+++ b/packages/agent/test/runtime/messenger/instance-registry.test.ts
@@ -40,8 +40,6 @@ describe("InstanceRegistry", () => {
 
   it("stores metadata", () => {
     InstanceRegistry.register("inst-1", "agent-a", { region: "us-east" });
-    expect(InstanceRegistry.getById("inst-1")?.metadata?.region).toBe(
-      "us-east",
-    );
+    expect(InstanceRegistry.getById("inst-1")?.metadata?.region).toBe("us-east");
   });
 });

--- a/packages/agent/test/runtime/messenger/messenger.test.ts
+++ b/packages/agent/test/runtime/messenger/messenger.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { Bus } from "@openomni/session";
-import {
-  AgentMessenger,
-  BusTransport,
-} from "../../../src/runtime/messenger/index";
+import { AgentMessenger, BusTransport } from "../../../src/runtime/messenger/index";
 import type { Messenger } from "@openomni/protocol";
 
 function makeEnvelope(
@@ -63,9 +60,7 @@ describe("AgentMessenger", () => {
     const transport = new BusTransport();
     const messenger = AgentMessenger.create(transport);
 
-    await expect(
-      messenger.send(makeEnvelope("agent-x", "agent-y")),
-    ).resolves.toBeUndefined();
+    await expect(messenger.send(makeEnvelope("agent-x", "agent-y"))).resolves.toBeUndefined();
   });
 
   it("allows message matching allow pattern", async () => {
@@ -74,9 +69,7 @@ describe("AgentMessenger", () => {
       allowPatterns: [{ from: "agent-a", to: "agent-b" }],
     });
 
-    await expect(
-      messenger.send(makeEnvelope("agent-a", "agent-b")),
-    ).resolves.toBeUndefined();
+    await expect(messenger.send(makeEnvelope("agent-a", "agent-b"))).resolves.toBeUndefined();
   });
 
   it("denies message not matching allow pattern", async () => {
@@ -85,9 +78,9 @@ describe("AgentMessenger", () => {
       allowPatterns: [{ from: "agent-a", to: "agent-b" }],
     });
 
-    await expect(
-      messenger.send(makeEnvelope("agent-c", "agent-b")),
-    ).rejects.toThrow("Authorization denied");
+    await expect(messenger.send(makeEnvelope("agent-c", "agent-b"))).rejects.toThrow(
+      "Authorization denied",
+    );
   });
 
   it("allows wildcard * in allow pattern", async () => {
@@ -96,9 +89,7 @@ describe("AgentMessenger", () => {
       allowPatterns: [{ from: "*", to: "*" }],
     });
 
-    await expect(
-      messenger.send(makeEnvelope("any-agent", "any-other")),
-    ).resolves.toBeUndefined();
+    await expect(messenger.send(makeEnvelope("any-agent", "any-other"))).resolves.toBeUndefined();
   });
 
   it("handles 3 concurrent sends without message loss", async () => {

--- a/packages/agent/test/runtime/messenger/request.test.ts
+++ b/packages/agent/test/runtime/messenger/request.test.ts
@@ -4,11 +4,7 @@ import { AgentMessenger } from "../../../src/runtime/messenger/messenger";
 import { BusTransport } from "../../../src/runtime/messenger/transport";
 import type { Messenger } from "@openomni/protocol";
 
-function makeEnvelope(
-  from: string,
-  to: string,
-  id?: string,
-): Messenger.MessageEnvelope {
+function makeEnvelope(from: string, to: string, id?: string): Messenger.MessageEnvelope {
   return {
     id: id ?? crypto.randomUUID(),
     traceId: "trace-1",
@@ -57,9 +53,7 @@ describe("AgentMessenger.request", () => {
 
     const requestEnvelope = makeEnvelope("agent-a", "agent-b");
 
-    await expect(
-      messenger.request(requestEnvelope, { timeout: 50 }),
-    ).rejects.toThrow("timed out");
+    await expect(messenger.request(requestEnvelope, { timeout: 50 })).rejects.toThrow("timed out");
   });
 
   it("rejects when aborted via signal", async () => {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "check-types": "tsc --noEmit",
+    "lint": "bunx biome check ./src",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/llm/src/agent/index.ts
+++ b/packages/llm/src/agent/index.ts
@@ -10,14 +10,8 @@ export namespace Agent {
    */
   export const Info = z.object({
     name: z.string().describe("Unique identifier for the agent"),
-    description: z
-      .string()
-      .optional()
-      .describe("Human-readable description of the agent"),
-    systemPrompt: z
-      .string()
-      .optional()
-      .describe("System prompt to guide agent behavior"),
+    description: z.string().optional().describe("Human-readable description of the agent"),
+    systemPrompt: z.string().optional().describe("System prompt to guide agent behavior"),
     temperature: z
       .number()
       .min(0)

--- a/packages/llm/src/auth/registry.ts
+++ b/packages/llm/src/auth/registry.ts
@@ -46,9 +46,7 @@ function createAnthropicOAuthMethod(
         return;
       }
       cb.updateProgress("Creating API key...");
-      const apiKeyResult = await anthropicOAuth.createApiKey(
-        tokenResult.access,
-      );
+      const apiKeyResult = await anthropicOAuth.createApiKey(tokenResult.access);
       if (apiKeyResult.type === "failed") {
         await Auth.set("anthropic", {
           type: "oauth",
@@ -71,11 +69,7 @@ const anthropicProvider: AuthProvider = {
   hint: "Claude Max or Console",
   methods: [
     createAnthropicOAuthMethod("max", "Max", "claude.ai Pro/Max subscription"),
-    createAnthropicOAuthMethod(
-      "console",
-      "Console",
-      "console.anthropic.com API",
-    ),
+    createAnthropicOAuthMethod("console", "Console", "console.anthropic.com API"),
   ],
 };
 
@@ -109,9 +103,7 @@ const openaiProvider: AuthProvider = {
           });
           cb.stopProgress("Login successful");
         } catch (err) {
-          cb.stopProgress(
-            `Login failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          cb.stopProgress(`Login failed: ${err instanceof Error ? err.message : String(err)}`);
         } finally {
           openaiOAuth.stopOAuthServer();
         }
@@ -144,9 +136,7 @@ const openaiProvider: AuthProvider = {
           });
           cb.stopProgress("Login successful");
         } catch (err) {
-          cb.stopProgress(
-            `Login failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          cb.stopProgress(`Login failed: ${err instanceof Error ? err.message : String(err)}`);
         }
       },
     },

--- a/packages/llm/src/auth/storage.ts
+++ b/packages/llm/src/auth/storage.ts
@@ -1,6 +1,6 @@
-import z from "zod"
-import { join } from "path"
-import { mkdirSync, existsSync, chmodSync } from "fs"
+import z from "zod";
+import { join } from "path";
+import { mkdirSync, existsSync, chmodSync } from "fs";
 
 const OauthAuth = z.object({
   type: z.literal("oauth"),
@@ -8,70 +8,70 @@ const OauthAuth = z.object({
   access: z.string(),
   expires: z.number(),
   accountId: z.string().optional(),
-})
+});
 
 const ApiAuth = z.object({
   type: z.literal("api"),
   key: z.string(),
-})
+});
 
-const Info = z.discriminatedUnion("type", [OauthAuth, ApiAuth])
-type Info = z.infer<typeof Info>
+const Info = z.discriminatedUnion("type", [OauthAuth, ApiAuth]);
+type Info = z.infer<typeof Info>;
 
 const getAuthFilePath = () => {
   if (process.env.OPENOMNI_AUTH_FILE) {
-    return process.env.OPENOMNI_AUTH_FILE
+    return process.env.OPENOMNI_AUTH_FILE;
   }
-  return join(process.env.HOME!, ".openomni", "auth.json")
-}
+  return join(process.env.HOME!, ".openomni", "auth.json");
+};
 
 const ensureAuthDir = () => {
-  const filepath = getAuthFilePath()
-  const dir = filepath.substring(0, filepath.lastIndexOf("/"))
+  const filepath = getAuthFilePath();
+  const dir = filepath.substring(0, filepath.lastIndexOf("/"));
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
+    mkdirSync(dir, { recursive: true });
   }
-}
+};
 
 export namespace Auth {
-  export type Info = z.infer<typeof Info>
+  export type Info = z.infer<typeof Info>;
 
   export async function get(providerID: string): Promise<Info | undefined> {
-    const auth = await all()
-    return auth[providerID]
+    const auth = await all();
+    return auth[providerID];
   }
 
   export async function all(): Promise<Record<string, Info>> {
-    const filepath = getAuthFilePath()
-    const file = Bun.file(filepath)
-    const data = await file.json().catch(() => ({}) as Record<string, unknown>)
+    const filepath = getAuthFilePath();
+    const file = Bun.file(filepath);
+    const data = await file.json().catch(() => ({}) as Record<string, unknown>);
     return Object.entries(data).reduce(
       (acc, [key, value]) => {
-        const parsed = Info.safeParse(value)
-        if (!parsed.success) return acc
-        acc[key] = parsed.data
-        return acc
+        const parsed = Info.safeParse(value);
+        if (!parsed.success) return acc;
+        acc[key] = parsed.data;
+        return acc;
       },
       {} as Record<string, Info>,
-    )
+    );
   }
 
   export async function set(key: string, info: Info) {
-    ensureAuthDir()
-    const filepath = getAuthFilePath()
-    const file = Bun.file(filepath)
-    const data = await all()
-    await Bun.write(file, JSON.stringify({ ...data, [key]: info }, null, 2))
-    chmodSync(filepath, 0o600)
+    ensureAuthDir();
+    const filepath = getAuthFilePath();
+    const file = Bun.file(filepath);
+    const data = await all();
+    await Bun.write(file, JSON.stringify({ ...data, [key]: info }, null, 2));
+    chmodSync(filepath, 0o600);
   }
 
   export async function remove(key: string) {
-    ensureAuthDir()
-    const filepath = getAuthFilePath()
-    const file = Bun.file(filepath)
-    const data = await all()
-    delete data[key]
-    await Bun.write(file, JSON.stringify(data, null, 2))
-    chmodSync(filepath, 0o600)
+    ensureAuthDir();
+    const filepath = getAuthFilePath();
+    const file = Bun.file(filepath);
+    const data = await all();
+    delete data[key];
+    await Bun.write(file, JSON.stringify(data, null, 2));
+    chmodSync(filepath, 0o600);
   }
 }

--- a/packages/llm/src/error.ts
+++ b/packages/llm/src/error.ts
@@ -70,7 +70,4 @@ export const AbortedError = NamedError.create(
   }),
 );
 
-export const OutputLengthError = NamedError.create(
-  "OutputLengthError",
-  z.object({}),
-);
+export const OutputLengthError = NamedError.create("OutputLengthError", z.object({}));

--- a/packages/llm/src/fetch/anthropic.ts
+++ b/packages/llm/src/fetch/anthropic.ts
@@ -59,10 +59,7 @@ export function createOAuthFetch(
     await pendingRefresh;
   }
 
-  return async function oauthFetch(
-    input: string | Request | URL,
-    init?: RequestInit,
-  ) {
+  return async function oauthFetch(input: string | Request | URL, init?: RequestInit) {
     await ensureValidToken();
 
     const requestHeaders = new Headers();
@@ -83,9 +80,7 @@ export function createOAuthFetch(
       .split(",")
       .map((b) => b.trim())
       .filter(Boolean);
-    const mergedBetas = [
-      ...new Set([...REQUIRED_BETAS, ...incomingBetas]),
-    ].join(",");
+    const mergedBetas = [...new Set([...REQUIRED_BETAS, ...incomingBetas])].join(",");
 
     requestHeaders.set("authorization", `Bearer ${currentAccess}`);
     requestHeaders.set("anthropic-beta", mergedBetas);

--- a/packages/llm/src/fetch/openai.ts
+++ b/packages/llm/src/fetch/openai.ts
@@ -6,11 +6,7 @@ type ProviderFetch = NonNullable<OpenAIProviderSettings["fetch"]>;
 
 const OAUTH_DUMMY_KEY = "oauth-dummy-key";
 
-type TokenRefreshCallback = (tokens: {
-  access: string;
-  refresh: string;
-  expires: number;
-}) => void;
+type TokenRefreshCallback = (tokens: { access: string; refresh: string; expires: number }) => void;
 
 export function createCodexOAuthFetch(
   auth: Extract<Auth.Info, { type: "oauth" }>,
@@ -59,9 +55,7 @@ export function createCodexOAuthFetch(
         init.headers.delete("authorization");
         init.headers.delete("Authorization");
       } else if (Array.isArray(init.headers)) {
-        init.headers = init.headers.filter(
-          ([key]) => key.toLowerCase() !== "authorization",
-        );
+        init.headers = init.headers.filter(([key]) => key.toLowerCase() !== "authorization");
       } else {
         delete (init.headers as Record<string, string>)["authorization"];
         delete (init.headers as Record<string, string>)["Authorization"];
@@ -79,9 +73,7 @@ export function createCodexOAuthFetch(
           if (value !== undefined) headers.set(key, String(value));
         }
       } else {
-        for (const [key, value] of Object.entries(
-          init.headers as Record<string, string>,
-        )) {
+        for (const [key, value] of Object.entries(init.headers as Record<string, string>)) {
           if (value !== undefined) headers.set(key, String(value));
         }
       }
@@ -99,8 +91,7 @@ export function createCodexOAuthFetch(
         : new URL(typeof input === "string" ? input : (input as Request).url);
 
     const url =
-      parsed.pathname.includes("/v1/responses") ||
-      parsed.pathname.includes("/chat/completions")
+      parsed.pathname.includes("/v1/responses") || parsed.pathname.includes("/chat/completions")
         ? new URL(CODEX_API_ENDPOINT)
         : parsed;
 

--- a/packages/llm/src/model/index.ts
+++ b/packages/llm/src/model/index.ts
@@ -91,10 +91,8 @@ export namespace ModelsDev {
     const cached = await file.json().catch(() => undefined);
     if (cached) return cached as Record<string, Provider>;
 
-    const snapshotModule =
-      await import("../provider/models-snapshot.json").catch(() => undefined);
-    if (snapshotModule?.default)
-      return snapshotModule.default as Record<string, Provider>;
+    const snapshotModule = await import("../provider/models-snapshot.json").catch(() => undefined);
+    if (snapshotModule?.default) return snapshotModule.default as Record<string, Provider>;
 
     if (process.env.OPENOMNI_DISABLE_MODELS_FETCH) return buildFallback();
 

--- a/packages/llm/src/oauth/anthropic.ts
+++ b/packages/llm/src/oauth/anthropic.ts
@@ -1,47 +1,47 @@
-import { z } from "zod"
-import { generatePKCE } from "./pkce"
+import { z } from "zod";
+import { generatePKCE } from "./pkce";
 
-const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
-const SCOPES = "org:create_api_key user:profile user:inference"
-const CREATE_API_KEY_URL = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key"
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
+const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
+const SCOPES = "org:create_api_key user:profile user:inference";
+const CREATE_API_KEY_URL = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
 
 const TokenResponse = z.object({
   access_token: z.string(),
   refresh_token: z.string(),
   expires_in: z.number(),
-})
+});
 
 const ApiKeyResponse = z.object({
   raw_key: z.string(),
-})
+});
 
 type OAuthResult =
   | { type: "success"; access: string; refresh: string; expires: number }
-  | { type: "failed" }
+  | { type: "failed" };
 
-type ApiKeyResult =
-  | { type: "success"; key: string }
-  | { type: "failed" }
+type ApiKeyResult = { type: "success"; key: string } | { type: "failed" };
 
-export async function authorize(mode: "max" | "console"): Promise<{ url: string; verifier: string }> {
-  const pkce = await generatePKCE()
-  const domain = mode === "console" ? "console.anthropic.com" : "claude.ai"
-  const url = new URL(`https://${domain}/oauth/authorize`)
-  url.searchParams.set("code", "true")
-  url.searchParams.set("client_id", CLIENT_ID)
-  url.searchParams.set("response_type", "code")
-  url.searchParams.set("redirect_uri", REDIRECT_URI)
-  url.searchParams.set("scope", SCOPES)
-  url.searchParams.set("code_challenge", pkce.challenge)
-  url.searchParams.set("code_challenge_method", "S256")
-  url.searchParams.set("state", pkce.verifier)
-  return { url: url.toString(), verifier: pkce.verifier }
+export async function authorize(
+  mode: "max" | "console",
+): Promise<{ url: string; verifier: string }> {
+  const pkce = await generatePKCE();
+  const domain = mode === "console" ? "console.anthropic.com" : "claude.ai";
+  const url = new URL(`https://${domain}/oauth/authorize`);
+  url.searchParams.set("code", "true");
+  url.searchParams.set("client_id", CLIENT_ID);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("scope", SCOPES);
+  url.searchParams.set("code_challenge", pkce.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", pkce.verifier);
+  return { url: url.toString(), verifier: pkce.verifier };
 }
 
 export async function exchange(code: string, verifier: string): Promise<OAuthResult> {
-  const splits = code.split("#")
+  const splits = code.split("#");
   const result = await fetch(TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -53,15 +53,15 @@ export async function exchange(code: string, verifier: string): Promise<OAuthRes
       redirect_uri: REDIRECT_URI,
       code_verifier: verifier,
     }),
-  })
-  if (!result.ok) return { type: "failed" }
-  const json = TokenResponse.parse(await result.json())
+  });
+  if (!result.ok) return { type: "failed" };
+  const json = TokenResponse.parse(await result.json());
   return {
     type: "success",
     access: json.access_token,
     refresh: json.refresh_token,
     expires: Date.now() + json.expires_in * 1000,
-  }
+  };
 }
 
 export async function refreshToken(token: string): Promise<OAuthResult> {
@@ -73,15 +73,15 @@ export async function refreshToken(token: string): Promise<OAuthResult> {
       refresh_token: token,
       client_id: CLIENT_ID,
     }),
-  })
-  if (!result.ok) return { type: "failed" }
-  const json = TokenResponse.parse(await result.json())
+  });
+  if (!result.ok) return { type: "failed" };
+  const json = TokenResponse.parse(await result.json());
   return {
     type: "success",
     access: json.access_token,
     refresh: json.refresh_token,
     expires: Date.now() + json.expires_in * 1000,
-  }
+  };
 }
 
 export async function createApiKey(accessToken: string): Promise<ApiKeyResult> {
@@ -91,8 +91,8 @@ export async function createApiKey(accessToken: string): Promise<ApiKeyResult> {
       "Content-Type": "application/json",
       authorization: `Bearer ${accessToken}`,
     },
-  })
-  if (!result.ok) return { type: "failed" }
-  const json = ApiKeyResponse.parse(await result.json())
-  return { type: "success", key: json.raw_key }
+  });
+  if (!result.ok) return { type: "failed" };
+  const json = ApiKeyResponse.parse(await result.json());
+  return { type: "success", key: json.raw_key };
 }

--- a/packages/llm/src/oauth/openai.ts
+++ b/packages/llm/src/oauth/openai.ts
@@ -2,8 +2,7 @@ import { AuthError, TokenRefreshError } from "../error";
 
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const ISSUER = "https://auth.openai.com";
-export const CODEX_API_ENDPOINT =
-  "https://chatgpt.com/backend-api/codex/responses";
+export const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
 export const OAUTH_PORT = 1455;
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000;
 
@@ -44,11 +43,7 @@ let pendingOAuth:
     }
   | undefined;
 
-export function buildAuthorizeUrl(
-  redirectUri: string,
-  pkce: PkceCodes,
-  state: string,
-): string {
+export function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string): string {
   const params = new URLSearchParams({
     response_type: "code",
     client_id: CLIENT_ID,
@@ -89,9 +84,7 @@ export async function exchangeCodeForTokens(
   return response.json() as Promise<TokenResponse>;
 }
 
-export async function refreshAccessToken(
-  refreshToken: string,
-): Promise<TokenResponse> {
+export async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -110,9 +103,7 @@ export async function refreshAccessToken(
   return response.json() as Promise<TokenResponse>;
 }
 
-export function parseJwtClaims(
-  token: string,
-): Record<string, unknown> | undefined {
+export function parseJwtClaims(token: string): Record<string, unknown> | undefined {
   const parts = token.split(".");
   if (parts.length !== 3) return undefined;
   try {
@@ -137,9 +128,7 @@ export function extractAccountId(tokens: TokenResponse): string | undefined {
     if (accountId) return accountId;
   }
   if (tokens.access_token) {
-    const claims = parseJwtClaims(tokens.access_token) as
-      | IdTokenClaims
-      | undefined;
+    const claims = parseJwtClaims(tokens.access_token) as IdTokenClaims | undefined;
     return claims ? extractAccountIdFromClaims(claims) : undefined;
   }
   return undefined;
@@ -172,57 +161,41 @@ export async function startOAuthServer(): Promise<{
             const errorMsg = errorDescription || error;
             pendingOAuth?.reject(new Error(errorMsg));
             pendingOAuth = undefined;
-            return new Response(
-              `<html><body>Error: ${errorMsg}</body></html>`,
-              {
-                headers: { "Content-Type": "text/html" },
-              },
-            );
+            return new Response(`<html><body>Error: ${errorMsg}</body></html>`, {
+              headers: { "Content-Type": "text/html" },
+            });
           }
 
           if (!code) {
             const errorMsg = "Missing authorization code";
             pendingOAuth?.reject(new Error(errorMsg));
             pendingOAuth = undefined;
-            return new Response(
-              `<html><body>Error: ${errorMsg}</body></html>`,
-              {
-                status: 400,
-                headers: { "Content-Type": "text/html" },
-              },
-            );
+            return new Response(`<html><body>Error: ${errorMsg}</body></html>`, {
+              status: 400,
+              headers: { "Content-Type": "text/html" },
+            });
           }
 
           if (!pendingOAuth || state !== pendingOAuth.state) {
             const errorMsg = "Invalid state - potential CSRF attack";
             pendingOAuth?.reject(new Error(errorMsg));
             pendingOAuth = undefined;
-            return new Response(
-              `<html><body>Error: ${errorMsg}</body></html>`,
-              {
-                status: 400,
-                headers: { "Content-Type": "text/html" },
-              },
-            );
+            return new Response(`<html><body>Error: ${errorMsg}</body></html>`, {
+              status: 400,
+              headers: { "Content-Type": "text/html" },
+            });
           }
 
           const current = pendingOAuth;
           pendingOAuth = undefined;
 
-          exchangeCodeForTokens(
-            code,
-            `http://localhost:${OAUTH_PORT}/auth/callback`,
-            current.pkce,
-          )
+          exchangeCodeForTokens(code, `http://localhost:${OAUTH_PORT}/auth/callback`, current.pkce)
             .then((tokens) => current.resolve(tokens))
             .catch((err) => current.reject(err));
 
-          return new Response(
-            "<html><body>Success! You can close this tab.</body></html>",
-            {
-              headers: { "Content-Type": "text/html" },
-            },
-          );
+          return new Response("<html><body>Success! You can close this tab.</body></html>", {
+            headers: { "Content-Type": "text/html" },
+          });
         }
 
         if (url.pathname === "/cancel") {
@@ -235,12 +208,7 @@ export async function startOAuthServer(): Promise<{
       },
     });
   } catch (err: unknown) {
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      err.code === "EADDRINUSE"
-    ) {
+    if (err && typeof err === "object" && "code" in err && err.code === "EADDRINUSE") {
       return {
         port: OAUTH_PORT,
         redirectUri: `http://localhost:${OAUTH_PORT}/auth/callback`,
@@ -262,18 +230,13 @@ export function stopOAuthServer(): void {
   }
 }
 
-export function waitForOAuthCallback(
-  pkce: PkceCodes,
-  state: string,
-): Promise<TokenResponse> {
+export function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResponse> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(
       () => {
         if (pendingOAuth) {
           pendingOAuth = undefined;
-          reject(
-            new Error("OAuth callback timeout - authorization took too long"),
-          );
+          reject(new Error("OAuth callback timeout - authorization took too long"));
         }
       },
       5 * 60 * 1000,

--- a/packages/llm/src/oauth/pkce.ts
+++ b/packages/llm/src/oauth/pkce.ts
@@ -1,26 +1,26 @@
 export async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
-  const verifier = generateRandomString(43)
-  const encoder = new TextEncoder()
-  const data = encoder.encode(verifier)
-  const hash = await crypto.subtle.digest("SHA-256", data)
-  const challenge = base64UrlEncode(hash)
-  return { verifier, challenge }
+  const verifier = generateRandomString(43);
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  const challenge = base64UrlEncode(hash);
+  return { verifier, challenge };
 }
 
 export function generateState(): string {
-  return base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+  return base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer);
 }
 
 function generateRandomString(length: number): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-  const bytes = crypto.getRandomValues(new Uint8Array(length))
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+  const bytes = crypto.getRandomValues(new Uint8Array(length));
   return Array.from(bytes)
     .map((b) => chars[b % chars.length])
-    .join("")
+    .join("");
 }
 
 function base64UrlEncode(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer)
-  const binary = String.fromCharCode(...bytes)
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+  const bytes = new Uint8Array(buffer);
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }

--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -99,10 +99,7 @@ export namespace Provider {
   });
   export type Info = z.infer<typeof Info>;
 
-  export function fromModelsDevModel(
-    provider: ModelsDev.Provider,
-    model: ModelsDev.Model,
-  ): Model {
+  export function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     return {
       id: model.id,
       providerID: provider.id,
@@ -184,9 +181,7 @@ export namespace Provider {
     return Object.keys(data);
   }
 
-  export async function getProviderInfo(
-    providerID: string,
-  ): Promise<Info | undefined> {
+  export async function getProviderInfo(providerID: string): Promise<Info | undefined> {
     const data = await ModelsDev.get();
     const provider = data[providerID];
     if (!provider) return undefined;

--- a/packages/llm/src/provider/models-snapshot.json
+++ b/packages/llm/src/provider/models-snapshot.json
@@ -1,9 +1,7 @@
 {
   "anthropic": {
     "id": "anthropic",
-    "env": [
-      "ANTHROPIC_API_KEY"
-    ],
+    "env": ["ANTHROPIC_API_KEY"],
     "npm": "@ai-sdk/anthropic",
     "name": "Anthropic",
     "doc": "https://docs.anthropic.com/en/docs/about-claude/models",
@@ -20,14 +18,8 @@
         "release_date": "2025-05-22",
         "last_updated": "2025-05-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -53,14 +45,8 @@
         "release_date": "2024-10-22",
         "last_updated": "2024-10-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -86,14 +72,8 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -119,14 +99,8 @@
         "release_date": "2025-10-15",
         "last_updated": "2025-10-15",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -152,14 +126,8 @@
         "release_date": "2024-06-20",
         "last_updated": "2024-06-20",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -185,14 +153,8 @@
         "release_date": "2024-10-22",
         "last_updated": "2024-10-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -218,14 +180,8 @@
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -251,14 +207,8 @@
         "release_date": "2024-02-29",
         "last_updated": "2024-02-29",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -284,14 +234,8 @@
         "release_date": "2025-11-01",
         "last_updated": "2025-11-01",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -317,14 +261,8 @@
         "release_date": "2025-09-29",
         "last_updated": "2025-09-29",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -350,14 +288,8 @@
         "release_date": "2025-09-29",
         "last_updated": "2025-09-29",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -383,14 +315,8 @@
         "release_date": "2025-05-22",
         "last_updated": "2025-05-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -416,14 +342,8 @@
         "release_date": "2025-05-22",
         "last_updated": "2025-05-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -449,14 +369,8 @@
         "release_date": "2024-10-22",
         "last_updated": "2024-10-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -482,14 +396,8 @@
         "release_date": "2024-03-13",
         "last_updated": "2024-03-13",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -515,14 +423,8 @@
         "release_date": "2025-02-19",
         "last_updated": "2025-02-19",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -548,14 +450,8 @@
         "release_date": "2025-02-19",
         "last_updated": "2025-02-19",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -581,14 +477,8 @@
         "release_date": "2025-05-22",
         "last_updated": "2025-05-22",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -614,14 +504,8 @@
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -647,14 +531,8 @@
         "release_date": "2024-03-04",
         "last_updated": "2024-03-04",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -680,14 +558,8 @@
         "release_date": "2025-10-15",
         "last_updated": "2025-10-15",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -705,9 +577,7 @@
   },
   "openai": {
     "id": "openai",
-    "env": [
-      "OPENAI_API_KEY"
-    ],
+    "env": ["OPENAI_API_KEY"],
     "npm": "@ai-sdk/openai",
     "name": "OpenAI",
     "doc": "https://platform.openai.com/docs/models",
@@ -725,13 +595,8 @@
         "release_date": "2025-04-14",
         "last_updated": "2025-04-14",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -756,12 +621,8 @@
         "release_date": "2024-01-25",
         "last_updated": "2024-01-25",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -786,12 +647,8 @@
         "release_date": "2023-11-06",
         "last_updated": "2024-04-09",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -816,13 +673,8 @@
         "release_date": "2025-03-19",
         "last_updated": "2025-03-19",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -847,13 +699,8 @@
         "release_date": "2024-05-13",
         "last_updated": "2024-05-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -878,14 +725,8 @@
         "release_date": "2025-12-11",
         "last_updated": "2025-12-11",
         "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -912,13 +753,8 @@
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -945,13 +781,8 @@
         "release_date": "2024-08-06",
         "last_updated": "2024-08-06",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -977,13 +808,8 @@
         "release_date": "2025-04-14",
         "last_updated": "2025-04-14",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1008,13 +834,8 @@
         "release_date": "2024-06-26",
         "last_updated": "2024-06-26",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1040,12 +861,8 @@
         "release_date": "2023-03-01",
         "last_updated": "2023-11-06",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1071,13 +888,8 @@
         "release_date": "2025-12-11",
         "last_updated": "2025-12-11",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1102,12 +914,8 @@
         "release_date": "2024-01-25",
         "last_updated": "2024-01-25",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1132,13 +940,8 @@
         "release_date": "2023-11-06",
         "last_updated": "2024-04-09",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1162,12 +965,8 @@
         "release_date": "2024-09-12",
         "last_updated": "2024-09-12",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1193,13 +992,8 @@
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1226,12 +1020,8 @@
         "release_date": "2024-12-20",
         "last_updated": "2025-01-29",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1257,13 +1047,8 @@
         "release_date": "2025-12-11",
         "last_updated": "2025-12-11",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1289,13 +1074,8 @@
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1321,12 +1101,8 @@
         "release_date": "2025-05-16",
         "last_updated": "2025-05-16",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1352,13 +1128,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1385,13 +1156,8 @@
         "release_date": "2025-09-15",
         "last_updated": "2025-09-15",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1418,13 +1184,8 @@
         "release_date": "2024-05-13",
         "last_updated": "2024-08-06",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1450,13 +1211,8 @@
         "release_date": "2025-04-14",
         "last_updated": "2025-04-14",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1482,13 +1238,8 @@
         "release_date": "2025-04-16",
         "last_updated": "2025-04-16",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1514,13 +1265,8 @@
         "release_date": "2024-12-05",
         "last_updated": "2024-12-05",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1546,13 +1292,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1579,12 +1320,8 @@
         "release_date": "2024-09-12",
         "last_updated": "2024-09-12",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1609,12 +1346,8 @@
         "release_date": "2022-12-15",
         "last_updated": "2022-12-15",
         "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1639,13 +1372,8 @@
         "release_date": "2025-06-10",
         "last_updated": "2025-06-10",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1670,13 +1398,8 @@
         "release_date": "2024-11-20",
         "last_updated": "2024-11-20",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1702,13 +1425,8 @@
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1735,13 +1453,8 @@
         "release_date": "2025-04-16",
         "last_updated": "2025-04-16",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1766,13 +1479,8 @@
         "release_date": "2024-06-26",
         "last_updated": "2024-06-26",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1798,13 +1506,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1830,13 +1533,8 @@
         "release_date": "2024-07-18",
         "last_updated": "2024-07-18",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1862,13 +1560,8 @@
         "release_date": "2025-08-07",
         "last_updated": "2025-08-07",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1895,13 +1588,8 @@
         "release_date": "2025-10-06",
         "last_updated": "2025-10-06",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1927,13 +1615,8 @@
         "release_date": "2025-12-11",
         "last_updated": "2025-12-11",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {
@@ -1960,13 +1643,8 @@
         "release_date": "2025-11-13",
         "last_updated": "2025-11-13",
         "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
+          "input": ["text", "image"],
+          "output": ["text"]
         },
         "open_weights": false,
         "cost": {

--- a/packages/llm/src/provider/provider.ts
+++ b/packages/llm/src/provider/provider.ts
@@ -12,11 +12,7 @@ const BUNDLED_PROVIDERS: Record<string, (options: any) => any> = {
   "@ai-sdk/openai": createOpenAI,
 };
 
-type CustomModelLoader = (
-  sdk: any,
-  modelID: string,
-  options?: Record<string, any>,
-) => any;
+type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => any;
 
 interface CustomLoaderResult {
   getModel?: CustomModelLoader;
@@ -58,18 +54,15 @@ export function getSDK(model: Provider.Model, auth: Auth.Info): any {
     sdkOptions.apiKey = auth.key;
   } else if (providerID === "anthropic") {
     const oauthAuth = auth as Extract<Auth.Info, { type: "oauth" }>;
-    const oauthFetch = createOAuthFetch(
-      oauthAuth,
-      async (access, refresh, expires) => {
-        await Auth.set(providerID, {
-          type: "oauth",
-          access,
-          refresh,
-          expires,
-          ...(oauthAuth.accountId && { accountId: oauthAuth.accountId }),
-        });
-      },
-    );
+    const oauthFetch = createOAuthFetch(oauthAuth, async (access, refresh, expires) => {
+      await Auth.set(providerID, {
+        type: "oauth",
+        access,
+        refresh,
+        expires,
+        ...(oauthAuth.accountId && { accountId: oauthAuth.accountId }),
+      });
+    });
     sdkOptions.apiKey = "";
     sdkOptions.fetch = oauthFetch;
   } else if (providerID === "openai") {
@@ -89,10 +82,7 @@ export function getSDK(model: Provider.Model, auth: Auth.Info): any {
   return factory(sdkOptions);
 }
 
-export function getLanguage(
-  model: Provider.Model,
-  auth: Auth.Info,
-): LanguageModelV1 {
+export function getLanguage(model: Provider.Model, auth: Auth.Info): LanguageModelV1 {
   const sdk = getSDK(model, auth);
   const providerID = model.providerID;
   const customLoader = CUSTOM_LOADERS[providerID];
@@ -106,9 +96,7 @@ export function getLanguage(
   return sdk.languageModel(modelID);
 }
 
-export function fromModelsDevProvider(
-  provider: ModelsDev.Provider,
-): Provider.Info {
+export function fromModelsDevProvider(provider: ModelsDev.Provider): Provider.Info {
   const models: Record<string, Provider.Model> = {};
 
   if (provider.models) {
@@ -116,10 +104,7 @@ export function fromModelsDevProvider(
       const isValid = typeof rawModel === "object" && rawModel !== null;
       if (!isValid) continue;
 
-      models[id] = Provider.fromModelsDevModel(
-        provider,
-        rawModel as ModelsDev.Model,
-      );
+      models[id] = Provider.fromModelsDevModel(provider, rawModel as ModelsDev.Model);
     }
   }
 

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -29,8 +29,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   const abortSignal = signal || abortController!.signal;
 
   const sessionID =
-    messages[0]?.info.sessionID ||
-    `session-${Math.random().toString(36).substring(2, 11)}`;
+    messages[0]?.info.sessionID || `session-${Math.random().toString(36).substring(2, 11)}`;
   const messageID = `msg-${Math.random().toString(36).substring(2, 11)}`;
   const parentID = messages[messages.length - 1]?.info.id || "";
 
@@ -84,10 +83,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
         ? [{ role: "system" as const, content: streamInput.system }]
         : [];
 
-      const sdkTools: Record<
-        string,
-        { description?: string; parameters: unknown }
-      > = {};
+      const sdkTools: Record<string, { description?: string; parameters: unknown }> = {};
       for (const spec of input.tools) {
         sdkTools[spec.name] = {
           description: spec.description,

--- a/packages/llm/src/session/convert.ts
+++ b/packages/llm/src/session/convert.ts
@@ -12,9 +12,7 @@ export function toModelMessages(
     if (msg.parts.length === 0) continue;
 
     if (msg.info.role === "user") {
-      const textParts = msg.parts.filter(
-        (p): p is Message.TextPart => p.type === "text",
-      );
+      const textParts = msg.parts.filter((p): p is Message.TextPart => p.type === "text");
       const content = textParts.map((p) => p.text).join("\n");
       if (content.length > 0) {
         coreMessages.push({

--- a/packages/llm/src/session/message.ts
+++ b/packages/llm/src/session/message.ts
@@ -140,10 +140,7 @@ export namespace Message {
   });
   export type AssistantMessage = z.infer<typeof AssistantMessage>;
 
-  export const Info = z.discriminatedUnion("role", [
-    UserMessage,
-    AssistantMessage,
-  ]);
+  export const Info = z.discriminatedUnion("role", [UserMessage, AssistantMessage]);
   export type Info = z.infer<typeof Info>;
 
   export const WithParts = z.object({

--- a/packages/llm/src/session/processor.ts
+++ b/packages/llm/src/session/processor.ts
@@ -124,9 +124,7 @@ export namespace Processor {
                       type: "text",
                       text: "",
                       time: { start: now },
-                      metadata:
-                        (event.providerMetadata as Record<string, unknown>) ||
-                        {},
+                      metadata: (event.providerMetadata as Record<string, unknown>) || {},
                     };
                     addMessagePart(currentText);
                     break;
@@ -136,10 +134,7 @@ export namespace Processor {
                     if (currentText) {
                       currentText.text += String(event.text || "");
                       if (event.providerMetadata) {
-                        currentText.metadata = event.providerMetadata as Record<
-                          string,
-                          unknown
-                        >;
+                        currentText.metadata = event.providerMetadata as Record<string, unknown>;
                       }
                       updateMessagePart(currentText);
                     }
@@ -154,10 +149,7 @@ export namespace Processor {
                         end: Date.now(),
                       };
                       if (event.providerMetadata) {
-                        currentText.metadata = event.providerMetadata as Record<
-                          string,
-                          unknown
-                        >;
+                        currentText.metadata = event.providerMetadata as Record<string, unknown>;
                       }
                       updateMessagePart(currentText);
                     }
@@ -176,9 +168,7 @@ export namespace Processor {
                         type: "reasoning",
                         text: "",
                         time: { start: now, end: undefined },
-                        metadata:
-                          (event.providerMetadata as Record<string, unknown>) ||
-                          {},
+                        metadata: (event.providerMetadata as Record<string, unknown>) || {},
                       };
                       reasoningMap[reasoningId] = part;
                       addMessagePart(part);
@@ -192,10 +182,7 @@ export namespace Processor {
                       const part = reasoningMap[reasoningId];
                       part.text += String(event.text || "");
                       if (event.providerMetadata) {
-                        part.metadata = event.providerMetadata as Record<
-                          string,
-                          unknown
-                        >;
+                        part.metadata = event.providerMetadata as Record<string, unknown>;
                       }
                       updateMessagePart(part);
                     }
@@ -212,10 +199,7 @@ export namespace Processor {
                         end: Date.now(),
                       };
                       if (event.providerMetadata) {
-                        part.metadata = event.providerMetadata as Record<
-                          string,
-                          unknown
-                        >;
+                        part.metadata = event.providerMetadata as Record<string, unknown>;
                       }
                       updateMessagePart(part);
                       delete reasoningMap[reasoningId];
@@ -261,8 +245,7 @@ export namespace Processor {
                           title: result.title,
                           metadata: result.metadata ?? {},
                           time: {
-                            start:
-                              (toolPart.state as any).time?.start ?? Date.now(),
+                            start: (toolPart.state as any).time?.start ?? Date.now(),
                             end: Date.now(),
                           },
                         };
@@ -273,15 +256,13 @@ export namespace Processor {
                           output: result.output,
                         });
                       } catch (err) {
-                        const errorMessage =
-                          err instanceof Error ? err.message : String(err);
+                        const errorMessage = err instanceof Error ? err.message : String(err);
                         toolPart.state = {
                           status: "error",
                           input: toolPart.state.input,
                           error: errorMessage,
                           time: {
-                            start:
-                              (toolPart.state as any).time?.start ?? Date.now(),
+                            start: (toolPart.state as any).time?.start ?? Date.now(),
                             end: Date.now(),
                           },
                         };
@@ -311,9 +292,7 @@ export namespace Processor {
                   }
 
                   case "step-finish": {
-                    const finishReason = String(
-                      event.finishReason || "end_turn",
-                    );
+                    const finishReason = String(event.finishReason || "end_turn");
                     const usage = event.usage as
                       | {
                           promptTokens?: number;
@@ -338,8 +317,7 @@ export namespace Processor {
                     assistantMessage.finish = finishReason;
                     if (usage) {
                       assistantMessage.tokens.input += usage.promptTokens ?? 0;
-                      assistantMessage.tokens.output +=
-                        usage.completionTokens ?? 0;
+                      assistantMessage.tokens.output += usage.completionTokens ?? 0;
                     }
                     break;
                   }
@@ -366,10 +344,7 @@ export namespace Processor {
 
               if (retryReason !== undefined) {
                 attempt++;
-                const delayMs = Retry.delay(
-                  attempt,
-                  APIError.isInstance(e) ? e : undefined,
-                );
+                const delayMs = Retry.delay(attempt, APIError.isInstance(e) ? e : undefined);
 
                 publishStatus({
                   type: "retry",
@@ -381,10 +356,7 @@ export namespace Processor {
                 try {
                   await Retry.sleep(delayMs, abort);
                 } catch (sleepError) {
-                  if (
-                    sleepError instanceof DOMException &&
-                    sleepError.name === "AbortError"
-                  ) {
+                  if (sleepError instanceof DOMException && sleepError.name === "AbortError") {
                     cleanupPendingTools(pendingTools, updateMessagePart, sink);
                     publishStatus({ type: "idle" });
                     throw sleepError;
@@ -437,10 +409,7 @@ export namespace Processor {
           input: tool.state.input,
           error: "Processing was interrupted",
           time: {
-            start:
-              tool.state.status === "running"
-                ? tool.state.time.start
-                : Date.now(),
+            start: tool.state.status === "running" ? tool.state.time.start : Date.now(),
             end: Date.now(),
           },
         };

--- a/packages/llm/src/session/retry.ts
+++ b/packages/llm/src/session/retry.ts
@@ -115,10 +115,7 @@ export namespace Retry {
     initialDelay?: number;
   }
 
-  export async function withRetry<T>(
-    fn: () => Promise<T>,
-    options?: WithRetryOptions,
-  ): Promise<T> {
+  export async function withRetry<T>(fn: () => Promise<T>, options?: WithRetryOptions): Promise<T> {
     const maxAttempts = options?.maxAttempts ?? 3;
     const signal = options?.signal;
     const initialDelay = options?.initialDelay ?? RETRY_INITIAL_DELAY;
@@ -157,10 +154,7 @@ export namespace Retry {
           try {
             await sleep(delayMs, signal ?? new AbortController().signal);
           } catch (sleepError) {
-            if (
-              sleepError instanceof DOMException &&
-              sleepError.name === "AbortError"
-            ) {
+            if (sleepError instanceof DOMException && sleepError.name === "AbortError") {
               throw sleepError;
             }
             throw sleepError;

--- a/packages/llm/src/token/index.ts
+++ b/packages/llm/src/token/index.ts
@@ -42,9 +42,7 @@ interface OpenAIUsage {
 }
 
 export namespace TokenTracker {
-  export function extractUsage(response: {
-    usage?: AnthropicUsage | OpenAIUsage;
-  }): TokenUsage {
+  export function extractUsage(response: { usage?: AnthropicUsage | OpenAIUsage }): TokenUsage {
     const usage = response.usage;
     if (!usage) return { inputTokens: 0, outputTokens: 0 };
 
@@ -68,15 +66,12 @@ export namespace TokenTracker {
   export function calculateCost(usage: TokenUsage, modelId: string): TokenCost {
     const pricing = MODEL_PRICING[modelId];
     if (!pricing) {
-      console.warn(
-        `[TokenTracker] No pricing data for model '${modelId}'. Cost set to 0.`,
-      );
+      console.warn(`[TokenTracker] No pricing data for model '${modelId}'. Cost set to 0.`);
       return { inputCost: 0, outputCost: 0, totalCost: 0 };
     }
 
     const inputCost = (usage.inputTokens / 1_000_000) * pricing.inputPerMillion;
-    const outputCost =
-      (usage.outputTokens / 1_000_000) * pricing.outputPerMillion;
+    const outputCost = (usage.outputTokens / 1_000_000) * pricing.outputPerMillion;
     return {
       inputCost,
       outputCost,

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -61,27 +61,19 @@ export namespace ProviderTransform {
     return undefined;
   }
 
-  export function variants(
-    model: Provider.Model,
-  ): Record<string, Record<string, any>> {
+  export function variants(model: Provider.Model): Record<string, Record<string, any>> {
     if (!model.capabilities?.reasoning) return {};
 
     const npm = model.api?.npm;
     const id = model.id.toLowerCase();
 
     // For anthropic models
-    if (
-      npm === "@ai-sdk/anthropic" ||
-      npm === "@ai-sdk/google-vertex/anthropic"
-    ) {
+    if (npm === "@ai-sdk/anthropic" || npm === "@ai-sdk/google-vertex/anthropic") {
       return {
         high: {
           thinking: {
             type: "enabled",
-            budgetTokens: Math.min(
-              16_000,
-              Math.floor((model.limit?.output ?? 0) / 2 - 1),
-            ),
+            budgetTokens: Math.min(16_000, Math.floor((model.limit?.output ?? 0) / 2 - 1)),
           },
         },
         max: {
@@ -114,10 +106,7 @@ export namespace ProviderTransform {
     return {};
   }
 
-  function normalizeAnthropic(
-    msgs: CoreMessage[],
-    model: NormalizeOptions,
-  ): CoreMessage[] {
+  function normalizeAnthropic(msgs: CoreMessage[], model: NormalizeOptions): CoreMessage[] {
     let result = msgs
       .map((msg) => {
         if (typeof msg.content === "string") {
@@ -135,16 +124,11 @@ export namespace ProviderTransform {
         if (filtered.length === 0) return undefined;
         return { ...msg, content: filtered };
       })
-      .filter(
-        (msg): msg is CoreMessage => msg !== undefined && msg.content !== "",
-      );
+      .filter((msg): msg is CoreMessage => msg !== undefined && msg.content !== "");
 
     if (model.modelId.includes("claude")) {
       result = result.map((msg) => {
-        if (
-          (msg.role === "assistant" || msg.role === "tool") &&
-          Array.isArray(msg.content)
-        ) {
+        if ((msg.role === "assistant" || msg.role === "tool") && Array.isArray(msg.content)) {
           return {
             ...msg,
             content: msg.content.map((part: any) => {
@@ -154,9 +138,10 @@ export namespace ProviderTransform {
               ) {
                 return {
                   ...part,
-                  toolCallId: (
-                    part as { toolCallId: string }
-                  ).toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_"),
+                  toolCallId: (part as { toolCallId: string }).toolCallId.replace(
+                    /[^a-zA-Z0-9_-]/g,
+                    "_",
+                  ),
                 };
               }
               return part;

--- a/packages/llm/test/auth/storage.test.ts
+++ b/packages/llm/test/auth/storage.test.ts
@@ -1,52 +1,52 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { Auth } from "../../src/auth"
-import { rmSync, existsSync } from "fs"
-import { join } from "path"
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Auth } from "../../src/auth";
+import { rmSync, existsSync } from "fs";
+import { join } from "path";
 
-const testAuthDir = join(process.env.HOME!, ".openomni-test")
-const testAuthFile = join(testAuthDir, "auth.json")
+const testAuthDir = join(process.env.HOME!, ".openomni-test");
+const testAuthFile = join(testAuthDir, "auth.json");
 
 describe("Auth Storage", () => {
-  const originalEnv = process.env.OPENOMNI_AUTH_FILE
+  const originalEnv = process.env.OPENOMNI_AUTH_FILE;
 
   beforeEach(() => {
-    process.env.OPENOMNI_AUTH_FILE = testAuthFile
+    process.env.OPENOMNI_AUTH_FILE = testAuthFile;
     if (existsSync(testAuthFile)) {
-      rmSync(testAuthFile)
+      rmSync(testAuthFile);
     }
     if (existsSync(testAuthDir)) {
-      rmSync(testAuthDir, { recursive: true })
+      rmSync(testAuthDir, { recursive: true });
     }
-  })
+  });
 
   afterEach(() => {
     if (existsSync(testAuthFile)) {
-      rmSync(testAuthFile)
+      rmSync(testAuthFile);
     }
     if (existsSync(testAuthDir)) {
-      rmSync(testAuthDir, { recursive: true })
+      rmSync(testAuthDir, { recursive: true });
     }
     if (originalEnv) {
-      process.env.OPENOMNI_AUTH_FILE = originalEnv
+      process.env.OPENOMNI_AUTH_FILE = originalEnv;
     } else {
-      delete process.env.OPENOMNI_AUTH_FILE
+      delete process.env.OPENOMNI_AUTH_FILE;
     }
-  })
+  });
   it("should write OAuth auth to auth.json", async () => {
     await Auth.set("anthropic", {
       type: "oauth",
       refresh: "r",
       access: "a",
       expires: 999,
-    })
+    });
 
-    const stored = await Auth.get("anthropic")
-    expect(stored).toBeDefined()
-    expect(stored?.type).toBe("oauth")
-    expect(stored?.refresh).toBe("r")
-    expect(stored?.access).toBe("a")
-    expect(stored?.expires).toBe(999)
-  })
+    const stored = await Auth.get("anthropic");
+    expect(stored).toBeDefined();
+    expect(stored?.type).toBe("oauth");
+    expect(stored?.refresh).toBe("r");
+    expect(stored?.access).toBe("a");
+    expect(stored?.expires).toBe(999);
+  });
 
   it("should return stored value with correct Zod type", async () => {
     await Auth.set("anthropic", {
@@ -55,18 +55,18 @@ describe("Auth Storage", () => {
       access: "access_token",
       expires: 1234567890,
       accountId: "account123",
-    })
+    });
 
-    const stored = await Auth.get("anthropic")
-    expect(stored).toBeDefined()
-    expect(stored?.type).toBe("oauth")
-    expect(stored?.accountId).toBe("account123")
-  })
+    const stored = await Auth.get("anthropic");
+    expect(stored).toBeDefined();
+    expect(stored?.type).toBe("oauth");
+    expect(stored?.accountId).toBe("account123");
+  });
 
   it("should return undefined for nonexistent key", async () => {
-    const stored = await Auth.get("nonexistent")
-    expect(stored).toBeUndefined()
-  })
+    const stored = await Auth.get("nonexistent");
+    expect(stored).toBeUndefined();
+  });
 
   it("should remove entry from auth.json", async () => {
     await Auth.set("anthropic", {
@@ -74,15 +74,15 @@ describe("Auth Storage", () => {
       refresh: "r",
       access: "a",
       expires: 999,
-    })
+    });
 
-    let stored = await Auth.get("anthropic")
-    expect(stored).toBeDefined()
+    let stored = await Auth.get("anthropic");
+    expect(stored).toBeDefined();
 
-    await Auth.remove("anthropic")
-    stored = await Auth.get("anthropic")
-    expect(stored).toBeUndefined()
-  })
+    await Auth.remove("anthropic");
+    stored = await Auth.get("anthropic");
+    expect(stored).toBeUndefined();
+  });
 
   it("should return all entries", async () => {
     await Auth.set("anthropic", {
@@ -90,26 +90,26 @@ describe("Auth Storage", () => {
       refresh: "r1",
       access: "a1",
       expires: 999,
-    })
+    });
 
     await Auth.set("openai", {
       type: "api",
       key: "sk-xxx",
-    })
+    });
 
-    const all = await Auth.all()
-    expect(Object.keys(all).length).toBe(2)
-    expect(all.anthropic).toBeDefined()
-    expect(all.openai).toBeDefined()
-    expect(all.anthropic?.type).toBe("oauth")
-    expect(all.openai?.type).toBe("api")
-  })
+    const all = await Auth.all();
+    expect(Object.keys(all).length).toBe(2);
+    expect(all.anthropic).toBeDefined();
+    expect(all.openai).toBeDefined();
+    expect(all.anthropic?.type).toBe("oauth");
+    expect(all.openai?.type).toBe("api");
+  });
 
   it("should silently skip invalid data in auth.json", async () => {
-    const { mkdirSync } = await import("fs")
-    const dir = testAuthDir
+    const { mkdirSync } = await import("fs");
+    const dir = testAuthDir;
     if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
+      mkdirSync(dir, { recursive: true });
     }
 
     await Bun.write(
@@ -125,14 +125,14 @@ describe("Auth Storage", () => {
           type: "unknown",
           data: "bad",
         },
-      })
-    )
+      }),
+    );
 
-    const all = await Auth.all()
-    expect(Object.keys(all).length).toBe(1)
-    expect(all.valid).toBeDefined()
-    expect(all.invalid).toBeUndefined()
-  })
+    const all = await Auth.all();
+    expect(Object.keys(all).length).toBe(1);
+    expect(all.valid).toBeDefined();
+    expect(all.invalid).toBeUndefined();
+  });
 
   it("should set auth.json file with 0o600 permissions", async () => {
     await Auth.set("anthropic", {
@@ -140,25 +140,25 @@ describe("Auth Storage", () => {
       refresh: "r",
       access: "a",
       expires: 999,
-    })
+    });
 
-    const file = Bun.file(testAuthFile)
-    const stat = await file.stat()
+    const file = Bun.file(testAuthFile);
+    const stat = await file.stat();
     // Check that file has restrictive permissions (0o600 = rw-------)
-    const mode = stat?.mode ?? 0
-    const permissions = mode & 0o777
-    expect(permissions).toBe(0o600)
-  })
+    const mode = stat?.mode ?? 0;
+    const permissions = mode & 0o777;
+    expect(permissions).toBe(0o600);
+  });
 
   it("should work with API key auth type", async () => {
     await Auth.set("openai", {
       type: "api",
       key: "sk-xxx",
-    })
+    });
 
-    const stored = await Auth.get("openai")
-    expect(stored).toBeDefined()
-    expect(stored?.type).toBe("api")
-    expect(stored?.key).toBe("sk-xxx")
-  })
-})
+    const stored = await Auth.get("openai");
+    expect(stored).toBeDefined();
+    expect(stored?.type).toBe("api");
+    expect(stored?.key).toBe("sk-xxx");
+  });
+});

--- a/packages/llm/test/error.test.ts
+++ b/packages/llm/test/error.test.ts
@@ -55,9 +55,7 @@ describe("AuthError", () => {
   test("isInstance type guard", () => {
     const err = new AuthError({ message: "test", provider: "openai" });
     expect(AuthError.isInstance(err)).toBe(true);
-    expect(
-      AuthError.isInstance(new ProviderError({ message: "x", provider: "y" })),
-    ).toBe(false);
+    expect(AuthError.isInstance(new ProviderError({ message: "x", provider: "y" }))).toBe(false);
   });
 
   test("schema is defined", () => {
@@ -81,9 +79,7 @@ describe("ProviderError", () => {
   test("isInstance type guard", () => {
     const err = new ProviderError({ message: "test", provider: "x" });
     expect(ProviderError.isInstance(err)).toBe(true);
-    expect(
-      ProviderError.isInstance(new AuthError({ message: "x", provider: "y" })),
-    ).toBe(false);
+    expect(ProviderError.isInstance(new AuthError({ message: "x", provider: "y" }))).toBe(false);
   });
 });
 
@@ -111,11 +107,9 @@ describe("TokenRefreshError", () => {
   test("isInstance type guard", () => {
     const err = new TokenRefreshError({ message: "test", status: 500 });
     expect(TokenRefreshError.isInstance(err)).toBe(true);
-    expect(
-      TokenRefreshError.isInstance(
-        new AuthError({ message: "x", provider: "y" }),
-      ),
-    ).toBe(false);
+    expect(TokenRefreshError.isInstance(new AuthError({ message: "x", provider: "y" }))).toBe(
+      false,
+    );
   });
 
   test("can be caught and inspected", () => {
@@ -167,9 +161,7 @@ describe("SessionError", () => {
   test("isInstance type guard", () => {
     const err = new SessionError({ message: "test" });
     expect(SessionError.isInstance(err)).toBe(true);
-    expect(
-      SessionError.isInstance(new AuthError({ message: "x", provider: "y" })),
-    ).toBe(false);
+    expect(SessionError.isInstance(new AuthError({ message: "x", provider: "y" }))).toBe(false);
   });
 });
 
@@ -193,9 +185,7 @@ describe("StreamError", () => {
   test("isInstance type guard", () => {
     const err = new StreamError({ message: "test" });
     expect(StreamError.isInstance(err)).toBe(true);
-    expect(StreamError.isInstance(new SessionError({ message: "x" }))).toBe(
-      false,
-    );
+    expect(StreamError.isInstance(new SessionError({ message: "x" }))).toBe(false);
   });
 });
 
@@ -240,9 +230,7 @@ describe("RetryError", () => {
   test("isInstance type guard", () => {
     const err = new RetryError({ message: "test", attempts: 1 });
     expect(RetryError.isInstance(err)).toBe(true);
-    expect(RetryError.isInstance(new StreamError({ message: "x" }))).toBe(
-      false,
-    );
+    expect(RetryError.isInstance(new StreamError({ message: "x" }))).toBe(false);
   });
 });
 
@@ -301,9 +289,7 @@ describe("APIError", () => {
   test("isInstance type guard", () => {
     const err = new APIError({ message: "test", isRetryable: true });
     expect(APIError.isInstance(err)).toBe(true);
-    expect(
-      APIError.isInstance(new RetryError({ message: "x", attempts: 1 })),
-    ).toBe(false);
+    expect(APIError.isInstance(new RetryError({ message: "x", attempts: 1 }))).toBe(false);
   });
 });
 
@@ -327,11 +313,7 @@ describe("AbortedError", () => {
   test("isInstance type guard", () => {
     const err = new AbortedError({ message: "test" });
     expect(AbortedError.isInstance(err)).toBe(true);
-    expect(
-      AbortedError.isInstance(
-        new APIError({ message: "x", isRetryable: false }),
-      ),
-    ).toBe(false);
+    expect(AbortedError.isInstance(new APIError({ message: "x", isRetryable: false }))).toBe(false);
   });
 });
 
@@ -355,9 +337,7 @@ describe("OutputLengthError", () => {
   test("isInstance type guard", () => {
     const err = new OutputLengthError({});
     expect(OutputLengthError.isInstance(err)).toBe(true);
-    expect(
-      OutputLengthError.isInstance(new AbortedError({ message: "x" })),
-    ).toBe(false);
+    expect(OutputLengthError.isInstance(new AbortedError({ message: "x" }))).toBe(false);
   });
 
   test("can be thrown and caught", () => {

--- a/packages/llm/test/model/models.test.ts
+++ b/packages/llm/test/model/models.test.ts
@@ -163,17 +163,11 @@ describe("ModelsDev", () => {
 
   describe("env flags", () => {
     it("should use OPENOMNI_MODELS_PATH for cache location", async () => {
-      const fakePath = join(
-        tmpdir(),
-        `openomni-test-${Date.now()}`,
-        "models.json",
-      );
+      const fakePath = join(tmpdir(), `openomni-test-${Date.now()}`, "models.json");
       process.env.OPENOMNI_MODELS_PATH = fakePath;
 
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() =>
-        Promise.reject(new Error("offline")),
-      ) as typeof fetch;
+      globalThis.fetch = mock(() => Promise.reject(new Error("offline"))) as typeof fetch;
 
       try {
         const data = await ModelsDev.get();
@@ -186,17 +180,11 @@ describe("ModelsDev", () => {
     });
 
     it("should skip fetch when OPENOMNI_DISABLE_MODELS_FETCH is set", async () => {
-      const fakePath = join(
-        tmpdir(),
-        `openomni-test-${Date.now()}`,
-        "models.json",
-      );
+      const fakePath = join(tmpdir(), `openomni-test-${Date.now()}`, "models.json");
       process.env.OPENOMNI_MODELS_PATH = fakePath;
       process.env.OPENOMNI_DISABLE_MODELS_FETCH = "true";
 
-      const fetchSpy = mock(() =>
-        Promise.resolve(new Response("ok")),
-      ) as typeof fetch;
+      const fetchSpy = mock(() => Promise.resolve(new Response("ok"))) as typeof fetch;
       const originalFetch = globalThis.fetch;
       globalThis.fetch = fetchSpy;
 
@@ -214,15 +202,9 @@ describe("ModelsDev", () => {
   describe("snapshot fallback", () => {
     it("should return data from snapshot when fetch and cache fail", async () => {
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() =>
-        Promise.reject(new Error("offline")),
-      ) as typeof fetch;
+      globalThis.fetch = mock(() => Promise.reject(new Error("offline"))) as typeof fetch;
 
-      const fakePath = join(
-        tmpdir(),
-        `openomni-test-${Date.now()}`,
-        "models.json",
-      );
+      const fakePath = join(tmpdir(), `openomni-test-${Date.now()}`, "models.json");
       process.env.OPENOMNI_MODELS_PATH = fakePath;
       ModelsDev.Data.reset();
       try {
@@ -237,15 +219,9 @@ describe("ModelsDev", () => {
 
     it("should return empty object as final fallback when snapshot unavailable", async () => {
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() =>
-        Promise.reject(new Error("offline")),
-      ) as typeof fetch;
+      globalThis.fetch = mock(() => Promise.reject(new Error("offline"))) as typeof fetch;
 
-      const fakePath = join(
-        tmpdir(),
-        `openomni-test-${Date.now()}`,
-        "models.json",
-      );
+      const fakePath = join(tmpdir(), `openomni-test-${Date.now()}`, "models.json");
       process.env.OPENOMNI_MODELS_PATH = fakePath;
       process.env.OPENOMNI_DISABLE_MODELS_FETCH = "true";
       ModelsDev.Data.reset();

--- a/packages/llm/test/oauth/anthropic.test.ts
+++ b/packages/llm/test/oauth/anthropic.test.ts
@@ -1,125 +1,125 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test"
-import { authorize, exchange, refreshToken, createApiKey } from "../../src/oauth"
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { authorize, exchange, refreshToken, createApiKey } from "../../src/oauth";
 
-const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
 describe("anthropic oauth", () => {
   test('authorize("max") returns url with correct OAuth params', async () => {
-    const result = await authorize("max")
-    const url = new URL(result.url)
+    const result = await authorize("max");
+    const url = new URL(result.url);
 
-    expect(url.origin).toBe("https://claude.ai")
-    expect(url.pathname).toBe("/oauth/authorize")
-    expect(url.searchParams.get("client_id")).toBe(CLIENT_ID)
-    expect(url.searchParams.get("response_type")).toBe("code")
-    expect(url.searchParams.get("code_challenge_method")).toBe("S256")
-    expect(url.searchParams.get("code_challenge")).toBeTruthy()
-    expect(url.searchParams.get("scope")).toBe("org:create_api_key user:profile user:inference")
-    expect(result.verifier).toBeTruthy()
-    expect(typeof result.verifier).toBe("string")
-  })
+    expect(url.origin).toBe("https://claude.ai");
+    expect(url.pathname).toBe("/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe(CLIENT_ID);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(url.searchParams.get("scope")).toBe("org:create_api_key user:profile user:inference");
+    expect(result.verifier).toBeTruthy();
+    expect(typeof result.verifier).toBe("string");
+  });
 
   test('authorize("console") uses console.anthropic.com domain', async () => {
-    const result = await authorize("console")
-    const url = new URL(result.url)
+    const result = await authorize("console");
+    const url = new URL(result.url);
 
-    expect(url.origin).toBe("https://console.anthropic.com")
-    expect(url.pathname).toBe("/oauth/authorize")
-    expect(url.searchParams.get("client_id")).toBe(CLIENT_ID)
-  })
+    expect(url.origin).toBe("https://console.anthropic.com");
+    expect(url.pathname).toBe("/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe(CLIENT_ID);
+  });
 
   test("exchange(code, verifier) returns tokens on success", async () => {
     const mockTokens = {
       access_token: "acc_test123",
       refresh_token: "ref_test456",
       expires_in: 3600,
-    }
-    const originalFetch = globalThis.fetch
+    };
+    const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(() =>
       Promise.resolve(new Response(JSON.stringify(mockTokens), { status: 200 })),
-    ) as typeof fetch
+    ) as typeof fetch;
 
-    const result = await exchange("mycode#mystate", "myverifier")
+    const result = await exchange("mycode#mystate", "myverifier");
 
-    expect(result.type).toBe("success")
+    expect(result.type).toBe("success");
     if (result.type === "success") {
-      expect(result.access).toBe("acc_test123")
-      expect(result.refresh).toBe("ref_test456")
-      expect(result.expires).toBeGreaterThan(Date.now())
+      expect(result.access).toBe("acc_test123");
+      expect(result.refresh).toBe("ref_test456");
+      expect(result.expires).toBeGreaterThan(Date.now());
     }
 
-    const call = (globalThis.fetch as any).mock.calls[0]
-    expect(call[0]).toBe("https://console.anthropic.com/v1/oauth/token")
-    const body = JSON.parse(call[1].body)
-    expect(body.code).toBe("mycode")
-    expect(body.state).toBe("mystate")
-    expect(body.code_verifier).toBe("myverifier")
-    expect(body.grant_type).toBe("authorization_code")
-    expect(body.client_id).toBe(CLIENT_ID)
+    const call = (globalThis.fetch as any).mock.calls[0];
+    expect(call[0]).toBe("https://console.anthropic.com/v1/oauth/token");
+    const body = JSON.parse(call[1].body);
+    expect(body.code).toBe("mycode");
+    expect(body.state).toBe("mystate");
+    expect(body.code_verifier).toBe("myverifier");
+    expect(body.grant_type).toBe("authorization_code");
+    expect(body.client_id).toBe(CLIENT_ID);
 
-    globalThis.fetch = originalFetch
-  })
+    globalThis.fetch = originalFetch;
+  });
 
   test("exchange() returns failed on HTTP error", async () => {
-    const originalFetch = globalThis.fetch
+    const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(() =>
       Promise.resolve(new Response("error", { status: 400 })),
-    ) as typeof fetch
+    ) as typeof fetch;
 
-    const result = await exchange("bad#code", "verifier")
-    expect(result).toEqual({ type: "failed" })
+    const result = await exchange("bad#code", "verifier");
+    expect(result).toEqual({ type: "failed" });
 
-    globalThis.fetch = originalFetch
-  })
+    globalThis.fetch = originalFetch;
+  });
 
   test("refreshToken() calls refresh endpoint correctly", async () => {
     const mockTokens = {
       access_token: "new_acc",
       refresh_token: "new_ref",
       expires_in: 7200,
-    }
-    const originalFetch = globalThis.fetch
+    };
+    const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(() =>
       Promise.resolve(new Response(JSON.stringify(mockTokens), { status: 200 })),
-    ) as typeof fetch
+    ) as typeof fetch;
 
-    const result = await refreshToken("old_refresh")
+    const result = await refreshToken("old_refresh");
 
-    expect(result.type).toBe("success")
+    expect(result.type).toBe("success");
     if (result.type === "success") {
-      expect(result.access).toBe("new_acc")
-      expect(result.refresh).toBe("new_ref")
+      expect(result.access).toBe("new_acc");
+      expect(result.refresh).toBe("new_ref");
     }
 
-    const call = (globalThis.fetch as any).mock.calls[0]
-    expect(call[0]).toBe("https://console.anthropic.com/v1/oauth/token")
-    const body = JSON.parse(call[1].body)
-    expect(body.grant_type).toBe("refresh_token")
-    expect(body.refresh_token).toBe("old_refresh")
-    expect(body.client_id).toBe(CLIENT_ID)
+    const call = (globalThis.fetch as any).mock.calls[0];
+    expect(call[0]).toBe("https://console.anthropic.com/v1/oauth/token");
+    const body = JSON.parse(call[1].body);
+    expect(body.grant_type).toBe("refresh_token");
+    expect(body.refresh_token).toBe("old_refresh");
+    expect(body.client_id).toBe(CLIENT_ID);
 
-    globalThis.fetch = originalFetch
-  })
+    globalThis.fetch = originalFetch;
+  });
 
   test("createApiKey() calls API key creation endpoint", async () => {
-    const mockResponse = { raw_key: "sk-ant-test-key" }
-    const originalFetch = globalThis.fetch
+    const mockResponse = { raw_key: "sk-ant-test-key" };
+    const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(() =>
       Promise.resolve(new Response(JSON.stringify(mockResponse), { status: 200 })),
-    ) as typeof fetch
+    ) as typeof fetch;
 
-    const result = await createApiKey("my_access_token")
+    const result = await createApiKey("my_access_token");
 
-    expect(result.type).toBe("success")
+    expect(result.type).toBe("success");
     if (result.type === "success") {
-      expect(result.key).toBe("sk-ant-test-key")
+      expect(result.key).toBe("sk-ant-test-key");
     }
 
-    const call = (globalThis.fetch as any).mock.calls[0]
-    expect(call[0]).toBe("https://api.anthropic.com/api/oauth/claude_cli/create_api_key")
-    expect(call[1].method).toBe("POST")
-    expect(call[1].headers["authorization"]).toBe("Bearer my_access_token")
+    const call = (globalThis.fetch as any).mock.calls[0];
+    expect(call[0]).toBe("https://api.anthropic.com/api/oauth/claude_cli/create_api_key");
+    expect(call[1].method).toBe("POST");
+    expect(call[1].headers["authorization"]).toBe("Bearer my_access_token");
 
-    globalThis.fetch = originalFetch
-  })
-})
+    globalThis.fetch = originalFetch;
+  });
+});

--- a/packages/llm/test/oauth/openai.test.ts
+++ b/packages/llm/test/oauth/openai.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import {
   buildAuthorizeUrl,
   exchangeCodeForTokens,
@@ -9,39 +9,39 @@ import {
   stopOAuthServer,
   initiateDeviceAuth,
   pollDeviceAuth,
-} from "../../src/oauth"
+} from "../../src/oauth";
 
-const OAUTH_PORT = 1455
-const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
-const ISSUER = "https://auth.openai.com"
+const OAUTH_PORT = 1455;
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const ISSUER = "https://auth.openai.com";
 
 // Helper to create a fake JWT with given claims
 function fakeJwt(claims: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url")
-  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url")
-  return `${header}.${payload}.fake-signature`
+  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.fake-signature`;
 }
 
 describe("OpenAI OAuth", () => {
   describe("buildAuthorizeUrl()", () => {
     it("returns correct URL with PKCE, state, scopes", () => {
-      const pkce = { verifier: "test-verifier", challenge: "test-challenge" }
-      const state = "test-state"
-      const redirectUri = "http://localhost:1455/auth/callback"
+      const pkce = { verifier: "test-verifier", challenge: "test-challenge" };
+      const state = "test-state";
+      const redirectUri = "http://localhost:1455/auth/callback";
 
-      const url = buildAuthorizeUrl(redirectUri, pkce, state)
+      const url = buildAuthorizeUrl(redirectUri, pkce, state);
 
-      expect(url).toStartWith(`${ISSUER}/oauth/authorize?`)
-      const params = new URL(url).searchParams
-      expect(params.get("response_type")).toBe("code")
-      expect(params.get("client_id")).toBe(CLIENT_ID)
-      expect(params.get("redirect_uri")).toBe(redirectUri)
-      expect(params.get("scope")).toBe("openid profile email offline_access")
-      expect(params.get("code_challenge")).toBe("test-challenge")
-      expect(params.get("code_challenge_method")).toBe("S256")
-      expect(params.get("state")).toBe("test-state")
-    })
-  })
+      expect(url).toStartWith(`${ISSUER}/oauth/authorize?`);
+      const params = new URL(url).searchParams;
+      expect(params.get("response_type")).toBe("code");
+      expect(params.get("client_id")).toBe(CLIENT_ID);
+      expect(params.get("redirect_uri")).toBe(redirectUri);
+      expect(params.get("scope")).toBe("openid profile email offline_access");
+      expect(params.get("code_challenge")).toBe("test-challenge");
+      expect(params.get("code_challenge_method")).toBe("S256");
+      expect(params.get("state")).toBe("test-state");
+    });
+  });
 
   describe("exchangeCodeForTokens()", () => {
     it("calls token endpoint correctly", async () => {
@@ -50,35 +50,35 @@ describe("OpenAI OAuth", () => {
         access_token: "access",
         refresh_token: "refresh",
         expires_in: 3600,
-      }
+      };
 
-      const originalFetch = globalThis.fetch
+      const originalFetch = globalThis.fetch;
       globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
-        const u = url.toString()
-        expect(u).toBe(`${ISSUER}/oauth/token`)
-        expect(init?.method).toBe("POST")
-        const body = init?.body as string
-        const params = new URLSearchParams(body)
-        expect(params.get("grant_type")).toBe("authorization_code")
-        expect(params.get("code")).toBe("auth-code")
-        expect(params.get("client_id")).toBe(CLIENT_ID)
-        expect(params.get("code_verifier")).toBe("my-verifier")
-        return new Response(JSON.stringify(mockTokens), { status: 200 })
-      }) as typeof fetch
+        const u = url.toString();
+        expect(u).toBe(`${ISSUER}/oauth/token`);
+        expect(init?.method).toBe("POST");
+        const body = init?.body as string;
+        const params = new URLSearchParams(body);
+        expect(params.get("grant_type")).toBe("authorization_code");
+        expect(params.get("code")).toBe("auth-code");
+        expect(params.get("client_id")).toBe(CLIENT_ID);
+        expect(params.get("code_verifier")).toBe("my-verifier");
+        return new Response(JSON.stringify(mockTokens), { status: 200 });
+      }) as typeof fetch;
 
       try {
         const tokens = await exchangeCodeForTokens(
           "auth-code",
           "http://localhost:1455/auth/callback",
           { verifier: "my-verifier", challenge: "my-challenge" },
-        )
-        expect(tokens.access_token).toBe("access")
-        expect(tokens.refresh_token).toBe("refresh")
+        );
+        expect(tokens.access_token).toBe("access");
+        expect(tokens.refresh_token).toBe("refresh");
       } finally {
-        globalThis.fetch = originalFetch
+        globalThis.fetch = originalFetch;
       }
-    })
-  })
+    });
+  });
 
   describe("refreshAccessToken()", () => {
     it("refreshes correctly", async () => {
@@ -87,39 +87,39 @@ describe("OpenAI OAuth", () => {
         access_token: "new-access",
         refresh_token: "new-refresh",
         expires_in: 3600,
-      }
+      };
 
-      const originalFetch = globalThis.fetch
+      const originalFetch = globalThis.fetch;
       globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-        const body = init?.body as string
-        const params = new URLSearchParams(body)
-        expect(params.get("grant_type")).toBe("refresh_token")
-        expect(params.get("refresh_token")).toBe("old-refresh")
-        expect(params.get("client_id")).toBe(CLIENT_ID)
-        return new Response(JSON.stringify(mockTokens), { status: 200 })
-      }) as typeof fetch
+        const body = init?.body as string;
+        const params = new URLSearchParams(body);
+        expect(params.get("grant_type")).toBe("refresh_token");
+        expect(params.get("refresh_token")).toBe("old-refresh");
+        expect(params.get("client_id")).toBe(CLIENT_ID);
+        return new Response(JSON.stringify(mockTokens), { status: 200 });
+      }) as typeof fetch;
 
       try {
-        const tokens = await refreshAccessToken("old-refresh")
-        expect(tokens.access_token).toBe("new-access")
+        const tokens = await refreshAccessToken("old-refresh");
+        expect(tokens.access_token).toBe("new-access");
       } finally {
-        globalThis.fetch = originalFetch
+        globalThis.fetch = originalFetch;
       }
-    })
-  })
+    });
+  });
 
   describe("parseJwtClaims()", () => {
     it("extracts claims from JWT", () => {
-      const claims = { sub: "user-123", email: "test@example.com" }
-      const token = fakeJwt(claims)
-      const result = parseJwtClaims(token)
-      expect(result).toEqual(claims)
-    })
+      const claims = { sub: "user-123", email: "test@example.com" };
+      const token = fakeJwt(claims);
+      const result = parseJwtClaims(token);
+      expect(result).toEqual(claims);
+    });
 
     it("returns undefined for invalid JWT", () => {
-      expect(parseJwtClaims("not-a-jwt")).toBeUndefined()
-    })
-  })
+      expect(parseJwtClaims("not-a-jwt")).toBeUndefined();
+    });
+  });
 
   describe("extractAccountId()", () => {
     it("extracts chatgpt_account_id from various claim structures", () => {
@@ -130,7 +130,7 @@ describe("OpenAI OAuth", () => {
           access_token: "",
           refresh_token: "",
         }),
-      ).toBe("acct-1")
+      ).toBe("acct-1");
 
       // Nested under https://api.openai.com/auth
       expect(
@@ -141,7 +141,7 @@ describe("OpenAI OAuth", () => {
           access_token: "",
           refresh_token: "",
         }),
-      ).toBe("acct-2")
+      ).toBe("acct-2");
 
       // From organizations
       expect(
@@ -150,34 +150,34 @@ describe("OpenAI OAuth", () => {
           access_token: "",
           refresh_token: "",
         }),
-      ).toBe("org-1")
-    })
-  })
+      ).toBe("org-1");
+    });
+  });
 
   describe("startOAuthServer()", () => {
     afterEach(() => {
-      stopOAuthServer()
-    })
+      stopOAuthServer();
+    });
 
     it("starts Bun.serve on port 1455 and handles callback", async () => {
-      const { port, redirectUri } = await startOAuthServer()
-      expect(port).toBe(OAUTH_PORT)
-      expect(redirectUri).toBe(`http://localhost:${OAUTH_PORT}/auth/callback`)
+      const { port, redirectUri } = await startOAuthServer();
+      expect(port).toBe(OAUTH_PORT);
+      expect(redirectUri).toBe(`http://localhost:${OAUTH_PORT}/auth/callback`);
 
       // Verify server responds
-      const res = await fetch(`http://localhost:${OAUTH_PORT}/health-check`)
-      expect(res.status).toBe(404) // Unknown path returns 404
-    })
+      const res = await fetch(`http://localhost:${OAUTH_PORT}/health-check`);
+      expect(res.status).toBe(404); // Unknown path returns 404
+    });
 
     it("handles EADDRINUSE gracefully", async () => {
       // Start first server
-      await startOAuthServer()
+      await startOAuthServer();
 
       // Starting again should return existing server (not throw)
-      const { port } = await startOAuthServer()
-      expect(port).toBe(OAUTH_PORT)
-    })
-  })
+      const { port } = await startOAuthServer();
+      expect(port).toBe(OAUTH_PORT);
+    });
+  });
 
   describe("initiateDeviceAuth()", () => {
     it("returns user_code and device_auth_id", async () => {
@@ -185,23 +185,23 @@ describe("OpenAI OAuth", () => {
         device_auth_id: "dev-auth-123",
         user_code: "ABCD-1234",
         interval: "5",
-      }
+      };
 
-      const originalFetch = globalThis.fetch
+      const originalFetch = globalThis.fetch;
       globalThis.fetch = mock(async (url: string | URL | Request) => {
-        expect(url.toString()).toBe(`${ISSUER}/api/accounts/deviceauth/usercode`)
-        return new Response(JSON.stringify(mockResponse), { status: 200 })
-      }) as typeof fetch
+        expect(url.toString()).toBe(`${ISSUER}/api/accounts/deviceauth/usercode`);
+        return new Response(JSON.stringify(mockResponse), { status: 200 });
+      }) as typeof fetch;
 
       try {
-        const result = await initiateDeviceAuth()
-        expect(result.user_code).toBe("ABCD-1234")
-        expect(result.device_auth_id).toBe("dev-auth-123")
+        const result = await initiateDeviceAuth();
+        expect(result.user_code).toBe("ABCD-1234");
+        expect(result.device_auth_id).toBe("dev-auth-123");
       } finally {
-        globalThis.fetch = originalFetch
+        globalThis.fetch = originalFetch;
       }
-    })
-  })
+    });
+  });
 
   describe("pollDeviceAuth()", () => {
     it("polls and returns tokens when ready", async () => {
@@ -210,11 +210,11 @@ describe("OpenAI OAuth", () => {
         access_token: "dev-access",
         refresh_token: "dev-refresh",
         expires_in: 3600,
-      }
+      };
 
-      const originalFetch = globalThis.fetch
+      const originalFetch = globalThis.fetch;
       globalThis.fetch = mock(async (url: string | URL | Request) => {
-        const u = url.toString()
+        const u = url.toString();
         if (u.includes("/deviceauth/token")) {
           return new Response(
             JSON.stringify({
@@ -222,35 +222,35 @@ describe("OpenAI OAuth", () => {
               code_verifier: "dev-verifier",
             }),
             { status: 200 },
-          )
+          );
         }
         // Token exchange
-        return new Response(JSON.stringify(mockTokens), { status: 200 })
-      }) as typeof fetch
+        return new Response(JSON.stringify(mockTokens), { status: 200 });
+      }) as typeof fetch;
 
       try {
-        const tokens = await pollDeviceAuth("dev-auth-123", "ABCD-1234", 100)
-        expect(tokens.access_token).toBe("dev-access")
+        const tokens = await pollDeviceAuth("dev-auth-123", "ABCD-1234", 100);
+        expect(tokens.access_token).toBe("dev-access");
       } finally {
-        globalThis.fetch = originalFetch
+        globalThis.fetch = originalFetch;
       }
-    })
+    });
 
     it("handles pending status (403/404) by continuing to poll", async () => {
-      let callCount = 0
+      let callCount = 0;
       const mockTokens = {
         id_token: "id",
         access_token: "access",
         refresh_token: "refresh",
-      }
+      };
 
-      const originalFetch = globalThis.fetch
+      const originalFetch = globalThis.fetch;
       globalThis.fetch = mock(async (url: string | URL | Request) => {
-        const u = url.toString()
+        const u = url.toString();
         if (u.includes("/deviceauth/token")) {
-          callCount++
+          callCount++;
           if (callCount < 3) {
-            return new Response("pending", { status: 403 })
+            return new Response("pending", { status: 403 });
           }
           return new Response(
             JSON.stringify({
@@ -258,18 +258,18 @@ describe("OpenAI OAuth", () => {
               code_verifier: "verifier",
             }),
             { status: 200 },
-          )
+          );
         }
-        return new Response(JSON.stringify(mockTokens), { status: 200 })
-      }) as typeof fetch
+        return new Response(JSON.stringify(mockTokens), { status: 200 });
+      }) as typeof fetch;
 
       try {
-        const tokens = await pollDeviceAuth("dev-auth", "CODE", 10)
-        expect(tokens.access_token).toBe("access")
-        expect(callCount).toBeGreaterThanOrEqual(3)
+        const tokens = await pollDeviceAuth("dev-auth", "CODE", 10);
+        expect(tokens.access_token).toBe("access");
+        expect(callCount).toBeGreaterThanOrEqual(3);
       } finally {
-        globalThis.fetch = originalFetch
+        globalThis.fetch = originalFetch;
       }
-    })
-  })
-})
+    });
+  });
+});

--- a/packages/llm/test/oauth/pkce.test.ts
+++ b/packages/llm/test/oauth/pkce.test.ts
@@ -1,61 +1,61 @@
-import { describe, it, expect } from "bun:test"
-import { generatePKCE, generateState } from "../../src/oauth"
+import { describe, it, expect } from "bun:test";
+import { generatePKCE, generateState } from "../../src/oauth";
 
 describe("PKCE", () => {
   it("generatePKCE() returns { verifier, challenge } with correct types", async () => {
-    const result = await generatePKCE()
-    expect(result).toHaveProperty("verifier")
-    expect(result).toHaveProperty("challenge")
-    expect(typeof result.verifier).toBe("string")
-    expect(typeof result.challenge).toBe("string")
-  })
+    const result = await generatePKCE();
+    expect(result).toHaveProperty("verifier");
+    expect(result).toHaveProperty("challenge");
+    expect(typeof result.verifier).toBe("string");
+    expect(typeof result.challenge).toBe("string");
+  });
 
   it("verifier is 43 chars from URL-safe alphabet (A-Z, a-z, 0-9, -, _, ~)", async () => {
-    const result = await generatePKCE()
-    const { verifier } = result
-    expect(verifier.length).toBe(43)
+    const result = await generatePKCE();
+    const { verifier } = result;
+    expect(verifier.length).toBe(43);
     // Check all characters are from URL-safe alphabet
-    const urlSafeRegex = /^[A-Za-z0-9\-._~]+$/
-    expect(urlSafeRegex.test(verifier)).toBe(true)
-  })
+    const urlSafeRegex = /^[A-Za-z0-9\-._~]+$/;
+    expect(urlSafeRegex.test(verifier)).toBe(true);
+  });
 
   it("challenge is base64url encoded (no +, /, = padding)", async () => {
-    const result = await generatePKCE()
-    const { challenge } = result
+    const result = await generatePKCE();
+    const { challenge } = result;
     // Should not contain +, /, or = characters
-    expect(challenge).not.toMatch(/\+/)
-    expect(challenge).not.toMatch(/\//)
-    expect(challenge).not.toMatch(/=/)
+    expect(challenge).not.toMatch(/\+/);
+    expect(challenge).not.toMatch(/\//);
+    expect(challenge).not.toMatch(/=/);
     // Should be valid base64url characters
-    const base64UrlRegex = /^[A-Za-z0-9\-_]+$/
-    expect(base64UrlRegex.test(challenge)).toBe(true)
-  })
+    const base64UrlRegex = /^[A-Za-z0-9\-_]+$/;
+    expect(base64UrlRegex.test(challenge)).toBe(true);
+  });
 
   it("challenge is SHA-256 hash of verifier", async () => {
-    const result = await generatePKCE()
-    const { verifier, challenge } = result
+    const result = await generatePKCE();
+    const { verifier, challenge } = result;
 
     // Recompute the challenge from verifier
-    const encoder = new TextEncoder()
-    const data = encoder.encode(verifier)
-    const hash = await crypto.subtle.digest("SHA-256", data)
-    const bytes = new Uint8Array(hash)
-    const binary = String.fromCharCode(...bytes)
+    const encoder = new TextEncoder();
+    const data = encoder.encode(verifier);
+    const hash = await crypto.subtle.digest("SHA-256", data);
+    const bytes = new Uint8Array(hash);
+    const binary = String.fromCharCode(...bytes);
     const expectedChallenge = btoa(binary)
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
-      .replace(/=+$/, "")
+      .replace(/=+$/, "");
 
-    expect(challenge).toBe(expectedChallenge)
-  })
+    expect(challenge).toBe(expectedChallenge);
+  });
 
   it("generateState() returns base64url string (32 bytes)", () => {
-    const state = generateState()
+    const state = generateState();
     // Should be base64url encoded
-    const base64UrlRegex = /^[A-Za-z0-9\-_]+$/
-    expect(base64UrlRegex.test(state)).toBe(true)
+    const base64UrlRegex = /^[A-Za-z0-9\-_]+$/;
+    expect(base64UrlRegex.test(state)).toBe(true);
     // 32 bytes = 256 bits, base64url encoded = ~43 characters
-    expect(state.length).toBeGreaterThan(40)
-    expect(state.length).toBeLessThan(50)
-  })
-})
+    expect(state.length).toBeGreaterThan(40);
+    expect(state.length).toBeLessThan(50);
+  });
+});

--- a/packages/llm/test/provider/anthropic.test.ts
+++ b/packages/llm/test/provider/anthropic.test.ts
@@ -113,11 +113,7 @@ describe("createOAuthFetch (Anthropic)", () => {
 
     globalThis.fetch = mock(async (input: any, init: any) => {
       const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : input.url;
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("oauth/token")) {
         refreshCalled = true;
         return new Response(
@@ -133,9 +129,7 @@ describe("createOAuthFetch (Anthropic)", () => {
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     }) as any;
 
-    const onTokenRefresh = mock(
-      (_access: string, _refresh: string, _expires: number) => {},
-    );
+    const onTokenRefresh = mock((_access: string, _refresh: string, _expires: number) => {});
 
     const oauthFetch = createOAuthFetch(auth, onTokenRefresh);
     await oauthFetch("https://api.anthropic.com/v1/messages", {
@@ -145,11 +139,7 @@ describe("createOAuthFetch (Anthropic)", () => {
 
     expect(refreshCalled).toBe(true);
     expect(capturedAuthHeader).toBe("Bearer new-tok");
-    expect(onTokenRefresh).toHaveBeenCalledWith(
-      "new-tok",
-      "new-ref",
-      expect.any(Number),
-    );
+    expect(onTokenRefresh).toHaveBeenCalledWith("new-tok", "new-ref", expect.any(Number));
   });
 
   test("concurrent requests share single token refresh (promise dedup)", async () => {
@@ -164,11 +154,7 @@ describe("createOAuthFetch (Anthropic)", () => {
 
     globalThis.fetch = mock(async (input: any, _init: any) => {
       const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : input.url;
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("oauth/token")) {
         refreshCount++;
         await new Promise((r) => setTimeout(r, 50));

--- a/packages/llm/test/provider/openai.test.ts
+++ b/packages/llm/test/provider/openai.test.ts
@@ -1,9 +1,5 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
-import {
-  getSDK,
-  CODEX_ALLOWED_MODELS,
-  Provider,
-} from "../../src/provider/index";
+import { getSDK, CODEX_ALLOWED_MODELS, Provider } from "../../src/provider/index";
 import { createCodexOAuthFetch } from "../../src/fetch/openai";
 import type { Auth } from "../../src/auth";
 
@@ -21,9 +17,7 @@ function makeModel(overrides?: Partial<Provider.Model>): Provider.Model {
   };
 }
 
-const mockFetch = mock(() =>
-  Promise.resolve(new Response(JSON.stringify({}), { status: 200 })),
-);
+const mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 })));
 
 describe("getSDK (OpenAI)", () => {
   afterEach(() => {
@@ -88,9 +82,7 @@ describe("createCodexOAuthFetch (OpenAI)", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url] = mockFetch.mock.calls[0] as [URL, RequestInit];
-    expect(url.toString()).toBe(
-      "https://chatgpt.com/backend-api/codex/responses",
-    );
+    expect(url.toString()).toBe("https://chatgpt.com/backend-api/codex/responses");
   });
 
   test("rewrites URL for /chat/completions path", async () => {
@@ -108,9 +100,7 @@ describe("createCodexOAuthFetch (OpenAI)", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url] = mockFetch.mock.calls[0] as [URL, RequestInit];
-    expect(url.toString()).toBe(
-      "https://chatgpt.com/backend-api/codex/responses",
-    );
+    expect(url.toString()).toBe("https://chatgpt.com/backend-api/codex/responses");
   });
 
   test("injects Bearer token and removes dummy auth header", async () => {
@@ -191,8 +181,7 @@ describe("createCodexOAuthFetch (OpenAI)", () => {
     let refreshCount = 0;
 
     globalThis.fetch = mock((...args: any[]) => {
-      const url =
-        typeof args[0] === "string" ? args[0] : (args[0]?.toString?.() ?? "");
+      const url = typeof args[0] === "string" ? args[0] : (args[0]?.toString?.() ?? "");
       if (typeof url === "string" && url.includes("/oauth/token")) {
         refreshCount++;
         return Promise.resolve(

--- a/packages/llm/test/provider/registry.test.ts
+++ b/packages/llm/test/provider/registry.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { getSDK, Provider } from "../../src/provider/index";
 import type { Auth } from "../../src/auth";
 
-function makeModel(
-  providerID: string,
-  npm: string,
-  id?: string,
-): Provider.Model {
+function makeModel(providerID: string, npm: string, id?: string): Provider.Model {
   return {
     id: id ?? "test-model",
     providerID,
@@ -19,11 +15,7 @@ describe("Provider Registry", () => {
   describe("getSDK", () => {
     it("should return configured Anthropic provider with API auth", () => {
       const auth: Auth.Info = { type: "api", key: "test-api-key" };
-      const model = makeModel(
-        "anthropic",
-        "@ai-sdk/anthropic",
-        "claude-sonnet-4-20250514",
-      );
+      const model = makeModel("anthropic", "@ai-sdk/anthropic", "claude-sonnet-4-20250514");
       const provider = getSDK(model, auth);
       expect(provider).toBeDefined();
       expect(provider.languageModel).toBeDefined();
@@ -36,11 +28,7 @@ describe("Provider Registry", () => {
         refresh: "test-refresh-token",
         expires: Date.now() + 3600000,
       };
-      const model = makeModel(
-        "anthropic",
-        "@ai-sdk/anthropic",
-        "claude-sonnet-4-20250514",
-      );
+      const model = makeModel("anthropic", "@ai-sdk/anthropic", "claude-sonnet-4-20250514");
       const provider = getSDK(model, auth);
       expect(provider).toBeDefined();
       expect(provider.languageModel).toBeDefined();
@@ -112,9 +100,7 @@ describe("Provider Registry", () => {
     });
 
     it("should throw error for unknown provider", async () => {
-      await expect(Provider.listModels("unknown")).rejects.toThrow(
-        "Unknown provider: unknown",
-      );
+      await expect(Provider.listModels("unknown")).rejects.toThrow("Unknown provider: unknown");
     });
   });
 

--- a/packages/llm/test/session/integration.test.ts
+++ b/packages/llm/test/session/integration.test.ts
@@ -78,9 +78,7 @@ describe("Integration", () => {
     expect(Session.getParts(userMsg.id)).toHaveLength(1);
     expect(Session.getParts(assistantMsg.id)).toHaveLength(1);
     expect(Session.getParts(userMsg.id)[0].type).toBe("text");
-    expect((Session.getParts(userMsg.id)[0] as Message.TextPart).text).toBe(
-      "Hello, world!",
-    );
+    expect((Session.getParts(userMsg.id)[0] as Message.TextPart).text).toBe("Hello, world!");
   });
 
   it("should fire bus events on session changes", () => {

--- a/packages/llm/test/session/retry.test.ts
+++ b/packages/llm/test/session/retry.test.ts
@@ -61,10 +61,7 @@ describe("Retry", () => {
       const controller = new AbortController();
       const start = Date.now();
       // Request a delay larger than RETRY_MAX_DELAY
-      const promise = Retry.sleep(
-        Retry.RETRY_MAX_DELAY + 1000,
-        controller.signal,
-      );
+      const promise = Retry.sleep(Retry.RETRY_MAX_DELAY + 1000, controller.signal);
 
       // Should complete within reasonable time (capped at RETRY_MAX_DELAY)
       setTimeout(() => controller.abort(), 100);

--- a/packages/llm/test/transform/transform.test.ts
+++ b/packages/llm/test/transform/transform.test.ts
@@ -6,9 +6,7 @@ import type { Provider } from "../../src/provider/index";
 describe("ProviderTransform.sdkKey", () => {
   test("maps anthropic packages", () => {
     expect(ProviderTransform.sdkKey("@ai-sdk/anthropic")).toBe("anthropic");
-    expect(ProviderTransform.sdkKey("@ai-sdk/google-vertex/anthropic")).toBe(
-      "anthropic",
-    );
+    expect(ProviderTransform.sdkKey("@ai-sdk/google-vertex/anthropic")).toBe("anthropic");
   });
 
   test("maps openai packages", () => {
@@ -22,9 +20,7 @@ describe("ProviderTransform.sdkKey", () => {
   });
 
   test("maps openrouter", () => {
-    expect(ProviderTransform.sdkKey("@openrouter/ai-sdk-provider")).toBe(
-      "openrouter",
-    );
+    expect(ProviderTransform.sdkKey("@openrouter/ai-sdk-provider")).toBe("openrouter");
   });
 
   test("returns undefined for unknown packages", () => {
@@ -69,9 +65,7 @@ describe("ProviderTransform.normalizeMessages", () => {
     ];
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
     expect(result).toHaveLength(1);
-    expect(result[0].content).toEqual([
-      { type: "text", text: "actual content" },
-    ]);
+    expect(result[0].content).toEqual([{ type: "text", text: "actual content" }]);
   });
 
   test("anthropic removes message when all array parts are empty", () => {
@@ -145,10 +139,7 @@ describe("ProviderTransform.normalizeMessages", () => {
         ],
       },
     ];
-    const result = ProviderTransform.normalizeMessages(
-      msgs,
-      nonClaudeAnthropicModel,
-    );
+    const result = ProviderTransform.normalizeMessages(msgs, nonClaudeAnthropicModel);
     const part = (result[0].content as any[])[0];
     expect(part.toolCallId).toBe("call.with.dots");
   });

--- a/packages/openomni/package.json
+++ b/packages/openomni/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "check-types": "tsc --noEmit",
+    "lint": "bunx biome check ./src",
     "test": "bun test",
     "test:ci": "bun test test/team test/dag test/ingress"
   },

--- a/packages/openomni/src/dag/index.ts
+++ b/packages/openomni/src/dag/index.ts
@@ -30,9 +30,7 @@ export namespace DAG {
     for (const step of steps) {
       for (const dependencyId of step.dependsOn) {
         if (!nodes.has(dependencyId)) {
-          throw new Error(
-            `Step "${step.stepId}" depends on unknown step "${dependencyId}"`,
-          );
+          throw new Error(`Step "${step.stepId}" depends on unknown step "${dependencyId}"`);
         }
 
         const dependents = reverseEdges.get(dependencyId);
@@ -104,10 +102,7 @@ export namespace DAG {
     };
   }
 
-  export function getReady(
-    dag: DAGStructure,
-    completed: Set<string>,
-  ): string[] {
+  export function getReady(dag: DAGStructure, completed: Set<string>): string[] {
     const ready: string[] = [];
     for (const nodeId of dag.nodes) {
       if (completed.has(nodeId)) {
@@ -168,10 +163,7 @@ export namespace DAG {
   }
 }
 
-function findCycle(
-  nodes: Set<string>,
-  adjacency: Map<string, Set<string>>,
-): string[] {
+function findCycle(nodes: Set<string>, adjacency: Map<string, Set<string>>): string[] {
   const visiting = new Set<string>();
   const visited = new Set<string>();
   const stack: string[] = [];

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -5,6 +5,7 @@ export * from "./plan/structural-gate.js";
 export * from "./plan/plan-pipeline.js";
 export * from "./team/index.js";
 export * from "./dag/index.js";
+export { FileTaskStore, TaskStorage } from "./legacy/index.js";
 
 /** @deprecated Legacy orchestration modules — CLI depends on these, do not delete */
 export * as _DEPRECATED_legacy from "./legacy/index.js";

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -1,8 +1,4 @@
-import {
-  InboundEventSchema,
-  type InboundEvent,
-  type IngressResult,
-} from "@openomni/protocol";
+import { InboundEventSchema, type InboundEvent, type IngressResult } from "@openomni/protocol";
 import { Bus, Storage, SurfaceKey } from "@openomni/session";
 import { IngressEventProjector } from "./event-projector";
 import { IngressHandlers } from "./handlers";
@@ -18,8 +14,7 @@ export namespace IngressEngine {
   export async function ingest(event: InboundEvent): Promise<IngressResult> {
     InboundEventSchema.parse(event);
 
-    const agentModel =
-      event.mode === "team" ? event.agents.executor.model : event.agent.model;
+    const agentModel = event.mode === "team" ? event.agents.executor.model : event.agent.model;
     const { session } = IngressSessionResolver.resolve(event, {
       providerID: agentModel.provider,
       modelID: agentModel.id,

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -52,11 +52,7 @@ export namespace IngressHandlers {
     };
 
     const result = await TeamOrchestrator.execute(plan, orchestratorConfig);
-    SessionBridge.storeTeamResult(
-      ctx.sessionId,
-      result,
-      ctx.event.agents.reviewer.model,
-    );
+    SessionBridge.storeTeamResult(ctx.sessionId, result, ctx.event.agents.reviewer.model);
 
     return {
       mode: "team",
@@ -95,11 +91,7 @@ export namespace IngressHandlers {
     const runResult = await agent.run({ messages });
     const output = runResult.text;
 
-    SessionBridge.storeDirectResult(
-      ctx.sessionId,
-      output,
-      ctx.event.agent.model,
-    );
+    SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
 
     return {
       mode: "direct",

--- a/packages/openomni/src/ingress/session-bridge.ts
+++ b/packages/openomni/src/ingress/session-bridge.ts
@@ -133,9 +133,7 @@ export namespace SessionBridge {
    * Build a simple message array for ChatAgent.run() from session messages.
    * Each message with a TextPart becomes { role, content }.
    */
-  export function buildDirectMessages(
-    sessionId: string,
-  ): Array<{ role: string; content: string }> {
+  export function buildDirectMessages(sessionId: string): Array<{ role: string; content: string }> {
     const messages = Session.getMessages(sessionId);
     const result: Array<{ role: string; content: string }> = [];
 

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -32,11 +32,7 @@ export namespace IngressSessionResolver {
    *   {surface: "slack", channel: "C123"} → "slack::C123"
    */
   export function extractSurfaceKey(event: ResolvableEvent): string {
-    const parts = [
-      event.surface,
-      event.workspace ?? "",
-      event.channel ?? "",
-    ];
+    const parts = [event.surface, event.workspace ?? "", event.channel ?? ""];
     return SurfaceKey.create(parts);
   }
 

--- a/packages/openomni/src/legacy/agent/communication.ts
+++ b/packages/openomni/src/legacy/agent/communication.ts
@@ -80,26 +80,18 @@ export class MessagingError extends Error {
 export namespace AgentMessenger {
   const inboxes = new Map<string, MessageEnvelope[]>();
   const auditLogs = new Map<string, AuditEntry[]>();
-  const subscribers = new Map<
-    string,
-    ((envelope: MessageEnvelope) => void)[]
-  >();
+  const subscribers = new Map<string, ((envelope: MessageEnvelope) => void)[]>();
   let allowPatterns: AllowPattern[] | null = null;
   let bothPolicyEnabled = false;
 
   const isValidEnvelope = (envelope: MessageEnvelope): boolean => {
-    return Boolean(
-      envelope.toAgentId &&
-      envelope.fromAgentId &&
-      envelope.payload !== undefined,
-    );
+    return Boolean(envelope.toAgentId && envelope.fromAgentId && envelope.payload !== undefined);
   };
 
   const isAllowed = (from: string, to: string): boolean => {
     if (allowPatterns === null) return true;
     return allowPatterns.some(
-      (p) =>
-        (p.from === "*" || p.from === from) && (p.to === "*" || p.to === to),
+      (p) => (p.from === "*" || p.from === from) && (p.to === "*" || p.to === to),
     );
   };
 

--- a/packages/openomni/src/legacy/agent/definitions.ts
+++ b/packages/openomni/src/legacy/agent/definitions.ts
@@ -6,22 +6,10 @@ import { randomUUID } from "crypto";
  * Used by the router when matching tasks to agents
  */
 export const AgentCapabilitiesSchema = z.object({
-  skills: z
-    .array(z.string())
-    .optional()
-    .describe("Skills available to this agent"),
-  tools: z
-    .array(z.string())
-    .optional()
-    .describe("Tools available to this agent"),
-  toolAllowlist: z
-    .array(z.string())
-    .optional()
-    .describe("Explicit allowlist of tools"),
-  toolDenylist: z
-    .array(z.string())
-    .optional()
-    .describe("Explicit denylist of tools"),
+  skills: z.array(z.string()).optional().describe("Skills available to this agent"),
+  tools: z.array(z.string()).optional().describe("Tools available to this agent"),
+  toolAllowlist: z.array(z.string()).optional().describe("Explicit allowlist of tools"),
+  toolDenylist: z.array(z.string()).optional().describe("Explicit denylist of tools"),
 });
 
 export type AgentCapabilities = z.infer<typeof AgentCapabilitiesSchema>;
@@ -47,10 +35,7 @@ export type DataScope = z.infer<typeof DataScopeSchema>;
 
 export const PolicySpecSchema = z.object({
   tools: z.array(z.string()).describe("Tools allowed by this policy"),
-  dataScopes: z
-    .array(DataScopeSchema)
-    .optional()
-    .describe("Data access scopes"),
+  dataScopes: z.array(DataScopeSchema).optional().describe("Data access scopes"),
   capabilities: z
     .array(z.enum(["delegate", "escalate"]))
     .optional()
@@ -63,18 +48,9 @@ export const AgentProfileSchema = z.object({
   id: z.string().describe("Unique identifier for the agent profile"),
   name: z.string().describe("Human-readable name of the agent"),
   role: z.string().optional().describe("Role or specialization of the agent"),
-  systemPrompt: z
-    .string()
-    .optional()
-    .describe("System prompt to guide agent behavior"),
-  skills: z
-    .array(z.string())
-    .optional()
-    .describe("List of skills the agent possesses"),
-  tools: z
-    .array(z.string())
-    .optional()
-    .describe("List of tools the agent can use"),
+  systemPrompt: z.string().optional().describe("System prompt to guide agent behavior"),
+  skills: z.array(z.string()).optional().describe("List of skills the agent possesses"),
+  tools: z.array(z.string()).optional().describe("List of tools the agent can use"),
   policy: z
     .lazy(() => PolicySpecSchema)
     .optional()
@@ -95,19 +71,11 @@ export const AgentIdentitySchema = z.object({
 
 export type AgentIdentity = z.infer<typeof AgentIdentitySchema>;
 
-export const AgentStatusSchema = z.enum([
-  "idle",
-  "busy",
-  "degraded",
-  "offline",
-]);
+export const AgentStatusSchema = z.enum(["idle", "busy", "degraded", "offline"]);
 
 export type AgentStatus = z.infer<typeof AgentStatusSchema>;
 
-export function createAgentIdentity(
-  profile: AgentProfile,
-  version?: string,
-): AgentIdentity {
+export function createAgentIdentity(profile: AgentProfile, version?: string): AgentIdentity {
   return AgentIdentitySchema.parse({
     agentId: profile.id,
     instanceId: randomUUID(),

--- a/packages/openomni/src/legacy/agent/discovery.ts
+++ b/packages/openomni/src/legacy/agent/discovery.ts
@@ -79,9 +79,7 @@ function parseSimpleYaml(lines: string[]): Record<string, unknown> {
       }
 
       if (nested.length > 0) {
-        const isBlockArray = nested.every(
-          (l) => l.trim().startsWith("- ") || l.trim() === "",
-        );
+        const isBlockArray = nested.every((l) => l.trim().startsWith("- ") || l.trim() === "");
 
         if (isBlockArray) {
           result[key] = nested
@@ -120,10 +118,7 @@ function parseValue(raw: string): unknown {
 }
 
 function parseScalar(raw: string): unknown {
-  if (
-    (raw.startsWith('"') && raw.endsWith('"')) ||
-    (raw.startsWith("'") && raw.endsWith("'"))
-  ) {
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
     return raw.slice(1, -1);
   }
 
@@ -163,10 +158,7 @@ export interface AgentDiscoveryOptions {
  * extends the systemPrompt. Validates all definitions with Zod.
  */
 export namespace AgentDiscovery {
-  export function load(
-    dir: string,
-    options: AgentDiscoveryOptions = {},
-  ): AgentLoadResult[] {
+  export function load(dir: string, options: AgentDiscoveryOptions = {}): AgentLoadResult[] {
     const { allowOverride = false, strict = false } = options;
     const results: AgentLoadResult[] = [];
 
@@ -195,10 +187,7 @@ export namespace AgentDiscovery {
     return results;
   }
 
-  export function loadFile(
-    filePath: string,
-    options: AgentDiscoveryOptions = {},
-  ): AgentLoadResult {
+  export function loadFile(filePath: string, options: AgentDiscoveryOptions = {}): AgentLoadResult {
     const { allowOverride = false, strict = false } = options;
     const file = filePath;
 
@@ -227,8 +216,7 @@ export namespace AgentDiscovery {
 
       return { file, success: true, agent: validated };
     } catch (err: unknown) {
-      const msg =
-        err instanceof Error ? err.message : "Unknown error loading agent file";
+      const msg = err instanceof Error ? err.message : "Unknown error loading agent file";
       if (strict) throw err;
       return { file, success: false, error: msg };
     }
@@ -238,10 +226,7 @@ export namespace AgentDiscovery {
    * Atomically replaces an existing agent by clearing and re-registering all agents.
    * Required because BuiltinAgentRegistry.define() throws on duplicate names.
    */
-  function overrideAgent(
-    definition: AgentDefinition,
-    file: string,
-  ): AgentLoadResult {
+  function overrideAgent(definition: AgentDefinition, file: string): AgentLoadResult {
     const existing = BuiltinAgentRegistry.list();
     BuiltinAgentRegistry.clear();
 

--- a/packages/openomni/src/legacy/agent/registry/file-registry-storage.ts
+++ b/packages/openomni/src/legacy/agent/registry/file-registry-storage.ts
@@ -90,10 +90,7 @@ export class FileAgentRegistryStore implements AgentRegistryStore {
   }
 
   private flushProfile(id: string, profile: AgentProfile): void {
-    this.atomicWrite(
-      `${this.encodeFilename(id)}.json`,
-      JSON.stringify(profile, null, 2),
-    );
+    this.atomicWrite(`${this.encodeFilename(id)}.json`, JSON.stringify(profile, null, 2));
   }
 
   private atomicWrite(filename: string, data: string): void {

--- a/packages/openomni/src/legacy/agent/registry/profile-store.ts
+++ b/packages/openomni/src/legacy/agent/registry/profile-store.ts
@@ -60,8 +60,7 @@ export class AgentRegistry {
   private store: AgentRegistryStore;
 
   constructor(store?: AgentRegistryStore) {
-    this.store =
-      store ?? AgentRegistry.defaultStore ?? new InMemoryAgentRegistryStore();
+    this.store = store ?? AgentRegistry.defaultStore ?? new InMemoryAgentRegistryStore();
   }
 
   /**

--- a/packages/openomni/src/legacy/agent/registry/registry.ts
+++ b/packages/openomni/src/legacy/agent/registry/registry.ts
@@ -58,9 +58,7 @@ export namespace BuiltinAgentRegistry {
     const validated = AgentDefinitionSchema.parse(definition);
 
     if (registry.has(validated.name)) {
-      throw new Error(
-        `Agent "${validated.name}" is already registered in the registry`,
-      );
+      throw new Error(`Agent "${validated.name}" is already registered in the registry`);
     }
 
     registry.set(validated.name, validated);
@@ -153,8 +151,7 @@ export namespace BuiltinAgentRegistry {
     // implement: full-access agent for implementation
     define({
       name: "implement",
-      description:
-        "Full-access agent for implementing features, refactoring, and code generation",
+      description: "Full-access agent for implementing features, refactoring, and code generation",
       systemPrompt:
         "You are an expert software engineer. Your role is to implement features, refactor code, and generate solutions. You have full access to all tools and can read, write, and execute code. Focus on clean, maintainable, and well-tested implementations.",
       tools: [
@@ -187,8 +184,7 @@ export namespace BuiltinAgentRegistry {
     // review: read + LSP agent for code review and analysis
     define({
       name: "review",
-      description:
-        "Code review agent with read access and LSP tools for deep analysis",
+      description: "Code review agent with read access and LSP tools for deep analysis",
       systemPrompt:
         "You are an expert code reviewer. Your role is to analyze code quality, identify issues, and suggest improvements. You have read access and LSP tools for deep code understanding. Focus on correctness, performance, maintainability, and best practices.",
       tools: [

--- a/packages/openomni/src/legacy/config/index.ts
+++ b/packages/openomni/src/legacy/config/index.ts
@@ -77,9 +77,7 @@ export namespace ConfigManager {
   /**
    * Create a configuration with defaults merged with overrides
    */
-  export function create(
-    overrides: Partial<AutonomousLoopConfig> = {},
-  ): AutonomousLoopConfig {
+  export function create(overrides: Partial<AutonomousLoopConfig> = {}): AutonomousLoopConfig {
     const defaults = getDefaultsInternal();
     return deepMerge(defaults, overrides);
   }
@@ -104,9 +102,7 @@ export namespace ConfigManager {
       return false;
     }
 
-    if (
-      !["drop", "coalesce", "summarize"].includes(config.dedupe.onDuplicate)
-    ) {
+    if (!["drop", "coalesce", "summarize"].includes(config.dedupe.onDuplicate)) {
       return false;
     }
 

--- a/packages/openomni/src/legacy/conversation/conversation-supervisor.ts
+++ b/packages/openomni/src/legacy/conversation/conversation-supervisor.ts
@@ -26,11 +26,7 @@
 import { z } from "zod";
 import { Message } from "@openomni/protocol";
 import { Session } from "@openomni/session";
-import {
-  resolveAgentDefinition,
-  resolveLLM,
-  resolveToolExecutor,
-} from "../worker";
+import { resolveAgentDefinition, resolveLLM, resolveToolExecutor } from "../worker";
 import { BuiltinAgentRegistry } from "../agent";
 import { RunWorker } from "../worker";
 import type {
@@ -115,10 +111,7 @@ export const ClassifyIntentInput = z.object({
     .describe(
       "User intent classification: 'immediate' for simple queries/tasks that can be answered directly, 'plan_needed' for complex work requiring decomposition and approval",
     ),
-  reasoning: z
-    .string()
-    .optional()
-    .describe("Brief reasoning for the classification"),
+  reasoning: z.string().optional().describe("Brief reasoning for the classification"),
 });
 export type ClassifyIntentInput = z.infer<typeof ClassifyIntentInput>;
 
@@ -134,24 +127,13 @@ export const GeneratePlanInput = z.object({
     .array(
       z.object({
         description: z.string().describe("Work item description"),
-        effort: z
-          .enum(["trivial", "small", "medium", "large"])
-          .describe("Effort estimate"),
-        dependsOn: z
-          .array(z.number())
-          .optional()
-          .describe("Indices of dependent work items"),
-        suggestedAgent: z
-          .string()
-          .optional()
-          .describe("Recommended agent for this work item"),
+        effort: z.enum(["trivial", "small", "medium", "large"]).describe("Effort estimate"),
+        dependsOn: z.array(z.number()).optional().describe("Indices of dependent work items"),
+        suggestedAgent: z.string().optional().describe("Recommended agent for this work item"),
       }),
     )
     .describe("Array of work items"),
-  estimatedRuntimeMs: z
-    .number()
-    .optional()
-    .describe("Estimated total runtime in milliseconds"),
+  estimatedRuntimeMs: z.number().optional().describe("Estimated total runtime in milliseconds"),
 });
 export type GeneratePlanInput = z.infer<typeof GeneratePlanInput>;
 
@@ -310,21 +292,15 @@ export namespace ConversationSupervisor {
     }
 
     const parts = Session.getParts(lastMessage.id);
-    const toolParts = parts.filter(
-      (part): part is Message.ToolPart => part.type === "tool",
-    );
+    const toolParts = parts.filter((part): part is Message.ToolPart => part.type === "tool");
 
-    const classifyIntentCall = toolParts.find(
-      (part) => part.tool === "classify_intent",
-    );
+    const classifyIntentCall = toolParts.find((part) => part.tool === "classify_intent");
 
     if (classifyIntentCall) {
       const input = classifyIntentCall.state.input as ClassifyIntentInput;
 
       if (input.intent === "immediate") {
-        const textParts = parts.filter(
-          (part): part is Message.TextPart => part.type === "text",
-        );
+        const textParts = parts.filter((part): part is Message.TextPart => part.type === "text");
         const response = textParts.map((p) => p.text).join("");
 
         return {
@@ -333,9 +309,7 @@ export namespace ConversationSupervisor {
         };
       }
     } else {
-      const textParts = parts.filter(
-        (part): part is Message.TextPart => part.type === "text",
-      );
+      const textParts = parts.filter((part): part is Message.TextPart => part.type === "text");
       const response = textParts.map((p) => p.text).join("");
 
       if (response) {
@@ -399,9 +373,7 @@ When generating a plan, assign a suggestedAgent to each work item based on the a
       (part): part is Message.ToolPart => part.type === "tool",
     );
 
-    const generatePlanCall = planToolParts.find(
-      (part) => part.tool === "generate_plan",
-    );
+    const generatePlanCall = planToolParts.find((part) => part.tool === "generate_plan");
 
     if (!generatePlanCall) {
       return {
@@ -410,9 +382,7 @@ When generating a plan, assign a suggestedAgent to each work item based on the a
       };
     }
 
-    const planInputResult = GeneratePlanInput.safeParse(
-      generatePlanCall.state.input,
-    );
+    const planInputResult = GeneratePlanInput.safeParse(generatePlanCall.state.input);
     if (!planInputResult.success) {
       return {
         type: "error",
@@ -434,9 +404,7 @@ When generating a plan, assign a suggestedAgent to each work item based on the a
     const agentNames = new Set(availableAgents.map((a) => a.name));
     for (const item of plan.workItems) {
       if (item.suggestedAgent && !agentNames.has(item.suggestedAgent)) {
-        console.warn(
-          `[ConversationSupervisor] Invalid suggestedAgent: ${item.suggestedAgent}`,
-        );
+        console.warn(`[ConversationSupervisor] Invalid suggestedAgent: ${item.suggestedAgent}`);
       }
     }
 

--- a/packages/openomni/src/legacy/conversation/index.ts
+++ b/packages/openomni/src/legacy/conversation/index.ts
@@ -35,13 +35,7 @@ export namespace ConversationHandler {
    * @returns Decision with path ("inline" or "task") and reason
    */
   export function decide(request: RequestContext): Decision {
-    const {
-      estimatedDuration,
-      fileCount,
-      needsApproval,
-      userIntent,
-      complexity,
-    } = request;
+    const { estimatedDuration, fileCount, needsApproval, userIntent, complexity } = request;
 
     // Heuristic 1: Needs design review or approval → Task
     if (needsApproval) {
@@ -63,8 +57,7 @@ export namespace ConversationHandler {
     if (deferredKeywords.some((keyword) => intentLower.includes(keyword))) {
       return {
         path: "task",
-        reason:
-          'User requested deferred execution ("later", "when you have time")',
+        reason: 'User requested deferred execution ("later", "when you have time")',
       };
     }
 

--- a/packages/openomni/src/legacy/dispatch/dispatcher.ts
+++ b/packages/openomni/src/legacy/dispatch/dispatcher.ts
@@ -82,32 +82,16 @@ export namespace Dispatcher {
       }
 
       case "gt":
-        return (
-          typeof actualValue === "number" &&
-          typeof value === "number" &&
-          actualValue > value
-        );
+        return typeof actualValue === "number" && typeof value === "number" && actualValue > value;
 
       case "gte":
-        return (
-          typeof actualValue === "number" &&
-          typeof value === "number" &&
-          actualValue >= value
-        );
+        return typeof actualValue === "number" && typeof value === "number" && actualValue >= value;
 
       case "lt":
-        return (
-          typeof actualValue === "number" &&
-          typeof value === "number" &&
-          actualValue < value
-        );
+        return typeof actualValue === "number" && typeof value === "number" && actualValue < value;
 
       case "lte":
-        return (
-          typeof actualValue === "number" &&
-          typeof value === "number" &&
-          actualValue <= value
-        );
+        return typeof actualValue === "number" && typeof value === "number" && actualValue <= value;
 
       default:
         return false;
@@ -119,10 +103,7 @@ export namespace Dispatcher {
    * mode: 'all' requires all conditions to pass (AND logic)
    * mode: 'any' requires at least one condition to pass (OR logic)
    */
-  export function evaluateFilter(
-    filter: Task.TriggerFilter,
-    payload: unknown,
-  ): boolean {
+  export function evaluateFilter(filter: Task.TriggerFilter, payload: unknown): boolean {
     const { conditions, mode } = filter;
 
     if (conditions.length === 0) return true;

--- a/packages/openomni/src/legacy/dispatch/envelope.ts
+++ b/packages/openomni/src/legacy/dispatch/envelope.ts
@@ -166,10 +166,7 @@ export namespace Envelope {
    * @param maxAgeMs - Maximum age in milliseconds
    * @returns true if envelope timestamp is older than maxAgeMs, false otherwise
    */
-  export function isExpired(
-    envelope: EventEnvelope,
-    maxAgeMs: number,
-  ): boolean {
+  export function isExpired(envelope: EventEnvelope, maxAgeMs: number): boolean {
     const envelopeTime = new Date(envelope.receivedAt).getTime();
     const currentTime = new Date().getTime();
     return currentTime - envelopeTime > maxAgeMs;

--- a/packages/openomni/src/legacy/dispatch/router.ts
+++ b/packages/openomni/src/legacy/dispatch/router.ts
@@ -53,9 +53,7 @@ export namespace Router {
 
     if (match.tags && match.tags.length > 0) {
       const envelopeTags = Array.isArray(envelope.meta?.tags)
-        ? (envelope.meta.tags as unknown[]).filter(
-            (tag): tag is string => typeof tag === "string",
-          )
+        ? (envelope.meta.tags as unknown[]).filter((tag): tag is string => typeof tag === "string")
         : [];
 
       if (!match.tags.every((tag) => envelopeTags.includes(tag))) {
@@ -181,10 +179,7 @@ export namespace Router {
   /**
    * Configure the deduplication window and max entries
    */
-  export function configureDedupeWindow(
-    windowMs: number,
-    maxEntries: number,
-  ): void {
+  export function configureDedupeWindow(windowMs: number, maxEntries: number): void {
     dedupeWindowMs = windowMs;
     maxDedupeEntries = maxEntries;
   }

--- a/packages/openomni/src/legacy/execution/execution-review.ts
+++ b/packages/openomni/src/legacy/execution/execution-review.ts
@@ -12,11 +12,7 @@ import type {
   FailureAction,
   FailureDecision,
 } from "./execution-types";
-import type {
-  OrchestratorConfig,
-  OrchestratorRunInput,
-  ToolExecutor,
-} from "../worker";
+import type { OrchestratorConfig, OrchestratorRunInput, ToolExecutor } from "../worker";
 
 const DEFAULT_MAX_SUBAGENT_DEPTH = 3;
 const DISPATCH_AGENT_ID = "dispatch-supervisor";
@@ -185,11 +181,7 @@ export async function requestHandoffDocument(
     toolExecutor: context.toolExecutor,
   };
 
-  const result = await executeChildRunWithAbort(
-    config,
-    orchestratorInput,
-    abortSignal,
-  );
+  const result = await executeChildRunWithAbort(config, orchestratorInput, abortSignal);
 
   if (!result.success || !result.summary.trim()) {
     return [
@@ -206,9 +198,7 @@ export async function requestHandoffDocument(
 export function rotateAgent(state: DispatchTaskState, objective: string): void {
   const agent = BuiltinAgentRegistry.get(state.task.agentType);
   if (!agent) {
-    state.errors.push(
-      `Unable to rotate agent: ${state.task.agentType} not found`,
-    );
+    state.errors.push(`Unable to rotate agent: ${state.task.agentType} not found`);
     state.status = "failed";
     return;
   }
@@ -265,9 +255,7 @@ async function requestFailureDecision(
   const fallbackDecision: FailureDecision = {
     action: failedStep.attempts <= 1 ? "retry" : "skip",
     reasoning:
-      failedStep.attempts <= 1
-        ? "Retry once before skipping"
-        : "Skip after repeated failure",
+      failedStep.attempts <= 1 ? "Retry once before skipping" : "Skip after repeated failure",
   };
 
   let selectedDecision = fallbackDecision;
@@ -344,8 +332,7 @@ function defaultReviewDecision(summary: string): DispatchReviewDecision {
   if (normalized.startsWith("reject:")) {
     return {
       decision: "reject",
-      feedback:
-        summary.trim().slice("reject:".length).trim() || "Result rejected",
+      feedback: summary.trim().slice("reject:".length).trim() || "Result rejected",
     };
   }
 

--- a/packages/openomni/src/legacy/execution/execution-supervisor.ts
+++ b/packages/openomni/src/legacy/execution/execution-supervisor.ts
@@ -38,11 +38,7 @@ import type {
   SupervisorDecision,
   WorkerRuntimeConfig,
 } from "./execution-types";
-import type {
-  OrchestratorConfig,
-  OrchestratorRunInput,
-  ToolExecutor,
-} from "../worker";
+import type { OrchestratorConfig, OrchestratorRunInput, ToolExecutor } from "../worker";
 import { RunWorker } from "../worker";
 
 const DEFAULT_DISPATCH_TIMEOUT_MS = 5 * 60 * 1000;
@@ -62,9 +58,7 @@ export namespace ExecutionSupervisor {
   /**
    * Decision loop: plan -> select -> delegate -> re-evaluate.
    */
-  export async function run(
-    config: ExecutionSupervisorConfig,
-  ): Promise<ExecutionSupervisorResult> {
+  export async function run(config: ExecutionSupervisorConfig): Promise<ExecutionSupervisorResult> {
     const stepOutcomes: StepOutcome[] = [];
 
     while (true) {
@@ -91,12 +85,9 @@ export namespace ExecutionSupervisor {
     }
 
     const completedStepIds = new Set(stepOutcomes.map((o) => o.stepId));
-    const unexecutedSteps = config.plan.steps.filter(
-      (s) => !completedStepIds.has(s.stepId),
-    );
+    const unexecutedSteps = config.plan.steps.filter((s) => !completedStepIds.has(s.stepId));
     const allStepsExecuted = unexecutedSteps.length === 0;
-    const allSucceeded =
-      allStepsExecuted && stepOutcomes.every((o) => o.success);
+    const allSucceeded = allStepsExecuted && stepOutcomes.every((o) => o.success);
 
     const errors: string[] = stepOutcomes
       .filter((o) => !o.success)
@@ -111,8 +102,7 @@ export namespace ExecutionSupervisor {
 
     return {
       success: allSucceeded,
-      summary:
-        stepOutcomes.map((o) => o.summary).join("\n") || "No work executed.",
+      summary: stepOutcomes.map((o) => o.summary).join("\n") || "No work executed.",
       error: errors.length > 0 ? errors.join("; ") : undefined,
       terminalDecision: "finish",
       stepOutcomes,
@@ -148,8 +138,7 @@ export namespace ExecutionSupervisor {
 
     return executionPlan.steps.filter(
       (step) =>
-        !completedIds.has(step.stepId) &&
-        step.dependsOn.every((dep) => completedIds.has(dep)),
+        !completedIds.has(step.stepId) && step.dependsOn.every((dep) => completedIds.has(dep)),
     );
   }
 
@@ -188,15 +177,11 @@ export namespace ExecutionSupervisor {
     const dispatchContext: DispatchContext = {
       ...runtime.dispatchContext,
       ...(config.agentId ? { agentId: config.agentId } : {}),
-      ...(config.availableAgents
-        ? { availableAgents: [...config.availableAgents] }
-        : {}),
+      ...(config.availableAgents ? { availableAgents: [...config.availableAgents] } : {}),
     };
 
     const output = await executeDispatchGraph(input, dispatchContext);
-    const resultById = new Map(
-      output.results.map((result) => [result.id, result]),
-    );
+    const resultById = new Map(output.results.map((result) => [result.id, result]));
 
     return steps.map((step) => {
       const result = resultById.get(step.stepId);
@@ -226,10 +211,7 @@ async function executeDispatchGraph(
   const startedAt = Date.now();
   const graph = buildDependencyGraph(input.tasks);
   const hybridRuntime = await resolveDispatchHybridRuntime(context);
-  const workerRuntimeCache = new Map<
-    string,
-    Promise<WorkerRuntimeConfig | undefined>
-  >();
+  const workerRuntimeCache = new Map<string, Promise<WorkerRuntimeConfig | undefined>>();
 
   initializeTaskStates(graph, input.objective);
 
@@ -293,24 +275,18 @@ async function executeDispatchGraph(
       if (dispatchAbortController.signal.aborted) {
         cancelRunningChildren(
           running,
-          abortReason === "timeout"
-            ? "dispatch_timeout"
-            : "dispatch_parent_aborted",
+          abortReason === "timeout" ? "dispatch_timeout" : "dispatch_parent_aborted",
         );
         markPendingAsFailed(
           graph,
-          abortReason === "timeout"
-            ? "Dispatch timed out"
-            : "Dispatch aborted by parent",
+          abortReason === "timeout" ? "Dispatch timed out" : "Dispatch aborted by parent",
         );
         return buildOutput(
           input.objective,
           graph,
           startedAt,
           false,
-          abortReason === "timeout"
-            ? "Dispatch timed out"
-            : "Dispatch aborted by parent",
+          abortReason === "timeout" ? "Dispatch timed out" : "Dispatch aborted by parent",
         );
       }
 
@@ -349,32 +325,23 @@ async function executeDispatchGraph(
         );
       }
 
-      const next = await waitForNextResult(
-        running,
-        dispatchAbortController.signal,
-      );
+      const next = await waitForNextResult(running, dispatchAbortController.signal);
 
       if (next.type === "aborted") {
         cancelRunningChildren(
           running,
-          abortReason === "timeout"
-            ? "dispatch_timeout"
-            : "dispatch_parent_aborted",
+          abortReason === "timeout" ? "dispatch_timeout" : "dispatch_parent_aborted",
         );
         markPendingAsFailed(
           graph,
-          abortReason === "timeout"
-            ? "Dispatch timed out"
-            : "Dispatch aborted by parent",
+          abortReason === "timeout" ? "Dispatch timed out" : "Dispatch aborted by parent",
         );
         return buildOutput(
           input.objective,
           graph,
           startedAt,
           false,
-          abortReason === "timeout"
-            ? "Dispatch timed out"
-            : "Dispatch aborted by parent",
+          abortReason === "timeout" ? "Dispatch timed out" : "Dispatch aborted by parent",
         );
       }
 
@@ -411,19 +378,13 @@ async function executeDispatchGraph(
           if (failureDecision.reasoning.trim().length > 0) {
             state.summaries.push(`Skipped: ${failureDecision.reasoning}`);
           }
-          completeTaskAndUnblockDependents(
-            graph,
-            state.task.id,
-            completed,
-            ready,
-          );
+          completeTaskAndUnblockDependents(graph, state.task.id, completed, ready);
           continue;
         }
 
         if (failureDecision?.action === "replan") {
           const reason =
-            failureDecision.reasoning.trim() ||
-            "Supervisor requested replan for failed step";
+            failureDecision.reasoning.trim() || "Supervisor requested replan for failed step";
           state.status = "failed";
           state.errors.push(`Replan requested: ${reason}`);
           markPendingAsFailed(graph, "Dispatch requires replan");
@@ -441,33 +402,18 @@ async function executeDispatchGraph(
         !next.result.success && failureDecision
           ? {
               decision: "reject",
-              feedback:
-                failureDecision.reasoning ||
-                next.result.error ||
-                "Task execution failed",
+              feedback: failureDecision.reasoning || next.result.error || "Task execution failed",
             }
-          : await reviewTaskResult(
-              input.objective,
-              state,
-              next.result,
-              context,
-            );
+          : await reviewTaskResult(input.objective, state, next.result, context);
 
       if (reviewDecision.decision === "accept") {
-        completeTaskAndUnblockDependents(
-          graph,
-          state.task.id,
-          completed,
-          ready,
-        );
+        completeTaskAndUnblockDependents(graph, state.task.id, completed, ready);
 
         continue;
       }
 
       const feedback =
-        reviewDecision.feedback ||
-        next.result.error ||
-        "Result rejected. Revise and retry.";
+        reviewDecision.feedback || next.result.error || "Result rejected. Revise and retry.";
 
       state.totalRejections += 1;
       state.rejectionStreak += 1;
@@ -598,9 +544,7 @@ function buildDispatchInputFromSteps(
       description: step.description,
       agentType: "implement",
       suggestedAgent: step.suggestedAgent,
-      dependencies: step.dependsOn.filter((dependencyId) =>
-        selectedStepIds.has(dependencyId),
-      ),
+      dependencies: step.dependsOn.filter((dependencyId) => selectedStepIds.has(dependencyId)),
       fileScope: [],
     };
   });
@@ -623,11 +567,7 @@ function initializeTaskStates(graph: DependencyGraph, objective: string): void {
     state.agentInstanceId = createAgentInstanceId(state.task.id);
     state.agentHistory.push(state.agentInstanceId);
     state.sessionId = createSessionId(state.task.id);
-    ensurePersistentSession(
-      state.sessionId,
-      `${objective}: ${state.task.id}`,
-      agent.name,
-    );
+    ensurePersistentSession(state.sessionId, `${objective}: ${state.task.id}`, agent.name);
     state.childTaskId = createChildTask(state.task, state.agentInstanceId);
   }
 }
@@ -640,11 +580,7 @@ function createAgentInstanceId(taskId: string): string {
   return `dispatch-agent:${taskId}:${crypto.randomUUID()}`;
 }
 
-function ensurePersistentSession(
-  sessionId: string,
-  title: string,
-  agentName: string,
-): void {
+function ensurePersistentSession(sessionId: string, title: string, agentName: string): void {
   if (Session.get(sessionId)) {
     return;
   }
@@ -827,16 +763,14 @@ async function startTaskRun(
     toolExecutor: workerRuntime.toolExecutor,
   };
 
-  const promise = executeChildRunWithAbort(
-    config,
-    orchestratorInput,
-    abortSignal,
-  ).then((result) => ({
-    runId,
-    success: result.success,
-    summary: result.summary,
-    error: result.error,
-  }));
+  const promise = executeChildRunWithAbort(config, orchestratorInput, abortSignal).then(
+    (result) => ({
+      runId,
+      success: result.success,
+      summary: result.summary,
+      error: result.error,
+    }),
+  );
 
   return {
     taskId: state.task.id,
@@ -847,10 +781,7 @@ async function startTaskRun(
   };
 }
 
-function buildExecutionPrompt(
-  objective: string,
-  state: DispatchTaskState,
-): string {
+function buildExecutionPrompt(objective: string, state: DispatchTaskState): string {
   const lines: string[] = [
     `Objective: ${objective}`,
     `Task ID: ${state.task.id}`,
@@ -867,9 +798,7 @@ function buildExecutionPrompt(
   }
 
   if (state.feedbackHistory.length > 0) {
-    lines.push(
-      `Review Feedback History:\n- ${state.feedbackHistory.join("\n- ")}`,
-    );
+    lines.push(`Review Feedback History:\n- ${state.feedbackHistory.join("\n- ")}`);
   }
 
   if (state.handoffDocument) {
@@ -898,11 +827,7 @@ async function executeChildRunWithAbort(
   return new Promise((resolve) => {
     let settled = false;
 
-    const finalize = (result: {
-      success: boolean;
-      summary: string;
-      error: string;
-    }) => {
+    const finalize = (result: { success: boolean; summary: string; error: string }) => {
       if (settled) {
         return;
       }
@@ -982,9 +907,7 @@ async function waitForNextResult(
 }
 
 function normalizeFileScope(fileScope: string[]): string[] {
-  return Array.from(
-    new Set(fileScope.filter((path) => path.trim().length > 0)),
-  );
+  return Array.from(new Set(fileScope.filter((path) => path.trim().length > 0)));
 }
 
 function acquireFileLocks(files: string[], agentId: string): boolean {
@@ -1007,10 +930,7 @@ function releaseFileLocks(files: string[], agentId: string): void {
   }
 }
 
-function cancelRunningChildren(
-  running: Map<string, RunningTask>,
-  reason: string,
-): void {
+function cancelRunningChildren(running: Map<string, RunningTask>, reason: string): void {
   for (const active of running.values()) {
     if (active.runId) {
       TaskManager.cancelRun(active.runId, reason);

--- a/packages/openomni/src/legacy/execution/execution-types.ts
+++ b/packages/openomni/src/legacy/execution/execution-types.ts
@@ -87,9 +87,7 @@ export interface DispatchContext {
   agentId?: string;
   availableAgents?: string[];
   timeoutMs?: number;
-  review?: (
-    input: DispatchReviewInput,
-  ) => DispatchReviewDecision | Promise<DispatchReviewDecision>;
+  review?: (input: DispatchReviewInput) => DispatchReviewDecision | Promise<DispatchReviewDecision>;
   parentTaskId?: string;
   parentRunId?: string;
   parentSessionId?: string;

--- a/packages/openomni/src/legacy/execution/graph/execution-assignment.ts
+++ b/packages/openomni/src/legacy/execution/graph/execution-assignment.ts
@@ -119,10 +119,7 @@ export async function assignAgentsToReadyTasks(
   );
 
   for (const state of readyStates) {
-    const fallbackAgent = resolveFallbackAgentAssignment(
-      state.task,
-      hybridRuntime.availableAgents,
-    );
+    const fallbackAgent = resolveFallbackAgentAssignment(state.task, hybridRuntime.availableAgents);
     const assignedAgent = assignmentByStep.get(state.task.id) ?? fallbackAgent;
     if (!assignedAgent) {
       continue;
@@ -148,10 +145,7 @@ export function resolveFallbackAgentAssignment(
     return task.suggestedAgent;
   }
 
-  if (
-    availableAgents.includes(task.agentType) &&
-    BuiltinAgentRegistry.has(task.agentType)
-  ) {
+  if (availableAgents.includes(task.agentType) && BuiltinAgentRegistry.has(task.agentType)) {
     return task.agentType;
   }
 
@@ -169,11 +163,7 @@ export async function resolveWorkerRuntimeForTask(
     return cached;
   }
 
-  const pending = resolveWorkerRuntimeForTaskInternal(
-    agentId,
-    context,
-    hybridRuntime,
-  );
+  const pending = resolveWorkerRuntimeForTaskInternal(agentId, context, hybridRuntime);
   workerRuntimeCache?.set(agentId, pending);
   return pending;
 }
@@ -227,11 +217,7 @@ async function requestAgentAssignments(
           };
         }
 
-        const parsed = parseAgentAssignments(
-          call.input,
-          stepIds,
-          availableAgentIds,
-        );
+        const parsed = parseAgentAssignments(call.input, stepIds, availableAgentIds);
         if (parsed.length > 0) {
           selectedAssignments = parsed;
         }
@@ -265,10 +251,7 @@ async function requestAgentAssignments(
   );
 
   const assignmentByStep = new Map(
-    fallbackAssignments.map((assignment) => [
-      assignment.stepId,
-      assignment.agentId,
-    ]),
+    fallbackAssignments.map((assignment) => [assignment.stepId, assignment.agentId]),
   );
   for (const assignment of selectedAssignments) {
     assignmentByStep.set(assignment.stepId, assignment.agentId);
@@ -337,15 +320,11 @@ function parseAgentAssignments(
 }
 
 function resolveAvailableAgentIds(availableAgents?: string[]): string[] {
-  const registeredAgentIds = new Set(
-    BuiltinAgentRegistry.list().map((agent) => agent.name),
-  );
+  const registeredAgentIds = new Set(BuiltinAgentRegistry.list().map((agent) => agent.name));
 
   if (availableAgents && availableAgents.length > 0) {
     return Array.from(
-      new Set(
-        availableAgents.filter((agentId) => registeredAgentIds.has(agentId)),
-      ),
+      new Set(availableAgents.filter((agentId) => registeredAgentIds.has(agentId))),
     );
   }
 
@@ -389,8 +368,7 @@ async function resolveWorkerRuntimeForTaskInternal(
   try {
     const resolved = await resolveAgentForWorker(agentId);
     const systemPrompt =
-      typeof resolved.input.system === "string" &&
-      resolved.input.system.trim().length > 0
+      typeof resolved.input.system === "string" && resolved.input.system.trim().length > 0
         ? resolved.input.system.trim()
         : agent.systemPrompt;
 
@@ -416,10 +394,7 @@ async function resolveWorkerRuntimeForTaskInternal(
   }
 }
 
-function createFilteredToolExecutor(
-  allowedTools: string[],
-  upstream: ToolExecutor,
-): ToolExecutor {
+function createFilteredToolExecutor(allowedTools: string[], upstream: ToolExecutor): ToolExecutor {
   const allowed = new Set(allowedTools);
 
   return {
@@ -440,8 +415,7 @@ function createFilteredToolExecutor(
         allowedCalls.push(call);
       }
 
-      const upstreamResults =
-        allowedCalls.length > 0 ? await upstream.execute(allowedCalls) : [];
+      const upstreamResults = allowedCalls.length > 0 ? await upstream.execute(allowedCalls) : [];
       const upstreamByCallId = new Map(
         upstreamResults.map((result) => [result.toolCallId, result]),
       );

--- a/packages/openomni/src/legacy/execution/graph/execution-graph.ts
+++ b/packages/openomni/src/legacy/execution/graph/execution-graph.ts
@@ -1,9 +1,5 @@
 import { BuiltinAgentRegistry } from "../../agent";
-import type {
-  DependencyGraph,
-  DispatchTask,
-  DispatchTaskState,
-} from "../execution-types";
+import type { DependencyGraph, DispatchTask, DispatchTaskState } from "../execution-types";
 
 export function buildDependencyGraph(tasks: DispatchTask[]): DependencyGraph {
   const states = new Map<string, DispatchTaskState>();
@@ -17,9 +13,7 @@ export function buildDependencyGraph(tasks: DispatchTask[]): DependencyGraph {
 
     const agent = BuiltinAgentRegistry.get(task.agentType);
     if (!agent) {
-      throw new Error(
-        `Unknown agent type in dispatch task "${task.id}": ${task.agentType}`,
-      );
+      throw new Error(`Unknown agent type in dispatch task "${task.id}": ${task.agentType}`);
     }
 
     states.set(task.id, {
@@ -44,9 +38,7 @@ export function buildDependencyGraph(tasks: DispatchTask[]): DependencyGraph {
   for (const task of tasks) {
     for (const dependencyId of task.dependencies) {
       if (!states.has(dependencyId)) {
-        throw new Error(
-          `Task "${task.id}" depends on unknown task "${dependencyId}"`,
-        );
+        throw new Error(`Task "${task.id}" depends on unknown task "${dependencyId}"`);
       }
 
       const dependencyDependents = dependents.get(dependencyId);

--- a/packages/openomni/src/legacy/ingress/engine.ts
+++ b/packages/openomni/src/legacy/ingress/engine.ts
@@ -4,10 +4,7 @@ import { RunWorker } from "../worker";
 import { SessionResolver } from "./session-resolver";
 import { TaskManager } from "../task";
 import type { Session } from "@openomni/session";
-import type {
-  NotificationRequest,
-  NotificationResult,
-} from "@openomni/protocol";
+import type { NotificationRequest, NotificationResult } from "@openomni/protocol";
 import { DefaultRunExecutor, type RunExecutor } from "./run-executor";
 
 // ============================================================
@@ -211,14 +208,11 @@ export const DefaultRunPlanner: RunPlanner = {
     }
 
     const isCompletion =
-      envelope.name === "subagent.completed" ||
-      envelope.name === "subagent.failed";
+      envelope.name === "subagent.completed" || envelope.name === "subagent.failed";
 
     if (isCompletion) {
       if (!envelope.meta?.taskId) {
-        console.warn(
-          `[IngressEngine] Completion event without taskId dropped: ${envelope.name}`,
-        );
+        console.warn(`[IngressEngine] Completion event without taskId dropped: ${envelope.name}`);
         return [];
       }
 
@@ -260,9 +254,7 @@ export const DefaultRunPlanner: RunPlanner = {
 
     // D6: Block trigger_task from task execution context
     if (envelope.meta?.executionContext === "task") {
-      console.warn(
-        `[D6] trigger_task blocked: executionContext=task, event=${envelope.name}`,
-      );
+      console.warn(`[D6] trigger_task blocked: executionContext=task, event=${envelope.name}`);
       return [];
     }
 
@@ -283,8 +275,7 @@ export const DefaultRunPlanner: RunPlanner = {
           triggerSignal: {
             triggerId: (envelope.meta.triggerId as string) ?? envelope.eventId,
             type:
-              (envelope.meta
-                .triggerType as RunRequest["triggerSignal"] extends {
+              (envelope.meta.triggerType as RunRequest["triggerSignal"] extends {
                 type: infer T;
               }
                 ? T
@@ -368,9 +359,7 @@ export namespace IngressEngine {
   }
 
   function toEventEnvelope(event: InboundEvent): EventEnvelope {
-    const sourceId = [event.surface, event.workspace, event.channel]
-      .filter(Boolean)
-      .join(":");
+    const sourceId = [event.surface, event.workspace, event.channel].filter(Boolean).join(":");
 
     return Envelope.normalize({
       id: event.id,

--- a/packages/openomni/src/legacy/ingress/run-executor.ts
+++ b/packages/openomni/src/legacy/ingress/run-executor.ts
@@ -89,10 +89,7 @@ export class DefaultRunExecutor implements RunExecutor {
           };
         }
 
-        const triggerResult = await TaskManager.trigger(
-          request.taskId,
-          request.triggerSignal,
-        );
+        const triggerResult = await TaskManager.trigger(request.taskId, request.triggerSignal);
 
         if ("error" in triggerResult) {
           return {
@@ -278,9 +275,7 @@ export class DefaultRunExecutor implements RunExecutor {
           },
         };
 
-        const result = await notificationAdapter.notify(
-          request.notificationRequest,
-        );
+        const result = await notificationAdapter.notify(request.notificationRequest);
 
         return {
           success: result.delivered,

--- a/packages/openomni/src/legacy/task/lifecycle/state-machine.ts
+++ b/packages/openomni/src/legacy/task/lifecycle/state-machine.ts
@@ -82,20 +82,12 @@ export class TaskStateMachine {
    * @param lastRun - Last completed run (if any)
    * @returns Derived task status
    */
-  static deriveStatus(
-    task: Task.Info,
-    pendingRun?: Task.Run,
-    lastRun?: Task.Run,
-  ): Task.Status {
+  static deriveStatus(task: Task.Info, pendingRun?: Task.Run, lastRun?: Task.Run): Task.Status {
     // If there's a pending/active run, use its status
     if (pendingRun) {
       const runStatus = pendingRun.status;
       // Map Task.Run status to Task status
-      if (
-        runStatus === "scheduled" ||
-        runStatus === "running" ||
-        runStatus === "blocked"
-      ) {
+      if (runStatus === "scheduled" || runStatus === "running" || runStatus === "blocked") {
         return runStatus;
       }
     }
@@ -103,11 +95,7 @@ export class TaskStateMachine {
     // If last run is in terminal state
     if (lastRun) {
       const runStatus = lastRun.status;
-      if (
-        runStatus === "done" ||
-        runStatus === "failed" ||
-        runStatus === "cancelled"
-      ) {
+      if (runStatus === "done" || runStatus === "failed" || runStatus === "cancelled") {
         // Auto-reset to idle for recurring tasks
         if (this.shouldAutoReset(task)) {
           return "idle";
@@ -134,9 +122,7 @@ export class TaskStateMachine {
 
     // Validate transition
     if (!this.validateTransition(currentStatus, newStatus)) {
-      throw new Error(
-        `Invalid state transition: ${currentStatus} -> ${newStatus}`,
-      );
+      throw new Error(`Invalid state transition: ${currentStatus} -> ${newStatus}`);
     }
 
     // Apply transition
@@ -190,16 +176,8 @@ export class TaskStatusManager {
    * @param lastRun - Last completed run
    * @returns Updated task with derived status
    */
-  static updateFromRun(
-    task: Task.Info,
-    pendingRun?: Task.Run,
-    lastRun?: Task.Run,
-  ): Task.Info {
-    const derivedStatus = TaskStateMachine.deriveStatus(
-      task,
-      pendingRun,
-      lastRun,
-    );
+  static updateFromRun(task: Task.Info, pendingRun?: Task.Run, lastRun?: Task.Run): Task.Info {
+    const derivedStatus = TaskStateMachine.deriveStatus(task, pendingRun, lastRun);
 
     return {
       ...task,

--- a/packages/openomni/src/legacy/task/manager.ts
+++ b/packages/openomni/src/legacy/task/manager.ts
@@ -37,10 +37,7 @@ function isActiveRunStatus(status: Task.Run["status"]): boolean {
   return status === "scheduled" || status === "running" || status === "blocked";
 }
 
-function upsertRunHistory(
-  history: Task.Run[] | undefined,
-  run: Task.Run,
-): Task.Run[] {
+function upsertRunHistory(history: Task.Run[] | undefined, run: Task.Run): Task.Run[] {
   if (!history || history.length === 0) {
     return [run];
   }
@@ -109,10 +106,7 @@ export namespace TaskManager {
     return task;
   }
 
-  export function update(
-    id: string,
-    input: Task.UpdateInput,
-  ): Task.Info | undefined {
+  export function update(id: string, input: Task.UpdateInput): Task.Info | undefined {
     const validated = Task.UpdateInput.parse(input);
 
     const store = TaskStorage.getAdapter();
@@ -193,9 +187,7 @@ export namespace TaskManager {
 
     if (filter?.hasTriggersOfType) {
       const triggerType = filter.hasTriggersOfType;
-      tasks = tasks.filter((task) =>
-        task.triggers.some((trigger) => trigger.type === triggerType),
-      );
+      tasks = tasks.filter((task) => task.triggers.some((trigger) => trigger.type === triggerType));
     }
 
     return tasks;
@@ -286,9 +278,7 @@ export namespace TaskManager {
     }
 
     if (
-      (newStatus === "done" ||
-        newStatus === "failed" ||
-        newStatus === "cancelled") &&
+      (newStatus === "done" || newStatus === "failed" || newStatus === "cancelled") &&
       !run.endedAt
     ) {
       updatedRun.endedAt = now;
@@ -305,15 +295,9 @@ export namespace TaskManager {
             : undefined
           : task.pendingRun;
 
-      const lastRun = isActiveRunStatus(updatedRun.status)
-        ? task.lastRun
-        : updatedRun;
+      const lastRun = isActiveRunStatus(updatedRun.status) ? task.lastRun : updatedRun;
 
-      const statusUpdated = TaskStatusManager.updateFromRun(
-        task,
-        pendingRun,
-        lastRun,
-      );
+      const statusUpdated = TaskStatusManager.updateFromRun(task, pendingRun, lastRun);
 
       const updatedTask: Task.Info = {
         ...statusUpdated,
@@ -353,11 +337,7 @@ export namespace TaskManager {
     }
 
     // Can only cancel if in cancellable state
-    const cancellableStatuses: Task.Run["status"][] = [
-      "scheduled",
-      "running",
-      "blocked",
-    ];
+    const cancellableStatuses: Task.Run["status"][] = ["scheduled", "running", "blocked"];
     if (!cancellableStatuses.includes(run.status)) {
       return false;
     }
@@ -415,10 +395,7 @@ export namespace TaskManager {
   /**
    * List blocked runs awaiting approval (for crash recovery)
    */
-  export function listBlockedRuns(filter?: {
-    taskId?: string;
-    userId?: string;
-  }): Task.Run[] {
+  export function listBlockedRuns(filter?: { taskId?: string; userId?: string }): Task.Run[] {
     const store = TaskStorage.getAdapter();
     let blockedRuns = store.run.listByStatus(["blocked"]);
 
@@ -427,9 +404,7 @@ export namespace TaskManager {
     }
 
     if (filter?.userId) {
-      blockedRuns = blockedRuns.filter(
-        (r) => r.context?.userId === filter.userId,
-      );
+      blockedRuns = blockedRuns.filter((r) => r.context?.userId === filter.userId);
     }
 
     return blockedRuns;

--- a/packages/openomni/src/legacy/task/storage/file-task-storage.ts
+++ b/packages/openomni/src/legacy/task/storage/file-task-storage.ts
@@ -43,9 +43,7 @@ export class FileTaskStore implements TaskStore {
       if (!filter) return tasks;
 
       if (filter.status) {
-        const statuses = Array.isArray(filter.status)
-          ? filter.status
-          : [filter.status];
+        const statuses = Array.isArray(filter.status) ? filter.status : [filter.status];
         tasks = tasks.filter((t) => statuses.includes(t.status));
       }
 
@@ -54,15 +52,11 @@ export class FileTaskStore implements TaskStore {
       }
 
       if (filter.assignedAgentId) {
-        tasks = tasks.filter(
-          (t) => t.assignedAgentId === filter.assignedAgentId,
-        );
+        tasks = tasks.filter((t) => t.assignedAgentId === filter.assignedAgentId);
       }
 
       if (filter.tags && filter.tags.length > 0) {
-        tasks = tasks.filter((t) =>
-          filter.tags!.every((tag) => t.tags?.includes(tag)),
-        );
+        tasks = tasks.filter((t) => filter.tags!.every((tag) => t.tags?.includes(tag)));
       }
 
       return tasks;
@@ -203,10 +197,7 @@ export class FileTaskStore implements TaskStore {
     const path = join(this.dir, "statusIndex.json");
     if (!existsSync(path)) return;
     try {
-      const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<
-        string,
-        string[]
-      >;
+      const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, string[]>;
       this.statusIndex = new Map();
       for (const [status, ids] of Object.entries(raw)) {
         this.statusIndex.set(status as Task.Run["status"], new Set(ids));
@@ -258,10 +249,7 @@ export class FileTaskStore implements TaskStore {
   }
 
   private flushMap<V>(filename: string, map: Map<string, V>): void {
-    this.atomicWrite(
-      filename,
-      JSON.stringify(Object.fromEntries(map), null, 2),
-    );
+    this.atomicWrite(filename, JSON.stringify(Object.fromEntries(map), null, 2));
   }
 
   private flushTasks(): void {

--- a/packages/openomni/src/legacy/task/storage/storage.ts
+++ b/packages/openomni/src/legacy/task/storage/storage.ts
@@ -62,9 +62,7 @@ export class InMemoryTaskStore implements TaskStore {
       if (!filter) return tasks;
 
       if (filter.status) {
-        const statuses = Array.isArray(filter.status)
-          ? filter.status
-          : [filter.status];
+        const statuses = Array.isArray(filter.status) ? filter.status : [filter.status];
         tasks = tasks.filter((t) => statuses.includes(t.status));
       }
 
@@ -73,15 +71,11 @@ export class InMemoryTaskStore implements TaskStore {
       }
 
       if (filter.assignedAgentId) {
-        tasks = tasks.filter(
-          (t) => t.assignedAgentId === filter.assignedAgentId,
-        );
+        tasks = tasks.filter((t) => t.assignedAgentId === filter.assignedAgentId);
       }
 
       if (filter.tags && filter.tags.length > 0) {
-        tasks = tasks.filter((t) =>
-          filter.tags!.every((tag) => t.tags?.includes(tag)),
-        );
+        tasks = tasks.filter((t) => filter.tags!.every((tag) => t.tags?.includes(tag)));
       }
 
       return tasks;

--- a/packages/openomni/src/legacy/task/trigger-engine.ts
+++ b/packages/openomni/src/legacy/task/trigger-engine.ts
@@ -93,10 +93,7 @@ function stableStringify(obj: unknown): string {
   );
 }
 
-function generateIdempotencyKey(
-  taskId: string,
-  signal: Task.TriggerSignal,
-): string {
+function generateIdempotencyKey(taskId: string, signal: Task.TriggerSignal): string {
   const { triggerId, type, payload, occurredAt } = signal;
 
   switch (type) {
@@ -112,10 +109,7 @@ function generateIdempotencyKey(
       return `${taskId}:${triggerId}:${occurredAt}`;
     case "event": {
       const naturalKey = payload
-        ? createHash("sha256")
-            .update(stableStringify(payload))
-            .digest("hex")
-            .slice(0, 16)
+        ? createHash("sha256").update(stableStringify(payload)).digest("hex").slice(0, 16)
         : "no-payload";
       return `${taskId}:${triggerId}:${naturalKey}`;
     }
@@ -151,9 +145,7 @@ function checkConcurrency(
   const mode = concurrency?.mode ?? "drop";
 
   const runs = store.run.list(taskId);
-  const activeRuns = runs.filter(
-    (r) => r.status === "running" || r.status === "blocked",
-  );
+  const activeRuns = runs.filter((r) => r.status === "running" || r.status === "blocked");
   const scheduledRuns = runs.filter((r) => r.status === "scheduled");
 
   if (activeRuns.length >= maxRunning) {
@@ -184,10 +176,7 @@ export async function triggerTask(
       return { error: "not_found" };
     }
 
-    if (
-      signal.context?.originTaskId &&
-      signal.context.originTaskId === taskId
-    ) {
+    if (signal.context?.originTaskId && signal.context.originTaskId === taskId) {
       console.warn(
         `[anti-loop] self-retrigger blocked in TaskManager.trigger: originTaskId=${signal.context.originTaskId}, taskId=${taskId}`,
       );
@@ -203,22 +192,12 @@ export async function triggerTask(
 
     const idempotencyKey = generateIdempotencyKey(taskId, signal);
 
-    const deduped = checkDedupe(
-      store,
-      idempotencyKey,
-      policy.dedupe?.windowMs,
-      now,
-    );
+    const deduped = checkDedupe(store, idempotencyKey, policy.dedupe?.windowMs, now);
     if (deduped) {
       return { error: "deduped" };
     }
 
-    const concurrencyResult = checkConcurrency(
-      store,
-      taskId,
-      task,
-      policy.concurrency,
-    );
+    const concurrencyResult = checkConcurrency(store, taskId, task, policy.concurrency);
     if (!concurrencyResult.allowed) {
       return { error: "concurrency_blocked" };
     }
@@ -232,8 +211,7 @@ export async function triggerTask(
 
     const runId = randomUUID();
     const sessionKey = `task:${taskId}:run:${runId}`;
-    const status: Task.Run["status"] =
-      permission === "ask" ? "blocked" : "scheduled";
+    const status: Task.Run["status"] = permission === "ask" ? "blocked" : "scheduled";
 
     const taskRun: Task.Run = {
       runId,
@@ -255,11 +233,7 @@ export async function triggerTask(
 
     store.run.set(taskId, taskRun);
 
-    const statusUpdated = TaskStatusManager.updateFromRun(
-      task,
-      taskRun,
-      task.lastRun,
-    );
+    const statusUpdated = TaskStatusManager.updateFromRun(task, taskRun, task.lastRun);
     const updatedTask: Task.Info = {
       ...statusUpdated,
       updatedAt: now,

--- a/packages/openomni/src/legacy/task/types.ts
+++ b/packages/openomni/src/legacy/task/types.ts
@@ -103,18 +103,7 @@ export namespace Task {
 
   export const TriggerFilterCondition = z.object({
     path: z.string(),
-    op: z.enum([
-      "eq",
-      "neq",
-      "in",
-      "nin",
-      "exists",
-      "regex",
-      "gt",
-      "gte",
-      "lt",
-      "lte",
-    ]),
+    op: z.enum(["eq", "neq", "in", "nin", "exists", "regex", "gt", "gte", "lt", "lte"]),
     value: z.unknown().optional(),
   });
   export type TriggerFilterCondition = z.infer<typeof TriggerFilterCondition>;
@@ -207,14 +196,7 @@ export namespace Task {
     runId: z.string(),
     taskId: z.string(),
     sessionKey: z.string(), // SessionKey pattern: task:${string}:run:${string}
-    status: z.enum([
-      "scheduled",
-      "running",
-      "blocked",
-      "done",
-      "failed",
-      "cancelled",
-    ]),
+    status: z.enum(["scheduled", "running", "blocked", "done", "failed", "cancelled"]),
     trigger: z.object({
       id: z.string(),
       type: z.enum(["cron", "interval", "once", "event", "manual"]),

--- a/packages/openomni/src/legacy/tools/dispatch.ts
+++ b/packages/openomni/src/legacy/tools/dispatch.ts
@@ -19,14 +19,8 @@ export const DispatchInput = z.object({
         id: z.string().describe("Unique task identifier"),
         description: z.string().describe("Task description"),
         agentType: z.string().describe("Agent type to execute task"),
-        dependencies: z
-          .array(z.string())
-          .default([])
-          .describe("Task IDs this task depends on"),
-        fileScope: z
-          .array(z.string())
-          .default([])
-          .describe("Files this task operates on"),
+        dependencies: z.array(z.string()).default([]).describe("Task IDs this task depends on"),
+        fileScope: z.array(z.string()).default([]).describe("Files this task operates on"),
       }),
     )
     .describe("Array of tasks to dispatch"),
@@ -55,8 +49,7 @@ export namespace Dispatch {
       return {
         id: crypto.randomUUID(),
         toolCallId,
-        output:
-          "Nested delegation not allowed: dispatch child cannot call subagent/dispatch",
+        output: "Nested delegation not allowed: dispatch child cannot call subagent/dispatch",
         isError: true,
       };
     }
@@ -65,10 +58,7 @@ export namespace Dispatch {
       const output = await executeDispatch(input, context);
 
       for (const result of output.results) {
-        const eventName =
-          result.status === "completed"
-            ? "subagent.completed"
-            : "subagent.failed";
+        const eventName = result.status === "completed" ? "subagent.completed" : "subagent.failed";
 
         IngressEngine.ingest({
           id: crypto.randomUUID(),

--- a/packages/openomni/src/legacy/tools/schedule.ts
+++ b/packages/openomni/src/legacy/tools/schedule.ts
@@ -7,21 +7,12 @@ import { randomUUID } from "crypto";
 export const ScheduleInput = z.object({
   description: z.string().describe("Task description"),
   dueAt: z.string().datetime().describe("ISO 8601 datetime for execution"),
-  estimatedRuntimeMs: z
-    .number()
-    .positive()
-    .describe("Estimated runtime in milliseconds"),
+  estimatedRuntimeMs: z.number().positive().describe("Estimated runtime in milliseconds"),
   recurring: z
     .object({
       type: z.enum(["cron", "interval", "once"]).describe("Recurrence type"),
-      expression: z
-        .string()
-        .optional()
-        .describe("Cron expression (for cron type)"),
-      intervalMs: z
-        .number()
-        .optional()
-        .describe("Interval in milliseconds (for interval type)"),
+      expression: z.string().optional().describe("Cron expression (for cron type)"),
+      intervalMs: z.number().optional().describe("Interval in milliseconds (for interval type)"),
     })
     .optional()
     .describe("Recurrence configuration (optional)"),
@@ -74,8 +65,7 @@ export namespace ScheduleTool {
         toolCallId: "",
         output: JSON.stringify({
           error: "task_from_task_prohibited",
-          message:
-            "Cannot schedule a task from within a task execution context",
+          message: "Cannot schedule a task from within a task execution context",
         }),
         isError: true,
       };
@@ -97,8 +87,7 @@ export namespace ScheduleTool {
       }
 
       // Calculate plannedStartAt = dueAt - estimatedRuntimeMs - safetyBufferMs
-      let plannedStartAtMs =
-        dueAtMs - validated.estimatedRuntimeMs - SAFETY_BUFFER_MS;
+      let plannedStartAtMs = dueAtMs - validated.estimatedRuntimeMs - SAFETY_BUFFER_MS;
 
       // Handle late-start: if plannedStartAt is in the past, execute immediately
       const now = Date.now();

--- a/packages/openomni/src/legacy/tools/subagent.ts
+++ b/packages/openomni/src/legacy/tools/subagent.ts
@@ -1,16 +1,8 @@
 import { z } from "zod";
 import { Session } from "@openomni/session";
 import type { Tool } from "@openomni/protocol";
-import {
-  BuiltinAgentRegistry,
-  AgentMessenger,
-  type MessageEnvelope,
-} from "../agent";
-import type {
-  OrchestratorConfig,
-  OrchestratorRunInput,
-  SessionMode,
-} from "../worker";
+import { BuiltinAgentRegistry, AgentMessenger, type MessageEnvelope } from "../agent";
+import type { OrchestratorConfig, OrchestratorRunInput, SessionMode } from "../worker";
 import { RunWorker } from "../worker";
 import { TaskManager } from "../task";
 import { IngressEngine } from "../ingress";
@@ -18,10 +10,7 @@ import { IngressEngine } from "../ingress";
 export const SubagentInput = z.object({
   agentType: z.string().describe("Agent type: 'explore', 'implement', etc."),
   prompt: z.string().describe("Instruction for the subagent"),
-  sessionId: z
-    .string()
-    .optional()
-    .describe("Resume existing session (optional)"),
+  sessionId: z.string().optional().describe("Resume existing session (optional)"),
 });
 export type SubagentInput = z.infer<typeof SubagentInput>;
 
@@ -69,8 +58,7 @@ export namespace Subagent {
       return {
         id: crypto.randomUUID(),
         toolCallId,
-        output:
-          "Nested delegation not allowed: subagent cannot call subagent/dispatch",
+        output: "Nested delegation not allowed: subagent cannot call subagent/dispatch",
         isError: true,
       };
     }
@@ -192,11 +180,7 @@ export namespace Subagent {
     };
 
     try {
-      const result = await executeWithAbort(
-        config,
-        orchestratorInput,
-        context.abortSignal,
-      );
+      const result = await executeWithAbort(config, orchestratorInput, context.abortSignal);
 
       announceCompletion(context, input, config, result);
 
@@ -239,10 +223,7 @@ export namespace Subagent {
         },
         occurredAt: new Date().toISOString(),
       }).catch((error) => {
-        console.error(
-          `[Subagent] Failed to emit failure event for task ${childTask.id}:`,
-          error,
-        );
+        console.error(`[Subagent] Failed to emit failure event for task ${childTask.id}:`, error);
       });
 
       return {

--- a/packages/openomni/src/legacy/trigger/scheduler.ts
+++ b/packages/openomni/src/legacy/trigger/scheduler.ts
@@ -261,20 +261,13 @@ export namespace Scheduler {
     try {
       await IngressEngine.ingest(inboundEvent);
     } catch (error) {
-      console.error(
-        `[Scheduler] Error firing trigger ${trigger.id} for task ${taskId}:`,
-        error,
-      );
+      console.error(`[Scheduler] Error firing trigger ${trigger.id} for task ${taskId}:`, error);
     }
   }
 
   export function register(task: Task.Info): void {
     for (const trigger of task.triggers) {
-      if (
-        trigger.type === "cron" ||
-        trigger.type === "interval" ||
-        trigger.type === "once"
-      ) {
+      if (trigger.type === "cron" || trigger.type === "interval" || trigger.type === "once") {
         registerTrigger(task.id, trigger);
       }
     }
@@ -337,9 +330,7 @@ export namespace Scheduler {
         if (!fields) {
           const parsed = CronParser.parse(trigger.expr);
           if (!parsed) {
-            console.error(
-              `[Scheduler] Invalid cron expression: ${trigger.expr}`,
-            );
+            console.error(`[Scheduler] Invalid cron expression: ${trigger.expr}`);
             return false;
           }
           fields = parsed;
@@ -353,10 +344,7 @@ export namespace Scheduler {
           const currentFields = cronFieldsCache.get(trigger.expr);
           if (!currentFields) return;
 
-          const nextTime = CronParser.getNextFireTime(
-            currentFields,
-            new Date(),
-          );
+          const nextTime = CronParser.getNextFireTime(currentFields, new Date());
           const nextDelay = nextTime.getTime() - Date.now();
 
           const entry = registry.get(key);
@@ -399,10 +387,7 @@ export namespace Scheduler {
     }
   }
 
-  export function unregisterTrigger(
-    taskId: string,
-    triggerId: string,
-  ): boolean {
+  export function unregisterTrigger(taskId: string, triggerId: string): boolean {
     const key = makeKey(taskId, triggerId);
     const entry = registry.get(key);
 
@@ -416,10 +401,7 @@ export namespace Scheduler {
     return true;
   }
 
-  export function getNextFireTime(
-    taskId: string,
-    triggerId: string,
-  ): number | undefined {
+  export function getNextFireTime(taskId: string, triggerId: string): number | undefined {
     const key = makeKey(taskId, triggerId);
     return registry.get(key)?.nextFireTime;
   }

--- a/packages/openomni/src/legacy/trigger/watcher.ts
+++ b/packages/openomni/src/legacy/trigger/watcher.ts
@@ -116,11 +116,8 @@ class FilesystemWatcher implements Watcher {
   private matchesPatterns(path: string): boolean {
     const { includePatterns, excludePatterns } = this.config;
     const matchesInclude =
-      includePatterns.length === 0 ||
-      includePatterns.some((pattern) => path.includes(pattern));
-    const matchesExclude = excludePatterns.some((pattern) =>
-      path.includes(pattern),
-    );
+      includePatterns.length === 0 || includePatterns.some((pattern) => path.includes(pattern));
+    const matchesExclude = excludePatterns.some((pattern) => path.includes(pattern));
 
     return matchesInclude && !matchesExclude;
   }

--- a/packages/openomni/src/legacy/worker/agent-resolution.ts
+++ b/packages/openomni/src/legacy/worker/agent-resolution.ts
@@ -1,10 +1,5 @@
 import type { Run, Sink, Tool } from "@openomni/protocol";
-import {
-  ModelsDev,
-  Provider,
-  run as llmRun,
-  type RunInput,
-} from "@openomni/llm";
+import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
 import { BuiltinAgentRegistry, type AgentDefinition } from "../agent";
 import type { ToolExecutor, OrchestratorRunInput } from "./run";
 
@@ -24,9 +19,7 @@ const fallbackToolExecutor: ToolExecutor = {
   },
 };
 
-export function resolveAgentDefinition(
-  agentId?: string,
-): AgentDefinition | undefined {
+export function resolveAgentDefinition(agentId?: string): AgentDefinition | undefined {
   if (!agentId) return undefined;
   return BuiltinAgentRegistry.get(agentId);
 }
@@ -67,9 +60,7 @@ async function resolveProviderModel(config: {
 
   const rawModel = providerData.models?.[config.modelID];
   if (!rawModel) {
-    throw new Error(
-      `Model not found: ${config.modelID} for provider ${config.providerID}`,
-    );
+    throw new Error(`Model not found: ${config.modelID} for provider ${config.providerID}`);
   }
 
   return Provider.fromModelsDevModel(providerData, rawModel as ModelsDev.Model);
@@ -77,14 +68,9 @@ async function resolveProviderModel(config: {
 
 // Bridges Provider.Model → OrchestratorRunInput["llm"] by wrapping
 // the llm package's run() function with the resolved model.
-function createLLMRunner(
-  providerModel: Provider.Model,
-): OrchestratorRunInput["llm"] {
+function createLLMRunner(providerModel: Provider.Model): OrchestratorRunInput["llm"] {
   return {
-    async run(
-      input: Record<string, unknown>,
-      sink: Sink,
-    ): Promise<Run.Outcome> {
+    async run(input: Record<string, unknown>, sink: Sink): Promise<Run.Outcome> {
       const runInput: RunInput = {
         messages: (input.messages ?? []) as RunInput["messages"],
         tools: (input.tools ?? []) as RunInput["tools"],

--- a/packages/openomni/src/legacy/worker/policy.ts
+++ b/packages/openomni/src/legacy/worker/policy.ts
@@ -58,10 +58,7 @@ export namespace ConcurrencyGate {
    * @param taskId - The ID of the task
    * @param decision - The decision made: 'allow', 'queue', or 'drop'
    */
-  export function record(
-    _taskId: string,
-    decision: "allow" | "queue" | "drop",
-  ): void {
+  export function record(_taskId: string, decision: "allow" | "queue" | "drop"): void {
     if (decision === "allow") {
       stats.allowed++;
     } else if (decision === "queue") {
@@ -169,10 +166,7 @@ export namespace RunSupervisor {
    * @param budget - Budget limits to check against
    * @returns 'ok' if within budget, 'exceeded' if any limit is breached
    */
-  export function checkBudget(
-    state: RunState,
-    budget: RunBudget,
-  ): BudgetStatus {
+  export function checkBudget(state: RunState, budget: RunBudget): BudgetStatus {
     const elapsed = Date.now() - state.startTime;
 
     if (elapsed >= budget.maxWallTimeMs) {
@@ -212,10 +206,7 @@ export namespace RunSupervisor {
    * @param durationMs - Duration of the tool call in milliseconds
    * @returns New state with incremented tool call count and runtime
    */
-  export function recordToolCall(
-    state: RunState,
-    durationMs: number,
-  ): RunState {
+  export function recordToolCall(state: RunState, durationMs: number): RunState {
     return {
       ...state,
       toolCalls: state.toolCalls + 1,

--- a/packages/openomni/src/legacy/worker/run/run-worker-sink.ts
+++ b/packages/openomni/src/legacy/worker/run/run-worker-sink.ts
@@ -9,9 +9,7 @@ interface ToolPartRef {
   startedAt: number;
 }
 
-function createSyntheticAssistantMessage(
-  sessionID: string,
-): Message.AssistantMessage {
+function createSyntheticAssistantMessage(sessionID: string): Message.AssistantMessage {
   const now = Date.now();
   return {
     id: crypto.randomUUID(),
@@ -42,10 +40,7 @@ function createSyntheticAssistantMessage(
   };
 }
 
-function serializeSnapshot(snapshot: {
-  id: string;
-  timestamp: number;
-}): string {
+function serializeSnapshot(snapshot: { id: string; timestamp: number }): string {
   return `${snapshot.id}:${snapshot.timestamp}`;
 }
 

--- a/packages/openomni/src/legacy/worker/run/run-worker.ts
+++ b/packages/openomni/src/legacy/worker/run/run-worker.ts
@@ -51,11 +51,7 @@ export interface OrchestratorRunInput {
   };
 }
 
-type RetryReason =
-  | "timeout"
-  | "tool_error"
-  | "transient_error"
-  | "validation_error";
+type RetryReason = "timeout" | "tool_error" | "transient_error" | "validation_error";
 
 const DEFAULT_PERMISSION: PermissionLevel = "notify";
 
@@ -133,8 +129,7 @@ function resolveBudget(task: Task.Info) {
 
 function calculateBackoffMs(policy: Run.RetryPolicy, attempt: number): number {
   const rawDelay =
-    policy.backoffMs.initial *
-    Math.pow(policy.backoffMs.multiplier, Math.max(0, attempt - 1));
+    policy.backoffMs.initial * Math.pow(policy.backoffMs.multiplier, Math.max(0, attempt - 1));
   return Math.min(rawDelay, policy.backoffMs.max);
 }
 
@@ -160,11 +155,7 @@ function classifyRetryReason(errorMessage: string): RetryReason {
   return "transient_error";
 }
 
-function shouldRetry(
-  policy: Run.RetryPolicy,
-  reason: RetryReason,
-  attempt: number,
-): boolean {
+function shouldRetry(policy: Run.RetryPolicy, reason: RetryReason, attempt: number): boolean {
   if (attempt >= policy.maxAttempts) {
     return false;
   }
@@ -182,11 +173,7 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function createEphemeralSession(
-  taskId: string,
-  runId: string,
-  sessionKey: string,
-): Session.Info {
+function createEphemeralSession(taskId: string, runId: string, sessionKey: string): Session.Info {
   const existing = Session.get(sessionKey);
   if (existing) {
     Session.remove(sessionKey);
@@ -302,11 +289,7 @@ export namespace RunWorker {
     AuditLog.logPermission(config.runId, permission);
 
     if (permission.level === "deny") {
-      TaskManager.setRunStatus(
-        config.runId,
-        "failed",
-        permission.reason ?? "Permission denied",
-      );
+      TaskManager.setRunStatus(config.runId, "failed", permission.reason ?? "Permission denied");
 
       return {
         success: false,
@@ -344,19 +327,12 @@ export namespace RunWorker {
       }
       session = existing;
     } else {
-      session = createEphemeralSession(
-        config.taskId,
-        config.runId,
-        taskRun.sessionKey,
-      );
+      session = createEphemeralSession(config.taskId, config.runId, taskRun.sessionKey);
     }
 
     const sink = createSessionSink(session.id);
 
-    const retryPolicy = resolveRetryPolicy(
-      task.policy.retry,
-      config.maxRetries,
-    );
+    const retryPolicy = resolveRetryPolicy(task.policy.retry, config.maxRetries);
     const runBudget = resolveBudget(task);
     const toolExecutor = input.toolExecutor ?? fallbackToolExecutor;
 
@@ -461,10 +437,7 @@ export namespace RunWorker {
             for (const result of toolResults) {
               sink.onToolResult(result);
               accumulatedToolResults = [...accumulatedToolResults, result];
-              runState = RunSupervisor.recordToolCall(
-                runState,
-                perToolRuntimeMs,
-              );
+              runState = RunSupervisor.recordToolCall(runState, perToolRuntimeMs);
             }
 
             currentInput = {
@@ -477,11 +450,7 @@ export namespace RunWorker {
           const retryReason = classifyRetryReason(lastError);
 
           if (shouldRetry(retryPolicy, retryReason, attempt)) {
-            TaskManager.setRunStatus(
-              config.runId,
-              "scheduled",
-              `retrying:${retryReason}`,
-            );
+            TaskManager.setRunStatus(config.runId, "scheduled", `retrying:${retryReason}`);
 
             const backoffMs = calculateBackoffMs(retryPolicy, attempt);
             await sleep(backoffMs);

--- a/packages/openomni/src/legacy/worker/run/summary.ts
+++ b/packages/openomni/src/legacy/worker/run/summary.ts
@@ -16,10 +16,7 @@ export interface SummaryData {
 }
 
 export namespace SummaryDelivery {
-  export function extract(
-    sessionId: string,
-    _template: SummaryTemplate,
-  ): SummaryData {
+  export function extract(sessionId: string, _template: SummaryTemplate): SummaryData {
     const messages = Session.getMessages(sessionId);
 
     let result = "";
@@ -29,9 +26,7 @@ export namespace SummaryDelivery {
         const parts = Session.getParts(msg.id);
         const textParts = parts.filter((p) => p.type === "text");
         if (textParts.length > 0) {
-          result = textParts
-            .map((p) => (p as Message.TextPart).text)
-            .join("\n");
+          result = textParts.map((p) => (p as Message.TextPart).text).join("\n");
         }
         break;
       }

--- a/packages/openomni/src/legacy/worker/telemetry.ts
+++ b/packages/openomni/src/legacy/worker/telemetry.ts
@@ -85,10 +85,7 @@ export namespace Observability {
    * @param metadata - Correlation IDs and timing information
    * @returns Enriched event with metadata
    */
-  export function enrichEvent(
-    event: unknown,
-    metadata: EventMetadata,
-  ): unknown {
+  export function enrichEvent(event: unknown, metadata: EventMetadata): unknown {
     if (typeof event !== "object" || event === null) {
       return {
         data: event,
@@ -136,11 +133,7 @@ export namespace Observability {
    * @param event - The lifecycle event name
    * @param metrics - Run metrics to include
    */
-  export function emitRunEvent(
-    runId: string,
-    event: string,
-    metrics: RunMetrics,
-  ): void {
+  export function emitRunEvent(runId: string, event: string, metrics: RunMetrics): void {
     // Store metrics for later retrieval
     metricsStore.runs.set(runId, { ...metrics });
 

--- a/packages/openomni/src/plan/plan-agent.ts
+++ b/packages/openomni/src/plan/plan-agent.ts
@@ -43,10 +43,7 @@ export namespace PlanAgent {
     budget?: AgentBudget;
   }
 
-  export async function generate(
-    goal: string,
-    config: GenerateConfig,
-  ): Promise<PlanResult> {
+  export async function generate(goal: string, config: GenerateConfig): Promise<PlanResult> {
     const agent = ChatAgent.create({
       model: config.model,
       systemPrompt: config.systemPrompt ?? "",

--- a/packages/openomni/src/plan/plan-pipeline.ts
+++ b/packages/openomni/src/plan/plan-pipeline.ts
@@ -37,10 +37,7 @@ export namespace PlanPipeline {
       const enrichedGoal = previousFeedback
         ? `${goal}\n\n[Previous plan was rejected. Address this feedback:\n${previousFeedback}]`
         : goal;
-      const planResult = await PlanAgent.generate(
-        enrichedGoal,
-        config.generator,
-      );
+      const planResult = await PlanAgent.generate(enrichedGoal, config.generator);
       lastPlan = planResult.plan;
 
       const failedFeedback: string[] = [];
@@ -55,9 +52,7 @@ export namespace PlanPipeline {
 
         gateResults.push({ gateName: gate.name, verdict });
 
-        const hasErrorIssue = verdict.issues.some(
-          (issue) => issue.severity === "error",
-        );
+        const hasErrorIssue = verdict.issues.some((issue) => issue.severity === "error");
         const failed = !verdict.passed || hasErrorIssue;
 
         if (failed && verdict.feedback) {
@@ -82,8 +77,7 @@ export namespace PlanPipeline {
         };
       }
 
-      previousFeedback =
-        failedFeedback.length > 0 ? failedFeedback.join("\n") : undefined;
+      previousFeedback = failedFeedback.length > 0 ? failedFeedback.join("\n") : undefined;
       attempt += 1;
     }
 

--- a/packages/openomni/src/plan/spec-validator.ts
+++ b/packages/openomni/src/plan/spec-validator.ts
@@ -76,8 +76,7 @@ export namespace SpecValidator {
       } catch {
         issues.push({
           code: "circular_dependency",
-          message:
-            "Failed to build DAG — possible circular or invalid dependencies",
+          message: "Failed to build DAG — possible circular or invalid dependencies",
         });
       }
     }

--- a/packages/openomni/src/plan/structural-gate.ts
+++ b/packages/openomni/src/plan/structural-gate.ts
@@ -45,18 +45,12 @@ export const structuralGateCheck: Gate.Check = {
   },
 };
 
-function resolveConfig(
-  config?: StructuralGate.Config,
-): Required<StructuralGate.Config> {
+function resolveConfig(config?: StructuralGate.Config): Required<StructuralGate.Config> {
   return {
-    minDescriptionWords:
-      config?.minDescriptionWords ?? DEFAULT_MIN_DESCRIPTION_WORDS,
-    minExpectedOutputWords:
-      config?.minExpectedOutputWords ?? DEFAULT_MIN_EXPECTED_OUTPUT_WORDS,
-    maxDependencyDepth:
-      config?.maxDependencyDepth ?? DEFAULT_MAX_DEPENDENCY_DEPTH,
-    duplicateThreshold:
-      config?.duplicateThreshold ?? DEFAULT_DUPLICATE_THRESHOLD,
+    minDescriptionWords: config?.minDescriptionWords ?? DEFAULT_MIN_DESCRIPTION_WORDS,
+    minExpectedOutputWords: config?.minExpectedOutputWords ?? DEFAULT_MIN_EXPECTED_OUTPUT_WORDS,
+    maxDependencyDepth: config?.maxDependencyDepth ?? DEFAULT_MAX_DEPENDENCY_DEPTH,
+    duplicateThreshold: config?.duplicateThreshold ?? DEFAULT_DUPLICATE_THRESHOLD,
     requireGuardrail: config?.requireGuardrail ?? DEFAULT_REQUIRE_GUARDRAIL,
   };
 }

--- a/packages/openomni/src/team/review-loop.ts
+++ b/packages/openomni/src/team/review-loop.ts
@@ -55,10 +55,7 @@ export namespace ReviewLoop {
     ].join("\n");
   }
 
-  export async function review(
-    input: ReviewInput,
-    config: ReviewConfig,
-  ): Promise<ReviewOutput> {
+  export async function review(input: ReviewInput, config: ReviewConfig): Promise<ReviewOutput> {
     const agent = ChatAgent.create({
       model: config.model,
       systemPrompt: config.systemPrompt ?? DEFAULT_REVIEW_PROMPT,
@@ -73,9 +70,7 @@ export namespace ReviewLoop {
     try {
       parsed = JSON.parse(result.text);
     } catch {
-      throw new Error(
-        `Failed to parse review response as JSON: ${result.text}`,
-      );
+      throw new Error(`Failed to parse review response as JSON: ${result.text}`);
     }
 
     if (parsed.decision !== "accept" && parsed.decision !== "reject") {
@@ -88,10 +83,7 @@ export namespace ReviewLoop {
     };
   }
 
-  export function shouldHandoff(
-    attemptNumber: number,
-    maxAttempts: number,
-  ): boolean {
+  export function shouldHandoff(attemptNumber: number, maxAttempts: number): boolean {
     return attemptNumber >= maxAttempts - 1;
   }
 

--- a/packages/openomni/src/team/run-ledger.ts
+++ b/packages/openomni/src/team/run-ledger.ts
@@ -27,16 +27,11 @@ function cloneEntry(entry: RunLedgerEntry): RunLedgerEntry {
   return {
     ...entry,
     startedAt: entry.startedAt ? new Date(entry.startedAt.getTime()) : undefined,
-    completedAt: entry.completedAt
-      ? new Date(entry.completedAt.getTime())
-      : undefined,
+    completedAt: entry.completedAt ? new Date(entry.completedAt.getTime()) : undefined,
   };
 }
 
-function getEntryOrThrow(
-  entries: Map<string, RunLedgerEntry>,
-  stepId: string,
-): RunLedgerEntry {
+function getEntryOrThrow(entries: Map<string, RunLedgerEntry>, stepId: string): RunLedgerEntry {
   const entry = entries.get(stepId);
   if (!entry) {
     throw new Error(`Step not found: "${stepId}"`);

--- a/packages/openomni/src/team/team-orchestrator.ts
+++ b/packages/openomni/src/team/team-orchestrator.ts
@@ -41,10 +41,7 @@ export namespace TeamOrchestrator {
     results: Map<string, string>;
   }
 
-  export async function execute(
-    plan: Plan,
-    config: OrchestratorConfig,
-  ): Promise<TeamResult> {
+  export async function execute(plan: Plan, config: OrchestratorConfig): Promise<TeamResult> {
     if (plan.steps.length === 0) {
       return {
         status: "completed",
@@ -58,8 +55,7 @@ export namespace TeamOrchestrator {
     const dag = DAG.build(plan.steps);
     const acyclic = DAG.validateAcyclic(dag);
     if (!acyclic.valid) {
-      const cycleText =
-        acyclic.cycle.length > 0 ? `: ${acyclic.cycle.join(" -> ")}` : "";
+      const cycleText = acyclic.cycle.length > 0 ? `: ${acyclic.cycle.join(" -> ")}` : "";
       throw new Error(`Plan contains cycle${cycleText}`);
     }
 
@@ -138,15 +134,7 @@ export namespace TeamOrchestrator {
                 error: "approval_rejected",
               },
             });
-            skipDependents(
-              stepId,
-              dag,
-              ledger,
-              failed,
-              skipped,
-              completed,
-              pendingRetry,
-            );
+            skipDependents(stepId, dag, ledger, failed, skipped, completed, pendingRetry);
             progressed = true;
             continue;
           }
@@ -235,8 +223,7 @@ export namespace TeamOrchestrator {
           }
 
           ledger.recordRejection(stepId);
-          const attempts =
-            ledger.getStepState(stepId)?.attempts ?? attemptNumber;
+          const attempts = ledger.getStepState(stepId)?.attempts ?? attemptNumber;
 
           if (attempts >= maxAttemptsPerStep) {
             ledger.transition(stepId, "failed");
@@ -253,15 +240,7 @@ export namespace TeamOrchestrator {
                 error: `Max attempts (${maxAttemptsPerStep}) reached`,
               },
             });
-            skipDependents(
-              stepId,
-              dag,
-              ledger,
-              failed,
-              skipped,
-              completed,
-              pendingRetry,
-            );
+            skipDependents(stepId, dag, ledger, failed, skipped, completed, pendingRetry);
             progressed = true;
             continue;
           }
@@ -271,10 +250,7 @@ export namespace TeamOrchestrator {
             handoffDocument = review.feedback;
           }
 
-          if (
-            ReviewLoop.shouldHandoff(attempts, maxAttemptsPerStep) &&
-            review.feedback
-          ) {
+          if (ReviewLoop.shouldHandoff(attempts, maxAttemptsPerStep) && review.feedback) {
             handoffDocument = await ReviewLoop.generateHandoff(
               {
                 step,
@@ -318,25 +294,12 @@ export namespace TeamOrchestrator {
               error: "Execution error",
             },
           });
-          skipDependents(
-            stepId,
-            dag,
-            ledger,
-            failed,
-            skipped,
-            completed,
-            pendingRetry,
-          );
+          skipDependents(stepId, dag, ledger, failed, skipped, completed, pendingRetry);
           progressed = true;
         }
       }
 
-      const stall = StallDetector.check(
-        ledger,
-        dag,
-        stallConfig,
-        noProgressTurns,
-      );
+      const stall = StallDetector.check(ledger, dag, stallConfig, noProgressTurns);
       if (stall.stalled && stall.reason) {
         // Publish stall.detected event (fire-and-forget)
         safePublish(Team.Events.StallDetected, {
@@ -349,13 +312,7 @@ export namespace TeamOrchestrator {
           },
         });
 
-        return buildResult(
-          plan.steps,
-          ledger,
-          results,
-          "stalled",
-          stall.reason,
-        );
+        return buildResult(plan.steps, ledger, results, "stalled", stall.reason);
       }
 
       if (isExecutionFinished(plan.steps, ledger)) {
@@ -397,18 +354,13 @@ function resolveTeammate(
   config: TeamOrchestrator.OrchestratorConfig,
 ): Teammate.TeammateConfig {
   if (step.suggestedAgent && config.teammates.has(step.suggestedAgent)) {
-    return (
-      config.teammates.get(step.suggestedAgent) ?? config.defaultTeammateConfig
-    );
+    return config.teammates.get(step.suggestedAgent) ?? config.defaultTeammateConfig;
   }
 
   return config.defaultTeammateConfig;
 }
 
-function buildContext(
-  step: PlanStep,
-  results: Map<string, string>,
-): string | undefined {
+function buildContext(step: PlanStep, results: Map<string, string>): string | undefined {
   if (step.dependsOn.length === 0) {
     return undefined;
   }

--- a/packages/openomni/src/team/teammate.ts
+++ b/packages/openomni/src/team/teammate.ts
@@ -62,10 +62,7 @@ export namespace Teammate {
    * Merge config-level and step-level tools, deduplicating by name.
    * Step tools take precedence over config tools with the same name.
    */
-  function mergeTools(
-    configTools?: Tool.Spec[],
-    stepTools?: Tool.Spec[],
-  ): Tool.Spec[] | undefined {
+  function mergeTools(configTools?: Tool.Spec[], stepTools?: Tool.Spec[]): Tool.Spec[] | undefined {
     if (!configTools && !stepTools) return undefined;
     if (!configTools) return stepTools;
     if (!stepTools) return configTools;

--- a/packages/openomni/test/dag/dag.test.ts
+++ b/packages/openomni/test/dag/dag.test.ts
@@ -48,12 +48,7 @@ describe("DAG", () => {
   });
 
   it("unblocks diamond DAG only after both prerequisites complete", () => {
-    const dag = DAG.build([
-      step("A"),
-      step("B", ["A"]),
-      step("C", ["A"]),
-      step("D", ["B", "C"]),
-    ]);
+    const dag = DAG.build([step("A"), step("B", ["A"]), step("C", ["A"]), step("D", ["B", "C"])]);
     const completed = new Set<string>();
 
     expect(DAG.getReady(dag, completed)).toEqual(["A"]);
@@ -71,11 +66,7 @@ describe("DAG", () => {
   });
 
   it("detects cycle A -> B -> C -> A", () => {
-    const dag = DAG.build([
-      step("A", ["C"]),
-      step("B", ["A"]),
-      step("C", ["B"]),
-    ]);
+    const dag = DAG.build([step("A", ["C"]), step("B", ["A"]), step("C", ["B"])]);
 
     expect(DAG.validateAcyclic(dag)).toEqual({
       valid: false,
@@ -108,24 +99,17 @@ describe("DAG", () => {
   it("does not mutate DAGStructure in getReady", () => {
     const dag = DAG.build([step("A"), step("B", ["A"])]);
     const nodesBefore = [...dag.nodes];
-    const edgesBefore = [...dag.edges.entries()].map(([id, deps]) => [
-      id,
-      [...deps],
-    ]);
-    const reverseEdgesBefore = [...dag.reverseEdges.entries()].map(
-      ([id, deps]) => [id, [...deps]],
-    );
+    const edgesBefore = [...dag.edges.entries()].map(([id, deps]) => [id, [...deps]]);
+    const reverseEdgesBefore = [...dag.reverseEdges.entries()].map(([id, deps]) => [id, [...deps]]);
     const pendingBefore = [...dag.pendingDeps.entries()];
 
     DAG.getReady(dag, new Set());
 
     expect([...dag.nodes]).toEqual(nodesBefore);
-    expect(
-      [...dag.edges.entries()].map(([id, deps]) => [id, [...deps]]),
-    ).toEqual(edgesBefore);
-    expect(
-      [...dag.reverseEdges.entries()].map(([id, deps]) => [id, [...deps]]),
-    ).toEqual(reverseEdgesBefore);
+    expect([...dag.edges.entries()].map(([id, deps]) => [id, [...deps]])).toEqual(edgesBefore);
+    expect([...dag.reverseEdges.entries()].map(([id, deps]) => [id, [...deps]])).toEqual(
+      reverseEdgesBefore,
+    );
     expect([...dag.pendingDeps.entries()]).toEqual(pendingBefore);
   });
 });

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Message, Run, Sink } from "@openomni/protocol";
 import type { InboundEvent } from "@openomni/protocol";
 
@@ -44,6 +44,10 @@ let IngressEngine: typeof import("../../src/ingress/engine").IngressEngine;
 
 beforeAll(async () => {
   ({ IngressEngine } = await import("../../src/ingress/engine"));
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 beforeEach(() => {

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Message } from "@openomni/protocol";
 import type { InboundEvent, Plan } from "@openomni/protocol";
 import { Bus, Session, Storage, SurfaceKey } from "@openomni/session";
@@ -88,6 +88,10 @@ afterEach(() => {
   if (originalFns.storeDirectResult) {
     SessionBridge.storeDirectResult = originalFns.storeDirectResult;
   }
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 function createSession(): string {

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Message } from "@openomni/protocol";
 import type { InboundEvent, Plan } from "@openomni/protocol";
 import { Bus, Session, Storage, SurfaceKey } from "@openomni/session";
@@ -84,11 +76,9 @@ beforeEach(() => {
 
 afterEach(() => {
   if (originalFns.planGenerate) PlanAgent.generate = originalFns.planGenerate;
-  if (originalFns.teamExecute)
-    TeamOrchestrator.execute = originalFns.teamExecute;
+  if (originalFns.teamExecute) TeamOrchestrator.execute = originalFns.teamExecute;
   if (originalFns.chatCreate) ChatAgent.create = originalFns.chatCreate;
-  if (originalFns.buildPlanGoal)
-    SessionBridge.buildPlanGoal = originalFns.buildPlanGoal;
+  if (originalFns.buildPlanGoal) SessionBridge.buildPlanGoal = originalFns.buildPlanGoal;
   if (originalFns.storePlanResult) {
     SessionBridge.storePlanResult = originalFns.storePlanResult;
   }
@@ -107,11 +97,7 @@ function createSession(): string {
   }).id;
 }
 
-function addTextMessage(
-  sessionId: string,
-  role: "user" | "assistant",
-  text: string,
-): void {
+function addTextMessage(sessionId: string, role: "user" | "assistant", text: string): void {
   if (role === "user") {
     const message: Message.UserMessage = {
       id: crypto.randomUUID(),
@@ -238,11 +224,7 @@ describe("IngressHandlers", () => {
       systemPrompt: "planner system",
       budget: { maxTurns: 2 },
     });
-    expect(storePlanResultMock).toHaveBeenCalledWith(
-      sessionId,
-      planResult,
-      event.agent.model,
-    );
+    expect(storePlanResultMock).toHaveBeenCalledWith(sessionId, planResult, event.agent.model);
   });
 
   it("handleTeam executes extracted plan and returns team result", async () => {
@@ -258,14 +240,13 @@ describe("IngressHandlers", () => {
     const plan = createPlan();
     SessionBridge.storePlanResult(sessionId, { plan }, reviewerModel);
 
-    const teamResult: import("../../src/team/team-orchestrator").TeamOrchestrator.TeamResult =
-      {
-        status: "completed",
-        completedSteps: ["s1"],
-        failedSteps: [],
-        skippedSteps: [],
-        results: new Map([["s1", "done"]]),
-      };
+    const teamResult: import("../../src/team/team-orchestrator").TeamOrchestrator.TeamResult = {
+      status: "completed",
+      completedSteps: ["s1"],
+      failedSteps: [],
+      skippedSteps: [],
+      results: new Map([["s1", "done"]]),
+    };
 
     const executeMock = mock(async () => teamResult);
     const storeTeamResultMock = mock(() => {});
@@ -306,11 +287,7 @@ describe("IngressHandlers", () => {
         }),
       }),
     );
-    expect(storeTeamResultMock).toHaveBeenCalledWith(
-      sessionId,
-      teamResult,
-      reviewerModel,
-    );
+    expect(storeTeamResultMock).toHaveBeenCalledWith(sessionId, teamResult, reviewerModel);
     expect(result.mode).toBe("team");
     expect(result.result).toEqual({
       ...teamResult,
@@ -340,9 +317,9 @@ describe("IngressHandlers", () => {
       },
     };
 
-    await expect(
-      IngressHandlers.handleTeam({ sessionId, event }),
-    ).rejects.toThrow(/No plan found in session/);
+    await expect(IngressHandlers.handleTeam({ sessionId, event })).rejects.toThrow(
+      /No plan found in session/,
+    );
     expect(executeMock).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/openomni/test/ingress/integration.test.ts
+++ b/packages/openomni/test/ingress/integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { InboundEvent, Message, Run, Sink } from "@openomni/protocol";
 import { ZodError } from "zod";
 
@@ -50,6 +50,10 @@ let SessionBridge: typeof import("../../src/ingress/session-bridge").SessionBrid
 beforeAll(async () => {
   ({ IngressEngine } = await import("../../src/ingress/engine"));
   ({ SessionBridge } = await import("../../src/ingress/session-bridge"));
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 beforeEach(() => {

--- a/packages/openomni/test/ingress/integration.test.ts
+++ b/packages/openomni/test/ingress/integration.test.ts
@@ -119,9 +119,7 @@ function enqueuePlan(planId: string, goal: string, stepId: string): void {
   );
 }
 
-function extractTextMessages(
-  input: unknown,
-): Array<{ role: string; content: string }> {
+function extractTextMessages(input: unknown): Array<{ role: string; content: string }> {
   if (!input || typeof input !== "object") {
     return [];
   }
@@ -193,9 +191,7 @@ describe("IngressEngine integration pipeline", () => {
 
       const replanInput = llmInputs[1];
       const replanMessages = extractTextMessages(replanInput);
-      const replanGoal = replanMessages
-        .map((message) => message.content)
-        .join("\n");
+      const replanGoal = replanMessages.map((message) => message.content).join("\n");
       expect(replanGoal).toContain("Previous plan:");
       expect(replanGoal).toContain("Build a REST API");
       expect(replanGoal).toContain("User feedback:");
@@ -260,9 +256,7 @@ describe("IngressEngine integration pipeline", () => {
 
       const secondInput = llmInputs[1];
       const secondMessages = extractTextMessages(secondInput);
-      const secondUserMessages = secondMessages.filter(
-        (message) => message.role === "user",
-      );
+      const secondUserMessages = secondMessages.filter((message) => message.role === "user");
 
       expect(secondUserMessages).toHaveLength(2);
       expect(secondUserMessages[0]?.content).toBe("Hello");
@@ -305,9 +299,7 @@ describe("IngressEngine integration pipeline", () => {
       expect(planB.goal).toBe("Plan B");
 
       const replanInputForProjectB = llmInputs[1];
-      const replanMessagesForProjectB = extractTextMessages(
-        replanInputForProjectB,
-      )
+      const replanMessagesForProjectB = extractTextMessages(replanInputForProjectB)
         .map((message) => message.content)
         .join("\n");
       expect(replanMessagesForProjectB).not.toContain("Previous plan:");

--- a/packages/openomni/test/ingress/session-bridge.test.ts
+++ b/packages/openomni/test/ingress/session-bridge.test.ts
@@ -112,27 +112,21 @@ describe("SessionBridge", () => {
       expect(extracted.steps[0].stepId).toBe("s1");
       expect(extracted.steps[1].dependsOn).toEqual(["s1"]);
       expect(extracted.createdAt).toBeInstanceOf(Date);
-      expect(extracted.createdAt.toISOString()).toBe(
-        plan.createdAt.toISOString(),
-      );
+      expect(extracted.createdAt.toISOString()).toBe(plan.createdAt.toISOString());
       expect(extracted.version).toBe(1);
     });
   });
 
   describe("extractPlan", () => {
     it("should throw Error with 'No plan' when session is empty", () => {
-      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(
-        /No plan found in session/,
-      );
+      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(/No plan found in session/);
     });
 
     it("should throw Error with 'No plan' when session has only user messages", () => {
       addUserMessage(sessionId, "Hello");
       addUserMessage(sessionId, "Build me something");
 
-      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(
-        /No plan found in session/,
-      );
+      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(/No plan found in session/);
     });
 
     it("should ignore plan prefix in user messages (spoofing prevention)", () => {
@@ -145,9 +139,7 @@ describe("SessionBridge", () => {
       });
       addUserMessage(sessionId, `__OPENOMNI_PLAN__${fakePlan}`);
 
-      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(
-        /No plan found in session/,
-      );
+      expect(() => SessionBridge.extractPlan(sessionId)).toThrow(/No plan found in session/);
     });
   });
 
@@ -204,7 +196,13 @@ describe("SessionBridge", () => {
     it("should exclude __OPENOMNI_PLAN__ parts from direct messages", () => {
       addUserMessage(sessionId, "Hello");
       // Simulate a plan stored as assistant message
-      const plan = JSON.stringify({ planId: "p1", goal: "test", steps: [], createdAt: new Date(), version: 1 });
+      const plan = JSON.stringify({
+        planId: "p1",
+        goal: "test",
+        steps: [],
+        createdAt: new Date(),
+        version: 1,
+      });
       addAssistantMessage(sessionId, `__OPENOMNI_PLAN__${plan}`);
       addUserMessage(sessionId, "Continue chat");
 

--- a/packages/openomni/test/integration/plan-to-team.test.ts
+++ b/packages/openomni/test/integration/plan-to-team.test.ts
@@ -1,114 +1,69 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import * as SessionModule from "@openomni/session";
-import type { Message, Run, Sink } from "@openomni/protocol";
-
-const responseQueue: string[] = [];
-const llmInputs: unknown[] = [];
-
-type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
-
-let mockRunFn: MockLlmFn = async (_input: unknown, sink: Sink) => {
-  const text = responseQueue.shift() ?? "{}";
-  sink.onMessage(createAssistantMessage(text));
-  return { type: "stop" } as Run.Outcome;
-};
-
-const mockModelsGet = mock(async () => ({
-  anthropic: {
-    id: "anthropic",
-    name: "Anthropic",
-    models: {
-      "claude-3-haiku-20240307": {
-        id: "claude-3-haiku-20240307",
-        name: "Claude 3 Haiku",
-      },
-    },
-  },
-}));
-
-const mockProviderFromModelsDevModel = mock(() => ({
-  id: "claude-3-haiku-20240307",
-  providerID: "anthropic",
-}));
-
-const mockBusPublish = mock(() => {});
-
-mock.module("@openomni/llm", () => ({
-  ModelsDev: { get: mockModelsGet },
-  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
-  run: (input: unknown, sink: Sink) => {
-    llmInputs.push(input);
-    return mockRunFn(input, sink);
-  },
-  TokenTracker: {
-    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
-  },
-}));
-
-mock.module("@openomni/session", () => ({
-  ...SessionModule,
-  Bus: { ...SessionModule.Bus, publish: mockBusPublish },
-}));
+import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { ChatAgent, type AgentResult, type ChatAgentInput } from "@openomni/agent";
 
 let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;
 let TeamOrchestrator: typeof import("../../src/team/team-orchestrator").TeamOrchestrator;
+type OrchestratorConfig =
+  import("../../src/team/team-orchestrator").TeamOrchestrator.OrchestratorConfig;
 
-beforeAll(async () => {
-  ({ PlanAgent } = await import("../../src/plan/plan-agent"));
-  ({ TeamOrchestrator } = await import("../../src/team/team-orchestrator"));
+const originalCreate = ChatAgent.create;
+const createSpy = spyOn(ChatAgent, "create");
+
+beforeEach(async () => {
+  if (!PlanAgent || !TeamOrchestrator) {
+    const planModulePath = `${new URL("../../src/plan/plan-agent.ts", import.meta.url).pathname}?plan-to-team-isolated`;
+    const teamModulePath = `${new URL("../../src/team/team-orchestrator.ts", import.meta.url).pathname}?plan-to-team-isolated`;
+    ({ PlanAgent } = (await import(planModulePath)) as typeof import("../../src/plan/plan-agent"));
+    ({ TeamOrchestrator } = (await import(
+      teamModulePath
+    )) as typeof import("../../src/team/team-orchestrator"));
+  }
 });
 
-beforeEach(() => {
-  responseQueue.length = 0;
-  llmInputs.length = 0;
-  mockBusPublish.mockClear();
-  mockModelsGet.mockClear();
-  mockProviderFromModelsDevModel.mockClear();
-  mockRunFn = async (_input: unknown, sink: Sink) => {
-    const text = responseQueue.shift() ?? "{}";
-    sink.onMessage(createAssistantMessage(text));
-    return { type: "stop" } as Run.Outcome;
-  };
-});
+const responses: string[] = [];
+const runInputs: ChatAgentInput[] = [];
+let matcher: (input: ChatAgentInput) => boolean = () => false;
 
-function createAssistantMessage(text: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "integration-test";
-  const now = Date.now();
-
-  const info: Message.AssistantMessage = {
-    id,
-    sessionID,
-    role: "assistant",
-    time: { created: now },
-    parentID: "",
-    modelID: "claude-3-haiku-20240307",
-    providerID: "anthropic",
-    agent: "chat-agent",
-    path: { cwd: "", root: "" },
-    cost: 0,
-    tokens: {
-      input: 10,
-      output: 5,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-  };
-
-  const textPart: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID,
-    messageID: id,
-    type: "text",
+function makeAgentResult(text: string): AgentResult {
+  return {
     text,
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    finishReason: "stop",
   };
-
-  return { info, parts: [textPart] };
 }
 
+beforeEach(() => {
+  responses.length = 0;
+  runInputs.length = 0;
+  matcher = () => false;
+
+  createSpy.mockImplementation((config) => {
+    const realAgent = originalCreate(config);
+    return {
+      ...realAgent,
+      run: async (input: ChatAgentInput) => {
+        if (!matcher(input)) {
+          return realAgent.run(input);
+        }
+
+        runInputs.push(input);
+        const next = responses.shift();
+        if (next === undefined) {
+          throw new Error("No mocked response queued for matched ChatAgent.run call");
+        }
+        return makeAgentResult(next);
+      },
+    };
+  });
+});
+
+afterAll(() => {
+  createSpy.mockRestore();
+});
+
 function enqueuePlan(goal: string, steps: Array<{ stepId: string; dependsOn: string[] }>) {
-  responseQueue.push(
+  responses.push(
     JSON.stringify({
       planId: "plan-integration",
       goal,
@@ -124,7 +79,7 @@ function enqueuePlan(goal: string, steps: Array<{ stepId: string; dependsOn: str
   );
 }
 
-function makeConfig(): import("../../src/team/team-orchestrator").TeamOrchestrator.OrchestratorConfig {
+function makeConfig(): OrchestratorConfig {
   return {
     reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     teammates: new Map(),
@@ -136,35 +91,35 @@ function makeConfig(): import("../../src/team/team-orchestrator").TeamOrchestrat
   };
 }
 
-function extractUserText(input: unknown): string {
-  if (!input || typeof input !== "object") {
-    return "";
-  }
-
-  const candidate = input as {
-    messages?: Array<{ parts?: Array<{ type?: string; text?: string }> }>;
-  };
-
-  const messages = candidate.messages ?? [];
-  return messages
-    .flatMap((message) => message.parts ?? [])
-    .filter((part) => part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text as string)
+function extractUserText(input: ChatAgentInput): string {
+  return input.messages
+    .filter((message) => message.role === "user")
+    .map((message) => message.content)
     .join("\n");
 }
 
 describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
   it("completes two-step dependent plan end-to-end", async () => {
     const goal = "Build and validate release package";
+    matcher = (input) => {
+      const text = extractUserText(input);
+      return (
+        text.includes(goal) ||
+        text.includes("Task: Do s1") ||
+        text.includes("Task: Do s2") ||
+        text.includes("Step: Do s1") ||
+        text.includes("Step: Do s2")
+      );
+    };
 
     enqueuePlan(goal, [
       { stepId: "s1", dependsOn: [] },
       { stepId: "s2", dependsOn: ["s1"] },
     ]);
-    responseQueue.push("Step 1 completed");
-    responseQueue.push(JSON.stringify({ decision: "accept" }));
-    responseQueue.push("Step 2 completed");
-    responseQueue.push(JSON.stringify({ decision: "accept" }));
+    responses.push("Step 1 completed");
+    responses.push(JSON.stringify({ decision: "accept" }));
+    responses.push("Step 2 completed");
+    responses.push(JSON.stringify({ decision: "accept" }));
 
     const planResult = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -179,10 +134,14 @@ describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
 
   it("completes one-step plan end-to-end", async () => {
     const goal = "Run one verification";
+    matcher = (input) => {
+      const text = extractUserText(input);
+      return text.includes(goal) || text.includes("Task: Do s1") || text.includes("Step: Do s1");
+    };
 
     enqueuePlan(goal, [{ stepId: "s1", dependsOn: [] }]);
-    responseQueue.push("Single step completed");
-    responseQueue.push(JSON.stringify({ decision: "accept" }));
+    responses.push("Single step completed");
+    responses.push(JSON.stringify({ decision: "accept" }));
 
     const planResult = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -197,19 +156,23 @@ describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
 
   it("retries once after rejection and then succeeds", async () => {
     const goal = "Retry rejected step";
+    matcher = (input) => {
+      const text = extractUserText(input);
+      return text.includes(goal) || text.includes("Task: Do s1") || text.includes("Step: Do s1");
+    };
 
     enqueuePlan(goal, [{ stepId: "s1", dependsOn: [] }]);
-    responseQueue.push("Step output attempt 1");
-    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "Need fixes" }));
-    responseQueue.push("Step output attempt 2");
-    responseQueue.push(JSON.stringify({ decision: "accept" }));
+    responses.push("Step output attempt 1");
+    responses.push(JSON.stringify({ decision: "reject", feedback: "Need fixes" }));
+    responses.push("Step output attempt 2");
+    responses.push(JSON.stringify({ decision: "accept" }));
 
     const planResult = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     });
     const result = await TeamOrchestrator.execute(planResult.plan, makeConfig());
 
-    const executionCalls = llmInputs
+    const executionCalls = runInputs
       .map((input) => extractUserText(input))
       .filter((text) => text.includes("Execute the following task:"));
 
@@ -219,10 +182,12 @@ describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
   });
 
   it("throws when plan output is invalid JSON", async () => {
-    responseQueue.push("{ invalid json");
+    const goal = "Generate broken plan";
+    matcher = (input) => extractUserText(input).includes(goal);
+    responses.push("{ invalid json");
 
     return expect(
-      PlanAgent.generate("Generate broken plan", {
+      PlanAgent.generate(goal, {
         model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       }),
     ).rejects.toThrow(/Failed to parse plan/);

--- a/packages/openomni/test/integration/plan-to-team.test.ts
+++ b/packages/openomni/test/integration/plan-to-team.test.ts
@@ -107,10 +107,7 @@ function createAssistantMessage(text: string): Message.WithParts {
   return { info, parts: [textPart] };
 }
 
-function enqueuePlan(
-  goal: string,
-  steps: Array<{ stepId: string; dependsOn: string[] }>,
-) {
+function enqueuePlan(goal: string, steps: Array<{ stepId: string; dependsOn: string[] }>) {
   responseQueue.push(
     JSON.stringify({
       planId: "plan-integration",
@@ -172,10 +169,7 @@ describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
     const planResult = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     });
-    const result = await TeamOrchestrator.execute(
-      planResult.plan,
-      makeConfig(),
-    );
+    const result = await TeamOrchestrator.execute(planResult.plan, makeConfig());
 
     expect(result.status).toBe("completed");
     expect(result.completedSteps).toEqual(["s1", "s2"]);
@@ -193,10 +187,7 @@ describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
     const planResult = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     });
-    const result = await TeamOrchestrator.execute(
-      planResult.plan,
-      makeConfig(),
-    );
+    const result = await TeamOrchestrator.execute(planResult.plan, makeConfig());
 
     expect(result.status).toBe("completed");
     expect(result.completedSteps).toEqual(["s1"]);
@@ -209,19 +200,14 @@ describe("PlanAgent.generate -> TeamOrchestrator.execute integration", () => {
 
     enqueuePlan(goal, [{ stepId: "s1", dependsOn: [] }]);
     responseQueue.push("Step output attempt 1");
-    responseQueue.push(
-      JSON.stringify({ decision: "reject", feedback: "Need fixes" }),
-    );
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "Need fixes" }));
     responseQueue.push("Step output attempt 2");
     responseQueue.push(JSON.stringify({ decision: "accept" }));
 
     const planResult = await PlanAgent.generate(goal, {
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     });
-    const result = await TeamOrchestrator.execute(
-      planResult.plan,
-      makeConfig(),
-    );
+    const result = await TeamOrchestrator.execute(planResult.plan, makeConfig());
 
     const executionCalls = llmInputs
       .map((input) => extractUserText(input))

--- a/packages/openomni/test/legacy/agent/communication-a2a.test.ts
+++ b/packages/openomni/test/legacy/agent/communication-a2a.test.ts
@@ -7,9 +7,7 @@ import {
   type AuditEntry,
 } from "../../../src/legacy/agent/communication";
 
-const createEnvelope = (
-  overrides: Partial<MessageEnvelope> = {},
-): MessageEnvelope => ({
+const createEnvelope = (overrides: Partial<MessageEnvelope> = {}): MessageEnvelope => ({
   traceId: randomUUID(),
   sessionId: randomUUID(),
   runId: randomUUID(),
@@ -441,18 +439,14 @@ describe("AgentMessenger Allow Pattern Gate", () => {
 
   describe("blocked communication", () => {
     it("throws MessagingError when no pattern matches", async () => {
-      AgentMessenger.configureAllowPatterns([
-        { from: "other-agent", to: "other-target" },
-      ]);
+      AgentMessenger.configureAllowPatterns([{ from: "other-agent", to: "other-target" }]);
 
       const envelope = createEnvelope({
         fromAgentId: sender,
         toAgentId: receiver,
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
     });
 
     it("includes source and target in error message", async () => {
@@ -476,39 +470,29 @@ describe("AgentMessenger Allow Pattern Gate", () => {
         toAgentId: receiver,
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
     });
 
     it("blocks when source matches but target does not", async () => {
-      AgentMessenger.configureAllowPatterns([
-        { from: sender, to: "wrong-target" },
-      ]);
+      AgentMessenger.configureAllowPatterns([{ from: sender, to: "wrong-target" }]);
 
       const envelope = createEnvelope({
         fromAgentId: sender,
         toAgentId: receiver,
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
     });
 
     it("blocks when target matches but source does not", async () => {
-      AgentMessenger.configureAllowPatterns([
-        { from: "wrong-source", to: receiver },
-      ]);
+      AgentMessenger.configureAllowPatterns([{ from: "wrong-source", to: receiver }]);
 
       const envelope = createEnvelope({
         fromAgentId: sender,
         toAgentId: receiver,
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
     });
   });
 
@@ -617,9 +601,7 @@ describe("AgentMessenger Allow Pattern Gate", () => {
         toAgentId: receiver,
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
     });
   });
 });
@@ -643,9 +625,7 @@ describe("AgentMessenger Both Policy Enforcement", () => {
         persistencePolicy: "both",
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
       await expect(AgentMessenger.send(envelope)).rejects.toThrow(
         'Persistence policy "both" requires explicit opt-in via enableBothPolicy()',
       );
@@ -705,9 +685,7 @@ describe("AgentMessenger Both Policy Enforcement", () => {
         persistencePolicy: "both",
       });
 
-      await expect(AgentMessenger.send(envelope)).rejects.toThrow(
-        MessagingError,
-      );
+      await expect(AgentMessenger.send(envelope)).rejects.toThrow(MessagingError);
     });
 
     it("enableBothPolicy() is idempotent", async () => {

--- a/packages/openomni/test/legacy/agent/communication-policy.test.ts
+++ b/packages/openomni/test/legacy/agent/communication-policy.test.ts
@@ -7,9 +7,7 @@ import {
   type AuditEntry,
 } from "../../../src/legacy/agent/communication";
 
-const createEnvelope = (
-  overrides: Partial<MessageEnvelope> = {},
-): MessageEnvelope => ({
+const createEnvelope = (overrides: Partial<MessageEnvelope> = {}): MessageEnvelope => ({
   traceId: randomUUID(),
   sessionId: randomUUID(),
   runId: randomUUID(),

--- a/packages/openomni/test/legacy/agent/communication.test.ts
+++ b/packages/openomni/test/legacy/agent/communication.test.ts
@@ -6,9 +6,7 @@ import {
   type MessageEnvelope,
 } from "../../../src/legacy/agent/communication";
 
-const createEnvelope = (
-  overrides: Partial<MessageEnvelope> = {},
-): MessageEnvelope => ({
+const createEnvelope = (overrides: Partial<MessageEnvelope> = {}): MessageEnvelope => ({
   traceId: randomUUID(),
   sessionId: randomUUID(),
   runId: randomUUID(),
@@ -163,9 +161,9 @@ describe("AgentMessenger", () => {
       toAgentId: `agent-${randomUUID()}`,
     };
 
-    return expect(
-      AgentMessenger.request(envelope, { timeoutMs: 10 }),
-    ).rejects.toThrow(MessagingError);
+    return expect(AgentMessenger.request(envelope, { timeoutMs: 10 })).rejects.toThrow(
+      MessagingError,
+    );
   });
 
   it("request rejects on send error", async () => {
@@ -173,9 +171,7 @@ describe("AgentMessenger", () => {
       toAgentId: "",
     });
 
-    return expect(AgentMessenger.request(invalidEnvelope)).rejects.toThrow(
-      MessagingError,
-    );
+    return expect(AgentMessenger.request(invalidEnvelope)).rejects.toThrow(MessagingError);
   });
 
   it("Invalid envelope throws MessagingError", async () => {
@@ -184,9 +180,7 @@ describe("AgentMessenger", () => {
       payload: undefined,
     };
 
-    return expect(AgentMessenger.send(invalidEnvelope)).rejects.toThrow(
-      MessagingError,
-    );
+    return expect(AgentMessenger.send(invalidEnvelope)).rejects.toThrow(MessagingError);
   });
 
   it("Multiple subscribers all receive message", async () => {

--- a/packages/openomni/test/legacy/agent/discovery.test.ts
+++ b/packages/openomni/test/legacy/agent/discovery.test.ts
@@ -105,9 +105,7 @@ describe("AgentDiscovery.load", () => {
 
   it("loads valid supervisor agent from .md file", () => {
     const results = AgentDiscovery.load(FIXTURES_DIR);
-    const supervisor = results.find(
-      (r) => r.agent?.name === "conversation-supervisor",
-    );
+    const supervisor = results.find((r) => r.agent?.name === "conversation-supervisor");
 
     expect(supervisor).toBeDefined();
     expect(supervisor!.success).toBe(true);
@@ -120,9 +118,7 @@ describe("AgentDiscovery.load", () => {
     const results = AgentDiscovery.load(FIXTURES_DIR);
     const worker = results.find((r) => r.agent?.name === "code-analyzer");
 
-    expect(worker!.agent!.systemPrompt).toContain(
-      "You are a code analysis agent.",
-    );
+    expect(worker!.agent!.systemPrompt).toContain("You are a code analysis agent.");
     expect(worker!.agent!.systemPrompt).toContain("Extended Instructions");
     expect(worker!.agent!.systemPrompt).toContain("anti-patterns");
   });
@@ -149,9 +145,9 @@ describe("AgentDiscovery.load", () => {
   });
 
   it("throws in strict mode for non-existent directory", () => {
-    expect(() =>
-      AgentDiscovery.load("/non/existent/path", { strict: true }),
-    ).toThrow("Agent discovery directory does not exist");
+    expect(() => AgentDiscovery.load("/non/existent/path", { strict: true })).toThrow(
+      "Agent discovery directory does not exist",
+    );
   });
 });
 
@@ -202,14 +198,10 @@ describe("AgentDiscovery override protection", () => {
     const worker = results.find((r) => r.file.includes("valid-worker.md"));
 
     expect(worker!.success).toBe(true);
-    expect(worker!.agent!.description).toBe(
-      "Analyzes codebases for patterns and issues",
-    );
+    expect(worker!.agent!.description).toBe("Analyzes codebases for patterns and issues");
 
     const registered = BuiltinAgentRegistry.get("code-analyzer");
-    expect(registered!.description).toBe(
-      "Analyzes codebases for patterns and issues",
-    );
+    expect(registered!.description).toBe("Analyzes codebases for patterns and issues");
   });
 
   it("throws in strict mode when agent name conflicts without override", () => {
@@ -238,9 +230,7 @@ describe("AgentDiscovery override protection", () => {
 
 describe("AgentDiscovery.loadFile", () => {
   it("loads a single agent file", () => {
-    const result = AgentDiscovery.loadFile(
-      join(FIXTURES_DIR, "valid-worker.md"),
-    );
+    const result = AgentDiscovery.loadFile(join(FIXTURES_DIR, "valid-worker.md"));
 
     expect(result.success).toBe(true);
     expect(result.agent!.name).toBe("code-analyzer");

--- a/packages/openomni/test/legacy/conversation/handler.test.ts
+++ b/packages/openomni/test/legacy/conversation/handler.test.ts
@@ -90,9 +90,7 @@ describe("ConversationHandler", () => {
       const result = ConversationHandler.decide(context);
 
       expect(result.path).toBe("task");
-      expect(result.reason).toBe(
-        "Requires file writes across multiple modules",
-      );
+      expect(result.reason).toBe("Requires file writes across multiple modules");
     });
 
     it("returns 'inline' when estimatedDuration < 30s (Heuristic 5)", () => {

--- a/packages/openomni/test/legacy/dispatch/dispatcher.test.ts
+++ b/packages/openomni/test/legacy/dispatch/dispatcher.test.ts
@@ -9,12 +9,8 @@ describe("Dispatcher.evaluateCondition", () => {
       op: "eq",
       value: "active",
     };
-    expect(Dispatcher.evaluateCondition(condition, { status: "active" })).toBe(
-      true,
-    );
-    expect(
-      Dispatcher.evaluateCondition(condition, { status: "inactive" }),
-    ).toBe(false);
+    expect(Dispatcher.evaluateCondition(condition, { status: "active" })).toBe(true);
+    expect(Dispatcher.evaluateCondition(condition, { status: "inactive" })).toBe(false);
   });
 
   it("neq operator matches non-equal values", () => {
@@ -23,12 +19,8 @@ describe("Dispatcher.evaluateCondition", () => {
       op: "neq",
       value: "active",
     };
-    expect(
-      Dispatcher.evaluateCondition(condition, { status: "inactive" }),
-    ).toBe(true);
-    expect(Dispatcher.evaluateCondition(condition, { status: "active" })).toBe(
-      false,
-    );
+    expect(Dispatcher.evaluateCondition(condition, { status: "inactive" })).toBe(true);
+    expect(Dispatcher.evaluateCondition(condition, { status: "active" })).toBe(false);
   });
 
   it("in operator checks array membership", () => {
@@ -37,12 +29,8 @@ describe("Dispatcher.evaluateCondition", () => {
       op: "in",
       value: ["admin", "editor"],
     };
-    expect(Dispatcher.evaluateCondition(condition, { role: "admin" })).toBe(
-      true,
-    );
-    expect(Dispatcher.evaluateCondition(condition, { role: "viewer" })).toBe(
-      false,
-    );
+    expect(Dispatcher.evaluateCondition(condition, { role: "admin" })).toBe(true);
+    expect(Dispatcher.evaluateCondition(condition, { role: "viewer" })).toBe(false);
   });
 
   it("nin operator checks non-membership", () => {
@@ -51,12 +39,8 @@ describe("Dispatcher.evaluateCondition", () => {
       op: "nin",
       value: ["admin", "editor"],
     };
-    expect(Dispatcher.evaluateCondition(condition, { role: "viewer" })).toBe(
-      true,
-    );
-    expect(Dispatcher.evaluateCondition(condition, { role: "admin" })).toBe(
-      false,
-    );
+    expect(Dispatcher.evaluateCondition(condition, { role: "viewer" })).toBe(true);
+    expect(Dispatcher.evaluateCondition(condition, { role: "admin" })).toBe(false);
   });
 
   it("exists operator checks path existence", () => {
@@ -70,14 +54,10 @@ describe("Dispatcher.evaluateCondition", () => {
       op: "exists",
       value: false,
     };
-    expect(Dispatcher.evaluateCondition(existsTrue, { name: "alice" })).toBe(
-      true,
-    );
+    expect(Dispatcher.evaluateCondition(existsTrue, { name: "alice" })).toBe(true);
     expect(Dispatcher.evaluateCondition(existsTrue, { age: 30 })).toBe(false);
     expect(Dispatcher.evaluateCondition(existsFalse, { age: 30 })).toBe(true);
-    expect(Dispatcher.evaluateCondition(existsFalse, { name: "alice" })).toBe(
-      false,
-    );
+    expect(Dispatcher.evaluateCondition(existsFalse, { name: "alice" })).toBe(false);
   });
 
   it("regex operator matches patterns", () => {
@@ -86,15 +66,9 @@ describe("Dispatcher.evaluateCondition", () => {
       op: "regex",
       value: "^[a-z]+@example\\.com$",
     };
-    expect(
-      Dispatcher.evaluateCondition(condition, { email: "alice@example.com" }),
-    ).toBe(true);
-    expect(
-      Dispatcher.evaluateCondition(condition, { email: "ALICE@example.com" }),
-    ).toBe(false);
-    expect(
-      Dispatcher.evaluateCondition(condition, { email: "alice@other.com" }),
-    ).toBe(false);
+    expect(Dispatcher.evaluateCondition(condition, { email: "alice@example.com" })).toBe(true);
+    expect(Dispatcher.evaluateCondition(condition, { email: "ALICE@example.com" })).toBe(false);
+    expect(Dispatcher.evaluateCondition(condition, { email: "alice@other.com" })).toBe(false);
   });
 
   it("gt/gte/lt/lte operators for numeric comparison", () => {
@@ -163,15 +137,9 @@ describe("Dispatcher.evaluateFilter", () => {
         { path: "score", op: "gt", value: 50 },
       ],
     };
-    expect(
-      Dispatcher.evaluateFilter(filter, { status: "active", score: 80 }),
-    ).toBe(true);
-    expect(
-      Dispatcher.evaluateFilter(filter, { status: "active", score: 30 }),
-    ).toBe(false);
-    expect(
-      Dispatcher.evaluateFilter(filter, { status: "inactive", score: 80 }),
-    ).toBe(false);
+    expect(Dispatcher.evaluateFilter(filter, { status: "active", score: 80 })).toBe(true);
+    expect(Dispatcher.evaluateFilter(filter, { status: "active", score: 30 })).toBe(false);
+    expect(Dispatcher.evaluateFilter(filter, { status: "inactive", score: 80 })).toBe(false);
   });
 
   it("mode 'any' requires at least one condition to pass", () => {
@@ -182,14 +150,8 @@ describe("Dispatcher.evaluateFilter", () => {
         { path: "score", op: "gt", value: 90 },
       ],
     };
-    expect(
-      Dispatcher.evaluateFilter(filter, { status: "active", score: 10 }),
-    ).toBe(true);
-    expect(
-      Dispatcher.evaluateFilter(filter, { status: "inactive", score: 95 }),
-    ).toBe(true);
-    expect(
-      Dispatcher.evaluateFilter(filter, { status: "inactive", score: 10 }),
-    ).toBe(false);
+    expect(Dispatcher.evaluateFilter(filter, { status: "active", score: 10 })).toBe(true);
+    expect(Dispatcher.evaluateFilter(filter, { status: "inactive", score: 95 })).toBe(true);
+    expect(Dispatcher.evaluateFilter(filter, { status: "inactive", score: 10 })).toBe(false);
   });
 });

--- a/packages/openomni/test/legacy/dispatch/envelope.test.ts
+++ b/packages/openomni/test/legacy/dispatch/envelope.test.ts
@@ -111,9 +111,7 @@ describe("Envelope Functions", () => {
 
   describe("Envelope.isExpired", () => {
     it("returns true for old envelopes", () => {
-      const twoHoursAgo = new Date(
-        Date.now() - 2 * 60 * 60 * 1000,
-      ).toISOString();
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
       const oldEnvelope: EventEnvelope = {
         eventId: "test-id",
         name: "test-event",

--- a/packages/openomni/test/legacy/e2e/agent-orchestration.test.ts
+++ b/packages/openomni/test/legacy/e2e/agent-orchestration.test.ts
@@ -10,10 +10,7 @@ import type {
   RunResult,
 } from "../../../src/legacy/ingress/interfaces";
 import type { RunExecutor } from "../../../src/legacy/ingress/run-executor";
-import {
-  RunWorker,
-  type OrchestratorRunInput,
-} from "../../../src/legacy/worker/run/run-worker";
+import { RunWorker, type OrchestratorRunInput } from "../../../src/legacy/worker/run/run-worker";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import { TaskStorage } from "../../../src/legacy/task/storage";
 import type { Task } from "../../../src/legacy/task/types";
@@ -122,10 +119,7 @@ function createTask(overrides: Partial<Task.CreateInput> = {}): Task.Info {
   });
 }
 
-async function createRun(
-  taskId: string,
-  triggerId = "manual-1",
-): Promise<string> {
+async function createRun(taskId: string, triggerId = "manual-1"): Promise<string> {
   const result = await TaskManager.trigger(taskId, {
     triggerId,
     type: "manual",
@@ -139,11 +133,7 @@ async function createRun(
   return result.runId;
 }
 
-function emitAssistantText(
-  sink: Sink,
-  text: string,
-  sessionID = "test-session",
-): void {
+function emitAssistantText(sink: Sink, text: string, sessionID = "test-session"): void {
   const messageID = crypto.randomUUID();
 
   sink.onMessage({
@@ -271,9 +261,7 @@ describe("Agent orchestration e2e", () => {
     const llm: OrchestratorRunInput["llm"] = {
       run: async (input, sink) => {
         llmInputs.push(input);
-        const toolResults = isToolResultArray(input.toolResults)
-          ? input.toolResults
-          : [];
+        const toolResults = isToolResultArray(input.toolResults) ? input.toolResults : [];
 
         if (toolResults.length === 0) {
           const call: Tool.Call = {
@@ -287,10 +275,7 @@ describe("Agent orchestration e2e", () => {
           return { type: "await_tool" as const, toolCalls: [call] };
         }
 
-        emitAssistantText(
-          sink,
-          `Tool loop finished with: ${toolResults[0].output}`,
-        );
+        emitAssistantText(sink, `Tool loop finished with: ${toolResults[0].output}`);
         return { type: "stop" as const };
       },
     };
@@ -346,9 +331,7 @@ describe("Agent orchestration e2e", () => {
       run: async (input, sink) => {
         const prompt = typeof input.prompt === "string" ? input.prompt : "";
         seenPrompts.push(prompt);
-        const toolResults = isToolResultArray(input.toolResults)
-          ? input.toolResults
-          : [];
+        const toolResults = isToolResultArray(input.toolResults) ? input.toolResults : [];
 
         if (prompt === "spawn-depth-2" && toolResults.length === 0) {
           const subCall: Tool.Call = {
@@ -513,9 +496,7 @@ describe("Agent orchestration e2e", () => {
     const mainLLM: OrchestratorRunInput["llm"] = {
       run: async (input, sink) => {
         mainTurns += 1;
-        const toolResults = isToolResultArray(input.toolResults)
-          ? input.toolResults
-          : [];
+        const toolResults = isToolResultArray(input.toolResults) ? input.toolResults : [];
 
         if (toolResults.length === 0) {
           const subagentCall: Tool.Call = {
@@ -532,10 +513,7 @@ describe("Agent orchestration e2e", () => {
           return { type: "await_tool" as const, toolCalls: [subagentCall] };
         }
 
-        emitAssistantText(
-          sink,
-          `Main agent received subagent output: ${toolResults[0].output}`,
-        );
+        emitAssistantText(sink, `Main agent received subagent output: ${toolResults[0].output}`);
         return { type: "stop" as const };
       },
     };

--- a/packages/openomni/test/legacy/e2e/conversation-supervisor.test.ts
+++ b/packages/openomni/test/legacy/e2e/conversation-supervisor.test.ts
@@ -1,18 +1,108 @@
-import { describe, it, expect, beforeEach } from "bun:test";
-import {
-  ConversationSupervisor,
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type {
   ConversationSupervisorConfig,
   ConversationInput,
 } from "../../../src/legacy/conversation";
+import type { Message, Run, Sink } from "@openomni/protocol";
 import { Session } from "@openomni/session";
 import { TaskStorage } from "../../../src/legacy/task/storage";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import type { Task } from "../../../src/legacy/task/types";
 
+type MockLlmFn = (input: unknown, sink: Sink) => Promise<Run.Outcome>;
+
+let mockRunFn: MockLlmFn = async (_input: unknown, sink: Sink) => {
+  sink.onMessage(createAssistantMessage("Mock assistant response"));
+  return { type: "stop" };
+};
+
+const mockModelsGet = mock(async () => ({
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    models: {
+      "claude-3-haiku-20240307": {
+        id: "claude-3-haiku-20240307",
+        name: "Claude 3 Haiku",
+      },
+      "claude-sonnet-4-20250514": {
+        id: "claude-sonnet-4-20250514",
+        name: "Claude Sonnet 4",
+      },
+    },
+  },
+}));
+
+const mockProviderFromModelsDevModel = mock(() => ({
+  id: "claude-sonnet-4-20250514",
+  providerID: "anthropic",
+}));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+  TokenTracker: {
+    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
+  },
+}));
+
+let ConversationSupervisor: typeof import("../../../src/legacy/conversation").ConversationSupervisor;
+
+beforeAll(async () => {
+  ({ ConversationSupervisor } = await import("../../../src/legacy/conversation"));
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+function createAssistantMessage(text: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const sessionID = "conversation-supervisor-test";
+  const now = Date.now();
+
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID: "",
+    modelID: "claude-sonnet-4-20250514",
+    providerID: "anthropic",
+    agent: "chat-agent",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: {
+      input: 1,
+      output: 1,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+
+  return { info, parts: [textPart] };
+}
+
 describe("ConversationSupervisor", () => {
   beforeEach(() => {
     TaskStorage.reset();
     Session.storage.clear();
+    mockModelsGet.mockClear();
+    mockProviderFromModelsDevModel.mockClear();
+    mockRunFn = async (_input: unknown, sink: Sink) => {
+      sink.onMessage(createAssistantMessage("Mock assistant response"));
+      return { type: "stop" };
+    };
   });
 
   function createTask(overrides: Partial<Task.CreateInput> = {}): Task.Info {

--- a/packages/openomni/test/legacy/e2e/integration.test.ts
+++ b/packages/openomni/test/legacy/e2e/integration.test.ts
@@ -9,8 +9,7 @@ import { FilesystemWatcher } from "../../../src/legacy/trigger/watcher";
 import { Router, Dispatcher, Envelope } from "../../../src/legacy/dispatch";
 import { RunWorker } from "../../../src/legacy/worker/run/run-worker";
 
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 function createTask(overrides: Partial<Task.CreateInput> = {}): Task.Info {
   return TaskManager.create({
@@ -106,9 +105,7 @@ describe("P7-3 E2E integration flows", () => {
     );
 
     expect(orchestration.success).toBe(true);
-    expect(orchestration.summary).toContain(
-      "Manual trigger orchestration completed.",
-    );
+    expect(orchestration.summary).toContain("Manual trigger orchestration completed.");
 
     const run = TaskManager.getRun(triggerResult.runId);
     expect(run?.status).toBe("done");

--- a/packages/openomni/test/legacy/execution/orchestration-wiring.test.ts
+++ b/packages/openomni/test/legacy/execution/orchestration-wiring.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  afterEach,
-  afterAll,
-  spyOn,
-} from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn } from "bun:test";
 import { RunWorker } from "../../../src/legacy/worker/run/run-worker";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import { TaskStorage } from "../../../src/legacy/task/storage";

--- a/packages/openomni/test/legacy/ingress/adapters.test.ts
+++ b/packages/openomni/test/legacy/ingress/adapters.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type {
-  EventSourceAdapter,
-  EventDecoder,
-  InboundEvent,
-} from "../../../src/legacy/ingress";
+import type { EventSourceAdapter, EventDecoder, InboundEvent } from "../../../src/legacy/ingress";
 
 describe("EventSourceAdapter interface", () => {
   it("should allow mock implementation with required properties", () => {

--- a/packages/openomni/test/legacy/ingress/engine.test.ts
+++ b/packages/openomni/test/legacy/ingress/engine.test.ts
@@ -32,9 +32,7 @@ describe("IngressEngine", () => {
   beforeEach(() => {
     IngressEngine.ingest = originalIngest;
     if ((IngressEngine.ingest as unknown as { mock?: unknown }).mock) {
-      (
-        IngressEngine.ingest as unknown as { mockRestore: () => void }
-      ).mockRestore();
+      (IngressEngine.ingest as unknown as { mockRestore: () => void }).mockRestore();
     }
     IngressEngine.reset();
     IngressEngine.configure({});

--- a/packages/openomni/test/legacy/ingress/engine.test.ts
+++ b/packages/openomni/test/legacy/ingress/engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { IngressEngine } from "../../../src/legacy/ingress/engine";
+import { ConversationSupervisor } from "../../../src/legacy/conversation";
 import { Session, SurfaceKey } from "@openomni/session";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import { TaskStorage } from "../../../src/legacy/task/storage";
@@ -8,10 +9,11 @@ import type {
   RunResult,
   DeliveryAdapter,
   RunPlanner,
-} from "../../../src/legacy/ingress/interfaces";
+} from "../../../src/legacy/ingress/engine";
 import { randomUUID } from "crypto";
 
 const originalIngest = IngressEngine.ingest;
+const originalConversationRun = ConversationSupervisor.run;
 
 function makeEvent(overrides: Partial<InboundEvent> = {}): InboundEvent {
   return {
@@ -30,6 +32,10 @@ function makeEvent(overrides: Partial<InboundEvent> = {}): InboundEvent {
 
 describe("IngressEngine", () => {
   beforeEach(() => {
+    ConversationSupervisor.run = async () => ({
+      type: "error",
+      error: "mocked conversation supervisor failure",
+    });
     IngressEngine.ingest = originalIngest;
     if ((IngressEngine.ingest as unknown as { mock?: unknown }).mock) {
       (IngressEngine.ingest as unknown as { mockRestore: () => void }).mockRestore();
@@ -42,6 +48,7 @@ describe("IngressEngine", () => {
   });
 
   afterEach(() => {
+    ConversationSupervisor.run = originalConversationRun;
     IngressEngine.reset();
     IngressEngine.configure({});
     Session.storage.clear();

--- a/packages/openomni/test/legacy/ingress/event-projector.test.ts
+++ b/packages/openomni/test/legacy/ingress/event-projector.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach } from "bun:test";
-import {
-  EventProjector,
-  DefaultEventProjector,
-} from "../../../src/legacy/ingress/event-projector";
+import { EventProjector, DefaultEventProjector } from "../../../src/legacy/ingress/event-projector";
 import { Envelope } from "../../../src/legacy/dispatch/envelope";
 import { Session } from "@openomni/session";
 import { Message } from "@openomni/protocol";

--- a/packages/openomni/test/legacy/ingress/notification.test.ts
+++ b/packages/openomni/test/legacy/ingress/notification.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { NoopNotificationAdapter } from "../../../src/legacy/ingress/engine";
 import type { NotificationAdapter } from "../../../src/legacy/ingress/interfaces";
-import type {
-  NotificationRequest,
-  NotificationResult,
-} from "@openomni/protocol";
+import type { NotificationRequest, NotificationResult } from "@openomni/protocol";
 
 describe("NotificationAdapter", () => {
   describe("NotificationAdapter interface", () => {
@@ -23,9 +20,7 @@ describe("NotificationAdapter", () => {
     it("should accept NotificationRequest and return NotificationResult", async () => {
       const adapter: NotificationAdapter = {
         name: "test",
-        async notify(
-          request: NotificationRequest,
-        ): Promise<NotificationResult> {
+        async notify(request: NotificationRequest): Promise<NotificationResult> {
           return {
             delivered: true,
             destination: "test@example.com",
@@ -103,9 +98,7 @@ describe("NotificationAdapter", () => {
     it("should support custom adapter with error handling", async () => {
       const adapter: NotificationAdapter = {
         name: "custom",
-        async notify(
-          request: NotificationRequest,
-        ): Promise<NotificationResult> {
+        async notify(request: NotificationRequest): Promise<NotificationResult> {
           if (request.severity === "error") {
             return {
               delivered: false,
@@ -131,9 +124,7 @@ describe("NotificationAdapter", () => {
     it("should support adapter with external message ID tracking", async () => {
       const adapter: NotificationAdapter = {
         name: "tracking",
-        async notify(
-          request: NotificationRequest,
-        ): Promise<NotificationResult> {
+        async notify(request: NotificationRequest): Promise<NotificationResult> {
           const messageId = `msg-${Date.now()}`;
           return {
             delivered: true,

--- a/packages/openomni/test/legacy/ingress/run-executor.test.ts
+++ b/packages/openomni/test/legacy/ingress/run-executor.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { DefaultRunExecutor, type RunExecutor } from "../../../src/legacy/ingress/run-executor";
+import { ConversationSupervisor } from "../../../src/legacy/conversation";
 import { Session, SurfaceKey } from "@openomni/session";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import { TaskStorage } from "../../../src/legacy/task/storage";
-import type { RunRequest } from "../../../src/legacy/ingress/interfaces";
+import type { RunRequest } from "../../../src/legacy/ingress/engine";
 import { randomUUID } from "crypto";
 
 function makeRunRequest(overrides: Partial<RunRequest> = {}): RunRequest {
@@ -39,11 +40,21 @@ function makeRunRequest(overrides: Partial<RunRequest> = {}): RunRequest {
 }
 
 describe("DefaultRunExecutor", () => {
+  const originalConversationRun = ConversationSupervisor.run;
+
   beforeEach(() => {
+    ConversationSupervisor.run = async () => ({
+      type: "error",
+      error: "mocked conversation supervisor failure",
+    });
     Session.storage.clear();
     SurfaceKey.clear();
     const store = TaskStorage.getAdapter();
     store.task.list().forEach((t) => store.task.remove(t.id));
+  });
+
+  afterEach(() => {
+    ConversationSupervisor.run = originalConversationRun;
   });
 
   describe("trigger_task", () => {

--- a/packages/openomni/test/legacy/ingress/run-executor.test.ts
+++ b/packages/openomni/test/legacy/ingress/run-executor.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach } from "bun:test";
-import {
-  DefaultRunExecutor,
-  type RunExecutor,
-} from "../../../src/legacy/ingress/run-executor";
+import { DefaultRunExecutor, type RunExecutor } from "../../../src/legacy/ingress/run-executor";
 import { Session, SurfaceKey } from "@openomni/session";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import { TaskStorage } from "../../../src/legacy/task/storage";

--- a/packages/openomni/test/legacy/integration/d5-mandatory.test.ts
+++ b/packages/openomni/test/legacy/integration/d5-mandatory.test.ts
@@ -4,11 +4,7 @@ import { Session, SurfaceKey } from "@openomni/session";
 import { TaskManager } from "../../../src/legacy/task/manager";
 import { TaskStorage } from "../../../src/legacy/task/storage";
 import { Scheduler } from "../../../src/legacy/trigger/scheduler";
-import type {
-  InboundEvent,
-  RunRequest,
-  RunResult,
-} from "../../../src/legacy/ingress/interfaces";
+import type { InboundEvent, RunRequest, RunResult } from "../../../src/legacy/ingress/interfaces";
 import type { RunExecutor } from "../../../src/legacy/ingress/run-executor";
 import { randomUUID } from "crypto";
 
@@ -33,10 +29,7 @@ class TestRunExecutor implements RunExecutor {
           };
         }
 
-        const triggerResult = await TaskManager.trigger(
-          request.taskId,
-          request.triggerSignal,
-        );
+        const triggerResult = await TaskManager.trigger(request.taskId, request.triggerSignal);
 
         if ("error" in triggerResult) {
           return {

--- a/packages/openomni/test/legacy/integration/supervisor-worker-split.test.ts
+++ b/packages/openomni/test/legacy/integration/supervisor-worker-split.test.ts
@@ -248,13 +248,9 @@ describe("Supervisor/Worker split boundary", () => {
       expect(result).toBeDefined();
       expect(result.type).toBeDefined();
       expect(typeof result.type).toBe("string");
-      expect([
-        "immediate",
-        "plan_pending",
-        "execution_forked",
-        "ended",
-        "error",
-      ]).toContain(result.type);
+      expect(["immediate", "plan_pending", "execution_forked", "ended", "error"]).toContain(
+        result.type,
+      );
 
       if (result.type === "error") {
         expect(typeof result.error).toBe("string");
@@ -263,17 +259,16 @@ describe("Supervisor/Worker split boundary", () => {
     });
 
     it("ExecutionSupervisor result has required fields", async () => {
-      const { ExecutionSupervisor } =
-        await import("../../../src/legacy/execution/execution-supervisor");
+      const { ExecutionSupervisor } = await import(
+        "../../../src/legacy/execution/execution-supervisor"
+      );
 
       const result = await ExecutionSupervisor.run({
         history: { summary: "test", constraints: [] },
         plan: {
           planId: "plan-1",
           objective: "test",
-          steps: [
-            { stepId: "step-0", description: "do something", dependsOn: [] },
-          ],
+          steps: [{ stepId: "step-0", description: "do something", dependsOn: [] }],
         },
         sessionMode: "persistent",
         sessionId: "session-1",

--- a/packages/openomni/test/legacy/task/file-task-storage.test.ts
+++ b/packages/openomni/test/legacy/task/file-task-storage.test.ts
@@ -20,11 +20,7 @@ function makeTask(id: string, overrides?: Partial<Task.Info>): Task.Info {
   };
 }
 
-function makeRun(
-  runId: string,
-  taskId: string,
-  overrides?: Partial<Task.Run>,
-): Task.Run {
+function makeRun(runId: string, taskId: string, overrides?: Partial<Task.Run>): Task.Run {
   return {
     runId,
     taskId,
@@ -102,18 +98,9 @@ describe("FileTaskStore", () => {
 
     test("listByStatus returns matching runs", () => {
       const store = new FileTaskStore(dir);
-      store.run.set(
-        "task-1",
-        makeRun("run-1", "task-1", { status: "scheduled" }),
-      );
-      store.run.set(
-        "task-1",
-        makeRun("run-2", "task-1", { status: "running" }),
-      );
-      store.run.set(
-        "task-2",
-        makeRun("run-3", "task-2", { status: "scheduled" }),
-      );
+      store.run.set("task-1", makeRun("run-1", "task-1", { status: "scheduled" }));
+      store.run.set("task-1", makeRun("run-2", "task-1", { status: "running" }));
+      store.run.set("task-2", makeRun("run-3", "task-2", { status: "scheduled" }));
 
       const scheduled = store.run.listByStatus(["scheduled"]);
       expect(scheduled).toHaveLength(2);
@@ -156,10 +143,7 @@ describe("FileTaskStore", () => {
       const now = Date.now();
 
       for (let i = 0; i < 5; i++) {
-        store.run.set(
-          "task-1",
-          makeRun(`run-${i}`, "task-1", { scheduledAt: now + i }),
-        );
+        store.run.set("task-1", makeRun(`run-${i}`, "task-1", { scheduledAt: now + i }));
       }
 
       const page = store.run.list("task-1", {
@@ -227,14 +211,8 @@ describe("FileTaskStore", () => {
       store1.task.set("task-1", makeTask("task-1"));
       store1.task.set("task-2", makeTask("task-2"));
       store1.run.set("task-1", makeRun("run-1", "task-1", { status: "done" }));
-      store1.run.set(
-        "task-1",
-        makeRun("run-2", "task-1", { status: "running" }),
-      );
-      store1.run.set(
-        "task-2",
-        makeRun("run-3", "task-2", { status: "scheduled" }),
-      );
+      store1.run.set("task-1", makeRun("run-2", "task-1", { status: "running" }));
+      store1.run.set("task-2", makeRun("run-3", "task-2", { status: "scheduled" }));
 
       const store2 = new FileTaskStore(dir);
       expect(store2.task.list()).toHaveLength(2);

--- a/packages/openomni/test/legacy/task/manager-lineage.test.ts
+++ b/packages/openomni/test/legacy/task/manager-lineage.test.ts
@@ -17,9 +17,7 @@ describe("TaskManager - Spawn Lineage Tracking", () => {
     });
   }
 
-  function createSignal(
-    overrides: Partial<Task.TriggerSignal> = {},
-  ): Task.TriggerSignal {
+  function createSignal(overrides: Partial<Task.TriggerSignal> = {}): Task.TriggerSignal {
     return {
       triggerId: "manual-1",
       type: "manual",

--- a/packages/openomni/test/legacy/task/manager-runs.test.ts
+++ b/packages/openomni/test/legacy/task/manager-runs.test.ts
@@ -17,9 +17,7 @@ describe("TaskManager - Run Management APIs", () => {
     });
   }
 
-  function createSignal(
-    overrides: Partial<Task.TriggerSignal> = {},
-  ): Task.TriggerSignal {
+  function createSignal(overrides: Partial<Task.TriggerSignal> = {}): Task.TriggerSignal {
     return {
       triggerId: "manual-1",
       type: "manual",
@@ -248,11 +246,7 @@ describe("TaskManager - Run Management APIs", () => {
       const task = createTask();
       const runId = await createRun(task.id);
 
-      const result = TaskManager.setRunStatus(
-        runId,
-        "cancelled",
-        "user_requested",
-      );
+      const result = TaskManager.setRunStatus(runId, "cancelled", "user_requested");
       expect(result).toBe(true);
     });
   });

--- a/packages/openomni/test/legacy/task/manager-trigger.test.ts
+++ b/packages/openomni/test/legacy/task/manager-trigger.test.ts
@@ -17,9 +17,7 @@ describe("TaskManager.trigger", () => {
     });
   }
 
-  function createSignal(
-    overrides: Partial<Task.TriggerSignal> = {},
-  ): Task.TriggerSignal {
+  function createSignal(overrides: Partial<Task.TriggerSignal> = {}): Task.TriggerSignal {
     return {
       triggerId: "manual-1",
       type: "manual",
@@ -130,14 +128,8 @@ describe("TaskManager.trigger", () => {
         policy: { dedupe: { windowMs: 60000 } },
       });
 
-      const result1 = await TaskManager.trigger(
-        task.id,
-        createSignal({ occurredAt: 1000 }),
-      );
-      const result2 = await TaskManager.trigger(
-        task.id,
-        createSignal({ occurredAt: 2000 }),
-      );
+      const result1 = await TaskManager.trigger(task.id, createSignal({ occurredAt: 1000 }));
+      const result2 = await TaskManager.trigger(task.id, createSignal({ occurredAt: 2000 }));
 
       expect("runId" in result1).toBe(true);
       expect("runId" in result2).toBe(true);

--- a/packages/openomni/test/legacy/task/state-machine.test.ts
+++ b/packages/openomni/test/legacy/task/state-machine.test.ts
@@ -8,21 +8,15 @@ import type { Task } from "../../../src/legacy/task/types";
 describe("TaskStateMachine", () => {
   describe("validateTransition", () => {
     test("idle -> scheduled is valid", () => {
-      expect(TaskStateMachine.validateTransition("idle", "scheduled")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("idle", "scheduled")).toBe(true);
     });
 
     test("scheduled -> running is valid", () => {
-      expect(TaskStateMachine.validateTransition("scheduled", "running")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("scheduled", "running")).toBe(true);
     });
 
     test("scheduled -> cancelled is valid", () => {
-      expect(
-        TaskStateMachine.validateTransition("scheduled", "cancelled"),
-      ).toBe(true);
+      expect(TaskStateMachine.validateTransition("scheduled", "cancelled")).toBe(true);
     });
 
     test("running -> done is valid", () => {
@@ -30,33 +24,23 @@ describe("TaskStateMachine", () => {
     });
 
     test("running -> failed is valid", () => {
-      expect(TaskStateMachine.validateTransition("running", "failed")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("running", "failed")).toBe(true);
     });
 
     test("running -> cancelled is valid", () => {
-      expect(TaskStateMachine.validateTransition("running", "cancelled")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("running", "cancelled")).toBe(true);
     });
 
     test("running -> blocked is valid", () => {
-      expect(TaskStateMachine.validateTransition("running", "blocked")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("running", "blocked")).toBe(true);
     });
 
     test("blocked -> running is valid", () => {
-      expect(TaskStateMachine.validateTransition("blocked", "running")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("blocked", "running")).toBe(true);
     });
 
     test("blocked -> cancelled is valid", () => {
-      expect(TaskStateMachine.validateTransition("blocked", "cancelled")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("blocked", "cancelled")).toBe(true);
     });
 
     test("done -> idle is valid", () => {
@@ -68,15 +52,11 @@ describe("TaskStateMachine", () => {
     });
 
     test("cancelled -> idle is valid", () => {
-      expect(TaskStateMachine.validateTransition("cancelled", "idle")).toBe(
-        true,
-      );
+      expect(TaskStateMachine.validateTransition("cancelled", "idle")).toBe(true);
     });
 
     test("idle -> running is invalid", () => {
-      expect(TaskStateMachine.validateTransition("idle", "running")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("idle", "running")).toBe(false);
     });
 
     test("idle -> done is invalid", () => {
@@ -84,45 +64,31 @@ describe("TaskStateMachine", () => {
     });
 
     test("scheduled -> done is invalid", () => {
-      expect(TaskStateMachine.validateTransition("scheduled", "done")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("scheduled", "done")).toBe(false);
     });
 
     test("scheduled -> blocked is invalid", () => {
-      expect(TaskStateMachine.validateTransition("scheduled", "blocked")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("scheduled", "blocked")).toBe(false);
     });
 
     test("running -> scheduled is invalid", () => {
-      expect(TaskStateMachine.validateTransition("running", "scheduled")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("running", "scheduled")).toBe(false);
     });
 
     test("blocked -> scheduled is invalid", () => {
-      expect(TaskStateMachine.validateTransition("blocked", "scheduled")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("blocked", "scheduled")).toBe(false);
     });
 
     test("blocked -> done is invalid", () => {
-      expect(TaskStateMachine.validateTransition("blocked", "done")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("blocked", "done")).toBe(false);
     });
 
     test("done -> running is invalid", () => {
-      expect(TaskStateMachine.validateTransition("done", "running")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("done", "running")).toBe(false);
     });
 
     test("done -> scheduled is invalid", () => {
-      expect(TaskStateMachine.validateTransition("done", "scheduled")).toBe(
-        false,
-      );
+      expect(TaskStateMachine.validateTransition("done", "scheduled")).toBe(false);
     });
   });
 
@@ -294,9 +260,7 @@ describe("TaskStateMachine", () => {
         scheduledAt: Date.now(),
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun)).toBe(
-        "scheduled",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun)).toBe("scheduled");
     });
 
     test("derives running from pending run", () => {
@@ -312,9 +276,7 @@ describe("TaskStateMachine", () => {
         startedAt: Date.now(),
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun)).toBe(
-        "running",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun)).toBe("running");
     });
 
     test("derives blocked from pending run", () => {
@@ -330,9 +292,7 @@ describe("TaskStateMachine", () => {
         startedAt: Date.now(),
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun)).toBe(
-        "blocked",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun)).toBe("blocked");
     });
 
     test("auto-resets to idle for recurring task after done", () => {
@@ -349,9 +309,7 @@ describe("TaskStateMachine", () => {
         endedAt: Date.now(),
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, undefined, lastRun)).toBe(
-        "idle",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, undefined, lastRun)).toBe("idle");
     });
 
     test("auto-resets to idle for recurring task after failed", () => {
@@ -369,9 +327,7 @@ describe("TaskStateMachine", () => {
         error: "Something went wrong",
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, undefined, lastRun)).toBe(
-        "idle",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, undefined, lastRun)).toBe("idle");
     });
 
     test("auto-resets to idle for recurring task after cancelled", () => {
@@ -388,9 +344,7 @@ describe("TaskStateMachine", () => {
         endedAt: Date.now(),
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, undefined, lastRun)).toBe(
-        "idle",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, undefined, lastRun)).toBe("idle");
     });
 
     test("keeps done status for one-time task", () => {
@@ -412,9 +366,7 @@ describe("TaskStateMachine", () => {
         endedAt: Date.now(),
       };
 
-      expect(
-        TaskStateMachine.deriveStatus(oneTimeTask, undefined, lastRun),
-      ).toBe("done");
+      expect(TaskStateMachine.deriveStatus(oneTimeTask, undefined, lastRun)).toBe("done");
     });
 
     test("keeps failed status for one-time task", () => {
@@ -437,9 +389,7 @@ describe("TaskStateMachine", () => {
         error: "Failed",
       };
 
-      expect(
-        TaskStateMachine.deriveStatus(oneTimeTask, undefined, lastRun),
-      ).toBe("failed");
+      expect(TaskStateMachine.deriveStatus(oneTimeTask, undefined, lastRun)).toBe("failed");
     });
 
     test("keeps cancelled status for one-time task", () => {
@@ -461,9 +411,7 @@ describe("TaskStateMachine", () => {
         endedAt: Date.now(),
       };
 
-      expect(
-        TaskStateMachine.deriveStatus(oneTimeTask, undefined, lastRun),
-      ).toBe("cancelled");
+      expect(TaskStateMachine.deriveStatus(oneTimeTask, undefined, lastRun)).toBe("cancelled");
     });
 
     test("prefers pending run status over last run", () => {
@@ -492,9 +440,7 @@ describe("TaskStateMachine", () => {
         endedAt: Date.now() - 500,
       };
 
-      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun, lastRun)).toBe(
-        "running",
-      );
+      expect(TaskStateMachine.deriveStatus(baseTask, pendingRun, lastRun)).toBe("running");
     });
   });
 
@@ -537,10 +483,7 @@ describe("TaskStateMachine", () => {
 
     test("auto-resets recurring task from cancelled to idle", () => {
       const runningTask: Task.Info = { ...baseTask, status: "running" };
-      const updated = TaskStateMachine.applyTransition(
-        runningTask,
-        "cancelled",
-      );
+      const updated = TaskStateMachine.applyTransition(runningTask, "cancelled");
       expect(updated.status).toBe("idle");
     });
 
@@ -657,11 +600,7 @@ describe("TaskStatusManager", () => {
         endedAt: Date.now(),
       };
 
-      const updated = TaskStatusManager.updateFromRun(
-        baseTask,
-        undefined,
-        lastRun,
-      );
+      const updated = TaskStatusManager.updateFromRun(baseTask, undefined, lastRun);
       expect(updated.status).toBe("idle");
       expect(updated.lastRun).toEqual(lastRun);
     });
@@ -691,11 +630,7 @@ describe("TaskStatusManager", () => {
         endedAt: Date.now() - 500,
       };
 
-      const updated = TaskStatusManager.updateFromRun(
-        baseTask,
-        pendingRun,
-        lastRun,
-      );
+      const updated = TaskStatusManager.updateFromRun(baseTask, pendingRun, lastRun);
       expect(updated.status).toBe("scheduled");
       expect(updated.pendingRun).toEqual(pendingRun);
       expect(updated.lastRun).toEqual(lastRun);

--- a/packages/openomni/test/legacy/task/storage.test.ts
+++ b/packages/openomni/test/legacy/task/storage.test.ts
@@ -419,10 +419,7 @@ describe("InMemoryTaskStore", () => {
 
       const scheduledRuns = store.run.listByStatus(["scheduled"]);
       expect(scheduledRuns).toHaveLength(2);
-      expect(scheduledRuns.map((r) => r.runId).sort()).toEqual([
-        "run-1",
-        "run-3",
-      ]);
+      expect(scheduledRuns.map((r) => r.runId).sort()).toEqual(["run-1", "run-3"]);
 
       const activeRuns = store.run.listByStatus(["scheduled", "running"]);
       expect(activeRuns).toHaveLength(3);

--- a/packages/openomni/test/legacy/tools/dispatch.test.ts
+++ b/packages/openomni/test/legacy/tools/dispatch.test.ts
@@ -89,15 +89,11 @@ function createMockLLM(config?: {
         const prompt = String(input.prompt ?? "");
         const taskId = extractTaskId(prompt);
         const sessionId = String(input.sessionID ?? "unknown-session");
-        const isHandoff = prompt.includes(
-          "Create a handoff document for replacement agent.",
-        );
+        const isHandoff = prompt.includes("Create a handoff document for replacement agent.");
 
         calls.push({ taskId, prompt, sessionId, isHandoff });
 
-        const startLabel = isHandoff
-          ? `start:handoff:${taskId}`
-          : `start:${taskId}`;
+        const startLabel = isHandoff ? `start:handoff:${taskId}` : `start:${taskId}`;
         events.push(startLabel);
 
         inFlight += 1;
@@ -114,9 +110,7 @@ function createMockLLM(config?: {
 
         emitAssistantText(sink, sessionId, summary);
 
-        const endLabel = isHandoff
-          ? `stop:handoff:${taskId}`
-          : `stop:${taskId}`;
+        const endLabel = isHandoff ? `stop:handoff:${taskId}` : `stop:${taskId}`;
         events.push(endLabel);
 
         return { type: "stop" as const };
@@ -282,9 +276,7 @@ describe("Dispatch", () => {
     expect(executionCalls[2]?.prompt).toContain("needs-fix-2");
     expect(executionCalls[3]?.prompt).toContain("Handoff Document");
 
-    const firstThreeSessions = executionCalls
-      .slice(0, 3)
-      .map((call) => call.sessionId);
+    const firstThreeSessions = executionCalls.slice(0, 3).map((call) => call.sessionId);
     expect(new Set(firstThreeSessions).size).toBe(1);
 
     expect(sendSpy.mock.calls.length).toBeGreaterThanOrEqual(3);

--- a/packages/openomni/test/legacy/tools/nested-delegation.test.ts
+++ b/packages/openomni/test/legacy/tools/nested-delegation.test.ts
@@ -44,9 +44,7 @@ function createMockLLM() {
   };
 }
 
-function baseSubagentContext(
-  overrides: Partial<SubagentContext> = {},
-): SubagentContext {
+function baseSubagentContext(overrides: Partial<SubagentContext> = {}): SubagentContext {
   return {
     parentDepth: 0,
     llm: createMockLLM(),
@@ -54,9 +52,7 @@ function baseSubagentContext(
   };
 }
 
-function baseDispatchContext(
-  overrides: Partial<DispatchContext> = {},
-): DispatchContext {
+function baseDispatchContext(overrides: Partial<DispatchContext> = {}): DispatchContext {
   return {
     llm: createMockLLM(),
     ...overrides,
@@ -177,9 +173,7 @@ describe("Nested Delegation Guard", () => {
 
       expect(result.isError).toBe(true);
       expect(result.output).toContain("Nested delegation not allowed");
-      expect(result.output).toContain(
-        "dispatch child cannot call subagent/dispatch",
-      );
+      expect(result.output).toContain("dispatch child cannot call subagent/dispatch");
       expect(result.toolCallId).toBe("dispatch-nested");
       expect(result.id).toBeDefined();
     });

--- a/packages/openomni/test/legacy/tools/schedule-late.test.ts
+++ b/packages/openomni/test/legacy/tools/schedule-late.test.ts
@@ -105,9 +105,7 @@ describe("ScheduleTool - Late-Start Execution", () => {
     expect(task).toBeDefined();
 
     // Verify plannedStartAt is approximately now (within 1 second)
-    const plannedStartAtStr = task?.metadata?.plannedStartAt as
-      | string
-      | undefined;
+    const plannedStartAtStr = task?.metadata?.plannedStartAt as string | undefined;
     expect(plannedStartAtStr).toBeDefined();
     const plannedStartAtMs = new Date(plannedStartAtStr || "").getTime();
     expect(Math.abs(plannedStartAtMs - now)).toBeLessThan(1000);

--- a/packages/openomni/test/legacy/tools/schedule-recurring.test.ts
+++ b/packages/openomni/test/legacy/tools/schedule-recurring.test.ts
@@ -385,12 +385,7 @@ describe("ScheduleTool - Recurring Schedules", () => {
       const now = Date.now();
       const dueAtMs = now + 60 * 60 * 1000;
 
-      const expressions = [
-        "0 0 * * *",
-        "*/15 * * * *",
-        "0 0 1 * *",
-        "0 0 * * 0",
-      ];
+      const expressions = ["0 0 * * *", "*/15 * * * *", "0 0 1 * *", "0 0 * * 0"];
 
       for (const expr of expressions) {
         const input = {
@@ -462,8 +457,7 @@ describe("ScheduleTool - Recurring Schedules", () => {
 
       const output = JSON.parse(result.output);
       const plannedStartAtMs = new Date(output.plannedStartAt).getTime();
-      const expectedPlannedStartAtMs =
-        dueAtMs - estimatedRuntimeMs - safetyBufferMs;
+      const expectedPlannedStartAtMs = dueAtMs - estimatedRuntimeMs - safetyBufferMs;
 
       expect(plannedStartAtMs).toBe(expectedPlannedStartAtMs);
     });

--- a/packages/openomni/test/legacy/tools/schedule.test.ts
+++ b/packages/openomni/test/legacy/tools/schedule.test.ts
@@ -42,8 +42,7 @@ describe("ScheduleTool", () => {
 
       // Verify plannedStartAt calculation
       const plannedStartAtMs = new Date(output.plannedStartAt).getTime();
-      const expectedPlannedStartAtMs =
-        dueAtMs - estimatedRuntimeMs - safetyBufferMs;
+      const expectedPlannedStartAtMs = dueAtMs - estimatedRuntimeMs - safetyBufferMs;
       expect(plannedStartAtMs).toBe(expectedPlannedStartAtMs);
     });
 
@@ -236,8 +235,7 @@ describe("ScheduleTool", () => {
       expect(plannedStartAtMs).toBe(expectedMs);
 
       // Verify the math: plannedStartAt + estimatedRuntime + safetyBuffer = dueAt
-      const reconstructedDueAt =
-        plannedStartAtMs + estimatedRuntimeMs + safetyBufferMs;
+      const reconstructedDueAt = plannedStartAtMs + estimatedRuntimeMs + safetyBufferMs;
       expect(reconstructedDueAt).toBe(dueAtMs);
     });
 

--- a/packages/openomni/test/legacy/tools/subagent-announce.test.ts
+++ b/packages/openomni/test/legacy/tools/subagent-announce.test.ts
@@ -1,19 +1,8 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import type { Sink } from "@openomni/protocol";
 import { Session } from "@openomni/session";
 import { BuiltinAgentRegistry } from "../../../src/legacy/agent/registry/registry";
-import {
-  AgentMessenger,
-  type MessageEnvelope,
-} from "../../../src/legacy/agent/communication";
+import { AgentMessenger, type MessageEnvelope } from "../../../src/legacy/agent/communication";
 import { TaskStorage } from "../../../src/legacy/task/storage";
 import { Subagent, type SubagentContext } from "../../../src/legacy/tools/subagent";
 
@@ -57,9 +46,7 @@ function createMockLLM(behavior: "stop" | "error" = "stop") {
   };
 }
 
-function baseContext(
-  overrides: Partial<SubagentContext> = {},
-): SubagentContext {
+function baseContext(overrides: Partial<SubagentContext> = {}): SubagentContext {
   return {
     parentDepth: 0,
     llm: createMockLLM(),
@@ -191,9 +178,7 @@ describe("Subagent Completion Announce", () => {
     });
 
     it("announce failure does not affect parent run result", async () => {
-      AgentMessenger.configureAllowPatterns([
-        { from: "blocked-agent", to: "blocked-agent" },
-      ]);
+      AgentMessenger.configureAllowPatterns([{ from: "blocked-agent", to: "blocked-agent" }]);
 
       const result = await Subagent.execute(
         "call-announce-fail",
@@ -212,9 +197,7 @@ describe("Subagent Completion Announce", () => {
     it("announce failure logs error but does not throw", async () => {
       const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
 
-      AgentMessenger.configureAllowPatterns([
-        { from: "blocked-agent", to: "blocked-agent" },
-      ]);
+      AgentMessenger.configureAllowPatterns([{ from: "blocked-agent", to: "blocked-agent" }]);
 
       await Subagent.execute(
         "call-log-error",
@@ -224,10 +207,7 @@ describe("Subagent Completion Announce", () => {
 
       await new Promise((r) => setTimeout(r, 5));
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Announce failed (non-fatal):",
-        expect.any(Error),
-      );
+      expect(consoleSpy).toHaveBeenCalledWith("Announce failed (non-fatal):", expect.any(Error));
 
       consoleSpy.mockRestore();
     });

--- a/packages/openomni/test/legacy/tools/subagent.test.ts
+++ b/packages/openomni/test/legacy/tools/subagent.test.ts
@@ -48,9 +48,7 @@ function createMockLLM(behavior: "stop" | "error" | "hang" = "stop") {
   };
 }
 
-function baseContext(
-  overrides: Partial<SubagentContext> = {},
-): SubagentContext {
+function baseContext(overrides: Partial<SubagentContext> = {}): SubagentContext {
   return {
     parentDepth: 0,
     llm: createMockLLM(),
@@ -81,11 +79,7 @@ describe("Subagent", () => {
     });
 
     it("returns error for invalid input (missing prompt)", async () => {
-      const result = await Subagent.execute(
-        "call-2",
-        { agentType: "explore" },
-        baseContext(),
-      );
+      const result = await Subagent.execute("call-2", { agentType: "explore" }, baseContext());
 
       expect(result.isError).toBe(true);
       expect(result.output).toContain("Invalid subagent input");

--- a/packages/openomni/test/legacy/trigger/scheduler.test.ts
+++ b/packages/openomni/test/legacy/trigger/scheduler.test.ts
@@ -52,9 +52,7 @@ describe("CronParser", () => {
       expect(fields).not.toBeNull();
       expect(fields!.minute).toEqual([0, 30]);
       expect(fields!.hour).toEqual([9, 10, 11, 12, 13, 14, 15, 16, 17]);
-      expect(fields!.dayOfMonth).toEqual([
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-      ]);
+      expect(fields!.dayOfMonth).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
       expect(fields!.month).toEqual([1, 6]);
       expect(fields!.dayOfWeek).toEqual([1, 2, 3, 4, 5]);
     });

--- a/packages/openomni/test/legacy/trigger/watcher.test.ts
+++ b/packages/openomni/test/legacy/trigger/watcher.test.ts
@@ -41,12 +41,9 @@ describe("FilesystemWatcher", () => {
   const createWatcher = (overrides: Partial<WatcherConfig> = {}) => {
     watcher?.clearAll();
     events = [];
-    watcher = new FilesystemWatcher(
-      { ...baseConfig, ...overrides },
-      (event) => {
-        events.push(event);
-      },
-    );
+    watcher = new FilesystemWatcher({ ...baseConfig, ...overrides }, (event) => {
+      events.push(event);
+    });
     return watcher;
   };
 

--- a/packages/openomni/test/legacy/worker/agent-resolution.test.ts
+++ b/packages/openomni/test/legacy/worker/agent-resolution.test.ts
@@ -31,9 +31,7 @@ const FAKE_ANTHROPIC_PROVIDER: ModelsDev.Provider = {
 };
 
 function mockModelsDevGet(data?: Record<string, ModelsDev.Provider>) {
-  return spyOn(ModelsDev, "get").mockResolvedValue(
-    data ?? { anthropic: FAKE_ANTHROPIC_PROVIDER },
-  );
+  return spyOn(ModelsDev, "get").mockResolvedValue(data ?? { anthropic: FAKE_ANTHROPIC_PROVIDER });
 }
 
 describe("agent-resolution", () => {
@@ -124,9 +122,7 @@ describe("agent-resolution", () => {
 
     it("rejects disallowed tools", async () => {
       const executor = resolveToolExecutor(["read", "grep"]);
-      const results = await executor.execute([
-        { id: "call-1", tool: "write", input: {} },
-      ]);
+      const results = await executor.execute([{ id: "call-1", tool: "write", input: {} }]);
 
       expect(results).toHaveLength(1);
       expect(results[0].isError).toBe(true);
@@ -136,9 +132,7 @@ describe("agent-resolution", () => {
 
     it("accepts allowed tools with placeholder response", async () => {
       const executor = resolveToolExecutor(["read", "write"]);
-      const results = await executor.execute([
-        { id: "call-1", tool: "read", input: {} },
-      ]);
+      const results = await executor.execute([{ id: "call-1", tool: "read", input: {} }]);
 
       expect(results).toHaveLength(1);
       expect(results[0].toolCallId).toBe("call-1");
@@ -171,9 +165,7 @@ describe("agent-resolution", () => {
 
     it("preserves toolCallId from input", async () => {
       const executor = resolveToolExecutor(["read"]);
-      const results = await executor.execute([
-        { id: "my-call-id", tool: "read", input: {} },
-      ]);
+      const results = await executor.execute([{ id: "my-call-id", tool: "read", input: {} }]);
 
       expect(results[0].toolCallId).toBe("my-call-id");
     });
@@ -236,9 +228,7 @@ describe("agent-resolution", () => {
     it("throws when default model also fails", async () => {
       const spy = mockModelsDevGet({});
       try {
-        await expect(resolveLLM(undefined)).rejects.toThrow(
-          "Provider not found: anthropic",
-        );
+        await expect(resolveLLM(undefined)).rejects.toThrow("Provider not found: anthropic");
       } finally {
         spy.mockRestore();
       }
@@ -279,9 +269,7 @@ describe("agent-resolution", () => {
       const spy = mockModelsDevGet();
       try {
         const config = await resolveAgentForWorker("implement");
-        expect((config.input as any).system).toContain(
-          "expert software engineer",
-        );
+        expect((config.input as any).system).toContain("expert software engineer");
       } finally {
         spy.mockRestore();
       }

--- a/packages/openomni/test/legacy/worker/agent-resolution.test.ts
+++ b/packages/openomni/test/legacy/worker/agent-resolution.test.ts
@@ -1,13 +1,6 @@
-import { describe, it, expect, beforeEach, spyOn } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { ModelsDev } from "@openomni/llm";
 import { BuiltinAgentRegistry } from "../../../src/legacy/agent/registry/registry";
-import { ModelsDev } from "@openomni/llm/src/provider";
-import {
-  resolveAgentDefinition,
-  resolveLLM,
-  resolveToolExecutor,
-  resolveAgentForWorker,
-  fallbackToolExecutor,
-} from "../../../src/legacy/worker/agent-resolution";
 
 const FAKE_ANTHROPIC_PROVIDER: ModelsDev.Provider = {
   id: "anthropic",
@@ -30,16 +23,58 @@ const FAKE_ANTHROPIC_PROVIDER: ModelsDev.Provider = {
   },
 };
 
-function mockModelsDevGet(data?: Record<string, ModelsDev.Provider>) {
-  return spyOn(ModelsDev, "get").mockResolvedValue(data ?? { anthropic: FAKE_ANTHROPIC_PROVIDER });
-}
+let modelsCatalog: Record<string, ModelsDev.Provider> = {
+  anthropic: FAKE_ANTHROPIC_PROVIDER,
+};
+
+const mockModelsGet = mock(async () => modelsCatalog);
+const mockProviderFromModelsDevModel = mock((provider: { id: string }, model: { id: string }) => ({
+  id: model.id,
+  providerID: provider.id,
+}));
+const mockRun = mock(async () => ({ type: "stop" as const }));
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mockModelsGet },
+  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  run: mockRun,
+  TokenTracker: {
+    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
+  },
+}));
+
+let resolveAgentDefinition: typeof import("../../../src/legacy/worker/agent-resolution").resolveAgentDefinition;
+let resolveLLM: typeof import("../../../src/legacy/worker/agent-resolution").resolveLLM;
+let resolveToolExecutor: typeof import("../../../src/legacy/worker/agent-resolution").resolveToolExecutor;
+let resolveAgentForWorker: typeof import("../../../src/legacy/worker/agent-resolution").resolveAgentForWorker;
+let fallbackToolExecutor: typeof import("../../../src/legacy/worker/agent-resolution").fallbackToolExecutor;
+
+beforeAll(async () => {
+  ({
+    resolveAgentDefinition,
+    resolveLLM,
+    resolveToolExecutor,
+    resolveAgentForWorker,
+    fallbackToolExecutor,
+  } = await import("../../../src/legacy/worker/agent-resolution"));
+});
+
+beforeEach(() => {
+  modelsCatalog = { anthropic: FAKE_ANTHROPIC_PROVIDER };
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
+  mockRun.mockClear();
+
+  BuiltinAgentRegistry.clear();
+  BuiltinAgentRegistry.initializeBuiltins();
+});
+
+afterAll(() => {
+  mock.restore();
+});
 
 describe("agent-resolution", () => {
-  beforeEach(() => {
-    BuiltinAgentRegistry.clear();
-    BuiltinAgentRegistry.initializeBuiltins();
-  });
-
   describe("resolveAgentDefinition", () => {
     it("returns definition for existing agent", () => {
       const def = resolveAgentDefinition("explore");
@@ -173,121 +208,80 @@ describe("agent-resolution", () => {
 
   describe("resolveLLM", () => {
     it("returns LLM runner for valid model config", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const llm = await resolveLLM({
-          providerID: "anthropic",
-          modelID: "claude-sonnet-4-20250514",
-        });
-        expect(llm).toBeDefined();
-        expect(typeof llm.run).toBe("function");
-      } finally {
-        spy.mockRestore();
-      }
+      const llm = await resolveLLM({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-20250514",
+      });
+      expect(llm).toBeDefined();
+      expect(typeof llm.run).toBe("function");
     });
 
     it("returns default LLM runner when model is undefined", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const llm = await resolveLLM(undefined);
-        expect(llm).toBeDefined();
-        expect(typeof llm.run).toBe("function");
-      } finally {
-        spy.mockRestore();
-      }
+      const llm = await resolveLLM(undefined);
+      expect(llm).toBeDefined();
+      expect(typeof llm.run).toBe("function");
     });
 
     it("falls back to default when custom model provider not found", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const llm = await resolveLLM({
-          providerID: "nonexistent-provider",
-          modelID: "some-model",
-        });
-        expect(llm).toBeDefined();
-        expect(typeof llm.run).toBe("function");
-      } finally {
-        spy.mockRestore();
-      }
+      const llm = await resolveLLM({
+        providerID: "nonexistent-provider",
+        modelID: "some-model",
+      });
+      expect(llm).toBeDefined();
+      expect(typeof llm.run).toBe("function");
     });
 
     it("falls back to default when custom model ID not found", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const llm = await resolveLLM({
-          providerID: "anthropic",
-          modelID: "nonexistent-model",
-        });
-        expect(llm).toBeDefined();
-        expect(typeof llm.run).toBe("function");
-      } finally {
-        spy.mockRestore();
-      }
+      const llm = await resolveLLM({
+        providerID: "anthropic",
+        modelID: "nonexistent-model",
+      });
+      expect(llm).toBeDefined();
+      expect(typeof llm.run).toBe("function");
     });
 
     it("throws when default model also fails", async () => {
-      const spy = mockModelsDevGet({});
-      try {
-        await expect(resolveLLM(undefined)).rejects.toThrow("Provider not found: anthropic");
-      } finally {
-        spy.mockRestore();
-      }
+      modelsCatalog = {};
+      await expect(resolveLLM(undefined)).rejects.toThrow("Provider not found: anthropic");
     });
   });
 
   describe("resolveAgentForWorker", () => {
     it("returns complete config for existing agent", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const config = await resolveAgentForWorker("explore");
-        expect(config.llm).toBeDefined();
-        expect(typeof config.llm.run).toBe("function");
-        expect(config.input).toHaveProperty("system");
-        expect(typeof (config.input as any).system).toBe("string");
-        expect((config.input as any).system.length).toBeGreaterThan(0);
-        expect(config.toolExecutor).toBeDefined();
-        expect(config.toolExecutor).not.toBe(fallbackToolExecutor);
-      } finally {
-        spy.mockRestore();
+      const config = await resolveAgentForWorker("explore");
+      expect(config.llm).toBeDefined();
+      expect(typeof config.llm.run).toBe("function");
+      expect(config.input).toHaveProperty("system");
+      if ("system" in config.input && typeof config.input.system === "string") {
+        expect(config.input.system.length).toBeGreaterThan(0);
       }
+      expect(config.toolExecutor).toBeDefined();
+      expect(config.toolExecutor).not.toBe(fallbackToolExecutor);
     });
 
     it("returns fallback config for nonexistent agent", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const config = await resolveAgentForWorker("nonexistent-agent");
-        expect(config.llm).toBeDefined();
-        expect(typeof config.llm.run).toBe("function");
-        expect(config.input).toEqual({});
-        expect(config.toolExecutor).toBe(fallbackToolExecutor);
-      } finally {
-        spy.mockRestore();
-      }
+      const config = await resolveAgentForWorker("nonexistent-agent");
+      expect(config.llm).toBeDefined();
+      expect(typeof config.llm.run).toBe("function");
+      expect(config.input).toEqual({});
+      expect(config.toolExecutor).toBe(fallbackToolExecutor);
     });
 
     it("uses agent systemPrompt in input", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const config = await resolveAgentForWorker("implement");
-        expect((config.input as any).system).toContain("expert software engineer");
-      } finally {
-        spy.mockRestore();
+      const config = await resolveAgentForWorker("implement");
+      if ("system" in config.input && typeof config.input.system === "string") {
+        expect(config.input.system).toContain("expert software engineer");
       }
     });
 
     it("uses agent tools for toolExecutor", async () => {
-      const spy = mockModelsDevGet();
-      try {
-        const config = await resolveAgentForWorker("explore");
-        const results = await config.toolExecutor.execute([
-          { id: "c1", tool: "read", input: {} },
-          { id: "c2", tool: "write", input: {} },
-        ]);
-        expect(results[0].output).toContain("allowed but no executor");
-        expect(results[1].output).toContain("not allowed");
-      } finally {
-        spy.mockRestore();
-      }
+      const config = await resolveAgentForWorker("explore");
+      const results = await config.toolExecutor.execute([
+        { id: "c1", tool: "read", input: {} },
+        { id: "c2", tool: "write", input: {} },
+      ]);
+      expect(results[0].output).toContain("allowed but no executor");
+      expect(results[1].output).toContain("not allowed");
     });
   });
 

--- a/packages/openomni/test/plan/plan-agent.test.ts
+++ b/packages/openomni/test/plan/plan-agent.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Message, Run, Sink } from "@openomni/protocol";
 
 // --- Mock setup (must be before dynamic import) ---
@@ -41,6 +41,10 @@ let PlanAgent: typeof import("../../src/plan/plan-agent").PlanAgent;
 
 beforeAll(async () => {
   ({ PlanAgent } = await import("../../src/plan/plan-agent"));
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 // --- Helpers ---

--- a/packages/openomni/test/plan/plan-pipeline.test.ts
+++ b/packages/openomni/test/plan/plan-pipeline.test.ts
@@ -65,10 +65,7 @@ describe("PlanPipeline.run", () => {
     if (result.ok) {
       expect(result.attempts).toBe(1);
       expect(result.gateResults).toHaveLength(2);
-      expect(result.gateResults.map((entry) => entry.gateName)).toEqual([
-        "gate-a",
-        "gate-b",
-      ]);
+      expect(result.gateResults.map((entry) => entry.gateName)).toEqual(["gate-a", "gate-b"]);
     }
   });
 

--- a/packages/openomni/test/plan/spec-validator.test.ts
+++ b/packages/openomni/test/plan/spec-validator.test.ts
@@ -126,9 +126,7 @@ describe("SpecValidator", () => {
       });
       const result = SpecValidator.validate(plan, { strictness: "strict" });
       expect(result.valid).toBe(false);
-      const issue = result.issues.find(
-        (i) => i.code === "missing_expected_output",
-      );
+      const issue = result.issues.find((i) => i.code === "missing_expected_output");
       expect(issue).toBeDefined();
       expect(issue?.stepId).toBe("step-1");
     });

--- a/packages/openomni/test/plan/structural-gate.test.ts
+++ b/packages/openomni/test/plan/structural-gate.test.ts
@@ -32,12 +32,8 @@ describe("StructuralGate", () => {
   describe("Check 1: DAG validity", () => {
     it("passes for valid DAG", () => {
       const result = StructuralGate.evaluate(makePlan());
-      expect(
-        result.issues.find((issue) => issue.code === "invalid_dag"),
-      ).toBeUndefined();
-      expect(
-        result.issues.find((issue) => issue.code === "circular_dependency"),
-      ).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "invalid_dag")).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "circular_dependency")).toBeUndefined();
     });
 
     it("fails for circular dependency", () => {
@@ -61,9 +57,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan);
-      const cycleIssue = result.issues.find(
-        (issue) => issue.code === "circular_dependency",
-      );
+      const cycleIssue = result.issues.find((issue) => issue.code === "circular_dependency");
 
       expect(cycleIssue).toBeDefined();
       expect(cycleIssue?.severity).toBe("error");
@@ -85,9 +79,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan);
-      const invalidDagIssue = result.issues.find(
-        (issue) => issue.code === "invalid_dag",
-      );
+      const invalidDagIssue = result.issues.find((issue) => issue.code === "invalid_dag");
 
       expect(invalidDagIssue).toBeDefined();
       expect(invalidDagIssue?.severity).toBe("error");
@@ -97,9 +89,7 @@ describe("StructuralGate", () => {
   describe("Check 2: Field completeness", () => {
     it("passes for complete fields", () => {
       const result = StructuralGate.evaluate(makePlan());
-      expect(
-        result.issues.find((issue) => issue.code === "empty_field"),
-      ).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "empty_field")).toBeUndefined();
     });
 
     it("fails for empty description", () => {
@@ -116,9 +106,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan);
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "empty_field",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "empty_field");
 
       expect(issue).toBeDefined();
       expect(issue?.stepId).toBe("step-1");
@@ -140,9 +128,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan);
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "empty_field",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "empty_field");
 
       expect(issue).toBeDefined();
       expect(issue?.stepId).toBe("step-1");
@@ -163,9 +149,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan, { requireGuardrail: true });
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "missing_guardrail",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "missing_guardrail");
 
       expect(issue).toBeDefined();
       expect(issue?.stepId).toBe("step-1");
@@ -184,9 +168,7 @@ describe("StructuralGate", () => {
         result.issues.find((issue) => issue.code === "low_quality_description"),
       ).toBeUndefined();
       expect(
-        result.issues.find(
-          (issue) => issue.code === "low_quality_expected_output",
-        ),
+        result.issues.find((issue) => issue.code === "low_quality_expected_output"),
       ).toBeUndefined();
     });
 
@@ -204,9 +186,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan, { minDescriptionWords: 3 });
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "low_quality_description",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "low_quality_description");
 
       expect(issue).toBeDefined();
       expect(issue?.severity).toBe("warning");
@@ -263,9 +243,7 @@ describe("StructuralGate", () => {
       const result = StructuralGate.evaluate(plan, {
         duplicateThreshold: 0.85,
       });
-      expect(
-        result.issues.find((issue) => issue.code === "duplicate_steps"),
-      ).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "duplicate_steps")).toBeUndefined();
     });
 
     it("warns for similar steps above threshold", () => {
@@ -289,9 +267,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan, { duplicateThreshold: 0.8 });
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "duplicate_steps",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "duplicate_steps");
 
       expect(issue).toBeDefined();
       expect(issue?.severity).toBe("warning");
@@ -305,9 +281,7 @@ describe("StructuralGate", () => {
       const result = StructuralGate.evaluate(makePlan(), {
         maxDependencyDepth: 2,
       });
-      expect(
-        result.issues.find((issue) => issue.code === "deep_dependency_chain"),
-      ).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "deep_dependency_chain")).toBeUndefined();
     });
 
     it("warns for deep chain", () => {
@@ -345,9 +319,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan, { maxDependencyDepth: 2 });
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "deep_dependency_chain",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "deep_dependency_chain");
 
       expect(issue).toBeDefined();
       expect(issue?.severity).toBe("warning");
@@ -357,9 +329,7 @@ describe("StructuralGate", () => {
   describe("Check 6: Isolated step detection", () => {
     it("passes for connected steps", () => {
       const result = StructuralGate.evaluate(makePlan());
-      expect(
-        result.issues.find((issue) => issue.code === "isolated_step"),
-      ).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "isolated_step")).toBeUndefined();
     });
 
     it("warns for isolated step in multi-step plan", () => {
@@ -390,9 +360,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan);
-      const issue = result.issues.find(
-        (candidate) => candidate.code === "isolated_step",
-      );
+      const issue = result.issues.find((candidate) => candidate.code === "isolated_step");
 
       expect(issue).toBeDefined();
       expect(issue?.severity).toBe("warning");
@@ -413,9 +381,7 @@ describe("StructuralGate", () => {
       });
 
       const result = StructuralGate.evaluate(plan);
-      expect(
-        result.issues.find((issue) => issue.code === "isolated_step"),
-      ).toBeUndefined();
+      expect(result.issues.find((issue) => issue.code === "isolated_step")).toBeUndefined();
     });
   });
 
@@ -435,12 +401,8 @@ describe("StructuralGate", () => {
 
       const result = StructuralGate.evaluate(plan, { minDescriptionWords: 3 });
       expect(result.passed).toBe(true);
-      expect(result.issues.some((issue) => issue.severity === "warning")).toBe(
-        true,
-      );
-      expect(result.issues.some((issue) => issue.severity === "error")).toBe(
-        false,
-      );
+      expect(result.issues.some((issue) => issue.severity === "warning")).toBe(true);
+      expect(result.issues.some((issue) => issue.severity === "error")).toBe(false);
     });
 
     it("returns passed: false when any error exists", () => {
@@ -458,9 +420,7 @@ describe("StructuralGate", () => {
 
       const result = StructuralGate.evaluate(plan);
       expect(result.passed).toBe(false);
-      expect(result.issues.some((issue) => issue.severity === "error")).toBe(
-        true,
-      );
+      expect(result.issues.some((issue) => issue.severity === "error")).toBe(true);
     });
 
     it("collects all issues across all checks", () => {
@@ -497,26 +457,14 @@ describe("StructuralGate", () => {
         requireGuardrail: true,
       });
 
-      expect(result.issues.some((issue) => issue.code === "empty_field")).toBe(
+      expect(result.issues.some((issue) => issue.code === "empty_field")).toBe(true);
+      expect(result.issues.some((issue) => issue.code === "missing_guardrail")).toBe(true);
+      expect(result.issues.some((issue) => issue.code === "low_quality_description")).toBe(true);
+      expect(result.issues.some((issue) => issue.code === "low_quality_expected_output")).toBe(
         true,
       );
-      expect(
-        result.issues.some((issue) => issue.code === "missing_guardrail"),
-      ).toBe(true);
-      expect(
-        result.issues.some((issue) => issue.code === "low_quality_description"),
-      ).toBe(true);
-      expect(
-        result.issues.some(
-          (issue) => issue.code === "low_quality_expected_output",
-        ),
-      ).toBe(true);
-      expect(
-        result.issues.some((issue) => issue.code === "duplicate_steps"),
-      ).toBe(true);
-      expect(
-        result.issues.some((issue) => issue.code === "isolated_step"),
-      ).toBe(true);
+      expect(result.issues.some((issue) => issue.code === "duplicate_steps")).toBe(true);
+      expect(result.issues.some((issue) => issue.code === "isolated_step")).toBe(true);
     });
 
     it("skips duplicate and depth checks when DAG is invalid", () => {
@@ -544,15 +492,9 @@ describe("StructuralGate", () => {
         maxDependencyDepth: 0,
       });
 
-      expect(result.issues.some((issue) => issue.code === "invalid_dag")).toBe(
-        true,
-      );
-      expect(
-        result.issues.some((issue) => issue.code === "duplicate_steps"),
-      ).toBe(false);
-      expect(
-        result.issues.some((issue) => issue.code === "deep_dependency_chain"),
-      ).toBe(false);
+      expect(result.issues.some((issue) => issue.code === "invalid_dag")).toBe(true);
+      expect(result.issues.some((issue) => issue.code === "duplicate_steps")).toBe(false);
+      expect(result.issues.some((issue) => issue.code === "deep_dependency_chain")).toBe(false);
     });
   });
 });

--- a/packages/openomni/test/team/approval-gate.test.ts
+++ b/packages/openomni/test/team/approval-gate.test.ts
@@ -56,10 +56,7 @@ const defaultTeammateConfig: Teammate.TeammateConfig = {
   model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
 };
 
-function makeConfig(overrides?: {
-  approvalGate?: ApprovalGate.Gate;
-  maxAttemptsPerStep?: number;
-}) {
+function makeConfig(overrides?: { approvalGate?: ApprovalGate.Gate; maxAttemptsPerStep?: number }) {
   return {
     reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     teammates: new Map<string, Teammate.TeammateConfig>(),
@@ -177,10 +174,7 @@ describe("TeamOrchestrator with ApprovalGate", () => {
 
     const plan = makePlan([makeStep("s1", { requiresApproval: true })]);
 
-    const resultPromise = TeamOrchestrator.execute(
-      plan,
-      makeConfig({ approvalGate: gate }),
-    );
+    const resultPromise = TeamOrchestrator.execute(plan, makeConfig({ approvalGate: gate }));
 
     // Small delay to let orchestrator reach the approval gate
     await new Promise((r) => setTimeout(r, 10));
@@ -197,10 +191,7 @@ describe("TeamOrchestrator with ApprovalGate", () => {
 
     const plan = makePlan([makeStep("s1", { requiresApproval: true })]);
 
-    const resultPromise = TeamOrchestrator.execute(
-      plan,
-      makeConfig({ approvalGate: gate }),
-    );
+    const resultPromise = TeamOrchestrator.execute(plan, makeConfig({ approvalGate: gate }));
 
     await new Promise((r) => setTimeout(r, 10));
     gate.respond("rejected");
@@ -215,10 +206,7 @@ describe("TeamOrchestrator with ApprovalGate", () => {
 
     const plan = makePlan([makeStep("s1", { requiresApproval: true })]);
 
-    const result = await TeamOrchestrator.execute(
-      plan,
-      makeConfig({ approvalGate: gate }),
-    );
+    const result = await TeamOrchestrator.execute(plan, makeConfig({ approvalGate: gate }));
 
     expect(result.status).toBe("failed");
     expect(result.failedSteps).toEqual(["s1"]);
@@ -232,10 +220,7 @@ describe("TeamOrchestrator with ApprovalGate", () => {
       makeStep("s2", { dependsOn: ["s1"] }),
     ]);
 
-    const resultPromise = TeamOrchestrator.execute(
-      plan,
-      makeConfig({ approvalGate: gate }),
-    );
+    const resultPromise = TeamOrchestrator.execute(plan, makeConfig({ approvalGate: gate }));
 
     await new Promise((r) => setTimeout(r, 10));
     gate.respond("rejected");
@@ -279,10 +264,7 @@ describe("TeamOrchestrator with ApprovalGate", () => {
 
     const plan = makePlan([makeStep("s1", { requiresApproval: true })]);
 
-    const result = await TeamOrchestrator.execute(
-      plan,
-      makeConfig({ approvalGate: customGate }),
-    );
+    const result = await TeamOrchestrator.execute(plan, makeConfig({ approvalGate: customGate }));
 
     expect(result.status).toBe("completed");
     expect(result.completedSteps).toEqual(["s1"]);

--- a/packages/openomni/test/team/event-stream.test.ts
+++ b/packages/openomni/test/team/event-stream.test.ts
@@ -45,11 +45,7 @@ beforeEach(() => {
   publishedEvents.length = 0;
 });
 
-function makeStep(
-  stepId: string,
-  dependsOn: string[] = [],
-  suggestedAgent?: string,
-): PlanStep {
+function makeStep(stepId: string, dependsOn: string[] = [], suggestedAgent?: string): PlanStep {
   return {
     stepId,
     description: `${stepId} task`,
@@ -80,8 +76,7 @@ function makeConfig(overrides?: {
 }) {
   return {
     reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
-    teammates:
-      overrides?.teammates ?? new Map<string, Teammate.TeammateConfig>(),
+    teammates: overrides?.teammates ?? new Map<string, Teammate.TeammateConfig>(),
     defaultTeammateConfig,
     maxAttemptsPerStep: overrides?.maxAttemptsPerStep,
   };
@@ -95,9 +90,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1")]);
     await TeamOrchestrator.execute(plan, makeConfig());
 
-    const planCreatedEvent = publishedEvents.find(
-      (e) => e.eventName === "plan.created",
-    );
+    const planCreatedEvent = publishedEvents.find((e) => e.eventName === "plan.created");
     expect(planCreatedEvent).toBeDefined();
     expect(planCreatedEvent?.data).toMatchObject({
       payload: {
@@ -117,9 +110,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1"), makeStep("s2")]);
     await TeamOrchestrator.execute(plan, makeConfig());
 
-    const assignedEvents = publishedEvents.filter(
-      (e) => e.eventName === "step.assigned",
-    );
+    const assignedEvents = publishedEvents.filter((e) => e.eventName === "step.assigned");
     expect(assignedEvents.length).toBe(2);
     expect(assignedEvents[0]?.data).toMatchObject({
       payload: {
@@ -144,9 +135,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1")]);
     await TeamOrchestrator.execute(plan, makeConfig());
 
-    const startedEvent = publishedEvents.find(
-      (e) => e.eventName === "step.started",
-    );
+    const startedEvent = publishedEvents.find((e) => e.eventName === "step.started");
     expect(startedEvent).toBeDefined();
     expect(startedEvent?.data).toMatchObject({
       payload: {
@@ -165,9 +154,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1")]);
     await TeamOrchestrator.execute(plan, makeConfig());
 
-    const completedEvent = publishedEvents.find(
-      (e) => e.eventName === "step.completed",
-    );
+    const completedEvent = publishedEvents.find((e) => e.eventName === "step.completed");
     expect(completedEvent).toBeDefined();
     expect(completedEvent?.data).toMatchObject({
       payload: {
@@ -185,9 +172,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1")]);
     await TeamOrchestrator.execute(plan, makeConfig());
 
-    const decisionEvent = publishedEvents.find(
-      (e) => e.eventName === "review.decision",
-    );
+    const decisionEvent = publishedEvents.find((e) => e.eventName === "review.decision");
     expect(decisionEvent).toBeDefined();
     expect(decisionEvent?.data).toMatchObject({
       payload: {
@@ -209,9 +194,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1")]);
     await TeamOrchestrator.execute(plan, makeConfig({ maxAttemptsPerStep: 3 }));
 
-    const failedEvent = publishedEvents.find(
-      (e) => e.eventName === "step.failed",
-    );
+    const failedEvent = publishedEvents.find((e) => e.eventName === "step.failed");
     expect(failedEvent).toBeDefined();
     expect(failedEvent?.data).toMatchObject({
       payload: {
@@ -228,9 +211,7 @@ describe("TeamOrchestrator event stream", () => {
     const plan = makePlan([makeStep("s1")]);
     await TeamOrchestrator.execute(plan, makeConfig());
 
-    const completeEvent = publishedEvents.find(
-      (e) => e.eventName === "execution.complete",
-    );
+    const completeEvent = publishedEvents.find((e) => e.eventName === "execution.complete");
     expect(completeEvent).toBeDefined();
     expect(completeEvent?.data).toMatchObject({
       payload: {

--- a/packages/openomni/test/team/review-loop.test.ts
+++ b/packages/openomni/test/team/review-loop.test.ts
@@ -141,18 +141,16 @@ describe("ReviewLoop", () => {
     it("throws when LLM returns invalid JSON", async () => {
       setupMockResponse("This is definitely not JSON");
 
-      await expect(
-        ReviewLoop.review(defaultInput, defaultConfig),
-      ).rejects.toThrow(/failed to parse/i);
+      await expect(ReviewLoop.review(defaultInput, defaultConfig)).rejects.toThrow(
+        /failed to parse/i,
+      );
     });
 
     it("includes guardrail in review prompt when step has guardrail", async () => {
       let capturedInput: any;
       mockRunFn = async (input: any, sink: Sink) => {
         capturedInput = input;
-        sink.onMessage(
-          createAssistantMessage(JSON.stringify({ decision: "accept" })),
-        );
+        sink.onMessage(createAssistantMessage(JSON.stringify({ decision: "accept" })));
         return { type: "stop" } as Run.Outcome;
       };
 
@@ -161,20 +159,15 @@ describe("ReviewLoop", () => {
         guardrail: "Must not expose user passwords in logs",
       };
 
-      await ReviewLoop.review(
-        { ...defaultInput, step: stepWithGuardrail },
-        defaultConfig,
-      );
+      await ReviewLoop.review({ ...defaultInput, step: stepWithGuardrail }, defaultConfig);
 
       // The user message (first in messages array) should contain the guardrail
       const messages = capturedInput.messages as Message.WithParts[];
       const userMsg = messages[0];
-      const textPart = userMsg.parts.find(
-        (p: Message.Part) => p.type === "text",
-      ) as Message.TextPart | undefined;
-      expect(textPart?.text).toContain(
-        "Must not expose user passwords in logs",
-      );
+      const textPart = userMsg.parts.find((p: Message.Part) => p.type === "text") as
+        | Message.TextPart
+        | undefined;
+      expect(textPart?.text).toContain("Must not expose user passwords in logs");
     });
   });
 
@@ -205,9 +198,7 @@ describe("ReviewLoop", () => {
 
   describe("generateHandoff", () => {
     it("returns a non-empty handoff document", async () => {
-      setupMockResponse(
-        "## Handoff Document\n\nThe login feature was rejected because...",
-      );
+      setupMockResponse("## Handoff Document\n\nThe login feature was rejected because...");
 
       const handoff = await ReviewLoop.generateHandoff(
         defaultInput,

--- a/packages/openomni/test/team/review-loop.test.ts
+++ b/packages/openomni/test/team/review-loop.test.ts
@@ -1,91 +1,56 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { ChatAgent, type AgentResult, type ChatAgentInput } from "@openomni/agent";
 import type { PlanStep } from "@openomni/protocol";
-import type { Message, Run, Sink } from "@openomni/protocol";
+import { ReviewLoop } from "../../src/team/review-loop";
 
-// --- Mock setup (must be before dynamic import) ---
+const originalCreate = ChatAgent.create;
+const createSpy = spyOn(ChatAgent, "create");
 
-type MockLlmFn = (input: any, sink: Sink) => Promise<Run.Outcome>;
+function makeAgentResult(text: string): AgentResult {
+  return {
+    text,
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    finishReason: "stop",
+  };
+}
 
-let mockRunFn: MockLlmFn = async () => ({ type: "stop" });
-
-const mockModelsGet = mock(async () => ({
-  anthropic: {
-    id: "anthropic",
-    name: "Anthropic",
-    models: {
-      "claude-3-haiku-20240307": {
-        id: "claude-3-haiku-20240307",
-        name: "Claude 3 Haiku",
-      },
-    },
-  },
-}));
-
-const mockProviderFromModelsDevModel = mock(() => ({
-  id: "claude-3-haiku-20240307",
-  providerID: "anthropic",
-}));
-
-mock.module("@openomni/llm", () => ({
-  ModelsDev: { get: mockModelsGet },
-  Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
-  run: (input: any, sink: Sink) => mockRunFn(input, sink),
-  TokenTracker: {
-    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
-  },
-}));
-
-// --- Dynamic import after mock ---
-
-let ReviewLoop: typeof import("../../src/team/review-loop").ReviewLoop;
-
-beforeAll(async () => {
-  ({ ReviewLoop } = await import("../../src/team/review-loop"));
+let capturedInput: ChatAgentInput | undefined;
+let runImpl = mock(async (input: ChatAgentInput) => {
+  capturedInput = input;
+  return makeAgentResult("{}");
 });
 
-// --- Helpers ---
+beforeEach(() => {
+  capturedInput = undefined;
+  runImpl = mock(async (input: ChatAgentInput) => {
+    capturedInput = input;
+    return makeAgentResult("{}");
+  });
 
-function createAssistantMessage(text: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "review-test";
-  const now = Date.now();
-  const info: Message.AssistantMessage = {
-    id,
-    sessionID,
-    role: "assistant",
-    time: { created: now },
-    parentID: "",
-    modelID: "claude-3-haiku-20240307",
-    providerID: "anthropic",
-    agent: "chat-agent",
-    path: { cwd: "", root: "" },
-    cost: 0,
-    tokens: {
-      input: 10,
-      output: 5,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-  };
-  const textPart: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID,
-    messageID: id,
-    type: "text",
-    text,
-  };
-  return { info, parts: [textPart] };
-}
+  createSpy.mockImplementation((config) => {
+    const realAgent = originalCreate(config);
+    return {
+      ...realAgent,
+      run: async (input: ChatAgentInput) => {
+        const firstMessage = input.messages[0]?.content ?? "";
+        if (
+          firstMessage.includes("You are reviewing the output of a task execution") ||
+          firstMessage.includes(
+            "Generate a handoff document for the following failed task execution",
+          )
+        ) {
+          return runImpl(input);
+        }
+        return realAgent.run(input);
+      },
+    };
+  });
+});
 
-function setupMockResponse(text: string) {
-  mockRunFn = async (_input: any, sink: Sink) => {
-    sink.onMessage(createAssistantMessage(text));
-    return { type: "stop" } as Run.Outcome;
-  };
-}
-
-// --- Fixtures ---
+afterAll(() => {
+  createSpy.mockRestore();
+});
 
 const defaultConfig = {
   model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -105,18 +70,13 @@ const defaultInput = {
   attemptNumber: 1,
 };
 
-// --- Tests ---
-
 describe("ReviewLoop", () => {
-  beforeEach(() => {
-    mockRunFn = async () => ({ type: "stop" }) as Run.Outcome;
-    mockModelsGet.mockClear();
-    mockProviderFromModelsDevModel.mockClear();
-  });
-
   describe("review", () => {
     it("returns accept decision when LLM accepts", async () => {
-      setupMockResponse(JSON.stringify({ decision: "accept" }));
+      runImpl = mock(async (input: ChatAgentInput) => {
+        capturedInput = input;
+        return makeAgentResult(JSON.stringify({ decision: "accept" }));
+      });
 
       const output = await ReviewLoop.review(defaultInput, defaultConfig);
 
@@ -125,12 +85,15 @@ describe("ReviewLoop", () => {
     });
 
     it("returns reject decision with feedback", async () => {
-      setupMockResponse(
-        JSON.stringify({
-          decision: "reject",
-          feedback: "Missing error handling",
-        }),
-      );
+      runImpl = mock(async (input: ChatAgentInput) => {
+        capturedInput = input;
+        return makeAgentResult(
+          JSON.stringify({
+            decision: "reject",
+            feedback: "Missing error handling",
+          }),
+        );
+      });
 
       const output = await ReviewLoop.review(defaultInput, defaultConfig);
 
@@ -139,7 +102,10 @@ describe("ReviewLoop", () => {
     });
 
     it("throws when LLM returns invalid JSON", async () => {
-      setupMockResponse("This is definitely not JSON");
+      runImpl = mock(async (input: ChatAgentInput) => {
+        capturedInput = input;
+        return makeAgentResult("This is definitely not JSON");
+      });
 
       await expect(ReviewLoop.review(defaultInput, defaultConfig)).rejects.toThrow(
         /failed to parse/i,
@@ -147,12 +113,10 @@ describe("ReviewLoop", () => {
     });
 
     it("includes guardrail in review prompt when step has guardrail", async () => {
-      let capturedInput: any;
-      mockRunFn = async (input: any, sink: Sink) => {
+      runImpl = mock(async (input: ChatAgentInput) => {
         capturedInput = input;
-        sink.onMessage(createAssistantMessage(JSON.stringify({ decision: "accept" })));
-        return { type: "stop" } as Run.Outcome;
-      };
+        return makeAgentResult(JSON.stringify({ decision: "accept" }));
+      });
 
       const stepWithGuardrail: PlanStep = {
         ...defaultStep,
@@ -161,13 +125,8 @@ describe("ReviewLoop", () => {
 
       await ReviewLoop.review({ ...defaultInput, step: stepWithGuardrail }, defaultConfig);
 
-      // The user message (first in messages array) should contain the guardrail
-      const messages = capturedInput.messages as Message.WithParts[];
-      const userMsg = messages[0];
-      const textPart = userMsg.parts.find((p: Message.Part) => p.type === "text") as
-        | Message.TextPart
-        | undefined;
-      expect(textPart?.text).toContain("Must not expose user passwords in logs");
+      const prompt = capturedInput?.messages[0]?.content;
+      expect(prompt).toContain("Must not expose user passwords in logs");
     });
   });
 
@@ -177,8 +136,6 @@ describe("ReviewLoop", () => {
     });
 
     it("returns true at penultimate attempt (handoff before final retry)", () => {
-      // Fix for off-by-one: handoff triggers at maxAttempts - 1
-      // so the final retry gets a handoff document
       expect(ReviewLoop.shouldHandoff(2, 3)).toBe(true);
     });
 
@@ -187,7 +144,6 @@ describe("ReviewLoop", () => {
     });
 
     it("returns true on first attempt with max=2 (penultimate = first)", () => {
-      // With max=2, attempt 1 is the penultimate, so handoff triggers
       expect(ReviewLoop.shouldHandoff(1, 2)).toBe(true);
     });
 
@@ -198,7 +154,10 @@ describe("ReviewLoop", () => {
 
   describe("generateHandoff", () => {
     it("returns a non-empty handoff document", async () => {
-      setupMockResponse("## Handoff Document\n\nThe login feature was rejected because...");
+      runImpl = mock(async (input: ChatAgentInput) => {
+        capturedInput = input;
+        return makeAgentResult("## Handoff Document\n\nThe login feature was rejected because...");
+      });
 
       const handoff = await ReviewLoop.generateHandoff(
         defaultInput,

--- a/packages/openomni/test/team/run-ledger.test.ts
+++ b/packages/openomni/test/team/run-ledger.test.ts
@@ -48,9 +48,7 @@ describe("RunLedger", () => {
 
   it("throws when transitioning ready → succeeded (must run first)", () => {
     const ledger = RunLedger.create(makeSteps(["step-2"]));
-    expect(() => ledger.transition("step-2", "succeeded")).toThrow(
-      /invalid.*transition/i,
-    );
+    expect(() => ledger.transition("step-2", "succeeded")).toThrow(/invalid.*transition/i);
   });
 
   it("throws when transitioning succeeded → running", () => {
@@ -58,9 +56,7 @@ describe("RunLedger", () => {
     ledger.transition("step-1", "running");
     ledger.transition("step-1", "succeeded");
 
-    expect(() => ledger.transition("step-1", "running")).toThrow(
-      /invalid.*transition/i,
-    );
+    expect(() => ledger.transition("step-1", "running")).toThrow(/invalid.*transition/i);
   });
 
   it("increments attempts on recordAttempt", () => {
@@ -165,18 +161,11 @@ describe("RunLedger", () => {
 
   it("throws step not found for non-existent step", () => {
     const ledger = RunLedger.create(makeSteps(["s1"]));
-    expect(() => ledger.transition("nope", "running")).toThrow(
-      /step not found/i,
-    );
+    expect(() => ledger.transition("nope", "running")).toThrow(/step not found/i);
   });
 
   it("allows transition to skipped from any state", () => {
-    const steps = makeSteps([
-      "ready-s",
-      "running-s",
-      "succeeded-s",
-      "failed-s",
-    ]);
+    const steps = makeSteps(["ready-s", "running-s", "succeeded-s", "failed-s"]);
     const ledger = RunLedger.create(steps);
 
     ledger.transition("running-s", "running");
@@ -210,9 +199,7 @@ describe("RunLedger", () => {
     ledger.transition("step-1", "running");
     ledger.transition("step-1", "failed");
 
-    expect(() => ledger.transition("step-1", "running")).toThrow(
-      /invalid.*transition/i,
-    );
+    expect(() => ledger.transition("step-1", "running")).toThrow(/invalid.*transition/i);
   });
 
   it("getStepState returns undefined for unknown step", () => {
@@ -232,8 +219,6 @@ describe("RunLedger", () => {
 
   it("throws on resetRejectionStreak for unknown step", () => {
     const ledger = RunLedger.create(makeSteps(["s1"]));
-    expect(() => ledger.resetRejectionStreak("nope")).toThrow(
-      /step not found/i,
-    );
+    expect(() => ledger.resetRejectionStreak("nope")).toThrow(/step not found/i);
   });
 });

--- a/packages/openomni/test/team/stall-detector.test.ts
+++ b/packages/openomni/test/team/stall-detector.test.ts
@@ -29,10 +29,7 @@ describe("StallDetector", () => {
       ledger.recordRejection("A");
       ledger.recordRejection("A");
 
-      const result = StallDetector.checkConsecutiveRejections(
-        ledger,
-        DEFAULT_CONFIG,
-      );
+      const result = StallDetector.checkConsecutiveRejections(ledger, DEFAULT_CONFIG);
       expect(result.stalled).toBe(true);
       expect(result.reason).toBe("consecutive_rejections");
       expect(result.stalledStepId).toBe("A");
@@ -46,35 +43,29 @@ describe("StallDetector", () => {
       ledger.recordRejection("A");
       ledger.recordRejection("A");
 
-      const result = StallDetector.checkConsecutiveRejections(
-        ledger,
-        DEFAULT_CONFIG,
-      );
+      const result = StallDetector.checkConsecutiveRejections(ledger, DEFAULT_CONFIG);
       expect(result.stalled).toBe(false);
     });
   });
 
-    it("ignores terminal (failed/succeeded/skipped) steps when checking rejections", () => {
-      const steps = [makeStep("A"), makeStep("B")];
-      const ledger = RunLedger.create(steps);
+  it("ignores terminal (failed/succeeded/skipped) steps when checking rejections", () => {
+    const steps = [makeStep("A"), makeStep("B")];
+    const ledger = RunLedger.create(steps);
 
-      // Step A: failed with high rejection streak
-      ledger.transition("A", "running");
-      ledger.recordRejection("A");
-      ledger.recordRejection("A");
-      ledger.recordRejection("A");
-      ledger.transition("A", "failed");
+    // Step A: failed with high rejection streak
+    ledger.transition("A", "running");
+    ledger.recordRejection("A");
+    ledger.recordRejection("A");
+    ledger.recordRejection("A");
+    ledger.transition("A", "failed");
 
-      // Step B: running with no rejections
-      ledger.transition("B", "running");
+    // Step B: running with no rejections
+    ledger.transition("B", "running");
 
-      // Should NOT detect stall — A is terminal and should be filtered
-      const result = StallDetector.checkConsecutiveRejections(
-        ledger,
-        DEFAULT_CONFIG,
-      );
-      expect(result.stalled).toBe(false);
-    });
+    // Should NOT detect stall — A is terminal and should be filtered
+    const result = StallDetector.checkConsecutiveRejections(ledger, DEFAULT_CONFIG);
+    expect(result.stalled).toBe(false);
+  });
 
   describe("checkNoProgress", () => {
     it("detects stall when noProgressTurns >= max and no running steps", () => {
@@ -82,13 +73,7 @@ describe("StallDetector", () => {
       const ledger = RunLedger.create(steps);
       const dag = DAG.build(steps);
 
-
-      const result = StallDetector.checkNoProgress(
-        ledger,
-        dag,
-        DEFAULT_CONFIG,
-        5,
-      );
+      const result = StallDetector.checkNoProgress(ledger, dag, DEFAULT_CONFIG, 5);
       expect(result.stalled).toBe(true);
       expect(result.reason).toBe("no_progress");
     });
@@ -100,12 +85,7 @@ describe("StallDetector", () => {
 
       ledger.transition("A", "running");
 
-      const result = StallDetector.checkNoProgress(
-        ledger,
-        dag,
-        DEFAULT_CONFIG,
-        5,
-      );
+      const result = StallDetector.checkNoProgress(ledger, dag, DEFAULT_CONFIG, 5);
       expect(result.stalled).toBe(false);
     });
 
@@ -114,12 +94,7 @@ describe("StallDetector", () => {
       const ledger = RunLedger.create(steps);
       const dag = DAG.build(steps);
 
-      const result = StallDetector.checkNoProgress(
-        ledger,
-        dag,
-        DEFAULT_CONFIG,
-        3,
-      );
+      const result = StallDetector.checkNoProgress(ledger, dag, DEFAULT_CONFIG, 3);
       expect(result.stalled).toBe(false);
     });
   });

--- a/packages/openomni/test/team/team-orchestrator.test.ts
+++ b/packages/openomni/test/team/team-orchestrator.test.ts
@@ -9,9 +9,7 @@ const executedTasks: string[] = [];
 mock.module("@openomni/agent", () => ({
   ChatAgent: {
     create: () => ({
-      run: async (input: {
-        messages: Array<{ role: string; content: string }>;
-      }) => {
+      run: async (input: { messages: Array<{ role: string; content: string }> }) => {
         const userPrompt = input.messages[0]?.content ?? "";
         if (userPrompt.includes("Execute the following task:")) {
           const matchedTask = userPrompt.match(/Task:\s*(.+)/);
@@ -43,11 +41,7 @@ beforeEach(() => {
   executedTasks.length = 0;
 });
 
-function makeStep(
-  stepId: string,
-  dependsOn: string[] = [],
-  suggestedAgent?: string,
-): PlanStep {
+function makeStep(stepId: string, dependsOn: string[] = [], suggestedAgent?: string): PlanStep {
   return {
     stepId,
     description: `${stepId} task`,
@@ -82,8 +76,7 @@ function makeConfig(overrides?: {
 }) {
   return {
     reviewModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
-    teammates:
-      overrides?.teammates ?? new Map<string, Teammate.TeammateConfig>(),
+    teammates: overrides?.teammates ?? new Map<string, Teammate.TeammateConfig>(),
     defaultTeammateConfig,
     maxAttemptsPerStep: overrides?.maxAttemptsPerStep,
     stallConfig: overrides?.stallConfig,
@@ -121,17 +114,12 @@ describe("TeamOrchestrator.execute", () => {
 
   it("retries once after rejection and then succeeds", async () => {
     responseQueue.push("first attempt output");
-    responseQueue.push(
-      JSON.stringify({ decision: "reject", feedback: "needs improvement" }),
-    );
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "needs improvement" }));
     responseQueue.push("second attempt output");
     responseQueue.push(JSON.stringify({ decision: "accept" }));
 
     const plan = makePlan([makeStep("s1")]);
-    const result = await TeamOrchestrator.execute(
-      plan,
-      makeConfig({ maxAttemptsPerStep: 3 }),
-    );
+    const result = await TeamOrchestrator.execute(plan, makeConfig({ maxAttemptsPerStep: 3 }));
 
     expect(result.status).toBe("completed");
     expect(result.completedSteps).toEqual(["s1"]);
@@ -143,15 +131,10 @@ describe("TeamOrchestrator.execute", () => {
     responseQueue.push("attempt 1 output");
     responseQueue.push(JSON.stringify({ decision: "reject", feedback: "bad" }));
     responseQueue.push("attempt 2 output");
-    responseQueue.push(
-      JSON.stringify({ decision: "reject", feedback: "still bad" }),
-    );
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "still bad" }));
 
     const plan = makePlan([makeStep("s1")]);
-    const result = await TeamOrchestrator.execute(
-      plan,
-      makeConfig({ maxAttemptsPerStep: 2 }),
-    );
+    const result = await TeamOrchestrator.execute(plan, makeConfig({ maxAttemptsPerStep: 2 }));
 
     expect(result.status).toBe("failed");
     expect(result.failedSteps).toEqual(["s1"]);
@@ -160,15 +143,10 @@ describe("TeamOrchestrator.execute", () => {
 
   it("skips dependents when a prerequisite step fails", async () => {
     responseQueue.push("attempt output");
-    responseQueue.push(
-      JSON.stringify({ decision: "reject", feedback: "fatal" }),
-    );
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "fatal" }));
 
     const plan = makePlan([makeStep("s1"), makeStep("s2", ["s1"])]);
-    const result = await TeamOrchestrator.execute(
-      plan,
-      makeConfig({ maxAttemptsPerStep: 1 }),
-    );
+    const result = await TeamOrchestrator.execute(plan, makeConfig({ maxAttemptsPerStep: 1 }));
 
     expect(result.status).toBe("failed");
     expect(result.failedSteps).toEqual(["s1"]);
@@ -177,13 +155,9 @@ describe("TeamOrchestrator.execute", () => {
 
   it("returns stalled when consecutive rejection threshold is hit", async () => {
     responseQueue.push("attempt 1 output");
-    responseQueue.push(
-      JSON.stringify({ decision: "reject", feedback: "nope" }),
-    );
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "nope" }));
     responseQueue.push("attempt 2 output");
-    responseQueue.push(
-      JSON.stringify({ decision: "reject", feedback: "still nope" }),
-    );
+    responseQueue.push(JSON.stringify({ decision: "reject", feedback: "still nope" }));
 
     const plan = makePlan([makeStep("s1")]);
     const result = await TeamOrchestrator.execute(
@@ -204,9 +178,7 @@ describe("TeamOrchestrator.execute", () => {
   it("throws on cyclic DAG", async () => {
     const plan = makePlan([makeStep("s1", ["s2"]), makeStep("s2", ["s1"])]);
 
-    return expect(TeamOrchestrator.execute(plan, makeConfig())).rejects.toThrow(
-      /cycle/i,
-    );
+    return expect(TeamOrchestrator.execute(plan, makeConfig())).rejects.toThrow(/cycle/i);
   });
 
   it("completes an empty plan", async () => {

--- a/packages/openomni/test/team/teammate.test.ts
+++ b/packages/openomni/test/team/teammate.test.ts
@@ -130,8 +130,7 @@ describe("Teammate", () => {
         model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       };
 
-      const handoffDocument =
-        "Previous attempt notes: try a different approach";
+      const handoffDocument = "Previous attempt notes: try a different approach";
 
       await Teammate.execute({ step, handoffDocument }, config);
 
@@ -211,9 +210,7 @@ describe("Teammate", () => {
       const userMessage = input.messages[0];
       expect(userMessage.content).toContain("Execute the following task:");
       expect(userMessage.content).toContain("Task: Analyze the data");
-      expect(userMessage.content).toContain(
-        "Expected Output: A summary of findings",
-      );
+      expect(userMessage.content).toContain("Expected Output: A summary of findings");
     });
 
     it("should pass systemPrompt to ChatAgent config when provided", async () => {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -14,6 +14,7 @@
     "build": "tsc",
     "check-types": "tsc --noEmit",
     "dev": "tsc --watch",
+    "lint": "bunx biome check ./src",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/protocol/src/bus/index.ts
+++ b/packages/protocol/src/bus/index.ts
@@ -6,10 +6,7 @@ export namespace BusEvent {
     schema: z.ZodSchema<T>;
   }
 
-  export function define<T>(
-    name: string,
-    schema: z.ZodSchema<T>,
-  ): Descriptor<T> {
+  export function define<T>(name: string, schema: z.ZodSchema<T>): Descriptor<T> {
     return { name, schema };
   }
 }

--- a/packages/protocol/src/error/index.ts
+++ b/packages/protocol/src/error/index.ts
@@ -4,10 +4,7 @@ export abstract class NamedError extends Error {
   abstract schema(): z.ZodType;
   abstract toObject(): { name: string; data: unknown };
 
-  static create<Name extends string, Data extends z.ZodType>(
-    name: Name,
-    data: Data,
-  ) {
+  static create<Name extends string, Data extends z.ZodType>(name: Name, data: Data) {
     const schema = z.object({
       name: z.literal(name),
       data,
@@ -37,10 +34,7 @@ export abstract class NamedError extends Error {
 
       static isInstance(input: unknown): input is InstanceType<typeof result> {
         return (
-          typeof input === "object" &&
-          input !== null &&
-          "name" in input &&
-          input.name === name
+          typeof input === "object" && input !== null && "name" in input && input.name === name
         );
       }
 

--- a/packages/protocol/src/message/index.ts
+++ b/packages/protocol/src/message/index.ts
@@ -140,10 +140,7 @@ export namespace Message {
   });
   export type AssistantMessage = z.infer<typeof AssistantMessage>;
 
-  export const Info = z.discriminatedUnion("role", [
-    UserMessage,
-    AssistantMessage,
-  ]);
+  export const Info = z.discriminatedUnion("role", [UserMessage, AssistantMessage]);
   export type Info = z.infer<typeof Info>;
 
   export const WithParts = z.object({

--- a/packages/protocol/src/messenger/index.ts
+++ b/packages/protocol/src/messenger/index.ts
@@ -26,10 +26,7 @@ export namespace Messenger {
   export const MessageEnvelopeSchema = z.object({
     id: z.string().describe("Unique message ID"),
     traceId: z.string().describe("Trace ID for distributed tracing"),
-    correlationId: z
-      .string()
-      .nullable()
-      .describe("Correlation ID for request/response pairing"),
+    correlationId: z.string().nullable().describe("Correlation ID for request/response pairing"),
     sessionId: z.string().describe("Session ID"),
     runId: z.string().describe("Run ID"),
     fromAgentId: z.string().describe("Sender agent ID"),

--- a/packages/protocol/src/notification/index.ts
+++ b/packages/protocol/src/notification/index.ts
@@ -3,12 +3,7 @@ import { z } from "zod";
 export const NotificationSeverity = z.enum(["info", "warning", "error"]);
 export type NotificationSeverity = z.infer<typeof NotificationSeverity>;
 
-export const DeliveryMode = z.enum([
-  "reply_current_session",
-  "dm",
-  "new_session",
-  "new_thread",
-]);
+export const DeliveryMode = z.enum(["reply_current_session", "dm", "new_session", "new_thread"]);
 export type DeliveryMode = z.infer<typeof DeliveryMode>;
 
 export const NotificationRequest = z.object({

--- a/packages/protocol/src/run/index.ts
+++ b/packages/protocol/src/run/index.ts
@@ -36,14 +36,7 @@ export namespace Run {
       max: z.number(),
     }),
     retryOn: z
-      .array(
-        z.enum([
-          "timeout",
-          "tool_error",
-          "transient_error",
-          "validation_error",
-        ]),
-      )
+      .array(z.enum(["timeout", "tool_error", "transient_error", "validation_error"]))
       .optional(),
   });
   export type RetryPolicy = z.infer<typeof RetryPolicy>;

--- a/packages/protocol/src/team/index.ts
+++ b/packages/protocol/src/team/index.ts
@@ -17,13 +17,7 @@ export namespace Team {
   /**
    * Step execution state enum
    */
-  export const StepState = z.enum([
-    "ready",
-    "running",
-    "succeeded",
-    "failed",
-    "skipped",
-  ]);
+  export const StepState = z.enum(["ready", "running", "succeeded", "failed", "skipped"]);
   export type StepState = z.infer<typeof StepState>;
 
   /**

--- a/packages/protocol/test/guardrail.test.ts
+++ b/packages/protocol/test/guardrail.test.ts
@@ -31,12 +31,8 @@ describe("Guardrail schemas", () => {
 
   describe("GuardrailType", () => {
     it("accepts valid enum values", () => {
-      expect(() =>
-        Guardrail.GuardrailType.parse("output_validation"),
-      ).not.toThrow();
-      expect(() =>
-        Guardrail.GuardrailType.parse("content_filter"),
-      ).not.toThrow();
+      expect(() => Guardrail.GuardrailType.parse("output_validation")).not.toThrow();
+      expect(() => Guardrail.GuardrailType.parse("content_filter")).not.toThrow();
       expect(() => Guardrail.GuardrailType.parse("cost_limit")).not.toThrow();
       expect(() => Guardrail.GuardrailType.parse("custom")).not.toThrow();
     });

--- a/packages/protocol/test/notification.test.ts
+++ b/packages/protocol/test/notification.test.ts
@@ -27,9 +27,7 @@ describe("NotificationSeverity", () => {
 
 describe("DeliveryMode", () => {
   test("should parse valid delivery modes", () => {
-    expect(DeliveryMode.parse("reply_current_session")).toBe(
-      "reply_current_session",
-    );
+    expect(DeliveryMode.parse("reply_current_session")).toBe("reply_current_session");
     expect(DeliveryMode.parse("dm")).toBe("dm");
     expect(DeliveryMode.parse("new_session")).toBe("new_session");
     expect(DeliveryMode.parse("new_thread")).toBe("new_thread");

--- a/packages/protocol/test/plan.test.ts
+++ b/packages/protocol/test/plan.test.ts
@@ -1,9 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import {
-  PlanStepSchema,
-  PlanSchema,
-  PlanResultSchema,
-} from "../src/plan/index.js";
+import { PlanStepSchema, PlanSchema, PlanResultSchema } from "../src/plan/index.js";
 
 describe("PlanStep", () => {
   test("should parse valid step with required fields", () => {

--- a/packages/protocol/test/team.test.ts
+++ b/packages/protocol/test/team.test.ts
@@ -5,13 +5,7 @@ import { Team, BusEvent } from "../src/index.js";
 describe("Team Protocol Types", () => {
   describe("StepState", () => {
     it("should validate valid step states", () => {
-      const validStates = [
-        "ready",
-        "running",
-        "succeeded",
-        "failed",
-        "skipped",
-      ];
+      const validStates = ["ready", "running", "succeeded", "failed", "skipped"];
       validStates.forEach((state) => {
         expect(() => Team.StepState.parse(state)).not.toThrow();
       });
@@ -83,11 +77,7 @@ describe("Team Protocol Types", () => {
 
   describe("StallReason", () => {
     it("should validate valid stall reasons", () => {
-      const validReasons = [
-        "consecutive_rejections",
-        "no_progress",
-        "unsatisfiable_deps",
-      ];
+      const validReasons = ["consecutive_rejections", "no_progress", "unsatisfiable_deps"];
       validReasons.forEach((reason) => {
         expect(() => Team.StallReason.parse(reason)).not.toThrow();
       });

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "check-types": "tsc --noEmit",
+    "lint": "bunx biome check ./src",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/session/src/artifact/index.ts
+++ b/packages/session/src/artifact/index.ts
@@ -7,11 +7,7 @@ const contents = new Map<string, string>();
 const indices = new Map<string, ArtifactSchema.Meta[]>();
 const artifactSessions = new Map<string, string>();
 
-function contentKey(
-  sessionId: string,
-  artifactId: string,
-  version: number,
-): string {
+function contentKey(sessionId: string, artifactId: string, version: number): string {
   return `artifact:${sessionId}:${artifactId}:v${version}`;
 }
 
@@ -48,17 +44,13 @@ export namespace Artifact {
     if (matching.length === 0) return null;
 
     const latest = matching.reduce((a, b) => (a.version > b.version ? a : b));
-    const content = contents.get(
-      contentKey(sessionId, artifactId, latest.version),
-    );
+    const content = contents.get(contentKey(sessionId, artifactId, latest.version));
     if (content === undefined) return null;
 
     return { meta: latest, content };
   }
 
-  export async function list(
-    sessionId: string,
-  ): Promise<ArtifactSchema.Meta[]> {
+  export async function list(sessionId: string): Promise<ArtifactSchema.Meta[]> {
     const idxKey = indexKey(sessionId);
     const metas = indices.get(idxKey) ?? [];
 
@@ -73,17 +65,13 @@ export namespace Artifact {
     return Array.from(latest.values());
   }
 
-  export async function versions(
-    artifactId: string,
-  ): Promise<ArtifactSchema.Meta[]> {
+  export async function versions(artifactId: string): Promise<ArtifactSchema.Meta[]> {
     const sessionId = artifactSessions.get(artifactId);
     if (!sessionId) return [];
 
     const idxKey = indexKey(sessionId);
     const metas = indices.get(idxKey) ?? [];
-    return metas
-      .filter((m) => m.id === artifactId)
-      .sort((a, b) => a.version - b.version);
+    return metas.filter((m) => m.id === artifactId).sort((a, b) => a.version - b.version);
   }
 
   export function _reset(): void {

--- a/packages/session/src/bus/index.ts
+++ b/packages/session/src/bus/index.ts
@@ -6,10 +6,7 @@ export namespace BusEvent {
     schema: z.ZodSchema<T>;
   }
 
-  export function define<T>(
-    name: string,
-    schema: z.ZodSchema<T>,
-  ): Descriptor<T> {
+  export function define<T>(name: string, schema: z.ZodSchema<T>): Descriptor<T> {
     return { name, schema };
   }
 }

--- a/packages/session/src/event-log/index.ts
+++ b/packages/session/src/event-log/index.ts
@@ -8,9 +8,7 @@ function resolveDefaultEventLogDir(): string {
   const maybeWrapped = adapter as Storage.Adapter & {
     underlying?: unknown;
   };
-  const maybeUnderlying = maybeWrapped.underlying as
-    | { baseDir?: string }
-    | undefined;
+  const maybeUnderlying = maybeWrapped.underlying as { baseDir?: string } | undefined;
 
   const maybeDirect = adapter as Storage.Adapter & { baseDir?: string };
   const baseDir = maybeDirect.baseDir ?? maybeUnderlying?.baseDir;
@@ -28,16 +26,11 @@ export namespace EventLog {
     backend = new FileEventLog(baseDir);
   }
 
-  export async function append(
-    sessionId: string,
-    event: ExecutionEvent.T,
-  ): Promise<void> {
+  export async function append(sessionId: string, event: ExecutionEvent.T): Promise<void> {
     backend.append(sessionId, event);
   }
 
-  export async function* replay(
-    sessionId: string,
-  ): AsyncGenerator<ExecutionEvent.T> {
+  export async function* replay(sessionId: string): AsyncGenerator<ExecutionEvent.T> {
     for (const event of backend.replay(sessionId)) {
       yield event;
     }

--- a/packages/session/src/snapshot/index.ts
+++ b/packages/session/src/snapshot/index.ts
@@ -27,9 +27,7 @@ export class InMemorySnapshotProvider implements Snapshot.Provider {
   track(sessionID: string): string {
     const adapter = Storage.getAdapter();
     const snapshotID = `snap-${Math.random().toString(36).substring(2, 11)}`;
-    const messages = adapter.message
-      .list(sessionID)
-      .map((m: Message.Info) => ({ ...m }));
+    const messages = adapter.message.list(sessionID).map((m: Message.Info) => ({ ...m }));
     const parts = new Map<string, Message.Part[]>();
     for (const msg of messages) {
       const msgParts = adapter.part
@@ -72,9 +70,7 @@ export class InMemorySnapshotProvider implements Snapshot.Provider {
     const adapter = Storage.getAdapter();
     const currentMsgs = adapter.message.list(sessionID);
 
-    const snapshotIDs = new Set(
-      snapshot.messages.map((m: Message.Info) => m.id),
-    );
+    const snapshotIDs = new Set(snapshot.messages.map((m: Message.Info) => m.id));
     const currentIDs = new Set(currentMsgs.map((m: Message.Info) => m.id));
 
     const added = currentMsgs

--- a/packages/session/src/storage/cache.ts
+++ b/packages/session/src/storage/cache.ts
@@ -8,9 +8,7 @@ export class CachedStorageAdapter implements Storage.Adapter {
   private messageCache = new Map<string, Message.Info[]>();
   private partCache = new Map<string, Message.Part[]>();
 
-  constructor(
-    private readonly underlying: Storage.Adapter & { clear?: () => void },
-  ) {}
+  constructor(private readonly underlying: Storage.Adapter & { clear?: () => void }) {}
 
   session = {
     get: (id: string): SessionInfo | undefined => {
@@ -119,10 +117,7 @@ export class CachedStorageAdapter implements Storage.Adapter {
     this.sessionListCache = null;
     this.messageCache.clear();
     this.partCache.clear();
-    if (
-      "clear" in this.underlying &&
-      typeof this.underlying.clear === "function"
-    ) {
+    if ("clear" in this.underlying && typeof this.underlying.clear === "function") {
       this.underlying.clear();
     }
   }

--- a/packages/session/src/storage/file-storage.ts
+++ b/packages/session/src/storage/file-storage.ts
@@ -65,7 +65,6 @@ export class FileStorageAdapter implements Storage.Adapter {
     write();
   }
 
-
   private readJSON<T>(filePath: string): T | undefined {
     try {
       const raw = readFileSync(filePath, "utf-8");
@@ -143,16 +142,11 @@ export class FileStorageAdapter implements Storage.Adapter {
 
   message = {
     get: (sessionID: string, messageID: string): Message.Info | undefined => {
-      return this.readJSON<Message.Info>(
-        join(this.messagesDir, sessionID, `${messageID}.json`),
-      );
+      return this.readJSON<Message.Info>(join(this.messagesDir, sessionID, `${messageID}.json`));
     },
 
     set: (sessionID: string, message: Message.Info): void => {
-      this.atomicWrite(
-        join(this.messagesDir, sessionID, `${message.id}.json`),
-        message,
-      );
+      this.atomicWrite(join(this.messagesDir, sessionID, `${message.id}.json`), message);
     },
 
     list: (sessionID: string): Message.Info[] => {
@@ -164,9 +158,7 @@ export class FileStorageAdapter implements Storage.Adapter {
         const msg = this.readJSON<Message.Info>(join(dir, file));
         if (msg) results.push(msg);
       }
-      results.sort(
-        (a, b) => a.time.created - b.time.created || a.id.localeCompare(b.id),
-      );
+      results.sort((a, b) => a.time.created - b.time.created || a.id.localeCompare(b.id));
       return results;
     },
 
@@ -192,9 +184,7 @@ export class FileStorageAdapter implements Storage.Adapter {
 
   part = {
     get: (messageID: string, partID: string): Message.Part | undefined => {
-      return this.readJSON<Message.Part>(
-        join(this.partsDir, messageID, `${partID}.json`),
-      );
+      return this.readJSON<Message.Part>(join(this.partsDir, messageID, `${partID}.json`));
     },
 
     set: (messageID: string, part: Message.Part): void => {

--- a/packages/session/src/storage/gitignore.ts
+++ b/packages/session/src/storage/gitignore.ts
@@ -9,11 +9,7 @@ export function ensureGitignore(dir: string, pattern: string): void {
     content = readFileSync(gitignorePath, "utf-8");
   } catch (err: unknown) {
     if (
-      !(
-        err instanceof Error &&
-        "code" in err &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
-      )
+      !(err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT")
     ) {
       throw err;
     }
@@ -30,11 +26,7 @@ export function ensureGitignore(dir: string, pattern: string): void {
   }
 
   let newContent = content;
-  if (
-    content.length > 0 &&
-    !content.endsWith("\n") &&
-    !content.endsWith("\r\n")
-  ) {
+  if (content.length > 0 && !content.endsWith("\n") && !content.endsWith("\r\n")) {
     newContent += eol;
   }
   newContent += pattern + eol;

--- a/packages/session/src/storage/lock.ts
+++ b/packages/session/src/storage/lock.ts
@@ -52,7 +52,9 @@ function isStale(lockPath: string, staleMs: number): boolean {
 function forceRemoveLock(lockPath: string): void {
   try {
     rmSync(lockPath, { recursive: true, force: true });
-  } catch {}
+  } catch {
+    void 0;
+  }
 }
 
 function writeLockInfo(lockPath: string): void {
@@ -98,7 +100,9 @@ export namespace FileLock {
   export function release(lockPath: string): void {
     try {
       rmSync(lockPath, { recursive: true, force: true });
-    } catch {}
+    } catch {
+      void 0;
+    }
   }
 
   export function withLock<T>(lockPath: string, fn: () => T, options?: LockOptions): T {
@@ -108,7 +112,9 @@ export namespace FileLock {
     } finally {
       try {
         release(lockPath);
-      } catch {}
+      } catch {
+        void 0;
+      }
     }
   }
 

--- a/packages/session/src/storage/lock.ts
+++ b/packages/session/src/storage/lock.ts
@@ -1,11 +1,4 @@
-import {
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-  statSync,
-  existsSync,
-  rmSync,
-} from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, statSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 interface LockOptions {
@@ -31,10 +24,7 @@ function readLockInfo(lockPath: string): LockInfo | null {
   try {
     const raw = readFileSync(join(lockPath, "info.json"), "utf-8");
     const parsed = JSON.parse(raw);
-    if (
-      typeof parsed.pid === "number" &&
-      typeof parsed.timestamp === "number"
-    ) {
+    if (typeof parsed.pid === "number" && typeof parsed.timestamp === "number") {
       return parsed as LockInfo;
     }
     return null;
@@ -94,9 +84,7 @@ export namespace FileLock {
           }
 
           if (Date.now() - startTime > timeoutMs) {
-            throw new Error(
-              `FileLock: timeout acquiring lock after ${timeoutMs}ms: ${lockPath}`,
-            );
+            throw new Error(`FileLock: timeout acquiring lock after ${timeoutMs}ms: ${lockPath}`);
           }
 
           syncSleep(pollMs);
@@ -113,11 +101,7 @@ export namespace FileLock {
     } catch {}
   }
 
-  export function withLock<T>(
-    lockPath: string,
-    fn: () => T,
-    options?: LockOptions,
-  ): T {
+  export function withLock<T>(lockPath: string, fn: () => T, options?: LockOptions): T {
     acquire(lockPath, options);
     try {
       return fn();
@@ -128,10 +112,7 @@ export namespace FileLock {
     }
   }
 
-  export function isLocked(
-    lockPath: string,
-    options?: Pick<LockOptions, "staleMs">,
-  ): boolean {
+  export function isLocked(lockPath: string, options?: Pick<LockOptions, "staleMs">): boolean {
     if (!existsSync(lockPath)) return false;
     const staleMs = options?.staleMs ?? DEFAULT_STALE_MS;
     return !isStale(lockPath, staleMs);

--- a/packages/session/src/storage/part-time.ts
+++ b/packages/session/src/storage/part-time.ts
@@ -1,10 +1,7 @@
 import { Message } from "@openomni/protocol";
 
 export function getPartStartTime(part: Message.Part): number | undefined {
-  if (
-    (part.type === "text" || part.type === "reasoning") &&
-    part.time?.start !== undefined
-  ) {
+  if ((part.type === "text" || part.type === "reasoning") && part.time?.start !== undefined) {
     return part.time.start;
   }
 

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -54,19 +54,13 @@ export class SqliteStorageAdapter implements Storage.Adapter {
         "CREATE TABLE IF NOT EXISTS message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, data TEXT NOT NULL, time_created INTEGER NOT NULL)",
       )
       .run();
-    this.db
-      .query(
-        "CREATE INDEX IF NOT EXISTS idx_message_session ON message(session_id)",
-      )
-      .run();
+    this.db.query("CREATE INDEX IF NOT EXISTS idx_message_session ON message(session_id)").run();
     this.db
       .query(
         "CREATE TABLE IF NOT EXISTS part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, data TEXT NOT NULL, time_start INTEGER)",
       )
       .run();
-    this.db
-      .query("CREATE INDEX IF NOT EXISTS idx_part_message ON part(message_id)")
-      .run();
+    this.db.query("CREATE INDEX IF NOT EXISTS idx_part_message ON part(message_id)").run();
 
     this.sessionStatements = {
       get: this.db.query("SELECT data FROM session WHERE id = ?"),
@@ -78,24 +72,18 @@ export class SqliteStorageAdapter implements Storage.Adapter {
     };
 
     this.messageStatements = {
-      get: this.db.query(
-        "SELECT data FROM message WHERE id = ? AND session_id = ?",
-      ),
+      get: this.db.query("SELECT data FROM message WHERE id = ? AND session_id = ?"),
       set: this.db.query(
         "INSERT OR REPLACE INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)",
       ),
       list: this.db.query(
         "SELECT data FROM message WHERE session_id = ? ORDER BY time_created ASC, id ASC",
       ),
-      remove: this.db.query(
-        "DELETE FROM message WHERE id = ? AND session_id = ?",
-      ),
+      remove: this.db.query("DELETE FROM message WHERE id = ? AND session_id = ?"),
     };
 
     this.partStatements = {
-      get: this.db.query(
-        "SELECT data FROM part WHERE id = ? AND message_id = ?",
-      ),
+      get: this.db.query("SELECT data FROM part WHERE id = ? AND message_id = ?"),
       set: this.db.query(
         "INSERT OR REPLACE INTO part (id, message_id, data, time_start) VALUES (?, ?, ?, ?)",
       ),
@@ -118,7 +106,6 @@ export class SqliteStorageAdapter implements Storage.Adapter {
     }
     return JSON.parse(row.data) as T;
   }
-
 
   session = {
     get: (id: string): SessionInfo | undefined => {
@@ -148,10 +135,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
 
   message = {
     get: (sessionID: string, messageID: string): Message.Info | undefined => {
-      const row = this.messageStatements.get.get(
-        messageID,
-        sessionID,
-      ) as DataRow | null;
+      const row = this.messageStatements.get.get(messageID, sessionID) as DataRow | null;
       return this.parseData<Message.Info>(row);
     },
 
@@ -177,21 +161,13 @@ export class SqliteStorageAdapter implements Storage.Adapter {
 
   part = {
     get: (messageID: string, partID: string): Message.Part | undefined => {
-      const row = this.partStatements.get.get(
-        partID,
-        messageID,
-      ) as DataRow | null;
+      const row = this.partStatements.get.get(partID, messageID) as DataRow | null;
       return this.parseData<Message.Part>(row);
     },
 
     set: (messageID: string, part: Message.Part): void => {
       const timeStart = getPartStartTime(part);
-      this.partStatements.set.run(
-        part.id,
-        messageID,
-        JSON.stringify(part),
-        timeStart ?? null,
-      );
+      this.partStatements.set.run(part.id, messageID, JSON.stringify(part), timeStart ?? null);
     },
 
     list: (messageID: string): Message.Part[] => {

--- a/packages/session/src/surface-key/index.ts
+++ b/packages/session/src/surface-key/index.ts
@@ -78,12 +78,7 @@ export namespace SurfaceKey {
   ]);
 
   export function fromChannel(descriptor: ChannelDescriptor): string {
-    const parts = [
-      descriptor.surface,
-      descriptor.namespace,
-      descriptor.kind,
-      descriptor.id,
-    ];
+    const parts = [descriptor.surface, descriptor.namespace, descriptor.kind, descriptor.id];
     if (descriptor.threadId) {
       parts.push("thread", descriptor.threadId);
     }

--- a/packages/session/test/artifact/artifact.test.ts
+++ b/packages/session/test/artifact/artifact.test.ts
@@ -4,9 +4,7 @@ import type { Artifact as ArtifactSchema } from "@openomni/protocol";
 
 const now = new Date().toISOString();
 
-function makeMeta(
-  overrides: Partial<ArtifactSchema.Meta> = {},
-): ArtifactSchema.Meta {
+function makeMeta(overrides: Partial<ArtifactSchema.Meta> = {}): ArtifactSchema.Meta {
   return {
     id: "art-1",
     sessionId: "sess-1",
@@ -74,11 +72,7 @@ describe("Artifact", () => {
     });
 
     it("deduplicates to latest version per artifact", async () => {
-      await Artifact.store(
-        "sess-1",
-        makeMeta({ id: "art-1", version: 1 }),
-        "v1",
-      );
+      await Artifact.store("sess-1", makeMeta({ id: "art-1", version: 1 }), "v1");
       await Artifact.store(
         "sess-1",
         makeMeta({ id: "art-1", version: 2, title: "updated.txt" }),
@@ -93,11 +87,7 @@ describe("Artifact", () => {
 
     it("isolates artifacts between sessions", async () => {
       await Artifact.store("sess-1", makeMeta({ id: "art-1" }), "c1");
-      await Artifact.store(
-        "sess-2",
-        makeMeta({ id: "art-2", sessionId: "sess-2" }),
-        "c2",
-      );
+      await Artifact.store("sess-2", makeMeta({ id: "art-2", sessionId: "sess-2" }), "c2");
 
       const s1 = await Artifact.list("sess-1");
       const s2 = await Artifact.list("sess-2");
@@ -110,21 +100,9 @@ describe("Artifact", () => {
 
   describe("versions", () => {
     it("returns all versions sorted by version number", async () => {
-      await Artifact.store(
-        "sess-1",
-        makeMeta({ version: 1, title: "v1" }),
-        "content-v1",
-      );
-      await Artifact.store(
-        "sess-1",
-        makeMeta({ version: 3, title: "v3" }),
-        "content-v3",
-      );
-      await Artifact.store(
-        "sess-1",
-        makeMeta({ version: 2, title: "v2" }),
-        "content-v2",
-      );
+      await Artifact.store("sess-1", makeMeta({ version: 1, title: "v1" }), "content-v1");
+      await Artifact.store("sess-1", makeMeta({ version: 3, title: "v3" }), "content-v3");
+      await Artifact.store("sess-1", makeMeta({ version: 2, title: "v2" }), "content-v2");
 
       const vers = await Artifact.versions("art-1");
       expect(vers).toHaveLength(3);

--- a/packages/session/test/file-storage.test.ts
+++ b/packages/session/test/file-storage.test.ts
@@ -27,22 +27,14 @@ function makeUserMessage(sessionID: string, messageID: string): Message.Info {
   };
 }
 
-function makeUserMessageAt(
-  sessionID: string,
-  messageID: string,
-  created: number,
-): Message.Info {
+function makeUserMessageAt(sessionID: string, messageID: string, created: number): Message.Info {
   return {
     ...makeUserMessage(sessionID, messageID),
     time: { created },
   };
 }
 
-function makeTextPart(
-  sessionID: string,
-  messageID: string,
-  partID: string,
-): Message.Part {
+function makeTextPart(sessionID: string, messageID: string, partID: string): Message.Part {
   return {
     id: partID,
     sessionID,

--- a/packages/session/test/session/metadata-hooks.test.ts
+++ b/packages/session/test/session/metadata-hooks.test.ts
@@ -71,10 +71,7 @@ describe("Session.addMessage metadata hooks", () => {
       });
 
       Session.addMessage(session.id, makeUserMessage(session.id));
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 10, output: 5 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 10, output: 5 }));
 
       const updated = Session.get(session.id)!;
       expect(updated.messageCount).toBe(2);
@@ -87,15 +84,9 @@ describe("Session.addMessage metadata hooks", () => {
       });
 
       Session.addMessage(session.id, makeUserMessage(session.id));
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 10, output: 5 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 10, output: 5 }));
       Session.addMessage(session.id, makeUserMessage(session.id));
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 20, output: 10 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 20, output: 10 }));
 
       const updated = Session.get(session.id)!;
       expect(updated.messageCount).toBe(4);
@@ -121,10 +112,7 @@ describe("Session.addMessage metadata hooks", () => {
         model: { providerID: "test", modelID: "test-model" },
       });
 
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 100, output: 50 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 100, output: 50 }));
 
       const updated = Session.get(session.id)!;
       expect(updated.tokens).toEqual({
@@ -140,14 +128,8 @@ describe("Session.addMessage metadata hooks", () => {
         model: { providerID: "test", modelID: "test-model" },
       });
 
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 100, output: 50 }),
-      );
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 200, output: 80 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 100, output: 50 }));
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 200, output: 80 }));
 
       const updated = Session.get(session.id)!;
       expect(updated.tokens).toEqual({
@@ -163,15 +145,9 @@ describe("Session.addMessage metadata hooks", () => {
         model: { providerID: "test", modelID: "test-model" },
       });
 
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 100, output: 50 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 100, output: 50 }));
       Session.addMessage(session.id, makeUserMessage(session.id));
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 200, output: 80 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 200, output: 80 }));
 
       const updated = Session.get(session.id)!;
       expect(updated.tokens).toEqual({
@@ -205,9 +181,7 @@ describe("Session.addMessage metadata hooks", () => {
   describe("edge cases", () => {
     test("does not throw when session does not exist", () => {
       const msg = makeUserMessage("nonexistent-session");
-      expect(() =>
-        Session.addMessage("nonexistent-session", msg),
-      ).not.toThrow();
+      expect(() => Session.addMessage("nonexistent-session", msg)).not.toThrow();
     });
 
     test("preserves other session fields when updating metadata", () => {
@@ -217,10 +191,7 @@ describe("Session.addMessage metadata hooks", () => {
         ttlMs: 60000,
       });
 
-      Session.addMessage(
-        session.id,
-        makeAssistantMessage(session.id, { input: 50, output: 25 }),
-      );
+      Session.addMessage(session.id, makeAssistantMessage(session.id, { input: 50, output: 25 }));
 
       const updated = Session.get(session.id)!;
       expect(updated.title).toBe("Original Title");

--- a/packages/session/test/storage/cache.test.ts
+++ b/packages/session/test/storage/cache.test.ts
@@ -24,11 +24,7 @@ function makeUserMessage(sessionID: string, messageID: string): Message.Info {
   };
 }
 
-function makeTextPart(
-  sessionID: string,
-  messageID: string,
-  partID: string,
-): Message.Part {
+function makeTextPart(sessionID: string, messageID: string, partID: string): Message.Part {
   return {
     id: partID,
     sessionID,

--- a/packages/session/test/storage/initialize.test.ts
+++ b/packages/session/test/storage/initialize.test.ts
@@ -101,9 +101,7 @@ describe("Storage.initialize", () => {
     initialize({ cwd: tmpDir });
     initialize({ cwd: tmpDir });
     const content = readFileSync(join(tmpDir, ".gitignore"), "utf-8");
-    const matches = content
-      .split("\n")
-      .filter((line) => line.trim() === ".openomni/");
+    const matches = content.split("\n").filter((line) => line.trim() === ".openomni/");
     expect(matches).toHaveLength(1);
   });
 

--- a/packages/session/test/storage/lock.test.ts
+++ b/packages/session/test/storage/lock.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import {
-  mkdtempSync,
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-  existsSync,
-  rmSync,
-} from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { FileLock } from "../../src/storage/lock";
@@ -50,9 +43,7 @@ describe("FileLock.acquire", () => {
     mkdirSync(lockPath);
     // No info.json — could be a freshly acquired lock between mkdirSync and writeLockInfo.
     // Directory mtime is recent, so it should NOT be considered stale.
-    expect(() =>
-      FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
-    ).toThrow(/timeout/i);
+    expect(() => FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 })).toThrow(/timeout/i);
 
     rmSync(lockPath, { recursive: true, force: true });
   });
@@ -61,9 +52,7 @@ describe("FileLock.acquire", () => {
     mkdirSync(lockPath);
     writeFileSync(join(lockPath, "info.json"), "NOT_JSON");
     // Unreadable info.json, but directory mtime is recent → not stale.
-    expect(() =>
-      FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
-    ).toThrow(/timeout/i);
+    expect(() => FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 })).toThrow(/timeout/i);
 
     rmSync(lockPath, { recursive: true, force: true });
   });
@@ -85,9 +74,7 @@ describe("FileLock.acquire", () => {
       JSON.stringify({ pid: process.pid, timestamp: Date.now() }),
     );
 
-    expect(() =>
-      FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 }),
-    ).toThrow(/timeout/i);
+    expect(() => FileLock.acquire(lockPath, { timeoutMs: 150, pollMs: 50 })).toThrow(/timeout/i);
 
     rmSync(lockPath, { recursive: true, force: true });
   });

--- a/packages/session/test/storage/sqlite-storage.test.ts
+++ b/packages/session/test/storage/sqlite-storage.test.ts
@@ -15,11 +15,7 @@ function makeSession(id: string): SessionInfo {
   };
 }
 
-function makeUserMessage(
-  sessionID: string,
-  messageID: string,
-  timeCreated?: number,
-): Message.Info {
+function makeUserMessage(sessionID: string, messageID: string, timeCreated?: number): Message.Info {
   return {
     id: messageID,
     sessionID,
@@ -119,10 +115,7 @@ describe("SqliteStorageAdapter", () => {
   let adapter: SqliteStorageAdapter;
 
   beforeEach(() => {
-    dbPath = join(
-      tmpdir(),
-      `test-sqlite-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
-    );
+    dbPath = join(tmpdir(), `test-sqlite-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
     adapter = new SqliteStorageAdapter(dbPath);
   });
 
@@ -284,13 +277,7 @@ describe("SqliteStorageAdapter", () => {
       adapter.part.set("m1", makeTextPart("s1", "m1", "p0"));
 
       const list = adapter.part.list("m1");
-      expect(list.map((item) => item.id)).toEqual([
-        "p1",
-        "p2",
-        "p3",
-        "p0",
-        "p4",
-      ]);
+      expect(list.map((item) => item.id)).toEqual(["p1", "p2", "p3", "p0", "p4"]);
     });
 
     test("list: only returns parts for the given message", () => {
@@ -334,18 +321,9 @@ describe("SqliteStorageAdapter", () => {
     });
 
     test("part list: tool parts with non-pending state use state.time.start for sorting", () => {
-      adapter.part.set(
-        "m1",
-        makeToolPart("s1", "m1", "tool-pending", "pending"),
-      );
-      adapter.part.set(
-        "m1",
-        makeToolPart("s1", "m1", "tool-running", "running", 300),
-      );
-      adapter.part.set(
-        "m1",
-        makeToolPart("s1", "m1", "tool-completed", "completed", 100),
-      );
+      adapter.part.set("m1", makeToolPart("s1", "m1", "tool-pending", "pending"));
+      adapter.part.set("m1", makeToolPart("s1", "m1", "tool-running", "running", 300));
+      adapter.part.set("m1", makeToolPart("s1", "m1", "tool-completed", "completed", 100));
       adapter.part.set("m1", makeToolPart("s1", "m1", "text", "error", 200));
 
       const list = adapter.part.list("m1");
@@ -363,11 +341,7 @@ describe("SqliteStorageAdapter", () => {
       adapter.part.set("m1", makeToolPart("s1", "m1", "m-pending", "pending"));
 
       const list = adapter.part.list("m1");
-      expect(list.map((item) => item.id)).toEqual([
-        "a-no-time",
-        "m-pending",
-        "z-no-time",
-      ]);
+      expect(list.map((item) => item.id)).toEqual(["a-no-time", "m-pending", "z-no-time"]);
     });
   });
 

--- a/packages/session/test/surface-key.test.ts
+++ b/packages/session/test/surface-key.test.ts
@@ -18,26 +18,15 @@ describe("SurfaceKey", () => {
     });
 
     test("throws error on empty parts", () => {
-      expect(() => SurfaceKey.create([])).toThrow(
-        "SurfaceKey parts cannot be empty",
-      );
+      expect(() => SurfaceKey.create([])).toThrow("SurfaceKey parts cannot be empty");
     });
 
     test("throws error if format validation fails (no colon)", () => {
-      expect(() => SurfaceKey.create(["singlepart"])).toThrow(
-        /Invalid surfaceKey format/,
-      );
+      expect(() => SurfaceKey.create(["singlepart"])).toThrow(/Invalid surfaceKey format/);
     });
 
     test("creates complex keys with multiple colons", () => {
-      const key = SurfaceKey.create([
-        "slack",
-        "workspaceA",
-        "channel",
-        "C123",
-        "thread",
-        "171000",
-      ]);
+      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123", "thread", "171000"]);
       expect(key).toBe("slack:workspaceA:channel:C123:thread:171000");
     });
   });
@@ -259,9 +248,7 @@ describe("SurfaceKey", () => {
     });
 
     test("parses a thread key", () => {
-      const parsed = SurfaceKey.parse(
-        "slack:workspaceA:group:C456:thread:171000",
-      );
+      const parsed = SurfaceKey.parse("slack:workspaceA:group:C456:thread:171000");
       expect(parsed.kind).toBe("group");
       expect(parsed.id).toBe("C456");
       expect(parsed.threadId).toBe("171000");

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -13,7 +13,9 @@ declare const Bun: {
     exists(): Promise<boolean>;
     text(): Promise<string>;
   };
-  Glob: new (pattern: string) => {
+  Glob: new (
+    pattern: string,
+  ) => {
     scan(options: {
       cwd: string;
       absolute: boolean;
@@ -66,11 +68,7 @@ const RULES: Record<PackageKey, PackageRule> = {
     displayName: "agent",
     packageJsonPath: "packages/agent/package.json",
     packageName: "@openomni/agent",
-    allowedDeps: new Set([
-      "@openomni/protocol",
-      "@openomni/llm",
-      "@openomni/session",
-    ]),
+    allowedDeps: new Set(["@openomni/protocol", "@openomni/llm", "@openomni/session"]),
   },
   openomni: {
     displayName: "openomni",
@@ -142,11 +140,7 @@ function collectOpenOmniDeps(pkg: Record<string, unknown>): string[] {
 }
 
 function isTestFile(path: string): boolean {
-  if (
-    path.includes("/test/") ||
-    path.includes("/tests/") ||
-    path.includes("/__tests__/")
-  ) {
+  if (path.includes("/test/") || path.includes("/tests/") || path.includes("/__tests__/")) {
     return true;
   }
 
@@ -195,8 +189,7 @@ async function validateDependencyDirection(): Promise<string[]> {
 async function validateDeepImports(): Promise<string[]> {
   const violations: string[] = [];
   // Matches both `from "@openomni/.../src/..."` and side-effect `import "@openomni/.../src/..."`
-  const importPattern =
-    /(?:from\s+|import\s+)["'](@openomni\/[^"']+\/src\/[^"']*)["']/g;
+  const importPattern = /(?:from\s+|import\s+)["'](@openomni\/[^"']+\/src\/[^"']*)["']/g;
   const sourceGlob = Bun.glob ? Bun.glob("**/*.ts") : new Bun.Glob("**/*.ts");
 
   for await (const filePath of sourceGlob.scan({
@@ -394,9 +387,7 @@ async function checkDocFreshness(): Promise<string[]> {
         stderr: "pipe",
       }) as { stdout: ReadableStream; exited: Promise<number> };
 
-      const lastTouchHash = (
-        await new Response(lastTouchProc.stdout).text()
-      ).trim();
+      const lastTouchHash = (await new Response(lastTouchProc.stdout).text()).trim();
       await lastTouchProc.exited;
 
       if (!lastTouchHash) continue;
@@ -407,10 +398,7 @@ async function checkDocFreshness(): Promise<string[]> {
         stderr: "pipe",
       }) as { stdout: ReadableStream; exited: Promise<number> };
 
-      const commitsSince = parseInt(
-        (await new Response(sinceProc.stdout).text()).trim(),
-        10,
-      );
+      const commitsSince = parseInt((await new Response(sinceProc.stdout).text()).trim(), 10);
       await sinceProc.exited;
 
       if (commitsSince >= STALE_THRESHOLD) {
@@ -431,11 +419,7 @@ async function main(): Promise<void> {
   const deepImportViolations = await validateDeepImports();
   const goldenViolations = await validateGoldenPrinciples();
   const freshnessWarnings = await checkDocFreshness();
-  const violations = [
-    ...depViolations,
-    ...deepImportViolations,
-    ...goldenViolations,
-  ];
+  const violations = [...depViolations, ...deepImportViolations, ...goldenViolations];
 
   // Print freshness warnings (non-blocking)
   for (const warning of freshnessWarnings) {
@@ -450,9 +434,7 @@ async function main(): Promise<void> {
   }
 
   if (violations.length === 0 && freshnessWarnings.length > 0) {
-    console.log(
-      `OK: no violations, but ${freshnessWarnings.length} stale doc(s) detected`,
-    );
+    console.log(`OK: no violations, but ${freshnessWarnings.length} stale doc(s) detected`);
     process.exit(0);
   }
 

--- a/turbo.json
+++ b/turbo.json
@@ -4,14 +4,24 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$"]
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": ["dist/**"]
+    },
+    "check-types": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig.json"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "inputs": ["$TURBO_DEFAULT$"]
     },
-    "check-types": {},
-    "test": {},
-    "test:ci": {},
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "test:ci": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary

- **Biome** replaces Prettier — lint + format in one tool (`biome.json`)
- **Lefthook** pre-commit hooks — biome check on staged files, commitlint on commit-msg, type-check + dep-check on pre-push
- **commitlint** enforces conventional commit format (`.commitlintrc.yml`)
- **Coverage reporting** enabled via `bunfig.toml` (text + lcov, no thresholds yet)
- **turbo.json** improved with proper `outputs`, `inputs`, `dependsOn` — second build is FULL TURBO
- **CI workflow** refactored into 3 parallel jobs: static analysis (matrix: lint/check-types), dependency rules, tests with coverage artifact upload
- **Test fixes** — 36 pre-existing failing tests in `packages/openomni` fixed (mock pollution + stale mocks)

## What changed

| File | Purpose |
|------|---------|
| `biome.json` | Lint + format config (replaces Prettier) |
| `lefthook.yml` | Pre-commit, commit-msg, pre-push hooks |
| `.commitlintrc.yml` | Conventional commit enforcement |
| `bunfig.toml` | Coverage reporting (text + lcov) |
| `turbo.json` | Proper outputs/inputs/dependsOn for caching |
| `.github/workflows/ci.yml` | 3-job parallel CI (static/deps/test) |
| `.git-blame-ignore-revs` | Skip format migration in git blame |
| `script/check-deps.ts` | Updated allowed deps (agent→session) |
| `docs/golden-principles.md` | Added tooling enforcement notes |
| `docs/quality-score.md` | Updated date, lint column, Biome note |

## Verification

All gates pass locally:
- `bunx biome check .` → 0 errors, 520 warnings (all warn-level)
- `bun run check-types` → 9/9 FULL TURBO
- `bun run script/check-deps.ts` → OK, no violations
- Per-package `bun test` → 1721 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up a faster, stricter CI pipeline: switch to `@biomejs/biome` for lint+format, add `lefthook` and `@commitlint/cli`, enable coverage, improve `turbo` caching, and refactor GitHub Actions into parallel jobs. Also fixes 36 pre-existing tests in `packages/openomni` to stabilize CI.

- Refactors
  - Replaced Prettier with `@biomejs/biome` (lint + format via `biome.json`) and added repo scripts.
  - Added `lefthook` pre-commit/pre-push hooks and `@commitlint/cli` to enforce conventional commits.
  - Enabled Bun test coverage (text + lcov) via `bunfig.toml`.
  - Tuned `turbo` caching with proper `outputs`, `inputs`, and `dependsOn` for faster rebuilds.
  - Split CI into 3 parallel jobs: static analysis (lint + type checks), dependency rules, and tests with coverage artifact.

- Bug Fixes
  - Fixed 36 failing tests in `packages/openomni` (mock pollution and stale mocks).

<sup>Written for commit 4abca56d727cf58aba49136a6f8ca2f86ec96dad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

