### PR TITLE
chore(llm): refresh models snapshot and automate weekly updates

### DIFF
--- a/.github/workflows/generate-models-snapshot.yml
+++ b/.github/workflows/generate-models-snapshot.yml
@@ -1,0 +1,37 @@
+name: Refresh models snapshot
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+      - name: Regenerate snapshot
+        run: bun run script/generate-models-snapshot.ts
+      - name: Format
+        run: bun run format
+      - name: Open PR if snapshot changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(llm): refresh models-snapshot.json from models.dev"
+          branch: chore/refresh-models-snapshot
+          delete-branch: true
+          title: "chore(llm): refresh models-snapshot.json"
+          body: |
+            Automated weekly refresh of `packages/llm/src/provider/models-snapshot.json`
+            from https://models.dev/api.json.
+
+            Run locally: `bun run script/generate-models-snapshot.ts`
+          labels: dependencies

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "bunx biome check --write .",
     "format": "bunx biome format --write .",
     "check-types": "turbo run check-types",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "generate:models-snapshot": "bun run script/generate-models-snapshot.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",

--- a/packages/llm/src/provider/models-snapshot.json
+++ b/packages/llm/src/provider/models-snapshot.json
@@ -6,44 +6,17 @@
     "name": "Anthropic",
     "doc": "https://docs.anthropic.com/en/docs/about-claude/models",
     "models": {
-      "claude-opus-4-0": {
-        "id": "claude-opus-4-0",
-        "name": "Claude Opus 4 (latest)",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-03-31",
-        "release_date": "2025-05-22",
-        "last_updated": "2025-05-22",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cache_read": 1.5,
-          "cache_write": 18.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 32000
-        }
-      },
-      "claude-3-5-sonnet-20241022": {
-        "id": "claude-3-5-sonnet-20241022",
-        "name": "Claude Sonnet 3.5 v2",
+      "claude-3-sonnet-20240229": {
+        "id": "claude-3-sonnet-20240229",
+        "name": "Claude Sonnet 3",
         "family": "claude-sonnet",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2024-04-30",
-        "release_date": "2024-10-22",
-        "last_updated": "2024-10-22",
+        "knowledge": "2023-08-31",
+        "release_date": "2024-03-04",
+        "last_updated": "2024-03-04",
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
@@ -53,38 +26,11 @@
           "input": 3,
           "output": 15,
           "cache_read": 0.3,
-          "cache_write": 3.75
+          "cache_write": 0.3
         },
         "limit": {
           "context": 200000,
-          "output": 8192
-        }
-      },
-      "claude-opus-4-1": {
-        "id": "claude-opus-4-1",
-        "name": "Claude Opus 4.1 (latest)",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-03-31",
-        "release_date": "2025-08-05",
-        "last_updated": "2025-08-05",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cache_read": 1.5,
-          "cache_write": 18.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 32000
+          "output": 4096
         }
       },
       "claude-haiku-4-5": {
@@ -114,71 +60,17 @@
           "output": 64000
         }
       },
-      "claude-3-5-sonnet-20240620": {
-        "id": "claude-3-5-sonnet-20240620",
-        "name": "Claude Sonnet 3.5",
-        "family": "claude-sonnet",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-04-30",
-        "release_date": "2024-06-20",
-        "last_updated": "2024-06-20",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cache_read": 0.3,
-          "cache_write": 3.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 8192
-        }
-      },
-      "claude-3-5-haiku-latest": {
-        "id": "claude-3-5-haiku-latest",
-        "name": "Claude Haiku 3.5 (latest)",
-        "family": "claude-haiku",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-07-31",
-        "release_date": "2024-10-22",
-        "last_updated": "2024-10-22",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.8,
-          "output": 4,
-          "cache_read": 0.08,
-          "cache_write": 1
-        },
-        "limit": {
-          "context": 200000,
-          "output": 8192
-        }
-      },
-      "claude-opus-4-5": {
-        "id": "claude-opus-4-5",
-        "name": "Claude Opus 4.5 (latest)",
+      "claude-opus-4-5-20251101": {
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
         "family": "claude-opus",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
         "temperature": true,
         "knowledge": "2025-03-31",
-        "release_date": "2025-11-24",
-        "last_updated": "2025-11-24",
+        "release_date": "2025-11-01",
+        "last_updated": "2025-11-01",
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
@@ -222,44 +114,44 @@
           "output": 4096
         }
       },
-      "claude-opus-4-5-20251101": {
-        "id": "claude-opus-4-5-20251101",
-        "name": "Claude Opus 4.5",
-        "family": "claude-opus",
+      "claude-3-5-haiku-20241022": {
+        "id": "claude-3-5-haiku-20241022",
+        "name": "Claude Haiku 3.5",
+        "family": "claude-haiku",
         "attachment": true,
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
-        "release_date": "2025-11-01",
-        "last_updated": "2025-11-01",
+        "knowledge": "2024-07-31",
+        "release_date": "2024-10-22",
+        "last_updated": "2024-10-22",
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 5,
-          "output": 25,
-          "cache_read": 0.5,
-          "cache_write": 6.25
+          "input": 0.8,
+          "output": 4,
+          "cache_read": 0.08,
+          "cache_write": 1
         },
         "limit": {
           "context": 200000,
-          "output": 64000
+          "output": 8192
         }
       },
-      "claude-sonnet-4-5": {
-        "id": "claude-sonnet-4-5",
-        "name": "Claude Sonnet 4.5 (latest)",
+      "claude-3-5-sonnet-20241022": {
+        "id": "claude-3-5-sonnet-20241022",
+        "name": "Claude Sonnet 3.5 v2",
         "family": "claude-sonnet",
         "attachment": true,
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-07-31",
-        "release_date": "2025-09-29",
-        "last_updated": "2025-09-29",
+        "knowledge": "2024-04-30",
+        "release_date": "2024-10-22",
+        "last_updated": "2024-10-22",
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
@@ -273,7 +165,88 @@
         },
         "limit": {
           "context": 200000,
+          "output": 8192
+        }
+      },
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-08",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 1000000,
           "output": 64000
+        }
+      },
+      "claude-opus-4-0": {
+        "id": "claude-opus-4-0",
+        "name": "Claude Opus 4 (latest)",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22",
+        "last_updated": "2025-05-22",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        }
+      },
+      "claude-3-haiku-20240307": {
+        "id": "claude-3-haiku-20240307",
+        "name": "Claude Haiku 3",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2023-08-31",
+        "release_date": "2024-03-13",
+        "last_updated": "2024-03-13",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.25,
+          "output": 1.25,
+          "cache_read": 0.03,
+          "cache_write": 0.3
+        },
+        "limit": {
+          "context": 200000,
+          "output": 4096
         }
       },
       "claude-sonnet-4-5-20250929": {
@@ -303,6 +276,195 @@
           "output": 64000
         }
       },
+      "claude-3-5-haiku-latest": {
+        "id": "claude-3-5-haiku-latest",
+        "name": "Claude Haiku 3.5 (latest)",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-07-31",
+        "release_date": "2024-10-22",
+        "last_updated": "2024-10-22",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.8,
+          "output": 4,
+          "cache_read": 0.08,
+          "cache_write": 1
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        }
+      },
+      "claude-opus-4-1": {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        }
+      },
+      "claude-sonnet-4-0": {
+        "id": "claude-sonnet-4-0",
+        "name": "Claude Sonnet 4 (latest)",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22",
+        "last_updated": "2025-05-22",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "claude-3-5-sonnet-20240620": {
+        "id": "claude-3-5-sonnet-20240620",
+        "name": "Claude Sonnet 3.5",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-04-30",
+        "release_date": "2024-06-20",
+        "last_updated": "2024-06-20",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        }
+      },
+      "claude-opus-4-5": {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-11-24",
+        "last_updated": "2025-11-24",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "claude-opus-4-1-20250805": {
+        "id": "claude-opus-4-1-20250805",
+        "name": "Claude Opus 4.1",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        }
+      },
+      "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
       "claude-sonnet-4-20250514": {
         "id": "claude-sonnet-4-20250514",
         "name": "Claude Sonnet 4",
@@ -314,6 +476,107 @@
         "knowledge": "2025-03-31",
         "release_date": "2025-05-22",
         "last_updated": "2025-05-22",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 30,
+                "output": 150,
+                "cache_read": 3,
+                "cache_write": 37.5
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        }
+      },
+      "claude-3-7-sonnet-20250219": {
+        "id": "claude-3-7-sonnet-20250219",
+        "name": "Claude Sonnet 3.7",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-10-31",
+        "release_date": "2025-02-19",
+        "last_updated": "2025-02-19",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "claude-sonnet-4-5": {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-07-31",
+        "release_date": "2025-09-29",
+        "last_updated": "2025-09-29",
         "modalities": {
           "input": ["text", "image", "pdf"],
           "output": ["text"]
@@ -356,222 +619,6 @@
           "context": 200000,
           "output": 32000
         }
-      },
-      "claude-3-5-haiku-20241022": {
-        "id": "claude-3-5-haiku-20241022",
-        "name": "Claude Haiku 3.5",
-        "family": "claude-haiku",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-07-31",
-        "release_date": "2024-10-22",
-        "last_updated": "2024-10-22",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.8,
-          "output": 4,
-          "cache_read": 0.08,
-          "cache_write": 1
-        },
-        "limit": {
-          "context": 200000,
-          "output": 8192
-        }
-      },
-      "claude-3-haiku-20240307": {
-        "id": "claude-3-haiku-20240307",
-        "name": "Claude Haiku 3",
-        "family": "claude-haiku",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2023-08-31",
-        "release_date": "2024-03-13",
-        "last_updated": "2024-03-13",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.25,
-          "output": 1.25,
-          "cache_read": 0.03,
-          "cache_write": 0.3
-        },
-        "limit": {
-          "context": 200000,
-          "output": 4096
-        }
-      },
-      "claude-3-7-sonnet-20250219": {
-        "id": "claude-3-7-sonnet-20250219",
-        "name": "Claude Sonnet 3.7",
-        "family": "claude-sonnet",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-10-31",
-        "release_date": "2025-02-19",
-        "last_updated": "2025-02-19",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cache_read": 0.3,
-          "cache_write": 3.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 64000
-        }
-      },
-      "claude-3-7-sonnet-latest": {
-        "id": "claude-3-7-sonnet-latest",
-        "name": "Claude Sonnet 3.7 (latest)",
-        "family": "claude-sonnet",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-10-31",
-        "release_date": "2025-02-19",
-        "last_updated": "2025-02-19",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cache_read": 0.3,
-          "cache_write": 3.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 64000
-        }
-      },
-      "claude-sonnet-4-0": {
-        "id": "claude-sonnet-4-0",
-        "name": "Claude Sonnet 4 (latest)",
-        "family": "claude-sonnet",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-03-31",
-        "release_date": "2025-05-22",
-        "last_updated": "2025-05-22",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cache_read": 0.3,
-          "cache_write": 3.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 64000
-        }
-      },
-      "claude-opus-4-1-20250805": {
-        "id": "claude-opus-4-1-20250805",
-        "name": "Claude Opus 4.1",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-03-31",
-        "release_date": "2025-08-05",
-        "last_updated": "2025-08-05",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 15,
-          "output": 75,
-          "cache_read": 1.5,
-          "cache_write": 18.75
-        },
-        "limit": {
-          "context": 200000,
-          "output": 32000
-        }
-      },
-      "claude-3-sonnet-20240229": {
-        "id": "claude-3-sonnet-20240229",
-        "name": "Claude Sonnet 3",
-        "family": "claude-sonnet",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2023-08-31",
-        "release_date": "2024-03-04",
-        "last_updated": "2024-03-04",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 3,
-          "output": 15,
-          "cache_read": 0.3,
-          "cache_write": 0.3
-        },
-        "limit": {
-          "context": 200000,
-          "output": 4096
-        }
-      },
-      "claude-haiku-4-5-20251001": {
-        "id": "claude-haiku-4-5-20251001",
-        "name": "Claude Haiku 4.5",
-        "family": "claude-haiku",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-02-28",
-        "release_date": "2025-10-15",
-        "last_updated": "2025-10-15",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 1,
-          "output": 5,
-          "cache_read": 0.1,
-          "cache_write": 1.25
-        },
-        "limit": {
-          "context": 200000,
-          "output": 64000
-        }
       }
     }
   },
@@ -582,108 +629,32 @@
     "name": "OpenAI",
     "doc": "https://platform.openai.com/docs/models",
     "models": {
-      "gpt-4.1-nano": {
-        "id": "gpt-4.1-nano",
-        "name": "GPT-4.1 nano",
-        "family": "gpt-nano",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2024-04",
-        "release_date": "2025-04-14",
-        "last_updated": "2025-04-14",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.1,
-          "output": 0.4,
-          "cache_read": 0.03
-        },
-        "limit": {
-          "context": 1047576,
-          "output": 32768
-        }
-      },
-      "text-embedding-3-small": {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "family": "text-embedding",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": false,
-        "temperature": false,
-        "knowledge": "2024-01",
-        "release_date": "2024-01-25",
-        "last_updated": "2024-01-25",
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.02,
-          "output": 0
-        },
-        "limit": {
-          "context": 8191,
-          "output": 1536
-        }
-      },
-      "gpt-4": {
-        "id": "gpt-4",
-        "name": "GPT-4",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": false,
-        "temperature": true,
-        "knowledge": "2023-11",
-        "release_date": "2023-11-06",
-        "last_updated": "2024-04-09",
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 30,
-          "output": 60
-        },
-        "limit": {
-          "context": 8192,
-          "output": 8192
-        }
-      },
-      "o1-pro": {
-        "id": "o1-pro",
-        "name": "o1-pro",
-        "family": "o-pro",
+      "gpt-5.1-codex-max": {
+        "id": "gpt-5.1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
         "structured_output": true,
         "temperature": false,
-        "knowledge": "2023-09",
-        "release_date": "2025-03-19",
-        "last_updated": "2025-03-19",
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
         "modalities": {
           "input": ["text", "image"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 150,
-          "output": 600
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
         },
         "limit": {
-          "context": 200000,
-          "output": 100000
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
         }
       },
       "gpt-4o-2024-05-13": {
@@ -712,167 +683,31 @@
           "output": 4096
         }
       },
-      "gpt-5.2-codex": {
-        "id": "gpt-5.2-codex",
-        "name": "GPT-5.2 Codex",
-        "family": "gpt-codex",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2025-08-31",
-        "release_date": "2025-12-11",
-        "last_updated": "2025-12-11",
-        "modalities": {
-          "input": ["text", "image", "pdf"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
-        },
-        "limit": {
-          "context": 400000,
-          "input": 272000,
-          "output": 128000
-        }
-      },
-      "gpt-5.1-codex": {
-        "id": "gpt-5.1-codex",
-        "name": "GPT-5.1 Codex",
-        "family": "gpt-codex",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-09-30",
-        "release_date": "2025-11-13",
-        "last_updated": "2025-11-13",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 1.25,
-          "output": 10,
-          "cache_read": 0.125
-        },
-        "limit": {
-          "context": 400000,
-          "input": 272000,
-          "output": 128000
-        }
-      },
-      "gpt-4o-2024-08-06": {
-        "id": "gpt-4o-2024-08-06",
-        "name": "GPT-4o (2024-08-06)",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2023-09",
-        "release_date": "2024-08-06",
-        "last_updated": "2024-08-06",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cache_read": 1.25
-        },
-        "limit": {
-          "context": 128000,
-          "output": 16384
-        }
-      },
-      "gpt-4.1-mini": {
-        "id": "gpt-4.1-mini",
-        "name": "GPT-4.1 mini",
-        "family": "gpt-mini",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2024-04",
-        "release_date": "2025-04-14",
-        "last_updated": "2025-04-14",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.4,
-          "output": 1.6,
-          "cache_read": 0.1
-        },
-        "limit": {
-          "context": 1047576,
-          "output": 32768
-        }
-      },
-      "o3-deep-research": {
-        "id": "o3-deep-research",
-        "name": "o3-deep-research",
-        "family": "o",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": false,
-        "knowledge": "2024-05",
-        "release_date": "2024-06-26",
-        "last_updated": "2024-06-26",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 10,
-          "output": 40,
-          "cache_read": 2.5
-        },
-        "limit": {
-          "context": 200000,
-          "output": 100000
-        }
-      },
-      "gpt-3.5-turbo": {
-        "id": "gpt-3.5-turbo",
-        "name": "GPT-3.5-turbo",
-        "family": "gpt",
+      "o1-mini": {
+        "id": "o1-mini",
+        "name": "o1-mini",
+        "family": "o-mini",
         "attachment": false,
-        "reasoning": false,
+        "reasoning": true,
         "tool_call": false,
-        "structured_output": false,
-        "temperature": true,
-        "knowledge": "2021-09-01",
-        "release_date": "2023-03-01",
-        "last_updated": "2023-11-06",
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2023-09",
+        "release_date": "2024-09-12",
+        "last_updated": "2024-09-12",
         "modalities": {
           "input": ["text"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 0.5,
-          "output": 1.5,
-          "cache_read": 1.25
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.55
         },
         "limit": {
-          "context": 16385,
-          "output": 4096
+          "context": 128000,
+          "output": 65536
         }
       },
       "gpt-5.2-pro": {
@@ -882,7 +717,7 @@
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
-        "structured_output": true,
+        "structured_output": false,
         "temperature": false,
         "knowledge": "2025-08-31",
         "release_date": "2025-12-11",
@@ -927,6 +762,117 @@
           "output": 3072
         }
       },
+      "gpt-5.3-chat-latest": {
+        "id": "gpt-5.3-chat-latest",
+        "name": "GPT-5.3 Chat (latest)",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-03",
+        "last_updated": "2026-03-03",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        }
+      },
+      "gpt-5-mini": {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05-30",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-5-nano": {
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05-30",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.05,
+          "output": 0.4,
+          "cache_read": 0.005
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-5.3-codex": {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
       "gpt-4-turbo": {
         "id": "gpt-4-turbo",
         "name": "GPT-4 Turbo",
@@ -953,30 +899,311 @@
           "output": 4096
         }
       },
-      "o1-preview": {
-        "id": "o1-preview",
-        "name": "o1-preview",
-        "family": "o",
+      "text-embedding-ada-002": {
+        "id": "text-embedding-ada-002",
+        "name": "text-embedding-ada-002",
+        "family": "text-embedding",
         "attachment": false,
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": false,
-        "temperature": true,
-        "knowledge": "2023-09",
-        "release_date": "2024-09-12",
-        "last_updated": "2024-09-12",
+        "temperature": false,
+        "knowledge": "2022-12",
+        "release_date": "2022-12-15",
+        "last_updated": "2022-12-15",
         "modalities": {
           "input": ["text"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 15,
-          "output": 60,
-          "cache_read": 7.5
+          "input": 0.1,
+          "output": 0
+        },
+        "limit": {
+          "context": 8192,
+          "output": 1536
+        }
+      },
+      "gpt-5.2": {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "o3-pro": {
+        "id": "o3-pro",
+        "name": "o3-pro",
+        "family": "o-pro",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "release_date": "2025-06-10",
+        "last_updated": "2025-06-10",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 20,
+          "output": 80
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-07-18",
+        "last_updated": "2024-07-18",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.08
         },
         "limit": {
           "context": 128000,
-          "output": 32768
+          "output": 16384
+        }
+      },
+      "o4-mini-deep-research": {
+        "id": "o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "family": "o-mini",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "release_date": "2024-06-26",
+        "last_updated": "2024-06-26",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "gpt-5.4-mini": {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.75,
+          "output": 4.5,
+          "cache_read": 0.075
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 1.5,
+                "output": 9,
+                "cache_read": 0.15
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        }
+      },
+      "o4-mini": {
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "family": "o-mini",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "release_date": "2025-04-16",
+        "last_updated": "2025-04-16",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.28
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "gpt-5.4-nano": {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.2,
+          "output": 1.25,
+          "cache_read": 0.02
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-image-1": {
+        "id": "gpt-image-1",
+        "name": "gpt-image-1",
+        "family": "gpt-image",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": false,
+        "temperature": false,
+        "release_date": "2025-04-24",
+        "last_updated": "2025-04-24",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["image"]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        }
+      },
+      "gpt-5.2-codex": {
+        "id": "gpt-5.2-codex",
+        "name": "GPT-5.2 Codex",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-5.2-chat-latest": {
+        "id": "gpt-5.2-chat-latest",
+        "name": "GPT-5.2 Chat",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
         }
       },
       "gpt-5.1-codex-mini": {
@@ -1007,54 +1234,53 @@
           "output": 128000
         }
       },
-      "o3-mini": {
-        "id": "o3-mini",
-        "name": "o3-mini",
-        "family": "o-mini",
+      "o1-preview": {
+        "id": "o1-preview",
+        "name": "o1-preview",
+        "family": "o",
         "attachment": false,
         "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-05",
-        "release_date": "2024-12-20",
-        "last_updated": "2025-01-29",
+        "tool_call": false,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-09-12",
+        "last_updated": "2024-09-12",
         "modalities": {
           "input": ["text"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cache_read": 0.55
+          "input": 15,
+          "output": 60,
+          "cache_read": 7.5
         },
         "limit": {
-          "context": 200000,
-          "output": 100000
+          "context": 128000,
+          "output": 32768
         }
       },
-      "gpt-5.2-chat-latest": {
-        "id": "gpt-5.2-chat-latest",
-        "name": "GPT-5.2 Chat",
-        "family": "gpt-codex",
+      "gpt-4o-2024-08-06": {
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "family": "gpt",
         "attachment": true,
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
         "structured_output": true,
-        "temperature": false,
-        "knowledge": "2025-08-31",
-        "release_date": "2025-12-11",
-        "last_updated": "2025-12-11",
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-08-06",
+        "last_updated": "2024-08-06",
         "modalities": {
           "input": ["text", "image"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
         },
         "limit": {
           "context": 128000,
@@ -1089,6 +1315,216 @@
           "output": 128000
         }
       },
+      "gpt-image-1-mini": {
+        "id": "gpt-image-1-mini",
+        "name": "gpt-image-1-mini",
+        "family": "gpt-image",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": false,
+        "temperature": false,
+        "release_date": "2025-09-26",
+        "last_updated": "2025-09-26",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        }
+      },
+      "o1": {
+        "id": "o1",
+        "name": "o1",
+        "family": "o",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2023-09",
+        "release_date": "2024-12-05",
+        "last_updated": "2024-12-05",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cache_read": 7.5
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "gpt-5.4-pro": {
+        "id": "gpt-5.4-pro",
+        "name": "GPT-5.4 Pro",
+        "family": "gpt-pro",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": false,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 30,
+          "output": 180,
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          }
+        },
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "gpt-3.5-turbo": {
+        "id": "gpt-3.5-turbo",
+        "name": "GPT-3.5-turbo",
+        "family": "gpt",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": false,
+        "temperature": true,
+        "knowledge": "2021-09-01",
+        "release_date": "2023-03-01",
+        "last_updated": "2023-11-06",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.5,
+          "output": 1.5,
+          "cache_read": 1.25
+        },
+        "limit": {
+          "context": 16385,
+          "output": 4096
+        }
+      },
+      "o3-deep-research": {
+        "id": "o3-deep-research",
+        "name": "o3-deep-research",
+        "family": "o",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "release_date": "2024-06-26",
+        "last_updated": "2024-06-26",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 10,
+          "output": 40,
+          "cache_read": 2.5
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "o3-mini": {
+        "id": "o3-mini",
+        "name": "o3-mini",
+        "family": "o-mini",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "release_date": "2024-12-20",
+        "last_updated": "2025-01-29",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.55
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "text-embedding-3-small": {
+        "id": "text-embedding-3-small",
+        "name": "text-embedding-3-small",
+        "family": "text-embedding",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": false,
+        "temperature": false,
+        "knowledge": "2024-01",
+        "release_date": "2024-01-25",
+        "last_updated": "2024-01-25",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.02,
+          "output": 0
+        },
+        "limit": {
+          "context": 8191,
+          "output": 1536
+        }
+      },
+      "o1-pro": {
+        "id": "o1-pro",
+        "name": "o1-pro",
+        "family": "o-pro",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2023-09",
+        "release_date": "2025-03-19",
+        "last_updated": "2025-03-19",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 150,
+          "output": 600
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
       "codex-mini-latest": {
         "id": "codex-mini-latest",
         "name": "Codex Mini",
@@ -1115,32 +1551,30 @@
           "output": 100000
         }
       },
-      "gpt-5-nano": {
-        "id": "gpt-5-nano",
-        "name": "GPT-5 Nano",
-        "family": "gpt-nano",
+      "gpt-4": {
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "family": "gpt",
         "attachment": true,
-        "reasoning": true,
+        "reasoning": false,
         "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-05-30",
-        "release_date": "2025-08-07",
-        "last_updated": "2025-08-07",
+        "structured_output": false,
+        "temperature": true,
+        "knowledge": "2023-11",
+        "release_date": "2023-11-06",
+        "last_updated": "2024-04-09",
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 0.05,
-          "output": 0.4,
-          "cache_read": 0.005
+          "input": 30,
+          "output": 60
         },
         "limit": {
-          "context": 400000,
-          "input": 272000,
-          "output": 128000
+          "context": 8192,
+          "output": 8192
         }
       },
       "gpt-5-codex": {
@@ -1171,250 +1605,58 @@
           "output": 128000
         }
       },
-      "gpt-4o": {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
         "family": "gpt",
         "attachment": true,
-        "reasoning": false,
+        "reasoning": true,
         "tool_call": true,
         "structured_output": true,
-        "temperature": true,
-        "knowledge": "2023-09",
-        "release_date": "2024-05-13",
-        "last_updated": "2024-08-06",
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
           "input": 2.5,
-          "output": 10,
-          "cache_read": 1.25
+          "output": 15,
+          "cache_read": 0.25,
+          "context_over_200k": {
+            "input": 5,
+            "output": 22.5,
+            "cache_read": 0.5
+          }
         },
         "limit": {
-          "context": 128000,
-          "output": 16384
-        }
-      },
-      "gpt-4.1": {
-        "id": "gpt-4.1",
-        "name": "GPT-4.1",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2024-04",
-        "release_date": "2025-04-14",
-        "last_updated": "2025-04-14",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cache_read": 0.5
-        },
-        "limit": {
-          "context": 1047576,
-          "output": 32768
-        }
-      },
-      "o4-mini": {
-        "id": "o4-mini",
-        "name": "o4-mini",
-        "family": "o-mini",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-05",
-        "release_date": "2025-04-16",
-        "last_updated": "2025-04-16",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cache_read": 0.28
-        },
-        "limit": {
-          "context": 200000,
-          "output": 100000
-        }
-      },
-      "o1": {
-        "id": "o1",
-        "name": "o1",
-        "family": "o",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2023-09",
-        "release_date": "2024-12-05",
-        "last_updated": "2024-12-05",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 15,
-          "output": 60,
-          "cache_read": 7.5
-        },
-        "limit": {
-          "context": 200000,
-          "output": 100000
-        }
-      },
-      "gpt-5-mini": {
-        "id": "gpt-5-mini",
-        "name": "GPT-5 Mini",
-        "family": "gpt-mini",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-05-30",
-        "release_date": "2025-08-07",
-        "last_updated": "2025-08-07",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.25,
-          "output": 2,
-          "cache_read": 0.025
-        },
-        "limit": {
-          "context": 400000,
-          "input": 272000,
+          "context": 1050000,
+          "input": 922000,
           "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 5,
+                "output": 30,
+                "cache_read": 0.5
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
         }
       },
-      "o1-mini": {
-        "id": "o1-mini",
-        "name": "o1-mini",
-        "family": "o-mini",
-        "attachment": false,
-        "reasoning": true,
-        "tool_call": false,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2023-09",
-        "release_date": "2024-09-12",
-        "last_updated": "2024-09-12",
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cache_read": 0.55
-        },
-        "limit": {
-          "context": 128000,
-          "output": 65536
-        }
-      },
-      "text-embedding-ada-002": {
-        "id": "text-embedding-ada-002",
-        "name": "text-embedding-ada-002",
-        "family": "text-embedding",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": false,
-        "temperature": false,
-        "knowledge": "2022-12",
-        "release_date": "2022-12-15",
-        "last_updated": "2022-12-15",
-        "modalities": {
-          "input": ["text"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 0.1,
-          "output": 0
-        },
-        "limit": {
-          "context": 8192,
-          "output": 1536
-        }
-      },
-      "o3-pro": {
-        "id": "o3-pro",
-        "name": "o3-pro",
-        "family": "o-pro",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-05",
-        "release_date": "2025-06-10",
-        "last_updated": "2025-06-10",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 20,
-          "output": 80
-        },
-        "limit": {
-          "context": 200000,
-          "output": 100000
-        }
-      },
-      "gpt-4o-2024-11-20": {
-        "id": "gpt-4o-2024-11-20",
-        "name": "GPT-4o (2024-11-20)",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2023-09",
-        "release_date": "2024-11-20",
-        "last_updated": "2024-11-20",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 2.5,
-          "output": 10,
-          "cache_read": 1.25
-        },
-        "limit": {
-          "context": 128000,
-          "output": 16384
-        }
-      },
-      "gpt-5.1-codex-max": {
-        "id": "gpt-5.1-codex-max",
-        "name": "GPT-5.1 Codex Max",
+      "gpt-5.1-chat-latest": {
+        "id": "gpt-5.1-chat-latest",
+        "name": "GPT-5.1 Chat",
         "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
@@ -1435,9 +1677,84 @@
           "cache_read": 0.125
         },
         "limit": {
-          "context": 400000,
-          "input": 272000,
-          "output": 128000
+          "context": 128000,
+          "output": 16384
+        }
+      },
+      "gpt-5.3-codex-spark": {
+        "id": "gpt-5.3-codex-spark",
+        "name": "GPT-5.3 Codex Spark",
+        "family": "gpt-codex-spark",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "limit": {
+          "context": 128000,
+          "input": 100000,
+          "output": 32000
+        }
+      },
+      "chatgpt-image-latest": {
+        "id": "chatgpt-image-latest",
+        "name": "chatgpt-image-latest",
+        "family": "gpt-image",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": false,
+        "temperature": false,
+        "release_date": "2025-12-16",
+        "last_updated": "2025-12-16",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        }
+      },
+      "gpt-4.1-nano": {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.03
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
         }
       },
       "o3": {
@@ -1453,7 +1770,7 @@
         "release_date": "2025-04-16",
         "last_updated": "2025-04-16",
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
         "open_weights": false,
@@ -1467,80 +1784,54 @@
           "output": 100000
         }
       },
-      "o4-mini-deep-research": {
-        "id": "o4-mini-deep-research",
-        "name": "o4-mini-deep-research",
-        "family": "o-mini",
+      "gpt-5-pro": {
+        "id": "gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "family": "gpt-pro",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
-        "temperature": false,
-        "knowledge": "2024-05",
-        "release_date": "2024-06-26",
-        "last_updated": "2024-06-26",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cache_read": 0.5
-        },
-        "limit": {
-          "context": 200000,
-          "output": 100000
-        }
-      },
-      "gpt-5-chat-latest": {
-        "id": "gpt-5-chat-latest",
-        "name": "GPT-5 Chat (latest)",
-        "family": "gpt-codex",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": false,
         "structured_output": true,
-        "temperature": true,
+        "temperature": false,
         "knowledge": "2024-09-30",
-        "release_date": "2025-08-07",
-        "last_updated": "2025-08-07",
+        "release_date": "2025-10-06",
+        "last_updated": "2025-10-06",
         "modalities": {
           "input": ["text", "image"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 1.25,
-          "output": 10
+          "input": 15,
+          "output": 120
         },
         "limit": {
           "context": 400000,
           "input": 272000,
-          "output": 128000
+          "output": 272000
         }
       },
-      "gpt-4o-mini": {
-        "id": "gpt-4o-mini",
-        "name": "GPT-4o mini",
-        "family": "gpt-mini",
+      "gpt-4o": {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "family": "gpt",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
         "knowledge": "2023-09",
-        "release_date": "2024-07-18",
-        "last_updated": "2024-07-18",
+        "release_date": "2024-05-13",
+        "last_updated": "2024-08-06",
         "modalities": {
-          "input": ["text", "image"],
+          "input": ["text", "image", "pdf"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 0.15,
-          "output": 0.6,
-          "cache_read": 0.08
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
         },
         "limit": {
           "context": 128000,
@@ -1575,54 +1866,26 @@
           "output": 128000
         }
       },
-      "gpt-5-pro": {
-        "id": "gpt-5-pro",
-        "name": "GPT-5 Pro",
-        "family": "gpt-pro",
+      "gpt-5-chat-latest": {
+        "id": "gpt-5-chat-latest",
+        "name": "GPT-5 Chat (latest)",
+        "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
-        "tool_call": true,
+        "tool_call": false,
         "structured_output": true,
-        "temperature": false,
+        "temperature": true,
         "knowledge": "2024-09-30",
-        "release_date": "2025-10-06",
-        "last_updated": "2025-10-06",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
         "modalities": {
           "input": ["text", "image"],
           "output": ["text"]
         },
         "open_weights": false,
         "cost": {
-          "input": 15,
-          "output": 120
-        },
-        "limit": {
-          "context": 400000,
-          "input": 272000,
-          "output": 272000
-        }
-      },
-      "gpt-5.2": {
-        "id": "gpt-5.2",
-        "name": "GPT-5.2",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2025-08-31",
-        "release_date": "2025-12-11",
-        "last_updated": "2025-12-11",
-        "modalities": {
-          "input": ["text", "image"],
-          "output": ["text"]
-        },
-        "open_weights": false,
-        "cost": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
+          "input": 1.25,
+          "output": 10
         },
         "limit": {
           "context": 400000,
@@ -1630,9 +1893,84 @@
           "output": 128000
         }
       },
-      "gpt-5.1-chat-latest": {
-        "id": "gpt-5.1-chat-latest",
-        "name": "GPT-5.1 Chat",
+      "gpt-image-1.5": {
+        "id": "gpt-image-1.5",
+        "name": "gpt-image-1.5",
+        "family": "gpt-image",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": false,
+        "temperature": false,
+        "release_date": "2025-11-25",
+        "last_updated": "2025-11-25",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 0,
+          "input": 0,
+          "output": 0
+        }
+      },
+      "gpt-4.1": {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "gpt-4.1-mini": {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.1
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "gpt-5.1-codex": {
+        "id": "gpt-5.1-codex",
+        "name": "GPT-5.1 Codex",
         "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
@@ -1651,6 +1989,34 @@
           "input": 1.25,
           "output": 10,
           "cache_read": 0.125
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-4o-2024-11-20": {
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-11-20",
+        "last_updated": "2024-11-20",
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "open_weights": false,
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
         },
         "limit": {
           "context": 128000,

--- a/script/generate-models-snapshot.ts
+++ b/script/generate-models-snapshot.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+// Fetch the models.dev catalog, narrow it to the providers bundled with
+// @openomni/llm, and write the result to packages/llm/src/provider/models-snapshot.json.
+//
+// The snapshot is the second rung of ModelsDev.get()'s fallback chain (user
+// cache → this snapshot → live fetch → empty). Keeping it fresh avoids silent
+// downgrades in fresh installs and CI runs where neither the cache nor
+// models.dev is reachable.
+
+const MODELS_URL = process.env.MODELS_DEV_URL ?? "https://models.dev/api.json";
+const BUNDLED_PROVIDERS = ["anthropic", "openai"] as const;
+const SNAPSHOT_PATH = "packages/llm/src/provider/models-snapshot.json";
+
+const response = await fetch(MODELS_URL, { signal: AbortSignal.timeout(15_000) });
+if (!response.ok) {
+  console.error(`[generate-models-snapshot] ${MODELS_URL} → ${response.status}`);
+  process.exit(1);
+}
+
+const catalog = (await response.json()) as Record<string, unknown>;
+const subset: Record<string, unknown> = {};
+for (const providerID of BUNDLED_PROVIDERS) {
+  const entry = catalog[providerID];
+  if (!entry) {
+    console.error(`[generate-models-snapshot] provider missing from catalog: ${providerID}`);
+    process.exit(1);
+  }
+  subset[providerID] = entry;
+}
+
+await Bun.write(SNAPSHOT_PATH, `${JSON.stringify(subset, null, 2)}\n`);
+console.log(
+  `[generate-models-snapshot] wrote ${SNAPSHOT_PATH} (${BUNDLED_PROVIDERS.length} providers)`,
+);


### PR DESCRIPTION
## Problem

The bundled `packages/llm/src/provider/models-snapshot.json` is the second rung of `ModelsDev.get()`'s fallback chain (user cache → snapshot → live fetch → empty). When the snapshot goes stale:

- Fresh clones and CI runs that miss both the user cache and the live fetch fall back to an outdated catalog.
- Per PR #96, the resolver then walks its family-fallback path and silently downgrades newly-released models (e.g. `claude-sonnet-4-6` → `claude-sonnet-4-5-20250929`) to the newest concrete model the stale snapshot knows about.

The existing snapshot was missing the Anthropic 4-6 family and the OpenAI gpt-5.3/5.4 family that have shipped on models.dev since.

## Changes

- `script/generate-models-snapshot.ts` — fetches `https://models.dev/api.json`, narrows it to the two providers bundled with `@openomni/llm` (`anthropic`, `openai`), and writes the result to `packages/llm/src/provider/models-snapshot.json`. Overridable via `MODELS_DEV_URL`.
- `.github/workflows/generate-models-snapshot.yml` — runs the script every Monday at 06:17 UTC (and on manual dispatch) and opens a PR through `peter-evans/create-pull-request` whenever the catalog has changed. Keeps a human in the loop instead of pushing straight to `main`.
- `package.json` — adds `bun run generate:models-snapshot` convenience script.
- `packages/llm/src/provider/models-snapshot.json` — regenerated with the current catalog. Anthropic gains `claude-sonnet-4-6` and `claude-opus-4-6`; OpenAI gains `gpt-5.3-*`, `gpt-5.4-*`, and `gpt-image-*`. Removes the now-retired `claude-3-7-sonnet-latest` alias.

## Validation

- `bun run generate:models-snapshot` — produces the committed snapshot.
- `bun run check-types` — passes (10/10 tasks).
- `bunx biome check` on new files — clean.

## Follow-up

A separate PR will remove the silent family-fallback path in `apps/server/src/agents/model-resolution.ts` so that a stale snapshot surfaces as an explicit "Model not found" error instead of a transparent downgrade. This PR addresses the immediate data staleness; the resolver behavior change will be tracked in its own issue.