### PR TITLE
feat(protocol,agent): agent execution infrastructure (issues #63-#68)

### DIFF
--- a/packages/agent/src/bun-test.d.ts
+++ b/packages/agent/src/bun-test.d.ts
@@ -1,0 +1,9 @@
+declare module "bun:test" {
+  export const beforeAll: any;
+  export const afterAll: any;
+  export const describe: any;
+  export const expect: any;
+  export const it: any;
+  export const mock: any;
+  export const test: any;
+}

--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -22,13 +22,19 @@ export function createBudgetState(): BudgetState {
   };
 }
 
-export function checkBudget(state: BudgetState, budget?: AgentBudget): "ok" | "exceeded" {
+export function checkBudget(
+  state: BudgetState,
+  budget?: AgentBudget,
+): "ok" | "reassurance" | "warning" | "exceeded" {
   const maxWallTimeMs = budget?.maxWallTimeMs ?? 5 * 60 * 1000;
   const maxTurns = budget?.maxTurns ?? 24;
   const maxToolCalls = budget?.maxToolCalls ?? 40;
   const maxToolRuntimeMs = budget?.maxToolRuntimeMs ?? 2 * 60 * 1000;
+  const warningRatio = budget?.warningThreshold ?? 0.8;
+  const reassuranceRatio = budget?.reassuranceThreshold ?? 0.6;
 
   const elapsed = Date.now() - state.startTime;
+
   if (elapsed >= maxWallTimeMs) return "exceeded";
   if (state.turns >= maxTurns) return "exceeded";
   if (state.toolCalls >= maxToolCalls) return "exceeded";
@@ -45,7 +51,37 @@ export function checkBudget(state: BudgetState, budget?: AgentBudget): "ok" | "e
     return "exceeded";
   if (budget?.maxCost !== undefined && state.totalCost >= budget.maxCost) return "exceeded";
 
+  const ratios: number[] = [
+    elapsed / maxWallTimeMs,
+    state.turns / maxTurns,
+    state.toolCalls / maxToolCalls,
+    state.toolRuntimeMs / maxToolRuntimeMs,
+  ];
+  if (budget?.maxCost !== undefined) ratios.push(state.totalCost / budget.maxCost);
+  if (budget?.maxTotalTokens !== undefined)
+    ratios.push((state.totalInputTokens + state.totalOutputTokens) / budget.maxTotalTokens);
+  if (budget?.maxInputTokens !== undefined)
+    ratios.push(state.totalInputTokens / budget.maxInputTokens);
+  if (budget?.maxOutputTokens !== undefined)
+    ratios.push(state.totalOutputTokens / budget.maxOutputTokens);
+
+  const maxRatio = Math.max(...ratios);
+
+  if (maxRatio >= warningRatio) return "warning";
+  if (maxRatio >= reassuranceRatio) return "reassurance";
   return "ok";
+}
+
+export function describeBudgetRemaining(state: BudgetState, budget?: AgentBudget): string {
+  const parts: string[] = [];
+  const maxTurns = budget?.maxTurns ?? 24;
+  const remainingTurns = maxTurns - state.turns;
+  parts.push(`${remainingTurns} turn${remainingTurns !== 1 ? "s" : ""} remaining`);
+  if (budget?.maxCost !== undefined) {
+    const remaining = (budget.maxCost - state.totalCost).toFixed(4);
+    parts.push(`$${remaining} budget remaining`);
+  }
+  return parts.join(", ");
 }
 
 export function recordTurn(state: BudgetState): BudgetState {

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,5 +1,5 @@
 import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
-import type { Message, Sink, Tool } from "@openomni/protocol";
+import type { Message, Sink } from "@openomni/protocol";
 import type { ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, TokenUsage } from "./types";
 import { createBudgetState, checkBudget, recordTurn, recordTokenUsage } from "./budget";
 import {
@@ -14,6 +14,7 @@ import { InMemoryCompactor } from "./execution/compaction";
 import { Telemetry } from "./telemetry";
 import type { AgentEvent } from "./types";
 import type { MemoryResult } from "./memory";
+import { createAssistantMessage, createUserMessage } from "./message-factory";
 
 /**
  * ChatAgent instance interface
@@ -49,55 +50,6 @@ async function resolveProviderModel(model: {
   return Provider.fromModelsDevModel(providerData, rawModel as ModelsDev.Model);
 }
 
-function createUserMessage(content: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "chat-agent";
-  const now = Date.now();
-  const info: Message.UserMessage = {
-    id,
-    sessionID,
-    role: "user",
-    time: { created: now },
-    agent: "chat-agent",
-    model: { providerID: "", modelID: "" },
-  };
-  const textPart: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID,
-    messageID: id,
-    type: "text",
-    text: content,
-  };
-  return { info, parts: [textPart] };
-}
-
-function createAssistantMessage(content: string, parentID: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "chat-agent";
-  const now = Date.now();
-  const info: Message.AssistantMessage = {
-    id,
-    sessionID,
-    role: "assistant",
-    time: { created: now },
-    parentID,
-    modelID: "",
-    providerID: "",
-    agent: "chat-agent",
-    path: { cwd: process.cwd(), root: process.cwd() },
-    cost: 0,
-    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-  };
-  const textPart: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID,
-    messageID: id,
-    type: "text",
-    text: content,
-  };
-  return { info, parts: [textPart] };
-}
-
 function getLastUserMessageText(messages: Message.WithParts[]): string | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].info.role === "user") {
@@ -119,7 +71,7 @@ function prependContextMessage(
   messages: Message.WithParts[],
   contextText: string,
 ): Message.WithParts[] {
-  return [createUserMessage(contextText), ...messages];
+  return [createUserMessage(contextText, "chat-agent"), ...messages];
 }
 
 function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.WithParts[] {
@@ -129,8 +81,8 @@ function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.With
     const parentID = output.length > 0 ? output[output.length - 1].info.id : "";
     output.push(
       message.role === "user"
-        ? createUserMessage(message.content)
-        : createAssistantMessage(message.content, parentID),
+        ? createUserMessage(message.content, "chat-agent")
+        : createAssistantMessage(message.content, parentID, "chat-agent"),
     );
   }
 
@@ -286,8 +238,8 @@ export namespace ChatAgent {
                           messages.length > 0 ? messages[messages.length - 1].info.id : "";
                         messages = [
                           ...messages,
-                          createAssistantMessage(lastAssistantText, parentID),
-                          createUserMessage(verdict.message),
+                          createAssistantMessage(lastAssistantText, parentID, "chat-agent"),
+                          createUserMessage(verdict.message, "chat-agent"),
                         ];
 
                         if (config.compaction) {

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,7 +1,13 @@
 import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type { ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, TokenUsage } from "./types";
-import { createBudgetState, checkBudget, recordTurn, recordTokenUsage } from "./budget";
+import {
+  createBudgetState,
+  checkBudget,
+  recordTurn,
+  recordTokenUsage,
+  describeBudgetRemaining,
+} from "./budget";
 import {
   DEFAULT_RETRY_POLICY,
   calculateBackoffMs,
@@ -206,8 +212,12 @@ export namespace ChatAgent {
                   throw new Error("toolExecutor is required when tools are provided");
                 }
 
+                let reassuranceIssued = false;
+                let warningIssued = false;
+
                 while (true) {
-                  if (checkBudget(budgetState, config.budget) === "exceeded") {
+                  const budgetStatus = checkBudget(budgetState, config.budget);
+                  if (budgetStatus === "exceeded") {
                     return {
                       text: lastAssistantText,
                       steps,
@@ -215,6 +225,29 @@ export namespace ChatAgent {
                       finishReason: "max-steps",
                       compactionCount: compactionCount > 0 ? compactionCount : undefined,
                     };
+                  }
+
+                  if (budgetStatus === "reassurance" && !reassuranceIssued) {
+                    const remaining = describeBudgetRemaining(budgetState, config.budget);
+                    messages = [
+                      ...messages,
+                      createUserMessage(
+                        `[Budget Status] ${remaining}. You have plenty of budget remaining. Do NOT rush or skip tasks. Complete your work thoroughly.`,
+                        "chat-agent",
+                      ),
+                    ];
+                    reassuranceIssued = true;
+                  }
+                  if (budgetStatus === "warning" && !warningIssued) {
+                    const remaining = describeBudgetRemaining(budgetState, config.budget);
+                    messages = [
+                      ...messages,
+                      createUserMessage(
+                        `[Budget Warning] ${remaining}. Wrap up your current task and provide a summary.`,
+                        "chat-agent",
+                      ),
+                    ];
+                    warningIssued = true;
                   }
 
                   budgetState = recordTurn(budgetState);

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,6 +1,15 @@
 import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
-import type { ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, TokenUsage } from "./types";
+import type {
+  ChatAgentConfig,
+  ChatAgentInput,
+  AgentResult,
+  AgentStep,
+  ExecutionHooks,
+  HookContext,
+  HookVerdict,
+  TokenUsage,
+} from "./types";
 import {
   createBudgetState,
   checkBudget,
@@ -129,6 +138,56 @@ function createGuardedToolExecutor(
         isError: true,
       };
     }
+    return toolExecutor(call);
+  };
+}
+
+function createHookedToolExecutor(
+  toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
+  hooks: ExecutionHooks | undefined,
+  getContext: () => Omit<HookContext, "toolName" | "toolCallId" | "input">,
+): (call: Tool.Call) => Promise<Tool.Result> {
+  if (!hooks?.preToolUse) return toolExecutor;
+
+  return async (call: Tool.Call): Promise<Tool.Result> => {
+    const context: HookContext = {
+      ...getContext(),
+      toolName: call.tool,
+      toolCallId: call.id,
+      input: call.input,
+    };
+
+    let verdict: HookVerdict;
+    try {
+      verdict = await hooks.preToolUse!(context);
+    } catch (err) {
+      console.warn("[hooks.preToolUse] threw, treating as continue:", err);
+      verdict = { action: "continue" };
+    }
+
+    if (verdict.action === "skip") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Skipped: ${verdict.reason ?? "hook"}]`,
+        isError: false,
+      };
+    }
+
+    if (verdict.action === "abort") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Aborted: ${verdict.reason ?? "hook"}]`,
+        isError: true,
+      };
+    }
+
+    if (verdict.action === "transform") {
+      const transformed: Tool.Call = { ...call, input: verdict.input };
+      return toolExecutor(transformed);
+    }
+
     return toolExecutor(call);
   };
 }
@@ -270,16 +329,26 @@ export namespace ChatAgent {
                     }
                   }
 
+                  const baseExecutor =
+                    config.toolExecutor && config.permissions
+                      ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
+                      : config.toolExecutor;
+
+                  const hookedExecutor = baseExecutor
+                    ? createHookedToolExecutor(baseExecutor, config.hooks, () => ({
+                        steps,
+                        turnCount: budgetState.turns,
+                        elapsedMs: Date.now() - startTime,
+                      }))
+                    : undefined;
+
                   const runInput: RunInput = {
                     messages: effectiveMessages,
                     tools: config.tools ?? [],
                     system: buildSystemPrompt(config.systemPrompt, config.tools ?? []),
                     signal: config.signal,
                     model: providerModel,
-                    toolExecutor:
-                      config.toolExecutor && config.permissions
-                        ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
-                        : config.toolExecutor,
+                    toolExecutor: hookedExecutor,
                     toolChoice: configuredToolChoice,
                     maxSteps: config.budget?.maxToolCalls ?? 24,
                   };
@@ -297,7 +366,51 @@ export namespace ChatAgent {
                       await config.onStepFinish(step);
                     }
 
-                    if (config.stepGuard) {
+                    if (config.hooks?.postTurn) {
+                      if (config.stepGuard) {
+                        console.warn(
+                          "[hooks] Both hooks.postTurn and stepGuard are set. hooks.postTurn takes precedence.",
+                        );
+                      }
+
+                      const hookContext: HookContext = {
+                        steps,
+                        turnCount: budgetState.turns,
+                        elapsedMs: Date.now() - startTime,
+                      };
+
+                      let postTurnVerdict: HookVerdict;
+                      try {
+                        postTurnVerdict = await config.hooks.postTurn(hookContext);
+                      } catch (err) {
+                        console.warn("[hooks.postTurn] threw, treating as continue:", err);
+                        postTurnVerdict = { action: "continue" };
+                      }
+
+                      if (postTurnVerdict.action === "inject") {
+                        const parentID =
+                          messages.length > 0 ? messages[messages.length - 1].info.id : "";
+                        messages = [
+                          ...messages,
+                          createAssistantMessage(lastAssistantText, parentID, "chat-agent"),
+                          createUserMessage(postTurnVerdict.message, "chat-agent"),
+                        ];
+
+                        continuationCount++;
+                        continue;
+                      }
+
+                      if (postTurnVerdict.action === "abort") {
+                        return {
+                          text: lastAssistantText,
+                          steps,
+                          usage: totalUsage,
+                          finishReason: "stop",
+                          compactionCount: compactionCount > 0 ? compactionCount : undefined,
+                          guardAborted: true,
+                        };
+                      }
+                    } else if (config.stepGuard) {
                       const verdict = await config.stepGuard(step, {
                         steps,
                         usage: totalUsage,

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,5 +1,5 @@
 import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
-import type { Message, Sink } from "@openomni/protocol";
+import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type { ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, TokenUsage } from "./types";
 import { createBudgetState, checkBudget, recordTurn, recordTokenUsage } from "./budget";
 import {
@@ -15,6 +15,7 @@ import { Telemetry } from "./telemetry";
 import type { AgentEvent } from "./types";
 import type { MemoryResult } from "./memory";
 import { createAssistantMessage, createUserMessage } from "./message-factory";
+import { ToolGuard } from "./tool-guard";
 
 /**
  * ChatAgent instance interface
@@ -87,6 +88,43 @@ function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.With
   }
 
   return output;
+}
+
+function buildSystemPrompt(basePrompt: string | undefined, tools: Tool.Spec[]): string | undefined {
+  const toolPrompts = tools
+    .filter((t) => t.prompt)
+    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
+    .join("\n\n");
+
+  if (!toolPrompts) return basePrompt;
+  if (!basePrompt) return toolPrompts;
+  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
+}
+
+function createGuardedToolExecutor(
+  toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
+  permission: Guardrail.ToolPermission,
+): (call: Tool.Call) => Promise<Tool.Result> {
+  return async (call: Tool.Call): Promise<Tool.Result> => {
+    const verdict = ToolGuard.check(call.tool, call.input, permission);
+    if (verdict === "deny") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Blocked: Tool "${call.tool}" is not permitted by policy]`,
+        isError: true,
+      };
+    }
+    if (verdict === "require_approval") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Blocked: Tool "${call.tool}" requires approval]`,
+        isError: true,
+      };
+    }
+    return toolExecutor(call);
+  };
 }
 
 /**
@@ -202,10 +240,13 @@ export namespace ChatAgent {
                   const runInput: RunInput = {
                     messages: effectiveMessages,
                     tools: config.tools ?? [],
-                    system: config.systemPrompt,
+                    system: buildSystemPrompt(config.systemPrompt, config.tools ?? []),
                     signal: config.signal,
                     model: providerModel,
-                    toolExecutor: config.toolExecutor,
+                    toolExecutor:
+                      config.toolExecutor && config.permissions
+                        ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
+                        : config.toolExecutor,
                     toolChoice: configuredToolChoice,
                     maxSteps: config.budget?.maxToolCalls ?? 24,
                   };

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -32,6 +32,7 @@ import type { AgentEvent } from "./types";
 import type { MemoryResult } from "./memory";
 import { createAssistantMessage, createUserMessage } from "./message-factory";
 import { ToolGuard } from "./tool-guard";
+import { buildSystemPrompt } from "./prompt-builder";
 
 function summarizeInput(input: Record<string, unknown>): string {
   try {
@@ -113,17 +114,6 @@ function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.With
   }
 
   return output;
-}
-
-function buildSystemPrompt(basePrompt: string | undefined, tools: Tool.Spec[]): string | undefined {
-  const toolPrompts = tools
-    .filter((t) => t.prompt)
-    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
-    .join("\n\n");
-
-  if (!toolPrompts) return basePrompt;
-  if (!basePrompt) return toolPrompts;
-  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
 }
 
 function createGuardedToolExecutor(
@@ -249,6 +239,18 @@ function createHookedToolExecutor(
     if (verdict.action === "transform") {
       const transformed: Tool.Call = { ...call, input: verdict.input };
       return toolExecutor(transformed);
+    }
+
+    if (verdict.action === "retry") {
+      console.warn(
+        '[hooks.preToolUse] "retry" verdict is not supported for preToolUse, treating as continue',
+      );
+    }
+
+    if (verdict.action === "inject") {
+      console.warn(
+        '[hooks.preToolUse] "inject" verdict is not supported for preToolUse, treating as continue',
+      );
     }
 
     return toolExecutor(call);
@@ -493,6 +495,28 @@ export namespace ChatAgent {
                           createAssistantMessage(lastAssistantText, parentID, "chat-agent"),
                           createUserMessage(postTurnVerdict.message, "chat-agent"),
                         ];
+
+                        if (config.compaction) {
+                          const totalTokens =
+                            budgetState.totalInputTokens + budgetState.totalOutputTokens;
+                          if (InMemoryCompactor.shouldCompact(totalTokens, config.compaction)) {
+                            const result = await InMemoryCompactor.compact(
+                              messages,
+                              config.compaction,
+                            );
+                            if (result.compacted) {
+                              const messagesBefore = messages.length;
+                              messages = result.messages;
+                              compactionCount += 1;
+                              config.eventEmitter?.emit("agent.compaction", {
+                                sessionId: "chat-agent",
+                                time: Date.now(),
+                                messagesBefore,
+                                messagesAfter: result.messages.length,
+                              });
+                            }
+                          }
+                        }
 
                         continuationCount++;
                         continue;

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -130,6 +130,7 @@ function createGuardedToolExecutor(
   toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
   permission: Guardrail.ToolPermission,
   eventEmitter?: AgentEventEmitter,
+  stepGuard?: ChatAgentConfig["stepGuard"],
 ): (call: Tool.Call) => Promise<Tool.Result> {
   return async (call: Tool.Call): Promise<Tool.Result> => {
     const verdict = ToolGuard.check(call.tool, call.input, permission);
@@ -149,6 +150,36 @@ function createGuardedToolExecutor(
       };
     }
     if (verdict === "require_approval") {
+      if (stepGuard) {
+        const syntheticStep: AgentStep = {
+          type: "tool-call",
+          content: `Tool "${call.tool}" requires approval`,
+          toolCalls: [call],
+        };
+        const guardContext = {
+          steps: [],
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          turnCount: 0,
+          isCompletion: false,
+          continuationCount: 0,
+          elapsedMs: 0,
+        };
+        try {
+          const guardVerdict = await stepGuard(syntheticStep, guardContext);
+          if (guardVerdict.action === "continue") {
+            eventEmitter?.emit("agent.tool.invoked", {
+              sessionId: "chat-agent",
+              time: Date.now(),
+              toolCallId: call.id,
+              toolName: call.tool,
+              inputSummary: summarizeInput(call.input),
+            });
+            return toolExecutor(call);
+          }
+        } catch (_error) {
+          void _error;
+        }
+      }
       eventEmitter?.emit("agent.tool.blocked", {
         sessionId: "chat-agent",
         time: Date.now(),
@@ -385,6 +416,7 @@ export namespace ChatAgent {
                           config.toolExecutor,
                           config.permissions,
                           config.eventEmitter,
+                          config.stepGuard,
                         )
                       : config.toolExecutor;
 
@@ -558,6 +590,12 @@ export namespace ChatAgent {
 
                 if (shouldRetry(retryPolicy, retryReason, attempt)) {
                   const backoffMs = calculateBackoffMs(retryPolicy, attempt);
+                  config.eventEmitter?.emit("agent.error.retry", {
+                    sessionId: "chat-agent",
+                    time: Date.now(),
+                    attempt,
+                    error: lastError,
+                  });
                   await sleep(backoffMs);
                   attempt += 1;
                   continue;

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -594,6 +594,7 @@ export namespace ChatAgent {
                     sessionId: "chat-agent",
                     time: Date.now(),
                     attempt,
+                    maxAttempts: retryPolicy.maxAttempts,
                     error: lastError,
                   });
                   await sleep(backoffMs);

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,6 +1,7 @@
 import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type {
+  AgentEventEmitter,
   ChatAgentConfig,
   ChatAgentInput,
   AgentResult,
@@ -31,6 +32,15 @@ import type { AgentEvent } from "./types";
 import type { MemoryResult } from "./memory";
 import { createAssistantMessage, createUserMessage } from "./message-factory";
 import { ToolGuard } from "./tool-guard";
+
+function summarizeInput(input: Record<string, unknown>): string {
+  try {
+    const str = JSON.stringify(input);
+    return str.length > 100 ? `${str.slice(0, 97)}...` : str;
+  } catch {
+    return "[unserializable]";
+  }
+}
 
 /**
  * ChatAgent instance interface
@@ -119,10 +129,18 @@ function buildSystemPrompt(basePrompt: string | undefined, tools: Tool.Spec[]): 
 function createGuardedToolExecutor(
   toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
   permission: Guardrail.ToolPermission,
+  eventEmitter?: AgentEventEmitter,
 ): (call: Tool.Call) => Promise<Tool.Result> {
   return async (call: Tool.Call): Promise<Tool.Result> => {
     const verdict = ToolGuard.check(call.tool, call.input, permission);
     if (verdict === "deny") {
+      eventEmitter?.emit("agent.tool.blocked", {
+        sessionId: "chat-agent",
+        time: Date.now(),
+        toolCallId: call.id,
+        toolName: call.tool,
+        reason: "denied by policy",
+      });
       return {
         id: crypto.randomUUID(),
         toolCallId: call.id,
@@ -131,6 +149,13 @@ function createGuardedToolExecutor(
       };
     }
     if (verdict === "require_approval") {
+      eventEmitter?.emit("agent.tool.blocked", {
+        sessionId: "chat-agent",
+        time: Date.now(),
+        toolCallId: call.id,
+        toolName: call.tool,
+        reason: "requires approval",
+      });
       return {
         id: crypto.randomUUID(),
         toolCallId: call.id,
@@ -138,6 +163,13 @@ function createGuardedToolExecutor(
         isError: true,
       };
     }
+    eventEmitter?.emit("agent.tool.invoked", {
+      sessionId: "chat-agent",
+      time: Date.now(),
+      toolCallId: call.id,
+      toolName: call.tool,
+      inputSummary: summarizeInput(call.input),
+    });
     return toolExecutor(call);
   };
 }
@@ -286,6 +318,12 @@ export namespace ChatAgent {
                     };
                   }
 
+                  config.eventEmitter?.emit("agent.turn.start", {
+                    sessionId: "chat-agent",
+                    time: Date.now(),
+                    turnIndex: budgetState.turns,
+                  });
+
                   if (budgetStatus === "reassurance" && !reassuranceIssued) {
                     const remaining = describeBudgetRemaining(budgetState, config.budget);
                     messages = [
@@ -296,6 +334,12 @@ export namespace ChatAgent {
                       ),
                     ];
                     reassuranceIssued = true;
+                    config.eventEmitter?.emit("agent.budget.reassurance", {
+                      sessionId: "chat-agent",
+                      time: Date.now(),
+                      remaining,
+                      threshold: config.budget?.reassuranceThreshold ?? 0.6,
+                    });
                   }
                   if (budgetStatus === "warning" && !warningIssued) {
                     const remaining = describeBudgetRemaining(budgetState, config.budget);
@@ -307,6 +351,12 @@ export namespace ChatAgent {
                       ),
                     ];
                     warningIssued = true;
+                    config.eventEmitter?.emit("agent.budget.warning", {
+                      sessionId: "chat-agent",
+                      time: Date.now(),
+                      remaining,
+                      threshold: config.budget?.warningThreshold ?? 0.8,
+                    });
                   }
 
                   budgetState = recordTurn(budgetState);
@@ -331,7 +381,11 @@ export namespace ChatAgent {
 
                   const baseExecutor =
                     config.toolExecutor && config.permissions
-                      ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
+                      ? createGuardedToolExecutor(
+                          config.toolExecutor,
+                          config.permissions,
+                          config.eventEmitter,
+                        )
                       : config.toolExecutor;
 
                   const hookedExecutor = baseExecutor
@@ -356,6 +410,18 @@ export namespace ChatAgent {
                   const outcome = await llmRun(runInput, trackingSink);
 
                   if (outcome.type === "stop") {
+                    config.eventEmitter?.emit("agent.turn.complete", {
+                      sessionId: "chat-agent",
+                      time: Date.now(),
+                      turnIndex: budgetState.turns,
+                      usage: {
+                        inputTokens: totalUsage.inputTokens,
+                        outputTokens: totalUsage.outputTokens,
+                        totalTokens: totalUsage.totalTokens,
+                        totalCost: totalUsage.totalCost,
+                      },
+                    });
+
                     const step: AgentStep = {
                       type: "text",
                       content: lastAssistantText,
@@ -438,8 +504,15 @@ export namespace ChatAgent {
                               config.compaction,
                             );
                             if (result.compacted) {
+                              const messagesBefore = messages.length;
                               messages = result.messages;
                               compactionCount += 1;
+                              config.eventEmitter?.emit("agent.compaction", {
+                                sessionId: "chat-agent",
+                                time: Date.now(),
+                                messagesBefore,
+                                messagesAfter: result.messages.length,
+                              });
                             }
                           }
                         }

--- a/packages/agent/src/core/delegation.ts
+++ b/packages/agent/src/core/delegation.ts
@@ -1,16 +1,18 @@
 import type { BudgetState } from "./budget";
 import type { AgentBudget } from "./types";
+import type { Guardrail } from "@openomni/protocol";
 
 export type DelegationContext = {
   depth: number;
   maxDepth: number;
   visitedAgents: Set<string>;
   parentAbort: AbortSignal;
-  budgetPolicy: "inherit" | "independent" | "split";
+  budgetPolicy: Guardrail.DelegationPolicy["budgetPolicy"];
   budgetAllocation?: number;
   reserveForParent?: number;
   parentBudgetState?: BudgetState;
   parentBudget?: AgentBudget;
+  onChildBudgetConsumed?: (inputTokens: number, outputTokens: number, cost: number) => void;
 };
 
 export function allocateBudget(

--- a/packages/agent/src/core/delegation.ts
+++ b/packages/agent/src/core/delegation.ts
@@ -1,10 +1,56 @@
+import type { BudgetState } from "./budget";
+import type { AgentBudget } from "./types";
+
 export type DelegationContext = {
   depth: number;
   maxDepth: number;
   visitedAgents: Set<string>;
   parentAbort: AbortSignal;
-  budgetPolicy: "inherit" | "independent";
+  budgetPolicy: "inherit" | "independent" | "split";
+  budgetAllocation?: number;
+  reserveForParent?: number;
+  parentBudgetState?: BudgetState;
+  parentBudget?: AgentBudget;
 };
+
+export function allocateBudget(
+  parentState: BudgetState,
+  parentBudget: AgentBudget | undefined,
+  context: Pick<DelegationContext, "budgetPolicy" | "budgetAllocation" | "reserveForParent">,
+): AgentBudget {
+  const policy = context.budgetPolicy;
+
+  if (policy === "independent") {
+    return { maxTurns: 10, maxToolCalls: 20 };
+  }
+
+  const maxTurns = parentBudget?.maxTurns ?? 24;
+  const remainingTurns = maxTurns - parentState.turns;
+
+  if (policy === "inherit") {
+    return {
+      ...parentBudget,
+      maxTurns: Math.max(1, remainingTurns),
+      maxCost:
+        parentBudget?.maxCost !== undefined
+          ? Math.max(0, parentBudget.maxCost - parentState.totalCost)
+          : undefined,
+    };
+  }
+
+  const allocation = context.budgetAllocation ?? 0.5;
+  const reserve = context.reserveForParent ?? 0.2;
+  const factor = (1 - reserve) * allocation;
+
+  return {
+    ...parentBudget,
+    maxTurns: Math.max(1, Math.floor(remainingTurns * factor)),
+    maxCost:
+      parentBudget?.maxCost !== undefined
+        ? Math.max(0, (parentBudget.maxCost - parentState.totalCost) * factor)
+        : undefined,
+  };
+}
 
 export function checkDelegation(
   agentName: string,

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -71,6 +71,7 @@ function createGuardedToolExecutor(
   toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
   permission: Guardrail.ToolPermission,
   eventEmitter?: AgentEventEmitter,
+  stepGuard?: ChatAgentConfig["stepGuard"],
 ): (call: Tool.Call) => Promise<Tool.Result> {
   return async (call: Tool.Call): Promise<Tool.Result> => {
     const verdict = ToolGuard.check(call.tool, call.input, permission);
@@ -90,6 +91,36 @@ function createGuardedToolExecutor(
       };
     }
     if (verdict === "require_approval") {
+      if (stepGuard) {
+        const syntheticStep: AgentStep = {
+          type: "tool-call",
+          content: `Tool "${call.tool}" requires approval`,
+          toolCalls: [call],
+        };
+        const guardContext = {
+          steps: [],
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          turnCount: 0,
+          isCompletion: false,
+          continuationCount: 0,
+          elapsedMs: 0,
+        };
+        try {
+          const guardVerdict = await stepGuard(syntheticStep, guardContext);
+          if (guardVerdict.action === "continue") {
+            eventEmitter?.emit("agent.tool.invoked", {
+              sessionId: "stream-engine",
+              time: Date.now(),
+              toolCallId: call.id,
+              toolName: call.tool,
+              inputSummary: summarizeInput(call.input),
+            });
+            return toolExecutor(call);
+          }
+        } catch (_error) {
+          void _error;
+        }
+      }
       eventEmitter?.emit("agent.tool.blocked", {
         sessionId: "stream-engine",
         time: Date.now(),
@@ -273,6 +304,7 @@ export async function* streamAgent(
                 config.toolExecutor,
                 config.permissions,
                 config.eventEmitter,
+                config.stepGuard,
               )
             : config.toolExecutor;
 
@@ -498,6 +530,12 @@ export async function* streamAgent(
 
       if (shouldRetry(retryPolicy, retryReason, attempt)) {
         const backoffMs = calculateBackoffMs(retryPolicy, attempt);
+        config.eventEmitter?.emit("agent.error.retry", {
+          sessionId: "stream-engine",
+          time: Date.now(),
+          attempt,
+          error: lastError,
+        });
         yield {
           type: "error",
           error: error instanceof Error ? error : new Error(lastError),

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -1,8 +1,9 @@
 import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
-import type { Message, Sink, Tool } from "@openomni/protocol";
+import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
 import { createBudgetState, checkBudget, recordTurn } from "../budget";
 import { createAssistantMessage, createUserMessage } from "../message-factory";
+import { ToolGuard } from "../tool-guard";
 import {
   DEFAULT_RETRY_POLICY,
   calculateBackoffMs,
@@ -34,6 +35,43 @@ function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.With
     );
   }
   return output;
+}
+
+function buildSystemPrompt(basePrompt: string | undefined, tools: Tool.Spec[]): string | undefined {
+  const toolPrompts = tools
+    .filter((t) => t.prompt)
+    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
+    .join("\n\n");
+
+  if (!toolPrompts) return basePrompt;
+  if (!basePrompt) return toolPrompts;
+  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
+}
+
+function createGuardedToolExecutor(
+  toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
+  permission: Guardrail.ToolPermission,
+): (call: Tool.Call) => Promise<Tool.Result> {
+  return async (call: Tool.Call): Promise<Tool.Result> => {
+    const verdict = ToolGuard.check(call.tool, call.input, permission);
+    if (verdict === "deny") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Blocked: Tool "${call.tool}" is not permitted by policy]`,
+        isError: true,
+      };
+    }
+    if (verdict === "require_approval") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Blocked: Tool "${call.tool}" requires approval]`,
+        isError: true,
+      };
+    }
+    return toolExecutor(call);
+  };
 }
 
 export async function* streamAgent(
@@ -89,10 +127,13 @@ export async function* streamAgent(
         const runInput: RunInput = {
           messages,
           tools: config.tools ?? [],
-          system: config.systemPrompt,
+          system: buildSystemPrompt(config.systemPrompt, config.tools ?? []),
           signal: config.signal,
           model: providerModel,
-          toolExecutor: config.toolExecutor,
+          toolExecutor:
+            config.toolExecutor && config.permissions
+              ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
+              : config.toolExecutor,
           toolChoice: configuredToolChoice,
           maxSteps: config.budget?.maxToolCalls ?? 24,
         };

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -534,6 +534,7 @@ export async function* streamAgent(
           sessionId: "stream-engine",
           time: Date.now(),
           attempt,
+          maxAttempts: retryPolicy.maxAttempts,
           error: lastError,
         });
         yield {

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -21,6 +21,8 @@ import {
   shouldRetry,
   sleep,
 } from "../retry";
+import { buildSystemPrompt } from "../prompt-builder";
+import { InMemoryCompactor } from "./compaction";
 
 function summarizeInput(input: Record<string, unknown>): string {
   try {
@@ -54,17 +56,6 @@ function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.With
     );
   }
   return output;
-}
-
-function buildSystemPrompt(basePrompt: string | undefined, tools: Tool.Spec[]): string | undefined {
-  const toolPrompts = tools
-    .filter((t) => t.prompt)
-    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
-    .join("\n\n");
-
-  if (!toolPrompts) return basePrompt;
-  if (!basePrompt) return toolPrompts;
-  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
 }
 
 function createGuardedToolExecutor(
@@ -193,6 +184,18 @@ function createHookedToolExecutor(
     if (verdict.action === "transform") {
       const transformed: Tool.Call = { ...call, input: verdict.input };
       return toolExecutor(transformed);
+    }
+
+    if (verdict.action === "retry") {
+      console.warn(
+        '[hooks.preToolUse] "retry" verdict is not supported for preToolUse, treating as continue',
+      );
+    }
+
+    if (verdict.action === "inject") {
+      console.warn(
+        '[hooks.preToolUse] "inject" verdict is not supported for preToolUse, treating as continue',
+      );
     }
 
     return toolExecutor(call);
@@ -453,6 +456,24 @@ export async function* streamAgent(
                 createAssistantMessage(lastAssistantText, parentID, "stream-engine"),
                 createUserMessage(postTurnVerdict.message, "stream-engine"),
               ];
+
+              if (config.compaction) {
+                const totalTokens = budgetState.totalInputTokens + budgetState.totalOutputTokens;
+                if (InMemoryCompactor.shouldCompact(totalTokens, config.compaction)) {
+                  const result = await InMemoryCompactor.compact(messages, config.compaction);
+                  if (result.compacted) {
+                    const messagesBefore = messages.length;
+                    messages = result.messages;
+                    config.eventEmitter?.emit("agent.compaction", {
+                      sessionId: "stream-engine",
+                      time: Date.now(),
+                      messagesBefore,
+                      messagesAfter: result.messages.length,
+                    });
+                  }
+                }
+              }
+
               continuationCount++;
               turnIndex++;
               continue;

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -1,7 +1,7 @@
 import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
-import { createBudgetState, checkBudget, recordTurn } from "../budget";
+import { createBudgetState, checkBudget, recordTurn, describeBudgetRemaining } from "../budget";
 import { createAssistantMessage, createUserMessage } from "../message-factory";
 import { ToolGuard } from "../tool-guard";
 import {
@@ -106,8 +106,12 @@ export async function* streamAgent(
         throw new Error("toolExecutor is required when tools are provided");
       }
 
+      let reassuranceIssued = false;
+      let warningIssued = false;
+
       while (true) {
-        if (checkBudget(budgetState, config.budget) === "exceeded") {
+        const budgetStatus = checkBudget(budgetState, config.budget);
+        if (budgetStatus === "exceeded") {
           yield {
             type: "complete",
             result: {
@@ -118,6 +122,31 @@ export async function* streamAgent(
             },
           };
           return;
+        }
+
+        if (budgetStatus === "reassurance" && !reassuranceIssued) {
+          const remaining = describeBudgetRemaining(budgetState, config.budget);
+          messages = [
+            ...messages,
+            createUserMessage(
+              `[Budget Status] ${remaining}. You have plenty of budget remaining. Do NOT rush or skip tasks. Complete your work thoroughly.`,
+              "stream-engine",
+            ),
+          ];
+          reassuranceIssued = true;
+          yield { type: "budget_reassurance", remaining };
+        }
+        if (budgetStatus === "warning" && !warningIssued) {
+          const remaining = describeBudgetRemaining(budgetState, config.budget);
+          messages = [
+            ...messages,
+            createUserMessage(
+              `[Budget Warning] ${remaining}. Wrap up your current task and provide a summary.`,
+              "stream-engine",
+            ),
+          ];
+          warningIssued = true;
+          yield { type: "budget_warning", remaining };
         }
 
         budgetState = recordTurn(budgetState);

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -2,6 +2,7 @@ import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type {
   AgentEvent,
+  AgentEventEmitter,
   AgentStep,
   ChatAgentConfig,
   ChatAgentInput,
@@ -20,6 +21,15 @@ import {
   shouldRetry,
   sleep,
 } from "../retry";
+
+function summarizeInput(input: Record<string, unknown>): string {
+  try {
+    const str = JSON.stringify(input);
+    return str.length > 100 ? `${str.slice(0, 97)}...` : str;
+  } catch {
+    return "[unserializable]";
+  }
+}
 
 async function resolveProviderModel(model: {
   provider: string;
@@ -60,10 +70,18 @@ function buildSystemPrompt(basePrompt: string | undefined, tools: Tool.Spec[]): 
 function createGuardedToolExecutor(
   toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
   permission: Guardrail.ToolPermission,
+  eventEmitter?: AgentEventEmitter,
 ): (call: Tool.Call) => Promise<Tool.Result> {
   return async (call: Tool.Call): Promise<Tool.Result> => {
     const verdict = ToolGuard.check(call.tool, call.input, permission);
     if (verdict === "deny") {
+      eventEmitter?.emit("agent.tool.blocked", {
+        sessionId: "stream-engine",
+        time: Date.now(),
+        toolCallId: call.id,
+        toolName: call.tool,
+        reason: "denied by policy",
+      });
       return {
         id: crypto.randomUUID(),
         toolCallId: call.id,
@@ -72,6 +90,13 @@ function createGuardedToolExecutor(
       };
     }
     if (verdict === "require_approval") {
+      eventEmitter?.emit("agent.tool.blocked", {
+        sessionId: "stream-engine",
+        time: Date.now(),
+        toolCallId: call.id,
+        toolName: call.tool,
+        reason: "requires approval",
+      });
       return {
         id: crypto.randomUUID(),
         toolCallId: call.id,
@@ -79,6 +104,13 @@ function createGuardedToolExecutor(
         isError: true,
       };
     }
+    eventEmitter?.emit("agent.tool.invoked", {
+      sessionId: "stream-engine",
+      time: Date.now(),
+      toolCallId: call.id,
+      toolName: call.tool,
+      inputSummary: summarizeInput(call.input),
+    });
     return toolExecutor(call);
   };
 }
@@ -186,6 +218,12 @@ export async function* streamAgent(
           return;
         }
 
+        config.eventEmitter?.emit("agent.turn.start", {
+          sessionId: "stream-engine",
+          time: Date.now(),
+          turnIndex: budgetState.turns,
+        });
+
         if (budgetStatus === "reassurance" && !reassuranceIssued) {
           const remaining = describeBudgetRemaining(budgetState, config.budget);
           messages = [
@@ -196,6 +234,12 @@ export async function* streamAgent(
             ),
           ];
           reassuranceIssued = true;
+          config.eventEmitter?.emit("agent.budget.reassurance", {
+            sessionId: "stream-engine",
+            time: Date.now(),
+            remaining,
+            threshold: config.budget?.reassuranceThreshold ?? 0.6,
+          });
           yield { type: "budget_reassurance", remaining };
         }
         if (budgetStatus === "warning" && !warningIssued) {
@@ -208,6 +252,12 @@ export async function* streamAgent(
             ),
           ];
           warningIssued = true;
+          config.eventEmitter?.emit("agent.budget.warning", {
+            sessionId: "stream-engine",
+            time: Date.now(),
+            remaining,
+            threshold: config.budget?.warningThreshold ?? 0.8,
+          });
           yield { type: "budget_warning", remaining };
         }
 
@@ -219,7 +269,11 @@ export async function* streamAgent(
 
         const baseExecutor =
           config.toolExecutor && config.permissions
-            ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
+            ? createGuardedToolExecutor(
+                config.toolExecutor,
+                config.permissions,
+                config.eventEmitter,
+              )
             : config.toolExecutor;
 
         const hookedExecutor = baseExecutor
@@ -297,6 +351,18 @@ export async function* streamAgent(
         const outcome = await llmRun(runInput, trackingSink);
 
         if (outcome.type === "stop") {
+          config.eventEmitter?.emit("agent.turn.complete", {
+            sessionId: "stream-engine",
+            time: Date.now(),
+            turnIndex,
+            usage: {
+              inputTokens: totalUsage.inputTokens,
+              outputTokens: totalUsage.outputTokens,
+              totalTokens: totalUsage.totalTokens,
+              totalCost: totalUsage.totalCost,
+            },
+          });
+
           if (lastAssistantText) yield { type: "text_chunk", text: lastAssistantText };
 
           for (const toolCall of turnToolCalls) {

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -2,6 +2,7 @@ import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm
 import type { Message, Sink, Tool } from "@openomni/protocol";
 import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
 import { createBudgetState, checkBudget, recordTurn } from "../budget";
+import { createAssistantMessage, createUserMessage } from "../message-factory";
 import {
   DEFAULT_RETRY_POLICY,
   calculateBackoffMs,
@@ -22,71 +23,14 @@ async function resolveProviderModel(model: {
   return Provider.fromModelsDevModel(providerData, rawModel as ModelsDev.Model);
 }
 
-function createUserMessage(content: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "stream-engine";
-  const now = Date.now();
-  const info: Message.UserMessage = {
-    id,
-    sessionID,
-    role: "user",
-    time: { created: now },
-    agent: "stream-engine",
-    model: { providerID: "", modelID: "" },
-  };
-  return {
-    info,
-    parts: [
-      {
-        id: crypto.randomUUID(),
-        sessionID,
-        messageID: id,
-        type: "text",
-        text: content,
-      },
-    ],
-  };
-}
-
-function createAssistantMessage(content: string, parentID: string): Message.WithParts {
-  const id = crypto.randomUUID();
-  const sessionID = "stream-engine";
-  const now = Date.now();
-  const info: Message.AssistantMessage = {
-    id,
-    sessionID,
-    role: "assistant",
-    time: { created: now },
-    parentID,
-    modelID: "",
-    providerID: "",
-    agent: "stream-engine",
-    path: { cwd: process.cwd(), root: process.cwd() },
-    cost: 0,
-    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-  };
-  return {
-    info,
-    parts: [
-      {
-        id: crypto.randomUUID(),
-        sessionID,
-        messageID: id,
-        type: "text",
-        text: content,
-      },
-    ],
-  };
-}
-
 function toMessagesWithParts(messages: ChatAgentInput["messages"]): Message.WithParts[] {
   const output: Message.WithParts[] = [];
   for (const message of messages) {
     const parentID = output.length > 0 ? output[output.length - 1].info.id : "";
     output.push(
       message.role === "user"
-        ? createUserMessage(message.content)
-        : createAssistantMessage(message.content, parentID),
+        ? createUserMessage(message.content, "stream-engine")
+        : createAssistantMessage(message.content, parentID, "stream-engine"),
     );
   }
   return output;
@@ -233,8 +177,8 @@ export async function* streamAgent(
               const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
               messages = [
                 ...messages,
-                createAssistantMessage(lastAssistantText, parentID),
-                createUserMessage(verdict.message),
+                createAssistantMessage(lastAssistantText, parentID, "stream-engine"),
+                createUserMessage(verdict.message, "stream-engine"),
               ];
               continuationCount++;
               turnIndex++;

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -1,6 +1,15 @@
 import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
-import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
+import type {
+  AgentEvent,
+  AgentStep,
+  ChatAgentConfig,
+  ChatAgentInput,
+  ExecutionHooks,
+  HookContext,
+  HookVerdict,
+  TokenUsage,
+} from "../types";
 import { createBudgetState, checkBudget, recordTurn, describeBudgetRemaining } from "../budget";
 import { createAssistantMessage, createUserMessage } from "../message-factory";
 import { ToolGuard } from "../tool-guard";
@@ -70,6 +79,59 @@ function createGuardedToolExecutor(
         isError: true,
       };
     }
+    return toolExecutor(call);
+  };
+}
+
+function createHookedToolExecutor(
+  toolExecutor: (call: Tool.Call) => Promise<Tool.Result>,
+  hooks: ExecutionHooks | undefined,
+  getContext: () => Omit<HookContext, "toolName" | "toolCallId" | "input">,
+  onVerdict?: (verdict: HookVerdict) => void,
+): (call: Tool.Call) => Promise<Tool.Result> {
+  if (!hooks?.preToolUse) return toolExecutor;
+
+  return async (call: Tool.Call): Promise<Tool.Result> => {
+    const context: HookContext = {
+      ...getContext(),
+      toolName: call.tool,
+      toolCallId: call.id,
+      input: call.input,
+    };
+
+    let verdict: HookVerdict;
+    try {
+      verdict = await hooks.preToolUse!(context);
+    } catch (err) {
+      console.warn("[hooks.preToolUse] threw, treating as continue:", err);
+      verdict = { action: "continue" };
+    }
+
+    onVerdict?.(verdict);
+
+    if (verdict.action === "skip") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Skipped: ${verdict.reason ?? "hook"}]`,
+        isError: false,
+      };
+    }
+
+    if (verdict.action === "abort") {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        output: `[Aborted: ${verdict.reason ?? "hook"}]`,
+        isError: true,
+      };
+    }
+
+    if (verdict.action === "transform") {
+      const transformed: Tool.Call = { ...call, input: verdict.input };
+      return toolExecutor(transformed);
+    }
+
     return toolExecutor(call);
   };
 }
@@ -153,16 +215,33 @@ export async function* streamAgent(
 
         if (config.signal?.aborted) throw new Error("aborted");
 
+        const preToolUseVerdicts: HookVerdict[] = [];
+
+        const baseExecutor =
+          config.toolExecutor && config.permissions
+            ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
+            : config.toolExecutor;
+
+        const hookedExecutor = baseExecutor
+          ? createHookedToolExecutor(
+              baseExecutor,
+              config.hooks,
+              () => ({
+                steps,
+                turnCount: budgetState.turns,
+                elapsedMs: Date.now() - startTime,
+              }),
+              (verdict) => preToolUseVerdicts.push(verdict),
+            )
+          : undefined;
+
         const runInput: RunInput = {
           messages,
           tools: config.tools ?? [],
           system: buildSystemPrompt(config.systemPrompt, config.tools ?? []),
           signal: config.signal,
           model: providerModel,
-          toolExecutor:
-            config.toolExecutor && config.permissions
-              ? createGuardedToolExecutor(config.toolExecutor, config.permissions)
-              : config.toolExecutor,
+          toolExecutor: hookedExecutor,
           toolChoice: configuredToolChoice,
           maxSteps: config.budget?.maxToolCalls ?? 24,
         };
@@ -226,6 +305,14 @@ export async function* streamAgent(
           for (const toolResult of turnToolResults) {
             yield { type: "tool_call_complete", ...toolResult };
           }
+          for (const verdict of preToolUseVerdicts) {
+            yield {
+              type: "hook_verdict",
+              timing: "pre_tool_use",
+              action: verdict.action,
+              reason: "reason" in verdict ? verdict.reason : undefined,
+            };
+          }
 
           yield { type: "turn_complete", turnIndex, usage: turnUsage };
 
@@ -233,7 +320,60 @@ export async function* streamAgent(
           steps.push(step);
           if (config.onStepFinish) await config.onStepFinish(step);
 
-          if (config.stepGuard) {
+          if (config.hooks?.postTurn) {
+            if (config.stepGuard) {
+              console.warn(
+                "[hooks] Both hooks.postTurn and stepGuard are set. hooks.postTurn takes precedence.",
+              );
+            }
+
+            const hookContext: HookContext = {
+              steps,
+              turnCount: budgetState.turns,
+              elapsedMs: Date.now() - startTime,
+            };
+
+            let postTurnVerdict: HookVerdict;
+            try {
+              postTurnVerdict = await config.hooks.postTurn(hookContext);
+            } catch (err) {
+              console.warn("[hooks.postTurn] threw, treating as continue:", err);
+              postTurnVerdict = { action: "continue" };
+            }
+
+            yield {
+              type: "hook_verdict",
+              timing: "post_turn",
+              action: postTurnVerdict.action,
+              reason: "reason" in postTurnVerdict ? postTurnVerdict.reason : undefined,
+            };
+
+            if (postTurnVerdict.action === "inject") {
+              const parentID = messages.length > 0 ? messages[messages.length - 1].info.id : "";
+              messages = [
+                ...messages,
+                createAssistantMessage(lastAssistantText, parentID, "stream-engine"),
+                createUserMessage(postTurnVerdict.message, "stream-engine"),
+              ];
+              continuationCount++;
+              turnIndex++;
+              continue;
+            }
+
+            if (postTurnVerdict.action === "abort") {
+              yield {
+                type: "complete",
+                result: {
+                  text: lastAssistantText,
+                  steps,
+                  usage: totalUsage,
+                  finishReason: "stop",
+                  guardAborted: true,
+                },
+              };
+              return;
+            }
+          } else if (config.stepGuard) {
             const verdict = await config.stepGuard(step, {
               steps,
               usage: totalUsage,

--- a/packages/agent/src/core/message-factory.ts
+++ b/packages/agent/src/core/message-factory.ts
@@ -1,0 +1,56 @@
+import type { Message } from "@openomni/protocol";
+
+export function createUserMessage(content: string, sessionID: string): Message.WithParts {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const info: Message.UserMessage = {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: now },
+    agent: sessionID,
+    model: { providerID: "", modelID: "" },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text: content,
+  };
+
+  return { info, parts: [textPart] };
+}
+
+export function createAssistantMessage(
+  content: string,
+  parentID: string,
+  sessionID: string,
+): Message.WithParts {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: now },
+    parentID,
+    modelID: "",
+    providerID: "",
+    agent: sessionID,
+    path: { cwd: process.cwd(), root: process.cwd() },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  };
+
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text: content,
+  };
+
+  return { info, parts: [textPart] };
+}

--- a/packages/agent/src/core/prompt-builder.ts
+++ b/packages/agent/src/core/prompt-builder.ts
@@ -1,0 +1,15 @@
+import type { Tool } from "@openomni/protocol";
+
+export function buildSystemPrompt(
+  basePrompt: string | undefined,
+  tools: Tool.Spec[],
+): string | undefined {
+  const toolPrompts = tools
+    .filter((t) => t.prompt)
+    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
+    .join("\n\n");
+
+  if (!toolPrompts) return basePrompt;
+  if (!basePrompt) return toolPrompts;
+  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
+}

--- a/packages/agent/src/core/tool-guard.ts
+++ b/packages/agent/src/core/tool-guard.ts
@@ -1,10 +1,40 @@
 import type { Guardrail } from "@openomni/protocol";
 
+function matchToolPattern(toolName: string, pattern: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith(".*")) return toolName.startsWith(`${pattern.slice(0, -2)}.`);
+  return toolName === pattern;
+}
+
+function matchInputField(input: Record<string, unknown>, field: string, pattern: string): boolean {
+  const value = String(input[field] ?? "");
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
 export namespace ToolGuard {
   export function check(
     toolName: string,
+    input: Record<string, unknown>,
     permission: Guardrail.ToolPermission,
   ): "allow" | "deny" | "require_approval" {
+    // 1. InputRules (highest priority)
+    const inputRules = permission.inputRules ?? [];
+    if (inputRules.length > 0) {
+      const sorted = [...inputRules].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+      for (const rule of sorted) {
+        if (
+          matchToolPattern(toolName, rule.toolPattern) &&
+          matchInputField(input, rule.field, rule.pattern)
+        ) {
+          return rule.action;
+        }
+      }
+    }
+    // 2. Fall through to existing tool-level logic
     if (permission.denylist?.includes(toolName)) return "deny";
     if (permission.requireApproval?.includes(toolName)) return "require_approval";
     if (permission.allowlist !== undefined) {

--- a/packages/agent/src/core/tool-guard.ts
+++ b/packages/agent/src/core/tool-guard.ts
@@ -1,5 +1,8 @@
 import type { Guardrail } from "@openomni/protocol";
 
+const MAX_REGEX_PATTERN_LENGTH = 200;
+const MAX_INPUT_LENGTH = 10_000;
+
 function matchToolPattern(toolName: string, pattern: string): boolean {
   if (pattern === "*") return true;
   if (pattern.endsWith(".*")) return toolName.startsWith(`${pattern.slice(0, -2)}.`);
@@ -7,7 +10,11 @@ function matchToolPattern(toolName: string, pattern: string): boolean {
 }
 
 function matchInputField(input: Record<string, unknown>, field: string, pattern: string): boolean {
-  const value = String(input[field] ?? "");
+  if (pattern.length > MAX_REGEX_PATTERN_LENGTH) return false;
+
+  const raw = String(input[field] ?? "");
+  const value = raw.length > MAX_INPUT_LENGTH ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
+
   try {
     return new RegExp(pattern).test(value);
   } catch {

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { Tool, Sink, Guardrail, Message } from "@openomni/protocol";
+import type { Tool, Sink, Guardrail, Message, Hook } from "@openomni/protocol";
 import type { Memory } from "./memory";
 
 export type ParallelToolsMode = "off" | "safe-only" | "all";
@@ -27,13 +27,7 @@ export interface HookContext {
   elapsedMs: number;
 }
 
-export type HookVerdict =
-  | { action: "continue" }
-  | { action: "skip"; reason?: string }
-  | { action: "abort"; reason?: string }
-  | { action: "retry"; reason?: string }
-  | { action: "transform"; input: Record<string, unknown> }
-  | { action: "inject"; message: string };
+export type HookVerdict = Hook.Verdict;
 
 export interface ExecutionHooks {
   preToolUse?: (context: HookContext) => Promise<HookVerdict> | HookVerdict;
@@ -131,6 +125,6 @@ export type AgentEvent =
   | { type: "complete"; result: AgentResult }
   | { type: "budget_warning"; remaining: string }
   | { type: "budget_reassurance"; remaining: string }
-  | { type: "hook_verdict"; timing: string; action: string; reason?: string };
+  | { type: "hook_verdict"; timing: Hook.Timing; action: HookVerdict["action"]; reason?: string };
 
 export type { Sink };

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -33,6 +33,8 @@ export interface AgentBudget {
   maxOutputTokens?: number;
   maxTotalTokens?: number;
   maxCost?: number;
+  warningThreshold?: number; // 0.0-1.0, default 0.8
+  reassuranceThreshold?: number; // 0.0-1.0, default 0.6
 }
 
 export interface ChatAgentConfig {
@@ -94,6 +96,8 @@ export type AgentEvent =
   | { type: "tool_call_complete"; toolCallId: string; result: Tool.Result }
   | { type: "turn_complete"; turnIndex: number; usage: TokenUsage }
   | { type: "error"; error: Error; willRetry: boolean }
-  | { type: "complete"; result: AgentResult };
+  | { type: "complete"; result: AgentResult }
+  | { type: "budget_warning"; remaining: string }
+  | { type: "budget_reassurance"; remaining: string };
 
 export type { Sink };

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -43,6 +43,10 @@ export interface ExecutionHooks {
   onError?: (context: HookContext & { error: Error }) => Promise<HookVerdict> | HookVerdict;
 }
 
+export interface AgentEventEmitter {
+  emit(eventName: string, data: Record<string, unknown>): void;
+}
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
@@ -88,6 +92,7 @@ export interface ChatAgentConfig {
     context: StepGuardContext,
   ) => Promise<StepGuardVerdict> | StepGuardVerdict;
   hooks?: ExecutionHooks;
+  eventEmitter?: AgentEventEmitter;
 }
 
 export interface ChatAgentInput {

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -17,6 +17,32 @@ export interface StepGuardContext {
   elapsedMs: number;
 }
 
+export interface HookContext {
+  toolName?: string;
+  toolCallId?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  steps: AgentStep[];
+  turnCount: number;
+  elapsedMs: number;
+}
+
+export type HookVerdict =
+  | { action: "continue" }
+  | { action: "skip"; reason?: string }
+  | { action: "abort"; reason?: string }
+  | { action: "retry"; reason?: string }
+  | { action: "transform"; input: Record<string, unknown> }
+  | { action: "inject"; message: string };
+
+export interface ExecutionHooks {
+  preToolUse?: (context: HookContext) => Promise<HookVerdict> | HookVerdict;
+  postToolUse?: (context: HookContext) => Promise<HookVerdict> | HookVerdict;
+  preTurn?: (context: HookContext) => Promise<HookVerdict> | HookVerdict;
+  postTurn?: (context: HookContext) => Promise<HookVerdict> | HookVerdict;
+  onError?: (context: HookContext & { error: Error }) => Promise<HookVerdict> | HookVerdict;
+}
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
@@ -61,6 +87,7 @@ export interface ChatAgentConfig {
     step: AgentStep,
     context: StepGuardContext,
   ) => Promise<StepGuardVerdict> | StepGuardVerdict;
+  hooks?: ExecutionHooks;
 }
 
 export interface ChatAgentInput {
@@ -98,6 +125,7 @@ export type AgentEvent =
   | { type: "error"; error: Error; willRetry: boolean }
   | { type: "complete"; result: AgentResult }
   | { type: "budget_warning"; remaining: string }
-  | { type: "budget_reassurance"; remaining: string };
+  | { type: "budget_reassurance"; remaining: string }
+  | { type: "hook_verdict"; timing: string; action: string; reason?: string };
 
 export type { Sink };

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,7 @@ export type {
   Sink,
   StepGuardVerdict,
   StepGuardContext,
+  AgentEventEmitter,
 } from "./core/types";
 export { AgentMessenger, BusTransport } from "./runtime/index";
 export type { Transport, AgentMessengerOptions } from "./runtime/index";

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -1,6 +1,6 @@
 import type { Tool } from "@openomni/protocol";
 import { ChatAgent } from "../../core/chat-agent";
-import { checkDelegation, type DelegationContext } from "../../core/delegation";
+import { allocateBudget, checkDelegation, type DelegationContext } from "../../core/delegation";
 import { AgentRegistry } from "../registry/registry";
 import { AgentMessenger } from "../messenger/messenger";
 import { BusTransport } from "../messenger/transport";
@@ -79,6 +79,11 @@ export namespace SubagentTool {
       }
 
       const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
+      const childBudget = ctx?.parentBudgetState
+        ? allocateBudget(ctx.parentBudgetState, ctx.parentBudget, ctx)
+        : definition.maxTurns
+          ? { maxTurns: definition.maxTurns }
+          : undefined;
 
       try {
         const childAgent = ChatAgent.create({
@@ -87,7 +92,7 @@ export namespace SubagentTool {
             id: "claude-3-haiku-20240307",
           },
           systemPrompt: definition.systemPrompt,
-          budget: definition.maxTurns ? { maxTurns: definition.maxTurns } : undefined,
+          budget: childBudget,
           permissions: definition.permissions,
           signal: childAbort,
         });

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -79,11 +79,18 @@ export namespace SubagentTool {
       }
 
       const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
-      const childBudget = ctx?.parentBudgetState
+      const allocated = ctx?.parentBudgetState
         ? allocateBudget(ctx.parentBudgetState, ctx.parentBudget, ctx)
         : definition.maxTurns
           ? { maxTurns: definition.maxTurns }
           : undefined;
+      const childBudget =
+        allocated && definition.maxTurns
+          ? {
+              ...allocated,
+              maxTurns: Math.min(allocated.maxTurns ?? Infinity, definition.maxTurns),
+            }
+          : allocated;
 
       try {
         const childAgent = ChatAgent.create({

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -101,6 +101,14 @@ export namespace SubagentTool {
           messages: [{ role: "user", content: prompt }],
         });
 
+        if (ctx?.onChildBudgetConsumed && result.usage) {
+          ctx.onChildBudgetConsumed(
+            result.usage.inputTokens,
+            result.usage.outputTokens,
+            result.usage.totalCost ?? 0,
+          );
+        }
+
         const messenger = AgentMessenger.create(new BusTransport(), {
           allowPatterns: options?.messengerAllowPatterns,
         });

--- a/packages/agent/test/core/budget-injection.test.ts
+++ b/packages/agent/test/core/budget-injection.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { checkBudget, describeBudgetRemaining, createBudgetState } from "../../src/core/budget";
+
+// Test the budget injection logic by verifying the state machine behavior
+// (We test the pure functions since the injection logic is in the agent loop)
+
+describe("budget injection state machine", () => {
+  it("returns reassurance at 60% threshold", () => {
+    // 15/24 = 62.5% — above reassuranceThreshold (0.6)
+    const state = { ...createBudgetState(), turns: 15 };
+    expect(checkBudget(state, { maxTurns: 24 })).toBe("reassurance");
+  });
+
+  it("returns warning at 80% threshold", () => {
+    // 20/24 = 83.3% — above warningThreshold (0.8)
+    const state = { ...createBudgetState(), turns: 20 };
+    expect(checkBudget(state, { maxTurns: 24 })).toBe("warning");
+  });
+
+  it("injects reassurance message exactly once at 60% threshold", () => {
+    // Simulate the flag logic
+    let reassuranceIssued = false;
+    const messages: string[] = [];
+
+    const injectIfNeeded = (turns: number) => {
+      const state = { ...createBudgetState(), turns };
+      const status = checkBudget(state, { maxTurns: 24 });
+      if (status === "reassurance" && !reassuranceIssued) {
+        messages.push("[Budget Status] message");
+        reassuranceIssued = true;
+      }
+    };
+
+    injectIfNeeded(14); // 58% — ok
+    injectIfNeeded(15); // 62.5% — reassurance → inject
+    injectIfNeeded(16); // 66.7% — reassurance → already issued, skip
+    injectIfNeeded(17); // 70.8% — reassurance → already issued, skip
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("[Budget Status]");
+  });
+
+  it("injects both reassurance and warning in sequence", () => {
+    let reassuranceIssued = false;
+    let warningIssued = false;
+    const messages: string[] = [];
+
+    const injectIfNeeded = (turns: number) => {
+      const state = { ...createBudgetState(), turns };
+      const status = checkBudget(state, { maxTurns: 24 });
+      if (status === "reassurance" && !reassuranceIssued) {
+        messages.push("[Budget Status]");
+        reassuranceIssued = true;
+      }
+      if (status === "warning" && !warningIssued) {
+        messages.push("[Budget Warning]");
+        warningIssued = true;
+      }
+    };
+
+    injectIfNeeded(15); // reassurance
+    injectIfNeeded(20); // warning
+    injectIfNeeded(21); // warning — already issued
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toContain("[Budget Status]");
+    expect(messages[1]).toContain("[Budget Warning]");
+  });
+
+  it("describeBudgetRemaining includes turns info", () => {
+    const state = { ...createBudgetState(), turns: 15 };
+    const desc = describeBudgetRemaining(state, { maxTurns: 24 });
+    expect(desc).toContain("9 turns remaining");
+  });
+});

--- a/packages/agent/test/core/budget-tokens.test.ts
+++ b/packages/agent/test/core/budget-tokens.test.ts
@@ -22,7 +22,7 @@ describe("BudgetState token tracking", () => {
     let state = createBudgetState();
     state = recordTokenUsage(state, 1000, 0, 0);
     expect(checkBudget(state, { maxInputTokens: 999 })).toBe("exceeded");
-    expect(checkBudget(state, { maxInputTokens: 1001 })).toBe("ok");
+    expect(checkBudget(state, { maxInputTokens: 1001 })).toBe("warning");
   });
 
   it("checkBudget exceeds when maxOutputTokens reached", () => {
@@ -35,13 +35,13 @@ describe("BudgetState token tracking", () => {
     let state = createBudgetState();
     state = recordTokenUsage(state, 300, 200, 0);
     expect(checkBudget(state, { maxTotalTokens: 499 })).toBe("exceeded");
-    expect(checkBudget(state, { maxTotalTokens: 501 })).toBe("ok");
+    expect(checkBudget(state, { maxTotalTokens: 501 })).toBe("warning");
   });
 
   it("checkBudget exceeds when maxCost reached", () => {
     let state = createBudgetState();
     state = recordTokenUsage(state, 0, 0, 1.5);
     expect(checkBudget(state, { maxCost: 1.0 })).toBe("exceeded");
-    expect(checkBudget(state, { maxCost: 2.0 })).toBe("ok");
+    expect(checkBudget(state, { maxCost: 2.0 })).toBe("reassurance");
   });
 });

--- a/packages/agent/test/core/budget.test.ts
+++ b/packages/agent/test/core/budget.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { checkBudget, describeBudgetRemaining, createBudgetState } from "../../src/core/budget";
+
+describe("checkBudget 4-state", () => {
+  it("returns ok when below reassurance threshold", () => {
+    const s = { ...createBudgetState(), turns: 12 };
+    expect(checkBudget(s, { maxTurns: 24 })).toBe("ok");
+  });
+
+  it("returns reassurance when between reassurance and warning thresholds", () => {
+    const s = { ...createBudgetState(), turns: 15 };
+    expect(checkBudget(s, { maxTurns: 24 })).toBe("reassurance");
+  });
+
+  it("returns warning when between warning and exceeded thresholds", () => {
+    const s = { ...createBudgetState(), turns: 20 };
+    expect(checkBudget(s, { maxTurns: 24 })).toBe("warning");
+  });
+
+  it("returns exceeded when at limit", () => {
+    const s = { ...createBudgetState(), turns: 24 };
+    expect(checkBudget(s, { maxTurns: 24 })).toBe("exceeded");
+  });
+
+  it("highest ratio wins (cost at 85%, turns at 21%)", () => {
+    const s = { ...createBudgetState(), totalCost: 0.85 };
+    expect(checkBudget(s, { maxTurns: 24, maxCost: 1.0 })).toBe("warning");
+  });
+
+  it("backward compat: undefined budget uses defaults", () => {
+    expect(checkBudget(createBudgetState())).toBe("ok");
+  });
+
+  it("custom thresholds override defaults", () => {
+    const s = { ...createBudgetState(), turns: 18 };
+    expect(checkBudget(s, { maxTurns: 24, warningThreshold: 0.9, reassuranceThreshold: 0.7 })).toBe(
+      "reassurance",
+    );
+  });
+});
+
+describe("describeBudgetRemaining", () => {
+  it("includes turns remaining", () => {
+    const s = { ...createBudgetState(), turns: 5 };
+    const desc = describeBudgetRemaining(s, { maxTurns: 24 });
+    expect(desc).toContain("19 turns remaining");
+  });
+
+  it("includes cost when maxCost provided", () => {
+    const s = { ...createBudgetState(), totalCost: 0.5 };
+    const desc = describeBudgetRemaining(s, { maxCost: 1.0 });
+    expect(desc).toContain("$0.5000 budget remaining");
+  });
+
+  it("singular turn when 1 remaining", () => {
+    const s = { ...createBudgetState(), turns: 23 };
+    const desc = describeBudgetRemaining(s, { maxTurns: 24 });
+    expect(desc).toContain("1 turn remaining");
+    expect(desc).not.toContain("turns");
+  });
+});

--- a/packages/agent/test/core/delegation.test.ts
+++ b/packages/agent/test/core/delegation.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { checkDelegation } from "../../src/core/delegation";
+import { allocateBudget, checkDelegation } from "../../src/core/delegation";
+import { createBudgetState } from "../../src/core/budget";
 import type { DelegationContext } from "../../src/core/delegation";
 
 const makeContext = (overrides: Partial<DelegationContext> = {}): DelegationContext => ({
   depth: 0,
   maxDepth: 3,
   visitedAgents: new Set(),
-  parentAbort: new AbortController().signal,
+  parentAbort: {} as any,
   budgetPolicy: "inherit",
   ...overrides,
 });
@@ -49,5 +50,62 @@ describe("checkDelegation", () => {
       visitedAgents: new Set(["agent-a"]),
     });
     expect(checkDelegation("agent-a", ctx)).toBe("circular_detected");
+  });
+});
+
+describe("allocateBudget", () => {
+  it("independent returns fixed default budget", () => {
+    const state = createBudgetState();
+    const result = allocateBudget(state, undefined, { budgetPolicy: "independent" });
+    expect(result.maxTurns).toBe(10);
+    expect(result.maxToolCalls).toBe(20);
+  });
+
+  it("inherit passes remaining turns to child", () => {
+    const state = { ...createBudgetState(), turns: 5 };
+    const result = allocateBudget(state, { maxTurns: 24 }, { budgetPolicy: "inherit" });
+    expect(result.maxTurns).toBe(19);
+  });
+
+  it("split allocates remaining × (1-reserve) × allocation", () => {
+    const state = { ...createBudgetState(), turns: 12 };
+    const result = allocateBudget(
+      state,
+      { maxTurns: 24 },
+      {
+        budgetPolicy: "split",
+        budgetAllocation: 0.5,
+        reserveForParent: 0.2,
+      },
+    );
+    expect(result.maxTurns).toBe(4);
+  });
+
+  it("split with near-zero remaining returns at least 1 turn", () => {
+    const state = { ...createBudgetState(), turns: 23 };
+    const result = allocateBudget(
+      state,
+      { maxTurns: 24 },
+      {
+        budgetPolicy: "split",
+        budgetAllocation: 0.5,
+        reserveForParent: 0.2,
+      },
+    );
+    expect(result.maxTurns).toBeGreaterThanOrEqual(1);
+  });
+
+  it("split with cost budget allocates proportionally", () => {
+    const state = { ...createBudgetState(), totalCost: 0.5 };
+    const result = allocateBudget(
+      state,
+      { maxTurns: 24, maxCost: 1.0 },
+      {
+        budgetPolicy: "split",
+        budgetAllocation: 0.5,
+        reserveForParent: 0.2,
+      },
+    );
+    expect(result.maxCost).toBeCloseTo(0.2, 5);
   });
 });

--- a/packages/agent/test/core/event-emitter.test.ts
+++ b/packages/agent/test/core/event-emitter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+
+describe("AgentEventEmitter interface", () => {
+  it("mock emitter captures events", () => {
+    const emitted: Array<{ name: string; data: Record<string, unknown> }> = [];
+    const emitter = {
+      emit(eventName: string, data: Record<string, unknown>) {
+        emitted.push({ name: eventName, data });
+      },
+    };
+
+    emitter.emit("agent.turn.start", { sessionId: "test", time: Date.now(), turnIndex: 0 });
+    emitter.emit("agent.tool.invoked", {
+      sessionId: "test",
+      time: Date.now(),
+      toolCallId: "tc1",
+      toolName: "bash",
+      inputSummary: "ls",
+    });
+    emitter.emit("agent.turn.complete", {
+      sessionId: "test",
+      time: Date.now(),
+      turnIndex: 0,
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+    });
+
+    expect(emitted).toHaveLength(3);
+    expect(emitted[0].name).toBe("agent.turn.start");
+    expect(emitted[1].name).toBe("agent.tool.invoked");
+    expect(emitted[2].name).toBe("agent.turn.complete");
+  });
+
+  it("runs without eventEmitter without errors", () => {
+    const emitter: { emit?: (name: string, data: Record<string, unknown>) => void } = {};
+    emitter.emit?.("agent.turn.start", { sessionId: "test", time: Date.now(), turnIndex: 0 });
+    expect(true).toBe(true);
+  });
+});

--- a/packages/agent/test/core/hooks.test.ts
+++ b/packages/agent/test/core/hooks.test.ts
@@ -1,0 +1,385 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+import type { Run, Sink, Tool } from "@openomni/protocol";
+import type { AgentEvent } from "../../src/core/types";
+import {
+  createStopOutcome,
+  mockProviderData,
+  mockProviderModel,
+  type MockLlmFn,
+} from "../helpers/mock-llm";
+
+let mockRunFn: MockLlmFn = async () => createStopOutcome();
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: { get: mock(async () => mockProviderData) },
+  Provider: { fromModelsDevModel: mock(() => mockProviderModel) },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+  TokenTracker: {
+    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
+  },
+}));
+
+let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+
+beforeAll(async () => {
+  ({ ChatAgent } = await import("../../src/core/chat-agent"));
+});
+
+function resetMockRunFn() {
+  mockRunFn = async () => createStopOutcome();
+}
+
+function newID(prefix: string): string {
+  return `${prefix}-${Math.random().toString(16).slice(2)}`;
+}
+
+function createAssistantMessage(text: string) {
+  return {
+    info: {
+      id: `msg-${Math.random().toString(16).slice(2)}`,
+      sessionID: "hooks-test",
+      role: "assistant" as const,
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: "claude-3-haiku-20240307",
+      providerID: "anthropic",
+      agent: "hooks-test",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    },
+    parts: [
+      {
+        id: `part-${Math.random().toString(16).slice(2)}`,
+        sessionID: "hooks-test",
+        messageID: "msg",
+        type: "text" as const,
+        text,
+      },
+    ],
+  };
+}
+
+async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("Execution hooks", () => {
+  it("preToolUse skip returns skipped result without executing tool", async () => {
+    resetMockRunFn();
+    const executor = mock(
+      async (call: Tool.Call): Promise<Tool.Result> => ({
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "executed",
+        isError: false,
+      }),
+    );
+
+    let observedToolResult: Tool.Result | undefined;
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call: Tool.Call = { id: "call-skip", tool: "bash", input: { command: "ls" } };
+      sink.onToolCall(call);
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+      toolExecutor: executor,
+      hooks: {
+        preToolUse: () => ({ action: "skip", reason: "policy" }),
+      },
+    });
+
+    await agent.run(
+      { messages: [{ role: "user", content: "run tool" }] },
+      {
+        onMessage: () => undefined,
+        onToolCall: () => undefined,
+        onToolResult: (result) => {
+          observedToolResult = result;
+        },
+        onSnapshot: () => undefined,
+      },
+    );
+
+    expect(executor).toHaveBeenCalledTimes(0);
+    expect(observedToolResult?.isError).toBe(false);
+    expect(String(observedToolResult?.output)).toContain("[Skipped: policy]");
+  });
+
+  it("preToolUse transform executes with transformed input", async () => {
+    resetMockRunFn();
+    let receivedInput: Record<string, unknown> | undefined;
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      receivedInput = call.input;
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "ok",
+        isError: false,
+      };
+    });
+
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call: Tool.Call = { id: "call-transform", tool: "bash", input: { command: "ls" } };
+      sink.onToolCall(call);
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+      toolExecutor: executor,
+      hooks: {
+        preToolUse: () => ({ action: "transform", input: { command: "pwd" } }),
+      },
+    });
+
+    await agent.run({ messages: [{ role: "user", content: "run tool" }] });
+
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(receivedInput).toEqual({ command: "pwd" });
+  });
+
+  it("postTurn inject continues with injected message", async () => {
+    resetMockRunFn();
+    let callCount = 0;
+    mockRunFn = async (_input, sink): Promise<Run.Outcome> => {
+      callCount++;
+      sink.onMessage(createAssistantMessage(`turn-${callCount}`));
+      return createStopOutcome();
+    };
+
+    let postTurnCalls = 0;
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      hooks: {
+        postTurn: () => {
+          postTurnCalls++;
+          return postTurnCalls === 1
+            ? { action: "inject", message: "continue please" }
+            : { action: "continue" };
+        },
+      },
+    });
+
+    const result = await agent.run({ messages: [{ role: "user", content: "hello" }] });
+    expect(result.finishReason).toBe("stop");
+    expect(result.guardAborted).toBeUndefined();
+    expect(callCount).toBe(2);
+  });
+
+  it("postTurn abort stops with guardAborted=true", async () => {
+    resetMockRunFn();
+    mockRunFn = async (_input, sink): Promise<Run.Outcome> => {
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      hooks: {
+        postTurn: () => ({ action: "abort", reason: "stop now" }),
+      },
+    });
+
+    const result = await agent.run({ messages: [{ role: "user", content: "hello" }] });
+    expect(result.finishReason).toBe("stop");
+    expect(result.guardAborted).toBe(true);
+  });
+
+  it("hook throws are treated as continue without crashing", async () => {
+    resetMockRunFn();
+    const globalObj = globalThis as unknown as {
+      console: { warn: (...args: unknown[]) => void };
+    };
+    const originalWarn = globalObj.console.warn;
+    const warnSpy = mock(() => undefined);
+    globalObj.console.warn = warnSpy;
+
+    try {
+      const executor = mock(
+        async (call: Tool.Call): Promise<Tool.Result> => ({
+          id: newID("result"),
+          toolCallId: call.id,
+          output: "executed",
+          isError: false,
+        }),
+      );
+
+      mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+        const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+        const call: Tool.Call = { id: "call-throw", tool: "bash", input: { command: "ls" } };
+        if (runInput.toolExecutor) {
+          sink.onToolCall(call);
+          const result = await runInput.toolExecutor(call);
+          sink.onToolResult(result);
+        }
+        sink.onMessage(createAssistantMessage("done"));
+        return createStopOutcome();
+      };
+
+      const agent = ChatAgent.create({
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+        toolExecutor: executor,
+        hooks: {
+          preToolUse: () => {
+            throw new Error("pre-tool-fail");
+          },
+          postTurn: () => {
+            throw new Error("post-turn-fail");
+          },
+        },
+      });
+
+      const result = await agent.run({ messages: [{ role: "user", content: "hello" }] });
+      expect(result.finishReason).toBe("stop");
+      expect(executor).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      globalObj.console.warn = originalWarn;
+    }
+  });
+
+  it("when hooks are not set, behavior remains unchanged", async () => {
+    resetMockRunFn();
+    let inputSeenByExecutor: Record<string, unknown> | undefined;
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      inputSeenByExecutor = call.input;
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "ok",
+        isError: false,
+      };
+    });
+
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call: Tool.Call = { id: "call-no-hooks", tool: "bash", input: { command: "ls" } };
+      if (runInput.toolExecutor) {
+        sink.onToolCall(call);
+        const result = await runInput.toolExecutor(call);
+        sink.onToolResult(result);
+      }
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+      toolExecutor: executor,
+    });
+
+    const result = await agent.run({ messages: [{ role: "user", content: "hello" }] });
+    expect(result.finishReason).toBe("stop");
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(inputSeenByExecutor).toEqual({ command: "ls" });
+  });
+
+  it("hooks.postTurn takes precedence over stepGuard and warns", async () => {
+    resetMockRunFn();
+    const globalObj = globalThis as unknown as {
+      console: { warn: (...args: unknown[]) => void };
+    };
+    const originalWarn = globalObj.console.warn;
+    const warnSpy = mock(() => undefined);
+    globalObj.console.warn = warnSpy;
+
+    try {
+      mockRunFn = async (_input, sink): Promise<Run.Outcome> => {
+        sink.onMessage(createAssistantMessage("done"));
+        return createStopOutcome();
+      };
+
+      const stepGuard = mock(() => ({ action: "abort" as const }));
+      const postTurn = mock(() => ({ action: "continue" as const }));
+
+      const agent = ChatAgent.create({
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        stepGuard,
+        hooks: { postTurn },
+      });
+
+      const result = await agent.run({ messages: [{ role: "user", content: "hello" }] });
+      expect(result.finishReason).toBe("stop");
+      expect(result.guardAborted).toBeUndefined();
+      expect(postTurn).toHaveBeenCalledTimes(1);
+      expect(stepGuard).toHaveBeenCalledTimes(0);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      globalObj.console.warn = originalWarn;
+    }
+  });
+
+  it("stream emits hook_verdict events for preToolUse and postTurn", async () => {
+    resetMockRunFn();
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call: Tool.Call = { id: "call-stream", tool: "bash", input: { command: "ls" } };
+      if (runInput.toolExecutor) {
+        sink.onToolCall(call);
+        const result = await runInput.toolExecutor(call);
+        sink.onToolResult(result);
+      }
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+      toolExecutor: async (call) => ({
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "ok",
+        isError: false,
+      }),
+      hooks: {
+        preToolUse: () => ({ action: "skip", reason: "hook-skip" }),
+        postTurn: () => ({ action: "continue" }),
+      },
+    });
+
+    const events = await collectEvents(
+      agent.stream({ messages: [{ role: "user", content: "hello" }] }),
+    );
+    const hookEvents = events.filter((e) => e.type === "hook_verdict");
+
+    expect(hookEvents).toHaveLength(2);
+    const pre = hookEvents.find(
+      (e): e is Extract<AgentEvent, { type: "hook_verdict" }> =>
+        e.type === "hook_verdict" && e.timing === "pre_tool_use",
+    );
+    const post = hookEvents.find(
+      (e): e is Extract<AgentEvent, { type: "hook_verdict" }> =>
+        e.type === "hook_verdict" && e.timing === "post_turn",
+    );
+
+    expect(pre?.action).toBe("skip");
+    expect(pre?.reason).toBe("hook-skip");
+    expect(post?.action).toBe("continue");
+  });
+});

--- a/packages/agent/test/core/prompt-builder.test.ts
+++ b/packages/agent/test/core/prompt-builder.test.ts
@@ -1,18 +1,5 @@
 import { describe, expect, it } from "bun:test";
-
-function buildSystemPrompt(
-  basePrompt: string | undefined,
-  tools: Array<{ name: string; prompt?: string }>,
-): string | undefined {
-  const toolPrompts = tools
-    .filter((t) => t.prompt)
-    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
-    .join("\n\n");
-
-  if (!toolPrompts) return basePrompt;
-  if (!basePrompt) return toolPrompts;
-  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
-}
+import { buildSystemPrompt } from "../../src/core/prompt-builder";
 
 describe("buildSystemPrompt", () => {
   it("combines base prompt with tool prompt", () => {

--- a/packages/agent/test/core/prompt-builder.test.ts
+++ b/packages/agent/test/core/prompt-builder.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+function buildSystemPrompt(
+  basePrompt: string | undefined,
+  tools: Array<{ name: string; prompt?: string }>,
+): string | undefined {
+  const toolPrompts = tools
+    .filter((t) => t.prompt)
+    .map((t) => `## Tool: ${t.name}\n${t.prompt}`)
+    .join("\n\n");
+
+  if (!toolPrompts) return basePrompt;
+  if (!basePrompt) return toolPrompts;
+  return `${basePrompt}\n\n---\n\n${toolPrompts}`;
+}
+
+describe("buildSystemPrompt", () => {
+  it("combines base prompt with tool prompt", () => {
+    const result = buildSystemPrompt("base", [{ name: "bash", prompt: "rules" }]);
+    expect(result).toBe("base\n\n---\n\n## Tool: bash\nrules");
+  });
+
+  it("returns base prompt when no tool has prompt", () => {
+    const result = buildSystemPrompt("base", [{ name: "bash" }]);
+    expect(result).toBe("base");
+  });
+
+  it("returns tool prompt when no base prompt", () => {
+    const result = buildSystemPrompt(undefined, [{ name: "bash", prompt: "rules" }]);
+    expect(result).toBe("## Tool: bash\nrules");
+  });
+
+  it("returns undefined when no base and no tool prompts", () => {
+    const result = buildSystemPrompt(undefined, []);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/agent/test/core/tool-guard-integration.test.ts
+++ b/packages/agent/test/core/tool-guard-integration.test.ts
@@ -1,0 +1,347 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+import type { Run, Sink, Tool } from "@openomni/protocol";
+import {
+  createStopOutcome,
+  mockProviderData,
+  mockProviderModel,
+  type MockLlmFn,
+} from "../helpers/mock-llm";
+
+let mockRunFn: MockLlmFn = async () => createStopOutcome();
+
+const mockModelsGet = mock(async () => mockProviderData);
+const mockProviderFromModelsDevModel = mock(() => mockProviderModel);
+
+mock.module("@openomni/llm", () => ({
+  ModelsDev: {
+    get: mockModelsGet,
+  },
+  Provider: {
+    fromModelsDevModel: mockProviderFromModelsDevModel,
+  },
+  run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
+  TokenTracker: {
+    extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
+    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
+  },
+}));
+
+let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+
+beforeAll(async () => {
+  ({ ChatAgent } = await import("../../src/core/chat-agent"));
+});
+
+function createAssistantMessage(text: string) {
+  const id = `msg-${Math.random().toString(16).slice(2)}`;
+  const sessionID = "tool-guard-integration-test";
+  const now = Date.now();
+
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "assistant" as const,
+      time: { created: now },
+      parentID: "",
+      modelID: "claude-3-haiku-20240307",
+      providerID: "anthropic",
+      agent: "chat-agent",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    },
+    parts: [
+      {
+        id: `part-${Math.random().toString(16).slice(2)}`,
+        sessionID,
+        messageID: id,
+        type: "text" as const,
+        text,
+      },
+    ],
+  };
+}
+
+function createToolCall(id: string, tool = "bash", input: Record<string, unknown> = {}): Tool.Call {
+  return { id, tool, input };
+}
+
+function newID(prefix: string): string {
+  return `${prefix}-${Math.random().toString(16).slice(2)}`;
+}
+
+function resetMocks() {
+  mockRunFn = async () => createStopOutcome();
+  mockModelsGet.mockClear();
+  mockProviderFromModelsDevModel.mockClear();
+}
+
+describe("ToolGuard integration via toolExecutor", () => {
+  it("deny blocks tool execution in run()", async () => {
+    resetMocks();
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "executed",
+        isError: false,
+      };
+    });
+
+    let observedToolResult: Tool.Result | undefined;
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call = createToolCall("call-deny", "bash", { command: "rm -rf /" });
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolCall(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [
+        {
+          name: "bash",
+          inputSchema: { type: "object", properties: { command: { type: "string" } } },
+        },
+      ],
+      toolExecutor: executor,
+      permissions: {
+        inputRules: [
+          {
+            toolPattern: "bash",
+            field: "command",
+            pattern: "rm\\s+-rf",
+            action: "deny",
+            priority: 10,
+          },
+        ],
+      },
+    });
+
+    await agent.run(
+      { messages: [{ role: "user", content: "run dangerous command" }] },
+      {
+        onMessage: () => undefined,
+        onToolCall: () => undefined,
+        onToolResult: (result) => {
+          observedToolResult = result;
+        },
+        onSnapshot: () => undefined,
+      },
+    );
+
+    expect(executor).toHaveBeenCalledTimes(0);
+    expect(observedToolResult?.isError).toBe(true);
+    expect(String(observedToolResult?.output)).toContain("[Blocked:");
+  });
+
+  it("require_approval blocks tool execution in run() when no approval flow exists", async () => {
+    resetMocks();
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "executed",
+        isError: false,
+      };
+    });
+
+    let observedToolResult: Tool.Result | undefined;
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call = createToolCall("call-approval", "bash", { command: "ls" });
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolCall(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [
+        {
+          name: "bash",
+          inputSchema: { type: "object", properties: { command: { type: "string" } } },
+        },
+      ],
+      toolExecutor: executor,
+      permissions: {
+        requireApproval: ["bash"],
+      },
+    });
+
+    await agent.run(
+      { messages: [{ role: "user", content: "run command with approval" }] },
+      {
+        onMessage: () => undefined,
+        onToolCall: () => undefined,
+        onToolResult: (result) => {
+          observedToolResult = result;
+        },
+        onSnapshot: () => undefined,
+      },
+    );
+
+    expect(executor).toHaveBeenCalledTimes(0);
+    expect(observedToolResult?.isError).toBe(true);
+    expect(String(observedToolResult?.output)).toContain("requires approval");
+  });
+
+  it("allow delegates to original toolExecutor", async () => {
+    resetMocks();
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: `executed:${call.tool}`,
+        isError: false,
+      };
+    });
+
+    let observedToolResult: Tool.Result | undefined;
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call = createToolCall("call-allow", "bash", { command: "ls" });
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolCall(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [
+        {
+          name: "bash",
+          inputSchema: { type: "object", properties: { command: { type: "string" } } },
+        },
+      ],
+      toolExecutor: executor,
+      permissions: {
+        allowlist: ["bash"],
+      },
+    });
+
+    await agent.run(
+      { messages: [{ role: "user", content: "safe command" }] },
+      {
+        onMessage: () => undefined,
+        onToolCall: () => undefined,
+        onToolResult: (result) => {
+          observedToolResult = result;
+        },
+        onSnapshot: () => undefined,
+      },
+    );
+
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(observedToolResult?.isError).toBe(false);
+    expect(observedToolResult?.output).toBe("executed:bash");
+  });
+
+  it("without permissions uses original executor for backward compatibility", async () => {
+    resetMocks();
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "executed",
+        isError: false,
+      };
+    });
+
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call = createToolCall("call-backward", "bash", { command: "rm -rf /" });
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolCall(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [
+        {
+          name: "bash",
+          inputSchema: { type: "object", properties: { command: { type: "string" } } },
+        },
+      ],
+      toolExecutor: executor,
+    });
+
+    await agent.run({ messages: [{ role: "user", content: "dangerous command" }] });
+
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it("deny also blocks tool execution in stream() path", async () => {
+    resetMocks();
+    const executor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      return {
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "executed",
+        isError: false,
+      };
+    });
+
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      const call = createToolCall("call-stream-deny", "bash", { command: "rm -rf /" });
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolCall(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [
+        {
+          name: "bash",
+          inputSchema: { type: "object", properties: { command: { type: "string" } } },
+        },
+      ],
+      toolExecutor: executor,
+      permissions: {
+        inputRules: [
+          {
+            toolPattern: "bash",
+            field: "command",
+            pattern: "rm\\s+-rf",
+            action: "deny",
+            priority: 10,
+          },
+        ],
+      },
+    });
+
+    const events = [] as Array<{ type: string; result?: Tool.Result }>;
+    for await (const event of agent.stream({ messages: [{ role: "user", content: "stream" }] })) {
+      if (event.type === "tool_call_complete") {
+        events.push({ type: event.type, result: event.result });
+      } else {
+        events.push({ type: event.type });
+      }
+    }
+
+    const toolResultEvent = events.find((event) => event.type === "tool_call_complete");
+    expect(executor).toHaveBeenCalledTimes(0);
+    expect(toolResultEvent?.result?.isError).toBe(true);
+    expect(String(toolResultEvent?.result?.output)).toContain("[Blocked:");
+  });
+});

--- a/packages/agent/test/core/tool-guard.test.ts
+++ b/packages/agent/test/core/tool-guard.test.ts
@@ -3,55 +3,164 @@ import { ToolGuard } from "../../src/core/tool-guard";
 
 describe("ToolGuard.check", () => {
   it("allows tool when no restrictions (undefined allowlist)", () => {
-    expect(ToolGuard.check("any_tool", {})).toBe("allow");
+    expect(ToolGuard.check("any_tool", {}, {})).toBe("allow");
   });
 
   it("denies tool on denylist", () => {
-    expect(ToolGuard.check("dangerous_tool", { denylist: ["dangerous_tool"] })).toBe("deny");
+    expect(ToolGuard.check("dangerous_tool", {}, { denylist: ["dangerous_tool"] })).toBe("deny");
   });
 
   it("allows tool not on denylist", () => {
-    expect(ToolGuard.check("safe_tool", { denylist: ["dangerous_tool"] })).toBe("allow");
+    expect(ToolGuard.check("safe_tool", {}, { denylist: ["dangerous_tool"] })).toBe("allow");
   });
 
   it("denies all tools when allowlist is empty array", () => {
-    expect(ToolGuard.check("any_tool", { allowlist: [] })).toBe("deny");
+    expect(ToolGuard.check("any_tool", {}, { allowlist: [] })).toBe("deny");
   });
 
   it("allows all tools when allowlist contains wildcard *", () => {
-    expect(ToolGuard.check("any_tool", { allowlist: ["*"] })).toBe("allow");
+    expect(ToolGuard.check("any_tool", {}, { allowlist: ["*"] })).toBe("allow");
   });
 
   it("allows tool explicitly in allowlist", () => {
-    expect(ToolGuard.check("allowed_tool", { allowlist: ["allowed_tool"] })).toBe("allow");
+    expect(ToolGuard.check("allowed_tool", {}, { allowlist: ["allowed_tool"] })).toBe("allow");
   });
 
   it("denies tool not in allowlist", () => {
-    expect(ToolGuard.check("other_tool", { allowlist: ["allowed_tool"] })).toBe("deny");
+    expect(ToolGuard.check("other_tool", {}, { allowlist: ["allowed_tool"] })).toBe("deny");
   });
 
   it("allows tool matching prefix wildcard mcp.*", () => {
-    expect(ToolGuard.check("mcp.search", { allowlist: ["mcp.*"] })).toBe("allow");
+    expect(ToolGuard.check("mcp.search", {}, { allowlist: ["mcp.*"] })).toBe("allow");
   });
 
   it("denies tool not matching prefix wildcard", () => {
-    expect(ToolGuard.check("other.search", { allowlist: ["mcp.*"] })).toBe("deny");
+    expect(ToolGuard.check("other.search", {}, { allowlist: ["mcp.*"] })).toBe("deny");
   });
 
   it("returns require_approval for tool in requireApproval list", () => {
     expect(
-      ToolGuard.check("sensitive_tool", {
-        requireApproval: ["sensitive_tool"],
-      }),
+      ToolGuard.check(
+        "sensitive_tool",
+        {},
+        {
+          requireApproval: ["sensitive_tool"],
+        },
+      ),
     ).toBe("require_approval");
   });
 
   it("denylist takes priority over requireApproval", () => {
     expect(
-      ToolGuard.check("tool", {
-        denylist: ["tool"],
-        requireApproval: ["tool"],
-      }),
+      ToolGuard.check(
+        "tool",
+        {},
+        {
+          denylist: ["tool"],
+          requireApproval: ["tool"],
+        },
+      ),
+    ).toBe("deny");
+  });
+
+  it("input rule denies bash with rm -rf pattern", () => {
+    expect(
+      ToolGuard.check(
+        "bash",
+        { command: "rm -rf /" },
+        {
+          inputRules: [
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "rm\\s+-rf",
+              action: "deny",
+              priority: 10,
+            },
+          ],
+        },
+      ),
+    ).toBe("deny");
+  });
+
+  it("input rule allows non-matching command", () => {
+    expect(
+      ToolGuard.check(
+        "bash",
+        { command: "ls -la" },
+        {
+          inputRules: [
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "rm\\s+-rf",
+              action: "deny",
+              priority: 10,
+            },
+          ],
+        },
+      ),
+    ).toBe("allow");
+  });
+
+  it("input rule priority: higher priority wins", () => {
+    expect(
+      ToolGuard.check(
+        "bash",
+        { command: "sudo apt install" },
+        {
+          inputRules: [
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "sudo",
+              action: "require_approval",
+              priority: 5,
+            },
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "sudo",
+              action: "deny",
+              priority: 10,
+            },
+          ],
+        },
+      ),
+    ).toBe("deny");
+  });
+
+  it("invalid regex pattern falls back gracefully", () => {
+    expect(
+      ToolGuard.check(
+        "bash",
+        { command: "test" },
+        {
+          inputRules: [
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "[invalid",
+              action: "deny",
+              priority: 10,
+            },
+          ],
+        },
+      ),
+    ).toBe("allow");
+  });
+
+  it("input rule with wildcard toolPattern matches all tools", () => {
+    expect(
+      ToolGuard.check(
+        "file_edit",
+        { filePath: "/etc/passwd" },
+        {
+          inputRules: [
+            { toolPattern: "*", field: "filePath", pattern: "^/etc/", action: "deny", priority: 5 },
+          ],
+        },
+      ),
     ).toBe("deny");
   });
 });

--- a/packages/agent/test/core/tool-guard.test.ts
+++ b/packages/agent/test/core/tool-guard.test.ts
@@ -150,6 +150,46 @@ describe("ToolGuard.check", () => {
     ).toBe("allow");
   });
 
+  it("rejects regex patterns longer than 200 characters", () => {
+    expect(
+      ToolGuard.check(
+        "bash",
+        { command: "safe" },
+        {
+          inputRules: [
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "a".repeat(201),
+              action: "deny",
+              priority: 10,
+            },
+          ],
+        },
+      ),
+    ).toBe("allow");
+  });
+
+  it("truncates long input values before regex matching", () => {
+    expect(
+      ToolGuard.check(
+        "bash",
+        { command: `${"a".repeat(10_000)}b` },
+        {
+          inputRules: [
+            {
+              toolPattern: "bash",
+              field: "command",
+              pattern: "b$",
+              action: "deny",
+              priority: 10,
+            },
+          ],
+        },
+      ),
+    ).toBe("allow");
+  });
+
   it("input rule with wildcard toolPattern matches all tools", () => {
     expect(
       ToolGuard.check(

--- a/packages/agent/test/tsconfig.json
+++ b/packages/agent/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["./**/*", "../src/bun-test.d.ts"]
+}

--- a/packages/protocol/src/event/agent-execution.ts
+++ b/packages/protocol/src/event/agent-execution.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { BusEvent } from "../bus/index.js";
+
+const AgentBase = z.object({
+  sessionId: z.string(),
+  agentId: z.string().optional(),
+  time: z.number(),
+});
+
+export namespace AgentExecution {
+  export const TurnStart = BusEvent.define(
+    "agent.turn.start",
+    AgentBase.extend({
+      turnIndex: z.number(),
+    }),
+  );
+
+  export const TurnComplete = BusEvent.define(
+    "agent.turn.complete",
+    AgentBase.extend({
+      turnIndex: z.number(),
+      usage: z.object({
+        inputTokens: z.number(),
+        outputTokens: z.number(),
+        totalTokens: z.number(),
+        totalCost: z.number().optional(),
+      }),
+    }),
+  );
+
+  export const ToolInvoked = BusEvent.define(
+    "agent.tool.invoked",
+    AgentBase.extend({
+      toolCallId: z.string(),
+      toolName: z.string(),
+      inputSummary: z.string(),
+    }),
+  );
+
+  export const ToolBlocked = BusEvent.define(
+    "agent.tool.blocked",
+    AgentBase.extend({
+      toolCallId: z.string(),
+      toolName: z.string(),
+      reason: z.string(),
+    }),
+  );
+
+  export const BudgetWarning = BusEvent.define(
+    "agent.budget.warning",
+    AgentBase.extend({
+      remaining: z.string(),
+      threshold: z.number(),
+    }),
+  );
+
+  export const BudgetReassurance = BusEvent.define(
+    "agent.budget.reassurance",
+    AgentBase.extend({
+      remaining: z.string(),
+      threshold: z.number(),
+    }),
+  );
+
+  export const Compaction = BusEvent.define(
+    "agent.compaction",
+    AgentBase.extend({
+      messagesBefore: z.number(),
+      messagesAfter: z.number(),
+    }),
+  );
+
+  export const ErrorRetry = BusEvent.define(
+    "agent.error.retry",
+    AgentBase.extend({
+      attempt: z.number(),
+      maxAttempts: z.number(),
+      error: z.string(),
+    }),
+  );
+}

--- a/packages/protocol/src/event/index.ts
+++ b/packages/protocol/src/event/index.ts
@@ -191,3 +191,5 @@ export namespace Agent {
     }),
   );
 }
+
+export * from "./agent-execution.js";

--- a/packages/protocol/src/guardrail/index.ts
+++ b/packages/protocol/src/guardrail/index.ts
@@ -36,8 +36,10 @@ export namespace Guardrail {
 
   export const DelegationPolicy = z.object({
     maxDepth: z.number().default(3),
-    budgetPolicy: z.enum(["inherit", "independent"]),
+    budgetPolicy: z.enum(["inherit", "independent", "split"]),
     abortPropagation: z.boolean(),
+    budgetAllocation: z.number().min(0).max(1).default(0.5),
+    reserveForParent: z.number().min(0).max(1).default(0.2),
   });
   export type DelegationPolicy = z.infer<typeof DelegationPolicy>;
 }

--- a/packages/protocol/src/guardrail/index.ts
+++ b/packages/protocol/src/guardrail/index.ts
@@ -4,7 +4,17 @@ export namespace Guardrail {
   export const InputRule = z.object({
     toolPattern: z.string(),
     field: z.string(),
-    pattern: z.string(),
+    pattern: z.string().refine(
+      (p) => {
+        try {
+          new RegExp(p);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: "pattern must be a valid regular expression" },
+    ),
     action: z.enum(["allow", "deny", "require_approval"]),
     reason: z.string().optional(),
     priority: z.number().default(0),

--- a/packages/protocol/src/guardrail/index.ts
+++ b/packages/protocol/src/guardrail/index.ts
@@ -1,10 +1,21 @@
 import { z } from "zod";
 
 export namespace Guardrail {
+  export const InputRule = z.object({
+    toolPattern: z.string(),
+    field: z.string(),
+    pattern: z.string(),
+    action: z.enum(["allow", "deny", "require_approval"]),
+    reason: z.string().optional(),
+    priority: z.number().default(0),
+  });
+  export type InputRule = z.infer<typeof InputRule>;
+
   export const ToolPermission = z.object({
     allowlist: z.string().array().optional(),
     denylist: z.string().array().optional(),
     requireApproval: z.string().array().optional(),
+    inputRules: InputRule.array().optional(),
   });
   export type ToolPermission = z.infer<typeof ToolPermission>;
 

--- a/packages/protocol/src/hook/index.ts
+++ b/packages/protocol/src/hook/index.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export namespace Hook {
+  export const Timing = z.enum([
+    "pre_tool_use",
+    "post_tool_use",
+    "pre_turn",
+    "post_turn",
+    "on_error",
+  ]);
+  export type Timing = z.infer<typeof Timing>;
+
+  export const Verdict = z.discriminatedUnion("action", [
+    z.object({ action: z.literal("continue") }),
+    z.object({ action: z.literal("skip"), reason: z.string().optional() }),
+    z.object({ action: z.literal("abort"), reason: z.string().optional() }),
+    z.object({ action: z.literal("retry"), reason: z.string().optional() }),
+    z.object({
+      action: z.literal("transform"),
+      input: z.record(z.string(), z.unknown()),
+    }),
+    z.object({
+      action: z.literal("inject"),
+      message: z.string(),
+    }),
+  ]);
+  export type Verdict = z.infer<typeof Verdict>;
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -15,3 +15,4 @@ export * from "./event-log/index.js";
 export * from "./agent/index.js";
 export * from "./artifact/index.js";
 export * from "./gate/index.js";
+export * from "./hook/index.js";

--- a/packages/protocol/src/tool/index.ts
+++ b/packages/protocol/src/tool/index.ts
@@ -68,6 +68,7 @@ export namespace Tool {
     description: z.string().optional(),
     inputSchema: z.record(z.string(), z.unknown()),
     safe: z.boolean().optional(),
+    prompt: z.string().optional(),
   });
   export type Spec = z.infer<typeof Spec>;
 }

--- a/packages/protocol/test/agent-execution.test.ts
+++ b/packages/protocol/test/agent-execution.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { AgentExecution } from "../src/event/agent-execution.js";
+
+describe("AgentExecution BusEvents", () => {
+  const base = { sessionId: "s1", time: Date.now() };
+
+  test("TurnStart parses", () => {
+    expect(() => AgentExecution.TurnStart.schema.parse({ ...base, turnIndex: 0 })).not.toThrow();
+  });
+
+  test("TurnComplete parses", () => {
+    expect(() =>
+      AgentExecution.TurnComplete.schema.parse({
+        ...base,
+        turnIndex: 0,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      }),
+    ).not.toThrow();
+  });
+
+  test("ToolInvoked parses", () => {
+    expect(() =>
+      AgentExecution.ToolInvoked.schema.parse({
+        ...base,
+        toolCallId: "tc1",
+        toolName: "bash",
+        inputSummary: "command: ls",
+      }),
+    ).not.toThrow();
+  });
+
+  test("ToolBlocked parses", () => {
+    expect(() =>
+      AgentExecution.ToolBlocked.schema.parse({
+        ...base,
+        toolCallId: "tc1",
+        toolName: "bash",
+        reason: "denied by policy",
+      }),
+    ).not.toThrow();
+  });
+
+  test("BudgetWarning parses", () => {
+    expect(() =>
+      AgentExecution.BudgetWarning.schema.parse({
+        ...base,
+        remaining: "5 turns remaining",
+        threshold: 0.8,
+      }),
+    ).not.toThrow();
+  });
+
+  test("BudgetReassurance parses", () => {
+    expect(() =>
+      AgentExecution.BudgetReassurance.schema.parse({
+        ...base,
+        remaining: "15 turns remaining",
+        threshold: 0.6,
+      }),
+    ).not.toThrow();
+  });
+
+  test("Compaction parses", () => {
+    expect(() =>
+      AgentExecution.Compaction.schema.parse({
+        ...base,
+        messagesBefore: 20,
+        messagesAfter: 5,
+      }),
+    ).not.toThrow();
+  });
+
+  test("ErrorRetry parses", () => {
+    expect(() =>
+      AgentExecution.ErrorRetry.schema.parse({
+        ...base,
+        attempt: 2,
+        maxAttempts: 3,
+        error: "rate limit",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/protocol/test/guardrail.test.ts
+++ b/packages/protocol/test/guardrail.test.ts
@@ -124,6 +124,8 @@ describe("Guardrail schemas", () => {
       expect(result.maxDepth).toBe(3);
       expect(result.budgetPolicy).toBe("inherit");
       expect(result.abortPropagation).toBe(true);
+      expect(result.budgetAllocation).toBe(0.5);
+      expect(result.reserveForParent).toBe(0.2);
     });
 
     it("parses with explicit maxDepth", () => {
@@ -140,6 +142,40 @@ describe("Guardrail schemas", () => {
         Guardrail.DelegationPolicy.parse({
           budgetPolicy: "shared",
           abortPropagation: true,
+        }),
+      ).toThrow();
+    });
+
+    it("parses split policy", () => {
+      expect(
+        Guardrail.DelegationPolicy.parse({
+          budgetPolicy: "split",
+          budgetAllocation: 0.5,
+          reserveForParent: 0.2,
+          maxDepth: 3,
+          abortPropagation: false,
+        }),
+      ).toBeTruthy();
+    });
+
+    it("keeps backward compatibility for inherit without allocation fields", () => {
+      const result = Guardrail.DelegationPolicy.parse({
+        budgetPolicy: "inherit",
+        maxDepth: 3,
+        abortPropagation: false,
+      });
+
+      expect(result.budgetAllocation).toBe(0.5);
+      expect(result.reserveForParent).toBe(0.2);
+    });
+
+    it("rejects budgetAllocation greater than 1", () => {
+      expect(() =>
+        Guardrail.DelegationPolicy.parse({
+          budgetPolicy: "split",
+          budgetAllocation: 1.5,
+          maxDepth: 3,
+          abortPropagation: false,
         }),
       ).toThrow();
     });

--- a/packages/protocol/test/guardrail.test.ts
+++ b/packages/protocol/test/guardrail.test.ts
@@ -4,6 +4,34 @@ import { Guardrail } from "../src/guardrail/index";
 const it = test;
 
 describe("Guardrail schemas", () => {
+  describe("InputRule", () => {
+    it("parses a basic rule", () => {
+      const result = Guardrail.InputRule.parse({
+        toolPattern: "bash",
+        field: "command",
+        pattern: "rm",
+        action: "deny",
+      });
+
+      expect(result.toolPattern).toBe("bash");
+      expect(result.priority).toBe(0);
+    });
+
+    it("parses a rule with reason and priority", () => {
+      const result = Guardrail.InputRule.parse({
+        toolPattern: "bash",
+        field: "command",
+        pattern: "rm",
+        action: "deny",
+        reason: "dangerous",
+        priority: 10,
+      });
+
+      expect(result.reason).toBe("dangerous");
+      expect(result.priority).toBe(10);
+    });
+  });
+
   describe("ToolPermission", () => {
     it("parses empty object (all optional)", () => {
       expect(() => Guardrail.ToolPermission.parse({})).not.toThrow();
@@ -28,6 +56,27 @@ describe("Guardrail schemas", () => {
         requireApproval: ["sensitive"],
       });
       expect(result.requireApproval).toEqual(["sensitive"]);
+    });
+
+    it("parses with inputRules", () => {
+      const result = Guardrail.ToolPermission.parse({
+        inputRules: [
+          {
+            toolPattern: "bash",
+            field: "command",
+            pattern: "rm",
+            action: "deny",
+          },
+        ],
+      });
+
+      expect(result.inputRules?.[0]).toMatchObject({
+        toolPattern: "bash",
+        field: "command",
+        pattern: "rm",
+        action: "deny",
+        priority: 0,
+      });
     });
   });
 

--- a/packages/protocol/test/hook.test.ts
+++ b/packages/protocol/test/hook.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { Hook } from "../src/hook/index";
+
+describe("Hook.Timing", () => {
+  test("parses valid timing values", () => {
+    expect(Hook.Timing.parse("pre_tool_use")).toBe("pre_tool_use");
+    expect(Hook.Timing.parse("post_turn")).toBe("post_turn");
+  });
+
+  test("rejects invalid timing", () => {
+    expect(() => Hook.Timing.parse("invalid")).toThrow();
+  });
+});
+
+describe("Hook.Verdict", () => {
+  test("parses continue", () => {
+    expect(Hook.Verdict.parse({ action: "continue" })).toEqual({ action: "continue" });
+  });
+
+  test("parses skip with reason", () => {
+    expect(Hook.Verdict.parse({ action: "skip", reason: "test" })).toEqual({
+      action: "skip",
+      reason: "test",
+    });
+  });
+
+  test("parses transform with input", () => {
+    expect(Hook.Verdict.parse({ action: "transform", input: { key: "val" } })).toEqual({
+      action: "transform",
+      input: { key: "val" },
+    });
+  });
+
+  test("parses inject with message", () => {
+    expect(Hook.Verdict.parse({ action: "inject", message: "hello" })).toEqual({
+      action: "inject",
+      message: "hello",
+    });
+  });
+
+  test("rejects invalid action", () => {
+    expect(() => Hook.Verdict.parse({ action: "invalid" })).toThrow();
+  });
+
+  test("parses abort", () => {
+    expect(Hook.Verdict.parse({ action: "abort", reason: "stop" })).toEqual({
+      action: "abort",
+      reason: "stop",
+    });
+  });
+
+  test("parses retry", () => {
+    expect(Hook.Verdict.parse({ action: "retry" })).toEqual({ action: "retry" });
+  });
+});

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -278,6 +278,7 @@ describe("Tool.Spec", () => {
     expect(spec.inputSchema).toEqual({});
     expect(spec.description).toBeUndefined();
     expect(spec.safe).toBeUndefined();
+    expect(spec.prompt).toBeUndefined();
   });
 
   test("parses valid full spec", () => {
@@ -286,10 +287,33 @@ describe("Tool.Spec", () => {
       description: "Search the workspace",
       inputSchema: { type: "object" },
       safe: true,
+      prompt: "rules...",
     });
 
     expect(spec.description).toBe("Search the workspace");
     expect(spec.safe).toBe(true);
+    expect(spec.prompt).toBe("rules...");
+  });
+
+  test("parses valid spec with prompt only", () => {
+    const spec = Tool.Spec.parse({
+      name: "bash",
+      inputSchema: {},
+      prompt: "rules...",
+    });
+
+    expect(spec.name).toBe("bash");
+    expect(spec.prompt).toBe("rules...");
+  });
+
+  test("parses valid spec without prompt", () => {
+    const spec = Tool.Spec.parse({
+      name: "bash",
+      inputSchema: {},
+    });
+
+    expect(spec.name).toBe("bash");
+    expect(spec.prompt).toBeUndefined();
   });
 
   test("rejects missing name", () => {


### PR DESCRIPTION
## Summary

Implements the full agent execution infrastructure covering issues #63-#68: tool prompt injection, input-aware tool guard, 4-state budget with anti-anxiety, execution hooks, bus-based execution events, and subagent budget allocation.

## Changes

### Protocol (`packages/protocol`)
- **Tool.Spec.prompt** — Optional prompt field for tool-specific system prompt injection
- **InputRule schema** — Input-aware pattern matching rules for ToolPermission (toolPattern, field, regex pattern, action, priority)
- **Hook namespace** — `Hook.Timing` (5 values) + `Hook.Verdict` (6-action discriminated union)
- **AgentExecution BusEvents** — 8 events: turn_start, turn_complete, tool_invoked, tool_blocked, budget_warning, budget_reassurance, compaction, error_retry
- **DelegationPolicy.split** — `budgetPolicy: "split"` + `budgetAllocation` + `reserveForParent` fields

### Agent (`packages/agent`)
- **Message factory extraction** — `createUserMessage()`/`createAssistantMessage()` extracted to `message-factory.ts`
- **buildSystemPrompt()** — Synthesizes tool prompts into system prompt with `## Tool: {name}` sections
- **ToolGuard input-aware** — `check()` accepts input, evaluates InputRule with priority sorting and ReDoS protection
- **guardedToolExecutor** — Wraps toolExecutor with ToolGuard; deny → `[Blocked]`, require_approval → stepGuard delegation, allow → execute
- **4-state budget** — `checkBudget()` returns ok → reassurance → warning → exceeded (multi-dimension, highest ratio wins)
- **Budget injection** — Anti-anxiety reassurance at 60%, wrap-up warning at 80% (each exactly once per session)
- **ExecutionHooks** — `preToolUse` + `postTurn` implemented; coexists with stepGuard (hooks take precedence with warning)
- **AgentEventEmitter** — Minimal `emit(eventName, data)` interface; events emitted at correct lifecycle points with `inputSummary` (not full input)
- **allocateBudget()** — inherit/independent/split modes; `budgetPolicy` type derived from Zod schema; `onChildBudgetConsumed` callback for parent budget propagation

## Verification

- `bun run check-types` — PASS
- `bun test` (protocol: 323 tests, agent: 172 tests) — ALL PASS
- `bun run build --filter=@openomni/protocol` — PASS
- 4-agent review wave: Plan Compliance (oracle), Code Quality, Manual QA (30/30 scenarios), Scope Fidelity — ALL APPROVE

Closes #63
Closes #64
Closes #65
Closes #66
Closes #67
Closes #68

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the full agent execution stack: tool prompt injection, input-aware tool guard, 4-state budget with reassurance/warning, execution hooks, bus events, and subagent budget splitting. Implements requirements from issues #63–#68 to improve safety, control, and observability.

- **New Features**
  - `@openomni/protocol`
    - Tool prompts: `Tool.Spec.prompt` is merged into the system prompt as `## Tool: {name}` sections.
    - Guardrails: input-aware `Guardrail.InputRule` for per-field regex matching; `DelegationPolicy` adds `"split"` with `budgetAllocation` and `reserveForParent`.
    - Hooks: `Hook.Timing` and `Hook.Verdict` schemas for pre/post tool/turn and error handling.
    - Bus events: `AgentExecution` events for turn start/complete, tool invoked/blocked, budget reassurance/warning, compaction, and error retry.
  - `@openomni/agent`
    - ToolGuard: wraps `toolExecutor` when `permissions` are provided; evaluates input-aware rules; blocks or requires approval; emits tool events.
    - Budgeting: 4-state `checkBudget()` with one-time reassurance at 60% and warning at 80%; stream emits `budget_reassurance`/`budget_warning`.
    - Hooks: `preToolUse` and `postTurn` execution hooks; hooks take precedence over `stepGuard` with a warning.
    - Events: optional `eventEmitter.emit()` integration for all lifecycle points.
    - Delegation: `allocateBudget()` supports inherit/independent/split; parent budget propagation via `onChildBudgetConsumed`.
    - System prompt builder now auto-includes tool prompts.

- **Migration**
  - No breaking changes; all features are opt-in.
  - To gate tools, pass `permissions` with `allowlist`/`denylist`/`inputRules`.
  - To receive lifecycle telemetry, pass an `eventEmitter`.
  - To guide tools, set `prompt` on each tool spec.
  - If you consume `checkBudget()` directly, handle new states: `"reassurance"` and `"warning"` alongside `"ok"`/`"exceeded"`.

<sup>Written for commit 2eb1c888a2968d114caece0552ca03df2c255018. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

