### PR TITLE
fix(openomni,agent): fix subscription leak, model resolution, and edge cases

### DIFF
--- a/packages/agent/src/runtime/tools/background-output.ts
+++ b/packages/agent/src/runtime/tools/background-output.ts
@@ -45,7 +45,16 @@ export namespace BackgroundOutputTool {
         timeout?: number;
       };
 
-      const task = options?.backgroundManager?.getTask(taskId);
+      if (!options?.backgroundManager) {
+        return {
+          id: crypto.randomUUID(),
+          toolCallId: "",
+          output: "Background execution not available: no BackgroundManager configured",
+          isError: true,
+        };
+      }
+
+      const task = options.backgroundManager.getTask(taskId);
       if (!task) {
         return {
           id: crypto.randomUUID(),

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -110,6 +110,16 @@ export namespace SubagentTool {
         }
       }
 
+      const definition = AgentRegistry.get(agentName);
+      if (!definition) {
+        return {
+          id: crypto.randomUUID(),
+          toolCallId: "",
+          output: `Delegation failed: agent '${agentName}' is not registered`,
+          isError: true,
+        };
+      }
+
       if (background) {
         if (!options?.backgroundManager) {
           return {
@@ -122,24 +132,22 @@ export namespace SubagentTool {
         const task = await options.backgroundManager.launch({
           agentName,
           prompt,
-          model: fallbackModel,
-          parentSessionId: sessionId ?? "unknown",
+          model: definition.model ?? fallbackModel,
+          parentSessionId: sessionId ?? `anon_${crypto.randomUUID().slice(0, 8)}`,
         });
+        if (task.status === "failed") {
+          return {
+            id: crypto.randomUUID(),
+            toolCallId: "",
+            output: `Background task failed: ${task.error ?? "unknown error"}`,
+            isError: true,
+          };
+        }
         return {
           id: crypto.randomUUID(),
           toolCallId: "",
           output: `Background task launched.\n\nTask ID: ${task.id}\nStatus: ${task.status}`,
           isError: false,
-        };
-      }
-
-      const definition = AgentRegistry.get(agentName);
-      if (!definition) {
-        return {
-          id: crypto.randomUUID(),
-          toolCallId: "",
-          output: `Delegation failed: agent '${agentName}' is not registered`,
-          isError: true,
         };
       }
 

--- a/packages/openomni/src/subagent/background-manager.ts
+++ b/packages/openomni/src/subagent/background-manager.ts
@@ -40,6 +40,7 @@ export const BackgroundManager = {
     const tasks = new Map<string, Subagent.BackgroundTask>();
     const results = new Map<string, Subagent.BackgroundTaskResult>();
     const controllers = new Map<string, AbortController>();
+    const taskUnsubs = new Map<string, () => void>();
 
     function activeTasks(): Subagent.BackgroundTask[] {
       return [...tasks.values()].filter((t) => t.status === "running" || t.status === "pending");
@@ -65,6 +66,7 @@ export const BackgroundManager = {
           tasks.delete(id);
           results.delete(id);
           controllers.delete(id);
+          taskUnsubs.delete(id);
         }
       }
     }
@@ -91,7 +93,7 @@ export const BackgroundManager = {
         return makeFailedTask(input, `max depth (${maxDepth}) exceeded`);
       }
 
-      const descendantCount = [...tasks.values()].filter(
+      const descendantCount = active.filter(
         (t) => t.parentSessionId === input.parentSessionId,
       ).length;
       if (descendantCount >= maxDescendants) {
@@ -156,11 +158,13 @@ export const BackgroundManager = {
 
       const runUnsubs: Array<() => void> = [];
       const cleanupRunSubs = () => runUnsubs.forEach((u) => u());
+      taskUnsubs.set(id, cleanupRunSubs);
 
       runUnsubs.push(
         Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
           if (data.payload.sessionId !== sessionId) return;
           cleanupRunSubs();
+          taskUnsubs.delete(id);
 
           const current = tasks.get(id);
           if (!current || current.status === "cancelled") return;
@@ -204,6 +208,7 @@ export const BackgroundManager = {
         Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
           if (data.payload.sessionId !== sessionId) return;
           cleanupRunSubs();
+          taskUnsubs.delete(id);
 
           const current = tasks.get(id);
           if (!current || current.status === "cancelled") return;
@@ -212,7 +217,7 @@ export const BackgroundManager = {
             ...current,
             status: "failed",
             completedAt: Date.now(),
-            error: data.payload.error,
+            error: data.payload.error ?? "unknown error",
           };
           tasks.set(id, failed);
 
@@ -223,7 +228,7 @@ export const BackgroundManager = {
           Bus.publish(Subagent.Events.BackgroundTaskFailed, {
             traceId: crypto.randomUUID(),
             time: Date.now(),
-            payload: { taskId: id, error: data.payload.error },
+            payload: { taskId: id, error: data.payload.error ?? "unknown error" },
           });
         }),
       );
@@ -249,6 +254,8 @@ export const BackgroundManager = {
         return false;
 
       controllers.get(taskId)?.abort();
+      taskUnsubs.get(taskId)?.();
+      taskUnsubs.delete(taskId);
       tasks.set(taskId, { ...task, status: "cancelled", completedAt: Date.now() });
 
       Bus.publish(Subagent.Events.BackgroundTaskCancelled, {


### PR DESCRIPTION
## Summary

- Fix Bus subscription memory leak when background tasks are cancelled
- Use agent's configured model instead of hardcoded fallback for background tasks
- Fix descendant count to only count active tasks, not terminal ones
- Add explicit error handling for edge cases

## Fixes

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | P1 | Bus subscription leak on cancel — `WorkerRunCompleted`/`WorkerRunFailed` handlers never unsubscribed for cancelled tasks | Store cleanup fn in `taskUnsubs` Map, call from `cancel()` |
| 2 | P1 | `parentSessionId: "unknown"` poisons descendant limit for all tasks without explicit session | Generate unique `anon_` prefix per call |
| 3 | P2 | `makeFailedTask` result reported as "launched" to LLM | Check `task.status === "failed"` and return `isError: true` |
| 4 | P2 | `descendantCount` includes completed/failed tasks, permanently blocking new launches | Filter to `active` tasks only |
| 5 | P2 | Background tasks skip `AgentRegistry` check and always use `fallbackModel` (haiku) | Move registry check before background branch, use `definition.model` |
| 6 | P3 | `background-output` returns misleading "Task not found" when no BackgroundManager configured | Add explicit `backgroundManager` guard |
| 7 | P3 | `WorkerRunFailed` with `undefined` error propagates as `undefined` | Fallback to `"unknown error"` |

## Files Changed

- `packages/openomni/src/subagent/background-manager.ts` — Fixes 1, 4, 7
- `packages/agent/src/runtime/tools/subagent.ts` — Fixes 2, 3, 5
- `packages/agent/src/runtime/tools/background-output.ts` — Fix 6

## Testing

- `bun test --cwd packages/agent` — 294 pass
- `bun test background-manager.test.ts + background-integration.test.ts` — 27 pass
- `bun run check-types` — 0 errors

Follow-up to #88. Issues identified by Oracle architecture review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background task leaks and ensures background subagent runs use the registered model. Improves descendant counting and error handling to prevent blocked launches and clearer messages across `packages/openomni` and `packages/agent`.

- **Bug Fixes**
  - Stop Bus subscription leak on cancel/finish by tracking per-task unsubs and cleaning up (`background-manager.ts`).
  - Use the agent’s configured model for background runs; fail fast if the agent isn’t registered (`subagent.ts`).
  - Count only active descendants when enforcing limits; exclude completed/failed tasks (`background-manager.ts`).
  - Generate unique `anon_` session IDs when none is provided to avoid cross-task collisions (`subagent.ts`).
  - Return `isError: true` when a background launch immediately fails instead of reporting “launched” (`subagent.ts`).
  - Show a clear error when no `BackgroundManager` is configured and normalize undefined worker errors to “unknown error” (`background-output.ts`, `background-manager.ts`).

<sup>Written for commit 71139eefa5cf5873974a02ecc390ca480dce949d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

