### PR TITLE
test(protocol): harden schema validation test suite

### DIFF
--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { AgentProfile } from "../src/agent/index";
+
+const it = test;
 
 describe("AgentProfile.Definition", () => {
   it("parses minimal definition", () => {
@@ -29,4 +31,52 @@ describe("AgentProfile.Definition", () => {
   it("rejects missing required fields", () => {
     expect(() => AgentProfile.Definition.parse({ name: "x" })).toThrow();
   });
+});
+
+describe("rejection (schema-enforced)", () => {
+  it("rejects maxTurns = 0", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        maxTurns: 0,
+      }),
+    ).toThrow());
+  it("rejects maxTurns = -1", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        maxTurns: -1,
+      }),
+    ).toThrow());
+  it("rejects maxTurns = 1.5", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        maxTurns: 1.5,
+      }),
+    ).toThrow());
+});
+
+describe("acceptance (documents current behavior)", () => {
+  it("accepts maxTurns = 1", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        maxTurns: 1,
+      }),
+    ).not.toThrow());
+  it("accepts empty name string", () =>
+    expect(() => AgentProfile.Definition.parse({ name: "", description: "x" })).not.toThrow());
+  it("accepts permissions: {}", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        permissions: {},
+      }),
+    ).not.toThrow());
 });

--- a/packages/protocol/test/artifact.test.ts
+++ b/packages/protocol/test/artifact.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { Artifact } from "../src/artifact/index";
+
+const it = test;
 
 describe("Artifact schemas", () => {
   describe("Meta", () => {
@@ -46,6 +48,65 @@ describe("Artifact schemas", () => {
           createdAt: "2025-01-01T00:00:00Z",
         }),
       ).toThrow();
+    });
+
+    describe("version constraint (.int() only)", () => {
+      it("rejects float version", () =>
+        expect(() =>
+          Artifact.Meta.parse({
+            id: "a",
+            sessionId: "b",
+            mimeType: "text/plain",
+            title: "t",
+            version: 1.5,
+            createdAt: "x",
+          }),
+        ).toThrow());
+      it("accepts version 0 (no positive constraint)", () =>
+        expect(() =>
+          Artifact.Meta.parse({
+            id: "a",
+            sessionId: "b",
+            mimeType: "text/plain",
+            title: "t",
+            version: 0,
+            createdAt: "x",
+          }),
+        ).not.toThrow());
+      it("accepts version -1 (no min constraint)", () =>
+        expect(() =>
+          Artifact.Meta.parse({
+            id: "a",
+            sessionId: "b",
+            mimeType: "text/plain",
+            title: "t",
+            version: -1,
+            createdAt: "x",
+          }),
+        ).not.toThrow());
+    });
+
+    describe("acceptance (documents current behavior)", () => {
+      it("accepts empty string createdAt", () =>
+        expect(() =>
+          Artifact.Meta.parse({
+            id: "a",
+            sessionId: "b",
+            mimeType: "text/plain",
+            title: "t",
+            createdAt: "",
+          }),
+        ).not.toThrow());
+      it("accepts empty mimeType", () =>
+        expect(() =>
+          Artifact.Meta.parse({
+            id: "a",
+            sessionId: "b",
+            mimeType: "",
+            title: "t",
+            createdAt: "x",
+          }),
+        ).not.toThrow());
     });
   });
 

--- a/packages/protocol/test/bun-test.d.ts
+++ b/packages/protocol/test/bun-test.d.ts
@@ -1,0 +1,5 @@
+declare module "bun:test" {
+  export const describe: any;
+  export const test: any;
+  export const expect: any;
+}

--- a/packages/protocol/test/bus.test.ts
+++ b/packages/protocol/test/bus.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { BusEvent } from "../src/bus/index.js";
+
+describe("BusEvent.define", () => {
+  const schema = z.object({
+    id: z.string().min(1),
+    count: z.number().int().nonnegative(),
+  });
+
+  test("returns a descriptor with name and schema", () => {
+    const descriptor = BusEvent.define("bus:event", schema);
+
+    expect(descriptor).toEqual({
+      name: "bus:event",
+      schema,
+    });
+  });
+
+  test("preserves the provided name", () => {
+    const descriptor = BusEvent.define("bus:event", schema);
+
+    expect(descriptor.name).toBe("bus:event");
+  });
+
+  test("preserves the schema reference", () => {
+    const descriptor = BusEvent.define("bus:event", schema);
+
+    expect(descriptor.schema).toBe(schema);
+  });
+
+  test("parses valid payloads", () => {
+    const descriptor = BusEvent.define("bus:event", schema);
+
+    expect(descriptor.schema.parse({ id: "abc", count: 3 })).toEqual({
+      id: "abc",
+      count: 3,
+    });
+  });
+
+  test("throws for invalid payloads", () => {
+    const descriptor = BusEvent.define("bus:event", schema);
+
+    expect(() => descriptor.schema.parse({ id: "", count: -1 })).toThrow();
+  });
+
+  test("allows an empty string name", () => {
+    const descriptor = BusEvent.define("", schema);
+
+    expect(descriptor.name).toBe("");
+    expect(descriptor.schema).toBe(schema);
+  });
+});

--- a/packages/protocol/test/error.test.ts
+++ b/packages/protocol/test/error.test.ts
@@ -1,0 +1,185 @@
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
+
+import { NamedError, APIError } from "../src/error/index.js";
+
+describe("NamedError.create", () => {
+  const MyError = NamedError.create(
+    "MyError",
+    z.object({
+      message: z.string(),
+      detail: z.number(),
+    }),
+  );
+
+  test("returns a class with static schema helpers", () => {
+    expect(typeof MyError).toBe("function");
+    expect(MyError.name).toBe("MyError");
+    expect(MyError.Schema).toBeDefined();
+    expect(MyError.isInstance).toBeDefined();
+  });
+
+  test("creates instances with message and data from payload", () => {
+    const error = new MyError({ message: "boom", detail: 42 });
+
+    expect(error.name).toBe("MyError");
+    expect(error.message).toBe("boom");
+    expect(error.data).toEqual({ message: "boom", detail: 42 });
+  });
+
+  test("falls back to the error name when payload has no message", () => {
+    const NoMessageError = NamedError.create(
+      "NoMessageError",
+      z.object({
+        detail: z.number(),
+      }),
+    );
+
+    const error = new NoMessageError({ detail: 7 });
+
+    expect(error.message).toBe("NoMessageError");
+    expect(error.data).toEqual({ detail: 7 });
+  });
+
+  test("returns the schema and object shape", () => {
+    const error = new MyError({ message: "shape", detail: 1 });
+
+    expect(error.schema()).toBe(MyError.Schema);
+    expect(error.toObject()).toEqual({
+      name: "MyError",
+      data: { message: "shape", detail: 1 },
+    });
+  });
+
+  test("sets cause when provided", () => {
+    const cause = new Error("cause");
+    const error = new MyError({ message: "boom", detail: 1 }, { cause });
+
+    expect((error as Error & { cause?: unknown }).cause).toBe(cause);
+  });
+
+  test("isInstance matches real instances", () => {
+    expect(MyError.isInstance(new MyError({ message: "ok", detail: 1 }))).toBe(true);
+  });
+
+  test("isInstance rejects null", () => {
+    expect(MyError.isInstance(null)).toBe(false);
+  });
+
+  test("isInstance accepts plain objects with the same name", () => {
+    expect(MyError.isInstance({ name: "MyError" })).toBe(true);
+  });
+
+  test("isInstance rejects plain objects with a different name", () => {
+    expect(MyError.isInstance({ name: "OtherError" })).toBe(false);
+  });
+});
+
+describe("NamedError.Unknown", () => {
+  test("uses the built-in name and message field", () => {
+    const error = new NamedError.Unknown({ message: "oops" });
+
+    expect(error.name).toBe("UnknownError");
+    expect(error.message).toBe("oops");
+    expect(error.toObject()).toEqual({
+      name: "UnknownError",
+      data: { message: "oops" },
+    });
+  });
+
+  test("parses valid objects and rejects missing message", () => {
+    expect(
+      NamedError.Unknown.Schema.parse({
+        name: "UnknownError",
+        data: { message: "test" },
+      }),
+    ).toEqual({
+      name: "UnknownError",
+      data: { message: "test" },
+    });
+
+    expect(() =>
+      NamedError.Unknown.Schema.parse({
+        name: "UnknownError",
+        data: {},
+      }),
+    ).toThrow();
+  });
+});
+
+describe("APIError", () => {
+  test("parses the minimal shape", () => {
+    const parsed = APIError.Schema.parse({
+      name: "APIError",
+      data: {
+        message: "fail",
+        isRetryable: true,
+      },
+    });
+
+    expect(parsed).toEqual({
+      name: "APIError",
+      data: {
+        message: "fail",
+        isRetryable: true,
+      },
+    });
+  });
+
+  test("parses optional API metadata fields", () => {
+    const parsed = APIError.Schema.parse({
+      name: "APIError",
+      data: {
+        message: "fail",
+        isRetryable: false,
+        statusCode: 503,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody: "{}",
+        metadata: { requestId: "req-1" },
+      },
+    });
+
+    expect(parsed.data).toEqual({
+      message: "fail",
+      isRetryable: false,
+      statusCode: 503,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: "{}",
+      metadata: { requestId: "req-1" },
+    });
+  });
+
+  test("rejects missing isRetryable", () => {
+    expect(() =>
+      APIError.Schema.parse({
+        name: "APIError",
+        data: {
+          message: "fail",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("constructs and identifies APIError instances", () => {
+    const error = new APIError({ message: "fail", isRetryable: false });
+
+    expect(error.name).toBe("APIError");
+    expect(error.message).toBe("fail");
+    expect(APIError.isInstance(error)).toBe(true);
+    expect(APIError.isInstance(new NamedError.Unknown({ message: "oops" }))).toBe(false);
+  });
+});
+
+describe("NamedError.create with non-object data", () => {
+  test("falls back to the class name for string payloads", () => {
+    const StrError = NamedError.create("StrError", z.string());
+    const error = new StrError("just a string");
+
+    expect(error.message).toBe("StrError");
+    expect(error.data).toBe("just a string");
+    expect(error.toObject()).toEqual({
+      name: "StrError",
+      data: "just a string",
+    });
+  });
+});

--- a/packages/protocol/test/event-log.test.ts
+++ b/packages/protocol/test/event-log.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { ExecutionEvent } from "../src/event-log/index";
+
+const it = test;
 
 const now = new Date().toISOString();
 
@@ -85,4 +87,66 @@ describe("ExecutionEvent schemas", () => {
       }),
     ).toThrow();
   });
+});
+
+describe("required field rejection", () => {
+  it("llm_response: missing text rejects", () =>
+    expect(() =>
+      ExecutionEvent.Schema.parse({
+        type: "llm_response",
+        turnIndex: 0,
+        toolCalls: [],
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        timestamp: "x",
+        sequence: 1,
+      }),
+    ).toThrow());
+  it("tool_started: missing toolCallId rejects", () =>
+    expect(() =>
+      ExecutionEvent.Schema.parse({
+        type: "tool_started",
+        toolName: "x",
+        timestamp: "x",
+        sequence: 1,
+      }),
+    ).toThrow());
+  it("tool_completed: missing result rejects", () =>
+    expect(() =>
+      ExecutionEvent.Schema.parse({
+        type: "tool_completed",
+        toolCallId: "c",
+        timestamp: "x",
+        sequence: 1,
+      }),
+    ).toThrow());
+});
+
+describe("acceptance (documents current behavior)", () => {
+  it("sequence accepts float (bare z.number())", () =>
+    expect(() =>
+      ExecutionEvent.Schema.parse({
+        type: "session_suspended",
+        reason: "r",
+        timestamp: "x",
+        sequence: 1.5,
+      }),
+    ).not.toThrow());
+  it("sequence accepts negative", () =>
+    expect(() =>
+      ExecutionEvent.Schema.parse({
+        type: "session_suspended",
+        reason: "r",
+        timestamp: "x",
+        sequence: -1,
+      }),
+    ).not.toThrow());
+  it("timestamp accepts empty string (no format validation)", () =>
+    expect(() =>
+      ExecutionEvent.Schema.parse({
+        type: "session_suspended",
+        reason: "r",
+        timestamp: "",
+        sequence: 1,
+      }),
+    ).not.toThrow());
 });

--- a/packages/protocol/test/event.test.ts
+++ b/packages/protocol/test/event.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+import { Agent, Task } from "../src/event/index.js";
+
+const baseEvent = {
+  traceId: "trace-1",
+  time: 123,
+};
+
+describe("Task events", () => {
+  test("exposes the created event name and parses payloads", () => {
+    expect(Task.Created.name).toBe("task.created");
+
+    const result = Task.Created.schema.parse({
+      ...baseEvent,
+      payload: {
+        id: "task-1",
+        name: "Build",
+        status: "open",
+        description: "Build the app",
+      },
+    });
+
+    expect(result.payload).toEqual({
+      id: "task-1",
+      name: "Build",
+      status: "open",
+      description: "Build the app",
+    });
+  });
+
+  test("rejects created events without an id", () => {
+    expect(() =>
+      Task.Created.schema.parse({
+        ...baseEvent,
+        payload: {
+          name: "Build",
+          status: "open",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("exposes the updated event name", () => {
+    expect(Task.Updated.name).toBe("task.updated");
+  });
+
+  test("exposes the deleted event name", () => {
+    expect(Task.Deleted.name).toBe("task.deleted");
+  });
+
+  test("exposes the run started event name and parses payloads", () => {
+    expect(Task.RunStarted.name).toBe("task.run.started");
+
+    const result = Task.RunStarted.schema.parse({
+      ...baseEvent,
+      payload: {
+        id: "run-1",
+        taskId: "task-1",
+      },
+    });
+
+    expect(result.payload).toEqual({
+      id: "run-1",
+      taskId: "task-1",
+    });
+  });
+
+  test("rejects run started events without a taskId", () => {
+    expect(() =>
+      Task.RunStarted.schema.parse({
+        ...baseEvent,
+        payload: {
+          id: "run-1",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("exposes the run completed event name and parses payloads", () => {
+    expect(Task.RunCompleted.name).toBe("task.run.completed");
+
+    const result = Task.RunCompleted.schema.parse({
+      ...baseEvent,
+      payload: {
+        id: "run-1",
+        taskId: "task-1",
+        result: { ok: true },
+        duration: 12,
+      },
+    });
+
+    expect(result.payload).toEqual({
+      id: "run-1",
+      taskId: "task-1",
+      result: { ok: true },
+      duration: 12,
+    });
+  });
+
+  test("rejects run completed events without a duration", () => {
+    expect(() =>
+      Task.RunCompleted.schema.parse({
+        ...baseEvent,
+        payload: {
+          id: "run-1",
+          taskId: "task-1",
+          result: { ok: true },
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("exposes the run failed event name and parses payloads", () => {
+    expect(Task.RunFailed.name).toBe("task.run.failed");
+
+    const result = Task.RunFailed.schema.parse({
+      ...baseEvent,
+      payload: {
+        id: "run-1",
+        taskId: "task-1",
+        error: "boom",
+        duration: 12,
+      },
+    });
+
+    expect(result.payload).toEqual({
+      id: "run-1",
+      taskId: "task-1",
+      error: "boom",
+      duration: 12,
+    });
+  });
+
+  test("rejects run failed events without an error", () => {
+    expect(() =>
+      Task.RunFailed.schema.parse({
+        ...baseEvent,
+        payload: {
+          id: "run-1",
+          taskId: "task-1",
+          duration: 12,
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("exposes the scheduled event name", () => {
+    expect(Task.RunScheduled.name).toBe("task.run.scheduled");
+  });
+
+  test("exposes the blocked event name", () => {
+    expect(Task.RunBlocked.name).toBe("task.run.blocked");
+  });
+
+  test("exposes the cancelled event name", () => {
+    expect(Task.RunCancelled.name).toBe("task.run.cancelled");
+  });
+
+  test("exposes the deduped event name", () => {
+    expect(Task.RunDeduped.name).toBe("task.run.deduped");
+  });
+
+  test("exposes the summary created event name", () => {
+    expect(Task.SummaryCreated.name).toBe("task.summary.created");
+  });
+
+  test("exposes the summary delivered event name", () => {
+    expect(Task.SummaryDelivered.name).toBe("task.summary.delivered");
+  });
+
+  test("accepts empty trace ids", () => {
+    const result = Task.Deleted.schema.parse({
+      traceId: "",
+      time: 123,
+      payload: {
+        id: "task-1",
+      },
+    });
+
+    expect(result.traceId).toBe("");
+  });
+
+  test("accepts negative time values", () => {
+    const result = Task.Deleted.schema.parse({
+      traceId: "trace-1",
+      time: -1,
+      payload: {
+        id: "task-1",
+      },
+    });
+
+    expect(result.time).toBe(-1);
+  });
+});
+
+describe("Agent events", () => {
+  test("exposes the router selected event name", () => {
+    expect(Agent.RouterSelected.name).toBe("agent.router.selected");
+  });
+
+  test("exposes the permission requested event name", () => {
+    expect(Agent.PermissionRequested.name).toBe("agent.permission.requested");
+  });
+
+  test("exposes the tool executed event name and parses payloads", () => {
+    expect(Agent.ToolExecuted.name).toBe("agent.tool.executed");
+
+    const result = Agent.ToolExecuted.schema.parse({
+      ...baseEvent,
+      payload: {
+        agentId: "agent-1",
+        toolName: "read_file",
+        input: { path: "src/index.ts" },
+        output: { ok: true },
+        duration: 8,
+      },
+    });
+
+    expect(result.payload).toEqual({
+      agentId: "agent-1",
+      toolName: "read_file",
+      input: { path: "src/index.ts" },
+      output: { ok: true },
+      duration: 8,
+    });
+  });
+
+  test("rejects tool executed events without a duration", () => {
+    expect(() =>
+      Agent.ToolExecuted.schema.parse({
+        ...baseEvent,
+        payload: {
+          agentId: "agent-1",
+          toolName: "read_file",
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("accepts negative durations", () => {
+    const result = Agent.ToolExecuted.schema.parse({
+      ...baseEvent,
+      payload: {
+        agentId: "agent-1",
+        toolName: "read_file",
+        duration: -1,
+      },
+    });
+
+    expect(result.payload.duration).toBe(-1);
+  });
+
+  test("accepts empty trace ids on agent events", () => {
+    const result = Agent.RouterSelected.schema.parse({
+      traceId: "",
+      time: 123,
+      payload: {
+        agentId: "agent-1",
+        selectedRoute: "route-a",
+      },
+    });
+
+    expect(result.traceId).toBe("");
+  });
+});

--- a/packages/protocol/test/gate.test.ts
+++ b/packages/protocol/test/gate.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test as it } from "bun:test";
+import { Gate } from "../src/gate/index.js";
+
+describe("Gate schemas", () => {
+  describe("Issue", () => {
+    it("parses an error issue with stepId", () => {
+      const result = Gate.Issue.parse({
+        code: "E001",
+        severity: "error",
+        stepId: "step-1",
+        message: "something failed",
+      });
+
+      expect(result).toEqual({
+        code: "E001",
+        severity: "error",
+        stepId: "step-1",
+        message: "something failed",
+      });
+    });
+
+    it("parses a warning issue without stepId", () => {
+      const result = Gate.Issue.parse({
+        code: "W001",
+        severity: "warning",
+        message: "check this",
+      });
+
+      expect(result).toEqual({
+        code: "W001",
+        severity: "warning",
+        message: "check this",
+      });
+    });
+
+    it("rejects an invalid severity", () => {
+      expect(() =>
+        Gate.Issue.parse({
+          code: "X001",
+          severity: "info",
+          message: "invalid",
+        }),
+      ).toThrow();
+    });
+
+    it("rejects a missing message", () => {
+      expect(() =>
+        Gate.Issue.parse({
+          code: "X002",
+          severity: "error",
+        }),
+      ).toThrow();
+    });
+
+    it("rejects a missing code", () => {
+      expect(() =>
+        Gate.Issue.parse({
+          severity: "warning",
+          message: "missing code",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("Verdict", () => {
+    it("parses a passing verdict with empty issues", () => {
+      const result = Gate.Verdict.parse({
+        passed: true,
+        issues: [],
+      });
+
+      expect(result).toEqual({
+        passed: true,
+        issues: [],
+      });
+    });
+
+    it("parses a failing verdict with issues and feedback", () => {
+      const result = Gate.Verdict.parse({
+        passed: false,
+        issues: [
+          {
+            code: "E100",
+            severity: "error",
+            message: "fix required",
+          },
+        ],
+        feedback: "Please address the issue.",
+      });
+
+      expect(result).toEqual({
+        passed: false,
+        issues: [
+          {
+            code: "E100",
+            severity: "error",
+            message: "fix required",
+          },
+        ],
+        feedback: "Please address the issue.",
+      });
+    });
+
+    it("rejects a non-boolean passed value", () => {
+      expect(() =>
+        Gate.Verdict.parse({
+          passed: 1,
+          issues: [],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects missing issues", () => {
+      expect(() =>
+        Gate.Verdict.parse({
+          passed: true,
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("Context", () => {
+    it("rejects attempt 0", () => {
+      expect(() =>
+        Gate.Context.parse({
+          goal: "deliver",
+          attempt: 0,
+        }),
+      ).toThrow();
+    });
+
+    it("rejects attempt -1", () => {
+      expect(() =>
+        Gate.Context.parse({
+          goal: "deliver",
+          attempt: -1,
+        }),
+      ).toThrow();
+    });
+
+    it("rejects attempt 1.5", () => {
+      expect(() =>
+        Gate.Context.parse({
+          goal: "deliver",
+          attempt: 1.5,
+        }),
+      ).toThrow();
+    });
+
+    it("accepts attempt 1", () => {
+      const result = Gate.Context.parse({
+        goal: "deliver",
+        attempt: 1,
+      });
+
+      expect(result).toEqual({
+        goal: "deliver",
+        attempt: 1,
+      });
+    });
+
+    it("accepts attempt 100", () => {
+      const result = Gate.Context.parse({
+        goal: "deliver",
+        attempt: 100,
+      });
+
+      expect(result.attempt).toBe(100);
+    });
+
+    it("accepts an empty goal string", () => {
+      const result = Gate.Context.parse({
+        goal: "",
+        attempt: 1,
+      });
+
+      expect(result.goal).toBe("");
+    });
+
+    it("parses nested metadata objects", () => {
+      const result = Gate.Context.parse({
+        goal: "deliver",
+        attempt: 2,
+        metadata: {
+          nested: {
+            level: 1,
+            flags: [true, false],
+          },
+        },
+      });
+
+      expect(result.metadata).toEqual({
+        nested: {
+          level: 1,
+          flags: [true, false],
+        },
+      });
+    });
+  });
+});

--- a/packages/protocol/test/guardrail.test.ts
+++ b/packages/protocol/test/guardrail.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { Guardrail } from "../src/guardrail/index";
+
+const it = test;
 
 describe("Guardrail schemas", () => {
   describe("ToolPermission", () => {
@@ -91,6 +93,48 @@ describe("Guardrail schemas", () => {
           abortPropagation: true,
         }),
       ).toThrow();
+    });
+
+    describe("DelegationPolicy.maxDepth (bare z.number())", () => {
+      it("accepts float maxDepth", () =>
+        expect(() =>
+          Guardrail.DelegationPolicy.parse({
+            maxDepth: 1.5,
+            budgetPolicy: "inherit",
+            abortPropagation: true,
+          }),
+        ).not.toThrow());
+      it("accepts negative maxDepth", () =>
+        expect(() =>
+          Guardrail.DelegationPolicy.parse({
+            maxDepth: -1,
+            budgetPolicy: "inherit",
+            abortPropagation: true,
+          }),
+        ).not.toThrow());
+      it("accepts zero maxDepth", () =>
+        expect(() =>
+          Guardrail.DelegationPolicy.parse({
+            maxDepth: 0,
+            budgetPolicy: "inherit",
+            abortPropagation: true,
+          }),
+        ).not.toThrow());
+    });
+
+    describe("action enum completeness", () => {
+      ["reject", "retry", "warn", "escalate"].forEach((action) => {
+        it(`accepts action "${action}"`, () =>
+          expect(() =>
+            Guardrail.GuardrailSchema.parse({
+              type: "custom",
+              rule: "r",
+              action,
+            }),
+          ).not.toThrow());
+      });
+      it("empty allowlist accepted", () =>
+        expect(() => Guardrail.ToolPermission.parse({ allowlist: [] })).not.toThrow());
     });
   });
 });

--- a/packages/protocol/test/message.test.ts
+++ b/packages/protocol/test/message.test.ts
@@ -1,0 +1,398 @@
+import { describe, test, expect } from "bun:test";
+import { Message } from "../src/message/index.js";
+
+const base = { id: "p-1", sessionID: "ses-1", messageID: "msg-1" };
+
+describe("Message.TextPart", () => {
+  test("parses valid minimal text part", () => {
+    const part = Message.TextPart.parse({
+      ...base,
+      type: "text",
+      text: "hello",
+    });
+
+    expect(part.type).toBe("text");
+    expect(part.text).toBe("hello");
+    expect(part.time).toBeUndefined();
+    expect(part.metadata).toBeUndefined();
+  });
+
+  test("parses valid full text part with time and metadata", () => {
+    const part = Message.TextPart.parse({
+      ...base,
+      type: "text",
+      text: "hello",
+      time: { start: 100, end: 200 },
+      metadata: { source: "user" },
+    });
+
+    expect(part.time!.start).toBe(100);
+    expect(part.time!.end).toBe(200);
+    expect(part.metadata).toEqual({ source: "user" });
+  });
+
+  test("rejects missing text", () => {
+    expect(() => Message.TextPart.parse({ ...base, type: "text" })).toThrow();
+  });
+});
+
+describe("Message.ReasoningPart", () => {
+  test("parses valid reasoning part with required time", () => {
+    const part = Message.ReasoningPart.parse({
+      ...base,
+      type: "reasoning",
+      text: "thinking...",
+      time: { start: 10 },
+    });
+
+    expect(part.type).toBe("reasoning");
+    expect(part.text).toBe("thinking...");
+    expect(part.time.start).toBe(10);
+    expect(part.time.end).toBeUndefined();
+  });
+
+  test("rejects missing time", () => {
+    expect(() =>
+      Message.ReasoningPart.parse({
+        ...base,
+        type: "reasoning",
+        text: "thinking...",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing text", () => {
+    expect(() =>
+      Message.ReasoningPart.parse({
+        ...base,
+        type: "reasoning",
+        time: { start: 10 },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Message.StepStartPart", () => {
+  test("parses valid step-start part", () => {
+    const part = Message.StepStartPart.parse({
+      ...base,
+      type: "step-start",
+    });
+
+    expect(part.type).toBe("step-start");
+    expect(part.id).toBe("p-1");
+  });
+});
+
+describe("Message.StepFinishPart", () => {
+  test("parses valid step-finish part", () => {
+    const part = Message.StepFinishPart.parse({
+      ...base,
+      type: "step-finish",
+      reason: "end_turn",
+      cost: 0.05,
+      tokens: { input: 100, output: 50 },
+    });
+
+    expect(part.type).toBe("step-finish");
+    expect(part.reason).toBe("end_turn");
+    expect(part.cost).toBe(0.05);
+    expect(part.tokens).toEqual({ input: 100, output: 50 });
+  });
+
+  test("rejects missing cost", () => {
+    expect(() =>
+      Message.StepFinishPart.parse({
+        ...base,
+        type: "step-finish",
+        reason: "end_turn",
+        tokens: { input: 100, output: 50 },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing tokens", () => {
+    expect(() =>
+      Message.StepFinishPart.parse({
+        ...base,
+        type: "step-finish",
+        reason: "end_turn",
+        cost: 0.05,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Message.RetryPart", () => {
+  test("parses valid retry part with serialized APIError", () => {
+    const part = Message.RetryPart.parse({
+      ...base,
+      type: "retry",
+      attempt: 2,
+      error: {
+        name: "APIError",
+        data: { message: "rate limited", isRetryable: true },
+      },
+      time: { created: 1000 },
+    });
+
+    expect(part.type).toBe("retry");
+    expect(part.attempt).toBe(2);
+    expect(part.error.name).toBe("APIError");
+    expect(part.error.data.isRetryable).toBe(true);
+    expect(part.time.created).toBe(1000);
+  });
+
+  test("rejects missing attempt", () => {
+    expect(() =>
+      Message.RetryPart.parse({
+        ...base,
+        type: "retry",
+        error: {
+          name: "APIError",
+          data: { message: "fail", isRetryable: false },
+        },
+        time: { created: 1000 },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Message.ToolPart", () => {
+  const toolBase = {
+    ...base,
+    type: "tool" as const,
+    callID: "c-1",
+    tool: "search",
+  };
+
+  test("parses with pending state", () => {
+    const part = Message.ToolPart.parse({
+      ...toolBase,
+      state: { status: "pending", input: {} },
+    });
+
+    expect(part.type).toBe("tool");
+    expect(part.state.status).toBe("pending");
+  });
+
+  test("parses with running state", () => {
+    const part = Message.ToolPart.parse({
+      ...toolBase,
+      state: { status: "running", input: {}, time: { start: 0 } },
+    });
+
+    expect(part.state.status).toBe("running");
+  });
+
+  test("parses with completed state", () => {
+    const part = Message.ToolPart.parse({
+      ...toolBase,
+      state: {
+        status: "completed",
+        input: {},
+        output: "ok",
+        title: "t",
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    });
+
+    expect(part.state.status).toBe("completed");
+  });
+
+  test("parses with error state", () => {
+    const part = Message.ToolPart.parse({
+      ...toolBase,
+      state: {
+        status: "error",
+        input: {},
+        error: "fail",
+        time: { start: 0, end: 1 },
+      },
+    });
+
+    expect(part.state.status).toBe("error");
+  });
+
+  test("rejects missing callID", () => {
+    expect(() =>
+      Message.ToolPart.parse({
+        ...base,
+        type: "tool",
+        tool: "search",
+        state: { status: "pending", input: {} },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects wrong Tool.State status", () => {
+    expect(() =>
+      Message.ToolPart.parse({
+        ...toolBase,
+        state: { status: "done", input: {} },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Message.SnapshotPart", () => {
+  test("parses valid snapshot part", () => {
+    const part = Message.SnapshotPart.parse({
+      ...base,
+      type: "snapshot",
+      snapshot: '{"ctx":"data"}',
+    });
+
+    expect(part.type).toBe("snapshot");
+    expect(part.snapshot).toBe('{"ctx":"data"}');
+  });
+
+  test("rejects missing snapshot", () => {
+    expect(() => Message.SnapshotPart.parse({ ...base, type: "snapshot" })).toThrow();
+  });
+});
+
+describe("Message.CompactionPart", () => {
+  test("parses valid compaction part", () => {
+    const part = Message.CompactionPart.parse({
+      ...base,
+      type: "compaction",
+      auto: true,
+    });
+
+    expect(part.type).toBe("compaction");
+    expect(part.auto).toBe(true);
+  });
+
+  test("rejects missing auto", () => {
+    expect(() => Message.CompactionPart.parse({ ...base, type: "compaction" })).toThrow();
+  });
+});
+
+describe("Message.Part", () => {
+  test("rejects unknown type literal", () => {
+    expect(() => Message.Part.parse({ ...base, type: "unknown" })).toThrow();
+  });
+});
+
+const msgBase = { id: "msg-1", sessionID: "ses-1" };
+
+describe("Message.UserMessage", () => {
+  const validUser = {
+    ...msgBase,
+    role: "user" as const,
+    time: { created: 1000 },
+    agent: "build",
+    model: { providerID: "anthropic", modelID: "claude-opus-4-20250514" },
+  };
+
+  test("parses valid minimal user message", () => {
+    const msg = Message.UserMessage.parse(validUser);
+
+    expect(msg.role).toBe("user");
+    expect(msg.agent).toBe("build");
+    expect(msg.system).toBeUndefined();
+    expect(msg.tools).toBeUndefined();
+    expect(msg.variant).toBeUndefined();
+  });
+
+  test("parses valid full user message with system, tools, variant", () => {
+    const msg = Message.UserMessage.parse({
+      ...validUser,
+      system: "You are helpful.",
+      tools: { search: true, write: false },
+      variant: "fast",
+    });
+
+    expect(msg.system).toBe("You are helpful.");
+    expect(msg.tools).toEqual({ search: true, write: false });
+    expect(msg.variant).toBe("fast");
+  });
+
+  test("rejects missing agent", () => {
+    const { agent: _, ...noAgent } = validUser;
+    expect(() => Message.UserMessage.parse(noAgent)).toThrow();
+  });
+
+  test("rejects wrong role", () => {
+    expect(() => Message.UserMessage.parse({ ...validUser, role: "assistant" })).toThrow();
+  });
+});
+
+describe("Message.AssistantMessage", () => {
+  const validAssistant = {
+    ...msgBase,
+    role: "assistant" as const,
+    time: { created: 1000 },
+    parentID: "msg-0",
+    modelID: "claude-opus-4-20250514",
+    providerID: "anthropic",
+    agent: "build",
+    path: { cwd: "/home", root: "/" },
+    cost: 0.01,
+    tokens: {
+      input: 500,
+      output: 200,
+      reasoning: 0,
+      cache: { read: 100, write: 50 },
+    },
+  };
+
+  test("parses valid minimal assistant message", () => {
+    const msg = Message.AssistantMessage.parse(validAssistant);
+
+    expect(msg.role).toBe("assistant");
+    expect(msg.parentID).toBe("msg-0");
+    expect(msg.cost).toBe(0.01);
+    expect(msg.tokens.cache.read).toBe(100);
+    expect(msg.time.completed).toBeUndefined();
+    expect(msg.finish).toBeUndefined();
+  });
+
+  test("rejects missing parentID", () => {
+    const { parentID: _, ...noParent } = validAssistant;
+    expect(() => Message.AssistantMessage.parse(noParent)).toThrow();
+  });
+});
+
+describe("Message.Info", () => {
+  test("rejects wrong role", () => {
+    expect(() => Message.Info.parse({ ...msgBase, role: "system" })).toThrow();
+  });
+});
+
+describe("Message.WithParts", () => {
+  const userInfo = {
+    ...msgBase,
+    role: "user" as const,
+    time: { created: 1000 },
+    agent: "build",
+    model: { providerID: "anthropic", modelID: "claude-opus-4-20250514" },
+  };
+
+  const textPart = {
+    ...base,
+    type: "text" as const,
+    text: "hello",
+  };
+
+  test("parses valid WithParts", () => {
+    const wp = Message.WithParts.parse({
+      info: userInfo,
+      parts: [textPart],
+    });
+
+    expect(wp.info.role).toBe("user");
+    expect(wp.parts).toHaveLength(1);
+    expect(wp.parts[0].type).toBe("text");
+  });
+
+  test("rejects missing info", () => {
+    expect(() => Message.WithParts.parse({ parts: [textPart] })).toThrow();
+  });
+
+  test("rejects missing parts", () => {
+    expect(() => Message.WithParts.parse({ info: userInfo })).toThrow();
+  });
+});

--- a/packages/protocol/test/plan.test.ts
+++ b/packages/protocol/test/plan.test.ts
@@ -211,3 +211,92 @@ describe("PlanResult", () => {
     ).toThrow();
   });
 });
+
+describe("version constraint (.int() only)", () => {
+  test("rejects float version", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "p",
+        goal: "g",
+        steps: [],
+        createdAt: now,
+        version: 1.5,
+      }),
+    ).toThrow();
+  });
+
+  test("accepts version 0 (no positive constraint)", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "p",
+        goal: "g",
+        steps: [],
+        createdAt: now,
+        version: 0,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("superRefine gaps (documented, not fixed)", () => {
+  test("self-dependency A→A is accepted (not detected by superRefine)", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "p",
+        goal: "g",
+        steps: [
+          {
+            stepId: "A",
+            description: "d",
+            expectedOutput: "o",
+            dependsOn: ["A"],
+          },
+        ],
+        createdAt: now,
+        version: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  test("circular dependency A→B→A is accepted (not detected by superRefine)", () => {
+    const now = new Date();
+    expect(() =>
+      PlanSchema.parse({
+        planId: "p",
+        goal: "g",
+        steps: [
+          {
+            stepId: "A",
+            description: "d",
+            expectedOutput: "o",
+            dependsOn: ["B"],
+          },
+          {
+            stepId: "B",
+            description: "d",
+            expectedOutput: "o",
+            dependsOn: ["A"],
+          },
+        ],
+        createdAt: now,
+        version: 1,
+      }),
+    ).not.toThrow();
+  });
+
+  test("z.date() rejects string from JSON.parse (round-trip fails)", () => {
+    const now = new Date();
+    const plan = {
+      planId: "p",
+      goal: "g",
+      steps: [],
+      createdAt: now,
+      version: 1,
+    };
+    const json = JSON.stringify(plan);
+    expect(() => PlanSchema.parse(JSON.parse(json))).toThrow();
+  });
+});

--- a/packages/protocol/test/run.test.ts
+++ b/packages/protocol/test/run.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect } from "bun:test";
+import { Run } from "../src/run/index.js";
+import { Tool } from "../src/tool/index.js";
+
+describe("Run.Outcome", () => {
+  test("parses stop", () => {
+    expect(Run.Outcome.parse({ type: "stop" })).toEqual({ type: "stop" });
+  });
+
+  test("parses await_tool with an empty toolCalls array", () => {
+    expect(Run.Outcome.parse({ type: "await_tool", toolCalls: [] })).toEqual({
+      type: "await_tool",
+      toolCalls: [],
+    });
+  });
+
+  test("parses await_tool with tool calls", () => {
+    const toolCall = Tool.Call.parse({
+      id: "call-1",
+      tool: "search",
+      input: {},
+    });
+
+    const outcome = Run.Outcome.parse({
+      type: "await_tool",
+      toolCalls: [toolCall],
+    }) as Extract<Run.Outcome, { type: "await_tool" }>;
+
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolCalls[0]).toEqual(toolCall);
+  });
+
+  test("rejects await_tool without toolCalls", () => {
+    expect(() => Run.Outcome.parse({ type: "await_tool" })).toThrow();
+  });
+
+  test("parses aborted", () => {
+    expect(Run.Outcome.parse({ type: "aborted" })).toEqual({ type: "aborted" });
+  });
+
+  test("parses error with message only", () => {
+    const outcome = Run.Outcome.parse({
+      type: "error",
+      error: { message: "boom" },
+    }) as Extract<Run.Outcome, { type: "error" }>;
+
+    expect(outcome.error).toEqual({ message: "boom" });
+  });
+
+  test("parses error with name and stack", () => {
+    const outcome = Run.Outcome.parse({
+      type: "error",
+      error: {
+        message: "boom",
+        name: "BoomError",
+        stack: "stack trace",
+      },
+    }) as Extract<Run.Outcome, { type: "error" }>;
+
+    expect(outcome.error).toEqual({
+      message: "boom",
+      name: "BoomError",
+      stack: "stack trace",
+    });
+  });
+
+  test("rejects error without message", () => {
+    expect(() =>
+      Run.Outcome.parse({
+        type: "error",
+        error: {},
+      }),
+    ).toThrow();
+  });
+
+  test("rejects unknown outcome type", () => {
+    expect(() => Run.Outcome.parse({ type: "other" })).toThrow();
+  });
+});
+
+describe("Run.Snapshot", () => {
+  test("parses a valid snapshot", () => {
+    const snapshot = Run.Snapshot.parse({
+      id: "run-1",
+      sessionID: "session-1",
+      timestamp: 123,
+      state: { step: 1, active: true },
+    });
+
+    expect(snapshot.id).toBe("run-1");
+    expect(snapshot.sessionID).toBe("session-1");
+    expect(snapshot.timestamp).toBe(123);
+    expect(snapshot.state).toEqual({ step: 1, active: true });
+  });
+
+  test("rejects missing id", () => {
+    expect(() =>
+      Run.Snapshot.parse({
+        sessionID: "session-1",
+        timestamp: 123,
+        state: {},
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing sessionID", () => {
+    expect(() =>
+      Run.Snapshot.parse({
+        id: "run-1",
+        timestamp: 123,
+        state: {},
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Run.RetryPolicy", () => {
+  test("parses a valid retry policy with retryOn", () => {
+    const policy = Run.RetryPolicy.parse({
+      maxAttempts: 3,
+      backoffMs: {
+        initial: 100,
+        multiplier: 2,
+        max: 1000,
+      },
+      retryOn: ["timeout", "tool_error", "transient_error", "validation_error"],
+    });
+
+    expect(policy.retryOn).toEqual([
+      "timeout",
+      "tool_error",
+      "transient_error",
+      "validation_error",
+    ]);
+  });
+
+  test("parses a valid retry policy without retryOn", () => {
+    const policy = Run.RetryPolicy.parse({
+      maxAttempts: 1,
+      backoffMs: {
+        initial: 10,
+        multiplier: 1.5,
+        max: 100,
+      },
+    });
+
+    expect(policy.retryOn).toBeUndefined();
+  });
+
+  test("rejects invalid retryOn values", () => {
+    expect(() =>
+      Run.RetryPolicy.parse({
+        maxAttempts: 3,
+        backoffMs: {
+          initial: 100,
+          multiplier: 2,
+          max: 1000,
+        },
+        retryOn: ["invalid"],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Run.Budget", () => {
+  test("accepts negative and fractional numbers", () => {
+    const budget = Run.Budget.parse({
+      maxWallTimeMs: -1,
+      maxTurns: 0,
+      maxToolCalls: -100,
+      maxToolRuntimeMs: 0.5,
+    });
+
+    expect(budget).toEqual({
+      maxWallTimeMs: -1,
+      maxTurns: 0,
+      maxToolCalls: -100,
+      maxToolRuntimeMs: 0.5,
+    });
+  });
+
+  test("parses a normal budget", () => {
+    const budget = Run.Budget.parse({
+      maxWallTimeMs: 60000,
+      maxTurns: 20,
+      maxToolCalls: 10,
+      maxToolRuntimeMs: 15000,
+    });
+
+    expect(budget.maxTurns).toBe(20);
+  });
+});

--- a/packages/protocol/test/team.test.ts
+++ b/packages/protocol/test/team.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 import { Team, BusEvent } from "../src/index.js";
+
+const it = test;
 
 describe("Team Protocol Types", () => {
   describe("StepState", () => {
@@ -309,6 +311,94 @@ describe("Team Protocol Types", () => {
         },
       };
       expect(() => eventDescriptor.schema.parse(payload)).not.toThrow();
+    });
+
+    describe("Team.Events.ApprovalRequested", () => {
+      it("event name is correct", () =>
+        expect(Team.Events.ApprovalRequested.name).toBe("approval.requested"));
+      it("parses valid payload", () =>
+        expect(() =>
+          Team.Events.ApprovalRequested.schema.parse({
+            traceId: "t",
+            time: 1,
+            payload: {
+              planId: "p",
+              stepId: "s",
+              stepTitle: "title",
+              timeoutMs: 5000,
+            },
+          }),
+        ).not.toThrow());
+      it("rejects missing stepTitle", () =>
+        expect(() =>
+          Team.Events.ApprovalRequested.schema.parse({
+            traceId: "t",
+            time: 1,
+            payload: { planId: "p", stepId: "s", timeoutMs: 5000 },
+          }),
+        ).toThrow());
+      it("rejects missing timeoutMs", () =>
+        expect(() =>
+          Team.Events.ApprovalRequested.schema.parse({
+            traceId: "t",
+            time: 1,
+            payload: { planId: "p", stepId: "s", stepTitle: "title" },
+          }),
+        ).toThrow());
+    });
+
+    describe("StepStarted attempt constraint (.int().min(1))", () => {
+      it("attempt 0 rejects", () =>
+        expect(() =>
+          Team.Events.StepStarted.schema.parse({
+            traceId: "t",
+            time: 1,
+            payload: { planId: "p", stepId: "s", agentId: "a", attempt: 0 },
+          }),
+        ).toThrow());
+      it("attempt -1 rejects", () =>
+        expect(() =>
+          Team.Events.StepStarted.schema.parse({
+            traceId: "t",
+            time: 1,
+            payload: { planId: "p", stepId: "s", agentId: "a", attempt: -1 },
+          }),
+        ).toThrow());
+      it("attempt 1 accepts", () =>
+        expect(() =>
+          Team.Events.StepStarted.schema.parse({
+            traceId: "t",
+            time: 1,
+            payload: { planId: "p", stepId: "s", agentId: "a", attempt: 1 },
+          }),
+        ).not.toThrow());
+    });
+
+    describe("RunLedgerEntry constraints (.int().min(0))", () => {
+      it("attempts -1 rejects", () =>
+        expect(() =>
+          Team.RunLedgerEntry.parse({
+            stepId: "s",
+            state: "ready",
+            attempts: -1,
+          }),
+        ).toThrow());
+      it("attempts 1.5 rejects", () =>
+        expect(() =>
+          Team.RunLedgerEntry.parse({
+            stepId: "s",
+            state: "ready",
+            attempts: 1.5,
+          }),
+        ).toThrow());
+      it("attempts 0 accepts (boundary)", () =>
+        expect(() =>
+          Team.RunLedgerEntry.parse({
+            stepId: "s",
+            state: "ready",
+            attempts: 0,
+          }),
+        ).not.toThrow());
     });
   });
 });

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -1,0 +1,310 @@
+import { describe, test, expect } from "bun:test";
+import { Tool } from "../src/tool/index.js";
+
+describe("Tool.StatePending", () => {
+  test("parses valid pending state with empty input", () => {
+    const state = Tool.StatePending.parse({
+      status: "pending",
+      input: {},
+    });
+
+    expect(state.status).toBe("pending");
+    expect(state.input).toEqual({});
+  });
+
+  test("rejects missing input", () => {
+    expect(() => Tool.StatePending.parse({ status: "pending" })).toThrow();
+  });
+
+  test("rejects missing status", () => {
+    expect(() => Tool.StatePending.parse({ input: {} })).toThrow();
+  });
+
+  test("rejects wrong status", () => {
+    expect(() =>
+      Tool.StatePending.parse({
+        status: "running",
+        input: {},
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Tool.StateRunning", () => {
+  test("parses valid running state with negative start time", () => {
+    const state = Tool.StateRunning.parse({
+      status: "running",
+      input: { task: "demo" },
+      time: { start: -5 },
+    });
+
+    expect(state.status).toBe("running");
+    expect(state.time.start).toBe(-5);
+  });
+
+  test("rejects missing time", () => {
+    expect(() =>
+      Tool.StateRunning.parse({
+        status: "running",
+        input: {},
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing input", () => {
+    expect(() =>
+      Tool.StateRunning.parse({
+        status: "running",
+        time: { start: 1 },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Tool.StateCompleted", () => {
+  test("parses valid completed state with time.end set to 0", () => {
+    const state = Tool.StateCompleted.parse({
+      status: "completed",
+      input: { task: "demo" },
+      output: "done",
+      title: "Demo Task",
+      metadata: {},
+      time: { start: 1, end: 0 },
+    });
+
+    expect(state.status).toBe("completed");
+    expect(state.time.end).toBe(0);
+    expect(state.metadata).toEqual({});
+  });
+
+  test("rejects missing output", () => {
+    expect(() =>
+      Tool.StateCompleted.parse({
+        status: "completed",
+        input: {},
+        title: "Demo Task",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing title", () => {
+    expect(() =>
+      Tool.StateCompleted.parse({
+        status: "completed",
+        input: {},
+        output: "done",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing time", () => {
+    expect(() =>
+      Tool.StateCompleted.parse({
+        status: "completed",
+        input: {},
+        output: "done",
+        title: "Demo Task",
+        metadata: {},
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Tool.StateError", () => {
+  test("parses valid error state", () => {
+    const state = Tool.StateError.parse({
+      status: "error",
+      input: { task: "demo" },
+      error: "failed",
+      time: { start: 1, end: 2 },
+    });
+
+    expect(state.status).toBe("error");
+    expect(state.error).toBe("failed");
+  });
+
+  test("rejects missing error", () => {
+    expect(() =>
+      Tool.StateError.parse({
+        status: "error",
+        input: {},
+        time: { start: 1, end: 2 },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing time", () => {
+    expect(() =>
+      Tool.StateError.parse({
+        status: "error",
+        input: {},
+        error: "failed",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Tool.State", () => {
+  test("parses each variant by status", () => {
+    expect(
+      Tool.State.parse({
+        status: "pending",
+        input: {},
+      }).status,
+    ).toBe("pending");
+
+    expect(
+      Tool.State.parse({
+        status: "running",
+        input: {},
+        time: { start: 1 },
+      }).status,
+    ).toBe("running");
+
+    expect(
+      Tool.State.parse({
+        status: "completed",
+        input: {},
+        output: "done",
+        title: "done",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      }).status,
+    ).toBe("completed");
+
+    expect(
+      Tool.State.parse({
+        status: "error",
+        input: {},
+        error: "failed",
+        time: { start: 1, end: 2 },
+      }).status,
+    ).toBe("error");
+  });
+
+  test("rejects wrong status value", () => {
+    expect(() =>
+      Tool.State.parse({
+        status: "done",
+        input: {},
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing status field", () => {
+    expect(() => Tool.State.parse({ input: {} })).toThrow();
+  });
+});
+
+describe("Tool.Call", () => {
+  test("parses valid call", () => {
+    const call = Tool.Call.parse({
+      id: "call-1",
+      tool: "search",
+      input: { query: "openomni" },
+    });
+
+    expect(call.id).toBe("call-1");
+    expect(call.tool).toBe("search");
+    expect(call.input).toEqual({ query: "openomni" });
+  });
+
+  test("rejects missing id", () => {
+    expect(() =>
+      Tool.Call.parse({
+        tool: "search",
+        input: {},
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing tool", () => {
+    expect(() =>
+      Tool.Call.parse({
+        id: "call-1",
+        input: {},
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Tool.Result", () => {
+  test("parses valid minimal result", () => {
+    const result = Tool.Result.parse({
+      id: "res-1",
+      toolCallId: "call-1",
+      output: "ok",
+    });
+
+    expect(result.id).toBe("res-1");
+    expect(result.toolCallId).toBe("call-1");
+    expect(result.output).toBe("ok");
+    expect(result.isError).toBeUndefined();
+  });
+
+  test("parses valid full result", () => {
+    const result = Tool.Result.parse({
+      id: "res-1",
+      toolCallId: "call-1",
+      output: "failed",
+      isError: false,
+    });
+
+    expect(result.isError).toBe(false);
+  });
+
+  test("rejects missing output", () => {
+    expect(() =>
+      Tool.Result.parse({
+        id: "res-1",
+        toolCallId: "call-1",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Tool.Spec", () => {
+  test("parses valid minimal spec", () => {
+    const spec = Tool.Spec.parse({
+      name: "search",
+      inputSchema: {},
+    });
+
+    expect(spec.name).toBe("search");
+    expect(spec.inputSchema).toEqual({});
+    expect(spec.description).toBeUndefined();
+    expect(spec.safe).toBeUndefined();
+  });
+
+  test("parses valid full spec", () => {
+    const spec = Tool.Spec.parse({
+      name: "search",
+      description: "Search the workspace",
+      inputSchema: { type: "object" },
+      safe: true,
+    });
+
+    expect(spec.description).toBe("Search the workspace");
+    expect(spec.safe).toBe(true);
+  });
+
+  test("rejects missing name", () => {
+    expect(() =>
+      Tool.Spec.parse({
+        inputSchema: {},
+      }),
+    ).toThrow();
+  });
+
+  test("rejects missing inputSchema", () => {
+    expect(() =>
+      Tool.Spec.parse({
+        name: "search",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/protocol/test/tsconfig.json
+++ b/packages/protocol/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
## Summary

Hardens the `packages/protocol` test suite from 53% module coverage to 88%, adding 179 new tests across 7 new test files and 6 enhanced existing files.

- **7 new test files**: `error`, `bus`, `tool`, `gate`, `run`, `event`, `message`
- **6 enhanced test files**: `agent`, `artifact`, `event-log`, `guardrail`, `plan`, `team`
- **301 tests total** (up from 122), 0 failures
- **Two-category test strategy**: `rejection (schema-enforced)` vs `acceptance (documents current behavior)` — prevents false `.toThrow()` on unconstrained fields

## Key findings documented by tests

- `Plan` superRefine does NOT detect self-dependency (A→A) or circular deps (A→B→A)
- `Budget` fields accept negative values (bare `z.number()`, no constraints)
- All `z.string()` fields accept empty strings (no `.min(1)`)
- `z.date()` fields fail JSON round-trip (Date→string→`z.date()` rejects)
- `NamedError.isInstance()` uses name-only check (no prototype verification)

## Verification

```
bun test (packages/protocol): 301 pass, 0 fail, 16 files
bun run check-types: exit 0
False rejection audit: 0 false .toThrow() on unconstrained fields
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the `packages/protocol` test suite, raising module coverage from 53% to 88% with 179 new tests across new and updated files. Adds clear rejection/acceptance cases for schemas (numbers, empty strings, `z.date` JSON round-trip, `NamedError.isInstance`) and documents known gaps like plan self/circular dependencies.

<sup>Written for commit e6bb8eb53e5bfd5e8efa343086e21781c042b3a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

