### PR TITLE
refactor(openomni): split monolithic subagent runtime into focused modules

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -39,3 +39,4 @@ export {
 } from "./core/middleware/builtin/budget";
 export { createIdleNudgeMiddleware } from "./core/middleware/builtin/idle-nudge";
 export { createToolGuardMiddleware } from "./core/middleware/builtin/tool-guard";
+export { InMemoryCompactor } from "./core/execution/compaction";

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -9,15 +9,16 @@ Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@ope
 | `src/plan/` | LLM-driven plan generation and gating | `PlanAgent`, `PlanPipeline`, `PlanStore`, `Hashline`, `StructuralGate`, `PLAN_TOOL_SPECS`, `createPlanToolExecutor`, `normalizePlanPayload` |
 | `src/dag/` | Pure dependency-graph utilities | `DAG` |
 | `src/ingress/` | Inbound event resolution and mode dispatch | `IngressEngine`, `IngressEventProjector`, `IngressHandlers`, `IngressSessionResolver`, `SessionBridge` |
-| `src/storage/` | Task persistence adapter layer | `TaskStorage`, `FileTaskStore` (and internal `TaskStore` + `InMemoryTaskStore`) |
-| `src/subagent/` | Session-backed subagent execution | `SubagentRuntime`, `SubagentConsultation`, `BackgroundManager` |
+| `src/storage/` | Task persistence adapter layer | `TaskStorage` (configure mandatory), `TaskStore` interface |
+| `src/subagent/` | Session-backed subagent execution | `SubagentRuntime`, `SubagentConsultation`, `BackgroundManager`, `BackgroundStore` |
+| `src/execution-runtime/` | Tool system, workspace, and worker middleware | `buildWorkerMiddleware`, `WorkspaceLock`, `AgentToolProvider`, `SystemToolProvider`, `ToolProxyProvider`, `Tool`, `buildToolCatalog`, `createToolExecutor`, `createWorkerSubagentRuntime`, `defineTool` |
 
 ## Architecture
 
 - `src/dag/` is structural only — it knows step topology, not runtime state.
 - `src/plan/` turns a goal into a structured `Plan`, then runs enrichment + validation gates before the result is handed off.
 - `src/ingress/` is the entry path for inbound events. It resolves a session through `SurfaceKey`, projects the event into stored messages, then dispatches to the `plan` or `direct` handler.
-- `src/storage/` owns task persistence. The package exports a global `TaskStorage.configure(adapter)` singleton and a file-backed implementation for durable CLI / server use.
+- `src/storage/` owns task persistence. `TaskStorage.configure(adapter)` must be called before any storage access — there is no default adapter; the package throws if unconfigured.
 - `src/subagent/` owns the unified subagent runtime. `SubagentRuntime` runs session-locked spawn / send / resume / cancel / wait operations backed by `WorkerRun` records; `BackgroundManager` wraps the runtime for fire-and-forget execution with concurrency / depth limits.
 
 WHY: each domain stays small and focused so the domain docs can stay source-of-truth instead of repeating.
@@ -25,11 +26,12 @@ WHY: each domain stays small and focused so the domain docs can stay source-of-t
 ## Dependency Shape
 
 ```
-dag/       → no internal deps
-plan/      → dag/
-storage/   → no orchestration deps
-ingress/   → plan/, storage/
-subagent/  → no orchestration deps (uses @openomni/agent + @openomni/session + protocol directly)
+dag/                → no internal deps
+plan/               → dag/
+storage/            → no orchestration deps
+execution-runtime/  → no orchestration deps (tool system, workspace, middleware)
+ingress/            → plan/, storage/
+subagent/           → execution-runtime/ (uses @openomni/agent + @openomni/session + protocol directly)
 ```
 
 `src/index.ts` re-exports the public surface — use the package barrel instead of deep imports from consumer code.
@@ -43,13 +45,15 @@ Consumers should only use `@openomni/openomni` exports:
 - Ingress orchestration from `src/ingress/`
 - Task storage adapters from `src/storage/`
 - Subagent runtime + background manager from `src/subagent/`
+- Tool system, workspace lock, and worker middleware from `src/execution-runtime/`
 
 If a symbol is not re-exported from `src/index.ts`, treat it as private to its domain.
 
 ## Extension Points
 
 - Add a new plan gate or enricher in `src/plan/` so validation stays next to planning.
-- Add a new storage backend in `src/storage/` by implementing `TaskStore` and wiring it through `TaskStorage.configure()`.
+- Add a new storage backend in `src/storage/` by implementing `TaskStore` and passing it to `TaskStorage.configure()`.
+- Add new tools or tool providers in `src/execution-runtime/tool/` following the `ToolProvider` interface.
 - Extend ingress handling in `src/ingress/` when new inbound surfaces or mode dispatch rules arrive.
 - Add subagent capabilities (new timeout policies, abort semantics, recovery hooks) in `src/subagent/` next to `SubagentRuntime` / `BackgroundManager`.
 
@@ -64,8 +68,9 @@ If a symbol is not re-exported from `src/index.ts`, treat it as private to its d
 - `src/plan/AGENTS.md` — plan generation, gates, and plan tools
 - `src/dag/AGENTS.md` — dependency-graph helpers
 - `src/ingress/AGENTS.md` — inbound event handling and mode dispatch
-- `src/storage/AGENTS.md` — task persistence and file-backed storage
+- `src/storage/AGENTS.md` — task persistence and storage adapter contract
 - `src/subagent/AGENTS.md` — session-backed subagent runtime and background manager
+- `src/execution-runtime/AGENTS.md` — tool system, workspace lock, and worker middleware
 
 ## Style Rules
 

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -10,7 +10,7 @@ Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@ope
 | `src/dag/` | Pure dependency-graph utilities | `DAG` |
 | `src/ingress/` | Inbound event resolution and mode dispatch | `IngressEngine`, `IngressEventProjector`, `IngressHandlers`, `IngressSessionResolver`, `SessionBridge` |
 | `src/storage/` | Task persistence adapter layer | `TaskStorage` (configure mandatory), `TaskStore` interface |
-| `src/subagent/` | Session-backed subagent execution | `SubagentRuntime`, `SubagentConsultation`, `BackgroundManager`, `BackgroundStore` |
+| `src/subagent/` | Session-backed subagent execution | `SubagentRuntime`, `SubagentConsultation`, `BackgroundManager` |
 | `src/execution-runtime/` | Tool system, workspace, and worker middleware | `buildWorkerMiddleware`, `WorkspaceLock`, `AgentToolProvider`, `SystemToolProvider`, `ToolProxyProvider`, `Tool`, `buildToolCatalog`, `createToolExecutor`, `createWorkerSubagentRuntime`, `defineTool` |
 
 ## Architecture

--- a/packages/openomni/src/execution-runtime/filesystem/workspace-path.test.ts
+++ b/packages/openomni/src/execution-runtime/filesystem/workspace-path.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveContainedPath, resolveContainedPathForCreate } from "./workspace-path.js";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "workspace-path-test-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("resolveContainedPath", () => {
+  it("resolves a non-existent file whose parent dir exists inside root", () => {
+    const result = resolveContainedPath(workspaceRoot, "file.txt");
+    expect(result).toBe(join(workspaceRoot, "file.txt"));
+  });
+
+  it("accepts the root path itself", () => {
+    const result = resolveContainedPath(workspaceRoot, ".");
+    expect(result).toBe(workspaceRoot);
+  });
+
+  it("rejects path traversal via ..", () => {
+    expect(() => resolveContainedPath(workspaceRoot, "../../etc/passwd")).toThrow(
+      "Path must stay within workspace root",
+    );
+  });
+
+  it("rejects a single level traversal", () => {
+    expect(() => resolveContainedPath(workspaceRoot, "../sibling")).toThrow(
+      "Path must stay within workspace root",
+    );
+  });
+
+  it("rejects an absolute path outside root", () => {
+    expect(() => resolveContainedPath(workspaceRoot, "/etc/passwd")).toThrow(
+      "Path must stay within workspace root",
+    );
+  });
+
+  it("rejects an absolute path that is the root's sibling", () => {
+    const sibling = join(workspaceRoot, "..", "other-dir");
+    expect(() => resolveContainedPath(workspaceRoot, sibling)).toThrow(
+      "Path must stay within workspace root",
+    );
+  });
+
+  it("rejects a symlink that escapes the workspace root", () => {
+    const escapeTarget = mkdtempSync(join(tmpdir(), "escape-target-"));
+    const symlinkPath = join(workspaceRoot, "escape-link");
+    symlinkSync(escapeTarget, symlinkPath);
+    try {
+      expect(() => resolveContainedPath(workspaceRoot, "escape-link/secret.txt")).toThrow(
+        "Path escapes workspace root via symlink",
+      );
+    } finally {
+      rmSync(symlinkPath);
+      rmSync(escapeTarget, { recursive: true });
+    }
+  });
+
+  it("allows a symlink that points to a path within the workspace root", () => {
+    const symlinkPath = join(workspaceRoot, "internal-link");
+    symlinkSync(workspaceRoot, symlinkPath);
+    try {
+      const result = resolveContainedPath(workspaceRoot, "internal-link");
+      expect(result).toBe(symlinkPath);
+    } finally {
+      rmSync(symlinkPath);
+    }
+  });
+});
+
+describe("resolveContainedPathForCreate", () => {
+  it("resolves a new file path when parent exists", () => {
+    const result = resolveContainedPathForCreate(workspaceRoot, "newfile.txt");
+    expect(result).toBe(join(workspaceRoot, "newfile.txt"));
+  });
+
+  it("resolves a deeply nested new path (no intermediate dirs exist)", () => {
+    const result = resolveContainedPathForCreate(workspaceRoot, "a/b/c/deep.txt");
+    expect(result).toBe(join(workspaceRoot, "a/b/c/deep.txt"));
+  });
+
+  it("rejects path traversal via ..", () => {
+    expect(() => resolveContainedPathForCreate(workspaceRoot, "../../etc/new")).toThrow(
+      "Path must stay within workspace root",
+    );
+  });
+
+  it("rejects an absolute path outside root", () => {
+    expect(() => resolveContainedPathForCreate(workspaceRoot, "/tmp/malicious")).toThrow(
+      "Path must stay within workspace root",
+    );
+  });
+
+  it("rejects a symlink that escapes the workspace root", () => {
+    const escapeTarget = mkdtempSync(join(tmpdir(), "escape-create-"));
+    const symlinkPath = join(workspaceRoot, "create-escape-link");
+    symlinkSync(escapeTarget, symlinkPath);
+    try {
+      expect(() =>
+        resolveContainedPathForCreate(workspaceRoot, "create-escape-link/new.txt"),
+      ).toThrow("Path escapes workspace root via symlink");
+    } finally {
+      rmSync(symlinkPath);
+      rmSync(escapeTarget, { recursive: true });
+    }
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@openomni/protocol";
+import { AgentToolProvider } from "./provider.js";
+import type { NativeTool } from "../types.js";
+
+function makeCall(tool: string): Tool.Call {
+  return { id: "call-1", tool, input: {} };
+}
+
+function makeTool(name: string): NativeTool {
+  return {
+    spec: { name, inputSchema: { type: "object", properties: {} } },
+    riskTier: 0,
+    isReadOnly: false,
+    isDestructive: false,
+    isConcurrencySafe: false,
+    source: "agent",
+    execute: async (call) => ({
+      id: crypto.randomUUID(),
+      toolCallId: call.id,
+      output: `${name}-result`,
+    }),
+  };
+}
+
+describe("AgentToolProvider", () => {
+  it("includes the built-in subagent tool", () => {
+    const provider = new AgentToolProvider();
+    const tools = provider.listTools();
+
+    expect(tools.length).toBeGreaterThanOrEqual(1);
+    expect(tools.some((t) => t.spec.name === "subagent")).toBe(true);
+  });
+
+  it("register appends an extra tool to the list", () => {
+    const provider = new AgentToolProvider();
+    provider.register(makeTool("my-agent-tool"));
+
+    const tools = provider.listTools();
+
+    expect(tools.some((t) => t.spec.name === "my-agent-tool")).toBe(true);
+  });
+
+  it("name and category metadata are correct", () => {
+    const provider = new AgentToolProvider();
+
+    expect(provider.name).toBe("agent");
+    expect(provider.category).toBe("agent");
+  });
+
+  it("execute returns error for unknown tool", async () => {
+    const provider = new AgentToolProvider();
+
+    const result = await provider.execute(makeCall("nonexistent"));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("Unknown tool: nonexistent");
+  });
+
+  it("execute dispatches to a registered tool", async () => {
+    const provider = new AgentToolProvider();
+    provider.register(makeTool("helper-agent"));
+
+    const result = await provider.execute(makeCall("helper-agent"));
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe("helper-agent-result");
+  });
+
+  it("execute resolves underscore-to-dot alias for registered tools", async () => {
+    const provider = new AgentToolProvider();
+    provider.register(makeTool("my.agent.tool"));
+
+    const result = await provider.execute(makeCall("my_agent_tool"));
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe("my.agent.tool-result");
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/executor.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@openomni/protocol";
+import { createToolExecutor } from "./executor.js";
+import type { NativeTool, ToolRiskTier } from "./types.js";
+
+function makeCall(tool: string, input: Record<string, unknown> = {}): Tool.Call {
+  return { id: "call-1", tool, input };
+}
+
+function makeTool(
+  name: string,
+  overrides: Partial<NativeTool> & { riskTier?: ToolRiskTier } = {},
+): NativeTool {
+  const { riskTier = 0, ...rest } = overrides;
+  return {
+    spec: { name, inputSchema: { type: "object", properties: {} } },
+    riskTier,
+    isReadOnly: true,
+    isDestructive: false,
+    isConcurrencySafe: true,
+    source: "system",
+    execute: async (call) => ({
+      id: crypto.randomUUID(),
+      toolCallId: call.id,
+      output: `${name}-ok`,
+    }),
+    ...rest,
+  };
+}
+
+describe("createToolExecutor", () => {
+  it("dispatches to the correct tool and returns its result", async () => {
+    const executor = createToolExecutor({
+      tools: [
+        makeTool("read", {
+          execute: async (call) => ({ id: "r1", toolCallId: call.id, output: "file-content" }),
+        }),
+      ],
+    });
+
+    const result = await executor(makeCall("read"));
+
+    expect(result.output).toBe("file-content");
+    expect(result.isError).toBeUndefined();
+    expect(result.toolCallId).toBe("call-1");
+  });
+
+  it("returns an error result for unknown tools", async () => {
+    const executor = createToolExecutor({ tools: [] });
+
+    const result = await executor(makeCall("nonexistent"));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("Unknown tool: nonexistent");
+  });
+
+  it("denies tools matching the denylist", async () => {
+    const executor = createToolExecutor({
+      tools: [makeTool("bash")],
+      config: { permissions: { denylist: ["bash"] } },
+    });
+
+    const result = await executor(makeCall("bash"));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("[Blocked]");
+    expect(result.output).toContain("denied by policy");
+  });
+
+  it("denies tools absent from the allowlist", async () => {
+    const executor = createToolExecutor({
+      tools: [makeTool("write"), makeTool("read")],
+      config: { permissions: { allowlist: ["read"] } },
+    });
+
+    const writeResult = await executor(makeCall("write"));
+    expect(writeResult.isError).toBe(true);
+    expect(writeResult.output).toContain("[Blocked]");
+
+    const readResult = await executor(makeCall("read"));
+    expect(readResult.isError).toBeUndefined();
+  });
+
+  it("blocks tools that require approval", async () => {
+    const executor = createToolExecutor({
+      tools: [makeTool("bash")],
+      config: { permissions: { requireApproval: ["bash"] } },
+    });
+
+    const result = await executor(makeCall("bash"));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("requires approval");
+  });
+
+  it("wraps tool execution errors in an error result", async () => {
+    const executor = createToolExecutor({
+      tools: [
+        makeTool("fail", {
+          execute: async () => {
+            throw new Error("boom");
+          },
+        }),
+      ],
+    });
+
+    const result = await executor(makeCall("fail"));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe("boom");
+  });
+
+  it("dispatches to a dotted-name tool via its underscore alias", async () => {
+    const executor = createToolExecutor({
+      tools: [makeTool("grep.search")],
+    });
+
+    const result = await executor(makeCall("grep_search"));
+
+    expect(result.isError).toBeUndefined();
+    expect(result.output).toBe("grep.search-ok");
+  });
+
+  it("denylist wildcard pattern blocks the entire tool family", async () => {
+    const executor = createToolExecutor({
+      tools: [makeTool("file.read"), makeTool("file.write"), makeTool("bash")],
+      config: { permissions: { denylist: ["file.*"] } },
+    });
+
+    const readResult = await executor(makeCall("file.read"));
+    expect(readResult.isError).toBe(true);
+
+    const writeResult = await executor(makeCall("file.write"));
+    expect(writeResult.isError).toBe(true);
+
+    const bashResult = await executor(makeCall("bash"));
+    expect(bashResult.isError).toBeUndefined();
+  });
+
+  it("no permissions config allows all tools", async () => {
+    const executor = createToolExecutor({
+      tools: [makeTool("bash"), makeTool("read")],
+    });
+
+    expect((await executor(makeCall("bash"))).isError).toBeUndefined();
+    expect((await executor(makeCall("read"))).isError).toBeUndefined();
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/shared/input.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/shared/input.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "bun:test";
+import {
+  requireString,
+  optionalString,
+  optionalBoolean,
+  optionalPositiveInteger,
+  optionalPositiveNumber,
+} from "./input.js";
+
+describe("requireString", () => {
+  it("returns value when key is a non-empty string", () => {
+    expect(requireString({ name: "alice" }, "name")).toBe("alice");
+  });
+
+  it("throws when key is missing", () => {
+    expect(() => requireString({}, "name")).toThrow("name must be a non-empty string");
+  });
+
+  it("throws when value is an empty string", () => {
+    expect(() => requireString({ name: "" }, "name")).toThrow("name must be a non-empty string");
+  });
+
+  it("throws when value is not a string", () => {
+    expect(() => requireString({ count: 42 }, "count")).toThrow("count must be a non-empty string");
+    expect(() => requireString({ flag: true }, "flag")).toThrow("flag must be a non-empty string");
+    expect(() => requireString({ obj: {} }, "obj")).toThrow("obj must be a non-empty string");
+  });
+
+  it("throws when value is null", () => {
+    expect(() => requireString({ name: null }, "name")).toThrow("name must be a non-empty string");
+  });
+});
+
+describe("optionalString", () => {
+  it("returns undefined when key is absent", () => {
+    expect(optionalString({}, "name")).toBeUndefined();
+  });
+
+  it("returns the string when present and non-empty", () => {
+    expect(optionalString({ name: "bob" }, "name")).toBe("bob");
+  });
+
+  it("throws when value is present but empty", () => {
+    expect(() => optionalString({ name: "" }, "name")).toThrow("name must be a non-empty string");
+  });
+
+  it("throws when value is present but not a string", () => {
+    expect(() => optionalString({ name: 123 }, "name")).toThrow("name must be a non-empty string");
+  });
+});
+
+describe("optionalBoolean", () => {
+  it("returns undefined when key is absent", () => {
+    expect(optionalBoolean({}, "flag")).toBeUndefined();
+  });
+
+  it("returns true when value is true", () => {
+    expect(optionalBoolean({ flag: true }, "flag")).toBe(true);
+  });
+
+  it("returns false when value is false", () => {
+    expect(optionalBoolean({ flag: false }, "flag")).toBe(false);
+  });
+
+  it("throws when value is a string", () => {
+    expect(() => optionalBoolean({ flag: "true" }, "flag")).toThrow("flag must be a boolean");
+  });
+
+  it("throws when value is a number", () => {
+    expect(() => optionalBoolean({ flag: 1 }, "flag")).toThrow("flag must be a boolean");
+  });
+});
+
+describe("optionalPositiveInteger", () => {
+  it("returns undefined when key is absent", () => {
+    expect(optionalPositiveInteger({}, "limit")).toBeUndefined();
+  });
+
+  it("returns value for a positive integer", () => {
+    expect(optionalPositiveInteger({ limit: 5 }, "limit")).toBe(5);
+    expect(optionalPositiveInteger({ limit: 1 }, "limit")).toBe(1);
+  });
+
+  it("throws for zero", () => {
+    expect(() => optionalPositiveInteger({ limit: 0 }, "limit")).toThrow(
+      "limit must be a positive integer",
+    );
+  });
+
+  it("throws for negative integer", () => {
+    expect(() => optionalPositiveInteger({ limit: -3 }, "limit")).toThrow(
+      "limit must be a positive integer",
+    );
+  });
+
+  it("throws for non-integer number", () => {
+    expect(() => optionalPositiveInteger({ limit: 1.5 }, "limit")).toThrow(
+      "limit must be a positive integer",
+    );
+  });
+
+  it("throws for string value", () => {
+    expect(() => optionalPositiveInteger({ limit: "5" }, "limit")).toThrow(
+      "limit must be a positive integer",
+    );
+  });
+});
+
+describe("optionalPositiveNumber", () => {
+  it("returns undefined when key is absent", () => {
+    expect(optionalPositiveNumber({}, "temperature")).toBeUndefined();
+  });
+
+  it("returns value for a positive number", () => {
+    expect(optionalPositiveNumber({ temperature: 0.7 }, "temperature")).toBe(0.7);
+    expect(optionalPositiveNumber({ temperature: 1 }, "temperature")).toBe(1);
+  });
+
+  it("accepts non-integer positive numbers", () => {
+    expect(optionalPositiveNumber({ temperature: 2.5 }, "temperature")).toBe(2.5);
+  });
+
+  it("throws for zero", () => {
+    expect(() => optionalPositiveNumber({ temperature: 0 }, "temperature")).toThrow(
+      "temperature must be a positive number",
+    );
+  });
+
+  it("throws for negative number", () => {
+    expect(() => optionalPositiveNumber({ temperature: -0.1 }, "temperature")).toThrow(
+      "temperature must be a positive number",
+    );
+  });
+
+  it("throws for Infinity", () => {
+    expect(() => optionalPositiveNumber({ temperature: Infinity }, "temperature")).toThrow(
+      "temperature must be a positive number",
+    );
+  });
+
+  it("throws for NaN", () => {
+    expect(() => optionalPositiveNumber({ temperature: NaN }, "temperature")).toThrow(
+      "temperature must be a positive number",
+    );
+  });
+
+  it("throws for string value", () => {
+    expect(() => optionalPositiveNumber({ temperature: "0.7" }, "temperature")).toThrow(
+      "temperature must be a positive number",
+    );
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/shared/result.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/shared/result.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "bun:test";
+import type { Tool } from "@openomni/protocol";
+import { successResult, errorResult, fromError } from "./result.js";
+
+const call: Tool.Call = { id: "call-abc", tool: "test-tool", input: {} };
+
+describe("successResult", () => {
+  it("sets toolCallId from the call id", () => {
+    const result = successResult(call, "output text");
+    expect(result.toolCallId).toBe("call-abc");
+  });
+
+  it("sets the output string", () => {
+    const result = successResult(call, "hello world");
+    expect(result.output).toBe("hello world");
+  });
+
+  it("does not set isError", () => {
+    const result = successResult(call, "ok");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("generates a unique id each call", () => {
+    const a = successResult(call, "ok");
+    const b = successResult(call, "ok");
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("id is a valid UUID", () => {
+    const result = successResult(call, "ok");
+    expect(result.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});
+
+describe("errorResult", () => {
+  it("sets toolCallId from the call id", () => {
+    const result = errorResult(call, "something failed");
+    expect(result.toolCallId).toBe("call-abc");
+  });
+
+  it("sets the output string", () => {
+    const result = errorResult(call, "something failed");
+    expect(result.output).toBe("something failed");
+  });
+
+  it("sets isError to true", () => {
+    const result = errorResult(call, "err");
+    expect(result.isError).toBe(true);
+  });
+
+  it("generates a unique id each call", () => {
+    const a = errorResult(call, "err");
+    const b = errorResult(call, "err");
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("fromError", () => {
+  it("extracts message from an Error instance", () => {
+    const result = fromError(call, new Error("disk full"));
+    expect(result.output).toBe("disk full");
+    expect(result.isError).toBe(true);
+  });
+
+  it("converts non-Error to string", () => {
+    const result = fromError(call, "raw string error");
+    expect(result.output).toBe("raw string error");
+    expect(result.isError).toBe(true);
+  });
+
+  it("converts number to string", () => {
+    const result = fromError(call, 42);
+    expect(result.output).toBe("42");
+  });
+
+  it("converts null to string", () => {
+    const result = fromError(call, null);
+    expect(result.output).toBe("null");
+  });
+
+  it("converts undefined to string", () => {
+    const result = fromError(call, undefined);
+    expect(result.output).toBe("undefined");
+  });
+
+  it("propagates toolCallId correctly", () => {
+    const otherCall: Tool.Call = { id: "call-xyz", tool: "other", input: {} };
+    const result = fromError(otherCall, new Error("oops"));
+    expect(result.toolCallId).toBe("call-xyz");
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/system/provider.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/system/provider.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@openomni/protocol";
+import { SystemToolProvider } from "./provider.js";
+
+function makeCall(tool: string): Tool.Call {
+  return { id: "call-1", tool, input: {} };
+}
+
+describe("SystemToolProvider", () => {
+  it("includes only bash when no workspaceRoot is provided", () => {
+    const provider = new SystemToolProvider();
+    const tools = provider.listTools();
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.spec.name).toBe("bash");
+  });
+
+  it("includes bash plus all filesystem tools when workspaceRoot is set", () => {
+    const provider = new SystemToolProvider("/tmp");
+    const tools = provider.listTools();
+
+    expect(tools).toHaveLength(6);
+
+    const names = tools.map((t) => t.spec.name);
+    expect(names).toContain("bash");
+    expect(names).toContain("read");
+    expect(names).toContain("write");
+    expect(names).toContain("edit");
+    expect(names).toContain("grep.search");
+    expect(names).toContain("glob");
+  });
+
+  it("name and category metadata are correct", () => {
+    const provider = new SystemToolProvider();
+
+    expect(provider.name).toBe("system");
+    expect(provider.category).toBe("system");
+  });
+
+  it("execute returns error for unknown tool", async () => {
+    const provider = new SystemToolProvider();
+
+    const result = await provider.execute(makeCall("nonexistent"));
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("Unknown tool: nonexistent");
+  });
+
+  it("execute routes underscore alias to the dotted tool name", async () => {
+    const provider = new SystemToolProvider("/tmp");
+
+    const result = await provider.execute({
+      id: "call-1",
+      tool: "grep_search",
+      input: { pattern: "x", path: "/tmp" },
+    });
+
+    expect(result.output).not.toContain("Unknown tool: grep_search");
+  });
+});

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -37,6 +37,7 @@ export {
   ToolProxyProvider,
   SystemToolProvider,
   Tool,
+  WorkspaceLock,
   buildToolCatalog,
   buildWorkerMiddleware,
   createToolExecutor,

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -2,7 +2,6 @@
 // Plan Mode
 export {
   Hashline,
-  InMemoryPlanStore,
   PLAN_TOOL_SPECS,
   PlanAgent,
   PlanPipeline,

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -1,7 +1,6 @@
 import { Plan, type Ingress, type Execution } from "@openomni/protocol";
 import type { CoordinatorLike } from "./coordinator-like";
 import { SessionBridge } from "./session-bridge";
-import { PlanAgent } from "../plan/plan-agent";
 
 export namespace IngressHandlers {
   export interface HandlerContext {

--- a/packages/openomni/src/storage/AGENTS.md
+++ b/packages/openomni/src/storage/AGENTS.md
@@ -4,19 +4,20 @@ Task persistence layer for the openomni orchestration system.
 
 ## Files
 
-- **task-storage.ts** — `TaskStore` interface (the contract), `InMemoryTaskStore` (default in-memory impl), and `TaskStorage` namespace (global adapter singleton). All consumer code goes through `TaskStorage.getAdapter()`.
+- **task-storage.ts** — `TaskStore` interface (the contract) and `TaskStorage` namespace (global adapter singleton). All consumer code goes through `TaskStorage.getAdapter()`. `TaskStorage.configure(adapter)` must be called before any access — the package throws if unconfigured.
 - **file-task-storage.ts** — `FileTaskStore`, a file-backed `TaskStore` that mirrors in-memory state to JSON files on disk. Used by the CLI for durable task/run persistence.
-- **task-types.ts** — Minimal `Task.Info`, `Task.Run`, `Task.Status` types needed by the storage layer. Owned by T2; do not modify here.
-- **index.ts** — Barrel. Owned by T10; do not modify here.
+- **task-types.ts** — Minimal `Task.Info`, `Task.Run`, `Task.Status` types needed by the storage layer.
+- **index.ts** — Barrel.
 
 ## Architecture
 
-`TaskStore` exposes two sub-objects: `task` (CRUD for `Task.Info`) and `run` (CRUD for `Task.Run` with idempotency and status indexing). `TaskStorage.configure(adapter)` sets the active adapter globally; defaults to `InMemoryTaskStore`.
+`TaskStore` exposes two sub-objects: `task` (CRUD for `Task.Info`) and `run` (CRUD for `Task.Run` with idempotency and status indexing). `TaskStorage.configure(adapter)` sets the active adapter globally; there is no default — callers must configure before use.
 
-`FileTaskStore` maintains the same in-memory Maps as `InMemoryTaskStore` plus flushes to disk on every mutation. Reads are always from memory; disk is the persistence backing store loaded at construction.
+`FileTaskStore` maintains in-memory Maps and flushes to disk on every mutation. Reads are always from memory; disk is the persistence backing store loaded at construction.
 
 ## Gotchas
 
+- **configure is mandatory**: `TaskStorage.configure()` must be called at startup. Accessing the adapter before configuration throws.
 - **Atomic writes**: `FileTaskStore` writes via tmp-file + rename to avoid partial writes on crash. The tmp cleanup in the catch block is intentional — if rename fails, the stale tmp must not linger.
 - **No file locking**: Concurrent `FileTaskStore` instances on the same directory will corrupt state. Single-writer assumption.
 - **Status index serialization**: `Set<string>` is stored as `string[]` in JSON; rebuilt from runs on parse failure.

--- a/packages/openomni/src/storage/task-storage.ts
+++ b/packages/openomni/src/storage/task-storage.ts
@@ -35,152 +35,17 @@ export interface RunListOptions {
   sortOrder?: "asc" | "desc";
 }
 
-export class InMemoryTaskStore implements TaskStore {
-  private tasks = new Map<string, Task.Info>();
-  private runs = new Map<string, Task.Run>();
-  private taskRuns = new Map<string, string[]>(); // taskId -> runId[]
-  private idempotencyIndex = new Map<string, string>(); // idempotencyKey -> runId
-  private statusIndex = new Map<Task.Run["status"], Set<string>>(); // status -> Set<runId>
-
-  task = {
-    get: (id: string): Task.Info | undefined => {
-      return this.tasks.get(id);
-    },
-    set: (id: string, info: Task.Info): void => {
-      this.tasks.set(id, info);
-    },
-    list: (filter?: TaskListFilter): Task.Info[] => {
-      let tasks = Array.from(this.tasks.values());
-
-      if (!filter) return tasks;
-
-      if (filter.status) {
-        const statuses = Array.isArray(filter.status) ? filter.status : [filter.status];
-        tasks = tasks.filter((t) => statuses.includes(t.status));
-      }
-
-      if (filter.ownerId) {
-        tasks = tasks.filter((t) => t.owner.id === filter.ownerId);
-      }
-
-      if (filter.assignedAgentId) {
-        tasks = tasks.filter((t) => t.assignedAgentId === filter.assignedAgentId);
-      }
-
-      if (filter.tags && filter.tags.length > 0) {
-        tasks = tasks.filter((t) => filter.tags?.every((tag) => t.tags?.includes(tag)));
-      }
-
-      return tasks;
-    },
-    remove: (id: string): boolean => {
-      const runIds = this.taskRuns.get(id);
-      if (runIds) {
-        for (const runId of runIds) {
-          const run = this.runs.get(runId);
-          if (run) {
-            this.statusIndex.get(run.status)?.delete(runId);
-            this.idempotencyIndex.delete(run.idempotencyKey);
-            this.runs.delete(runId);
-          }
-        }
-        this.taskRuns.delete(id);
-      }
-
-      return this.tasks.delete(id);
-    },
-  };
-
-  run = {
-    get: (runId: string): Task.Run | undefined => {
-      return this.runs.get(runId);
-    },
-    set: (taskId: string, run: Task.Run): void => {
-      const existingRun = this.runs.get(run.runId);
-
-      if (existingRun && existingRun.status !== run.status) {
-        this.statusIndex.get(existingRun.status)?.delete(run.runId);
-      }
-
-      if (!this.statusIndex.has(run.status)) {
-        this.statusIndex.set(run.status, new Set());
-      }
-      this.statusIndex.get(run.status)?.add(run.runId);
-
-      this.idempotencyIndex.set(run.idempotencyKey, run.runId);
-      this.runs.set(run.runId, run);
-
-      const runIds = this.taskRuns.get(taskId) ?? [];
-      if (!runIds.includes(run.runId)) {
-        runIds.push(run.runId);
-        this.taskRuns.set(taskId, runIds);
-      }
-    },
-    list: (taskId: string, opts?: RunListOptions): Task.Run[] => {
-      const runIds = this.taskRuns.get(taskId) ?? [];
-      let runs = runIds
-        .map((id) => this.runs.get(id))
-        .filter((r): r is Task.Run => r !== undefined);
-
-      if (opts?.sortBy) {
-        const { sortBy } = opts;
-        const dir = opts.sortOrder === "asc" ? 1 : -1;
-        runs.sort((a, b) => dir * ((a[sortBy] ?? 0) - (b[sortBy] ?? 0)));
-      }
-      if (opts?.offset || opts?.limit) {
-        const start = opts.offset ?? 0;
-        runs = runs.slice(start, start + (opts.limit ?? runs.length));
-      }
-
-      return runs;
-    },
-    listByStatus: (statuses: Task.Run["status"][]): Task.Run[] => {
-      const collected = new Set<string>();
-      for (const s of statuses) this.statusIndex.get(s)?.forEach((id) => collected.add(id));
-      return [...collected]
-        .map((id) => this.runs.get(id))
-        .filter((r): r is Task.Run => r !== undefined);
-    },
-    remove: (runId: string): boolean => {
-      const run = this.runs.get(runId);
-      if (!run) return false;
-      this.statusIndex.get(run.status)?.delete(runId);
-      this.idempotencyIndex.delete(run.idempotencyKey);
-      const runIds = this.taskRuns.get(run.taskId);
-      if (runIds)
-        this.taskRuns.set(
-          run.taskId,
-          runIds.filter((id) => id !== runId),
-        );
-      return this.runs.delete(runId);
-    },
-    getByIdempotencyKey: (key: string): Task.Run | undefined => {
-      const runId = this.idempotencyIndex.get(key);
-      return runId ? this.runs.get(runId) : undefined;
-    },
-  };
-
-  clear(): void {
-    this.tasks.clear();
-    this.runs.clear();
-    this.taskRuns.clear();
-    this.idempotencyIndex.clear();
-    this.statusIndex.clear();
-  }
-}
-
 export namespace TaskStorage {
-  let adapter: TaskStore = new InMemoryTaskStore();
+  let adapter: TaskStore | undefined;
 
   export function configure(newAdapter: TaskStore): void {
     adapter = newAdapter;
   }
 
   export function getAdapter(): TaskStore {
+    if (!adapter) {
+      throw new Error("TaskStorage not configured. Call TaskStorage.configure() first.");
+    }
     return adapter;
-  }
-
-  export function reset(): void {
-    adapter = new InMemoryTaskStore();
   }
 }

--- a/packages/openomni/src/subagent/AGENTS.md
+++ b/packages/openomni/src/subagent/AGENTS.md
@@ -1,82 +1,32 @@
-# Subagent Module
+# subagent/
 
-Session-backed execution runtime for subagents. `SubagentRuntime` runs one agent turn per call with a per-session lock, persisting transcripts into `@openomni/session` and lifecycle via `WorkerRun`. `BackgroundManager` wraps the runtime for fire-and-forget concurrent work. `SubagentConsultation` handles advisory calls to other agents.
+Session-backed subagent execution runtime for the openomni orchestration layer.
 
 ## Files
 
-| File | Role |
-| --- | --- |
-| `runtime.ts` | `SubagentRuntime.spawn / spawnBackground / send / resume / cancel / wait` — session-locked subagent execution, timeouts, abort handling, transcript persistence |
-| `background-manager.ts` | `BackgroundManager.create(config?)` — fire-and-forget task manager with concurrency / depth / descendant limits and bus-event driven completion |
-| `consultation.ts` | `SubagentConsultation.consult(request, config)` — advisory queries (fresh-session or active-session), published as `Subagent.Events.WorkerConsultation*` |
-| `abort-registry.ts` | Per-session `AbortController` registry used by the runtime for cooperative cancellation |
-| `index.ts` | Barrel export (runtime + consultation + background manager) |
+| File | Role | Exported |
+|------|------|----------|
+| `runtime.ts` | `SubagentRuntime` — orchestration shell for spawn / send / resume / cancel / wait backed by `WorkerRun` records | yes |
+| `consultation.ts` | `SubagentConsultation` — one-shot synchronous subagent calls (request/response pattern) | yes |
+| `background-manager.ts` | `BackgroundManager` — fire-and-forget wrapper with concurrency and depth limits | yes |
+| `background-store.ts` | `BackgroundStore` — in-memory registry of active background runs | yes |
+| `shared.ts` | `RuntimeModel`, `RuntimeMessage` types and message factory helpers (parameterized agent field) | no |
+| `message-builder.ts` | Message construction and serialization for subagent communication | no |
+| `run-lifecycle.ts` | Abort, timeout, and finalize functions for `WorkerRun` lifecycle | no |
+| `transcript.ts` | Compaction bridge and `runWithTranscript` (imports from `@openomni/agent` barrel, no relative cross-package imports) | no |
+| `session-lock.ts` | `withSessionLock` wrapper — prevents concurrent writes to the same session | no |
+| `session-mailbox.ts` | Mailbox abstraction for queued message delivery to a session | no |
+| `abort-registry.ts` | Global registry mapping run IDs to abort controllers | no |
 
-## Composition
+## Module Split Rationale
 
-```
-SubagentRuntime
-  ├─ withSessionLock(sessionId, fn)       // serial execution per session
-  ├─ WorkerRun.create / updateStatus      // event-sourced run records
-  ├─ ChatAgent.create(...).run(...)       // delegates to @openomni/agent
-  ├─ Session.addMessage / addPart         // persist transcript (user + assistant + tool parts)
-  ├─ AbortControllerRegistry              // signal + controller per session
-  └─ Bus.publish(Subagent.Events.*)       // worker lifecycle visibility
+`runtime.ts` was refactored from ~1094 LOC into focused modules. The split follows single-responsibility: each internal module owns one concern (types, message construction, lifecycle, transcript, locking). Only the four public classes are re-exported from `index.ts`; the rest are internal implementation details.
 
-BackgroundManager
-  ├─ launch(input) → Subagent.BackgroundTask    // enforces maxConcurrentPerAgent / Total / depth / descendants
-  ├─ SubagentRuntime.spawnBackground(...)      // reuses the same locked execution path
-  ├─ Bus.subscribe(WorkerRunCompleted/Failed)  // marks task complete / failed + publishes BackgroundTask.* events
-  └─ cancel(taskId) / cleanup()                // abort + TTL eviction
+Internal modules (`shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-lock.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
 
-SubagentConsultation
-  ├─ fresh-session mode  → Session.createChild + WorkerRun + ChatAgent.run
-  └─ active-session mode → ChatAgent.run with target session context (no durable write)
-```
+## Dependencies
 
-## Worker Run Lifecycle
-
-`WorkerRun.status` transitions mirror `Subagent.WorkerRunStatus` in `@openomni/protocol`:
-
-```
-queued → starting → running → succeeded
-                          └─ failed
-                          └─ cancelled
-                          └─ interrupted
-                          └─ waiting_input → running (resumeCount++)
-```
-
-Terminal statuses: `succeeded | failed | cancelled | interrupted`. `finalizeRun()` reconciles meta status at the end of every run.
-
-## Timeouts
-
-- `softTimeoutMs` — emits `Subagent.Events.WorkerRunFailed` with `error: "soft timeout exceeded"` but does not abort.
-- `hardTimeoutMs` — marks the run `interrupted`, aborts the session, then publishes `WorkerRunFailed`.
-- `cancel()` with `hardTimeoutMs` (default 10s) — aborts the controller and waits for the abort entry to clear before marking `cancelled`.
-
-## BackgroundManager Limits
-
-Default config (override via `BackgroundManager.create(config)`):
-
-- `maxConcurrentPerAgent = 3`
-- `maxConcurrentTotal = 10`
-- `maxDepth = 5` (hops from the original parent session)
-- `maxDescendants = 10` (tasks sharing the same `parentSessionId`)
-- `taskTtlMs = 1_800_000` (30 minutes after completion)
-
-Tasks that exceed any limit fail immediately with a descriptive reason instead of being queued.
-
-## Events Published
-
-- `Subagent.Events.WorkerSessionSpawned` — new child session created
-- `Subagent.Events.WorkerRunStarted / WorkerRunCompleted / WorkerRunFailed` — run lifecycle
-- `Subagent.Events.WorkerSessionResumed / WorkerSessionCancelled` — session lifecycle
-- `Subagent.Events.WorkerConsultationRequested / WorkerConsultationCompleted` — consultations
-- `Subagent.Events.BackgroundTaskLaunched / BackgroundTaskCompleted / BackgroundTaskFailed / BackgroundTaskCancelled` — background manager lifecycle
-
-All events use `BusEvent.define()` definitions in `@openomni/protocol/subagent` and carry the standard `BaseEvent` correlation fields plus a domain-specific `payload`.
-
-## When NOT to use this module
-
-- For a pure ReAct call without session persistence, use `ChatAgent.create().run()` from `@openomni/agent` directly.
-- For ingestion of external events, use `IngressEngine` in `../ingress/` — it will internally dispatch to `ChatAgent` (direct mode) or `PlanAgent` (plan mode). `SubagentRuntime` is for worker-style delegated execution.
+- `@openomni/agent` (barrel only — no relative cross-package imports)
+- `@openomni/session`
+- `@openomni/protocol`
+- `../execution-runtime/` for tool system and workspace lock

--- a/packages/openomni/src/subagent/consultation.ts
+++ b/packages/openomni/src/subagent/consultation.ts
@@ -1,10 +1,15 @@
 import { ChatAgent, type ChatAgentConfig } from "@openomni/agent";
 import { type Message, Subagent } from "@openomni/protocol";
-import { Bus, type BusEvent, Session, WorkerRun } from "@openomni/session";
-
-type RuntimeModel = { provider: string; id: string };
-
-type RuntimeMessage = { role: "user" | "assistant"; content: string };
+import { Session, WorkerRun } from "@openomni/session";
+import {
+  type RuntimeModel,
+  type RuntimeMessage,
+  toSessionModel,
+  createUserMessage,
+  createAssistantMessage,
+  addTextPart,
+  publishEvent,
+} from "./shared";
 
 type ConsultationConfig = {
   model: RuntimeModel;
@@ -13,75 +18,6 @@ type ConsultationConfig = {
   toolExecutor?: ChatAgentConfig["toolExecutor"];
   budget?: ChatAgentConfig["budget"];
 };
-
-function toSessionModel(model: RuntimeModel): { providerID: string; modelID: string } {
-  return {
-    providerID: model.provider,
-    modelID: model.id,
-  };
-}
-
-function createUserMessage(sessionId: string, model: RuntimeModel): Message.UserMessage {
-  return {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    role: "user",
-    time: { created: Date.now() },
-    agent: "subagent-consultation",
-    model: toSessionModel(model),
-  };
-}
-
-function createAssistantMessage(sessionId: string, model: RuntimeModel): Message.AssistantMessage {
-  return {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    role: "assistant",
-    time: { created: Date.now() },
-    parentID: "",
-    modelID: model.id,
-    providerID: model.provider,
-    agent: "subagent-consultation",
-    path: { cwd: process.cwd(), root: process.cwd() },
-    cost: 0,
-    tokens: {
-      input: 0,
-      output: 0,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-  };
-}
-
-function addTextPart(sessionId: string, messageId: string, text: string): void {
-  const part: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    messageID: messageId,
-    type: "text",
-    text,
-  };
-  Session.addPart(messageId, part);
-}
-
-function publishEvent<TPayload extends { sessionId?: string; runId?: string }>(
-  event: BusEvent.Descriptor<{
-    traceId: string;
-    sessionId?: string;
-    runId?: string;
-    time: number;
-    payload: TPayload;
-  }>,
-  payload: TPayload,
-): void {
-  Bus.publish(event, {
-    traceId: crypto.randomUUID(),
-    sessionId: payload.sessionId,
-    runId: payload.runId,
-    time: Date.now(),
-    payload,
-  });
-}
 
 function createRuntimeAgent(config: ConsultationConfig) {
   return ChatAgent.create({
@@ -173,7 +109,7 @@ export namespace SubagentConsultation {
       workerMeta,
     });
 
-    const userMessage = createUserMessage(childSession.id, config.model);
+    const userMessage = createUserMessage(childSession.id, config.model, "subagent-consultation");
     Session.addMessage(childSession.id, userMessage);
     addTextPart(childSession.id, userMessage.id, request.question);
 
@@ -200,7 +136,11 @@ export namespace SubagentConsultation {
         messages: [{ role: "user", content: request.question }],
       });
 
-      const assistantMessage = createAssistantMessage(childSession.id, config.model);
+      const assistantMessage = createAssistantMessage(
+        childSession.id,
+        config.model,
+        "subagent-consultation",
+      );
       Session.addMessage(childSession.id, assistantMessage);
       addTextPart(childSession.id, assistantMessage.id, result.text);
 

--- a/packages/openomni/src/subagent/index.ts
+++ b/packages/openomni/src/subagent/index.ts
@@ -1,4 +1,4 @@
-export * from "./runtime.js";
-export * from "./consultation.js";
-export * from "./background-manager.js";
-export * from "./background-store.js";
+export { SubagentRuntime } from "./runtime.js";
+export { SubagentConsultation } from "./consultation.js";
+export { BackgroundManager } from "./background-manager.js";
+export { BackgroundStore } from "./background-store.js";

--- a/packages/openomni/src/subagent/message-builder.ts
+++ b/packages/openomni/src/subagent/message-builder.ts
@@ -1,0 +1,144 @@
+import type { ChatAgent } from "@openomni/agent";
+import type { Message, Tool } from "@openomni/protocol";
+import { Session } from "@openomni/session";
+import { type RuntimeMessage, addTextPart } from "./shared";
+
+export function createCompletedToolState(call: Tool.Call, output: string): Tool.StateCompleted {
+  const now = Date.now();
+  return {
+    status: "completed",
+    input: call.input,
+    output,
+    title: call.tool,
+    metadata: {},
+    time: {
+      start: now,
+      end: now,
+    },
+  };
+}
+
+export function addToolParts(
+  sessionId: string,
+  messageId: string,
+  steps: { toolCalls?: Tool.Call[]; toolResults?: Tool.Result[] }[],
+): void {
+  for (const step of steps) {
+    if (!step.toolCalls || !step.toolResults) {
+      continue;
+    }
+
+    const resultsByCallId = new Map(step.toolResults.map((result) => [result.toolCallId, result]));
+    for (const call of step.toolCalls) {
+      const result = resultsByCallId.get(call.id);
+      if (!result) {
+        continue;
+      }
+
+      const part: Message.ToolPart = {
+        id: crypto.randomUUID(),
+        sessionID: sessionId,
+        messageID: messageId,
+        type: "tool",
+        callID: call.id,
+        tool: call.tool,
+        state: createCompletedToolState(call, result.output),
+      };
+      Session.addPart(messageId, part);
+    }
+  }
+}
+
+export function serializeToolPart(part: Message.ToolPart, repair?: boolean): string {
+  const input = JSON.stringify(part.state.input);
+
+  switch (part.state.status) {
+    case "completed":
+      return `[Tool: ${part.tool}] Input: ${input} Output: ${part.state.output}`;
+    case "error":
+      return `[Tool: ${part.tool}] Input: ${input} Output: ${part.state.error}`;
+    case "pending":
+    case "running":
+      if (repair) {
+        return `[Tool: ${part.tool}] Error: tool execution interrupted (synthetic)`;
+      }
+      return `[Tool: ${part.tool}] Input: ${input} Output: (${part.state.status})`;
+  }
+}
+
+export function addAssistantResultParts(
+  sessionId: string,
+  messageId: string,
+  result: Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>,
+): void {
+  addTextPart(sessionId, messageId, result.text);
+  addToolParts(sessionId, messageId, result.steps);
+}
+
+export function toRuntimeMessage(
+  message: Message.WithParts,
+  repair?: boolean,
+): RuntimeMessage | undefined {
+  if (message.info.role !== "user" && message.info.role !== "assistant") {
+    return undefined;
+  }
+
+  const content: string[] = [];
+  for (const part of message.parts) {
+    if (part.type === "text") {
+      content.push(part.text);
+      continue;
+    }
+
+    if (part.type === "tool") {
+      content.push(serializeToolPart(part, repair));
+    }
+  }
+
+  if (content.length === 0) {
+    return undefined;
+  }
+
+  return { role: message.info.role, content: content.join("\n") };
+}
+
+export function buildSessionMessagesWithParts(sessionId: string): Message.WithParts[] {
+  const result: Message.WithParts[] = [];
+
+  for (const message of Session.getMessages(sessionId)) {
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+
+    const withParts: Message.WithParts = {
+      info: message,
+      parts: Session.getParts(message.id),
+    };
+
+    if (toRuntimeMessage(withParts) !== undefined) {
+      result.push(withParts);
+    }
+  }
+
+  return result;
+}
+
+export function buildRuntimeMessages(
+  messages: Message.WithParts[],
+  repair?: boolean,
+): RuntimeMessage[] {
+  const result: RuntimeMessage[] = [];
+
+  for (const message of messages) {
+    const runtimeMessage = toRuntimeMessage(message, repair);
+    if (runtimeMessage) {
+      result.push(runtimeMessage);
+    }
+  }
+
+  return result;
+}
+
+export function estimateRuntimeTokens(messages: RuntimeMessage[]): number {
+  return messages.reduce((total, message) => total + Math.ceil(message.content.length / 4), 0);
+}

--- a/packages/openomni/src/subagent/message-builder.ts
+++ b/packages/openomni/src/subagent/message-builder.ts
@@ -18,6 +18,19 @@ export function createCompletedToolState(call: Tool.Call, output: string): Tool.
   };
 }
 
+export function createErrorToolState(call: Tool.Call, error: string): Tool.StateError {
+  const now = Date.now();
+  return {
+    status: "error",
+    input: call.input,
+    error,
+    time: {
+      start: now,
+      end: now,
+    },
+  };
+}
+
 export function addToolParts(
   sessionId: string,
   messageId: string,
@@ -42,7 +55,9 @@ export function addToolParts(
         type: "tool",
         callID: call.id,
         tool: call.tool,
-        state: createCompletedToolState(call, result.output),
+        state: result.isError
+          ? createErrorToolState(call, result.output)
+          : createCompletedToolState(call, result.output),
       };
       Session.addPart(messageId, part);
     }

--- a/packages/openomni/src/subagent/run-lifecycle.ts
+++ b/packages/openomni/src/subagent/run-lifecycle.ts
@@ -1,3 +1,4 @@
+import type { ChatAgent } from "@openomni/agent";
 import { Subagent } from "@openomni/protocol";
 import { Session, WorkerRun } from "@openomni/session";
 import {
@@ -5,7 +6,8 @@ import {
   get as getAbortEntry,
   remove as removeAbortController,
 } from "./abort-registry";
-import { publishEvent } from "./shared";
+import { addAssistantResultParts } from "./message-builder";
+import { createAssistantMessage, publishEvent, type RuntimeModel } from "./shared";
 
 export function buildAbortSignal(controller: AbortController, signal?: AbortSignal): AbortSignal {
   return AbortSignal.any(
@@ -155,4 +157,49 @@ export function setupRunTimeouts(
 export function clearRunTimeouts(timers: TimeoutTimers): void {
   if (timers.soft) clearTimeout(timers.soft);
   if (timers.hard) clearTimeout(timers.hard);
+}
+
+type AgentRunResult = Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>;
+
+export async function executeRun(
+  sessionId: string,
+  runId: string,
+  model: RuntimeModel,
+  timers: TimeoutTimers | undefined,
+  runFn: () => Promise<AgentRunResult>,
+): Promise<{
+  sessionId: string;
+  runId: string;
+  output: string;
+  finishReason: AgentRunResult["finishReason"];
+}> {
+  try {
+    const result = await runFn();
+    const assistantMessage = createAssistantMessage(sessionId, model);
+    Session.addMessage(sessionId, assistantMessage);
+    addAssistantResultParts(sessionId, assistantMessage.id, result);
+    await WorkerRun.updateStatus(sessionId, runId, "succeeded", {
+      endedAt: Date.now(),
+      lastMessageId: assistantMessage.id,
+    });
+    publishEvent(Subagent.Events.WorkerRunCompleted, { sessionId, runId, status: "succeeded" });
+    return { sessionId, runId, output: result.text, finishReason: result.finishReason };
+  } catch (error) {
+    if (await shouldSkipFailureUpdate(sessionId, runId)) throw error;
+    await WorkerRun.updateStatus(sessionId, runId, "failed", { endedAt: Date.now() });
+    publishEvent(Subagent.Events.WorkerRunFailed, {
+      sessionId,
+      runId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    if (timers) clearRunTimeouts(timers);
+    try {
+      await finalizeRun(sessionId, runId);
+    } catch {
+      // cleanup must not mask the original error
+    }
+    removeAbortController(sessionId, runId);
+  }
 }

--- a/packages/openomni/src/subagent/run-lifecycle.ts
+++ b/packages/openomni/src/subagent/run-lifecycle.ts
@@ -1,0 +1,158 @@
+import { Subagent } from "@openomni/protocol";
+import { Session, WorkerRun } from "@openomni/session";
+import {
+  abort as abortSession,
+  get as getAbortEntry,
+  remove as removeAbortController,
+} from "./abort-registry";
+import { publishEvent } from "./shared";
+
+export function buildAbortSignal(controller: AbortController, signal?: AbortSignal): AbortSignal {
+  return AbortSignal.any(
+    [controller.signal, signal].filter(
+      (candidate): candidate is AbortSignal => candidate !== undefined,
+    ),
+  );
+}
+
+export async function shouldSkipFailureUpdate(sessionId: string, runId: string): Promise<boolean> {
+  const run = await WorkerRun.get(sessionId, runId);
+  if (run?.status === "cancelled" || run?.status === "interrupted") return true;
+  // Cancel in progress: controller aborted but entry kept for completion tracking
+  const entry = getAbortEntry(sessionId, runId);
+  return !!entry && entry.controller.signal.aborted;
+}
+
+export function isTerminalStatus(status: string): boolean {
+  return (
+    status === "succeeded" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "interrupted"
+  );
+}
+
+export function resolveMetaStatus(runStatus: string | undefined): string {
+  switch (runStatus) {
+    case "succeeded":
+      return "idle";
+    case "failed":
+    case "cancelled":
+    case "interrupted":
+      return runStatus;
+    default:
+      return "idle";
+  }
+}
+
+export async function finalizeRun(sessionId: string, runId: string): Promise<void> {
+  const run = await WorkerRun.get(sessionId, runId);
+  if (run && !isTerminalStatus(run.status) && !(await shouldSkipFailureUpdate(sessionId, runId))) {
+    await WorkerRun.updateStatus(sessionId, runId, "failed", { endedAt: Date.now() });
+    publishEvent(Subagent.Events.WorkerRunFailed, {
+      sessionId,
+      runId,
+      error: "non-terminal status at finally cleanup",
+    });
+  }
+
+  const finalRun = await WorkerRun.get(sessionId, runId);
+  const meta = Session.getWorkerMeta(sessionId);
+  if (meta && typeof meta === "object") {
+    Session.updateWorkerMeta(sessionId, {
+      ...meta,
+      status: resolveMetaStatus(finalRun?.status),
+    });
+  }
+}
+
+export async function waitForAbortEntryRemoval(sessionId: string, runId: string): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (getAbortEntry(sessionId, runId) === undefined) return;
+    await Promise.resolve();
+  }
+  while (getAbortEntry(sessionId, runId) !== undefined) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+export async function raceAbortCompletion(
+  sessionId: string,
+  runId: string,
+  hardTimeoutMs: number,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const abortWait = waitForAbortEntryRemoval(sessionId, runId).then(() => "settled" as const);
+  const timeout = new Promise<"timeout">((resolve) => {
+    timeoutId = setTimeout(() => resolve("timeout"), hardTimeoutMs);
+  });
+
+  const winner = await Promise.race([abortWait, timeout]);
+
+  if (winner === "timeout") {
+    removeAbortController(sessionId, runId);
+    const run = await WorkerRun.get(sessionId, runId);
+    if (run && !isTerminalStatus(run.status)) {
+      await WorkerRun.updateStatus(sessionId, runId, "interrupted", { endedAt: Date.now() });
+    }
+    publishEvent(Subagent.Events.WorkerRunFailed, {
+      sessionId,
+      runId,
+      error: "cancel timeout exceeded",
+    });
+  } else {
+    clearTimeout(timeoutId);
+    const run = await WorkerRun.get(sessionId, runId);
+    if (run && !isTerminalStatus(run.status)) {
+      await WorkerRun.updateStatus(sessionId, runId, "cancelled", { endedAt: Date.now() });
+    }
+  }
+}
+
+export type TimeoutTimers = {
+  soft?: ReturnType<typeof setTimeout>;
+  hard?: ReturnType<typeof setTimeout>;
+};
+
+export function setupRunTimeouts(
+  sessionId: string,
+  runId: string,
+  softTimeoutMs?: number,
+  hardTimeoutMs?: number,
+): TimeoutTimers {
+  const timers: TimeoutTimers = {};
+
+  if (softTimeoutMs !== undefined) {
+    timers.soft = setTimeout(() => {
+      publishEvent(Subagent.Events.WorkerRunFailed, {
+        sessionId,
+        runId,
+        error: "soft timeout exceeded",
+      });
+    }, softTimeoutMs);
+  }
+
+  if (hardTimeoutMs !== undefined) {
+    timers.hard = setTimeout(async () => {
+      try {
+        await WorkerRun.updateStatus(sessionId, runId, "interrupted", { endedAt: Date.now() });
+      } catch {
+        return;
+      }
+      publishEvent(Subagent.Events.WorkerRunFailed, {
+        sessionId,
+        runId,
+        error: "hard timeout exceeded",
+      });
+      abortSession(sessionId, runId);
+    }, hardTimeoutMs);
+  }
+
+  return timers;
+}
+
+export function clearRunTimeouts(timers: TimeoutTimers): void {
+  if (timers.soft) clearTimeout(timers.soft);
+  if (timers.hard) clearTimeout(timers.hard);
+}

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -1,5 +1,5 @@
 import { ChatAgent, type ChatAgentConfig } from "@openomni/agent";
-import { type Guardrail, type Message, Subagent, type Tool } from "@openomni/protocol";
+import { type Guardrail, type Message, Subagent } from "@openomni/protocol";
 import { Bus, type BusEvent, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
 import {
   abort as abortSession,
@@ -17,6 +17,12 @@ import {
   addTextPart,
   publishEvent,
 } from "./shared";
+import {
+  addAssistantResultParts,
+  buildRuntimeMessages,
+  buildSessionMessagesWithParts,
+  estimateRuntimeTokens,
+} from "./message-builder";
 
 type RuntimeConfig = {
   model: RuntimeModel;
@@ -53,143 +59,6 @@ type InMemoryCompactorLike = {
     removedCount: number;
   }>;
 };
-
-function createCompletedToolState(call: Tool.Call, output: string): Tool.StateCompleted {
-  const now = Date.now();
-  return {
-    status: "completed",
-    input: call.input,
-    output,
-    title: call.tool,
-    metadata: {},
-    time: {
-      start: now,
-      end: now,
-    },
-  };
-}
-
-function addToolParts(
-  sessionId: string,
-  messageId: string,
-  steps: { toolCalls?: Tool.Call[]; toolResults?: Tool.Result[] }[],
-): void {
-  for (const step of steps) {
-    if (!step.toolCalls || !step.toolResults) {
-      continue;
-    }
-
-    const resultsByCallId = new Map(step.toolResults.map((result) => [result.toolCallId, result]));
-    for (const call of step.toolCalls) {
-      const result = resultsByCallId.get(call.id);
-      if (!result) {
-        continue;
-      }
-
-      const part: Message.ToolPart = {
-        id: crypto.randomUUID(),
-        sessionID: sessionId,
-        messageID: messageId,
-        type: "tool",
-        callID: call.id,
-        tool: call.tool,
-        state: createCompletedToolState(call, result.output),
-      };
-      Session.addPart(messageId, part);
-    }
-  }
-}
-
-function serializeToolPart(part: Message.ToolPart, repair?: boolean): string {
-  const input = JSON.stringify(part.state.input);
-
-  switch (part.state.status) {
-    case "completed":
-      return `[Tool: ${part.tool}] Input: ${input} Output: ${part.state.output}`;
-    case "error":
-      return `[Tool: ${part.tool}] Input: ${input} Output: ${part.state.error}`;
-    case "pending":
-    case "running":
-      if (repair) {
-        return `[Tool: ${part.tool}] Error: tool execution interrupted (synthetic)`;
-      }
-      return `[Tool: ${part.tool}] Input: ${input} Output: (${part.state.status})`;
-  }
-}
-
-function addAssistantResultParts(
-  sessionId: string,
-  messageId: string,
-  result: Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>,
-): void {
-  addTextPart(sessionId, messageId, result.text);
-  addToolParts(sessionId, messageId, result.steps);
-}
-
-function toRuntimeMessage(
-  message: Message.WithParts,
-  repair?: boolean,
-): RuntimeMessage | undefined {
-  if (message.info.role !== "user" && message.info.role !== "assistant") {
-    return undefined;
-  }
-
-  const content: string[] = [];
-  for (const part of message.parts) {
-    if (part.type === "text") {
-      content.push(part.text);
-      continue;
-    }
-
-    if (part.type === "tool") {
-      content.push(serializeToolPart(part, repair));
-    }
-  }
-
-  if (content.length === 0) {
-    return undefined;
-  }
-
-  return { role: message.info.role, content: content.join("\n") };
-}
-
-function buildSessionMessagesWithParts(sessionId: string): Message.WithParts[] {
-  const result: Message.WithParts[] = [];
-
-  for (const message of Session.getMessages(sessionId)) {
-    if (message.role !== "user" && message.role !== "assistant") {
-      continue;
-    }
-
-    const withParts: Message.WithParts = {
-      info: message,
-      parts: Session.getParts(message.id),
-    };
-
-    if (toRuntimeMessage(withParts) !== undefined) {
-      result.push(withParts);
-    }
-  }
-
-  return result;
-}
-
-function buildRuntimeMessages(messages: Message.WithParts[], repair?: boolean): RuntimeMessage[] {
-  const result: RuntimeMessage[] = [];
-
-  for (const message of messages) {
-    const runtimeMessage = toRuntimeMessage(message, repair);
-    if (runtimeMessage) {
-      result.push(runtimeMessage);
-    }
-  }
-
-  return result;
-}
-
-function estimateRuntimeTokens(messages: RuntimeMessage[]): number {
-  return messages.reduce((total, message) => total + Math.ceil(message.content.length / 4), 0);
-}
 
 async function loadInMemoryCompactor(): Promise<InMemoryCompactorLike> {
   const module = (await import(

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -1,6 +1,6 @@
-import { ChatAgent, type ChatAgentConfig } from "@openomni/agent";
+import type { ChatAgent } from "@openomni/agent";
 import { type Guardrail, type Message, Subagent } from "@openomni/protocol";
-import { Bus, type BusEvent, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
+import { Bus, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
 import {
   get as getAbortEntry,
   register as registerAbortController,
@@ -17,7 +17,6 @@ import {
 } from "./run-lifecycle";
 import { sendToMailbox } from "./session-mailbox.js";
 import {
-  type RuntimeModel,
   type RuntimeMessage,
   toSessionModel,
   createUserMessage,
@@ -25,122 +24,14 @@ import {
   addTextPart,
   publishEvent,
 } from "./shared";
+import { addAssistantResultParts } from "./message-builder";
 import {
-  addAssistantResultParts,
-  buildRuntimeMessages,
-  buildSessionMessagesWithParts,
-  estimateRuntimeTokens,
-} from "./message-builder";
-
-type RuntimeConfig = {
-  model: RuntimeModel;
-  systemPrompt?: string;
-  tools?: ChatAgentConfig["tools"];
-  toolExecutor?: ChatAgentConfig["toolExecutor"];
-  budget?: ChatAgentConfig["budget"];
-};
-
-type SendCompactionConfig = {
-  contextWindowTokens: number;
-  thresholdRatio?: number;
-  onSummarize?: (messages: RuntimeMessage[]) => Promise<string>;
-};
-
-type InMemoryCompactorLike = {
-  shouldCompact(
-    totalTokens: number,
-    options: {
-      contextWindowTokens: number;
-      thresholdRatio?: number;
-    },
-  ): boolean;
-  compact(
-    messages: Message.WithParts[],
-    options: {
-      contextWindowTokens: number;
-      thresholdRatio?: number;
-      onSummarize?: (messages: Message.WithParts[]) => Promise<string>;
-    },
-  ): Promise<{
-    messages: Message.WithParts[];
-    compacted: boolean;
-    removedCount: number;
-  }>;
-};
-
-async function loadInMemoryCompactor(): Promise<InMemoryCompactorLike> {
-  const module = (await import(
-    new URL("../../../agent/src/core/execution/compaction.ts", import.meta.url).href
-  )) as { InMemoryCompactor: InMemoryCompactorLike };
-
-  return module.InMemoryCompactor;
-}
-
-function buildChildMessagesInternal(sessionId: string, repair?: boolean): RuntimeMessage[] {
-  return buildRuntimeMessages(buildSessionMessagesWithParts(sessionId), repair);
-}
-
-async function maybeCompactSendTranscript(
-  sessionId: string,
-  messages: RuntimeMessage[],
-  compaction?: SendCompactionConfig,
-): Promise<RuntimeMessage[]> {
-  if (!compaction) {
-    return messages;
-  }
-
-  const compactor = await loadInMemoryCompactor();
-  const totalTokens = estimateRuntimeTokens(messages);
-  if (
-    !compactor.shouldCompact(totalTokens, {
-      contextWindowTokens: compaction.contextWindowTokens,
-      thresholdRatio: compaction.thresholdRatio,
-    })
-  ) {
-    return messages;
-  }
-
-  const anchor = messages.find((message) => message.role === "user")?.content;
-  const result = await compactor.compact(buildSessionMessagesWithParts(sessionId), {
-    contextWindowTokens: compaction.contextWindowTokens,
-    thresholdRatio: compaction.thresholdRatio,
-    onSummarize: compaction.onSummarize
-      ? async (messagesToSummarize) =>
-          compaction.onSummarize!(buildRuntimeMessages(messagesToSummarize))
-      : undefined,
-  });
-
-  if (!result.compacted) {
-    return messages;
-  }
-
-  const compactedMessages = buildRuntimeMessages(result.messages);
-  if (!anchor) {
-    return compactedMessages;
-  }
-
-  return [{ role: "user", content: `Original goal: ${anchor}` }, ...compactedMessages];
-}
-
-async function runWithTranscript(
-  sessionId: string,
-  config: RuntimeConfig,
-  signal?: AbortSignal,
-  permissions?: Guardrail.ToolPermission,
-  messages = buildChildMessagesInternal(sessionId),
-): Promise<Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>> {
-  const agent = ChatAgent.create({
-    model: config.model,
-    systemPrompt: config.systemPrompt,
-    tools: config.tools,
-    budget: config.budget,
-    toolExecutor: config.toolExecutor,
-    signal,
-    permissions,
-  });
-
-  return agent.run({ messages });
-}
+  type RuntimeConfig,
+  type SendCompactionConfig,
+  buildChildMessagesInternal,
+  maybeCompactSendTranscript,
+  runWithTranscript,
+} from "./transcript";
 
 export namespace SubagentRuntime {
   export interface SpawnConfig extends RuntimeConfig {

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -8,10 +8,15 @@ import {
   remove as removeAbortController,
 } from "./abort-registry";
 import { sendToMailbox } from "./session-mailbox.js";
-
-type RuntimeModel = { provider: string; id: string };
-
-type RuntimeMessage = { role: "user" | "assistant"; content: string };
+import {
+  type RuntimeModel,
+  type RuntimeMessage,
+  toSessionModel,
+  createUserMessage,
+  createAssistantMessage,
+  addTextPart,
+  publishEvent,
+} from "./shared";
 
 type RuntimeConfig = {
   model: RuntimeModel;
@@ -48,56 +53,6 @@ type InMemoryCompactorLike = {
     removedCount: number;
   }>;
 };
-
-function toSessionModel(model: RuntimeModel): { providerID: string; modelID: string } {
-  return {
-    providerID: model.provider,
-    modelID: model.id,
-  };
-}
-
-function createUserMessage(sessionId: string, model: RuntimeModel): Message.UserMessage {
-  return {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    role: "user",
-    time: { created: Date.now() },
-    agent: "subagent-runtime",
-    model: toSessionModel(model),
-  };
-}
-
-function createAssistantMessage(sessionId: string, model: RuntimeModel): Message.AssistantMessage {
-  return {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    role: "assistant",
-    time: { created: Date.now() },
-    parentID: "",
-    modelID: model.id,
-    providerID: model.provider,
-    agent: "subagent-runtime",
-    path: { cwd: process.cwd(), root: process.cwd() },
-    cost: 0,
-    tokens: {
-      input: 0,
-      output: 0,
-      reasoning: 0,
-      cache: { read: 0, write: 0 },
-    },
-  };
-}
-
-function addTextPart(sessionId: string, messageId: string, text: string): void {
-  const part: Message.TextPart = {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    messageID: messageId,
-    type: "text",
-    text,
-  };
-  Session.addPart(messageId, part);
-}
 
 function createCompletedToolState(call: Tool.Call, output: string): Tool.StateCompleted {
   const now = Date.now();
@@ -169,25 +124,6 @@ function addAssistantResultParts(
 ): void {
   addTextPart(sessionId, messageId, result.text);
   addToolParts(sessionId, messageId, result.steps);
-}
-
-function publishEvent<TPayload extends { sessionId?: string; runId?: string }>(
-  event: BusEvent.Descriptor<{
-    traceId: string;
-    sessionId?: string;
-    runId?: string;
-    time: number;
-    payload: TPayload;
-  }>,
-  payload: TPayload,
-): void {
-  Bus.publish(event, {
-    traceId: crypto.randomUUID(),
-    sessionId: payload.sessionId,
-    runId: payload.runId,
-    time: Date.now(),
-    payload,
-  });
 }
 
 function toRuntimeMessage(

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -1,30 +1,22 @@
 import type { ChatAgent } from "@openomni/agent";
 import { type Guardrail, type Message, Subagent } from "@openomni/protocol";
 import { Bus, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
-import {
-  get as getAbortEntry,
-  register as registerAbortController,
-  remove as removeAbortController,
-} from "./abort-registry";
+import { get as getAbortEntry, register as registerAbortController } from "./abort-registry";
 import {
   buildAbortSignal,
-  clearRunTimeouts,
-  finalizeRun,
+  executeRun,
+  isTerminalStatus,
   raceAbortCompletion,
   setupRunTimeouts,
-  shouldSkipFailureUpdate,
-  isTerminalStatus,
 } from "./run-lifecycle";
 import { sendToMailbox } from "./session-mailbox.js";
 import {
   type RuntimeMessage,
-  toSessionModel,
-  createUserMessage,
-  createAssistantMessage,
   addTextPart,
+  createSpawnSession,
+  createUserMessage,
   publishEvent,
 } from "./shared";
-import { addAssistantResultParts } from "./message-builder";
 import {
   type RuntimeConfig,
   type SendCompactionConfig,
@@ -83,309 +75,6 @@ export namespace SubagentRuntime {
     output?: string;
   }
 
-  export function spawn(config: SpawnConfig): Promise<RunResult> {
-    const workerMeta = Subagent.ChildSessionMeta.parse({
-      kind: "subagent",
-      parentSessionId: config.parentSessionId,
-      agentName: config.agentName,
-      spawnDepth: config.parentSessionId ? undefined : 0,
-      status: "idle",
-    });
-
-    const session = config.parentSessionId
-      ? Session.createChild({
-          parentSessionId: config.parentSessionId,
-          title: config.title,
-          model: toSessionModel(config.model),
-          workerMeta,
-        })
-      : Session.create({
-          title: config.title,
-          model: toSessionModel(config.model),
-        });
-
-    if (!config.parentSessionId) {
-      Session.updateWorkerMeta(session.id, workerMeta);
-    }
-
-    publishEvent(Subagent.Events.WorkerSessionSpawned, {
-      sessionId: session.id,
-      parentSessionId: config.parentSessionId,
-      agentName: config.agentName,
-      spawnDepth: session.spawnDepth,
-      kind: "subagent",
-    });
-
-    return sendToMailbox(session.id, async () => {
-      const userMessage = createUserMessage(session.id, config.model);
-      Session.addMessage(session.id, userMessage);
-      addTextPart(session.id, userMessage.id, config.prompt);
-
-      const runId = crypto.randomUUID();
-      await WorkerRun.create(session.id, {
-        runId,
-        title: config.title,
-        prompt: config.prompt,
-      });
-      const abortEntry = registerAbortController(session.id, runId);
-      const signal = buildAbortSignal(abortEntry.controller, config.signal);
-      const timers = setupRunTimeouts(
-        session.id,
-        runId,
-        config.softTimeoutMs,
-        config.hardTimeoutMs,
-      );
-      await WorkerRun.updateStatus(session.id, runId, "starting");
-      publishEvent(Subagent.Events.WorkerRunStarted, {
-        sessionId: session.id,
-        runId,
-        title: config.title,
-      });
-
-      try {
-        await WorkerRun.updateStatus(session.id, runId, "running");
-        const permissions = config.permissions ?? { denylist: ["subagent"] };
-        const result = await runWithTranscript(session.id, config, signal, permissions);
-
-        const assistantMessage = createAssistantMessage(session.id, config.model);
-        Session.addMessage(session.id, assistantMessage);
-        addAssistantResultParts(session.id, assistantMessage.id, result);
-
-        await WorkerRun.updateStatus(session.id, runId, "succeeded", {
-          endedAt: Date.now(),
-          lastMessageId: assistantMessage.id,
-        });
-
-        publishEvent(Subagent.Events.WorkerRunCompleted, {
-          sessionId: session.id,
-          runId,
-          status: "succeeded",
-        });
-
-        return {
-          sessionId: session.id,
-          runId,
-          output: result.text,
-          finishReason: result.finishReason,
-        };
-      } catch (error) {
-        if (await shouldSkipFailureUpdate(session.id, runId)) {
-          throw error;
-        }
-
-        await WorkerRun.updateStatus(session.id, runId, "failed", {
-          endedAt: Date.now(),
-        });
-        publishEvent(Subagent.Events.WorkerRunFailed, {
-          sessionId: session.id,
-          runId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      } finally {
-        clearRunTimeouts(timers);
-        try {
-          await finalizeRun(session.id, runId);
-        } catch {
-          // cleanup must not mask the original error
-        }
-        removeAbortController(session.id, runId);
-      }
-    });
-  }
-
-  export async function spawnBackground(config: SpawnConfig): Promise<SpawnBackgroundResult> {
-    const workerMeta = Subagent.ChildSessionMeta.parse({
-      kind: "subagent",
-      parentSessionId: config.parentSessionId,
-      agentName: config.agentName,
-      spawnDepth: config.parentSessionId ? undefined : 0,
-      status: "idle",
-    });
-
-    const session = config.parentSessionId
-      ? Session.createChild({
-          parentSessionId: config.parentSessionId,
-          title: config.title,
-          model: toSessionModel(config.model),
-          workerMeta,
-        })
-      : Session.create({
-          title: config.title,
-          model: toSessionModel(config.model),
-        });
-
-    if (!config.parentSessionId) {
-      Session.updateWorkerMeta(session.id, workerMeta);
-    }
-
-    publishEvent(Subagent.Events.WorkerSessionSpawned, {
-      sessionId: session.id,
-      parentSessionId: config.parentSessionId,
-      agentName: config.agentName,
-      spawnDepth: session.spawnDepth,
-      kind: "subagent",
-    });
-
-    const userMessage = createUserMessage(session.id, config.model);
-    Session.addMessage(session.id, userMessage);
-    addTextPart(session.id, userMessage.id, config.prompt);
-
-    const runId = crypto.randomUUID();
-    await WorkerRun.create(session.id, {
-      runId,
-      title: config.title,
-      prompt: config.prompt,
-    });
-
-    const abortEntry = registerAbortController(session.id, runId);
-    const signal = buildAbortSignal(abortEntry.controller, config.signal);
-    const timers = setupRunTimeouts(session.id, runId, config.softTimeoutMs, config.hardTimeoutMs);
-
-    await WorkerRun.updateStatus(session.id, runId, "starting");
-    publishEvent(Subagent.Events.WorkerRunStarted, {
-      sessionId: session.id,
-      runId,
-      title: config.title,
-    });
-    await WorkerRun.updateStatus(session.id, runId, "running");
-
-    const backgroundRun = sendToMailbox(session.id, async () => {
-      try {
-        const permissions = config.permissions ?? { denylist: ["subagent"] };
-        const result = await runWithTranscript(session.id, config, signal, permissions);
-
-        const assistantMessage = createAssistantMessage(session.id, config.model);
-        Session.addMessage(session.id, assistantMessage);
-        addAssistantResultParts(session.id, assistantMessage.id, result);
-
-        await WorkerRun.updateStatus(session.id, runId, "succeeded", {
-          endedAt: Date.now(),
-          lastMessageId: assistantMessage.id,
-        });
-
-        publishEvent(Subagent.Events.WorkerRunCompleted, {
-          sessionId: session.id,
-          runId,
-          status: "succeeded",
-        });
-      } catch (error) {
-        if (await shouldSkipFailureUpdate(session.id, runId)) {
-          throw error;
-        }
-
-        await WorkerRun.updateStatus(session.id, runId, "failed", {
-          endedAt: Date.now(),
-        });
-        publishEvent(Subagent.Events.WorkerRunFailed, {
-          sessionId: session.id,
-          runId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      } finally {
-        clearRunTimeouts(timers);
-        try {
-          await finalizeRun(session.id, runId);
-        } catch {
-          // cleanup must not mask the original error
-        }
-        removeAbortController(session.id, runId);
-      }
-    });
-
-    backgroundRun.catch(() => undefined);
-
-    return {
-      sessionId: session.id,
-      runId,
-    };
-  }
-
-  export function send(config: SendConfig): Promise<RunResult> {
-    const session = Session.get(config.sessionId);
-    if (!session) {
-      throw new Error(`Session not found: ${config.sessionId}`);
-    }
-
-    return sendToMailbox(session.id, async () => {
-      const userMessage = createUserMessage(session.id, config.model);
-      Session.addMessage(session.id, userMessage);
-      addTextPart(session.id, userMessage.id, config.prompt);
-
-      const runId = crypto.randomUUID();
-      await WorkerRun.create(session.id, {
-        runId,
-        title: "retry",
-        prompt: config.prompt,
-      });
-      const abortEntry = registerAbortController(session.id, runId);
-      const signal = buildAbortSignal(abortEntry.controller, config.signal);
-      const timers = setupRunTimeouts(
-        session.id,
-        runId,
-        config.softTimeoutMs,
-        config.hardTimeoutMs,
-      );
-      await WorkerRun.updateStatus(session.id, runId, "starting");
-      await WorkerRun.updateStatus(session.id, runId, "running");
-
-      try {
-        const permissions = config.permissions ?? { denylist: ["subagent"] };
-        const messages = await maybeCompactSendTranscript(
-          session.id,
-          buildChildMessagesInternal(session.id),
-          config.compaction,
-        );
-        const result = await runWithTranscript(session.id, config, signal, permissions, messages);
-
-        const assistantMessage = createAssistantMessage(session.id, config.model);
-        Session.addMessage(session.id, assistantMessage);
-        addAssistantResultParts(session.id, assistantMessage.id, result);
-
-        await WorkerRun.updateStatus(session.id, runId, "succeeded", {
-          endedAt: Date.now(),
-          lastMessageId: assistantMessage.id,
-        });
-
-        publishEvent(Subagent.Events.WorkerRunCompleted, {
-          sessionId: session.id,
-          runId,
-          status: "succeeded",
-        });
-
-        return {
-          sessionId: session.id,
-          runId,
-          output: result.text,
-          finishReason: result.finishReason,
-        };
-      } catch (error) {
-        if (await shouldSkipFailureUpdate(session.id, runId)) {
-          throw error;
-        }
-
-        await WorkerRun.updateStatus(session.id, runId, "failed", {
-          endedAt: Date.now(),
-        });
-        publishEvent(Subagent.Events.WorkerRunFailed, {
-          sessionId: session.id,
-          runId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      } finally {
-        clearRunTimeouts(timers);
-        try {
-          await finalizeRun(session.id, runId);
-        } catch {
-          // cleanup must not mask the original error
-        }
-        removeAbortController(session.id, runId);
-      }
-    });
-  }
-
   export interface ResumeConfig extends RuntimeConfig {
     sessionId: string;
   }
@@ -402,6 +91,107 @@ export namespace SubagentRuntime {
     sessionId: string;
     runId?: string;
     hardTimeoutMs?: number;
+  }
+
+  export function spawn(config: SpawnConfig): Promise<RunResult> {
+    const session = createSpawnSession(config);
+
+    return sendToMailbox(session.id, async () => {
+      const userMessage = createUserMessage(session.id, config.model);
+      Session.addMessage(session.id, userMessage);
+      addTextPart(session.id, userMessage.id, config.prompt);
+
+      const runId = crypto.randomUUID();
+      await WorkerRun.create(session.id, { runId, title: config.title, prompt: config.prompt });
+      const abortEntry = registerAbortController(session.id, runId);
+      const signal = buildAbortSignal(abortEntry.controller, config.signal);
+      const timers = setupRunTimeouts(
+        session.id,
+        runId,
+        config.softTimeoutMs,
+        config.hardTimeoutMs,
+      );
+      await WorkerRun.updateStatus(session.id, runId, "starting");
+      publishEvent(Subagent.Events.WorkerRunStarted, {
+        sessionId: session.id,
+        runId,
+        title: config.title,
+      });
+
+      await WorkerRun.updateStatus(session.id, runId, "running");
+      const permissions = config.permissions ?? { denylist: ["subagent"] };
+      return executeRun(session.id, runId, config.model, timers, () =>
+        runWithTranscript(session.id, config, signal, permissions),
+      );
+    });
+  }
+
+  export async function spawnBackground(config: SpawnConfig): Promise<SpawnBackgroundResult> {
+    const session = createSpawnSession(config);
+
+    const userMessage = createUserMessage(session.id, config.model);
+    Session.addMessage(session.id, userMessage);
+    addTextPart(session.id, userMessage.id, config.prompt);
+
+    const runId = crypto.randomUUID();
+    await WorkerRun.create(session.id, { runId, title: config.title, prompt: config.prompt });
+    const abortEntry = registerAbortController(session.id, runId);
+    const signal = buildAbortSignal(abortEntry.controller, config.signal);
+    const timers = setupRunTimeouts(session.id, runId, config.softTimeoutMs, config.hardTimeoutMs);
+
+    await WorkerRun.updateStatus(session.id, runId, "starting");
+    publishEvent(Subagent.Events.WorkerRunStarted, {
+      sessionId: session.id,
+      runId,
+      title: config.title,
+    });
+    await WorkerRun.updateStatus(session.id, runId, "running");
+
+    const permissions = config.permissions ?? { denylist: ["subagent"] };
+    const backgroundRun = sendToMailbox(session.id, () =>
+      executeRun(session.id, runId, config.model, timers, () =>
+        runWithTranscript(session.id, config, signal, permissions),
+      ),
+    );
+    backgroundRun.catch(() => undefined);
+
+    return { sessionId: session.id, runId };
+  }
+
+  export function send(config: SendConfig): Promise<RunResult> {
+    const session = Session.get(config.sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${config.sessionId}`);
+    }
+
+    return sendToMailbox(session.id, async () => {
+      const userMessage = createUserMessage(session.id, config.model);
+      Session.addMessage(session.id, userMessage);
+      addTextPart(session.id, userMessage.id, config.prompt);
+
+      const runId = crypto.randomUUID();
+      await WorkerRun.create(session.id, { runId, title: "retry", prompt: config.prompt });
+      const abortEntry = registerAbortController(session.id, runId);
+      const signal = buildAbortSignal(abortEntry.controller, config.signal);
+      const timers = setupRunTimeouts(
+        session.id,
+        runId,
+        config.softTimeoutMs,
+        config.hardTimeoutMs,
+      );
+      await WorkerRun.updateStatus(session.id, runId, "starting");
+      await WorkerRun.updateStatus(session.id, runId, "running");
+
+      const permissions = config.permissions ?? { denylist: ["subagent"] };
+      const messages = await maybeCompactSendTranscript(
+        session.id,
+        buildChildMessagesInternal(session.id),
+        config.compaction,
+      );
+      return executeRun(session.id, runId, config.model, timers, () =>
+        runWithTranscript(session.id, config, signal, permissions, messages),
+      );
+    });
   }
 
   export async function resume(config: ResumeConfig): Promise<ResumeResult> {
@@ -430,54 +220,11 @@ export namespace SubagentRuntime {
         runId,
       });
 
-      try {
-        await WorkerRun.updateStatus(config.sessionId, runId, "running");
-        const result = await runWithTranscript(config.sessionId, config);
-
-        const assistantMessage = createAssistantMessage(config.sessionId, config.model);
-        Session.addMessage(config.sessionId, assistantMessage);
-        addAssistantResultParts(config.sessionId, assistantMessage.id, result);
-
-        await WorkerRun.updateStatus(config.sessionId, runId, "succeeded", {
-          endedAt: Date.now(),
-          lastMessageId: assistantMessage.id,
-        });
-
-        publishEvent(Subagent.Events.WorkerRunCompleted, {
-          sessionId: config.sessionId,
-          runId,
-          status: "succeeded",
-        });
-
-        return {
-          resumed: true,
-          sessionId: config.sessionId,
-          runId,
-          output: result.text,
-          finishReason: result.finishReason,
-        };
-      } catch (error) {
-        if (await shouldSkipFailureUpdate(config.sessionId, runId)) {
-          throw error;
-        }
-
-        await WorkerRun.updateStatus(config.sessionId, runId, "failed", {
-          endedAt: Date.now(),
-        });
-        publishEvent(Subagent.Events.WorkerRunFailed, {
-          sessionId: config.sessionId,
-          runId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      } finally {
-        try {
-          await finalizeRun(config.sessionId, runId);
-        } catch {
-          // cleanup must not mask the original error
-        }
-        removeAbortController(config.sessionId, runId);
-      }
+      await WorkerRun.updateStatus(config.sessionId, runId, "running");
+      const result = await executeRun(config.sessionId, runId, config.model, undefined, () =>
+        runWithTranscript(config.sessionId, config),
+      );
+      return { resumed: true, ...result };
     });
   }
 

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -2,11 +2,19 @@ import { ChatAgent, type ChatAgentConfig } from "@openomni/agent";
 import { type Guardrail, type Message, Subagent } from "@openomni/protocol";
 import { Bus, type BusEvent, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
 import {
-  abort as abortSession,
   get as getAbortEntry,
   register as registerAbortController,
   remove as removeAbortController,
 } from "./abort-registry";
+import {
+  buildAbortSignal,
+  clearRunTimeouts,
+  finalizeRun,
+  raceAbortCompletion,
+  setupRunTimeouts,
+  shouldSkipFailureUpdate,
+  isTerminalStatus,
+} from "./run-lifecycle";
 import { sendToMailbox } from "./session-mailbox.js";
 import {
   type RuntimeModel,
@@ -132,156 +140,6 @@ async function runWithTranscript(
   });
 
   return agent.run({ messages });
-}
-
-function buildAbortSignal(controller: AbortController, signal?: AbortSignal): AbortSignal {
-  return AbortSignal.any(
-    [controller.signal, signal].filter(
-      (candidate): candidate is AbortSignal => candidate !== undefined,
-    ),
-  );
-}
-
-async function shouldSkipFailureUpdate(sessionId: string, runId: string): Promise<boolean> {
-  const run = await WorkerRun.get(sessionId, runId);
-  if (run?.status === "cancelled" || run?.status === "interrupted") return true;
-  // Cancel in progress: controller aborted but entry kept for completion tracking
-  const entry = getAbortEntry(sessionId, runId);
-  return !!entry && entry.controller.signal.aborted;
-}
-
-function isTerminalStatus(status: string): boolean {
-  return (
-    status === "succeeded" ||
-    status === "failed" ||
-    status === "cancelled" ||
-    status === "interrupted"
-  );
-}
-
-function resolveMetaStatus(runStatus: string | undefined): string {
-  switch (runStatus) {
-    case "succeeded":
-      return "idle";
-    case "failed":
-    case "cancelled":
-    case "interrupted":
-      return runStatus;
-    default:
-      return "idle";
-  }
-}
-
-async function finalizeRun(sessionId: string, runId: string): Promise<void> {
-  const run = await WorkerRun.get(sessionId, runId);
-  if (run && !isTerminalStatus(run.status) && !(await shouldSkipFailureUpdate(sessionId, runId))) {
-    await WorkerRun.updateStatus(sessionId, runId, "failed", { endedAt: Date.now() });
-    publishEvent(Subagent.Events.WorkerRunFailed, {
-      sessionId,
-      runId,
-      error: "non-terminal status at finally cleanup",
-    });
-  }
-
-  const finalRun = await WorkerRun.get(sessionId, runId);
-  const meta = Session.getWorkerMeta(sessionId);
-  if (meta && typeof meta === "object") {
-    Session.updateWorkerMeta(sessionId, {
-      ...meta,
-      status: resolveMetaStatus(finalRun?.status),
-    });
-  }
-}
-
-async function waitForAbortEntryRemoval(sessionId: string, runId: string): Promise<void> {
-  for (let i = 0; i < 20; i++) {
-    if (getAbortEntry(sessionId, runId) === undefined) return;
-    await Promise.resolve();
-  }
-  while (getAbortEntry(sessionId, runId) !== undefined) {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-}
-
-async function raceAbortCompletion(
-  sessionId: string,
-  runId: string,
-  hardTimeoutMs: number,
-): Promise<void> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  const abortWait = waitForAbortEntryRemoval(sessionId, runId).then(() => "settled" as const);
-  const timeout = new Promise<"timeout">((resolve) => {
-    timeoutId = setTimeout(() => resolve("timeout"), hardTimeoutMs);
-  });
-
-  const winner = await Promise.race([abortWait, timeout]);
-
-  if (winner === "timeout") {
-    removeAbortController(sessionId, runId);
-    const run = await WorkerRun.get(sessionId, runId);
-    if (run && !isTerminalStatus(run.status)) {
-      await WorkerRun.updateStatus(sessionId, runId, "interrupted", { endedAt: Date.now() });
-    }
-    publishEvent(Subagent.Events.WorkerRunFailed, {
-      sessionId,
-      runId,
-      error: "cancel timeout exceeded",
-    });
-  } else {
-    clearTimeout(timeoutId);
-    const run = await WorkerRun.get(sessionId, runId);
-    if (run && !isTerminalStatus(run.status)) {
-      await WorkerRun.updateStatus(sessionId, runId, "cancelled", { endedAt: Date.now() });
-    }
-  }
-}
-
-type TimeoutTimers = {
-  soft?: ReturnType<typeof setTimeout>;
-  hard?: ReturnType<typeof setTimeout>;
-};
-
-function setupRunTimeouts(
-  sessionId: string,
-  runId: string,
-  softTimeoutMs?: number,
-  hardTimeoutMs?: number,
-): TimeoutTimers {
-  const timers: TimeoutTimers = {};
-
-  if (softTimeoutMs !== undefined) {
-    timers.soft = setTimeout(() => {
-      publishEvent(Subagent.Events.WorkerRunFailed, {
-        sessionId,
-        runId,
-        error: "soft timeout exceeded",
-      });
-    }, softTimeoutMs);
-  }
-
-  if (hardTimeoutMs !== undefined) {
-    timers.hard = setTimeout(async () => {
-      try {
-        await WorkerRun.updateStatus(sessionId, runId, "interrupted", { endedAt: Date.now() });
-      } catch {
-        return;
-      }
-      publishEvent(Subagent.Events.WorkerRunFailed, {
-        sessionId,
-        runId,
-        error: "hard timeout exceeded",
-      });
-      abortSession(sessionId, runId);
-    }, hardTimeoutMs);
-  }
-
-  return timers;
-}
-
-function clearRunTimeouts(timers: TimeoutTimers): void {
-  if (timers.soft) clearTimeout(timers.soft);
-  if (timers.hard) clearTimeout(timers.hard);
 }
 
 export namespace SubagentRuntime {

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -213,6 +213,8 @@ export namespace SubagentRuntime {
       const prompt = latestRun?.prompt ?? "resume";
 
       await WorkerRun.create(config.sessionId, { runId, title, prompt });
+      const abortEntry = registerAbortController(config.sessionId, runId);
+      const signal = buildAbortSignal(abortEntry.controller);
       await WorkerRun.updateStatus(config.sessionId, runId, "starting");
 
       publishEvent(Subagent.Events.WorkerSessionResumed, {
@@ -222,7 +224,7 @@ export namespace SubagentRuntime {
 
       await WorkerRun.updateStatus(config.sessionId, runId, "running");
       const result = await executeRun(config.sessionId, runId, config.model, undefined, () =>
-        runWithTranscript(config.sessionId, config),
+        runWithTranscript(config.sessionId, config, signal),
       );
       return { resumed: true, ...result };
     });

--- a/packages/openomni/src/subagent/session-lock.ts
+++ b/packages/openomni/src/subagent/session-lock.ts
@@ -1,0 +1,5 @@
+import { sendToMailbox } from "./session-mailbox.js";
+
+export function withSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+  return sendToMailbox(sessionId, fn);
+}

--- a/packages/openomni/src/subagent/shared.ts
+++ b/packages/openomni/src/subagent/shared.ts
@@ -1,4 +1,5 @@
 import type { Message } from "@openomni/protocol";
+import { Subagent } from "@openomni/protocol";
 import { Bus, type BusEvent, Session } from "@openomni/session";
 
 export type RuntimeModel = { provider: string; id: string };
@@ -61,6 +62,47 @@ export function addTextPart(sessionId: string, messageId: string, text: string):
     text,
   };
   Session.addPart(messageId, part);
+}
+
+export function createSpawnSession(config: {
+  parentSessionId?: string;
+  agentName: string;
+  title: string;
+  model: RuntimeModel;
+}): ReturnType<typeof Session.create> {
+  const workerMeta = Subagent.ChildSessionMeta.parse({
+    kind: "subagent",
+    parentSessionId: config.parentSessionId,
+    agentName: config.agentName,
+    spawnDepth: config.parentSessionId ? undefined : 0,
+    status: "idle",
+  });
+
+  const session = config.parentSessionId
+    ? Session.createChild({
+        parentSessionId: config.parentSessionId,
+        title: config.title,
+        model: toSessionModel(config.model),
+        workerMeta,
+      })
+    : Session.create({
+        title: config.title,
+        model: toSessionModel(config.model),
+      });
+
+  if (!config.parentSessionId) {
+    Session.updateWorkerMeta(session.id, workerMeta);
+  }
+
+  publishEvent(Subagent.Events.WorkerSessionSpawned, {
+    sessionId: session.id,
+    parentSessionId: config.parentSessionId,
+    agentName: config.agentName,
+    spawnDepth: session.spawnDepth,
+    kind: "subagent",
+  });
+
+  return session;
 }
 
 export function publishEvent<TPayload extends { sessionId?: string; runId?: string }>(

--- a/packages/openomni/src/subagent/shared.ts
+++ b/packages/openomni/src/subagent/shared.ts
@@ -1,0 +1,83 @@
+import type { Message } from "@openomni/protocol";
+import { Bus, type BusEvent, Session } from "@openomni/session";
+
+export type RuntimeModel = { provider: string; id: string };
+
+export type RuntimeMessage = { role: "user" | "assistant"; content: string };
+
+export function toSessionModel(model: RuntimeModel): { providerID: string; modelID: string } {
+  return {
+    providerID: model.provider,
+    modelID: model.id,
+  };
+}
+
+export function createUserMessage(
+  sessionId: string,
+  model: RuntimeModel,
+  agent: string = "subagent-runtime",
+): Message.UserMessage {
+  return {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    role: "user",
+    time: { created: Date.now() },
+    agent,
+    model: toSessionModel(model),
+  };
+}
+
+export function createAssistantMessage(
+  sessionId: string,
+  model: RuntimeModel,
+  agent: string = "subagent-runtime",
+): Message.AssistantMessage {
+  return {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "",
+    modelID: model.id,
+    providerID: model.provider,
+    agent,
+    path: { cwd: process.cwd(), root: process.cwd() },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+export function addTextPart(sessionId: string, messageId: string, text: string): void {
+  const part: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID: sessionId,
+    messageID: messageId,
+    type: "text",
+    text,
+  };
+  Session.addPart(messageId, part);
+}
+
+export function publishEvent<TPayload extends { sessionId?: string; runId?: string }>(
+  event: BusEvent.Descriptor<{
+    traceId: string;
+    sessionId?: string;
+    runId?: string;
+    time: number;
+    payload: TPayload;
+  }>,
+  payload: TPayload,
+): void {
+  Bus.publish(event, {
+    traceId: crypto.randomUUID(),
+    sessionId: payload.sessionId,
+    runId: payload.runId,
+    time: Date.now(),
+    payload,
+  });
+}

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -1,0 +1,87 @@
+import { ChatAgent, InMemoryCompactor, type ChatAgentConfig } from "@openomni/agent";
+import type { Guardrail } from "@openomni/protocol";
+import type { RuntimeModel, RuntimeMessage } from "./shared";
+import {
+  buildRuntimeMessages,
+  buildSessionMessagesWithParts,
+  estimateRuntimeTokens,
+} from "./message-builder";
+
+export type RuntimeConfig = {
+  model: RuntimeModel;
+  systemPrompt?: string;
+  tools?: ChatAgentConfig["tools"];
+  toolExecutor?: ChatAgentConfig["toolExecutor"];
+  budget?: ChatAgentConfig["budget"];
+};
+
+export type SendCompactionConfig = {
+  contextWindowTokens: number;
+  thresholdRatio?: number;
+  onSummarize?: (messages: RuntimeMessage[]) => Promise<string>;
+};
+
+export function buildChildMessagesInternal(sessionId: string, repair?: boolean): RuntimeMessage[] {
+  return buildRuntimeMessages(buildSessionMessagesWithParts(sessionId), repair);
+}
+
+export async function maybeCompactSendTranscript(
+  sessionId: string,
+  messages: RuntimeMessage[],
+  compaction?: SendCompactionConfig,
+): Promise<RuntimeMessage[]> {
+  if (!compaction) {
+    return messages;
+  }
+
+  const totalTokens = estimateRuntimeTokens(messages);
+  if (
+    !InMemoryCompactor.shouldCompact(totalTokens, {
+      contextWindowTokens: compaction.contextWindowTokens,
+      thresholdRatio: compaction.thresholdRatio,
+    })
+  ) {
+    return messages;
+  }
+
+  const anchor = messages.find((message) => message.role === "user")?.content;
+  const result = await InMemoryCompactor.compact(buildSessionMessagesWithParts(sessionId), {
+    contextWindowTokens: compaction.contextWindowTokens,
+    thresholdRatio: compaction.thresholdRatio,
+    onSummarize: compaction.onSummarize
+      ? async (messagesToSummarize) =>
+          compaction.onSummarize?.(buildRuntimeMessages(messagesToSummarize)) ?? ""
+      : undefined,
+  });
+
+  if (!result.compacted) {
+    return messages;
+  }
+
+  const compactedMessages = buildRuntimeMessages(result.messages);
+  if (!anchor) {
+    return compactedMessages;
+  }
+
+  return [{ role: "user", content: `Original goal: ${anchor}` }, ...compactedMessages];
+}
+
+export async function runWithTranscript(
+  sessionId: string,
+  config: RuntimeConfig,
+  signal?: AbortSignal,
+  permissions?: Guardrail.ToolPermission,
+  messages = buildChildMessagesInternal(sessionId),
+): Promise<Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>> {
+  const agent = ChatAgent.create({
+    model: config.model,
+    systemPrompt: config.systemPrompt,
+    tools: config.tools,
+    budget: config.budget,
+    toolExecutor: config.toolExecutor,
+    signal,
+    permissions,
+  });
+
+  return agent.run({ messages });
+}


### PR DESCRIPTION
## Summary

- Split `subagent/runtime.ts` from 1094 → 359 LOC into 5 focused internal modules (`shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-lock.ts`)
- Fixed cross-package boundary leak: replaced relative `../../../agent/` dynamic import with clean `@openomni/agent` barrel import
- Removed dead code: `InMemoryTaskStore` class, unused `PlanAgent` import, `InMemoryPlanStore` from public barrel
- Deduplicated `consultation.ts` by importing from shared helpers
- Replaced wildcard barrel exports with explicit named exports
- Added 76 new tests for execution-runtime (executor, providers, shared utils, workspace-path security)

## Changes

### Dead Code Removal
- `InMemoryTaskStore` removed, `TaskStorage.configure()` now mandatory (fail-fast)
- `InMemoryCompactor` exported from `@openomni/agent` barrel
- `InMemoryPlanStore` removed from public barrel (kept in domain barrel for internal use)
- Dead `PlanAgent` import removed from ingress handlers

### Module Extraction
- `shared.ts`: types + message factories with parameterized `agent` field
- `session-lock.ts`: session locking wrapper
- `message-builder.ts`: 8 message construction/serialization functions
- `run-lifecycle.ts`: abort/timeout/finalize (10 functions + 1 type)
- `transcript.ts`: compaction bridge + `runWithTranscript` — **fixes boundary leak**

### Integration
- `runtime.ts` slimmed to orchestration shell (359 LOC)
- `consultation.ts` deduplicated via shared helpers
- `subagent/index.ts`: wildcard → explicit named exports
- `WorkspaceLock` added to main barrel

### Tests + Docs
- 6 new test files for execution-runtime
- AGENTS.md updated for subagent/, execution-runtime/, storage/ domains

## Verification

| Metric | Result |
|--------|--------|
| `bun test` | 544 pass / 0 fail |
| `bun run check-types` | 0 errors (11/11 packages) |
| `runtime.ts` LOC | 359 (target ≤450) |
| Cross-package imports | 0 |
| Wildcard exports | 0 |
| Circular dependencies | None |

## Scope

Only `packages/openomni/` and one line in `packages/agent/src/index.ts`.
Untouched: `packages/protocol/`, `packages/session/`, `packages/llm/`, `apps/server/`, `src/plan/`, `src/dag/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the subagent runtime into focused internal modules and tightened package boundaries to reduce complexity and stop cross-package import leaks. Storage setup is now explicit, and new tests and fixes improve tool safety and cancellation.

- **Refactors**
  - Broke `subagent/runtime.ts` into `shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, and `session-lock.ts`; `runtime.ts` is now an orchestration shell.
  - Replaced deep relative import with the `@openomni/agent` barrel (`InMemoryCompactor`); fixes the cross-package boundary leak.
  - Removed dead code: `InMemoryTaskStore`, unused `PlanAgent` import; dropped `InMemoryPlanStore` from the public barrel.
  - Deduplicated `subagent/consultation.ts` via shared helpers; switched subagent barrel to explicit named exports; added `WorkspaceLock` to the main barrel.
  - Added tests for tool executor, providers, shared utils, and workspace path security; updated AGENTS docs.
  - Fix: `resume()` now registers an abort controller so `cancel()` works mid-run.
  - Fix: tool message builder records and serializes `isError` tool results correctly.

- **Migration**
  - Call `TaskStorage.configure(adapter)` at startup; there is no default adapter.
  - Update imports to use named exports from `subagent/` (no wildcard).
  - `InMemoryPlanStore` is no longer exported from the public barrel.
  - Use `InMemoryCompactor` from the `@openomni/agent` barrel if needed.

<sup>Written for commit b223802b18a08a5cf41cc2ff3e643fa56db1f55c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

