### PR TITLE
fix(agent): propagate usage through middleware contexts

### DIFF
--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -45,6 +45,18 @@ export async function* streamAgent(
   let lastError = "";
 
   while (attempt <= retryPolicy.maxAttempts) {
+    let budgetState = createBudgetState();
+    let messages = toMessagesWithParts(input.messages, "stream-engine");
+    let lastAssistantText = "";
+    const steps: AgentStep[] = [];
+    const totalUsage: TokenUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+    let continuationCount = 0;
+    let compactionCount = 0;
+    const startTime = Date.now();
     const engine = MiddlewareEngine.create();
     engine.register(createBudgetReassuranceMiddleware());
     engine.register(createBudgetWarningMiddleware());
@@ -72,19 +84,7 @@ export async function* streamAgent(
     }
     try {
       const providerModel = await resolveProviderModel(config.model);
-      let budgetState = createBudgetState();
-      let messages = toMessagesWithParts(input.messages, "stream-engine");
-      let lastAssistantText = "";
-      const steps: AgentStep[] = [];
-      const totalUsage: TokenUsage = {
-        inputTokens: 0,
-        outputTokens: 0,
-        totalTokens: 0,
-      };
       let turnIndex = 0;
-      let continuationCount = 0;
-      let compactionCount = 0;
-      const startTime = Date.now();
       const configuredToolChoice = (
         config as ChatAgentConfig & { toolChoice?: "auto" | "required" | "none" }
       ).toolChoice;
@@ -217,6 +217,7 @@ export async function* streamAgent(
                 steps,
                 turnCount: budgetState.turns,
                 elapsedMs: Date.now() - startTime,
+                usage: totalUsage,
               }),
               onVerdict: (verdict) => preToolUseVerdicts.push(verdict),
             })
@@ -444,23 +445,28 @@ export async function* streamAgent(
     } catch (error) {
       const onErrorVerdict = await engine.dispatch("on_error", {
         toolInput: { error: error instanceof Error ? error : new Error(String(error)) },
-        steps: [],
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        turnCount: 0,
+        steps,
+        usage: totalUsage,
+        turnCount: budgetState.turns,
         isCompletion: false,
-        continuationCount: 0,
-        elapsedMs: 0,
+        continuationCount,
+        elapsedMs: Date.now() - startTime,
+        messages,
+        budgetState,
+        budget: config.budget,
+        eventEmitter: config.eventEmitter,
       });
 
       if (onErrorVerdict.action === "abort") {
         yield {
           type: "complete",
           result: {
-            text: "",
-            steps: [],
-            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            text: lastAssistantText,
+            steps,
+            usage: totalUsage,
             finishReason: "stop",
             guardAborted: true,
+            compactionCount: compactionCount > 0 ? compactionCount : undefined,
           },
         };
         return;

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -1,11 +1,13 @@
 import type { Tool } from "@openomni/protocol";
-import type { HookContext, HookVerdict } from "../types";
+import type { HookContext, HookVerdict, TokenUsage } from "../types";
 import type { MiddlewareEngineInstance } from "../middleware";
 
 export interface ToolExecutorOptions {
   toolExecutor: (call: Tool.Call) => Promise<Tool.Result>;
   engine: MiddlewareEngineInstance;
-  getContext?: () => Omit<HookContext, "toolName" | "toolCallId" | "input">;
+  getContext?: () => Omit<HookContext, "toolName" | "toolCallId" | "input"> & {
+    usage?: TokenUsage;
+  };
   onVerdict?: (verdict: HookVerdict) => void;
 }
 
@@ -16,11 +18,12 @@ export function createToolExecutor(
 
   return async (call: Tool.Call): Promise<Tool.Result> => {
     const ctx = getContext?.();
+    const usage = ctx?.usage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     const preVerdict = await engine.dispatch("pre_tool_use", {
       steps: ctx?.steps ?? [],
       turnCount: ctx?.turnCount ?? 0,
       elapsedMs: ctx?.elapsedMs ?? 0,
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      usage,
       isCompletion: false,
       continuationCount: 0,
       toolName: call.tool,
@@ -60,7 +63,7 @@ export function createToolExecutor(
       steps: ctx?.steps ?? [],
       turnCount: ctx?.turnCount ?? 0,
       elapsedMs: ctx?.elapsedMs ?? 0,
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      usage,
       isCompletion: false,
       continuationCount: 0,
       toolName: call.tool,

--- a/packages/agent/test/core/hooks.test.ts
+++ b/packages/agent/test/core/hooks.test.ts
@@ -36,7 +36,8 @@ function newID(prefix: string): string {
   return `${prefix}-${Math.random().toString(16).slice(2)}`;
 }
 
-function createAssistantMessage(text: string) {
+function createAssistantMessage(text: string, tokens?: { input: number; output: number }) {
+  const usage = tokens ?? { input: 0, output: 0 };
   return {
     info: {
       id: `msg-${Math.random().toString(16).slice(2)}`,
@@ -50,8 +51,8 @@ function createAssistantMessage(text: string) {
       path: { cwd: "", root: "" },
       cost: 0,
       tokens: {
-        input: 0,
-        output: 0,
+        input: usage.input,
+        output: usage.output,
         reasoning: 0,
         cache: { read: 0, write: 0 },
       },
@@ -161,6 +162,54 @@ describe("Execution hooks", () => {
 
     expect(executor).toHaveBeenCalledTimes(1);
     expect(receivedInput).toEqual({ command: "pwd" });
+  });
+
+  it("post_tool_use middleware receives accumulated usage from the stream engine", async () => {
+    resetMockRunFn();
+    let seenUsage:
+      | {
+          inputTokens: number;
+          outputTokens: number;
+          totalTokens: number;
+        }
+      | undefined;
+
+    mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+      const runInput = input as { toolExecutor?: (call: Tool.Call) => Promise<Tool.Result> };
+      sink.onMessage(createAssistantMessage("thinking", { input: 11, output: 7 }));
+      const call: Tool.Call = { id: "call-usage", tool: "bash", input: { command: "ls" } };
+      sink.onToolCall(call);
+      const result = await runInput.toolExecutor!(call);
+      sink.onToolResult(result);
+      sink.onMessage(createAssistantMessage("done"));
+      return createStopOutcome();
+    };
+
+    const agent = ChatAgent.create({
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+      toolExecutor: async (call) => ({
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "ok",
+        isError: false,
+      }),
+      middleware: [
+        {
+          name: "test:usage-capture",
+          timing: "post_tool_use",
+          priority: 100,
+          fn: (ctx) => {
+            seenUsage = ctx.usage;
+            return { action: "continue" };
+          },
+        },
+      ],
+    });
+
+    await agent.run({ messages: [{ role: "user", content: "run tool" }] });
+
+    expect(seenUsage).toEqual({ inputTokens: 11, outputTokens: 7, totalTokens: 18 });
   });
 
   it("postTurn inject continues with injected message", async () => {

--- a/packages/agent/test/core/middleware/dispatch-completion.test.ts
+++ b/packages/agent/test/core/middleware/dispatch-completion.test.ts
@@ -41,6 +41,39 @@ describe("post_tool_use middleware dispatch", () => {
     expect(calledCtx.toolOutput).toBe(toolOutput);
   });
 
+  it("forwards usage from getContext to tool middleware", async () => {
+    const postToolFn = mock((_ctx: MiddlewareContext) => ({ action: "continue" as const }));
+
+    const engine = MiddlewareEngine.create();
+    engine.register({
+      name: "test:post_tool_use",
+      timing: "post_tool_use",
+      priority: 100,
+      fn: postToolFn,
+    });
+
+    const executor = createToolExecutor({
+      toolExecutor: async (call) => ({
+        id: newID("result"),
+        toolCallId: call.id,
+        output: "ok",
+        isError: false,
+      }),
+      engine,
+      getContext: () => ({
+        steps: [],
+        turnCount: 1,
+        elapsedMs: 5,
+        usage: { inputTokens: 13, outputTokens: 8, totalTokens: 21 },
+      }),
+    });
+
+    await executor({ id: "call-usage", tool: "bash", input: { command: "ls" } });
+
+    const calledCtx = postToolFn.mock.calls[0][0] as MiddlewareContext;
+    expect(calledCtx.usage).toEqual({ inputTokens: 13, outputTokens: 8, totalTokens: 21 });
+  });
+
   it("transform verdict modifies the tool output", async () => {
     const engine = MiddlewareEngine.create();
     engine.register({

--- a/packages/agent/test/core/run-delegation.test.ts
+++ b/packages/agent/test/core/run-delegation.test.ts
@@ -174,6 +174,42 @@ describe("run() delegation contract", () => {
     await expect(agent.run(defaultInput)).rejects.toThrow("connection refused");
   });
 
+  it("preserves accumulated usage when on_error middleware aborts", async () => {
+    mockRunFn = async (_input, sink) => {
+      sink.onMessage(makeAssistantMessage("partial", 9, 4));
+      return createErrorOutcome("connection refused");
+    };
+
+    let seenUsage:
+      | {
+          inputTokens: number;
+          outputTokens: number;
+          totalTokens: number;
+        }
+      | undefined;
+
+    const agent = ChatAgent.create({
+      ...defaultConfig,
+      middleware: [
+        {
+          name: "test:on_error_abort",
+          timing: "on_error",
+          priority: 100,
+          fn: (ctx) => {
+            seenUsage = ctx.usage;
+            return { action: "abort" as const, reason: "stop" };
+          },
+        },
+      ],
+    });
+
+    const result = await agent.run(defaultInput);
+
+    expect(seenUsage).toEqual({ inputTokens: 9, outputTokens: 4, totalTokens: 13 });
+    expect(result.usage).toEqual({ inputTokens: 9, outputTokens: 4, totalTokens: 13 });
+    expect(result.text).toBe("partial");
+  });
+
   it("tracks compactionCount when a post_compaction middleware transforms messages", async () => {
     let turnCount = 0;
 


### PR DESCRIPTION
## Summary
- pass accumulated token usage into pre_tool_use and post_tool_use middleware dispatches
- preserve current run context and usage in the on_error middleware path instead of resetting to zero
- keep aborted completion results aligned with actual accumulated usage and add regression coverage

## Testing
- bun test packages/agent/test/core/hooks.test.ts packages/agent/test/core/run-delegation.test.ts packages/agent/test/core/middleware/dispatch-completion.test.ts
- bun run --cwd packages/agent check-types
- pre-push hook: turbo run check-types

Closes #89