### PR TITLE
feat(openomni): add toolExecutor and JSON fence extraction

### DIFF
--- a/packages/openomni/src/plan/plan-agent.ts
+++ b/packages/openomni/src/plan/plan-agent.ts
@@ -19,10 +19,18 @@ function normalizePlanPayload(payload: unknown): unknown {
   return { ...candidate, createdAt: parsedDate };
 }
 
+function extractJson(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{")) return trimmed;
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n\s*```\s*$/);
+  return fenceMatch ? fenceMatch[1].trim() : trimmed;
+}
+
 function parsePlan(text: string): PlanResult["plan"] {
+  const jsonText = extractJson(text);
   let parsed: unknown;
   try {
-    parsed = JSON.parse(text);
+    parsed = JSON.parse(jsonText);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to parse plan JSON: ${reason}`);
@@ -42,6 +50,7 @@ export namespace PlanAgent {
     systemPrompt?: string;
     budget?: AgentBudget;
     tools?: Tool.Spec[];
+    toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
   }
 
   export async function generate(goal: string, config: GenerateConfig): Promise<PlanResult> {
@@ -50,6 +59,7 @@ export namespace PlanAgent {
       systemPrompt: config.systemPrompt ?? "",
       budget: config.budget,
       tools: config.tools,
+      toolExecutor: config.toolExecutor,
     });
 
     const result = await agent.run({


### PR DESCRIPTION
## Summary

- Add `toolExecutor` to `PlanAgent.GenerateConfig` to enable actual tool execution during ReAct planning loops
- Add `extractJson()` helper to strip markdown code fences from LLM responses before JSON parsing

## Why

### toolExecutor
PR #54 added `tools?: Tool.Spec[]` to PlanAgent, but without a `toolExecutor` callback, ChatAgent falls back to stub responses (`"Tool executed (no executor configured)"`). The planning agent needs a real executor to read files, grep patterns, and explore the codebase before generating a plan.

### JSON fence extraction
LLMs commonly wrap JSON in ` ```json ... ``` ` code fences. Without stripping these, `JSON.parse()` fails with "Unexpected token". This is a practical reliability fix for production use.

## Changes

| Change | Lines |
|--------|-------|
| `GenerateConfig.toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>` | +1 |
| Pass `toolExecutor` to `ChatAgent.create()` | +1 |
| `extractJson()` — strips markdown code fences | +5 |
| Use `extractJson(text)` before `JSON.parse()` | +1 |

Fully backward compatible — both fields are optional.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables real tool execution in ReAct planning by adding `toolExecutor`, and improves JSON parsing by stripping markdown code fences. Backward compatible; new fields are optional.

- **New Features**
  - Add `tools` and `toolExecutor` to `PlanAgent.GenerateConfig`, and pass them to `ChatAgent.create()` in `@openomni/agent` so the planner can run tools (read files, grep, explore code).

- **Bug Fixes**
  - Add `extractJson()` to remove ```json fences and use it before `JSON.parse()` to avoid "Unexpected token" errors.

<sup>Written for commit 17daabe123d9a21627e3341451438154d47a5681. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

