### PR TITLE
feat(agent,protocol,openomni): add StepGuard and PlanEnricher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn-error.log*
 .cursor
 .claude
 .opencode
+*.local.ts

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -271,6 +271,8 @@ export namespace ChatAgent {
                 let lastAssistantText = "";
                 const steps: AgentStep[] = [];
                 let compactionCount = 0;
+                let continuationCount = 0;
+                const startTime = Date.now();
                 const totalUsage: TokenUsage = {
                   inputTokens: 0,
                   outputTokens: 0,
@@ -365,6 +367,40 @@ export namespace ChatAgent {
                       await config.onStepFinish(step);
                     }
 
+                    if (config.stepGuard) {
+                      const verdict = await config.stepGuard(step, {
+                        steps,
+                        usage: totalUsage,
+                        turnCount: budgetState.turns,
+                        isCompletion: true,
+                        continuationCount,
+                        elapsedMs: Date.now() - startTime,
+                      });
+
+                      if (verdict.action === "inject") {
+                        const parentID =
+                          messages.length > 0 ? messages[messages.length - 1].info.id : "";
+                        messages = [
+                          ...messages,
+                          createAssistantMessage(lastAssistantText, parentID),
+                          createUserMessage(verdict.message),
+                        ];
+                        continuationCount++;
+                        continue;
+                      }
+
+                      if (verdict.action === "abort") {
+                        return {
+                          text: lastAssistantText,
+                          steps,
+                          usage: totalUsage,
+                          finishReason: "stop",
+                          compactionCount: compactionCount > 0 ? compactionCount : undefined,
+                          guardAborted: true,
+                        };
+                      }
+                    }
+
                     return {
                       text: lastAssistantText,
                       steps,
@@ -413,6 +449,34 @@ export namespace ChatAgent {
 
                   if (config.onStepFinish) {
                     await config.onStepFinish(toolStep);
+                  }
+
+                  if (config.stepGuard) {
+                    const verdict = await config.stepGuard(toolStep, {
+                      steps,
+                      usage: totalUsage,
+                      turnCount: budgetState.turns,
+                      isCompletion: false,
+                      continuationCount,
+                      elapsedMs: Date.now() - startTime,
+                    });
+
+                    if (verdict.action === "inject") {
+                      messages = [...messages, createUserMessage(verdict.message)];
+                      continuationCount++;
+                      continue;
+                    }
+
+                    if (verdict.action === "abort") {
+                      return {
+                        text: lastAssistantText,
+                        steps,
+                        usage: totalUsage,
+                        finishReason: "stop",
+                        compactionCount: compactionCount > 0 ? compactionCount : undefined,
+                        guardAborted: true,
+                      };
+                    }
                   }
 
                   const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -22,7 +22,7 @@ import { InMemoryCompactor } from "./execution/compaction";
 import { ParallelToolExecutor } from "./execution/parallel-tools";
 import { Telemetry } from "./telemetry";
 import type { AgentEvent } from "./types";
-import type { Memory, MemoryResult } from "./memory";
+import type { MemoryResult } from "./memory";
 
 /**
  * ChatAgent instance interface
@@ -462,7 +462,18 @@ export namespace ChatAgent {
                     });
 
                     if (verdict.action === "inject") {
-                      messages = [...messages, createUserMessage(verdict.message)];
+                      const parentID =
+                        messages.length > 0 ? messages[messages.length - 1].info.id : "";
+                      const assistantWithTools = buildAssistantMessageWithTools(
+                        outcome.toolCalls,
+                        toolResults,
+                        parentID,
+                      );
+                      messages = [
+                        ...messages,
+                        assistantWithTools,
+                        createUserMessage(verdict.message),
+                      ];
                       continuationCount++;
                       continue;
                     }

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -310,7 +310,6 @@ export async function* streamAgent(
               createUserMessage(verdict.message),
             ];
             continuationCount++;
-            turnIndex++;
             continue;
           }
 

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -1,13 +1,6 @@
 import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
 import type { Message, Sink, Tool } from "@openomni/protocol";
-import type {
-  AgentEvent,
-  AgentResult,
-  AgentStep,
-  ChatAgentConfig,
-  ChatAgentInput,
-  TokenUsage,
-} from "../types";
+import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
 import { createBudgetState, checkBudget, recordTurn, recordToolCall } from "../budget";
 import {
   DEFAULT_RETRY_POLICY,
@@ -310,7 +303,12 @@ export async function* streamAgent(
           });
 
           if (verdict.action === "inject") {
-            messages = [...messages, createUserMessage(verdict.message)];
+            const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
+            messages = [
+              ...messages,
+              createAssistantMessage(lastAssistantText, parentID),
+              createUserMessage(verdict.message),
+            ];
             continuationCount++;
             turnIndex++;
             continue;

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -121,6 +121,8 @@ export async function* streamAgent(
         totalTokens: 0,
       };
       let turnIndex = 0;
+      let continuationCount = 0;
+      const startTime = Date.now();
 
       while (true) {
         if (checkBudget(budgetState, config.budget) === "exceeded") {
@@ -186,6 +188,43 @@ export async function* streamAgent(
           const step: AgentStep = { type: "text", content: lastAssistantText };
           steps.push(step);
           if (config.onStepFinish) await config.onStepFinish(step);
+
+          if (config.stepGuard) {
+            const verdict = await config.stepGuard(step, {
+              steps,
+              usage: totalUsage,
+              turnCount: turnIndex,
+              isCompletion: true,
+              continuationCount,
+              elapsedMs: Date.now() - startTime,
+            });
+
+            if (verdict.action === "inject") {
+              const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
+              messages = [
+                ...messages,
+                createAssistantMessage(lastAssistantText, parentID),
+                createUserMessage(verdict.message),
+              ];
+              continuationCount++;
+              turnIndex++;
+              continue;
+            }
+
+            if (verdict.action === "abort") {
+              yield {
+                type: "complete",
+                result: {
+                  text: lastAssistantText,
+                  steps,
+                  usage: totalUsage,
+                  finishReason: "stop",
+                  guardAborted: true,
+                },
+              };
+              return;
+            }
+          }
 
           yield {
             type: "complete",
@@ -259,6 +298,38 @@ export async function* streamAgent(
         };
         steps.push(toolStep);
         if (config.onStepFinish) await config.onStepFinish(toolStep);
+
+        if (config.stepGuard) {
+          const verdict = await config.stepGuard(toolStep, {
+            steps,
+            usage: totalUsage,
+            turnCount: turnIndex,
+            isCompletion: false,
+            continuationCount,
+            elapsedMs: Date.now() - startTime,
+          });
+
+          if (verdict.action === "inject") {
+            messages = [...messages, createUserMessage(verdict.message)];
+            continuationCount++;
+            turnIndex++;
+            continue;
+          }
+
+          if (verdict.action === "abort") {
+            yield {
+              type: "complete",
+              result: {
+                text: lastAssistantText,
+                steps,
+                usage: totalUsage,
+                finishReason: "stop",
+                guardAborted: true,
+              },
+            };
+            return;
+          }
+        }
 
         const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
         messages = [...messages, createAssistantMessage(lastAssistantText, parentID)];

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -2,6 +2,20 @@ import type { Tool, Sink, Guardrail, Message } from "@openomni/protocol";
 import type { ParallelToolsMode } from "./execution/parallel-tools";
 import type { Memory } from "./memory";
 
+export type StepGuardVerdict =
+  | { action: "continue" }
+  | { action: "inject"; message: string }
+  | { action: "abort"; reason?: string };
+
+export interface StepGuardContext {
+  steps: AgentStep[];
+  usage: TokenUsage;
+  turnCount: number;
+  isCompletion: boolean;
+  continuationCount: number;
+  elapsedMs: number;
+}
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
@@ -40,6 +54,10 @@ export interface ChatAgentConfig {
   };
   parallelTools?: ParallelToolsMode;
   memory?: Memory;
+  stepGuard?: (
+    step: AgentStep,
+    context: StepGuardContext,
+  ) => Promise<StepGuardVerdict> | StepGuardVerdict;
 }
 
 export interface ChatAgentInput {
@@ -61,6 +79,7 @@ export interface AgentResult {
   finishReason: "stop" | "tool-calls" | "max-steps" | "handoff";
   handoffTarget?: string;
   compactionCount?: number;
+  guardAborted?: boolean;
 }
 
 export type AgentEvent =

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -10,6 +10,8 @@ export type {
   AgentBudget,
   TokenUsage,
   Sink,
+  StepGuardVerdict,
+  StepGuardContext,
 } from "./core/types";
 export { AgentMessenger, BusTransport } from "./runtime/index";
 export type { Transport, AgentMessengerOptions } from "./runtime/index";

--- a/packages/agent/test/core/step-guard-stream.test.ts
+++ b/packages/agent/test/core/step-guard-stream.test.ts
@@ -1,0 +1,99 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Sink } from "@openomni/protocol";
+import type { AgentEvent } from "../../src/core/types";
+import {
+  createStopOutcome,
+  mockProviderData,
+  mockProviderModel,
+  type MockLlmFn,
+} from "../helpers/mock-llm";
+
+let mockRunFn: MockLlmFn = async () => createStopOutcome();
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mock(async () => mockProviderData) },
+  Provider: { fromModelsDevModel: mock(() => mockProviderModel) },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+  TokenTracker: {
+    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
+  },
+}));
+
+let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+
+beforeAll(async () => {
+  ({ ChatAgent } = await import("../../src/core/chat-agent"));
+});
+
+beforeEach(() => {
+  mockRunFn = async () => createStopOutcome();
+});
+
+async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("StepGuard (stream path)", () => {
+  it("emits complete event normally without guard", async () => {
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+
+    const events = await collectEvents(
+      agent.stream({ messages: [{ role: "user", content: "hello" }] }),
+    );
+
+    const completeEvent = events.find((e) => e.type === "complete");
+    expect(completeEvent).toBeDefined();
+    if (completeEvent?.type === "complete") {
+      expect(completeEvent.result.guardAborted).toBeUndefined();
+    }
+  });
+
+  it("does not emit complete on inject, continues loop", async () => {
+    let callCount = 0;
+    mockRunFn = async () => {
+      callCount++;
+      return createStopOutcome();
+    };
+
+    let guardCount = 0;
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async () => {
+        guardCount++;
+        return guardCount === 1 ? { action: "inject", message: "verify" } : { action: "continue" };
+      },
+    });
+
+    const events = await collectEvents(
+      agent.stream({ messages: [{ role: "user", content: "task" }] }),
+    );
+
+    const completeEvents = events.filter((e) => e.type === "complete");
+    expect(completeEvents).toHaveLength(1);
+    expect(callCount).toBe(2);
+  });
+
+  it("emits complete with guardAborted on abort", async () => {
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async () => ({ action: "abort" }),
+    });
+
+    const events = await collectEvents(
+      agent.stream({ messages: [{ role: "user", content: "hello" }] }),
+    );
+
+    const completeEvent = events.find((e) => e.type === "complete");
+    expect(completeEvent).toBeDefined();
+    if (completeEvent?.type === "complete") {
+      expect(completeEvent.result.guardAborted).toBe(true);
+    }
+  });
+});

--- a/packages/agent/test/core/step-guard.test.ts
+++ b/packages/agent/test/core/step-guard.test.ts
@@ -1,0 +1,147 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Sink } from "@openomni/protocol";
+import type { AgentStep, StepGuardContext, StepGuardVerdict } from "../../src/core/types";
+import {
+  createStopOutcome,
+  createToolCallOutcome,
+  mockProviderData,
+  mockProviderModel,
+  type MockLlmFn,
+} from "../helpers/mock-llm";
+
+let mockRunFn: MockLlmFn = async () => createStopOutcome();
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mock(async () => mockProviderData) },
+  Provider: { fromModelsDevModel: mock(() => mockProviderModel) },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+  TokenTracker: {
+    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
+  },
+}));
+
+let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+
+beforeAll(async () => {
+  ({ ChatAgent } = await import("../../src/core/chat-agent"));
+});
+
+beforeEach(() => {
+  mockRunFn = async () => createStopOutcome();
+});
+
+describe("StepGuard (run path)", () => {
+  it("runs normally when no stepGuard configured", async () => {
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    });
+    const result = await agent.run({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(result.finishReason).toBe("stop");
+    expect(result.guardAborted).toBeUndefined();
+  });
+
+  it("stops normally when guard returns continue", async () => {
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async () => ({ action: "continue" }),
+    });
+    const result = await agent.run({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(result.finishReason).toBe("stop");
+    expect(result.guardAborted).toBeUndefined();
+  });
+
+  it("injects message and continues when guard returns inject", async () => {
+    let callCount = 0;
+    mockRunFn = async () => {
+      callCount++;
+      return createStopOutcome();
+    };
+
+    let guardCallCount = 0;
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async () => {
+        guardCallCount++;
+        if (guardCallCount === 1) {
+          return { action: "inject", message: "Please verify your work." };
+        }
+        return { action: "continue" };
+      },
+    });
+
+    const result = await agent.run({
+      messages: [{ role: "user", content: "do task" }],
+    });
+    expect(result.finishReason).toBe("stop");
+    expect(result.guardAborted).toBeUndefined();
+    expect(callCount).toBe(2);
+    expect(guardCallCount).toBe(2);
+  });
+
+  it("returns with guardAborted when guard aborts", async () => {
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async () => ({ action: "abort", reason: "too long" }),
+    });
+    const result = await agent.run({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(result.finishReason).toBe("stop");
+    expect(result.guardAborted).toBe(true);
+  });
+
+  it("provides correct context to guard", async () => {
+    let capturedContext: StepGuardContext | null = null;
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async (_step, ctx) => {
+        capturedContext = ctx;
+        return { action: "continue" };
+      },
+    });
+    await agent.run({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(capturedContext).not.toBeNull();
+    expect(capturedContext!.isCompletion).toBe(true);
+    expect(capturedContext!.continuationCount).toBe(0);
+    expect(capturedContext!.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("increments continuationCount on each inject", async () => {
+    mockRunFn = async () => createStopOutcome();
+
+    const capturedCounts: number[] = [];
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async (_step, ctx) => {
+        capturedCounts.push(ctx.continuationCount);
+        if (ctx.continuationCount < 2) {
+          return { action: "inject", message: "keep going" };
+        }
+        return { action: "continue" };
+      },
+    });
+    await agent.run({
+      messages: [{ role: "user", content: "task" }],
+    });
+    expect(capturedCounts).toEqual([0, 1, 2]);
+  });
+
+  it("propagates error when guard throws", async () => {
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      stepGuard: async () => {
+        throw new Error("guard error");
+      },
+    });
+    await expect(agent.run({ messages: [{ role: "user", content: "hello" }] })).rejects.toThrow(
+      "guard error",
+    );
+  });
+});

--- a/packages/openomni/src/plan/plan-pipeline.ts
+++ b/packages/openomni/src/plan/plan-pipeline.ts
@@ -18,7 +18,7 @@ export namespace PlanPipeline {
 
   export interface EnricherRunResult {
     enricherName: string;
-    action: string;
+    actions: string[];
   }
 
   export type RunResult =
@@ -64,7 +64,7 @@ export namespace PlanPipeline {
             });
             enricherResults.push({
               enricherName: enricher.name,
-              action: enrichResult.applied.length > 0 ? enrichResult.applied[0].type : "skip",
+              actions: enrichResult.applied.map((a) => a.type),
             });
             if (enrichResult.applied.length > 0) {
               lastPlan = enrichResult.plan;

--- a/packages/openomni/src/plan/plan-pipeline.ts
+++ b/packages/openomni/src/plan/plan-pipeline.ts
@@ -1,4 +1,4 @@
-import type { Gate, Plan } from "@openomni/protocol";
+import { PlanSchema, type Gate, type Plan } from "@openomni/protocol";
 import { PlanAgent } from "./plan-agent.js";
 
 const DEFAULT_MAX_RETRIES = 3;
@@ -6,6 +6,7 @@ const DEFAULT_MAX_RETRIES = 3;
 export namespace PlanPipeline {
   export interface Config {
     generator: PlanAgent.GenerateConfig;
+    enrichers?: Gate.Enricher[];
     gates: Gate.Check[];
     maxRetries?: number;
   }
@@ -15,19 +16,32 @@ export namespace PlanPipeline {
     verdict: Gate.Verdict;
   }
 
+  export interface EnricherRunResult {
+    enricherName: string;
+    action: string;
+  }
+
   export type RunResult =
-    | { ok: true; plan: Plan; attempts: number; gateResults: GateRunResult[] }
+    | {
+        ok: true;
+        plan: Plan;
+        attempts: number;
+        gateResults: GateRunResult[];
+        enricherResults?: EnricherRunResult[];
+      }
     | {
         ok: false;
         lastPlan?: Plan;
         attempts: number;
         gateResults: GateRunResult[];
+        enricherResults?: EnricherRunResult[];
         reason: string;
       };
 
   export async function run(goal: string, config: Config): Promise<RunResult> {
     const maxRetries = Math.max(1, config.maxRetries ?? DEFAULT_MAX_RETRIES);
     const gateResults: GateRunResult[] = [];
+    const enricherResults: EnricherRunResult[] = [];
 
     let attempt = 1;
     let previousFeedback: string | undefined;
@@ -39,6 +53,48 @@ export namespace PlanPipeline {
         : goal;
       const planResult = await PlanAgent.generate(enrichedGoal, config.generator);
       lastPlan = planResult.plan;
+
+      if (config.enrichers && config.enrichers.length > 0) {
+        for (const enricher of config.enrichers) {
+          try {
+            const enrichResult = await enricher.enrich(lastPlan, {
+              goal,
+              attempt,
+              previousFeedback,
+            });
+            enricherResults.push({
+              enricherName: enricher.name,
+              action: enrichResult.applied.length > 0 ? enrichResult.applied[0].type : "skip",
+            });
+            if (enrichResult.applied.length > 0) {
+              lastPlan = enrichResult.plan;
+            }
+          } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            return {
+              ok: false,
+              lastPlan,
+              attempts: attempt,
+              gateResults,
+              enricherResults,
+              reason: `Enricher '${enricher.name}' failed: ${reason}`,
+            };
+          }
+        }
+
+        const revalidation = PlanSchema.safeParse(lastPlan);
+        if (!revalidation.success) {
+          return {
+            ok: false,
+            lastPlan,
+            attempts: attempt,
+            gateResults,
+            enricherResults,
+            reason: `Plan validation failed after enrichment: ${revalidation.error.message}`,
+          };
+        }
+        lastPlan = revalidation.data;
+      }
 
       const failedFeedback: string[] = [];
       let hasFailedGate = false;
@@ -74,6 +130,7 @@ export namespace PlanPipeline {
           plan: lastPlan,
           attempts: attempt,
           gateResults,
+          enricherResults: enricherResults.length > 0 ? enricherResults : undefined,
         };
       }
 
@@ -86,6 +143,7 @@ export namespace PlanPipeline {
       lastPlan,
       attempts: maxRetries,
       gateResults,
+      enricherResults: enricherResults.length > 0 ? enricherResults : undefined,
       reason: "Max retries exceeded",
     };
   }

--- a/packages/openomni/test/plan/plan-enricher.test.ts
+++ b/packages/openomni/test/plan/plan-enricher.test.ts
@@ -1,0 +1,282 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Gate, Plan } from "@openomni/protocol";
+
+// Prevent module cache contamination from @openomni/llm missing exports
+mock.module("@openomni/agent", () => ({
+  ChatAgent: { create: () => ({ run: async () => ({ text: "{}" }) }) },
+}));
+
+const mockGenerate = mock(async () => ({ plan: createPlan("plan-default") }));
+
+mock.module("../../src/plan/plan-agent", () => ({
+  PlanAgent: {
+    generate: mockGenerate,
+  },
+}));
+
+let PlanPipeline: typeof import("../../src/plan/plan-pipeline").PlanPipeline;
+
+beforeAll(async () => {
+  ({ PlanPipeline } = await import("../../src/plan/plan-pipeline"));
+});
+
+beforeEach(() => {
+  mockGenerate.mockClear();
+});
+
+describe("PlanPipeline enrichers", () => {
+  it("runs without enrichers like before", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1") });
+
+    const result = await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      gates: [],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.enricherResults).toBeUndefined();
+    }
+  });
+
+  it("enriches plan before passing to gates", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1", "orig-step") });
+
+    const enrichedPlan = createPlan("p1", "orig-step");
+    enrichedPlan.steps.push({
+      stepId: "added-step",
+      description: "verify the implementation thoroughly",
+      expectedOutput: "implementation is verified",
+      dependsOn: ["orig-step"],
+    });
+
+    const enricher: Gate.Enricher = {
+      name: "gap-enricher",
+      enrich: async () => ({
+        plan: enrichedPlan,
+        applied: [
+          {
+            type: "added_step",
+            stepId: "added-step",
+            description: "added gap step",
+          },
+        ],
+      }),
+    };
+
+    let planReceivedByGate: Plan | null = null;
+    const gate: Gate.Check = {
+      name: "capture-gate",
+      check: (plan) => {
+        planReceivedByGate = plan;
+        return { passed: true, issues: [] };
+      },
+    };
+
+    const result = await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      enrichers: [enricher],
+      gates: [gate],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(planReceivedByGate).not.toBeNull();
+    expect(planReceivedByGate!.steps).toHaveLength(2);
+    if (result.ok) {
+      expect(result.plan.steps).toHaveLength(2);
+      expect(result.enricherResults?.[0]?.enricherName).toBe("gap-enricher");
+      expect(result.enricherResults?.[0]?.action).toBe("added_step");
+    }
+  });
+
+  it("keeps original plan when enricher returns skip (empty applied)", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1") });
+
+    const enricher: Gate.Enricher = {
+      name: "skip-enricher",
+      enrich: async (plan) => ({ plan, applied: [] }),
+    };
+
+    let planReceivedByGate: Plan | null = null;
+    const gate: Gate.Check = {
+      name: "capture-gate",
+      check: (plan) => {
+        planReceivedByGate = plan;
+        return { passed: true, issues: [] };
+      },
+    };
+
+    await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      enrichers: [enricher],
+      gates: [gate],
+    });
+
+    expect(planReceivedByGate).not.toBeNull();
+    expect(planReceivedByGate!.steps).toHaveLength(1);
+  });
+
+  it("runs multiple enrichers in order", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1") });
+    const callOrder: string[] = [];
+
+    const enricherA: Gate.Enricher = {
+      name: "enricher-a",
+      enrich: async (plan) => {
+        callOrder.push("a");
+        return { plan, applied: [] };
+      },
+    };
+    const enricherB: Gate.Enricher = {
+      name: "enricher-b",
+      enrich: async (plan) => {
+        callOrder.push("b");
+        return { plan, applied: [] };
+      },
+    };
+
+    await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      enrichers: [enricherA, enricherB],
+      gates: [],
+    });
+
+    expect(callOrder).toEqual(["a", "b"]);
+  });
+
+  it("returns error when enricher throws", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1") });
+
+    const enricher: Gate.Enricher = {
+      name: "bad-enricher",
+      enrich: async () => {
+        throw new Error("enrichment failed");
+      },
+    };
+
+    const result = await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      enrichers: [enricher],
+      gates: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("bad-enricher");
+      expect(result.reason).toContain("enrichment failed");
+    }
+  });
+
+  it("fails when enriched plan is structurally invalid", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1") });
+
+    const enricher: Gate.Enricher = {
+      name: "bad-plan-enricher",
+      enrich: async () => ({
+        plan: {
+          planId: "p1",
+          goal: "test",
+          steps: [
+            {
+              stepId: "s1",
+              description: "step one in detail",
+              expectedOutput: "output one",
+              dependsOn: [],
+            },
+            {
+              stepId: "s1",
+              description: "duplicate step id",
+              expectedOutput: "oops",
+              dependsOn: [],
+            },
+          ],
+          createdAt: new Date(),
+          version: 1,
+        },
+        applied: [{ type: "added_step", stepId: "s1", description: "added duplicate" }],
+      }),
+    };
+
+    const result = await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      enrichers: [enricher],
+      gates: [],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("validation failed after enrichment");
+    }
+  });
+
+  it("runs enrichers on each retry attempt", async () => {
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p1") });
+    mockGenerate.mockResolvedValueOnce({ plan: createPlan("p2") });
+
+    let enrichCallCount = 0;
+    const enricher: Gate.Enricher = {
+      name: "counting-enricher",
+      enrich: async (plan) => {
+        enrichCallCount++;
+        return { plan, applied: [] };
+      },
+    };
+
+    let gateCallCount = 0;
+    const gate: Gate.Check = {
+      name: "fail-first-gate",
+      check: () => {
+        gateCallCount++;
+        if (gateCallCount === 1) {
+          return {
+            passed: false,
+            issues: [{ code: "fail", severity: "error", message: "fail" }],
+            feedback: "retry",
+          };
+        }
+        return { passed: true, issues: [] };
+      },
+    };
+
+    const result = await PlanPipeline.run("goal", {
+      generator: {
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      },
+      enrichers: [enricher],
+      gates: [gate],
+      maxRetries: 3,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(enrichCallCount).toBe(2);
+  });
+});
+
+function createPlan(planId: string, stepId = "step-1"): Plan {
+  return {
+    planId,
+    goal: "test goal",
+    steps: [
+      {
+        stepId,
+        description: "do something important",
+        expectedOutput: "something is done",
+        dependsOn: [],
+      },
+    ],
+    createdAt: new Date(),
+    version: 1,
+  };
+}

--- a/packages/openomni/test/plan/plan-enricher.test.ts
+++ b/packages/openomni/test/plan/plan-enricher.test.ts
@@ -89,7 +89,7 @@ describe("PlanPipeline enrichers", () => {
     if (result.ok) {
       expect(result.plan.steps).toHaveLength(2);
       expect(result.enricherResults?.[0]?.enricherName).toBe("gap-enricher");
-      expect(result.enricherResults?.[0]?.action).toBe("added_step");
+      expect(result.enricherResults?.[0]?.actions).toContain("added_step");
     }
   });
 

--- a/packages/protocol/src/gate/index.ts
+++ b/packages/protocol/src/gate/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { Plan } from "../plan/index.js";
+import type { Plan } from "../plan/index.js";
+import { PlanSchema } from "../plan/index.js";
 
 export namespace Gate {
   export const Issue = z.object({
@@ -28,5 +29,23 @@ export namespace Gate {
   export interface Check {
     name: string;
     check(plan: Plan, context: Context): Promise<Verdict> | Verdict;
+  }
+
+  export const EnrichAction = z.object({
+    type: z.enum(["added_step", "modified_step", "reordered", "added_dependency"]),
+    stepId: z.string().optional(),
+    description: z.string(),
+  });
+  export type EnrichAction = z.infer<typeof EnrichAction>;
+
+  export const EnrichResult = z.object({
+    plan: PlanSchema,
+    applied: z.array(EnrichAction),
+  });
+  export type EnrichResult = z.infer<typeof EnrichResult>;
+
+  export interface Enricher {
+    name: string;
+    enrich(plan: Plan, context: Context): Promise<EnrichResult> | EnrichResult;
   }
 }


### PR DESCRIPTION
## Summary

- Add **StepGuard** to ChatAgent — agent-level completion/turn guard that can inject messages or abort when the agent claims "done"
- Add **PlanEnricher** (Blue Team) to PlanPipeline — enriches plans before gate validation
- Fix tool step inject history loss bug in both run() and stream() paths

## StepGuard (agent package)

When an agent says "done" (LLM returns `stop`), the `stepGuard` callback can:
- **continue** — accept completion normally
- **inject** — add a user message and continue the loop ("verify your work")
- **abort** — stop with `guardAborted: true`

No `maxContinuations` — convergence is behavior-based: if the agent makes no mutating tool calls after injection, it's really done. Logic lives in the callback, not ChatAgent.

```typescript
const agent = ChatAgent.create({
  model, systemPrompt,
  stepGuard: async (step, ctx) => {
    if (!ctx.isCompletion) return { action: "continue" };
    if (ctx.continuationCount === 0) {
      return { action: "inject", message: "Verify your work is complete." };
    }
    return { action: "continue" }; // confirmed done
  },
});
```

Integrated in both `ChatAgent.run()` and `streamAgent()` paths.

## PlanEnricher (protocol + openomni)

Blue Team counterpart to Gate (Red Team). Enrichers run after plan generation, before gate validation:

```
Generate → Enrichers (Blue, add missing steps) → Gates (Red, validate) → retry
```

```typescript
PlanPipeline.run(goal, {
  generator: { model, systemPrompt },
  enrichers: [gapAnalyzer],     // Blue Team
  gates: [structuralGate],      // Red Team
});
```

Enriched plans are re-validated with `PlanSchema.safeParse()`. Enricher errors return `{ ok: false }`.

## Bug Fix

Tool step `inject` was losing message history — the `continue` statement skipped `buildAssistantMessageWithTools()`, so the next LLM call had no context of previous tool usage. Fixed in both `chat-agent.ts` and `stream-engine.ts`.

## Changes

| Package | File | What |
|---------|------|------|
| protocol | `src/gate/index.ts` | +Gate.Enricher, EnrichResult, EnrichAction |
| agent | `src/core/types.ts` | +StepGuardVerdict, StepGuardContext, guardAborted |
| agent | `src/core/chat-agent.ts` | StepGuard in run() loop (stop + tool branches) |
| agent | `src/core/execution/stream-engine.ts` | StepGuard in stream() loop |
| openomni | `src/plan/plan-pipeline.ts` | Enricher stage (generate → enrich → gate) |

## Tests

- `step-guard.test.ts`: 7 tests (inject, abort, continue, context, error propagation)
- `step-guard-stream.test.ts`: 3 tests (inject suppresses complete, abort)
- `plan-enricher.test.ts`: 7 tests (enrich, skip, multiple, error, revalidation, retry)
- All existing tests pass (144 agent, 42 openomni/plan, 122 protocol)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds StepGuard to `@openomni/agent` to guard “done” turns with inject/abort controls, and adds a Blue-Team PlanEnricher stage to `@openomni/openomni` to enrich plans before gate checks. Also fixes lost message history when injecting after tool calls.

- New Features
  - StepGuard in `ChatAgent.run()` and streaming: actions are continue, inject, or abort; provides context (steps, usage, turnCount, isCompletion, continuationCount, elapsedMs); sets `guardAborted` on abort.
  - PlanEnricher in PlanPipeline: `enrichers: Gate.Enricher[]` run after generation and before gates; plans are revalidated with `PlanSchema`; runs each retry and records `enricherResults`; errors fail fast with a clear reason.

- Bug Fixes
  - Preserve message history on injected turns after tool calls in both `run()` and streaming paths.

<sup>Written for commit 8b17b7a4432160905c4d2a3db7e23223b5ffc312. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

