### PR TITLE
fix(server): remove silent family-fallback in model resolver

### DIFF
--- a/apps/server/src/agents/model-resolution.ts
+++ b/apps/server/src/agents/model-resolution.ts
@@ -45,18 +45,6 @@ function matchConcreteSiblings(preferredID: string, models: CatalogModel[]): Cat
   );
 }
 
-function inferFamily(preferredID: string, models: CatalogModel[]): string | undefined {
-  return [
-    ...new Set(
-      models
-        .map((model) => model.family)
-        .filter((family): family is string => typeof family === "string" && family.length > 0),
-    ),
-  ]
-    .sort((a, b) => b.length - a.length)
-    .find((family) => preferredID === family || preferredID.startsWith(`${family}-`));
-}
-
 function findConcreteSibling(
   exact: CatalogModel,
   models: CatalogModel[],
@@ -85,6 +73,10 @@ function findConcreteSibling(
   return sortModels(candidates)[0];
 }
 
+// Catalog lookup: alias → concrete sibling → prefix match. No family-level
+// guess: if the requested ID is not in the catalog and has no concrete
+// sibling, surface the miss to the caller so a stale catalog does not silently
+// downgrade a newly-released model.
 export function resolveCatalogModel(
   preferredID: string,
   models: CatalogModel[],
@@ -95,15 +87,7 @@ export function resolveCatalogModel(
     return findConcreteSibling(exact, models) ?? exact;
   }
 
-  const prefixMatch = matchConcreteSiblings(preferredID, models)[0];
-  if (prefixMatch) return prefixMatch;
-
-  const family = inferFamily(preferredID, models);
-  if (!family) return undefined;
-
-  return sortModels(
-    models.filter((model) => model.family === family && isConcreteModelID(model.id)),
-  )[0];
+  return matchConcreteSiblings(preferredID, models)[0];
 }
 
 async function listProviderModels(providerID: string): Promise<CatalogModel[]> {
@@ -116,23 +100,30 @@ export async function resolveRuntimeModel(
   model: RuntimeModel,
   defaultModel?: RuntimeModel,
 ): Promise<RuntimeModel> {
+  let catalogError: string | undefined;
   try {
     const resolved = resolveCatalogModel(model.id, await listProviderModels(model.provider));
     if (resolved) {
       return { provider: model.provider, id: resolved.id };
     }
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.warn(`[server] failed to resolve agent model ${model.provider}/${model.id}: ${msg}`);
+    catalogError = error instanceof Error ? error.message : String(error);
   }
+
+  const reason = catalogError
+    ? `catalog lookup failed (${catalogError})`
+    : "model not in provider catalog";
 
   if (defaultModel && defaultModel.provider === model.provider) {
     console.warn(
-      `[server] falling back to default model for ${model.provider}/${model.id}: ${defaultModel.id}`,
+      `[server] ${reason} for ${model.provider}/${model.id} — falling back to default ${defaultModel.id}`,
     );
     return defaultModel;
   }
 
+  console.warn(
+    `[server] ${reason} for ${model.provider}/${model.id} — passing through unresolved; downstream will throw Model not found`,
+  );
   return model;
 }
 

--- a/apps/server/test/model-resolution.test.ts
+++ b/apps/server/test/model-resolution.test.ts
@@ -50,13 +50,13 @@ describe("resolveCatalogModel", () => {
     expect(resolveCatalogModel("claude-opus-4-5", models)?.id).toBe("claude-opus-4-5-20251101");
   });
 
-  it("falls back to the newest concrete model in the same family for newer aliases", () => {
+  it("returns undefined when the requested model has no exact or prefix match", () => {
     const models = [
       makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
       makeModel("claude-sonnet-4-20250514", "Claude Sonnet 4", "2025-05-22"),
     ];
 
-    expect(resolveCatalogModel("claude-sonnet-4-6", models)?.id).toBe("claude-sonnet-4-5-20250929");
+    expect(resolveCatalogModel("claude-sonnet-4-6", models)).toBeUndefined();
   });
 });
 
@@ -79,16 +79,74 @@ describe("resolveRuntimeModel", () => {
   it("falls back to the server default model for the same provider when lookup misses", async () => {
     Auth.get = async () => ({ type: "api", key: "test-key" });
     Provider.listModels = async () => [];
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
 
-    await expect(
-      resolveRuntimeModel(
-        { provider: "anthropic", id: "claude-sonnet-4-6" },
-        { provider: "anthropic", id: "claude-opus-4-20250514" },
-      ),
-    ).resolves.toEqual({
-      provider: "anthropic",
-      id: "claude-opus-4-20250514",
-    });
+    try {
+      await expect(
+        resolveRuntimeModel(
+          { provider: "anthropic", id: "claude-sonnet-4-6" },
+          { provider: "anthropic", id: "claude-opus-4-20250514" },
+        ),
+      ).resolves.toEqual({
+        provider: "anthropic",
+        id: "claude-opus-4-20250514",
+      });
+      expect(
+        warnings.some(
+          (w) => w.includes("claude-sonnet-4-6") && w.includes("claude-opus-4-20250514"),
+        ),
+      ).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("passes the requested model through when the catalog misses and no default is provided", async () => {
+    Auth.get = async () => ({ type: "api", key: "test-key" });
+    Provider.listModels = async () => [];
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+
+    try {
+      await expect(
+        resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-6" }),
+      ).resolves.toEqual({ provider: "anthropic", id: "claude-sonnet-4-6" });
+      expect(
+        warnings.some((w) => w.includes("claude-sonnet-4-6") && w.includes("Model not found")),
+      ).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("warns with the underlying catalog error and falls back to the default model when listModels throws", async () => {
+    Auth.get = async () => ({ type: "api", key: "test-key" });
+    Provider.listModels = async () => {
+      throw new Error("network down");
+    };
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+
+    try {
+      await expect(
+        resolveRuntimeModel(
+          { provider: "anthropic", id: "claude-sonnet-4-6" },
+          { provider: "anthropic", id: "claude-opus-4-20250514" },
+        ),
+      ).resolves.toEqual({
+        provider: "anthropic",
+        id: "claude-opus-4-20250514",
+      });
+      expect(
+        warnings.some((w) => w.includes("network down") && w.includes("claude-opus-4-20250514")),
+      ).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });
 


### PR DESCRIPTION
Closes #98.

## Problem

The family-fallback branch in \`resolveCatalogModel\` returned the newest concrete model in the same family prefix when the requested ID was missing from the catalog. The test case in #96 documented the behavior:

\`\`\`
claude-sonnet-4-6 requested → claude-sonnet-4-5-20250929 returned
\`\`\`

In practice that was a silent downgrade: the bundled \`models-snapshot.json\` shipped in #96 predated the 4-6 release, so every fresh clone and CI run resolved the \`dev\` agent's configured \`claude-sonnet-4-6\` to \`claude-sonnet-4-5-20250929\` with no log the operator could see. The outer \`resolveRuntimeModel\` only warned when \`Provider.listModels\` threw, not on a catalog miss.

By contrast, \`packages/agent/src/core/execution/shared.ts\` throws \`Model not found: <id>\` on a miss. That is the right default: a missing model is a data-freshness bug to surface, not paper over.

## Changes

- \`resolveCatalogModel\` — drop the family-guess branch. The \"exact → concrete sibling → prefix\" chain stays (still handles \`claude-sonnet-4-5\` → \`claude-sonnet-4-5-20250929\`). When none match, return \`undefined\` so the caller decides.
- \`resolveRuntimeModel\` — log on every miss, not only \`listModels\` throws:
  - Default fallback warning now carries both the requested ID and the reason (\`catalog lookup failed\` vs \`model not in provider catalog\`).
  - When no default is configured, the function still returns the requested model but now warns that it is being passed through unresolved so downstream will throw \`Model not found\`.
- \`apps/server/test/model-resolution.test.ts\`:
  - Drop the family-fallback test. Replace with a \"returns undefined when the requested model has no exact or prefix match\" case.
  - Add a warning-assertion case for the default-fallback path (covers the new warn payload).
  - Add a pass-through case with no default, asserting the unresolved warning.
  - Add a \`listModels\` throw case, asserting the underlying error makes it into the warning alongside the default ID.

## Validation

- \`bun test apps/server/test/model-resolution.test.ts\` → 8/8 pass.
- \`bun test\` in \`apps/server\` → 133/133 pass.
- \`bun run check-types\` → 10/10 pass.
- \`bunx biome check\` on changed files → clean.

## Related

- #96 introduced the family-fallback.
- #97 refreshed the bundled snapshot so the \"exact match\" path reaches the right ID in the common case. Together with this PR, a stale snapshot becomes a loud, actionable error instead of a silent downgrade.