### PR TITLE
refactor(session): remove as-any, non-null assertion, and stale comment

### DIFF
--- a/packages/session/src/bus/index.ts
+++ b/packages/session/src/bus/index.ts
@@ -17,7 +17,6 @@ export namespace Bus {
     const subs = subscribers.get(event.name);
     if (!subs) return;
 
-    // snapshot to avoid mutation during iteration
     const snapshot = [...subs];
 
     for (const sub of snapshot) {
@@ -47,8 +46,9 @@ export namespace Bus {
       match: options?.match as Record<string, unknown> | undefined,
     };
     subs.add(subscription);
+    const captured = subs;
     return () => {
-      subs!.delete(subscription);
+      captured.delete(subscription);
     };
   }
 

--- a/packages/session/test/event-log/malformed-row-warn.test.ts
+++ b/packages/session/test/event-log/malformed-row-warn.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import type { ExecutionEvent } from "@openomni/protocol";
 import { Log } from "../../src/log/index";
 import { Storage } from "../../src/storage/storage";
@@ -60,7 +61,9 @@ describe("EventLog.replay warns on malformed rows", () => {
     Storage.reset();
     try {
       adapter.close();
-    } catch {}
+    } catch {
+      /* already closed */
+    }
     unlinkSync(dbPath);
   });
 
@@ -68,10 +71,11 @@ describe("EventLog.replay warns on malformed rows", () => {
     ensureSession(adapter, "sess-1");
     await EventLog.append("sess-1", makeEvent("llm_response", 1));
 
-    const db = (adapter as any).db;
-    db.query(
-      "INSERT INTO event_log (session_id, type, data, time_created) VALUES (?, ?, ?, ?)",
-    ).run("sess-1", "llm_response", "{ invalid json", Date.now());
+    const rawDb = new Database(dbPath);
+    rawDb
+      .query("INSERT INTO event_log (session_id, type, data, time_created) VALUES (?, ?, ?, ?)")
+      .run("sess-1", "llm_response", "{ invalid json", Date.now());
+    rawDb.close();
 
     await EventLog.append("sess-1", makeEvent("session_suspended", 3));
 
@@ -98,13 +102,14 @@ describe("EventLog.replay warns on malformed rows", () => {
     ensureSession(adapter, "sess-3");
     await EventLog.append("sess-3", makeEvent("llm_response", 1));
 
-    const db = (adapter as any).db;
-    db.query(
-      "INSERT INTO event_log (session_id, type, data, time_created) VALUES (?, ?, ?, ?)",
-    ).run("sess-3", "llm_response", "{ bad json 1", Date.now());
-    db.query(
-      "INSERT INTO event_log (session_id, type, data, time_created) VALUES (?, ?, ?, ?)",
-    ).run("sess-3", "llm_response", "{ bad json 2", Date.now());
+    const rawDb = new Database(dbPath);
+    rawDb
+      .query("INSERT INTO event_log (session_id, type, data, time_created) VALUES (?, ?, ?, ?)")
+      .run("sess-3", "llm_response", "{ bad json 1", Date.now());
+    rawDb
+      .query("INSERT INTO event_log (session_id, type, data, time_created) VALUES (?, ?, ?, ?)")
+      .run("sess-3", "llm_response", "{ bad json 2", Date.now());
+    rawDb.close();
 
     await EventLog.append("sess-3", makeEvent("session_suspended", 4));
 


### PR DESCRIPTION
## Summary

Remove `as any`, non-null assertion, empty catch, and stale comment from plan-1 deliverables found during post-implementation review.

## Changes

- `subs!.delete(subscription)` → `captured.delete(subscription)` — eliminate non-null assertion via const capture (resolves Biome warning)
- `(adapter as any).db` → `new Database(dbPath)` — use separate SQLite handle for raw insert, removing `as any`
- Remove self-evident `// snapshot to avoid mutation during iteration` comment
- `catch {}` → `catch { /* already closed */ }` — clarify intent of empty catch block

## Type

- [x] `refactor` - Code restructuring (no behavior change)

## Affected Packages

- [x] `session`

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean (no new violations)
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md / docs updated if public API or architecture changed
- [ ] Relevant ADR added if this introduces a new design decision