### PR TITLE
fix(server): resolve agent model aliases via models.dev catalog

### DIFF
--- a/apps/server/src/agents/model-resolution.ts
+++ b/apps/server/src/agents/model-resolution.ts
@@ -1,0 +1,156 @@
+import type { ChatAgentConfig } from "@openomni/agent";
+import { Auth, Provider } from "@openomni/llm";
+
+const DATE_SUFFIX_RE = /-\d{8}$/;
+
+const statusOrder: Record<string, number> = {
+  active: 0,
+  beta: 1,
+  alpha: 2,
+  deprecated: 3,
+};
+
+type RuntimeModel = ChatAgentConfig["model"];
+type CatalogModel = Provider.Model;
+
+function isConcreteModelID(modelID: string): boolean {
+  return DATE_SUFFIX_RE.test(modelID);
+}
+
+function normalizeName(name: string): string {
+  return name
+    .replace(/\s*\(latest\)\s*$/iu, "")
+    .trim()
+    .toLowerCase();
+}
+
+function compareModels(a: CatalogModel, b: CatalogModel): number {
+  const releaseOrder = (b.release_date ?? "").localeCompare(a.release_date ?? "");
+  if (releaseOrder !== 0) return releaseOrder;
+
+  const statusDelta =
+    (statusOrder[a.status ?? "active"] ?? 99) - (statusOrder[b.status ?? "active"] ?? 99);
+  if (statusDelta !== 0) return statusDelta;
+
+  return b.id.localeCompare(a.id);
+}
+
+function sortModels(models: CatalogModel[]): CatalogModel[] {
+  return [...models].sort(compareModels);
+}
+
+function matchConcreteSiblings(preferredID: string, models: CatalogModel[]): CatalogModel[] {
+  return sortModels(
+    models.filter((model) => isConcreteModelID(model.id) && model.id.startsWith(`${preferredID}-`)),
+  );
+}
+
+function inferFamily(preferredID: string, models: CatalogModel[]): string | undefined {
+  return [
+    ...new Set(
+      models
+        .map((model) => model.family)
+        .filter((family): family is string => typeof family === "string" && family.length > 0),
+    ),
+  ]
+    .sort((a, b) => b.length - a.length)
+    .find((family) => preferredID === family || preferredID.startsWith(`${family}-`));
+}
+
+function findConcreteSibling(
+  exact: CatalogModel,
+  models: CatalogModel[],
+): CatalogModel | undefined {
+  let candidates = matchConcreteSiblings(exact.id, models);
+  if (candidates.length === 0) return undefined;
+
+  if (exact.family) {
+    const familyMatches = candidates.filter((candidate) => candidate.family === exact.family);
+    if (familyMatches.length > 0) candidates = familyMatches;
+  }
+
+  if (exact.release_date) {
+    const releaseMatches = candidates.filter(
+      (candidate) => candidate.release_date === exact.release_date,
+    );
+    if (releaseMatches.length > 0) candidates = releaseMatches;
+  }
+
+  const expectedName = normalizeName(exact.name);
+  const nameMatches = candidates.filter(
+    (candidate) => normalizeName(candidate.name) === expectedName,
+  );
+  if (nameMatches.length > 0) candidates = nameMatches;
+
+  return sortModels(candidates)[0];
+}
+
+export function resolveCatalogModel(
+  preferredID: string,
+  models: CatalogModel[],
+): CatalogModel | undefined {
+  const exact = models.find((model) => model.id === preferredID);
+  if (exact) {
+    if (isConcreteModelID(exact.id)) return exact;
+    return findConcreteSibling(exact, models) ?? exact;
+  }
+
+  const prefixMatch = matchConcreteSiblings(preferredID, models)[0];
+  if (prefixMatch) return prefixMatch;
+
+  const family = inferFamily(preferredID, models);
+  if (!family) return undefined;
+
+  return sortModels(
+    models.filter((model) => model.family === family && isConcreteModelID(model.id)),
+  )[0];
+}
+
+async function listProviderModels(providerID: string): Promise<CatalogModel[]> {
+  const auth = await Auth.get(providerID);
+  const authType = auth?.type === "proxy" ? "proxy" : "api";
+  return Provider.listModels(providerID, authType);
+}
+
+export async function resolveRuntimeModel(
+  model: RuntimeModel,
+  defaultModel?: RuntimeModel,
+): Promise<RuntimeModel> {
+  try {
+    const resolved = resolveCatalogModel(model.id, await listProviderModels(model.provider));
+    if (resolved) {
+      return { provider: model.provider, id: resolved.id };
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`[server] failed to resolve agent model ${model.provider}/${model.id}: ${msg}`);
+  }
+
+  if (defaultModel && defaultModel.provider === model.provider) {
+    console.warn(
+      `[server] falling back to default model for ${model.provider}/${model.id}: ${defaultModel.id}`,
+    );
+    return defaultModel;
+  }
+
+  return model;
+}
+
+export async function resolveDefaultProviderModel(): Promise<CatalogModel | undefined> {
+  try {
+    const credentials = await Auth.all();
+    const entries = Object.entries(credentials);
+    if (entries.length === 0) return undefined;
+
+    const [providerID, auth] = entries[0]!;
+    const authType = auth.type === "proxy" ? "proxy" : "api";
+    const models = await Provider.listModels(providerID, authType);
+    const preferred = models[0];
+    if (!preferred) return undefined;
+    return resolveCatalogModel(preferred.id, models) ?? preferred;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`[server] failed to resolve model: ${msg}`);
+    return undefined;
+  }
+}

--- a/apps/server/src/agents/model-resolution.ts
+++ b/apps/server/src/agents/model-resolution.ts
@@ -142,7 +142,10 @@ export async function resolveDefaultProviderModel(): Promise<CatalogModel | unde
     const entries = Object.entries(credentials);
     if (entries.length === 0) return undefined;
 
-    const [providerID, auth] = entries[0]!;
+    const firstEntry = entries[0];
+    if (!firstEntry) return undefined;
+
+    const [providerID, auth] = firstEntry;
     const authType = auth.type === "proxy" ? "proxy" : "api";
     const models = await Provider.listModels(providerID, authType);
     const preferred = models[0];

--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -10,6 +10,8 @@ export interface AgentToolSelection {
 export interface AgentDefinition {
   name: string;
   description: string;
+  // Agent definitions may use an alias/latest model ID. The server resolves it
+  // to a concrete provider model ID from models.dev before execution.
   model: ChatAgentConfig["model"];
   systemPrompt: string;
   tools: AgentToolSelection;

--- a/apps/server/src/bootstrap/providers.ts
+++ b/apps/server/src/bootstrap/providers.ts
@@ -1,20 +1,5 @@
-import { Auth, Provider } from "@openomni/llm";
+import { resolveDefaultProviderModel } from "../agents/model-resolution";
 
-export async function resolveModel(): Promise<Provider.Model | undefined> {
-  try {
-    const credentials = await Auth.all();
-    const entries = Object.entries(credentials);
-    if (entries.length === 0) return undefined;
-
-    const providerID = entries[0][0];
-    const auth = credentials[providerID];
-    if (!auth) return undefined;
-
-    const authType = auth.type === "oauth" ? "api" : auth.type;
-    const models = await Provider.listModels(providerID, authType);
-    return models[0];
-  } catch (err) {
-    console.warn("[server] failed to resolve model:", err instanceof Error ? err.message : err);
-    return undefined;
-  }
+export async function resolveModel() {
+  return resolveDefaultProviderModel();
 }

--- a/apps/server/src/handler/conversation.ts
+++ b/apps/server/src/handler/conversation.ts
@@ -1,6 +1,7 @@
 // server → openomni → agent → llm (direct agent imports forbidden)
 import { IngressEngine } from "@openomni/openomni";
 import type { Adapter, IngressResult } from "@openomni/protocol";
+import { resolveRuntimeModel } from "../agents/model-resolution";
 import { buildInboundEvent, type BridgeDeps } from "../ingress/bridge";
 import { resolveAgentName } from "../router";
 
@@ -17,6 +18,7 @@ async function processMessage(message: Adapter.InboundMessage, deps: BridgeDeps)
   try {
     const agentName = resolveAgentName({ message, defaultAgent: "dev" });
     const event = buildInboundEvent(message, agentName, deps);
+    event.agent.model = await resolveRuntimeModel(event.agent.model, deps.defaultModel);
     return toResponseText(await IngressEngine.ingest(event));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/apps/server/test/conversation.test.ts
+++ b/apps/server/test/conversation.test.ts
@@ -155,6 +155,20 @@ describe("tool selection by agent definition", () => {
 });
 
 describe("agent permissions applied to executor", () => {
+  it("executor accepts sanitized tool names and dispatches the original tool", async () => {
+    const dottedTool = createMockTool("fs.read");
+    const executor = createToolExecutor({ tools: [dottedTool] });
+
+    const result = await executor({
+      id: crypto.randomUUID(),
+      tool: "fs_read",
+      input: {},
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.output).toBe("fs.read result");
+  });
+
   it("executor with agent budget config respects timeout overrides", async () => {
     const slowTool: NativeTool = {
       spec: { name: "slow", inputSchema: { type: "object" } },

--- a/apps/server/test/model-resolution.test.ts
+++ b/apps/server/test/model-resolution.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Auth, Provider } from "@openomni/llm";
+import {
+  resolveCatalogModel,
+  resolveDefaultProviderModel,
+  resolveRuntimeModel,
+} from "../src/agents/model-resolution";
+
+function makeModel(
+  id: string,
+  name: string,
+  releaseDate: string,
+  family = "claude-sonnet",
+): Provider.Model {
+  return {
+    id,
+    providerID: "anthropic",
+    name,
+    family,
+    release_date: releaseDate,
+    status: "active",
+  };
+}
+
+const originalAuthAll = Auth.all;
+const originalAuthGet = Auth.get;
+const originalListModels = Provider.listModels;
+
+afterEach(() => {
+  Auth.all = originalAuthAll;
+  Auth.get = originalAuthGet;
+  Provider.listModels = originalListModels;
+});
+
+describe("resolveCatalogModel", () => {
+  it("maps exact latest aliases to concrete dated model IDs", () => {
+    const models = [
+      makeModel("claude-sonnet-4-5", "Claude Sonnet 4.5 (latest)", "2025-09-29"),
+      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
+    ];
+
+    expect(resolveCatalogModel("claude-sonnet-4-5", models)?.id).toBe("claude-sonnet-4-5-20250929");
+  });
+
+  it("resolves version aliases by concrete prefix match when the alias entry is absent", () => {
+    const models = [
+      makeModel("claude-opus-4-5-20251101", "Claude Opus 4.5", "2025-11-01", "claude-opus"),
+    ];
+
+    expect(resolveCatalogModel("claude-opus-4-5", models)?.id).toBe("claude-opus-4-5-20251101");
+  });
+
+  it("falls back to the newest concrete model in the same family for newer aliases", () => {
+    const models = [
+      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
+      makeModel("claude-sonnet-4-20250514", "Claude Sonnet 4", "2025-05-22"),
+    ];
+
+    expect(resolveCatalogModel("claude-sonnet-4-6", models)?.id).toBe("claude-sonnet-4-5-20250929");
+  });
+});
+
+describe("resolveRuntimeModel", () => {
+  it("resolves runtime agent models through the provider catalog", async () => {
+    Auth.get = async () => ({ type: "api", key: "test-key" });
+    Provider.listModels = async () => [
+      makeModel("claude-sonnet-4-5", "Claude Sonnet 4.5 (latest)", "2025-09-29"),
+      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
+    ];
+
+    await expect(
+      resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-5" }),
+    ).resolves.toEqual({
+      provider: "anthropic",
+      id: "claude-sonnet-4-5-20250929",
+    });
+  });
+
+  it("falls back to the server default model for the same provider when lookup misses", async () => {
+    Auth.get = async () => ({ type: "api", key: "test-key" });
+    Provider.listModels = async () => [];
+
+    await expect(
+      resolveRuntimeModel(
+        { provider: "anthropic", id: "claude-sonnet-4-6" },
+        { provider: "anthropic", id: "claude-opus-4-20250514" },
+      ),
+    ).resolves.toEqual({
+      provider: "anthropic",
+      id: "claude-opus-4-20250514",
+    });
+  });
+});
+
+describe("resolveDefaultProviderModel", () => {
+  it("converts the bootstrap default model to a concrete dated ID", async () => {
+    Auth.all = async () => ({
+      anthropic: { type: "api", key: "test-key" },
+    });
+    Provider.listModels = async () => [
+      makeModel("claude-sonnet-4-5", "Claude Sonnet 4.5 (latest)", "2025-09-29"),
+      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
+    ];
+
+    await expect(resolveDefaultProviderModel()).resolves.toMatchObject({
+      providerID: "anthropic",
+      id: "claude-sonnet-4-5-20250929",
+    });
+  });
+});


### PR DESCRIPTION
Closes #71.

## Problem

`AgentDefinition.model.id` uses short aliases like `claude-sonnet-4-5` that the Anthropic API rejects — it expects dated IDs like `claude-sonnet-4-5-20250929`. Only the bootstrap default went through `Provider.listModels()`; per-agent and per-message model IDs were passed through unresolved, so runs failed before the first token.

Related: tool names with dots (`fs.read`, `git.status`) violate Anthropic's tool-name pattern `^[a-zA-Z0-9_-]{1,128}$`. The executor already dispatches by a sanitized name, but that path had no regression test.

## Changes

- `apps/server/src/agents/model-resolution.ts` (new) — `resolveCatalogModel()` maps an alias or latest ID to a concrete dated model ID by walking the provider catalog: exact match → concrete sibling by name / family / release_date → prefix match → newest concrete model in the same family. Sorts by `release_date` then `status` (`active` > `beta` > `alpha` > `deprecated`).
- `apps/server/src/agents/model-resolution.ts` — `resolveRuntimeModel()` resolves per-message models and falls back to the server default when the provider matches. `resolveDefaultProviderModel()` replaces the old bootstrap helper using the same resolver.
- `apps/server/src/bootstrap/providers.ts` — `resolveModel()` now delegates to `resolveDefaultProviderModel()`.
- `apps/server/src/handler/conversation.ts` — resolves `event.agent.model` before `IngressEngine.ingest()` so the dated ID reaches the LLM layer.
- `apps/server/src/agents/types.ts` — documents that `AgentDefinition.model` may be an alias / latest ID.

## Tests

- `apps/server/test/model-resolution.test.ts` (new) — catalog resolution (exact latest alias, version alias by prefix, family fallback for newer aliases), runtime resolution (catalog hit, provider-matched default fallback), bootstrap default resolution to a concrete ID.
- `apps/server/test/conversation.test.ts` — adds a regression for the executor dispatching `fs_read` to a tool registered as `fs.read`, covering the sanitized tool-name path used for Anthropic compatibility.

## Validation

- `bun test apps/server/test/model-resolution.test.ts apps/server/test/conversation.test.ts`
- `bun run --cwd apps/server check-types`
- CI: lint, check-types, dependency rules, test — all green.

## Follow-ups (not in this PR)

- Cache `Provider.listModels()` per provider — currently called per message. Fine for now, but a likely first optimization once usage patterns are clearer.
- Emit the original requested alias in the family-fallback warning so operators can see silent downgrades.