### PR TITLE
refactor(agent): simplify subagent budget model and add variant/temperature

### DIFF
--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -7,7 +7,6 @@ export interface BudgetState {
   toolRuntimeMs: number;
   totalInputTokens: number;
   totalOutputTokens: number;
-  totalCost: number;
 }
 
 export function createBudgetState(): BudgetState {
@@ -18,7 +17,6 @@ export function createBudgetState(): BudgetState {
     toolRuntimeMs: 0,
     totalInputTokens: 0,
     totalOutputTokens: 0,
-    totalCost: 0,
   };
 }
 
@@ -35,35 +33,18 @@ export function checkBudget(
 
   const elapsed = Date.now() - state.startTime;
 
-  if (elapsed >= maxWallTimeMs) return "exceeded";
-  if (state.turns >= maxTurns) return "exceeded";
-  if (state.toolCalls >= maxToolCalls) return "exceeded";
-  if (state.toolRuntimeMs >= maxToolRuntimeMs) return "exceeded";
+  if (maxWallTimeMs !== -1 && elapsed >= maxWallTimeMs) return "exceeded";
+  if (maxTurns !== -1 && state.turns >= maxTurns) return "exceeded";
+  if (maxToolCalls !== -1 && state.toolCalls >= maxToolCalls) return "exceeded";
+  if (maxToolRuntimeMs !== -1 && state.toolRuntimeMs >= maxToolRuntimeMs) return "exceeded";
 
-  if (budget?.maxInputTokens !== undefined && state.totalInputTokens >= budget.maxInputTokens)
-    return "exceeded";
-  if (budget?.maxOutputTokens !== undefined && state.totalOutputTokens >= budget.maxOutputTokens)
-    return "exceeded";
-  if (
-    budget?.maxTotalTokens !== undefined &&
-    state.totalInputTokens + state.totalOutputTokens >= budget.maxTotalTokens
-  )
-    return "exceeded";
-  if (budget?.maxCost !== undefined && state.totalCost >= budget.maxCost) return "exceeded";
+  const ratios: number[] = [];
+  if (maxWallTimeMs !== -1) ratios.push(elapsed / maxWallTimeMs);
+  if (maxTurns !== -1) ratios.push(state.turns / maxTurns);
+  if (maxToolCalls !== -1) ratios.push(state.toolCalls / maxToolCalls);
+  if (maxToolRuntimeMs !== -1) ratios.push(state.toolRuntimeMs / maxToolRuntimeMs);
 
-  const ratios: number[] = [
-    elapsed / maxWallTimeMs,
-    state.turns / maxTurns,
-    state.toolCalls / maxToolCalls,
-    state.toolRuntimeMs / maxToolRuntimeMs,
-  ];
-  if (budget?.maxCost !== undefined) ratios.push(state.totalCost / budget.maxCost);
-  if (budget?.maxTotalTokens !== undefined)
-    ratios.push((state.totalInputTokens + state.totalOutputTokens) / budget.maxTotalTokens);
-  if (budget?.maxInputTokens !== undefined)
-    ratios.push(state.totalInputTokens / budget.maxInputTokens);
-  if (budget?.maxOutputTokens !== undefined)
-    ratios.push(state.totalOutputTokens / budget.maxOutputTokens);
+  if (ratios.length === 0) return "ok";
 
   const maxRatio = Math.max(...ratios);
 
@@ -75,11 +56,11 @@ export function checkBudget(
 export function describeBudgetRemaining(state: BudgetState, budget?: AgentBudget): string {
   const parts: string[] = [];
   const maxTurns = budget?.maxTurns ?? 24;
-  const remainingTurns = maxTurns - state.turns;
-  parts.push(`${remainingTurns} turn${remainingTurns !== 1 ? "s" : ""} remaining`);
-  if (budget?.maxCost !== undefined) {
-    const remaining = (budget.maxCost - state.totalCost).toFixed(4);
-    parts.push(`$${remaining} budget remaining`);
+  if (maxTurns === -1) {
+    parts.push("unlimited turns remaining");
+  } else {
+    const remainingTurns = maxTurns - state.turns;
+    parts.push(`${remainingTurns} turn${remainingTurns !== 1 ? "s" : ""} remaining`);
   }
   return parts.join(", ");
 }
@@ -100,12 +81,10 @@ export function recordTokenUsage(
   state: BudgetState,
   inputTokens: number,
   outputTokens: number,
-  cost: number,
 ): BudgetState {
   return {
     ...state,
     totalInputTokens: state.totalInputTokens + inputTokens,
     totalOutputTokens: state.totalOutputTokens + outputTokens,
-    totalCost: state.totalCost + cost,
   };
 }

--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -24,11 +24,10 @@ export function checkBudget(
   state: BudgetState,
   budget?: AgentBudget,
 ): "ok" | "reassurance" | "warning" | "exceeded" {
-  const maxWallTimeMs = budget?.maxWallTimeMs !== undefined ? budget.maxWallTimeMs : 5 * 60 * 1000;
-  const maxTurns = budget?.maxTurns !== undefined ? budget.maxTurns : 24;
-  const maxToolCalls = budget?.maxToolCalls !== undefined ? budget.maxToolCalls : 40;
-  const maxToolRuntimeMs =
-    budget?.maxToolRuntimeMs !== undefined ? budget.maxToolRuntimeMs : 2 * 60 * 1000;
+  const maxWallTimeMs = budget?.maxWallTimeMs ?? 5 * 60 * 1000;
+  const maxTurns = budget?.maxTurns ?? 24;
+  const maxToolCalls = budget?.maxToolCalls ?? 40;
+  const maxToolRuntimeMs = budget?.maxToolRuntimeMs ?? 2 * 60 * 1000;
   const warningRatio = budget?.warningThreshold ?? 0.8;
   const reassuranceRatio = budget?.reassuranceThreshold ?? 0.6;
 
@@ -56,7 +55,7 @@ export function checkBudget(
 
 export function describeBudgetRemaining(state: BudgetState, budget?: AgentBudget): string {
   const parts: string[] = [];
-  const maxTurns = budget?.maxTurns !== undefined ? budget.maxTurns : 24;
+  const maxTurns = budget?.maxTurns ?? 24;
   if (maxTurns === -1) {
     parts.push("unlimited turns remaining");
   } else {

--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -24,10 +24,11 @@ export function checkBudget(
   state: BudgetState,
   budget?: AgentBudget,
 ): "ok" | "reassurance" | "warning" | "exceeded" {
-  const maxWallTimeMs = budget?.maxWallTimeMs ?? 5 * 60 * 1000;
-  const maxTurns = budget?.maxTurns ?? 24;
-  const maxToolCalls = budget?.maxToolCalls ?? 40;
-  const maxToolRuntimeMs = budget?.maxToolRuntimeMs ?? 2 * 60 * 1000;
+  const maxWallTimeMs = budget?.maxWallTimeMs !== undefined ? budget.maxWallTimeMs : 5 * 60 * 1000;
+  const maxTurns = budget?.maxTurns !== undefined ? budget.maxTurns : 24;
+  const maxToolCalls = budget?.maxToolCalls !== undefined ? budget.maxToolCalls : 40;
+  const maxToolRuntimeMs =
+    budget?.maxToolRuntimeMs !== undefined ? budget.maxToolRuntimeMs : 2 * 60 * 1000;
   const warningRatio = budget?.warningThreshold ?? 0.8;
   const reassuranceRatio = budget?.reassuranceThreshold ?? 0.6;
 
@@ -55,7 +56,7 @@ export function checkBudget(
 
 export function describeBudgetRemaining(state: BudgetState, budget?: AgentBudget): string {
   const parts: string[] = [];
-  const maxTurns = budget?.maxTurns ?? 24;
+  const maxTurns = budget?.maxTurns !== undefined ? budget.maxTurns : 24;
   if (maxTurns === -1) {
     parts.push("unlimited turns remaining");
   } else {

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -311,13 +311,7 @@ export namespace ChatAgent {
                         },
                         config.model.id,
                       );
-                      budgetState = recordTokenUsage(
-                        budgetState,
-                        tokens.input,
-                        tokens.output,
-                        cost.totalCost,
-                      );
-                      totalUsage.totalCost = (totalUsage.totalCost ?? 0) + cost.totalCost;
+                      budgetState = recordTokenUsage(budgetState, tokens.input, tokens.output);
                     }
                     const text = message.parts
                       .filter((part): part is Message.TextPart => part.type === "text")
@@ -458,7 +452,6 @@ export namespace ChatAgent {
                         inputTokens: totalUsage.inputTokens,
                         outputTokens: totalUsage.outputTokens,
                         totalTokens: totalUsage.totalTokens,
-                        totalCost: totalUsage.totalCost,
                       },
                     });
 

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -43,9 +43,6 @@ function summarizeInput(input: Record<string, unknown>): string {
   }
 }
 
-/**
- * ChatAgent instance interface
- */
 export interface ChatAgentInstance {
   run(input: ChatAgentInput, sink?: Sink): Promise<AgentResult>;
   stream(input: ChatAgentInput, sink?: Sink): AsyncIterable<AgentEvent>;
@@ -171,8 +168,8 @@ function createGuardedToolExecutor(
             });
             return toolExecutor(call);
           }
-        } catch (_error) {
-          void _error;
+        } catch {
+          // stepGuard threw; treat as denial
         }
       }
       eventEmitter?.emit("agent.tool.blocked", {
@@ -266,9 +263,6 @@ function createHookedToolExecutor(
  * ChatAgent namespace — stateless agent for single-turn or multi-turn conversations
  */
 export namespace ChatAgent {
-  /**
-   * Create a new ChatAgent instance
-   */
   export function create(config: ChatAgentConfig): ChatAgentInstance {
     return {
       async run(input: ChatAgentInput, sink?: Sink): Promise<AgentResult> {
@@ -460,9 +454,7 @@ export namespace ChatAgent {
 
                     if (config.hooks?.postTurn) {
                       if (config.stepGuard) {
-                        console.warn(
-                          "[hooks] Both hooks.postTurn and stepGuard are set. hooks.postTurn takes precedence.",
-                        );
+                        console.warn("[hooks] hooks.postTurn takes precedence over stepGuard");
                       }
 
                       const hookContext: HookContext = {

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -444,6 +444,7 @@ export namespace ChatAgent {
                     toolExecutor: hookedExecutor,
                     toolChoice: configuredToolChoice,
                     maxSteps: config.budget?.maxToolCalls ?? 24,
+                    providerOptions: config.providerOptions,
                   };
 
                   const outcome = await llmRun(runInput, trackingSink);

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,4 +1,4 @@
-import { ModelsDev, Provider, run as llmRun, TokenTracker, type RunInput } from "@openomni/llm";
+import { ModelsDev, Provider, run as llmRun, type RunInput } from "@openomni/llm";
 import type { Guardrail, Message, Sink, Tool } from "@openomni/protocol";
 import type {
   AgentEventEmitter,
@@ -304,13 +304,6 @@ export namespace ChatAgent {
                       totalUsage.inputTokens += tokens.input;
                       totalUsage.outputTokens += tokens.output;
                       totalUsage.totalTokens += tokens.input + tokens.output;
-                      const cost = TokenTracker.calculateCost(
-                        {
-                          inputTokens: tokens.input,
-                          outputTokens: tokens.output,
-                        },
-                        config.model.id,
-                      );
                       budgetState = recordTokenUsage(budgetState, tokens.input, tokens.output);
                     }
                     const text = message.parts

--- a/packages/agent/src/core/delegation.ts
+++ b/packages/agent/src/core/delegation.ts
@@ -1,50 +1,10 @@
-import type { BudgetState } from "./budget";
-import type { AgentBudget } from "./types";
-import type { Guardrail } from "@openomni/protocol";
-
 export type DelegationContext = {
   depth: number;
   maxDepth: number;
   visitedAgents: Set<string>;
   parentAbort: AbortSignal;
-  budgetPolicy: Guardrail.DelegationPolicy["budgetPolicy"];
-  budgetAllocation?: number;
-  reserveForParent?: number;
-  parentBudgetState?: BudgetState;
-  parentBudget?: AgentBudget;
-  onChildBudgetConsumed?: (inputTokens: number, outputTokens: number) => void;
+  onChildTokensConsumed?: (inputTokens: number, outputTokens: number) => void;
 };
-
-export function allocateBudget(
-  parentState: BudgetState,
-  parentBudget: AgentBudget | undefined,
-  context: Pick<DelegationContext, "budgetPolicy" | "budgetAllocation" | "reserveForParent">,
-): AgentBudget {
-  const policy = context.budgetPolicy;
-
-  if (policy === "independent") {
-    return { maxTurns: 10, maxToolCalls: 20 };
-  }
-
-  const maxTurns = parentBudget?.maxTurns ?? 24;
-  const remainingTurns = maxTurns - parentState.turns;
-
-  if (policy === "inherit") {
-    return {
-      ...parentBudget,
-      maxTurns: Math.max(1, remainingTurns),
-    };
-  }
-
-  const allocation = context.budgetAllocation ?? 0.5;
-  const reserve = context.reserveForParent ?? 0.2;
-  const factor = (1 - reserve) * allocation;
-
-  return {
-    ...parentBudget,
-    maxTurns: Math.max(1, Math.floor(remainingTurns * factor)),
-  };
-}
 
 export function checkDelegation(
   agentName: string,

--- a/packages/agent/src/core/delegation.ts
+++ b/packages/agent/src/core/delegation.ts
@@ -12,7 +12,7 @@ export type DelegationContext = {
   reserveForParent?: number;
   parentBudgetState?: BudgetState;
   parentBudget?: AgentBudget;
-  onChildBudgetConsumed?: (inputTokens: number, outputTokens: number, cost: number) => void;
+  onChildBudgetConsumed?: (inputTokens: number, outputTokens: number) => void;
 };
 
 export function allocateBudget(
@@ -33,10 +33,6 @@ export function allocateBudget(
     return {
       ...parentBudget,
       maxTurns: Math.max(1, remainingTurns),
-      maxCost:
-        parentBudget?.maxCost !== undefined
-          ? Math.max(0, parentBudget.maxCost - parentState.totalCost)
-          : undefined,
     };
   }
 
@@ -47,10 +43,6 @@ export function allocateBudget(
   return {
     ...parentBudget,
     maxTurns: Math.max(1, Math.floor(remainingTurns * factor)),
-    maxCost:
-      parentBudget?.maxCost !== undefined
-        ? Math.max(0, (parentBudget.maxCost - parentState.totalCost) * factor)
-        : undefined,
   };
 }
 

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -113,8 +113,8 @@ function createGuardedToolExecutor(
             });
             return toolExecutor(call);
           }
-        } catch (_error) {
-          void _error;
+        } catch {
+          // stepGuard threw; fall through to approval-denied response
         }
       }
       eventEmitter?.emit("agent.tool.blocked", {
@@ -191,16 +191,8 @@ function createHookedToolExecutor(
       return toolExecutor(transformed);
     }
 
-    if (verdict.action === "retry") {
-      console.warn(
-        '[hooks.preToolUse] "retry" verdict is not supported for preToolUse, treating as continue',
-      );
-    }
-
-    if (verdict.action === "inject") {
-      console.warn(
-        '[hooks.preToolUse] "inject" verdict is not supported for preToolUse, treating as continue',
-      );
+    if (verdict.action === "retry" || verdict.action === "inject") {
+      console.warn(`[hooks.preToolUse] "${verdict.action}" not supported, treating as continue`);
     }
 
     return toolExecutor(call);

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -400,7 +400,6 @@ export async function* streamAgent(
               inputTokens: totalUsage.inputTokens,
               outputTokens: totalUsage.outputTokens,
               totalTokens: totalUsage.totalTokens,
-              totalCost: totalUsage.totalCost,
             },
           });
 

--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -338,6 +338,7 @@ export async function* streamAgent(
           toolExecutor: hookedExecutor,
           toolChoice: configuredToolChoice,
           maxSteps: config.budget?.maxToolCalls ?? 24,
+          providerOptions: config.providerOptions,
         };
 
         const turnUsage: TokenUsage = {

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -45,7 +45,6 @@ export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
-  totalCost?: number;
 }
 
 export interface AgentBudget {
@@ -53,10 +52,6 @@ export interface AgentBudget {
   maxToolCalls?: number;
   maxWallTimeMs?: number;
   maxToolRuntimeMs?: number;
-  maxInputTokens?: number;
-  maxOutputTokens?: number;
-  maxTotalTokens?: number;
-  maxCost?: number;
   warningThreshold?: number; // 0.0-1.0, default 0.8
   reassuranceThreshold?: number; // 0.0-1.0, default 0.6
 }
@@ -87,6 +82,7 @@ export interface ChatAgentConfig {
   ) => Promise<StepGuardVerdict> | StepGuardVerdict;
   hooks?: ExecutionHooks;
   eventEmitter?: AgentEventEmitter;
+  providerOptions?: Record<string, unknown>;
 }
 
 export interface ChatAgentInput {

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -101,7 +101,7 @@ export namespace SubagentTool {
         };
       }
 
-      const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
+      const childAbort = ctx?.parentAbort;
       const childBudget = definition.budget;
       const model = definition.model ?? fallbackModel;
       const variantOptions = ProviderTransform.resolveVariant(model, definition.variant);

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -1,6 +1,6 @@
 import type { Tool } from "@openomni/protocol";
 import { ChatAgent } from "../../core/chat-agent";
-import { allocateBudget, checkDelegation, type DelegationContext } from "../../core/delegation";
+import { checkDelegation, type DelegationContext } from "../../core/delegation";
 import { AgentRegistry } from "../registry/registry";
 import { AgentMessenger } from "../messenger/messenger";
 import { BusTransport } from "../messenger/transport";
@@ -101,19 +101,7 @@ export namespace SubagentTool {
       }
 
       const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
-      const allocated = ctx?.parentBudgetState
-        ? allocateBudget(ctx.parentBudgetState, ctx.parentBudget, ctx)
-        : definition.budget?.maxTurns
-          ? { maxTurns: definition.budget.maxTurns }
-          : undefined;
-      const childBudget =
-        allocated && definition.budget?.maxTurns
-          ? {
-              ...allocated,
-              maxTurns: Math.min(allocated.maxTurns ?? Infinity, definition.budget.maxTurns),
-            }
-          : allocated;
-
+      const childBudget = definition.budget;
       const model = definition.model ?? fallbackModel;
 
       if (options?.subagentRuntime) {
@@ -162,8 +150,8 @@ export namespace SubagentTool {
           messages: [{ role: "user", content: prompt }],
         });
 
-        if (ctx?.onChildBudgetConsumed && result.usage) {
-          ctx.onChildBudgetConsumed(result.usage.inputTokens, result.usage.outputTokens);
+        if (ctx?.onChildTokensConsumed && result.usage) {
+          ctx.onChildTokensConsumed(result.usage.inputTokens, result.usage.outputTokens);
         }
 
         const messenger = AgentMessenger.create(new BusTransport(), {

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -31,6 +31,20 @@ export interface SubagentToolSpec {
   execute: (args: unknown) => Promise<Tool.Result>;
 }
 
+function resolveVariantOptions(provider: string, variant?: string): Record<string, unknown> {
+  if (!variant) return {};
+  if (provider === "anthropic") {
+    if (variant === "high") return { thinking: { type: "enabled", budgetTokens: 16000 } };
+    if (variant === "max") return { thinking: { type: "enabled", budgetTokens: 31999 } };
+  }
+  if (provider === "openai") {
+    if (variant === "low") return { reasoningEffort: "low", reasoningSummary: "auto" };
+    if (variant === "medium") return { reasoningEffort: "medium", reasoningSummary: "auto" };
+    if (variant === "high") return { reasoningEffort: "high", reasoningSummary: "auto" };
+  }
+  return {};
+}
+
 export namespace SubagentTool {
   const fallbackModel = {
     provider: "anthropic",
@@ -103,6 +117,11 @@ export namespace SubagentTool {
       const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
       const childBudget = definition.budget;
       const model = definition.model ?? fallbackModel;
+      const variantOptions = resolveVariantOptions(model.provider, definition.variant);
+      const providerOptions: Record<string, unknown> = {
+        ...variantOptions,
+        ...(definition.temperature !== undefined && { temperature: definition.temperature }),
+      };
 
       if (options?.subagentRuntime) {
         try {
@@ -144,6 +163,7 @@ export namespace SubagentTool {
           budget: childBudget,
           permissions: definition.permissions,
           signal: childAbort,
+          providerOptions: Object.keys(providerOptions).length > 0 ? providerOptions : undefined,
         });
 
         const result = await childAgent.run({

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -103,14 +103,14 @@ export namespace SubagentTool {
       const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
       const allocated = ctx?.parentBudgetState
         ? allocateBudget(ctx.parentBudgetState, ctx.parentBudget, ctx)
-        : definition.maxTurns
-          ? { maxTurns: definition.maxTurns }
+        : definition.budget?.maxTurns
+          ? { maxTurns: definition.budget.maxTurns }
           : undefined;
       const childBudget =
-        allocated && definition.maxTurns
+        allocated && definition.budget?.maxTurns
           ? {
               ...allocated,
-              maxTurns: Math.min(allocated.maxTurns ?? Infinity, definition.maxTurns),
+              maxTurns: Math.min(allocated.maxTurns ?? Infinity, definition.budget.maxTurns),
             }
           : allocated;
 
@@ -163,11 +163,7 @@ export namespace SubagentTool {
         });
 
         if (ctx?.onChildBudgetConsumed && result.usage) {
-          ctx.onChildBudgetConsumed(
-            result.usage.inputTokens,
-            result.usage.outputTokens,
-            result.usage.totalCost ?? 0,
-          );
+          ctx.onChildBudgetConsumed(result.usage.inputTokens, result.usage.outputTokens);
         }
 
         const messenger = AgentMessenger.create(new BusTransport(), {

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -1,4 +1,5 @@
 import type { Tool } from "@openomni/protocol";
+import { ProviderTransform } from "@openomni/llm";
 import { ChatAgent } from "../../core/chat-agent";
 import { checkDelegation, type DelegationContext } from "../../core/delegation";
 import { AgentRegistry } from "../registry/registry";
@@ -29,20 +30,6 @@ export interface SubagentToolOptions {
 export interface SubagentToolSpec {
   spec: Tool.Spec;
   execute: (args: unknown) => Promise<Tool.Result>;
-}
-
-function resolveVariantOptions(provider: string, variant?: string): Record<string, unknown> {
-  if (!variant) return {};
-  if (provider === "anthropic") {
-    if (variant === "high") return { thinking: { type: "enabled", budgetTokens: 16000 } };
-    if (variant === "max") return { thinking: { type: "enabled", budgetTokens: 31999 } };
-  }
-  if (provider === "openai") {
-    if (variant === "low") return { reasoningEffort: "low", reasoningSummary: "auto" };
-    if (variant === "medium") return { reasoningEffort: "medium", reasoningSummary: "auto" };
-    if (variant === "high") return { reasoningEffort: "high", reasoningSummary: "auto" };
-  }
-  return {};
 }
 
 export namespace SubagentTool {
@@ -117,7 +104,7 @@ export namespace SubagentTool {
       const childAbort = ctx?.parentAbort ? AbortSignal.any([ctx.parentAbort]) : undefined;
       const childBudget = definition.budget;
       const model = definition.model ?? fallbackModel;
-      const variantOptions = resolveVariantOptions(model.provider, definition.variant);
+      const variantOptions = ProviderTransform.resolveVariant(model, definition.variant);
       const providerOptions: Record<string, unknown> = {
         ...variantOptions,
         ...(definition.temperature !== undefined && { temperature: definition.temperature }),

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -24,7 +24,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -25,6 +25,9 @@ mock.module("@openomni/llm", () => ({
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
   },
+  ProviderTransform: {
+    resolveVariant: () => ({}),
+  },
 }));
 
 let ChatAgent: typeof import("../src/core/chat-agent").ChatAgent;

--- a/packages/agent/test/core/budget-tokens.test.ts
+++ b/packages/agent/test/core/budget-tokens.test.ts
@@ -1,47 +1,18 @@
 import { describe, expect, it } from "bun:test";
-import { createBudgetState, checkBudget, recordTokenUsage } from "../../src/core/budget";
+import { createBudgetState, recordTokenUsage } from "../../src/core/budget";
 
 describe("BudgetState token tracking", () => {
   it("starts with zero token counts", () => {
     const state = createBudgetState();
     expect(state.totalInputTokens).toBe(0);
     expect(state.totalOutputTokens).toBe(0);
-    expect(state.totalCost).toBe(0);
   });
 
   it("recordTokenUsage accumulates tokens", () => {
     let state = createBudgetState();
-    state = recordTokenUsage(state, 100, 50, 0.001);
-    state = recordTokenUsage(state, 200, 100, 0.002);
+    state = recordTokenUsage(state, 100, 50);
+    state = recordTokenUsage(state, 200, 100);
     expect(state.totalInputTokens).toBe(300);
     expect(state.totalOutputTokens).toBe(150);
-    expect(state.totalCost).toBeCloseTo(0.003);
-  });
-
-  it("checkBudget exceeds when maxInputTokens reached", () => {
-    let state = createBudgetState();
-    state = recordTokenUsage(state, 1000, 0, 0);
-    expect(checkBudget(state, { maxInputTokens: 999 })).toBe("exceeded");
-    expect(checkBudget(state, { maxInputTokens: 1001 })).toBe("warning");
-  });
-
-  it("checkBudget exceeds when maxOutputTokens reached", () => {
-    let state = createBudgetState();
-    state = recordTokenUsage(state, 0, 500, 0);
-    expect(checkBudget(state, { maxOutputTokens: 499 })).toBe("exceeded");
-  });
-
-  it("checkBudget exceeds when maxTotalTokens reached", () => {
-    let state = createBudgetState();
-    state = recordTokenUsage(state, 300, 200, 0);
-    expect(checkBudget(state, { maxTotalTokens: 499 })).toBe("exceeded");
-    expect(checkBudget(state, { maxTotalTokens: 501 })).toBe("warning");
-  });
-
-  it("checkBudget exceeds when maxCost reached", () => {
-    let state = createBudgetState();
-    state = recordTokenUsage(state, 0, 0, 1.5);
-    expect(checkBudget(state, { maxCost: 1.0 })).toBe("exceeded");
-    expect(checkBudget(state, { maxCost: 2.0 })).toBe("reassurance");
   });
 });

--- a/packages/agent/test/core/budget.test.ts
+++ b/packages/agent/test/core/budget.test.ts
@@ -22,9 +22,26 @@ describe("checkBudget 4-state", () => {
     expect(checkBudget(s, { maxTurns: 24 })).toBe("exceeded");
   });
 
-  it("highest ratio wins (cost at 85%, turns at 21%)", () => {
-    const s = { ...createBudgetState(), totalCost: 0.85 };
-    expect(checkBudget(s, { maxTurns: 24, maxCost: 1.0 })).toBe("warning");
+  it("maxTurns -1 allows unlimited turns", () => {
+    const s = { ...createBudgetState(), turns: 1000 };
+    expect(checkBudget(s, { maxTurns: -1 })).toBe("ok");
+  });
+
+  it("maxTurns -1 with maxToolCalls limit uses only toolCalls ratio", () => {
+    const s = { ...createBudgetState(), turns: 1000, toolCalls: 9 };
+    expect(checkBudget(s, { maxTurns: -1, maxToolCalls: 10 })).toBe("warning");
+  });
+
+  it("all limits -1 always returns ok", () => {
+    const s = { ...createBudgetState(), turns: 1000, toolCalls: 1000, toolRuntimeMs: 1000000 };
+    expect(
+      checkBudget(s, {
+        maxTurns: -1,
+        maxToolCalls: -1,
+        maxWallTimeMs: -1,
+        maxToolRuntimeMs: -1,
+      }),
+    ).toBe("ok");
   });
 
   it("backward compat: undefined budget uses defaults", () => {
@@ -46,10 +63,10 @@ describe("describeBudgetRemaining", () => {
     expect(desc).toContain("19 turns remaining");
   });
 
-  it("includes cost when maxCost provided", () => {
-    const s = { ...createBudgetState(), totalCost: 0.5 };
-    const desc = describeBudgetRemaining(s, { maxCost: 1.0 });
-    expect(desc).toContain("$0.5000 budget remaining");
+  it("displays unlimited when maxTurns is -1", () => {
+    const s = { ...createBudgetState(), turns: 5 };
+    const desc = describeBudgetRemaining(s, { maxTurns: -1 });
+    expect(desc).toContain("unlimited turns remaining");
   });
 
   it("singular turn when 1 remaining", () => {

--- a/packages/agent/test/core/delegation.test.ts
+++ b/packages/agent/test/core/delegation.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { allocateBudget, checkDelegation } from "../../src/core/delegation";
-import { createBudgetState } from "../../src/core/budget";
+import { checkDelegation } from "../../src/core/delegation";
 import type { DelegationContext } from "../../src/core/delegation";
 
 const makeContext = (overrides: Partial<DelegationContext> = {}): DelegationContext => ({
   depth: 0,
   maxDepth: 3,
   visitedAgents: new Set(),
-  parentAbort: {} as any,
-  budgetPolicy: "inherit",
+  parentAbort: {} as AbortSignal,
   ...overrides,
 });
 
@@ -51,61 +49,14 @@ describe("checkDelegation", () => {
     });
     expect(checkDelegation("agent-a", ctx)).toBe("circular_detected");
   });
-});
 
-describe("allocateBudget", () => {
-  it("independent returns fixed default budget", () => {
-    const state = createBudgetState();
-    const result = allocateBudget(state, undefined, { budgetPolicy: "independent" });
-    expect(result.maxTurns).toBe(10);
-    expect(result.maxToolCalls).toBe(20);
-  });
-
-  it("inherit passes remaining turns to child", () => {
-    const state = { ...createBudgetState(), turns: 5 };
-    const result = allocateBudget(state, { maxTurns: 24 }, { budgetPolicy: "inherit" });
-    expect(result.maxTurns).toBe(19);
-  });
-
-  it("split allocates remaining × (1-reserve) × allocation", () => {
-    const state = { ...createBudgetState(), turns: 12 };
-    const result = allocateBudget(
-      state,
-      { maxTurns: 24 },
-      {
-        budgetPolicy: "split",
-        budgetAllocation: 0.5,
-        reserveForParent: 0.2,
-      },
-    );
-    expect(result.maxTurns).toBe(4);
-  });
-
-  it("split with near-zero remaining returns at least 1 turn", () => {
-    const state = { ...createBudgetState(), turns: 23 };
-    const result = allocateBudget(
-      state,
-      { maxTurns: 24 },
-      {
-        budgetPolicy: "split",
-        budgetAllocation: 0.5,
-        reserveForParent: 0.2,
-      },
-    );
-    expect(result.maxTurns).toBeGreaterThanOrEqual(1);
-  });
-
-  it("split with cost budget allocates proportionally", () => {
-    const state = { ...createBudgetState(), totalCost: 0.5 };
-    const result = allocateBudget(
-      state,
-      { maxTurns: 24, maxCost: 1.0 },
-      {
-        budgetPolicy: "split",
-        budgetAllocation: 0.5,
-        reserveForParent: 0.2,
-      },
-    );
-    expect(result.maxCost).toBeCloseTo(0.2, 5);
+  it("simplified DelegationContext can be constructed with only required fields", () => {
+    const ctx: DelegationContext = {
+      depth: 0,
+      maxDepth: 3,
+      visitedAgents: new Set(),
+      parentAbort: {} as AbortSignal,
+    };
+    expect(checkDelegation("agent-a", ctx)).toBe("allow");
   });
 });

--- a/packages/agent/test/core/hooks.test.ts
+++ b/packages/agent/test/core/hooks.test.ts
@@ -17,6 +17,9 @@ mock.module("@openomni/llm", () => ({
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
   },
+  ProviderTransform: {
+    resolveVariant: () => ({}),
+  },
 }));
 
 let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;

--- a/packages/agent/test/core/hooks.test.ts
+++ b/packages/agent/test/core/hooks.test.ts
@@ -16,7 +16,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/agent/test/core/step-guard-stream.test.ts
+++ b/packages/agent/test/core/step-guard-stream.test.ts
@@ -17,6 +17,9 @@ mock.module("@openomni/llm", () => ({
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
   },
+  ProviderTransform: {
+    resolveVariant: () => ({}),
+  },
 }));
 
 let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;

--- a/packages/agent/test/core/step-guard-stream.test.ts
+++ b/packages/agent/test/core/step-guard-stream.test.ts
@@ -16,7 +16,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/agent/test/core/step-guard.test.ts
+++ b/packages/agent/test/core/step-guard.test.ts
@@ -17,6 +17,9 @@ mock.module("@openomni/llm", () => ({
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
   },
+  ProviderTransform: {
+    resolveVariant: () => ({}),
+  },
 }));
 
 let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;

--- a/packages/agent/test/core/step-guard.test.ts
+++ b/packages/agent/test/core/step-guard.test.ts
@@ -16,7 +16,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -17,6 +17,9 @@ mock.module("@openomni/llm", () => ({
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
   },
+  ProviderTransform: {
+    resolveVariant: () => ({}),
+  },
 }));
 
 let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -16,7 +16,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/agent/test/core/tool-guard-integration.test.ts
+++ b/packages/agent/test/core/tool-guard-integration.test.ts
@@ -23,6 +23,9 @@ mock.module("@openomni/llm", () => ({
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
   },
+  ProviderTransform: {
+    resolveVariant: () => ({}),
+  },
 }));
 
 let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;

--- a/packages/agent/test/core/tool-guard-integration.test.ts
+++ b/packages/agent/test/core/tool-guard-integration.test.ts
@@ -22,7 +22,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: unknown, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/agent/test/runtime/tools/subagent.test.ts
+++ b/packages/agent/test/runtime/tools/subagent.test.ts
@@ -54,14 +54,13 @@ describe("SubagentTool", () => {
     resetState();
     AgentRegistry.define(makeDefinition("agent-a"));
     const visited = new Set(["agent-a"]);
-    const parentAbort = {} as any;
+    const parentAbort = {} as AbortSignal;
     const { execute } = SubagentTool.create({
       delegationContext: {
         depth: 1,
         maxDepth: 3,
         visitedAgents: visited,
         parentAbort,
-        budgetPolicy: "inherit",
       },
     });
 
@@ -73,20 +72,65 @@ describe("SubagentTool", () => {
   it("denies when depth limit exceeded", async () => {
     resetState();
     AgentRegistry.define(makeDefinition("agent-b"));
-    const parentAbort = {} as any;
+    const parentAbort = {} as AbortSignal;
     const { execute } = SubagentTool.create({
       delegationContext: {
         depth: 3,
         maxDepth: 3,
         visitedAgents: new Set(),
         parentAbort,
-        budgetPolicy: "inherit",
       },
     });
 
     const result = await execute({ agentName: "agent-b", prompt: "hi" });
     expect(result.isError).toBe(true);
     expect(result.output).toContain("depth");
+  });
+
+  it("passes definition budget directly to child agent", async () => {
+    resetState();
+    mockChatAgentCreate = mock(() => ({
+      run: mock(async () => ({ text: "ok", usage: undefined })),
+    }));
+    AgentRegistry.define(makeDefinition("budget-agent", { budget: { maxTurns: 10 } }));
+    const { execute } = SubagentTool.create();
+    await execute({ agentName: "budget-agent", prompt: "hi" });
+    expect(mockChatAgentCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ budget: { maxTurns: 10 } }),
+    );
+  });
+
+  it("passes temperature as providerOptions to child agent", async () => {
+    resetState();
+    mockChatAgentCreate = mock(() => ({
+      run: mock(async () => ({ text: "ok", usage: undefined })),
+    }));
+    AgentRegistry.define(
+      makeDefinition("temp-agent", {
+        temperature: 0.5,
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      }),
+    );
+    const { execute } = SubagentTool.create();
+    await execute({ agentName: "temp-agent", prompt: "hi" });
+    expect(mockChatAgentCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: expect.objectContaining({ temperature: 0.5 }),
+      }),
+    );
+  });
+
+  it("passes no providerOptions when no variant or temperature", async () => {
+    resetState();
+    mockChatAgentCreate = mock(() => ({
+      run: mock(async () => ({ text: "ok", usage: undefined })),
+    }));
+    AgentRegistry.define(makeDefinition("plain-agent"));
+    const { execute } = SubagentTool.create();
+    await execute({ agentName: "plain-agent", prompt: "hi" });
+    expect(mockChatAgentCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ providerOptions: undefined }),
+    );
   });
 
   it("spec has correct name and inputSchema", () => {

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -128,6 +128,7 @@ export namespace ProviderTransform {
           : undefined;
     if (!npm) return {};
     const syntheticModel = {
+      id: (model as { provider: string; id: string }).id,
       api: { npm },
       capabilities: { reasoning: true },
     } as unknown as Provider.Model;

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -106,9 +106,32 @@ export namespace ProviderTransform {
     return {};
   }
 
-  export function resolveVariant(model: Provider.Model, variant?: string): Record<string, unknown> {
+  export function resolveVariant(model: Provider.Model, variant?: string): Record<string, unknown>;
+  export function resolveVariant(
+    model: { provider: string; id: string },
+    variant?: string,
+  ): Record<string, unknown>;
+  export function resolveVariant(
+    model: Provider.Model | { provider: string; id: string },
+    variant?: string,
+  ): Record<string, unknown> {
     if (!variant) return {};
-    return variants(model)[variant] ?? {};
+    if ("providerID" in model || "capabilities" in model) {
+      return variants(model as Provider.Model)[variant] ?? {};
+    }
+    const providerName = (model as { provider: string; id: string }).provider;
+    const npm =
+      providerName === "anthropic"
+        ? "@ai-sdk/anthropic"
+        : providerName === "openai"
+          ? "@ai-sdk/openai"
+          : undefined;
+    if (!npm) return {};
+    const syntheticModel = {
+      api: { npm },
+      capabilities: { reasoning: true },
+    } as unknown as Provider.Model;
+    return variants(syntheticModel)[variant] ?? {};
   }
 
   function normalizeAnthropic(msgs: SDKMessage[], model: NormalizeOptions): SDKMessage[] {

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -67,7 +67,6 @@ export namespace ProviderTransform {
     const npm = model.api?.npm;
     const id = model.id.toLowerCase();
 
-    // For anthropic models
     if (npm === "@ai-sdk/anthropic" || npm === "@ai-sdk/google-vertex/anthropic") {
       return {
         high: {
@@ -85,7 +84,6 @@ export namespace ProviderTransform {
       };
     }
 
-    // For OpenAI models
     if (npm === "@ai-sdk/openai") {
       return {
         low: {
@@ -184,7 +182,6 @@ export namespace ProviderTransform {
     return applyAnthropicCaching(result);
   }
 
-  /** Inject ephemeral cacheControl on system msgs and last 2 user/assistant msgs. */
   export function applyAnthropicCaching(msgs: SDKMessage[]): SDKMessage[] {
     if (msgs.length === 0) return msgs;
 

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -106,6 +106,11 @@ export namespace ProviderTransform {
     return {};
   }
 
+  export function resolveVariant(model: Provider.Model, variant?: string): Record<string, unknown> {
+    if (!variant) return {};
+    return variants(model)[variant] ?? {};
+  }
+
   function normalizeAnthropic(msgs: SDKMessage[], model: NormalizeOptions): SDKMessage[] {
     let result = msgs
       .map((msg) => {

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -129,6 +129,7 @@ export namespace ProviderTransform {
       id: (model as { provider: string; id: string }).id,
       api: { npm },
       capabilities: { reasoning: true },
+      limit: { output: 64_000 },
     } as unknown as Provider.Model;
     return variants(syntheticModel)[variant] ?? {};
   }

--- a/packages/llm/test/transform/transform.test.ts
+++ b/packages/llm/test/transform/transform.test.ts
@@ -379,3 +379,71 @@ describe("ProviderTransform.topP", () => {
     expect(ProviderTransform.topP(model)).toBeUndefined();
   });
 });
+
+describe("ProviderTransform.resolveVariant", () => {
+  test("resolveVariant with anthropic reasoning model and high variant", () => {
+    const model: Provider.Model = {
+      id: "claude-sonnet-4-20250514",
+      providerID: "anthropic",
+      name: "Claude Sonnet 4",
+      api: { npm: "@ai-sdk/anthropic" },
+      capabilities: { reasoning: true },
+      limit: { context: 200000, output: 32000 },
+    };
+    const result = ProviderTransform.resolveVariant(model, "high");
+    expect(result).toBeDefined();
+    expect(result.thinking).toBeDefined();
+    expect(result.thinking.type).toBe("enabled");
+  });
+
+  test("resolveVariant with openai reasoning model and low variant", () => {
+    const model: Provider.Model = {
+      id: "o4-mini",
+      providerID: "openai",
+      name: "o4-mini",
+      api: { npm: "@ai-sdk/openai" },
+      capabilities: { reasoning: true },
+    };
+    const result = ProviderTransform.resolveVariant(model, "low");
+    expect(result).toBeDefined();
+    expect(result.reasoningEffort).toBe("low");
+    expect(result.reasoningSummary).toBe("auto");
+  });
+
+  test("resolveVariant with non-reasoning model returns empty object", () => {
+    const model: Provider.Model = {
+      id: "gpt-4o",
+      providerID: "openai",
+      name: "GPT-4o",
+      api: { npm: "@ai-sdk/openai" },
+      capabilities: { reasoning: false },
+    };
+    const result = ProviderTransform.resolveVariant(model, "high");
+    expect(result).toEqual({});
+  });
+
+  test("resolveVariant with undefined variant returns empty object", () => {
+    const model: Provider.Model = {
+      id: "claude-sonnet-4-20250514",
+      providerID: "anthropic",
+      name: "Claude Sonnet 4",
+      api: { npm: "@ai-sdk/anthropic" },
+      capabilities: { reasoning: true },
+      limit: { context: 200000, output: 32000 },
+    };
+    const result = ProviderTransform.resolveVariant(model, undefined);
+    expect(result).toEqual({});
+  });
+
+  test("resolveVariant with unknown variant returns empty object", () => {
+    const model: Provider.Model = {
+      id: "o4-mini",
+      providerID: "openai",
+      name: "o4-mini",
+      api: { npm: "@ai-sdk/openai" },
+      capabilities: { reasoning: true },
+    };
+    const result = ProviderTransform.resolveVariant(model, "unknownVariant");
+    expect(result).toEqual({});
+  });
+});

--- a/packages/openomni/test/ingress/_llm-mock.ts
+++ b/packages/openomni/test/ingress/_llm-mock.ts
@@ -91,6 +91,5 @@ mock.module("@openomni/llm", () => ({
   },
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));

--- a/packages/openomni/test/plan/plan-agent-create.test.ts
+++ b/packages/openomni/test/plan/plan-agent-create.test.ts
@@ -35,7 +35,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: MockRunInput, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/openomni/test/plan/plan-agent.test.ts
+++ b/packages/openomni/test/plan/plan-agent.test.ts
@@ -31,7 +31,6 @@ mock.module("@openomni/llm", () => ({
   run: (input: any, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),
-    calculateCost: () => ({ inputCost: 0, outputCost: 0, totalCost: 0 }),
   },
 }));
 

--- a/packages/protocol/src/agent/index.ts
+++ b/packages/protocol/src/agent/index.ts
@@ -2,6 +2,14 @@ import { z } from "zod";
 import { Guardrail } from "../guardrail/index.js";
 
 export namespace AgentProfile {
+  export const AgentBudget = z.object({
+    maxTurns: z.number().optional(),
+    maxToolCalls: z.number().optional(),
+    maxWallTimeMs: z.number().optional(),
+    maxToolRuntimeMs: z.number().optional(),
+  });
+  export type AgentBudget = z.infer<typeof AgentBudget>;
+
   export const Definition = z.object({
     name: z.string(),
     description: z.string(),
@@ -14,7 +22,9 @@ export namespace AgentProfile {
       })
       .optional(),
     permissions: Guardrail.ToolPermission.optional(),
-    maxTurns: z.number().int().positive().optional(),
+    variant: z.string().optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    budget: AgentBudget.optional(),
   });
   export type Definition = z.infer<typeof Definition>;
 }

--- a/packages/protocol/src/agent/index.ts
+++ b/packages/protocol/src/agent/index.ts
@@ -2,11 +2,28 @@ import { z } from "zod";
 import { Guardrail } from "../guardrail/index.js";
 
 export namespace AgentProfile {
+  const budgetLimit = z
+    .number()
+    .int()
+    .refine((n) => n === -1 || n > 0, {
+      message: "must be a positive integer or -1 (unlimited)",
+    });
+
   export const AgentBudget = z.object({
-    maxTurns: z.number().optional(),
-    maxToolCalls: z.number().optional(),
-    maxWallTimeMs: z.number().optional(),
-    maxToolRuntimeMs: z.number().optional(),
+    maxTurns: budgetLimit.optional(),
+    maxToolCalls: budgetLimit.optional(),
+    maxWallTimeMs: z
+      .number()
+      .refine((n) => n === -1 || n > 0, {
+        message: "must be a positive number or -1 (unlimited)",
+      })
+      .optional(),
+    maxToolRuntimeMs: z
+      .number()
+      .refine((n) => n === -1 || n > 0, {
+        message: "must be a positive number or -1 (unlimited)",
+      })
+      .optional(),
   });
   export type AgentBudget = z.infer<typeof AgentBudget>;
 

--- a/packages/protocol/src/event/agent-execution.ts
+++ b/packages/protocol/src/event/agent-execution.ts
@@ -23,7 +23,6 @@ export namespace AgentExecution {
         inputTokens: z.number(),
         outputTokens: z.number(),
         totalTokens: z.number(),
-        totalCost: z.number().optional(),
       }),
     }),
   );

--- a/packages/protocol/src/guardrail/index.ts
+++ b/packages/protocol/src/guardrail/index.ts
@@ -46,10 +46,7 @@ export namespace Guardrail {
 
   export const DelegationPolicy = z.object({
     maxDepth: z.number().default(3),
-    budgetPolicy: z.enum(["inherit", "independent", "split"]),
     abortPropagation: z.boolean(),
-    budgetAllocation: z.number().min(0).max(1).default(0.5),
-    reserveForParent: z.number().min(0).max(1).default(0.2),
   });
   export type DelegationPolicy = z.infer<typeof DelegationPolicy>;
 }

--- a/packages/protocol/src/guardrail/index.ts
+++ b/packages/protocol/src/guardrail/index.ts
@@ -46,7 +46,10 @@ export namespace Guardrail {
 
   export const DelegationPolicy = z.object({
     maxDepth: z.number().default(3),
+    budgetPolicy: z.enum(["inherit", "independent", "split"]),
     abortPropagation: z.boolean(),
+    budgetAllocation: z.number().min(0).max(1).default(0.5),
+    reserveForParent: z.number().min(0).max(1).default(0.2),
   });
   export type DelegationPolicy = z.infer<typeof DelegationPolicy>;
 }

--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -21,11 +21,15 @@ describe("AgentProfile.Definition", () => {
       tools: ["read_file", "write_file"],
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       permissions: { allowlist: ["read_file"] },
-      maxTurns: 10,
+      variant: "high",
+      temperature: 0.7,
+      budget: { maxTurns: 10 },
     });
     expect(result.model?.provider).toBe("anthropic");
     expect(result.permissions?.allowlist).toEqual(["read_file"]);
-    expect(result.maxTurns).toBe(10);
+    expect(result.variant).toBe("high");
+    expect(result.temperature).toBe(0.7);
+    expect(result.budget?.maxTurns).toBe(10);
   });
 
   it("rejects missing required fields", () => {
@@ -34,39 +38,55 @@ describe("AgentProfile.Definition", () => {
 });
 
 describe("rejection (schema-enforced)", () => {
-  it("rejects maxTurns = 0", () =>
+  it("rejects temperature < 0", () =>
     expect(() =>
       AgentProfile.Definition.parse({
         name: "x",
         description: "x",
-        maxTurns: 0,
+        temperature: -0.1,
       }),
     ).toThrow());
-  it("rejects maxTurns = -1", () =>
+  it("rejects temperature > 2", () =>
     expect(() =>
       AgentProfile.Definition.parse({
         name: "x",
         description: "x",
-        maxTurns: -1,
-      }),
-    ).toThrow());
-  it("rejects maxTurns = 1.5", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
-        name: "x",
-        description: "x",
-        maxTurns: 1.5,
+        temperature: 2.1,
       }),
     ).toThrow());
 });
 
 describe("acceptance (documents current behavior)", () => {
-  it("accepts maxTurns = 1", () =>
+  it("accepts variant string", () =>
     expect(() =>
       AgentProfile.Definition.parse({
         name: "x",
         description: "x",
-        maxTurns: 1,
+        variant: "high",
+      }),
+    ).not.toThrow());
+  it("accepts temperature = 0", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        temperature: 0,
+      }),
+    ).not.toThrow());
+  it("accepts temperature = 2", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        temperature: 2,
+      }),
+    ).not.toThrow());
+  it("accepts budget with maxTurns", () =>
+    expect(() =>
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        budget: { maxTurns: 10 },
       }),
     ).not.toThrow());
   it("accepts empty name string", () =>

--- a/packages/protocol/test/guardrail.test.ts
+++ b/packages/protocol/test/guardrail.test.ts
@@ -118,94 +118,44 @@ describe("Guardrail schemas", () => {
   describe("DelegationPolicy", () => {
     it("parses with defaults", () => {
       const result = Guardrail.DelegationPolicy.parse({
-        budgetPolicy: "inherit",
         abortPropagation: true,
       });
       expect(result.maxDepth).toBe(3);
-      expect(result.budgetPolicy).toBe("inherit");
       expect(result.abortPropagation).toBe(true);
-      expect(result.budgetAllocation).toBe(0.5);
-      expect(result.reserveForParent).toBe(0.2);
     });
 
     it("parses with explicit maxDepth", () => {
       const result = Guardrail.DelegationPolicy.parse({
         maxDepth: 5,
-        budgetPolicy: "independent",
         abortPropagation: false,
       });
       expect(result.maxDepth).toBe(5);
+      expect(result.abortPropagation).toBe(false);
     });
 
-    it("rejects invalid budgetPolicy", () => {
+    it("accepts float maxDepth", () =>
       expect(() =>
         Guardrail.DelegationPolicy.parse({
-          budgetPolicy: "shared",
+          maxDepth: 1.5,
           abortPropagation: true,
         }),
-      ).toThrow();
-    });
+      ).not.toThrow());
 
-    it("parses split policy", () => {
-      expect(
-        Guardrail.DelegationPolicy.parse({
-          budgetPolicy: "split",
-          budgetAllocation: 0.5,
-          reserveForParent: 0.2,
-          maxDepth: 3,
-          abortPropagation: false,
-        }),
-      ).toBeTruthy();
-    });
-
-    it("keeps backward compatibility for inherit without allocation fields", () => {
-      const result = Guardrail.DelegationPolicy.parse({
-        budgetPolicy: "inherit",
-        maxDepth: 3,
-        abortPropagation: false,
-      });
-
-      expect(result.budgetAllocation).toBe(0.5);
-      expect(result.reserveForParent).toBe(0.2);
-    });
-
-    it("rejects budgetAllocation greater than 1", () => {
+    it("accepts negative maxDepth", () =>
       expect(() =>
         Guardrail.DelegationPolicy.parse({
-          budgetPolicy: "split",
-          budgetAllocation: 1.5,
-          maxDepth: 3,
-          abortPropagation: false,
+          maxDepth: -1,
+          abortPropagation: true,
         }),
-      ).toThrow();
-    });
+      ).not.toThrow());
 
-    describe("DelegationPolicy.maxDepth (bare z.number())", () => {
-      it("accepts float maxDepth", () =>
-        expect(() =>
-          Guardrail.DelegationPolicy.parse({
-            maxDepth: 1.5,
-            budgetPolicy: "inherit",
-            abortPropagation: true,
-          }),
-        ).not.toThrow());
-      it("accepts negative maxDepth", () =>
-        expect(() =>
-          Guardrail.DelegationPolicy.parse({
-            maxDepth: -1,
-            budgetPolicy: "inherit",
-            abortPropagation: true,
-          }),
-        ).not.toThrow());
-      it("accepts zero maxDepth", () =>
-        expect(() =>
-          Guardrail.DelegationPolicy.parse({
-            maxDepth: 0,
-            budgetPolicy: "inherit",
-            abortPropagation: true,
-          }),
-        ).not.toThrow());
-    });
+    it("accepts zero maxDepth", () =>
+      expect(() =>
+        Guardrail.DelegationPolicy.parse({
+          maxDepth: 0,
+          abortPropagation: true,
+        }),
+      ).not.toThrow());
 
     describe("action enum completeness", () => {
       ["reject", "retry", "warn", "escalate"].forEach((action) => {


### PR DESCRIPTION
## Summary

Closes #81

- Remove over-engineered 3-policy budget allocation (`inherit`/`independent`/`split`) — child budget comes directly from agent definition
- Remove cost-related budget fields (`maxCost`, `maxInputTokens`, `maxOutputTokens`, `maxTotalTokens`, `totalCost`) from `AgentBudget`/`BudgetState`
- Extend `AgentProfile.Definition` with `variant`, `temperature`, and `budget` fields
- Add `-1` as unlimited support in `checkBudget()`
- Add `resolveVariant()` to LLM transform layer for provider-specific variant mapping
- Wire `providerOptions` through `ChatAgent` → `RunInput` for variant/temperature passthrough
- Simplify `DelegationContext` (10 fields → 5), rename `onChildBudgetConsumed` → `onChildTokensConsumed`
- Remove `allocateBudget()` entirely
- Remove `TokenTracker.calculateCost()` usage from agent package

## Changes

| Package | Files | What |
|---------|-------|------|
| protocol | `src/agent/index.ts` | Add `AgentBudget` Zod schema, `variant`, `temperature`, `budget` to Definition; remove `maxTurns` |
| protocol | `src/guardrail/index.ts` | Remove `budgetPolicy`, `budgetAllocation`, `reserveForParent` from `DelegationPolicy` |
| protocol | `src/event/agent-execution.ts` | Remove `totalCost` from `TurnComplete` event |
| agent | `src/core/budget.ts` | Remove cost fields/checks, add `-1` unlimited guards |
| agent | `src/core/types.ts` | Remove cost fields from `AgentBudget`, add `providerOptions` to `ChatAgentConfig` |
| agent | `src/core/delegation.ts` | Remove `allocateBudget()`, simplify `DelegationContext` |
| agent | `src/core/chat-agent.ts` | Remove `calculateCost()` usage, wire `providerOptions` |
| agent | `src/runtime/tools/subagent.ts` | Use `definition.budget` directly, wire variant/temperature via `ProviderTransform.resolveVariant()` |
| llm | `src/transform/index.ts` | Add `resolveVariant()` with `{provider, id}` overload |

## Testing

- 808 tests pass (174 agent + 345 protocol + 289 llm)
- `bun run check-types` passes with 0 errors
- All removed symbols verified absent via grep

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts budget complexity and adds model variant/temperature support. This addresses Linear #81 by removing cost-based budgeting and wiring provider options through `@openomni/llm`.

- **New Features**
  - Add `variant`, `temperature`, and `budget` to `AgentProfile.Definition`; subagents pass these via `providerOptions`.
  - Add `ProviderTransform.resolveVariant()` for provider-specific mapping; `ChatAgent` forwards `providerOptions` to LLM runs.
  - Support `-1` as “unlimited” for turns, wall time, tool calls, and tool runtime.

- **Migration**
  - Move limits to `definition.budget` (e.g., `budget.maxTurns`); remove `definition.maxTurns` and all cost/token budget fields (`maxCost`, `maxInputTokens`, `maxOutputTokens`, `maxTotalTokens`), and stop using `TokenTracker.calculateCost`.
  - Update guardrails and delegation: `DelegationPolicy` drops `budgetPolicy`/allocation fields; `allocateBudget()` is removed; subagents use `definition.budget` directly.
  - Update events and callbacks: remove `usage.totalCost` from `AgentExecution.TurnComplete`; rename `onChildBudgetConsumed` to `onChildTokensConsumed`.
  - Optional: set `variant`/`temperature` on profiles as needed; use `-1` for unlimited budgets.

<sup>Written for commit bf91712683b8eef6a3681bde74981381c8a800fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

