### PR TITLE
feat(openomni): support tools in PlanAgent for ReAct-based informed planning

### DIFF
--- a/packages/openomni/src/plan/plan-agent.ts
+++ b/packages/openomni/src/plan/plan-agent.ts
@@ -1,5 +1,5 @@
 import { ChatAgent, type AgentBudget } from "@openomni/agent";
-import { PlanSchema, type PlanResult } from "@openomni/protocol";
+import { PlanSchema, type PlanResult, type Tool } from "@openomni/protocol";
 
 function normalizePlanPayload(payload: unknown): unknown {
   if (!payload || typeof payload !== "object") {
@@ -41,6 +41,7 @@ export namespace PlanAgent {
     model: { provider: string; id: string };
     systemPrompt?: string;
     budget?: AgentBudget;
+    tools?: Tool.Spec[];
   }
 
   export async function generate(goal: string, config: GenerateConfig): Promise<PlanResult> {
@@ -48,6 +49,7 @@ export namespace PlanAgent {
       model: config.model,
       systemPrompt: config.systemPrompt ?? "",
       budget: config.budget,
+      tools: config.tools,
     });
 
     const result = await agent.run({


### PR DESCRIPTION
## Summary

- Add `tools?: Tool.Spec[]` to `PlanAgent.GenerateConfig`
- Pass tools through to `ChatAgent.create()` to enable multi-turn ReAct loops

## Before vs After

**Before (blind planning):**
```
goal → LLM 1 call (no tools) → JSON plan
       (can't see codebase, imagines everything)
```

**After (informed planning):**
```
goal → ChatAgent with tools → ReAct loop
       Turn 1: Read package.json, tsconfig.json
       Turn 2: Grep for existing patterns
       Turn 3: Read relevant source files
       ...
       Turn N: Generate plan based on actual codebase knowledge
       → JSON plan
```

## Changes

| File | Change |
|------|--------|
| `packages/openomni/src/plan/plan-agent.ts` | Add `tools?: Tool.Spec[]` to `GenerateConfig`, pass to `ChatAgent.create()` |

## Usage

```typescript
PlanPipeline.run("Add authentication", {
  generator: {
    model: { provider: "anthropic", id: "claude-sonnet-4-20250514" },
    systemPrompt: "Explore the codebase, then produce a plan as JSON.",
    tools: [readTool, grepTool, globTool],  // read-only tools
    budget: { maxTurns: 20 },
  },
  gates: [structuralGateCheck],
});
```

Without tools, PlanAgent behaves exactly as before (single LLM call). Fully backward compatible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional tools to planning so the agent can run ReAct-style, multi‑turn, code-aware loops before producing a JSON plan. Adds `tools?: Tool.Spec[]` to `PlanAgent.GenerateConfig` and forwards it to `ChatAgent.create()` from `@openomni/agent`; omitting `tools` keeps the previous single‑call behavior (backward compatible).

<sup>Written for commit 1a73648d3fa40ccac14e2eebe8e6520361eaf03a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

