### PR TITLE
fix(openomni): fix test mock pollution and simplify test:ci

### DIFF
--- a/packages/openomni/package.json
+++ b/packages/openomni/package.json
@@ -9,7 +9,7 @@
     "check-types": "tsc --noEmit",
     "lint": "bunx biome check ./src",
     "test": "bun test",
-    "test:ci": "bun test test/dag test/plan test/subagent test/ingress"
+    "test:ci": "bun test"
   },
   "dependencies": {
     "@openomni/agent": "workspace:*",

--- a/packages/openomni/test/plan/plan-agent-create.test.ts
+++ b/packages/openomni/test/plan/plan-agent-create.test.ts
@@ -32,6 +32,7 @@ const mockProviderFromModelsDevModel = mock(() => ({
 mock.module("@openomni/llm", () => ({
   ModelsDev: { get: mockModelsGet },
   Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  ProviderTransform: { resolveVariant: () => ({}) },
   run: (input: MockRunInput, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),

--- a/packages/openomni/test/plan/plan-agent.test.ts
+++ b/packages/openomni/test/plan/plan-agent.test.ts
@@ -28,6 +28,7 @@ const mockProviderFromModelsDevModel = mock(() => ({
 mock.module("@openomni/llm", () => ({
   ModelsDev: { get: mockModelsGet },
   Provider: { fromModelsDevModel: mockProviderFromModelsDevModel },
+  ProviderTransform: { resolveVariant: () => ({}) },
   run: (input: any, sink: Sink) => mockRunFn(input, sink),
   TokenTracker: {
     extractUsage: () => ({ inputTokens: 0, outputTokens: 0 }),

--- a/packages/openomni/test/plan/plan-enricher.test.ts
+++ b/packages/openomni/test/plan/plan-enricher.test.ts
@@ -1,23 +1,28 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Gate, Plan } from "@openomni/protocol";
 
-// Prevent module cache contamination from @openomni/llm missing exports
-mock.module("@openomni/agent", () => ({
-  ChatAgent: { create: () => ({ run: async () => ({ text: "{}" }) }) },
-}));
+type GenerateFn = Awaited<typeof import("../../src/plan/plan-agent")>["PlanAgent"]["generate"];
 
-const mockGenerate = mock(async () => ({ plan: createPlan("plan-default") }));
-
-mock.module("../../src/plan/plan-agent", () => ({
-  PlanAgent: {
-    generate: mockGenerate,
-  },
+const mockGenerate = mock<GenerateFn>(async (_goal, _config) => ({
+  plan: createPlan("plan-default"),
 }));
 
 let PlanPipeline: typeof import("../../src/plan/plan-pipeline").PlanPipeline;
+let originalGenerate: GenerateFn;
 
 beforeAll(async () => {
+  const { PlanAgent } = await import("../../src/plan/plan-agent");
+  originalGenerate = PlanAgent.generate;
+  PlanAgent.generate = mockGenerate;
   ({ PlanPipeline } = await import("../../src/plan/plan-pipeline"));
+});
+
+afterAll(() => {
+  if (originalGenerate) {
+    import("../../src/plan/plan-agent").then(({ PlanAgent }) => {
+      PlanAgent.generate = originalGenerate;
+    });
+  }
 });
 
 beforeEach(() => {

--- a/packages/openomni/test/plan/plan-pipeline.test.ts
+++ b/packages/openomni/test/plan/plan-pipeline.test.ts
@@ -1,23 +1,28 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Gate, Plan } from "@openomni/protocol";
 
-// Prevent module cache contamination from @openomni/llm missing exports
-mock.module("@openomni/agent", () => ({
-  ChatAgent: { create: () => ({ run: async () => ({ text: "{}" }) }) },
-}));
+type GenerateFn = Awaited<typeof import("../../src/plan/plan-agent")>["PlanAgent"]["generate"];
 
-const mockGenerate = mock(async () => ({ plan: createPlan("plan-default") }));
-
-mock.module("../../src/plan/plan-agent", () => ({
-  PlanAgent: {
-    generate: mockGenerate,
-  },
+const mockGenerate = mock<GenerateFn>(async (_goal, _config) => ({
+  plan: createPlan("plan-default"),
 }));
 
 let PlanPipeline: typeof import("../../src/plan/plan-pipeline").PlanPipeline;
+let originalGenerate: GenerateFn;
 
 beforeAll(async () => {
+  const { PlanAgent } = await import("../../src/plan/plan-agent");
+  originalGenerate = PlanAgent.generate;
+  PlanAgent.generate = mockGenerate;
   ({ PlanPipeline } = await import("../../src/plan/plan-pipeline"));
+});
+
+afterAll(() => {
+  if (originalGenerate) {
+    import("../../src/plan/plan-agent").then(({ PlanAgent }) => {
+      PlanAgent.generate = originalGenerate;
+    });
+  }
 });
 
 beforeEach(() => {

--- a/packages/openomni/test/plan/plan-pipeline.test.ts
+++ b/packages/openomni/test/plan/plan-pipeline.test.ts
@@ -17,11 +17,10 @@ beforeAll(async () => {
   ({ PlanPipeline } = await import("../../src/plan/plan-pipeline"));
 });
 
-afterAll(() => {
+afterAll(async () => {
   if (originalGenerate) {
-    import("../../src/plan/plan-agent").then(({ PlanAgent }) => {
-      PlanAgent.generate = originalGenerate;
-    });
+    const { PlanAgent } = await import("../../src/plan/plan-agent");
+    PlanAgent.generate = originalGenerate;
   }
 });
 


### PR DESCRIPTION
## Summary

- Simplify `test:ci` from hardcoded directory list to plain `bun test` — no more breakage when test directories are added/removed
- Fix mock pollution causing 6 `PlanAgent.generate` test failures when run in full suite
- Add missing `ProviderTransform` stub to `@openomni/llm` mocks in plan test files

## Root Cause

`plan-enricher.test.ts` and `plan-pipeline.test.ts` used `mock.module("../../src/plan/plan-agent", ...)` to replace the internal PlanAgent module. Bun's `mock.module` for relative paths doesn't properly restore via `mock.restore()`, leaving a stale mock that contaminated `plan-agent.test.ts` when running in the same process.

## Fix

Replace internal module mocking with direct property swap on the PlanAgent namespace:
```typescript
// Before (breaks other tests)
mock.module("../../src/plan/plan-agent", () => ({ PlanAgent: { generate: mockFn } }));

// After (isolated, restorable)
const original = PlanAgent.generate;
PlanAgent.generate = mockFn;
// afterAll: PlanAgent.generate = original;
```

## Verification

- `bun test` in packages/openomni: **236 pass, 0 fail** (was 230 pass, 6 fail)
- `bun run check-types`: **10/10 pass**
- `bun run test` workspace-wide: **8/8 pass**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mock pollution in plan tests and simplifies the `test:ci` script. The full suite now runs cleanly and won’t break when test folders change.

- **Bug Fixes**
  - Replaced `mock.module` for internal `../../src/plan/plan-agent` with a direct `PlanAgent.generate` swap and restore to isolate tests.
  - Added missing `ProviderTransform.resolveVariant` stub to `@openomni/llm` mocks.
  - Resolves 6 `PlanAgent.generate` failures when running the full suite.

- **Refactors**
  - Simplified `test:ci` from a hardcoded directory list to `bun test` to automatically include all tests.

<sup>Written for commit 9d7361c32bd451060e44b55c88cbca5848a9f1bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

