### PR TITLE
refactor(protocol): unify coding style and fix schema issues

### DIFF
--- a/apps/cli/src/cmd/config.ts
+++ b/apps/cli/src/cmd/config.ts
@@ -23,10 +23,6 @@ async function promptUsers(): Promise<string[] | undefined> {
     .filter(Boolean);
 }
 
-// ---------------------------------------------------------------------------
-// config add
-// ---------------------------------------------------------------------------
-
 const ConfigAddCommand: CommandModule = {
   command: "add",
   describe: "Configure an adapter",
@@ -117,10 +113,6 @@ const ConfigAddCommand: CommandModule = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// config list
-// ---------------------------------------------------------------------------
-
 const ConfigListCommand: CommandModule = {
   command: "list",
   aliases: ["ls"],
@@ -167,10 +159,6 @@ const ConfigListCommand: CommandModule = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// config remove
-// ---------------------------------------------------------------------------
-
 const ConfigRemoveCommand: CommandModule = {
   command: "remove",
   aliases: ["rm"],
@@ -200,10 +188,6 @@ const ConfigRemoveCommand: CommandModule = {
     prompts.outro(`${selected} configuration removed`);
   },
 };
-
-// ---------------------------------------------------------------------------
-// config (parent)
-// ---------------------------------------------------------------------------
 
 export const ConfigCommand: CommandModule = {
   command: "config",

--- a/apps/server/src/channel/types.ts
+++ b/apps/server/src/channel/types.ts
@@ -1,4 +1,4 @@
-import type { Adapter, IngressResult } from "@openomni/protocol";
+import type { Adapter, Ingress } from "@openomni/protocol";
 
 /**
  * Platform API calls: send messages, typing indicators, authentication, rate limiting.
@@ -23,7 +23,7 @@ export interface InboundNormalizer<TPayload = unknown> {
  * MUST NOT: interpret business logic, call IngressEngine, manage adapter lifecycle.
  */
 export interface OutboundFormatter {
-  format(result: IngressResult, channelId: string, client: ChannelClient): Promise<void>;
+  format(result: Ingress.IngressResult, channelId: string, client: ChannelClient): Promise<void>;
 }
 
 /**

--- a/apps/server/src/handler/conversation.ts
+++ b/apps/server/src/handler/conversation.ts
@@ -1,11 +1,11 @@
 // server → openomni → agent → llm (direct agent imports forbidden)
 import { IngressEngine } from "@openomni/openomni";
-import type { Adapter, IngressResult } from "@openomni/protocol";
+import type { Adapter, Ingress } from "@openomni/protocol";
 import { resolveRuntimeModel } from "../agents/model-resolution";
 import { buildInboundEvent, type BridgeDeps } from "../ingress/bridge";
 import { resolveAgentName } from "../router";
 
-function toResponseText(result: IngressResult): string {
+function toResponseText(result: Ingress.IngressResult): string {
   switch (result.mode) {
     case "direct":
       return result.result.output || "(no response)";

--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -1,4 +1,4 @@
-import type { Tool, Adapter, AgentDef, InboundEvent } from "@openomni/protocol";
+import type { Tool, Adapter, Ingress } from "@openomni/protocol";
 import { SurfaceKey } from "@openomni/session";
 import { getAgentDefinition } from "../agents/registry";
 import type { AgentDefinition } from "../agents/types";
@@ -62,7 +62,7 @@ function selectTools(
   return { specs, tools };
 }
 
-function buildAgentDef(agentName: string, deps: BridgeDeps): AgentDef {
+function buildAgentDef(agentName: string, deps: BridgeDeps): Ingress.AgentDef {
   const definition = getAgentDefinition(agentName) ?? createFallbackDefinition(agentName, deps);
   const { specs, tools } = selectTools(definition, deps);
 
@@ -88,7 +88,7 @@ function buildAgentDef(agentName: string, deps: BridgeDeps): AgentDef {
 function createBaseEvent(
   message: Adapter.InboundMessage,
   payload: string,
-): Omit<InboundEvent, "mode" | "agent" | "agents"> {
+): Omit<Ingress.InboundEvent, "mode" | "agent" | "agents"> {
   const descriptor = SurfaceKey.parse(message.surfaceKey);
 
   return {
@@ -114,7 +114,7 @@ export function buildInboundEvent(
   message: Adapter.InboundMessage,
   agentName: string,
   deps: BridgeDeps,
-): InboundEvent {
+): Ingress.InboundEvent {
   const mode = detectMode(message.text);
   const base = createBaseEvent(message, mode.text);
   const agent = buildAgentDef(agentName, deps);

--- a/apps/server/test/execution/e2e.test.ts
+++ b/apps/server/test/execution/e2e.test.ts
@@ -1,14 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ChatAgent, type ChatAgentInstance } from "@openomni/agent";
 import { IngressEngine } from "@openomni/openomni";
-import type { Execution } from "@openomni/protocol";
-import type { DirectEvent } from "@openomni/protocol";
+import type { Execution, Ingress } from "@openomni/protocol";
 
 type CoordinatorLike = {
   dispatch(sessionId: string, request: Execution.Request): Promise<Execution.Result>;
 };
 
-function makeDirectEvent(): DirectEvent {
+function makeDirectEvent(): Ingress.DirectEvent {
   return {
     id: crypto.randomUUID(),
     surface: "test",

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -62,3 +62,44 @@ Each package may depend only on packages to its LEFT. Reverse dependencies are b
 - Every subdirectory has `index.ts` that re-exports public API.
 - No `utils.ts` or `helpers.ts` catch-all files.
 - ESM only: `"type": "module"`, imports use `from "./foo"` (no `.ts` extension).
+
+## 8. Code Style
+
+### Comments
+
+- **WHY only**: comments explain _why_, never _what_. The code itself communicates what it does.
+- **No banner comments**: `// ───`, `// ===`, `// ---`, `// ***` visual separators are forbidden. Namespace and function names provide structure.
+- **No numbered steps**: `// 1. Resolve`, `// Step 2: Load` procedural markers are forbidden. Code flow is the sequence.
+- **No obvious JSDoc**: if the function name already says it, don't repeat it in a doc comment. `/** Creates a user */ function createUser()` is noise.
+- **TODO is OK**: `// TODO:` with a specific description of what needs to change and why.
+- **Business logic OK**: domain knowledge that isn't obvious from code (`// FK constraint requires inserting message before parts`).
+- **Algorithm OK**: naming a non-trivial algorithm (`// Kahn's algorithm for cycle detection`).
+
+### Naming
+
+- Variables/functions: `camelCase`, verbs (`resolveProvider`, `buildAgent`).
+- Types/interfaces: `PascalCase`, nouns (`AgentSpec`, `ModelFamily`).
+- Constants: `SCREAMING_SNAKE` only for true constants (magic numbers, config values). Functions and objects use `camelCase`.
+- Booleans: `is/has/can/should` prefix (`isStreaming`, `hasCredentials`).
+
+### Structure
+
+- **Data over code**: prefer declarative config objects over repetitive functions.
+- **One way to do it**: if a factory exists, always use the factory. No ad-hoc alternatives.
+- **No premature abstraction**: don't create interfaces, generics, or wrappers until a second use case appears.
+- **`readonly` preferred**: immutable interface fields use `readonly`.
+
+### Declaration Merging Pattern
+
+When a namespace's primary type conflicts with the namespace name, use declaration merging:
+
+```typescript
+export namespace Plan {
+  export const Schema = z.object({...});
+  export const StepSchema = z.object({...});
+  export type Step = z.infer<typeof StepSchema>;
+}
+export type Plan = z.infer<typeof Plan.Schema>;
+```
+
+This allows `Plan` to work as both a namespace (`Plan.Schema`, `Plan.Step`) and a type (`const p: Plan = ...`).

--- a/packages/openomni/src/dag/index.ts
+++ b/packages/openomni/src/dag/index.ts
@@ -1,4 +1,4 @@
-import type { PlanStep } from "@openomni/protocol";
+import type { Plan } from "@openomni/protocol";
 
 export interface DAGStructure {
   nodes: Set<string>;
@@ -10,7 +10,7 @@ export interface DAGStructure {
 type AcyclicResult = { valid: true } | { valid: false; cycle: string[] };
 
 export namespace DAG {
-  export function build(steps: PlanStep[]): DAGStructure {
+  export function build(steps: Plan.Step[]): DAGStructure {
     const nodes = new Set<string>();
     const edges = new Map<string, Set<string>>();
     const reverseEdges = new Map<string, Set<string>>();

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -8,7 +8,6 @@ export {
   PlanPipeline,
   StructuralGate,
   createPlanToolExecutor,
-  normalizePlanPayload,
   structuralGateCheck,
 } from "./plan";
 export type { EditResult, PlanDocument, PlanStore } from "./plan";

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -1,4 +1,4 @@
-import { InboundEventSchema, type InboundEvent, type IngressResult } from "@openomni/protocol";
+import { Ingress } from "@openomni/protocol";
 import { Bus, Storage, SurfaceKey } from "@openomni/session";
 import type { CoordinatorLike } from "./coordinator-like";
 import { IngressEventProjector } from "./event-projector";
@@ -20,8 +20,8 @@ export namespace IngressEngine {
     _coordinator = c;
   }
 
-  export async function ingest(event: InboundEvent): Promise<IngressResult> {
-    InboundEventSchema.parse(event);
+  export async function ingest(event: Ingress.InboundEvent): Promise<Ingress.IngressResult> {
+    Ingress.InboundEventSchema.parse(event);
 
     const agentModel = event.agent.model;
     const { session } = IngressSessionResolver.resolve(event, {

--- a/packages/openomni/src/ingress/event-projector.ts
+++ b/packages/openomni/src/ingress/event-projector.ts
@@ -1,8 +1,8 @@
-import type { InboundEvent, Message } from "@openomni/protocol";
+import type { Ingress, Message } from "@openomni/protocol";
 import { Session } from "@openomni/session";
 
 export namespace IngressEventProjector {
-  function extractTextPayload(event: InboundEvent): string {
+  function extractTextPayload(event: Ingress.InboundEvent): string {
     if (typeof event.payload === "string") {
       return event.payload;
     }
@@ -19,7 +19,7 @@ export namespace IngressEventProjector {
     return JSON.stringify(event.payload) ?? "";
   }
 
-  export function project(event: InboundEvent, sessionId: string): void {
+  export function project(event: Ingress.InboundEvent, sessionId: string): void {
     const message: Message.UserMessage = {
       id: crypto.randomUUID(),
       sessionID: sessionId,

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -1,19 +1,13 @@
 import { ChatAgent } from "@openomni/agent";
-import {
-  type Execution,
-  PlanResultSchema,
-  type InboundEvent,
-  type IngressResult,
-} from "@openomni/protocol";
+import { Plan, type Ingress, type Execution } from "@openomni/protocol";
 import type { CoordinatorLike } from "./coordinator-like";
 import { SessionBridge } from "./session-bridge";
 import { PlanAgent } from "../plan/plan-agent";
-import { normalizePlanPayload } from "../plan/plan-json";
 
 export namespace IngressHandlers {
   export interface HandlerContext {
     sessionId: string;
-    event: InboundEvent;
+    event: Ingress.InboundEvent;
     coordinator?: CoordinatorLike;
   }
 
@@ -48,7 +42,7 @@ export namespace IngressHandlers {
 
   export async function handlePlan(
     ctx: HandlerContext,
-  ): Promise<Extract<IngressResult, { mode: "plan" }>> {
+  ): Promise<Extract<Ingress.IngressResult, { mode: "plan" }>> {
     if (ctx.event.mode !== "plan") {
       throw new Error("handlePlan requires plan mode event");
     }
@@ -62,8 +56,7 @@ export namespace IngressHandlers {
         );
       }
       const raw = JSON.parse(coordinatorResult.output ?? "{}");
-      const normalized = { ...raw, plan: normalizePlanPayload(raw.plan) };
-      const planResult = PlanResultSchema.parse(normalized);
+      const planResult = Plan.ResultSchema.parse(raw);
       SessionBridge.storePlanResult(ctx.sessionId, planResult, ctx.event.agent.model);
       return { mode: "plan", sessionId: ctx.sessionId, result: planResult };
     }
@@ -82,7 +75,7 @@ export namespace IngressHandlers {
 
   export async function handleDirect(
     ctx: HandlerContext,
-  ): Promise<Extract<IngressResult, { mode: "direct" }>> {
+  ): Promise<Extract<Ingress.IngressResult, { mode: "direct" }>> {
     if (ctx.event.mode !== "direct") {
       throw new Error("handleDirect requires direct mode event");
     }

--- a/packages/openomni/src/ingress/session-bridge.ts
+++ b/packages/openomni/src/ingress/session-bridge.ts
@@ -1,7 +1,5 @@
-import { type Message, PlanSchema } from "@openomni/protocol";
-import type { Plan, PlanResult } from "@openomni/protocol";
+import { Plan, type Message } from "@openomni/protocol";
 import { Session } from "@openomni/session";
-import { normalizePlanPayload } from "../plan/plan-json";
 
 const PLAN_PREFIX = "__OPENOMNI_PLAN__";
 
@@ -84,8 +82,7 @@ export namespace SessionBridge {
     }
 
     const parsed = JSON.parse(lastPlanText);
-    const normalized = normalizePlanPayload(parsed);
-    return PlanSchema.parse(normalized);
+    return Plan.Schema.parse(parsed);
   }
 
   export function buildDirectMessages(
@@ -108,7 +105,7 @@ export namespace SessionBridge {
 
   export function storePlanResult(
     sessionId: string,
-    result: PlanResult,
+    result: Plan.Result,
     model: { provider: string; id: string },
   ): void {
     const message = createAssistantMessage(sessionId, model);

--- a/packages/openomni/src/plan/index.ts
+++ b/packages/openomni/src/plan/index.ts
@@ -5,4 +5,3 @@ export { Hashline } from "./hashline.js";
 export { InMemoryPlanStore } from "./plan-store.js";
 export type { EditResult, PlanDocument, PlanStore } from "./plan-store.js";
 export { StructuralGate, structuralGateCheck } from "./structural-gate.js";
-export { normalizePlanPayload } from "./plan-json.js";

--- a/packages/openomni/src/plan/plan-agent.ts
+++ b/packages/openomni/src/plan/plan-agent.ts
@@ -1,17 +1,17 @@
 import { ChatAgent, type AgentBudget, type ChatAgentInstance } from "@openomni/agent";
-import { PlanSchema, type PlanResult, type Tool } from "@openomni/protocol";
-import { extractJson, normalizePlanPayload } from "./plan-json.js";
+import { Plan, type Tool } from "@openomni/protocol";
+import { extractJson } from "./plan-json.js";
 import { InMemoryPlanStore, type PlanStore } from "./plan-store";
 import { PLAN_TOOL_SPECS, createPlanToolExecutor } from "./plan-tools";
 
-function parsePlan(text: string): PlanResult["plan"] {
+function parsePlan(text: string): Plan.Result["plan"] {
   let raw: unknown;
   try {
     raw = JSON.parse(extractJson(text));
   } catch (e) {
     throw new Error(`Failed to parse plan JSON: ${e instanceof Error ? e.message : String(e)}`);
   }
-  const result = PlanSchema.safeParse(normalizePlanPayload(raw));
+  const result = Plan.Schema.safeParse(raw);
   if (!result.success) throw new Error(`Failed to validate plan: ${result.error.message}`);
   return result.data;
 }
@@ -55,7 +55,7 @@ export namespace PlanAgent {
     });
   }
 
-  export async function generate(goal: string, config: GenerateConfig): Promise<PlanResult> {
+  export async function generate(goal: string, config: GenerateConfig): Promise<Plan.Result> {
     const agent = ChatAgent.create({
       model: config.model,
       systemPrompt: config.systemPrompt ?? "",

--- a/packages/openomni/src/plan/plan-json.ts
+++ b/packages/openomni/src/plan/plan-json.ts
@@ -1,19 +1,3 @@
-/**
- * Restores Date fields lost during JSON round-trip.
- * JSON.stringify converts Date → string; this converts back.
- */
-export function normalizePlanPayload(payload: unknown): unknown {
-  if (!payload || typeof payload !== "object") return payload;
-
-  const candidate = payload as Record<string, unknown>;
-  if (typeof candidate.createdAt !== "string") return payload;
-
-  const parsedDate = new Date(candidate.createdAt);
-  if (Number.isNaN(parsedDate.getTime())) return payload;
-
-  return { ...candidate, createdAt: parsedDate };
-}
-
 export function extractJson(text: string): string {
   const trimmed = text.trim();
   if (trimmed.startsWith("{")) return trimmed;

--- a/packages/openomni/src/plan/plan-pipeline.ts
+++ b/packages/openomni/src/plan/plan-pipeline.ts
@@ -1,4 +1,4 @@
-import { PlanSchema, type Gate, type Plan } from "@openomni/protocol";
+import { Plan, type Gate } from "@openomni/protocol";
 import { PlanAgent } from "./plan-agent.js";
 
 const DEFAULT_MAX_RETRIES = 3;
@@ -62,7 +62,7 @@ export namespace PlanPipeline {
             };
           }
         }
-        const revalidation = PlanSchema.safeParse(lastPlan);
+        const revalidation = Plan.Schema.safeParse(lastPlan);
         if (!revalidation.success) {
           return {
             ok: false,

--- a/packages/openomni/test/dag/dag.test.ts
+++ b/packages/openomni/test/dag/dag.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import type { PlanStep } from "@openomni/protocol";
+import type { Plan } from "@openomni/protocol";
 import { DAG } from "../../src/dag";
 
-function step(stepId: string, dependsOn: string[] = []): PlanStep {
+function step(stepId: string, dependsOn: string[] = []): Plan.Step {
   return {
     stepId,
     description: `Step ${stepId}`,

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { InboundEvent } from "@openomni/protocol";
+import type { Ingress } from "@openomni/protocol";
 import {
   defaultRunFn,
   mockModelsGet,
@@ -49,7 +49,7 @@ describe("IngressEngine", () => {
   it("ingest() with plan mode returns plan result", async () => {
     enqueuePlan("Create delivery plan");
 
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-plan-1",
       surface: "tui",
       workspace: "/repo",
@@ -73,7 +73,7 @@ describe("IngressEngine", () => {
   it("ingest() with direct mode returns direct result", async () => {
     testState.responseQueue.push("direct response");
 
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-direct-1",
       surface: "slack",
       workspace: "team-a",
@@ -109,7 +109,7 @@ describe("IngressEngine", () => {
     enqueuePlan("First plan");
     enqueuePlan("Second plan");
 
-    const eventA: InboundEvent = {
+    const eventA: Ingress.InboundEvent = {
       id: "event-reuse-1",
       surface: "tui",
       workspace: "/repo",
@@ -121,7 +121,7 @@ describe("IngressEngine", () => {
       },
     };
 
-    const eventB: InboundEvent = {
+    const eventB: Ingress.InboundEvent = {
       id: "event-reuse-2",
       surface: "tui",
       workspace: "/repo",
@@ -143,7 +143,7 @@ describe("IngressEngine", () => {
     enqueuePlan("Plan before reset");
     enqueuePlan("Plan after reset");
 
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-reset-1",
       surface: "tui",
       workspace: "/repo",

--- a/packages/openomni/test/ingress/event-projector.test.ts
+++ b/packages/openomni/test/ingress/event-projector.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { InboundEvent, Message } from "@openomni/protocol";
+import type { Ingress, Message } from "@openomni/protocol";
 import { Session, Storage } from "@openomni/session";
 import { IngressEventProjector } from "../../src/ingress/event-projector";
 
@@ -15,7 +15,7 @@ describe("IngressEventProjector", () => {
   });
 
   it("should store TextPart with string payload verbatim", () => {
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-1",
       surface: "slack",
       mode: "direct",
@@ -38,7 +38,7 @@ describe("IngressEventProjector", () => {
   });
 
   it("should extract text field from object payload", () => {
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-2",
       surface: "discord",
       mode: "direct",
@@ -57,7 +57,7 @@ describe("IngressEventProjector", () => {
 
   it("should JSON.stringify object payload without text field", () => {
     const payload = { type: "reaction", emoji: "👍", count: 5 };
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-3",
       surface: "telegram",
       mode: "direct",
@@ -75,7 +75,7 @@ describe("IngressEventProjector", () => {
   });
 
   it("should set UserMessage.agent to event.surface", () => {
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-4",
       surface: "whatsapp",
       mode: "direct",
@@ -93,7 +93,7 @@ describe("IngressEventProjector", () => {
   });
 
   it("should store both UserMessage and TextPart in session", () => {
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-5",
       surface: "email",
       mode: "direct",

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { Message } from "@openomni/protocol";
-import type { InboundEvent, Plan } from "@openomni/protocol";
+import type { Message, Ingress, Plan } from "@openomni/protocol";
 import { Bus, Session, Storage, SurfaceKey } from "@openomni/session";
 import { mockModelsGet, mockProviderFromModelsDevModel, resetTestState } from "./_llm-mock";
 
@@ -134,7 +133,7 @@ describe("IngressHandlers", () => {
   it("buildExecutionRequest preserves tool execution config", () => {
     const toolConfig = { workspaceRoot: "/workspace/openomni" };
     const permissions = { denylist: ["bash"] };
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-request-1",
       surface: "tui",
       mode: "direct",
@@ -165,7 +164,7 @@ describe("IngressHandlers", () => {
     const generateMock = mock(async () => ({ plan }));
     PlanAgent.generate = generateMock;
 
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-plan-1",
       surface: "tui",
       mode: "plan",
@@ -195,7 +194,7 @@ describe("IngressHandlers", () => {
     PlanAgent.generate = generateMock;
     SessionBridge.storePlanResult = storePlanResultMock;
 
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-plan-2",
       surface: "tui",
       mode: "plan",
@@ -248,7 +247,7 @@ describe("IngressHandlers", () => {
       output: "ok",
       isError: false,
     });
-    const event: InboundEvent = {
+    const event: Ingress.InboundEvent = {
       id: "event-direct-1",
       surface: "tui",
       mode: "direct",

--- a/packages/openomni/test/ingress/integration.test.ts
+++ b/packages/openomni/test/ingress/integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { InboundEvent } from "@openomni/protocol";
+import type { Ingress } from "@openomni/protocol";
 import { ZodError } from "zod";
 import {
   defaultRunFn,
@@ -219,7 +219,7 @@ describe("IngressEngine integration pipeline", () => {
       };
 
       await expect(
-        IngressEngine.ingest(invalidEvent as unknown as InboundEvent),
+        IngressEngine.ingest(invalidEvent as unknown as Ingress.InboundEvent),
       ).rejects.toBeInstanceOf(ZodError);
     });
   });

--- a/packages/openomni/test/ingress/session-bridge.test.ts
+++ b/packages/openomni/test/ingress/session-bridge.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import type { Message } from "@openomni/protocol";
-import type { Plan, PlanResult } from "@openomni/protocol";
+import type { Message, Plan } from "@openomni/protocol";
 import { Session, Storage } from "@openomni/session";
 import { SessionBridge } from "../../src/ingress/session-bridge";
 
@@ -99,7 +98,7 @@ describe("SessionBridge", () => {
   describe("storePlanResult + extractPlan round-trip", () => {
     it("should store and extract Plan with createdAt as Date", () => {
       const plan = createTestPlan();
-      const planResult: PlanResult = { plan };
+      const planResult: Plan.Result = { plan };
 
       SessionBridge.storePlanResult(sessionId, planResult, TEST_MODEL);
 

--- a/packages/protocol/src/adapter/index.ts
+++ b/packages/protocol/src/adapter/index.ts
@@ -1,121 +1,60 @@
-/**
- * Adapter — common contract for all surface adapters.
- *
- * Adapters are transport layers bridging external platforms (Telegram, Discord,
- * GitHub, TUI, etc.) with the OpenOmni conversation handler. Each adapter
- * declares its capabilities, and the orchestration layer adjusts behavior
- * accordingly.
- */
 export namespace Adapter {
-  // ── Capabilities ──────────────────────────────────────────────
-
-  /** Declares what a surface adapter supports. */
   export interface Capabilities {
-    /** Adapter can deliver streamed response chunks incrementally. */
     streaming: boolean;
-    /** Media support per direction. */
     media: {
       send: boolean;
       receive: boolean;
     };
-    /** Supports platform-native command registration (e.g. Telegram /commands). */
     commands: boolean;
-    /** Supports threaded conversations. */
     threads: boolean;
   }
 
-  // ── Trigger Rules ──────────────────────────────────────────
-
-  /**
-   * Composable trigger rules. All rules in a config must pass (AND logic)
-   * for the adapter to invoke the message handler.
-   * Empty array = always trigger (no filtering).
-   */
+  // TriggerRule uses AND logic — all rules must pass. Empty array = always trigger.
   export type TriggerRule =
-    /** Match specific platform events (e.g. "message", "issue_comment.created"). */
     | { type: "event"; events: string[] }
-    /** Require @mention of the bot. DMs implicitly pass. */
     | { type: "mention" }
-    /** Require message to start with a prefix (stripped before handler). */
     | { type: "prefix"; value: string }
-    /** Match specific labels (e.g. GitHub issue labels). */
     | { type: "label"; values: string[] }
-    /** Restrict to specific channels or chats. */
     | { type: "channel"; ids: string[] }
-    /** Filter by sender identity. */
     | { type: "sender"; allow?: string[]; deny?: string[] };
 
-  /**
-   * Context constructed by the adapter from a platform event.
-   * Passed to the trigger evaluation engine.
-   */
   export interface TriggerContext {
-    /** Platform event identifier (e.g. "message", "issue_comment.created"). */
     event: string;
-    /** Was the bot explicitly mentioned? */
     mentioned: boolean;
-    /** Channel or chat identifier. */
     channelId?: string;
-    /** Sender identifier. */
     senderId: string;
-    /** Associated labels (e.g. GitHub issue labels). */
     labels?: string[];
-    /** Is this a direct message? DMs bypass mention rules. */
+    /** DMs bypass mention rules */
     isDM?: boolean;
-    /** Message text content. */
     text: string;
   }
 
-  // ── Delivery Policy ───────────────────────────────────────────
-
-  /**
-   * Controls which messages from a multi-step agent run are delivered.
-   * - `"all"` — every intermediate message (reasoning steps, tool calls)
-   * - `"final"` — only the final assistant response
-   *
-   * TODO: DeliveryPolicy is not yet enforced — currently a placeholder type only
-   */
+  // TODO: DeliveryPolicy is not yet enforced — placeholder type only
   export type DeliveryPolicy = "all" | "final";
 
-  // ── Media ─────────────────────────────────────────────────────
-
-  /** A media attachment for inbound or outbound messages. */
   export interface MediaAttachment {
     kind: "image" | "file" | "audio" | "video";
-    /** Remote URL. Preferred when the platform accepts URLs directly. */
     url?: string;
-    /** Raw binary data. Used when URL is not available. */
     data?: Uint8Array;
     mimeType?: string;
     filename?: string;
   }
 
-  // ── Messages ──────────────────────────────────────────────────
-
-  /** Inbound message: platform → agent. */
   export interface InboundMessage {
-    /** Platform-specific message identifier. */
     id: string;
-    /** Resolved SurfaceKey for session routing. */
     surfaceKey: string;
-    /** Message text content. */
     text: string;
-    /** Sender identity. */
     sender: {
       id: string;
       name?: string;
     };
-    /** Attached media (images, files, etc.). */
     media?: MediaAttachment[];
-    /** ID of the message being replied to. */
     replyToId?: string;
-    /** Thread identifier. */
     threadId?: string;
-    /** Raw platform payload for escape-hatch access. */
+    /** Raw platform payload for escape-hatch access */
     raw?: unknown;
   }
 
-  /** Outbound message: agent → platform. */
   export interface OutboundMessage {
     text?: string;
     media?: MediaAttachment[];
@@ -123,9 +62,6 @@ export namespace Adapter {
     threadId?: string;
   }
 
-  // ── Commands ──────────────────────────────────────────────────
-
-  /** A platform command definition (e.g. /help, /status). */
   export interface Command {
     name: string;
     description: string;
@@ -136,108 +72,46 @@ export namespace Adapter {
     }>;
   }
 
-  /** Context passed to a command handler. */
   export interface CommandContext {
     command: string;
     args: Record<string, string>;
     message: InboundMessage;
   }
 
-  // ── Handlers ──────────────────────────────────────────────────
-
-  /**
-   * Handles an inbound message and returns an optional response.
-   * Returning `null` means no response should be sent.
-   */
+  /** Returns null to suppress response */
   export type MessageHandler = (message: InboundMessage) => Promise<OutboundMessage | null>;
-
-  /** Handles a platform command invocation. */
   export type CommandHandler = (ctx: CommandContext) => Promise<OutboundMessage | null>;
 
-  /**
-   * Streaming sink for adapters that support incremental delivery.
-   * The orchestration layer writes chunks; the adapter flushes them
-   * to the platform in real time.
-   */
   export interface StreamSink {
-    /** Append a text chunk. */
     write(text: string): void;
-    /** Attach media (forces flush of any buffered text). */
+    /** Forces flush of any buffered text */
     attach(media: MediaAttachment): void;
-    /** Signal that the response is complete. */
     end(): void;
-    /** Signal an error. */
     error(err: Error): void;
   }
 
-  /**
-   * Streaming handler — used instead of MessageHandler when the adapter
-   * supports incremental delivery.
-   */
   export type StreamingHandler = (message: InboundMessage, sink: StreamSink) => Promise<void>;
 
-  // ── Config ────────────────────────────────────────────────────
-
-  /** Shared adapter configuration. */
   export interface Config {
-    /** Composable trigger rules. AND logic — all must pass. Empty = always. */
     triggers: TriggerRule[];
-    /** Which messages from a multi-step run to deliver. */
     deliveryPolicy: DeliveryPolicy;
   }
 
-  // ── Surface Interface ─────────────────────────────────────────
-
-  /**
-   * A surface adapter — bridges a platform with the OpenOmni agent.
-   *
-   * Adapters declare capabilities and accept configuration. The orchestration
-   * layer wires handlers based on capabilities (e.g. streaming handler for
-   * streaming-capable adapters, standard handler for others).
-   */
   export interface Surface {
-    /** Unique adapter identifier (e.g. "telegram", "discord", "github"). */
     readonly id: string;
-    /** What this adapter supports. */
     readonly capabilities: Capabilities;
-    /** How this adapter should behave. */
     readonly config: Config;
 
-    // ── Lifecycle ──
-
-    /** Start listening for platform events. */
     start(): Promise<void>;
-    /** Stop listening and release resources. */
     stop(): void;
 
-    // ── Inbound ──
-
-    /**
-     * Register a handler for incoming messages.
-     * The adapter applies trigger and user filtering before invoking.
-     */
     onMessage(handler: MessageHandler): void;
-
-    /**
-     * Register a streaming handler (optional).
-     * When set on a streaming-capable adapter, called instead of the
-     * regular message handler.
-     */
+    /** When set on a streaming-capable adapter, called instead of the regular message handler */
     onStreamingMessage?(handler: StreamingHandler): void;
 
-    // ── Outbound ──
-
-    /**
-     * Send a message to a specific surface.
-     * Used for proactive messages or orchestration-managed delivery.
-     */
     send(surfaceKey: string, message: OutboundMessage): Promise<void>;
 
-    // ── Commands (optional) ──
-
-    /** Register commands with the platform. */
     registerCommands?(commands: Command[]): Promise<void>;
-    /** Register a handler for command invocations. */
     onCommand?(handler: CommandHandler): void;
   }
 }

--- a/packages/protocol/src/event-log/index.ts
+++ b/packages/protocol/src/event-log/index.ts
@@ -63,7 +63,6 @@ export namespace ExecutionEvent {
     StepFailed,
     SessionSuspended,
   ]);
-  export type T = z.infer<typeof Schema>;
 
   export type LlmResponse = z.infer<typeof LlmResponse>;
   export type ToolStarted = z.infer<typeof ToolStarted>;
@@ -72,3 +71,6 @@ export namespace ExecutionEvent {
   export type StepFailed = z.infer<typeof StepFailed>;
   export type SessionSuspended = z.infer<typeof SessionSuspended>;
 }
+
+// declaration merging: `ExecutionEvent` is both a namespace and a type
+export type ExecutionEvent = z.infer<typeof ExecutionEvent.Schema>;

--- a/packages/protocol/src/gate/index.ts
+++ b/packages/protocol/src/gate/index.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import type { Plan } from "../plan/index.js";
-import { PlanSchema } from "../plan/index.js";
+import { Plan } from "../plan/index.js";
 
 export namespace Gate {
   export const Issue = z.object({
@@ -39,7 +38,7 @@ export namespace Gate {
   export type EnrichAction = z.infer<typeof EnrichAction>;
 
   export const EnrichResult = z.object({
-    plan: PlanSchema,
+    plan: Plan.Schema,
     applied: z.array(EnrichAction),
   });
   export type EnrichResult = z.infer<typeof EnrichResult>;

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Guardrail } from "../guardrail/index.js";
 import { Tool } from "../tool/index.js";
-import type { PlanResult } from "../plan/index.js";
+import type { Plan } from "../plan/index.js";
 
 const AgentToolConfigSchema = z.object({
   systemTools: z.array(z.string()).optional(),
@@ -10,61 +10,56 @@ const AgentToolConfigSchema = z.object({
   workspaceRoot: z.string().optional(),
 });
 
-// AgentDef — agent configuration passed in by callers (CLI/CUI layer)
-export const AgentDefSchema = z.object({
-  model: z.object({ provider: z.string(), id: z.string() }),
-  systemPrompt: z.string().optional(),
-  tools: z.array(Tool.Spec).optional(),
-  budget: z.object({ maxTurns: z.number().optional() }).optional(),
-  permissions: Guardrail.ToolPermission.optional(),
-  toolConfig: AgentToolConfigSchema.optional(),
-});
-// IMPORTANT: toolExecutor is a runtime callback, NOT in Zod schema.
-// The TypeScript type extends the schema:
-export type AgentDef = z.infer<typeof AgentDefSchema> & {
-  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
-};
+export namespace Ingress {
+  export const AgentDefSchema = z.object({
+    model: z.object({ provider: z.string(), id: z.string() }),
+    systemPrompt: z.string().optional(),
+    tools: z.array(Tool.Spec).optional(),
+    budget: z.object({ maxTurns: z.number().optional() }).optional(),
+    permissions: Guardrail.ToolPermission.optional(),
+    toolConfig: AgentToolConfigSchema.optional(),
+  });
+  // toolExecutor is a runtime callback — can't be expressed in Zod
+  export type AgentDef = z.infer<typeof AgentDefSchema> & {
+    toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  };
 
-// InboundEvent — discriminated union by mode
-const InboundEventBase = {
-  id: z.string(),
-  surface: z.string(),
-  channel: z.string().optional(),
-  workspace: z.string().optional(),
-  userId: z.string().optional(),
-  payload: z.unknown(),
-  meta: z.record(z.unknown()).optional(),
-};
+  const InboundEventBase = {
+    id: z.string(),
+    surface: z.string(),
+    channel: z.string().optional(),
+    workspace: z.string().optional(),
+    userId: z.string().optional(),
+    payload: z.unknown(),
+    meta: z.record(z.unknown()).optional(),
+  };
 
-export const PlanEventSchema = z.object({
-  ...InboundEventBase,
-  mode: z.literal("plan"),
-  agent: AgentDefSchema,
-});
-export type PlanEvent = z.infer<typeof PlanEventSchema> & { agent: AgentDef };
+  export const PlanEventSchema = z.object({
+    ...InboundEventBase,
+    mode: z.literal("plan"),
+    agent: AgentDefSchema,
+  });
+  export type PlanEvent = z.infer<typeof PlanEventSchema> & { agent: AgentDef };
 
-export const DirectEventSchema = z.object({
-  ...InboundEventBase,
-  mode: z.literal("direct"),
-  agent: AgentDefSchema,
-});
-export type DirectEvent = z.infer<typeof DirectEventSchema> & {
-  agent: AgentDef;
-};
+  export const DirectEventSchema = z.object({
+    ...InboundEventBase,
+    mode: z.literal("direct"),
+    agent: AgentDefSchema,
+  });
+  export type DirectEvent = z.infer<typeof DirectEventSchema> & { agent: AgentDef };
 
-export const InboundEventSchema = z.discriminatedUnion("mode", [
-  PlanEventSchema,
-  DirectEventSchema,
-]);
-export type InboundEvent = PlanEvent | DirectEvent;
+  export const InboundEventSchema = z.discriminatedUnion("mode", [
+    PlanEventSchema,
+    DirectEventSchema,
+  ]);
+  export type InboundEvent = PlanEvent | DirectEvent;
 
-// DirectResult
-export type DirectResult = {
-  output: string;
-  finishReason: string;
-};
+  export type DirectResult = {
+    output: string;
+    finishReason: string;
+  };
 
-// IngressResult — discriminated union return type from IngressEngine.ingest()
-export type IngressResult =
-  | { mode: "plan"; sessionId: string; result: PlanResult }
-  | { mode: "direct"; sessionId: string; result: DirectResult };
+  export type IngressResult =
+    | { mode: "plan"; sessionId: string; result: Plan.Result }
+    | { mode: "direct"; sessionId: string; result: DirectResult };
+}

--- a/packages/protocol/src/notification/index.ts
+++ b/packages/protocol/src/notification/index.ts
@@ -1,30 +1,32 @@
 import { z } from "zod";
 
-export const NotificationSeverity = z.enum(["info", "warning", "error"]);
-export type NotificationSeverity = z.infer<typeof NotificationSeverity>;
+export namespace Notification {
+  export const Severity = z.enum(["info", "warning", "error"]);
+  export type Severity = z.infer<typeof Severity>;
 
-export const DeliveryMode = z.enum(["reply_current_session", "dm", "new_session", "new_thread"]);
-export type DeliveryMode = z.infer<typeof DeliveryMode>;
+  export const DeliveryMode = z.enum(["reply_current_session", "dm", "new_session", "new_thread"]);
+  export type DeliveryMode = z.infer<typeof DeliveryMode>;
 
-export const NotificationRequest = z.object({
-  type: z.string(),
-  taskId: z.string().optional(),
-  runId: z.string().optional(),
-  traceId: z.string().optional(),
-  severity: NotificationSeverity,
-  title: z.string(),
-  body: z.string(),
-  artifactRefs: z.array(z.string()).optional(),
-  conversationSessionId: z.string().optional(),
-  deliveryHint: DeliveryMode.optional(),
-  metadata: z.record(z.unknown()).optional(),
-});
-export type NotificationRequest = z.infer<typeof NotificationRequest>;
+  export const Request = z.object({
+    type: z.string(),
+    taskId: z.string().optional(),
+    runId: z.string().optional(),
+    traceId: z.string().optional(),
+    severity: Severity,
+    title: z.string(),
+    body: z.string(),
+    artifactRefs: z.array(z.string()).optional(),
+    conversationSessionId: z.string().optional(),
+    deliveryHint: DeliveryMode.optional(),
+    metadata: z.record(z.unknown()).optional(),
+  });
+  export type Request = z.infer<typeof Request>;
 
-export const NotificationResult = z.object({
-  delivered: z.boolean(),
-  destination: z.string().optional(),
-  externalMessageId: z.string().optional(),
-  error: z.string().optional(),
-});
-export type NotificationResult = z.infer<typeof NotificationResult>;
+  export const Result = z.object({
+    delivered: z.boolean(),
+    destination: z.string().optional(),
+    externalMessageId: z.string().optional(),
+    error: z.string().optional(),
+  });
+  export type Result = z.infer<typeof Result>;
+}

--- a/packages/protocol/src/plan/index.ts
+++ b/packages/protocol/src/plan/index.ts
@@ -1,59 +1,94 @@
 import { z } from "zod";
 import { Tool } from "../tool/index.js";
 
-export const PlanStepSchema = z.object({
-  stepId: z.string(),
-  description: z.string(),
-  expectedOutput: z.string(),
-  dependsOn: z.array(z.string()).default([]),
-  suggestedAgent: z.string().optional(),
-  guardrail: z.string().optional(),
-  tools: z.array(Tool.Spec).optional(),
-  requiresApproval: z.boolean().optional(),
-});
+export namespace Plan {
+  export const StepSchema = z.object({
+    stepId: z.string(),
+    description: z.string(),
+    expectedOutput: z.string(),
+    dependsOn: z.array(z.string()).default([]),
+    suggestedAgent: z.string().optional(),
+    guardrail: z.string().optional(),
+    tools: z.array(Tool.Spec).optional(),
+    requiresApproval: z.boolean().optional(),
+  });
+  export type Step = z.infer<typeof StepSchema>;
 
-export type PlanStep = z.infer<typeof PlanStepSchema>;
+  export const Schema = z
+    .object({
+      planId: z.string(),
+      goal: z.string(),
+      steps: z.array(StepSchema),
+      createdAt: z.coerce.date(),
+      version: z.number().int().default(1),
+    })
+    .superRefine((data, ctx) => {
+      const stepIds = data.steps.map((s) => s.stepId);
+      const uniqueIds = new Set(stepIds);
+      if (stepIds.length !== uniqueIds.size) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Step IDs must be unique",
+          path: ["steps"],
+        });
+        return;
+      }
 
-export const PlanSchema = z
-  .object({
-    planId: z.string(),
-    goal: z.string(),
-    steps: z.array(PlanStepSchema),
-    createdAt: z.date(),
-    version: z.number().int().default(1),
-  })
-  .superRefine((data, ctx) => {
-    // Check for duplicate step IDs
-    const stepIds = data.steps.map((s) => s.stepId);
-    const uniqueIds = new Set(stepIds);
-    if (stepIds.length !== uniqueIds.size) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Step IDs must be unique",
-        path: ["steps"],
-      });
-    }
-
-    // Check that all dependencies reference existing steps
-    const stepIdSet = new Set(stepIds);
-    for (const step of data.steps) {
-      for (const dep of step.dependsOn) {
-        if (!stepIdSet.has(dep)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Step "${step.stepId}" depends on non-existent step "${dep}"`,
-            path: ["steps"],
-          });
+      const stepIdSet = new Set(stepIds);
+      const deps = new Map<string, string[]>();
+      for (const step of data.steps) {
+        deps.set(step.stepId, step.dependsOn);
+        for (const dep of step.dependsOn) {
+          if (!stepIdSet.has(dep)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Step "${step.stepId}" depends on non-existent step "${dep}"`,
+              path: ["steps"],
+            });
+          }
         }
       }
-    }
+
+      // Kahn's algorithm for cycle detection
+      const inDegree = new Map<string, number>();
+      for (const id of stepIds) inDegree.set(id, 0);
+      for (const step of data.steps) {
+        for (const dep of step.dependsOn) {
+          inDegree.set(step.stepId, (inDegree.get(step.stepId) ?? 0) + 1);
+          void dep;
+        }
+      }
+
+      const queue = stepIds.filter((id) => inDegree.get(id) === 0);
+      let visited = 0;
+      while (queue.length > 0) {
+        const id = queue.shift()!;
+        visited++;
+        for (const step of data.steps) {
+          if (step.dependsOn.includes(id)) {
+            const deg = (inDegree.get(step.stepId) ?? 1) - 1;
+            inDegree.set(step.stepId, deg);
+            if (deg === 0) queue.push(step.stepId);
+          }
+        }
+      }
+
+      if (visited !== stepIds.length) {
+        const cycled = stepIds.filter((id) => (inDegree.get(id) ?? 0) > 0);
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Dependency cycle detected involving steps: ${cycled.join(", ")}`,
+          path: ["steps"],
+        });
+      }
+    });
+
+  export const ResultSchema = z.object({
+    plan: Schema,
+    reviewNotes: z.string().optional(),
   });
+  export type Result = z.infer<typeof ResultSchema>;
+}
 
-export type Plan = z.infer<typeof PlanSchema>;
-
-export const PlanResultSchema = z.object({
-  plan: PlanSchema,
-  reviewNotes: z.string().optional(),
-});
-
-export type PlanResult = z.infer<typeof PlanResultSchema>;
+// declaration merging: `Plan` is both a namespace and a type
+export type Plan = z.infer<typeof Plan.Schema>;

--- a/packages/protocol/test/ingress.test.ts
+++ b/packages/protocol/test/ingress.test.ts
@@ -1,14 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import {
-  AgentDefSchema,
-  PlanEventSchema,
-  DirectEventSchema,
-  InboundEventSchema,
-} from "../src/ingress/index.js";
+import { Ingress } from "../src/ingress/index.js";
 
 describe("AgentDef", () => {
   test("should parse agent with only model required", () => {
-    const agent = AgentDefSchema.parse({
+    const agent = Ingress.AgentDefSchema.parse({
       model: {
         provider: "anthropic",
         id: "claude-3-5-sonnet",
@@ -22,7 +17,7 @@ describe("AgentDef", () => {
   });
 
   test("should parse agent with optional fields", () => {
-    const agent = AgentDefSchema.parse({
+    const agent = Ingress.AgentDefSchema.parse({
       model: {
         provider: "openai",
         id: "gpt-4",
@@ -56,7 +51,7 @@ describe("AgentDef", () => {
 
 describe("PlanEvent", () => {
   test("should parse valid plan event with agent", () => {
-    const event = PlanEventSchema.parse({
+    const event = Ingress.PlanEventSchema.parse({
       id: "event-1",
       surface: "cli",
       mode: "plan",
@@ -75,7 +70,7 @@ describe("PlanEvent", () => {
   });
 
   test("should parse plan event with optional fields", () => {
-    const event = PlanEventSchema.parse({
+    const event = Ingress.PlanEventSchema.parse({
       id: "event-2",
       surface: "api",
       channel: "webhook",
@@ -100,7 +95,7 @@ describe("PlanEvent", () => {
 
   test("should reject plan event missing mode", () => {
     expect(() =>
-      PlanEventSchema.parse({
+      Ingress.PlanEventSchema.parse({
         id: "event-1",
         surface: "cli",
         payload: { goal: "Build API" },
@@ -116,7 +111,7 @@ describe("PlanEvent", () => {
 
   test("should reject plan event missing agent", () => {
     expect(() =>
-      PlanEventSchema.parse({
+      Ingress.PlanEventSchema.parse({
         id: "event-1",
         surface: "cli",
         mode: "plan",
@@ -127,7 +122,7 @@ describe("PlanEvent", () => {
 
   test("should reject plan event missing surface", () => {
     expect(() =>
-      PlanEventSchema.parse({
+      Ingress.PlanEventSchema.parse({
         id: "event-1",
         mode: "plan",
         payload: { goal: "Build API" },
@@ -144,7 +139,7 @@ describe("PlanEvent", () => {
 
 describe("DirectEvent", () => {
   test("should parse valid direct event with agent", () => {
-    const event = DirectEventSchema.parse({
+    const event = Ingress.DirectEventSchema.parse({
       id: "event-1",
       surface: "cli",
       mode: "direct",
@@ -163,7 +158,7 @@ describe("DirectEvent", () => {
 
 describe("InboundEvent (discriminated union)", () => {
   test("should parse plan event via discriminated union", () => {
-    const event = InboundEventSchema.parse({
+    const event = Ingress.InboundEventSchema.parse({
       id: "event-1",
       surface: "cli",
       mode: "plan",
@@ -179,7 +174,7 @@ describe("InboundEvent (discriminated union)", () => {
   });
 
   test("should parse direct event via discriminated union", () => {
-    const event = InboundEventSchema.parse({
+    const event = Ingress.InboundEventSchema.parse({
       id: "event-1",
       surface: "cli",
       mode: "direct",
@@ -196,7 +191,7 @@ describe("InboundEvent (discriminated union)", () => {
 
   test("should reject invalid mode value", () => {
     expect(() =>
-      InboundEventSchema.parse({
+      Ingress.InboundEventSchema.parse({
         id: "event-1",
         surface: "cli",
         mode: "auto",
@@ -213,7 +208,7 @@ describe("InboundEvent (discriminated union)", () => {
 
   test("should reject missing id", () => {
     expect(() =>
-      InboundEventSchema.parse({
+      Ingress.InboundEventSchema.parse({
         surface: "cli",
         mode: "plan",
         payload: { goal: "Build API" },

--- a/packages/protocol/test/notification.test.ts
+++ b/packages/protocol/test/notification.test.ts
@@ -1,53 +1,48 @@
 import { describe, test, expect } from "bun:test";
-import {
-  NotificationSeverity,
-  DeliveryMode,
-  NotificationRequest,
-  NotificationResult,
-} from "../src/notification";
+import { Notification } from "../src/notification";
 
 describe("NotificationSeverity", () => {
   test("should parse valid severity values", () => {
-    expect(NotificationSeverity.parse("info")).toBe("info");
-    expect(NotificationSeverity.parse("warning")).toBe("warning");
-    expect(NotificationSeverity.parse("error")).toBe("error");
+    expect(Notification.Severity.parse("info")).toBe("info");
+    expect(Notification.Severity.parse("warning")).toBe("warning");
+    expect(Notification.Severity.parse("error")).toBe("error");
   });
 
   test("should reject invalid severity values", () => {
-    expect(() => NotificationSeverity.parse("critical")).toThrow();
-    expect(() => NotificationSeverity.parse("debug")).toThrow();
-    expect(() => NotificationSeverity.parse("")).toThrow();
+    expect(() => Notification.Severity.parse("critical")).toThrow();
+    expect(() => Notification.Severity.parse("debug")).toThrow();
+    expect(() => Notification.Severity.parse("")).toThrow();
   });
 
   test("should infer correct type from schema", () => {
-    const severity: NotificationSeverity = "warning";
+    const severity: Notification.Severity = "warning";
     expect(severity).toBe("warning");
   });
 });
 
 describe("DeliveryMode", () => {
   test("should parse valid delivery modes", () => {
-    expect(DeliveryMode.parse("reply_current_session")).toBe("reply_current_session");
-    expect(DeliveryMode.parse("dm")).toBe("dm");
-    expect(DeliveryMode.parse("new_session")).toBe("new_session");
-    expect(DeliveryMode.parse("new_thread")).toBe("new_thread");
+    expect(Notification.DeliveryMode.parse("reply_current_session")).toBe("reply_current_session");
+    expect(Notification.DeliveryMode.parse("dm")).toBe("dm");
+    expect(Notification.DeliveryMode.parse("new_session")).toBe("new_session");
+    expect(Notification.DeliveryMode.parse("new_thread")).toBe("new_thread");
   });
 
   test("should reject invalid delivery modes", () => {
-    expect(() => DeliveryMode.parse("email")).toThrow();
-    expect(() => DeliveryMode.parse("sms")).toThrow();
-    expect(() => DeliveryMode.parse("")).toThrow();
+    expect(() => Notification.DeliveryMode.parse("email")).toThrow();
+    expect(() => Notification.DeliveryMode.parse("sms")).toThrow();
+    expect(() => Notification.DeliveryMode.parse("")).toThrow();
   });
 
   test("should infer correct type from schema", () => {
-    const mode: DeliveryMode = "dm";
+    const mode: Notification.DeliveryMode = "dm";
     expect(mode).toBe("dm");
   });
 });
 
 describe("NotificationRequest", () => {
   test("should parse valid minimal request", () => {
-    const request = NotificationRequest.parse({
+    const request = Notification.Request.parse({
       type: "task_alert",
       severity: "info",
       title: "Test Alert",
@@ -60,7 +55,7 @@ describe("NotificationRequest", () => {
   });
 
   test("should parse valid request with all optional fields", () => {
-    const request = NotificationRequest.parse({
+    const request = Notification.Request.parse({
       type: "task_error",
       taskId: "task-123",
       runId: "run-456",
@@ -84,14 +79,14 @@ describe("NotificationRequest", () => {
 
   test("should reject request missing required fields", () => {
     expect(() =>
-      NotificationRequest.parse({
+      Notification.Request.parse({
         type: "task_alert",
         severity: "info",
       }),
     ).toThrow();
 
     expect(() =>
-      NotificationRequest.parse({
+      Notification.Request.parse({
         severity: "info",
         title: "Test",
         body: "Test",
@@ -101,7 +96,7 @@ describe("NotificationRequest", () => {
 
   test("should reject request with invalid severity", () => {
     expect(() =>
-      NotificationRequest.parse({
+      Notification.Request.parse({
         type: "task_alert",
         severity: "critical",
         title: "Test",
@@ -112,7 +107,7 @@ describe("NotificationRequest", () => {
 
   test("should reject request with invalid deliveryHint", () => {
     expect(() =>
-      NotificationRequest.parse({
+      Notification.Request.parse({
         type: "task_alert",
         severity: "info",
         title: "Test",
@@ -123,7 +118,7 @@ describe("NotificationRequest", () => {
   });
 
   test("should allow empty artifactRefs array", () => {
-    const request = NotificationRequest.parse({
+    const request = Notification.Request.parse({
       type: "task_alert",
       severity: "info",
       title: "Test",
@@ -134,7 +129,7 @@ describe("NotificationRequest", () => {
   });
 
   test("should infer correct type from schema", () => {
-    const request: NotificationRequest = {
+    const request: Notification.Request = {
       type: "task_warning",
       severity: "warning",
       title: "Warning",
@@ -146,14 +141,14 @@ describe("NotificationRequest", () => {
 
 describe("NotificationResult", () => {
   test("should parse valid minimal result", () => {
-    const result = NotificationResult.parse({
+    const result = Notification.Result.parse({
       delivered: true,
     });
     expect(result.delivered).toBe(true);
   });
 
   test("should parse valid result with all optional fields", () => {
-    const result = NotificationResult.parse({
+    const result = Notification.Result.parse({
       delivered: true,
       destination: "slack-channel-123",
       externalMessageId: "msg-xyz",
@@ -164,7 +159,7 @@ describe("NotificationResult", () => {
   });
 
   test("should parse failed delivery result", () => {
-    const result = NotificationResult.parse({
+    const result = Notification.Result.parse({
       delivered: false,
       error: "Failed to connect to Slack",
     });
@@ -174,14 +169,14 @@ describe("NotificationResult", () => {
 
   test("should reject result missing delivered field", () => {
     expect(() =>
-      NotificationResult.parse({
+      Notification.Result.parse({
         destination: "slack",
       }),
     ).toThrow();
   });
 
   test("should infer correct type from schema", () => {
-    const result: NotificationResult = {
+    const result: Notification.Result = {
       delivered: true,
       destination: "discord",
     };
@@ -191,7 +186,7 @@ describe("NotificationResult", () => {
 
 describe("Round-trip serialization", () => {
   test("should round-trip NotificationRequest through JSON", () => {
-    const original: NotificationRequest = {
+    const original: Notification.Request = {
       type: "task_result",
       taskId: "task-1",
       severity: "info",
@@ -200,18 +195,18 @@ describe("Round-trip serialization", () => {
       metadata: { duration: 1234 },
     };
     const json = JSON.stringify(original);
-    const parsed = NotificationRequest.parse(JSON.parse(json));
+    const parsed = Notification.Request.parse(JSON.parse(json));
     expect(parsed).toEqual(original);
   });
 
   test("should round-trip NotificationResult through JSON", () => {
-    const original: NotificationResult = {
+    const original: Notification.Result = {
       delivered: true,
       destination: "webhook",
       externalMessageId: "ext-123",
     };
     const json = JSON.stringify(original);
-    const parsed = NotificationResult.parse(JSON.parse(json));
+    const parsed = Notification.Result.parse(JSON.parse(json));
     expect(parsed).toEqual(original);
   });
 });

--- a/packages/protocol/test/plan.test.ts
+++ b/packages/protocol/test/plan.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { PlanStepSchema, PlanSchema, PlanResultSchema } from "../src/plan/index.js";
+import { Plan } from "../src/plan/index.js";
 
 describe("PlanStep", () => {
   test("should parse valid step with required fields", () => {
-    const step = PlanStepSchema.parse({
+    const step = Plan.StepSchema.parse({
       stepId: "step-1",
       description: "Initialize project",
       expectedOutput: "Project initialized",
@@ -16,7 +16,7 @@ describe("PlanStep", () => {
   });
 
   test("should parse step with optional fields", () => {
-    const step = PlanStepSchema.parse({
+    const step = Plan.StepSchema.parse({
       stepId: "step-2",
       description: "Build API",
       expectedOutput: "API built",
@@ -39,7 +39,7 @@ describe("PlanStep", () => {
   });
 
   test("should default dependsOn to empty array", () => {
-    const step = PlanStepSchema.parse({
+    const step = Plan.StepSchema.parse({
       stepId: "step-1",
       description: "Test",
       expectedOutput: "Done",
@@ -49,7 +49,7 @@ describe("PlanStep", () => {
 
   test("should reject missing required fields", () => {
     expect(() =>
-      PlanStepSchema.parse({
+      Plan.StepSchema.parse({
         stepId: "step-1",
         description: "Test",
         // missing expectedOutput
@@ -61,7 +61,7 @@ describe("PlanStep", () => {
 describe("Plan", () => {
   test("should parse valid plan with empty steps", () => {
     const now = new Date();
-    const plan = PlanSchema.parse({
+    const plan = Plan.Schema.parse({
       planId: "plan-1",
       goal: "Build a web application",
       steps: [],
@@ -76,7 +76,7 @@ describe("Plan", () => {
 
   test("should parse valid plan with steps and dependencies", () => {
     const now = new Date();
-    const plan = PlanSchema.parse({
+    const plan = Plan.Schema.parse({
       planId: "plan-1",
       goal: "Build API",
       steps: [
@@ -102,7 +102,7 @@ describe("Plan", () => {
 
   test("should default version to 1", () => {
     const now = new Date();
-    const plan = PlanSchema.parse({
+    const plan = Plan.Schema.parse({
       planId: "plan-1",
       goal: "Test",
       steps: [],
@@ -114,7 +114,7 @@ describe("Plan", () => {
   test("should reject plan with duplicate step IDs", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "plan-1",
         goal: "Build API",
         steps: [
@@ -140,7 +140,7 @@ describe("Plan", () => {
   test("should reject plan with dependency on non-existent step", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "plan-1",
         goal: "Build API",
         steps: [
@@ -160,7 +160,7 @@ describe("Plan", () => {
   test("should reject missing required fields", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "plan-1",
         // missing goal
         steps: [],
@@ -180,7 +180,7 @@ describe("PlanResult", () => {
       createdAt: now,
       version: 1,
     };
-    const result = PlanResultSchema.parse({
+    const result = Plan.ResultSchema.parse({
       plan,
     });
     expect(result.plan.planId).toBe("plan-1");
@@ -196,7 +196,7 @@ describe("PlanResult", () => {
       createdAt: now,
       version: 1,
     };
-    const result = PlanResultSchema.parse({
+    const result = Plan.ResultSchema.parse({
       plan,
       reviewNotes: "Plan looks good, ready for execution",
     });
@@ -205,7 +205,7 @@ describe("PlanResult", () => {
 
   test("should reject missing plan", () => {
     expect(() =>
-      PlanResultSchema.parse({
+      Plan.ResultSchema.parse({
         // missing plan
       }),
     ).toThrow();
@@ -216,7 +216,7 @@ describe("version constraint (.int() only)", () => {
   test("rejects float version", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "p",
         goal: "g",
         steps: [],
@@ -229,7 +229,7 @@ describe("version constraint (.int() only)", () => {
   test("accepts version 0 (no positive constraint)", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "p",
         goal: "g",
         steps: [],
@@ -240,11 +240,11 @@ describe("version constraint (.int() only)", () => {
   });
 });
 
-describe("superRefine gaps (documented, not fixed)", () => {
-  test("self-dependency A→A is accepted (not detected by superRefine)", () => {
+describe("cycle detection", () => {
+  test("rejects self-dependency A→A", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "p",
         goal: "g",
         steps: [
@@ -258,13 +258,13 @@ describe("superRefine gaps (documented, not fixed)", () => {
         createdAt: now,
         version: 1,
       }),
-    ).not.toThrow();
+    ).toThrow();
   });
 
-  test("circular dependency A→B→A is accepted (not detected by superRefine)", () => {
+  test("rejects circular dependency A→B→A", () => {
     const now = new Date();
     expect(() =>
-      PlanSchema.parse({
+      Plan.Schema.parse({
         planId: "p",
         goal: "g",
         steps: [
@@ -284,10 +284,10 @@ describe("superRefine gaps (documented, not fixed)", () => {
         createdAt: now,
         version: 1,
       }),
-    ).not.toThrow();
+    ).toThrow();
   });
 
-  test("z.date() rejects string from JSON.parse (round-trip fails)", () => {
+  test("z.coerce.date() survives JSON round-trip", () => {
     const now = new Date();
     const plan = {
       planId: "p",
@@ -297,6 +297,7 @@ describe("superRefine gaps (documented, not fixed)", () => {
       version: 1,
     };
     const json = JSON.stringify(plan);
-    expect(() => PlanSchema.parse(JSON.parse(json))).toThrow();
+    const parsed = Plan.Schema.parse(JSON.parse(json));
+    expect(parsed.createdAt.getTime()).toBe(now.getTime());
   });
 });

--- a/packages/session/src/event-log/index.ts
+++ b/packages/session/src/event-log/index.ts
@@ -6,14 +6,14 @@ function getAdapter(): Storage.Adapter["eventLog"] | undefined {
 }
 
 export namespace EventLog {
-  export async function append(sessionId: string, event: ExecutionEvent.T): Promise<void> {
+  export async function append(sessionId: string, event: ExecutionEvent): Promise<void> {
     const adapter = getAdapter();
     if (adapter) {
       adapter.append(sessionId, event.type, JSON.stringify(event));
     }
   }
 
-  export async function* replay(sessionId: string): AsyncGenerator<ExecutionEvent.T> {
+  export async function* replay(sessionId: string): AsyncGenerator<ExecutionEvent> {
     const adapter = getAdapter();
     if (adapter) {
       for (const row of adapter.replay(sessionId)) {

--- a/packages/session/test/event-log/sqlite-event-log.test.ts
+++ b/packages/session/test/event-log/sqlite-event-log.test.ts
@@ -73,7 +73,7 @@ describe("EventLog with SQLite adapter", () => {
     const adapter2 = new SqliteStorageAdapter(dbPath);
     Storage.configure(adapter2);
 
-    const events: ExecutionEvent.T[] = [];
+    const events: ExecutionEvent[] = [];
     for await (const event of EventLog.replay("sess-1")) {
       events.push(event);
     }
@@ -111,7 +111,7 @@ describe("EventLog with SQLite adapter", () => {
   });
 
   test("replay returns empty for unknown session", async () => {
-    const events: ExecutionEvent.T[] = [];
+    const events: ExecutionEvent[] = [];
     for await (const event of EventLog.replay("unknown")) {
       events.push(event);
     }
@@ -124,9 +124,9 @@ describe("EventLog with SQLite adapter", () => {
     await EventLog.append("sess-a", makeEvent("llm_response", 1));
     await EventLog.append("sess-b", makeEvent("session_suspended", 1));
 
-    const eventsA: ExecutionEvent.T[] = [];
+    const eventsA: ExecutionEvent[] = [];
     for await (const e of EventLog.replay("sess-a")) eventsA.push(e);
-    const eventsB: ExecutionEvent.T[] = [];
+    const eventsB: ExecutionEvent[] = [];
     for await (const e of EventLog.replay("sess-b")) eventsB.push(e);
 
     expect(eventsA).toHaveLength(1);

--- a/packages/session/test/session/recovery.test.ts
+++ b/packages/session/test/session/recovery.test.ts
@@ -40,7 +40,7 @@ describe("Session recovery lifecycle", () => {
     const suspended = await Session.suspend(session.id);
     expect(suspended).toBe(true);
 
-    const events: ExecutionEvent.T[] = [];
+    const events: ExecutionEvent[] = [];
     for await (const event of EventLog.replay(session.id)) {
       events.push(event);
     }
@@ -108,7 +108,7 @@ describe("Session recovery lifecycle", () => {
     expect(abandoned).toBe(true);
     expect(Session.get(session.id)).toBeUndefined();
 
-    const replayed: ExecutionEvent.T[] = [];
+    const replayed: ExecutionEvent[] = [];
     for await (const event of EventLog.replay(session.id)) {
       replayed.push(event);
     }


### PR DESCRIPTION
## Summary

- Strip AI slop from adapter contract (banner comments, redundant JSDoc: 243→117 lines)
- Fix plan schema JSON round-trip by replacing `z.date()` with `z.coerce.date()`
- Unify plan, ingress, notification domains into namespace pattern (21/21 consistent)
- Add cycle detection to plan DAG validation via Kahn's algorithm
- Apply declaration merging pattern for `Plan` and `ExecutionEvent` types
- Remove now-unnecessary `normalizePlanPayload` workaround
- Add §8 Code Style section to golden-principles.md
- Remove CLI banner comments

## Breaking Changes

Protocol namespace changes — all consumers updated in this PR:

| Old | New |
|-----|-----|
| `PlanSchema` | `Plan.Schema` |
| `PlanStepSchema` | `Plan.StepSchema` |
| `PlanResultSchema` | `Plan.ResultSchema` |
| `type PlanStep` | `Plan.Step` |
| `type PlanResult` | `Plan.Result` |
| `InboundEventSchema` | `Ingress.InboundEventSchema` |
| `type InboundEvent` | `Ingress.InboundEvent` |
| `type AgentDef` | `Ingress.AgentDef` |
| `type DirectEvent` | `Ingress.DirectEvent` |
| `type IngressResult` | `Ingress.IngressResult` |
| `NotificationRequest` | `Notification.Request` |
| `ExecutionEvent.T` | `ExecutionEvent` |

`type Plan` remains unchanged via declaration merging.

## Verification

- `turbo run check-types --force`: 11/11 passed
- `turbo run test --force`: 9/9 passed, 0 failures
- 34 files changed, net -108 lines