### PR TITLE
docs: define persona workforce direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 OpenOmni — personal AI workforce infrastructure. The user primarily talks to one Main Persona, which manages specialized Sub Personas through controlled delegation, isolated sessions, and auditable lineage. The first user-facing domain persona is SNS / viral marketing; coding remains a first-class internal capability for automation and self-improvement. TypeScript monorepo (Bun + Turborepo) with 6 packages and 2 apps (CLI + Server).
 
-Product direction lives in `docs/persona-workforce.md`; the accepted architecture decision is [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md).
+Product direction lives in `docs/persona-workforce.md`; the staged implementation path is `docs/persona-runtime-roadmap.md`; the accepted architecture decision is [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md).
 
 ## STRUCTURE
 
@@ -80,6 +80,7 @@ Each layer depends only on layers to its left. `protocol` is the leaf (zero inte
 | Server channels | `apps/server/src/channel/` | Discord, Telegram, GitHub, WebSocket |
 | Server ingress bridge | `apps/server/src/ingress/` | `buildInboundEvent()`, `detectMode()` |
 | Persona workforce direction | `docs/persona-workforce.md` + `docs/design-decisions/005-persona-workforce-runtime.md` | Main Persona, Sub Personas, self-loop sessions, controlled inbound authority |
+| Persona runtime roadmap | `docs/persona-runtime-roadmap.md` | Target contracts and staged implementation plan |
 
 ## CONVENTIONS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## OVERVIEW
 
-OpenOmni — personal AI workforce infrastructure. The user primarily talks to one Main Persona, which manages specialized Sub Personas through controlled delegation, isolated sessions, and auditable lineage. TypeScript monorepo (Bun + Turborepo) with 6 packages and 2 apps (CLI + Server).
+OpenOmni — personal AI workforce infrastructure. The user primarily talks to one Main Persona, which manages specialized Sub Personas through controlled delegation, isolated sessions, and auditable lineage. The first user-facing domain persona is SNS / viral marketing; coding remains a first-class internal capability for automation and self-improvement. TypeScript monorepo (Bun + Turborepo) with 6 packages and 2 apps (CLI + Server).
 
 Product direction lives in `docs/persona-workforce.md`; the accepted architecture decision is [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md).
 
@@ -97,6 +97,16 @@ Ingress supports two execution modes today:
 | `plan` | `/plan` prefix | `handlePlan` → `CoordinatorLike.dispatch()` → `runPlan()` → `PlanAgent.create()` | `{ planId }` reference (plan stored in `Storage.PlanSubAdapter`) |
 
 Target direction: the user and Main Persona may submit new inbound work; ordinary Sub Personas cannot create new top-level inbound work unless explicitly granted manager authority.
+
+## PERSONA WORKFORCE MODEL
+
+| Concept | Meaning | Current hooks |
+| --- | --- | --- |
+| Main Persona | Default user-facing assistant and workforce manager | Ingress target agent + future persona policy |
+| Sub Persona | Specialized worker identity for a domain or role | `AgentRegistry`, `SubagentRuntime` |
+| Self-loop session | Isolated internal work session for complex reasoning | `Session.createChild()`, `WorkerRun` |
+| Controlled inbound | Only user/Main/trusted managers create top-level work | Future `IngressEngine` authority policy |
+| Persona promotion | Temporary worker becomes persistent after repeated value | Future persona lifecycle schema |
 
 ## ANTI-PATTERNS (THIS PROJECT)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,9 @@
 
 ## OVERVIEW
 
-OpenOmni — orchestration framework for LLM-powered autonomous agents. TypeScript monorepo (Bun + Turborepo) with 6 packages and 2 apps (CLI + Server).
+OpenOmni — personal AI workforce infrastructure. The user primarily talks to one Main Persona, which manages specialized Sub Personas through controlled delegation, isolated sessions, and auditable lineage. TypeScript monorepo (Bun + Turborepo) with 6 packages and 2 apps (CLI + Server).
+
+Product direction lives in `docs/persona-workforce.md`; the accepted architecture decision is [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md).
 
 ## STRUCTURE
 
@@ -77,6 +79,7 @@ Each layer depends only on layers to its left. `protocol` is the leaf (zero inte
 | Server tool providers | `apps/server/src/tool/` | 3 categories: `system/`, `agent/`, `mcp/` |
 | Server channels | `apps/server/src/channel/` | Discord, Telegram, GitHub, WebSocket |
 | Server ingress bridge | `apps/server/src/ingress/` | `buildInboundEvent()`, `detectMode()` |
+| Persona workforce direction | `docs/persona-workforce.md` + `docs/design-decisions/005-persona-workforce-runtime.md` | Main Persona, Sub Personas, self-loop sessions, controlled inbound authority |
 
 ## CONVENTIONS
 
@@ -86,12 +89,14 @@ Key patterns: Namespace exports (`Session.create()`), Zod-first types (`z.object
 
 ## MODES
 
-Ingress supports two execution modes:
+Ingress supports two execution modes today:
 
 | Mode | Trigger | Handler | Output |
 | --- | --- | --- | --- |
-| `direct` | Default (no prefix) | `handleDirect` → `ChatAgent.run()` | LLM response text |
-| `plan` | `/plan` prefix | `handlePlan` → `runPlan()` → `PlanAgent.create()` | `{ planId }` reference (plan stored in `Storage.PlanSubAdapter`) |
+| `direct` | Default (no prefix) | `handleDirect` → `CoordinatorLike.dispatch()` → worker execution | LLM response text |
+| `plan` | `/plan` prefix | `handlePlan` → `CoordinatorLike.dispatch()` → `runPlan()` → `PlanAgent.create()` | `{ planId }` reference (plan stored in `Storage.PlanSubAdapter`) |
+
+Target direction: the user and Main Persona may submit new inbound work; ordinary Sub Personas cannot create new top-level inbound work unless explicitly granted manager authority.
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
@@ -128,13 +133,13 @@ bun run --cwd apps/server dev        # Hono server with channels (set env tokens
 
 ## NOTES
 
-- README.md describes project architecture, dependency graph, and getting started.
+- README.md describes product direction, project architecture, dependency graph, and getting started.
 - `packages/protocol` publishes built `dist/` artifacts (`main: ./dist/index.js`). Other packages point `main` at source (`./src/index.ts`) for Bun's native TS support.
 - Lint + format via Biome (`biome.json`). No ESLint.
 - CI pipeline: `.github/workflows/ci.yml` — build, check-types, tests for all packages.
 - `dist/` dirs are gitignored but some exist locally — they are build artifacts, not source.
 - `@ai-sdk/anthropic` and `@ai-sdk/openai` are the two bundled providers. New providers via `@ai-sdk/openai-compatible` fallback.
-- `packages/agent` is organized as `src/core/` (ChatAgent + middleware) and `src/runtime/` (messenger, registry, tools, mcp). It has **no session dependency** — `BusTransport` lives in `packages/openomni`. The middleware engine is the current extension point; legacy hook-based config is routed through `middleware/compat.ts`.
+- `packages/agent` is organized as `src/core/` (ChatAgent + middleware) and `src/runtime/` (messenger, registry, tools, mcp). It has no durable session state ownership; session-backed orchestration lives in `packages/openomni`. The middleware engine is the current extension point; legacy hook-based config is routed through `middleware/compat.ts`.
 - `packages/openomni` orchestrates plans, ingress, and subagent runtime. It also owns `BusTransport` (session bus bridge) and the execution runtime (tool providers, worker middleware). `SubagentRuntime` is session-locked; `BackgroundManager` wraps it for fire-and-forget execution with concurrency / depth limits.
 - `packages/coordinator` owns multiprocess execution: worker pool lifecycle, IPC transport (Unix socket), recovery of interrupted runs, credentials injection, and tool-permission policy. It depends on all lower packages. See `packages/coordinator/AGENTS.md` for its module map.
 - **Plan Mode** (`PlanAgent`) is implemented in `packages/openomni/src/plan/`. It generates a structured `Plan` via LLM and validates via gates.

--- a/README.md
+++ b/README.md
@@ -4,70 +4,133 @@
 
 > ⚠️ This project is under active development.
 
-## Why
+OpenOmni is a runtime for managing AI personas as a personal workforce. The user talks primarily to one Main Persona. That Main Persona understands the user's goals, decides what should be handled directly, delegates specialized work to Sub Personas, and keeps the original user-facing session clean by isolating complex internal work in separate sessions.
 
-Working with AI agents today means operating tools instead of managing help. You choose the right agent, decide when to delegate, watch separate sessions, and manually carry context between them. Every session starts from scratch. Agents forget past decisions, repeat mistakes, and rediscover conventions you taught them yesterday.
+## Product Model
 
-When you want specialized help in a new domain — SNS operations instead of coding, research instead of writing, analysis instead of automation — you rebuild the same infrastructure again: identity, memory, tools, sessions, permissions, and review loops.
-
-OpenOmni exists to end this cycle. You talk to one Main Persona, and that persona manages a workforce of specialized Sub Personas: hiring, summoning, evaluating, promoting, pausing, or retiring them as work evolves.
-
-## What
-
-OpenOmni is a personal workforce layer, not a chatbot framework.
-
-- **One Main Persona.** The user has one default assistant identity that understands the relationship, goals, preferences, and workforce.
-- **Managed Sub Personas.** Specialized personas do SNS operations, coding, research, review, and future domain work under controlled authority.
-- **Isolated work sessions.** Complex work can fork into self-loop and child persona sessions so the original user session stays clean.
-- **Memory-ready by design.** OpenOmni records lineage and provenance so [Anamnesis](https://github.com/inonono66/anamnesis) can later turn verified experience into long-term associative memory.
-- **First domain: SNS operations.** The first user-facing specialist is the SNS / Viral Marketing Persona; coding remains a first-class internal capability for automation and self-improvement.
-
-## Design Principles
-
-- **Environment over agent.** When an agent fails, the harness is broken — not the prompt. Fix the system that surrounds the agent.
-- **Human intervention is a system gap.** Every time you step in, that's a defect signal. The system should learn from it and close the gap.
-- **Constraints enable speed.** Strict architectural rules don't slow agents down — they eliminate drift. More structure means faster autonomous work.
-- **Progressive disclosure.** Don't dump everything into context. Give agents a map. They find detail when they need it.
-- **Authority is hierarchical.** The user and Main Persona can create new inbound work; ordinary Sub Personas cannot recursively spawn top-level work unless explicitly trusted.
-
-## Architecture
-
-TypeScript monorepo powered by [Bun](https://bun.sh) and [Turborepo](https://turborepo.dev).
-
+```txt
+User
+  ↕
+Main Persona
+  ├─ SNS / Viral Marketing Persona
+  ├─ Coding Persona
+  ├─ Research Persona
+  ├─ Reviewer Persona
+  └─ Future domain personas
 ```
+
+The Main Persona is the relationship owner and workforce manager. Sub Personas are specialized workers. The user may target a specific persona directly, but ordinary Sub Personas cannot recursively create new top-level inbound work unless they are explicitly trusted as manager personas.
+
+The first user-facing domain is SNS and viral marketing. Coding remains a first-class internal capability because the system must build automations, improve tooling, and maintain itself.
+
+## Core Runtime Ideas
+
+### Main Persona as the default interface
+
+The user should not need to pick the right worker for every request. The Main Persona receives the request, decides whether it is simple or complex, chooses the right execution layer, and reports back with the distilled result.
+
+### Controlled inbound authority
+
+OpenOmni treats inbound work as an authority boundary.
+
+```txt
+External inbound
+  User / surface / API → IngressEngine → target persona
+
+Internal inbound
+  Main Persona → inbound.submit → IngressEngine → new work item
+```
+
+The user and Main Persona can create new inbound work. Normal Sub Personas return results and suggestions, but they cannot create new top-level work by default. This prevents unmanaged recursive task growth.
+
+### Three-layer execution
+
+| Layer | Name | Used when | Session behavior |
+| --- | --- | --- | --- |
+| 1 | Direct | The Main Persona can answer or act directly | Original session only |
+| 2 | Delegate | A specialized Sub Persona should handle the task | Child persona session |
+| 3 | Fork | The task needs deeper reasoning, planning, or multi-persona coordination | Isolated self-loop session |
+
+Layer 3 is not just a background job. It is a separate internal work session where the request can be restated, refined, debated, delegated, reviewed, and then written back as a clean result.
+
+### Session hygiene
+
+The original user session is the relationship and decision record. Internal thinking, failed attempts, worker transcripts, and experiments belong in child or self-loop sessions. This keeps the Main Persona's user-facing context readable and auditable.
+
+### Persona lifecycle
+
+Sub Personas can start as temporary workers. If a worker is repeatedly useful, its role can become a persistent persona.
+
+```txt
+ephemeral worker
+  → repeated useful work
+  → persona candidate
+  → evaluation
+  → approval or policy acceptance
+  → persistent persona
+```
+
+This lets OpenOmni grow a useful workforce without making every generated worker permanent.
+
+### Memory-ready design
+
+OpenOmni is designed to be integrated with [Anamnesis](https://github.com/inonono66/anamnesis), an associative cognitive graph engine. OpenOmni should provide session lineage, provenance, worker records, and memory candidates. Anamnesis can later decide how verified experience becomes long-term memory.
+
+Raw chat history is not treated as behavioral memory by default. Durable memory should be scoped, attributed, and reviewable.
+
+## System Architecture
+
+OpenOmni is a TypeScript monorepo powered by [Bun](https://bun.sh) and [Turborepo](https://turborepo.dev).
+
+```txt
 openomni/
 ├── apps/
 │   ├── cli/             # CLI entry point (auth + config)
 │   └── server/          # Hono server with Discord / Telegram / GitHub / WebSocket channels
 ├── packages/
-│   ├── protocol/        # Shared Zod schemas (20 domains — message, tool, run, event, plan, subagent, hook, …)
-│   ├── session/         # Session CRUD, pub/sub bus, storage adapters, event log, worker runs
-│   ├── llm/             # LLM abstraction (providers, auth, streaming, retry, token tracking)
-│   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + multi-agent runtime (messenger, MCP, subagent tools) — no session state ownership
-│   ├── openomni/        # Orchestration (Plan mode, DAG, Ingress, SubagentRuntime, BackgroundManager, BusTransport, execution runtime)
-│   └── coordinator/     # Multiprocess execution coordinator (worker pool, IPC, recovery, credentials, tool-permission)
+│   ├── protocol/        # Shared Zod schemas and cross-package contracts
+│   ├── session/         # Sessions, messages, storage, bus, event log, worker runs
+│   ├── llm/             # Model providers, auth, streaming, retry, token/cost tracking
+│   ├── agent/           # Stateless ChatAgent primitive, middleware, messenger, registry, tools, MCP
+│   ├── openomni/        # Ingress, plan mode, DAG, subagent runtime, background manager, execution runtime
+│   └── coordinator/     # Worker pool, IPC, recovery, credentials, tool-permission policy
 ```
 
-### Dependency Graph
+### Dependency graph
 
-```
+```txt
 protocol ← session ← llm ← agent ← openomni ← coordinator ← { cli, server }
 ```
 
-Each package depends only on packages to its left. `protocol` is the leaf with zero internal dependencies. `agent` owns execution behavior, not durable session state; sanctioned observability primitives may come from `session`. `cli` and `server` are sibling apps.
+Each package depends only on packages to its left. `protocol` is the leaf with zero internal dependencies. `agent` owns execution behavior, not durable session state; sanctioned observability primitives may come from `session`. Session-backed orchestration belongs in `openomni`.
 
-### Product Direction
+### Runtime path
 
-See [Persona Workforce Direction](docs/persona-workforce.md) and [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md) for the Main Persona, Sub Persona, controlled inbound authority, self-loop session, and first-domain strategy.
+```txt
+Surface event
+  → IngressEngine
+  → SurfaceKey / Session resolution
+  → message projection
+  → CoordinatorLike.dispatch
+  → worker execution runtime
+  → ChatAgent / PlanAgent / SubagentRuntime
+  → result integration
+```
 
-### Execution Modes
+Ingress currently supports two execution modes:
 
-Ingress supports two modes:
+- **`direct`** — dispatches a persona run against session history and returns the response.
+- **`plan`** — runs `PlanAgent.create()` with plan tools and stores a `{ planId }` reference in `Storage.PlanSubAdapter`.
 
-- **`direct`** — default. Dispatches the request through the coordinator seam to run a persona against session history and return the response.
-- **`plan`** — triggered by a `/plan` prefix. Runs `PlanAgent.create()` with plan tools to produce a plan stored in `Storage.PlanSubAdapter`.
+## Documentation Map
 
-## Getting Started
+- [Persona Workforce Direction](docs/persona-workforce.md) — product model, runtime concepts, persona lifecycle, and gaps.
+- [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md) — accepted decision for the persona workforce runtime direction.
+- [Golden Principles](docs/golden-principles.md) — package boundaries, dependency direction, and coding invariants.
+- [Observability Doctrine](docs/observability-doctrine.md) — Log, Bus, Telemetry, trace context, and sensitive data policy.
+- [Quality Score](docs/quality-score.md) — package quality status and known technical debt.
+
+## Development
 
 ```bash
 # Install dependencies
@@ -81,6 +144,9 @@ bun test
 
 # Type check
 bun run check-types
+
+# Check package boundaries and golden principles
+bun run script/check-deps.ts
 
 # Format
 bun run format

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # OpenOmni
 
-**Orchestration layer for autonomous multi-agent work.**
+**Personal AI workforce infrastructure.**
 
 > ⚠️ This project is under active development.
 
 ## Why
 
-Working with AI agents today means sitting at a terminal — run a task, wait, intervene, re-run, wait again. Every session starts from scratch. Agents forget past decisions, repeat mistakes, rediscover conventions you taught them yesterday.
+Working with AI agents today means operating tools instead of managing help. You choose the right agent, decide when to delegate, watch separate sessions, and manually carry context between them. Every session starts from scratch. Agents forget past decisions, repeat mistakes, and rediscover conventions you taught them yesterday.
 
-When you want the same agent patterns applied to a different domain — research instead of coding, analysis instead of writing — you rebuild everything. Even though 90% of the infrastructure is identical.
+When you want specialized help in a new domain — SNS operations instead of coding, research instead of writing, analysis instead of automation — you rebuild the same infrastructure again: identity, memory, tools, sessions, permissions, and review loops.
 
-OpenOmni exists to end this cycle. One infrastructure layer that handles orchestration, memory, and tool management for any domain. Send a task from anywhere. Get results back. The system handles the rest.
+OpenOmni exists to end this cycle. You talk to one Main Persona, and that persona manages a workforce of specialized Sub Personas: hiring, summoning, evaluating, promoting, pausing, or retiring them as work evolves.
 
 ## What
 
-OpenOmni is an orchestration layer, not a chatbot framework.
+OpenOmni is a personal workforce layer, not a chatbot framework.
 
-- **One layer, all domains.** Coding, research, analysis — same infrastructure. Only the agent prompt changes.
-- **Self-orchestrating.** Give it one goal. It decomposes the work, delegates to specialized agents, executes in parallel, and delivers results.
-- **Self-improving.** Agents accumulate knowledge across sessions through [Anamnesis](https://github.com/inonono66/anamnesis), an associative cognitive graph engine. Mistakes don't repeat. Conventions persist. Decisions carry their reasoning.
+- **One Main Persona.** The user has one default assistant identity that understands the relationship, goals, preferences, and workforce.
+- **Managed Sub Personas.** Specialized personas do SNS operations, coding, research, review, and future domain work under controlled authority.
+- **Isolated work sessions.** Complex work can fork into self-loop and child persona sessions so the original user session stays clean.
+- **Memory-ready by design.** OpenOmni records lineage and provenance so [Anamnesis](https://github.com/inonono66/anamnesis) can later turn verified experience into long-term associative memory.
+- **First domain: SNS operations.** The first user-facing specialist is the SNS / Viral Marketing Persona; coding remains a first-class internal capability for automation and self-improvement.
 
 ## Design Principles
 
@@ -26,6 +28,7 @@ OpenOmni is an orchestration layer, not a chatbot framework.
 - **Human intervention is a system gap.** Every time you step in, that's a defect signal. The system should learn from it and close the gap.
 - **Constraints enable speed.** Strict architectural rules don't slow agents down — they eliminate drift. More structure means faster autonomous work.
 - **Progressive disclosure.** Don't dump everything into context. Give agents a map. They find detail when they need it.
+- **Authority is hierarchical.** The user and Main Persona can create new inbound work; ordinary Sub Personas cannot recursively spawn top-level work unless explicitly trusted.
 
 ## Architecture
 
@@ -40,7 +43,7 @@ openomni/
 │   ├── protocol/        # Shared Zod schemas (20 domains — message, tool, run, event, plan, subagent, hook, …)
 │   ├── session/         # Session CRUD, pub/sub bus, storage adapters, event log, worker runs
 │   ├── llm/             # LLM abstraction (providers, auth, streaming, retry, token tracking)
-│   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + multi-agent runtime (messenger, MCP, subagent tools) — no session dependency
+│   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + multi-agent runtime (messenger, MCP, subagent tools) — no session state ownership
 │   ├── openomni/        # Orchestration (Plan mode, DAG, Ingress, SubagentRuntime, BackgroundManager, BusTransport, execution runtime)
 │   └── coordinator/     # Multiprocess execution coordinator (worker pool, IPC, recovery, credentials, tool-permission)
 ```
@@ -51,13 +54,17 @@ openomni/
 protocol ← session ← llm ← agent ← openomni ← coordinator ← { cli, server }
 ```
 
-Each package depends only on packages to its left. `protocol` is the leaf with zero internal dependencies. `cli` and `server` are sibling apps.
+Each package depends only on packages to its left. `protocol` is the leaf with zero internal dependencies. `agent` owns execution behavior, not durable session state; sanctioned observability primitives may come from `session`. `cli` and `server` are sibling apps.
+
+### Product Direction
+
+See [Persona Workforce Direction](docs/persona-workforce.md) and [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md) for the Main Persona, Sub Persona, controlled inbound authority, self-loop session, and first-domain strategy.
 
 ### Execution Modes
 
 Ingress supports two modes:
 
-- **`direct`** — default. Runs `ChatAgent` against session history and returns the response.
+- **`direct`** — default. Dispatches the request through the coordinator seam to run a persona against session history and return the response.
 - **`plan`** — triggered by a `/plan` prefix. Runs `PlanAgent.create()` with plan tools to produce a plan stored in `Storage.PlanSubAdapter`.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Ingress currently supports two execution modes:
 ## Documentation Map
 
 - [Persona Workforce Direction](docs/persona-workforce.md) — product model, runtime concepts, persona lifecycle, and gaps.
+- [Persona Runtime Roadmap](docs/persona-runtime-roadmap.md) — staged implementation path for authority, self-loop sessions, persona lifecycle, SNS, and memory readiness.
 - [ADR-005](docs/design-decisions/005-persona-workforce-runtime.md) — accepted decision for the persona workforce runtime direction.
 - [Golden Principles](docs/golden-principles.md) — package boundaries, dependency direction, and coding invariants.
 - [Observability Doctrine](docs/observability-doctrine.md) — Log, Bus, Telemetry, trace context, and sensitive data policy.

--- a/docs/design-decisions/003-layered-package-architecture.md
+++ b/docs/design-decisions/003-layered-package-architecture.md
@@ -17,7 +17,7 @@ protocol → session → llm → agent → openomni → coordinator → { cli, s
 - `protocol`: zero `@openomni/*` deps (leaf)
 - `session`: only `protocol`
 - `llm`: `protocol`, `session`
-- `agent`: `protocol`, `llm` — **no session dependency** (enforced; `BusTransport` lives in `openomni`)
+- `agent`: `protocol`, `llm`, and sanctioned `session` observability primitives — **no session state ownership** (session-backed orchestration and `BusTransport` live in `openomni`)
 - `openomni`: `protocol`, `session`, `llm`, `agent`
 - `coordinator`: all packages above — owns worker pool, IPC, recovery, credentials, tool-permission
 - `cli`, `server`: any `@openomni/*`; they do not depend on each other
@@ -30,7 +30,7 @@ Reverse dependencies (e.g., `protocol` importing from `session`) are build failu
 
 - **Prevents circular deps**: Linear chain makes cycles structurally impossible.
 - **Independent testability**: Lower packages (`protocol`, `session`) can be tested without upper packages.
-- **Clear ownership**: Each layer has a defined responsibility boundary.
+- **Clear ownership**: Each layer has a defined responsibility boundary. `agent` may emit observability but must not own durable session state.
 - **Enforceable**: `script/check-deps.ts` validates both dependency direction and package boundary violations in CI.
 
 ## Consequences

--- a/docs/design-decisions/004-stateless-chat-agent.md
+++ b/docs/design-decisions/004-stateless-chat-agent.md
@@ -10,7 +10,7 @@ Originally, `packages/agent` contained both the LLM ReAct loop and all orchestra
 
 Split responsibilities across two packages:
 
-- **`packages/agent`** — Stateless `ChatAgent` primitive plus the multi-agent runtime (messenger, registry, subagent / background tool specs, MCP client). No session dependency — sinks and transports are injected by callers.
+- **`packages/agent`** — Stateless `ChatAgent` primitive plus the multi-agent runtime (messenger, registry, subagent / background tool specs, MCP client). It does not own session lifecycle or durable conversation state; sinks and transports are injected by callers. It may use sanctioned session observability primitives.
 - **`packages/openomni`** — Orchestration: `IngressEngine`, `PlanAgent`, `runPlan`, DAG utilities, `TaskStorage`, and the session-backed subagent layer (`SubagentRuntime`, `BackgroundManager`, `SubagentConsultation`).
 
 `ChatAgent` remains a function-style primitive: take messages + tools, run the ReAct loop, return results. State (budget, memory, delegation depth) lives on a per-call context. Extension happens via the middleware engine in `packages/agent/src/core/middleware/`.
@@ -20,7 +20,7 @@ Split responsibilities across two packages:
 - **Single responsibility**: `ChatAgent` only runs an LLM tool-use loop. Orchestration is a separate concern.
 - **Reusability**: `ChatAgent` can be used standalone or composed by `SubagentRuntime`, `PlanAgent`, and `IngressEngine` without pulling in orchestration dependencies.
 - **Testability**: `ChatAgent` tests don't require session mocking, storage setup, or event bus wiring.
-- **Dependency hygiene**: `agent` depends on `protocol` + `llm` only. Code that needs `session` lives in `openomni`.
+- **Dependency hygiene**: `agent` depends on execution contracts and model access, while session-backed orchestration lives in `openomni`. Any `agent` use of `session` must be limited to observability primitives, not state ownership.
 
 ## Consequences
 

--- a/docs/design-decisions/005-persona-workforce-runtime.md
+++ b/docs/design-decisions/005-persona-workforce-runtime.md
@@ -1,0 +1,47 @@
+# ADR-005: Persona Workforce Runtime Direction
+
+**Status**: Accepted
+
+## Context
+
+OpenOmni previously described itself as an orchestration layer for autonomous multi-agent work. That framing is still technically useful, but it under-specifies the product relationship model.
+
+The intended product is a personal assistant that manages a workforce of specialized AI personas. The user should not need to choose the right agent for every task. The user should be able to talk to one Main Persona, and that Main Persona should decide whether to respond directly, delegate to a Sub Persona, or create an isolated session for deeper work.
+
+At the same time, the system must avoid unmanaged recursive work creation. If every Sub Persona can submit new inbound work, the runtime becomes a swarm with unclear authority, unclear cost control, and polluted session history.
+
+## Decision
+
+OpenOmni will use a persona workforce model:
+
+- The **Main Persona** is the default user-facing identity and workforce manager.
+- **Sub Personas** are specialized worker identities that perform delegated domain work.
+- The **user** may target any persona directly.
+- The **Main Persona** may submit internal inbound work to create new work items, scheduled work, or isolated sessions.
+- Normal **Sub Personas** may not submit new top-level inbound work unless explicitly granted manager authority.
+- Complex work uses isolated self-loop sessions so the original user session remains a clean relationship and decision record.
+
+The first domain persona is the SNS / Viral Marketing Persona. Coding remains a first-class internal capability for building automations and improving OpenOmni itself, but it is not the first user-facing domain.
+
+## Rationale
+
+- **Clear user relationship**: The user has one default assistant identity instead of needing to operate many agents directly.
+- **Controlled autonomy**: Internal inbound authority belongs to the user, the Main Persona, and trusted manager personas only.
+- **Session hygiene**: Original sessions store user-facing decisions and distilled results; internal reasoning and failed attempts live in child/self-loop sessions.
+- **Auditable delegation**: Persona lineage, worker runs, and event records can explain who did what and why.
+- **Natural growth model**: Temporary workers can become persistent personas after repeated useful work, instead of every generated agent becoming permanent by default.
+
+## Consequences
+
+- Protocol will eventually need persona lifecycle and inbound authority contracts.
+- Session metadata will need to distinguish original, self-loop, and child persona sessions.
+- Ingress should support internal submissions from authorized manager personas while rejecting recursive submissions from ordinary workers.
+- Result integration should distinguish raw worker transcripts from distilled writeback to the original session.
+- Anamnesis integration should use session lineage and provenance rather than treating raw chat history as behavioral memory.
+
+## Non-goals
+
+- This decision does not require immediate implementation of Anamnesis.
+- This decision does not make every Sub Persona persistent.
+- This decision does not allow personas to rewrite core orchestration, safety, or permission logic.
+- This decision does not make SNS automation fully autonomous; publishing and outbound engagement may still require approval gates.

--- a/docs/design-decisions/index.md
+++ b/docs/design-decisions/index.md
@@ -14,6 +14,7 @@ Each ADR follows: Context → Decision → Rationale → Consequences.
 | [002](./002-zod-first-types.md)              | Zod-first type definitions                       | Accepted   |
 | [003](./003-layered-package-architecture.md) | Strict layered package dependency direction      | Accepted   |
 | [004](./004-stateless-chat-agent.md)         | Stateless ChatAgent separated from orchestration | Accepted   |
+| [005](./005-persona-workforce-runtime.md)    | Persona workforce runtime direction              | Accepted   |
 | [009](./009-persistent-subagent-team-orchestration-draft.md) | Persistent subagent sessions (partial ship) | Superseded |
 
 ## Adding a New ADR

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -20,17 +20,20 @@
 ## 2. Dependency Direction
 
 ```
-protocol → session → llm → agent → openomni → cli
+protocol → session → llm → agent → openomni → coordinator → { cli, server }
 ```
 
-Each package may depend only on packages to its LEFT. Reverse dependencies are build failures.
+Each package may depend only on packages to its LEFT. Packages may skip intermediate layers when a lower-layer contract is explicitly allowed. Reverse dependencies are build failures.
 
 - `protocol`: zero `@openomni/*` deps (leaf)
 - `session`: only `@openomni/protocol`
 - `llm`: `@openomni/protocol`, `@openomni/session`
-- `agent`: `@openomni/protocol`, `@openomni/llm`
-- `openomni`: any `@openomni/*`
-- `cli`: any `@openomni/*`
+- `agent`: `@openomni/protocol`, `@openomni/llm`, and sanctioned `@openomni/session` observability primitives only
+- `openomni`: any lower package
+- `coordinator`: any lower package
+- `cli`, `server`: any package; they do not depend on each other
+
+`agent` must not own session lifecycle, conversation persistence, or durable state mutation. Session-backed orchestration belongs in `openomni`.
 
 ## 3. Zod-First Types
 

--- a/docs/observability-doctrine.md
+++ b/docs/observability-doctrine.md
@@ -201,3 +201,20 @@ Bus.publish(Subagent.Events.WorkerRunStarted, {
 | `agentName` | No | The agent profile name handling this work |
 
 When adding new bus events or log calls, include `traceId` in the context whenever it's available. It's the primary key for correlating observability data across the system.
+
+## Persona Workforce Observability
+
+The persona workforce model adds a user-facing question that observability must answer: who assigned work to whom, where did it run, and what was written back to the original session?
+
+Track these relationships with identifiers and summaries, not raw prompt bodies:
+
+- original session ID;
+- self-loop session ID, when work was forked;
+- child persona session ID;
+- persona or agent name;
+- worker run ID;
+- parent run ID, if available;
+- writeback target session ID;
+- result summary or memory candidate ID.
+
+Do not log full self-loop transcripts, drafts, social content bodies, user prompts, or private memory content. Store internal transcripts in session storage when required, and emit only correlation identifiers through Log, Bus, and Telemetry.

--- a/docs/persona-runtime-roadmap.md
+++ b/docs/persona-runtime-roadmap.md
@@ -1,0 +1,115 @@
+# Persona Runtime Roadmap
+
+This roadmap translates the persona workforce direction into implementation phases. It is intentionally staged so OpenOmni can gain the workforce model without introducing uncontrolled autonomy or memory pollution.
+
+## Current Foundations
+
+OpenOmni already has several primitives that map naturally to the persona workforce model:
+
+| Capability | Current primitive | Gap |
+| --- | --- | --- |
+| Stable user-facing sessions | `SurfaceKey`, `IngressSessionResolver` | No explicit original/self-loop/writeback policy |
+| Child work sessions | `Session.createChild()`, `workerMeta` | No `self-loop` session kind |
+| Delegated execution | `SubagentRuntime.spawn/send/resume/wait` | No persona lifecycle or promotion model |
+| Background work | `BackgroundManager` | Parent lineage must be preserved for workforce tasks |
+| Execution attempts | `WorkerRun` | No persona evaluation summary |
+| Persona definitions | `AgentProfile.Definition`, `AgentRegistry` | No durable promoted persona registry |
+| Memory retrieval | `ChatAgentConfig.memory`, memory middleware | No reflection/write candidate lifecycle |
+
+## Target Contracts
+
+These are the contracts the runtime should eventually expose. Names are provisional.
+
+### Persona profile
+
+Describes a persistent or temporary persona.
+
+- `personaId`
+- `displayName`
+- `kind`: `main | domain | specialist | reviewer | utility`
+- `lifecycle`: `trial | active | promoted | paused | retired`
+- `domain`: `sns | coding | research | review | custom`
+- `tools` and `permissions`
+- `memoryPolicy`
+- `promotionPolicy`
+
+### Inbound authority
+
+Controls who can submit new top-level work.
+
+- `external`: user, surface, API
+- `internalManager`: Main Persona or trusted manager persona
+- `worker`: ordinary Sub Persona; cannot create new top-level inbound work by default
+
+### Self-loop session
+
+Represents isolated internal reasoning.
+
+- parent original session
+- initiating persona
+- target domain persona, if any
+- reason: clarification, planning, review, recovery, scheduled reflection
+- distilled writeback target
+
+### Distilled writeback
+
+Controls what is written back to the original session.
+
+- summary
+- decisions
+- user-visible result
+- links to worker runs / child sessions
+- memory candidates
+- hidden internal transcript reference
+
+### Memory candidate
+
+Marks high-value information for Anamnesis or future memory processing.
+
+- source session / worker run
+- author persona
+- scope: user, domain, project, persona, session
+- category: preference, rule, lesson, failure, decision, skill
+- confidence and verification evidence
+
+## Implementation Phases
+
+### Phase 1: Authority and lineage
+
+- Add explicit metadata conventions for original, self-loop, and child persona sessions.
+- Preserve parent session lineage for background and delegated work.
+- Document which actors can submit external or internal inbound events.
+- Add tests around session lineage when implementation starts.
+
+### Phase 2: Self-loop runtime
+
+- Add a small orchestration layer that creates self-loop sessions for Layer 3 work.
+- Keep the original session clean by writing only distilled results back.
+- Start with manual or rule-based triggers: complex request, explicit user request, recovery, or scheduled review.
+
+### Phase 3: Persona lifecycle
+
+- Introduce persona lifecycle metadata.
+- Track repeated ephemeral worker usage and output adoption.
+- Produce persona promotion candidates instead of promoting automatically.
+- Keep persistent persona creation behind policy or user approval initially.
+
+### Phase 4: SNS domain persona
+
+- Define the first domain persona around SNS / viral marketing.
+- Start with research, drafts, content planning, and analytics.
+- Keep public posting, comments, and outbound DMs behind approval gates until trust and policy are established.
+
+### Phase 5: Memory readiness
+
+- Emit memory candidates from completed work and user corrections.
+- Do not treat raw session transcripts as durable behavioral memory.
+- Use session lineage and worker provenance as the input stream for Anamnesis.
+
+## Non-goals for the First Implementation
+
+- No unrestricted recursive task creation.
+- No automatic rewriting of core orchestration or safety policy.
+- No automatic promotion of every generated worker into a persistent persona.
+- No fully autonomous public social posting by default.
+- No dependency on Anamnesis before the runtime can produce scoped, attributed memory candidates.

--- a/docs/persona-workforce.md
+++ b/docs/persona-workforce.md
@@ -1,0 +1,164 @@
+# Persona Workforce Direction
+
+OpenOmni is a personal AI workforce infrastructure. The user primarily talks to one persistent Main Persona, and that persona hires, summons, evaluates, promotes, pauses, or retires specialized Sub Personas across domains.
+
+This document describes the product direction. It is not a claim that every capability below is implemented today.
+
+## Product Thesis
+
+OpenOmni is not an agent gateway and not a generic swarm. It is a personal workforce layer with a durable relationship model:
+
+```txt
+User
+  ↕
+Main Persona
+  ├─ SNS / Viral Marketing Persona
+  ├─ Coding Persona
+  ├─ Research Persona
+  ├─ Reviewer Persona
+  └─ Future domain personas
+```
+
+The Main Persona acts as the user's personal assistant and chief-of-staff. It owns the relationship with the user, understands the user's goals and preferences, and decides when to act directly or employ another persona.
+
+The first domain persona is the SNS / Viral Marketing Persona. Coding remains a first-class internal capability because the system must be able to build automations, improve tooling, and operate its own development workflow, but coding is not the first user-facing domain.
+
+## Core Concepts
+
+### Main Persona
+
+The Main Persona is the only default user-facing identity. It may:
+
+- answer simple requests directly;
+- delegate work to a Sub Persona;
+- submit new work through the inbound pipeline;
+- create isolated self-loop sessions for complex reasoning;
+- evaluate Sub Persona output before reporting back to the user;
+- propose changes to persona behavior, rules, skills, or tone.
+
+The Main Persona must not silently rewrite core system logic. It can evolve personality, rules, routing preferences, and skills within policy boundaries.
+
+### Sub Persona
+
+A Sub Persona is a specialized worker identity. It may perform assigned work and may use explicitly granted tools, but it does not own workforce management.
+
+Normal Sub Personas cannot submit new top-level inbound work. They report results, blockers, and follow-up suggestions back to the Main Persona or the caller that invoked them.
+
+### Direct User Targeting
+
+The user may bypass the Main Persona and target a specific persona directly. Direct targeting is a user authority, not a general agent authority.
+
+Recommended policy:
+
+- default path: user → Main Persona;
+- explicit path: user → named persona;
+- direct-to-persona work should still be visible to the Main Persona through session lineage, summaries, or event records so the personal assistant does not lose global context.
+
+### Controlled Inbound Authority
+
+OpenOmni has two inbound paths:
+
+```txt
+External inbound
+  User / surface / API → IngressEngine → target persona
+
+Internal inbound
+  Main Persona → inbound.submit → IngressEngine → new work item
+```
+
+Only the user, the Main Persona, and explicitly trusted manager personas may create internal inbound work. This prevents unmanaged recursive work creation by ordinary Sub Personas.
+
+## Three-Layer Execution Model
+
+The Main Persona chooses the cheapest sufficient execution layer.
+
+| Layer | Name | Use when | Session behavior |
+| --- | --- | --- | --- |
+| 1 | Direct | The Main Persona can answer or act without specialist help | Original session only |
+| 2 | Delegate | A known Sub Persona can complete the work | Child persona session |
+| 3 | Fork | The request needs deeper reasoning, debate, planning, or multi-persona coordination | New isolated self-loop session |
+
+Layer 3 is not just a background task. It is an isolated work session where the Main Persona or domain persona can restate the request, refine intent, summon Sub Personas, review outputs, and return a distilled result to the original session.
+
+The original session should remain a clean relationship and decision record. Internal reasoning, failed attempts, experiments, and worker transcripts belong in child/self-loop sessions.
+
+## Persona Lifecycle
+
+Sub Personas start as ephemeral workers unless they are deliberately defined as persistent personas.
+
+```txt
+ephemeral worker
+  → repeated useful work
+  → persona candidate
+  → evaluation
+  → approval or policy acceptance
+  → persistent persona
+```
+
+Suggested lifecycle states:
+
+- `trial` — a temporary worker role is being tested;
+- `active` — the persona is available for recurring work;
+- `promoted` — the persona has durable identity, rules, and skill history;
+- `paused` — the persona should not receive new work until reviewed;
+- `retired` — the persona is archived and unavailable by default.
+
+Promotion should consider repeat usage, output adoption rate, correction rate, role stability, and whether the persona has a reusable prompt/rule/skill combination.
+
+## First Domain: SNS / Viral Marketing
+
+The first domain persona should be the SNS / Viral Marketing Persona. It owns strategy and execution support for social content, while the Main Persona remains the user's general assistant.
+
+Responsibilities may include:
+
+- brand voice and account positioning;
+- trend and meme scouting;
+- content ideas and calendars;
+- platform-specific copywriting;
+- hooks, CTAs, and campaign experiments;
+- performance analysis and follow-up recommendations.
+
+Publishing, commenting, and outbound DMs should begin with approval gates. Drafting, research, planning, and analysis can be more autonomous.
+
+## Memory and Anamnesis
+
+Anamnesis is the intended long-term memory substrate, but OpenOmni should remain memory-ready before depending on the full memory system.
+
+OpenOmni should provide:
+
+- session lineage for original, self-loop, and child persona sessions;
+- provenance for who produced a result and why;
+- event streams that can later be ingested by Anamnesis;
+- memory candidate markers for high-value lessons, preferences, rules, and persona changes.
+
+Raw session history is not the same as memory. Durable behavioral memory should be scoped, attributed, and reviewable. Core logic and safety policy should not be rewritten by memory reflection. Personality, domain rules, tone, skills, and routing preferences may evolve within policy boundaries.
+
+## Competitive Positioning
+
+OpenOmni should not compete primarily on channel breadth or minimal implementation size.
+
+- OpenClaw is positioned around a local-first personal assistant gateway with broad channel and companion-app coverage.
+- Hermes Agent is positioned around a growing autonomous agent with memory, skill creation, and learning loops.
+- NanoClaw is positioned around a lightweight auditable personal assistant with container isolation.
+
+OpenOmni's distinct position is a memory-ready persona workforce: one Main Persona manages a controlled hierarchy of Sub Personas, isolates internal work from the original user session, and uses session lineage and event records to make delegated work auditable.
+
+## Current Implementation Hooks
+
+Existing primitives that support this direction:
+
+- `IngressEngine` and `SurfaceKey` keep external surfaces attached to stable sessions.
+- `Session.createChild()` and `workerMeta` can represent child persona and self-loop lineage.
+- `SubagentRuntime` and `BackgroundManager` provide delegated and asynchronous execution foundations.
+- `WorkerRun` records execution attempts for child sessions.
+- `AgentRegistry` is the current seed of a persona registry.
+- `ChatAgentConfig.memory` and memory middleware are the current Anamnesis retrieval attachment point.
+
+Known gaps:
+
+- no explicit `self-loop` session kind;
+- no formal inbound authority model;
+- no persona lifecycle schema;
+- no distilled writeback policy for original sessions;
+- no memory reflection lifecycle or Anamnesis write gate;
+- no durable registry for dynamically promoted personas.

--- a/docs/persona-workforce.md
+++ b/docs/persona-workforce.md
@@ -133,15 +133,15 @@ OpenOmni should provide:
 
 Raw session history is not the same as memory. Durable behavioral memory should be scoped, attributed, and reviewable. Core logic and safety policy should not be rewritten by memory reflection. Personality, domain rules, tone, skills, and routing preferences may evolve within policy boundaries.
 
-## Competitive Positioning
+## Design Priorities
 
-OpenOmni should not compete primarily on channel breadth or minimal implementation size.
+OpenOmni should optimize for a clear workforce model instead of maximizing the number of channels, tools, or autonomous loops at once.
 
-- OpenClaw is positioned around a local-first personal assistant gateway with broad channel and companion-app coverage.
-- Hermes Agent is positioned around a growing autonomous agent with memory, skill creation, and learning loops.
-- NanoClaw is positioned around a lightweight auditable personal assistant with container isolation.
-
-OpenOmni's distinct position is a memory-ready persona workforce: one Main Persona manages a controlled hierarchy of Sub Personas, isolates internal work from the original user session, and uses session lineage and event records to make delegated work auditable.
+- **Relationship continuity**: the Main Persona remains the stable user-facing identity.
+- **Controlled delegation**: Sub Personas work inside explicit authority and session boundaries.
+- **Session isolation**: internal reasoning and failed attempts do not pollute the original session.
+- **Auditable growth**: repeated useful work can promote a temporary worker into a persistent persona.
+- **Memory readiness**: session lineage and provenance prepare the system for long-term memory without treating raw transcripts as behavioral truth.
 
 ## Current Implementation Hooks
 

--- a/docs/quality-score.md
+++ b/docs/quality-score.md
@@ -2,15 +2,15 @@
 
 > Per-package quality assessment. Updated periodically to track progress.
 
-Last updated: 2026-04-19
+Last updated: 2026-04-29
 
 | Package  | Tests                  | Lint         | Types                      | API Stability           | Docs                           | Overall |
 | -------- | ---------------------- | ------------ | -------------------------- | ----------------------- | ------------------------------ | ------- |
 | protocol | ⭐⭐⭐ (4 test files)  | ⭐⭐ (Biome) | ⭐⭐⭐ (strict, no any)    | ⭐⭐⭐ (stable schemas) | ⭐⭐⭐ (AGENTS.md 48L)         | **A-**  |
 | session  | ⭐⭐⭐ (10 test files) | ⭐⭐ (Biome) | ⭐⭐⭐ (strict)            | ⭐⭐⭐ (stable)         | ⭐⭐⭐ (AGENTS.md 47L)         | **A-**  |
 | llm      | ⭐⭐⭐ (19 test files) | ⭐⭐ (Biome) | ⭐⭐ (noEmit)              | ⭐⭐ (evolving)         | ⭐⭐⭐ (AGENTS.md 52L)         | **B+**  |
-| agent    | ⭐⭐ (2 test files)    | ⭐⭐ (Biome) | ⭐⭐⭐ (strict)            | ⭐⭐ (stream() stub)    | ⭐⭐⭐ (AGENTS.md 95L)         | **B**   |
-| openomni | ⭐⭐⭐ (67 test files) | ⭐⭐ (Biome) | ⭐⭐ (some any remain)    | ⭐⭐ (active orchestration) | ⭐⭐⭐ (AGENTS.md 72L + docs/) | **B**   |
+| agent    | ⭐⭐ (2 test files)    | ⭐⭐ (Biome) | ⭐⭐⭐ (strict)            | ⭐⭐ (evolving runtime) | ⭐⭐⭐ (AGENTS.md 95L)         | **B**   |
+| openomni | ⭐⭐⭐ (67 test files) | ⭐⭐ (Biome) | ⭐⭐ (some any remain)    | ⭐⭐ (active orchestration) | ⭐⭐⭐ (AGENTS.md + persona docs) | **B**   |
 | cli      | ⭐ (0 test files)      | ⭐⭐ (Biome) | ⭐⭐ (strict)              | ⭐ (demo/hardcoded)     | ⭐⭐ (AGENTS.md 37L)           | **C**   |
 
 ## Rating Criteria
@@ -27,5 +27,5 @@ Last updated: 2026-04-19
 - CLI deep imports into `@openomni/llm/src/` internals (2 violations)
 - CLI has zero test files
 - openomni `any` usage reduced after plan mode refactoring (removed legacy plan-json, plan-pipeline, plan-store)
-- agent `stream()` is a stub (Phase 2 planned)
+- persona workforce runtime contracts are documented but not implemented yet: self-loop kind, inbound authority policy, distilled writeback, persona lifecycle, and memory candidates
 - Biome configured (replaces ESLint + Prettier)

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/openomni
 
-Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@openomni/session`, and `@openomni/llm` to add plan generation, DAG utilities, inbound event handling, task persistence, and a session-backed subagent runtime.
+Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@openomni/session`, and `@openomni/llm` to add plan generation, DAG utilities, inbound event handling, task persistence, and a session-backed subagent runtime. This package is the future home for the Main Persona orchestration seams: controlled inbound authority, self-loop session creation, persona delegation, and distilled writeback.
 
 ## Module Map
 
@@ -20,6 +20,7 @@ Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@ope
 - `src/ingress/` is the entry path for inbound events. It resolves a session through `SurfaceKey`, projects the event into stored messages, then dispatches to the `plan` or `direct` handler. `SessionBridge` manages plan storage via `Storage.PlanSubAdapter` (plan ID markers on messages).
 - `src/storage/` is now a thin re-export shim. Task types (`Task.Info`, `Task.Run`, `Task.Status`) moved to `@openomni/protocol/task` and are re-exported here for backward compatibility. Task, plan, and todo persistence is handled by the optional sub-adapters on `Storage.Adapter` in `@openomni/session`.
 - `src/subagent/` owns the unified subagent runtime. `SubagentRuntime` runs session-locked spawn / send / resume / cancel / wait operations backed by `WorkerRun` records; `BackgroundManager` wraps the runtime for fire-and-forget execution with concurrency / depth limits.
+- Persona workforce direction: `src/ingress/` remains the external/internal inbound seam, `src/subagent/` remains the child persona execution seam, and a future self-loop/writeback layer should live in this package rather than in `agent`.
 
 WHY: each domain stays small and focused so the domain docs can stay source-of-truth instead of repeating.
 
@@ -56,6 +57,7 @@ If a symbol is not re-exported from `src/index.ts`, treat it as private to its d
 - Add new tools or tool providers in `src/execution-runtime/tool/` following the `ToolProvider` interface. The three new providers (`TaskToolProvider`, `PlanToolProvider`, `TodoToolProvider`) each live in their own subdirectory (`task/`, `plan/`, `todo/`) and read from `Storage.get()` in `@openomni/session`.
 - Extend ingress handling in `src/ingress/` when new inbound surfaces or mode dispatch rules arrive.
 - Add subagent capabilities (new timeout policies, abort semantics, recovery hooks) in `src/subagent/` next to `SubagentRuntime` / `BackgroundManager`.
+- Add persona workforce orchestration here when implementing `docs/persona-runtime-roadmap.md`: authority checks near ingress, self-loop creation near session-backed orchestration, and distilled writeback near `SessionBridge`.
 
 ## What This Package Is Not
 

--- a/packages/openomni/docs/ingress-engine.md
+++ b/packages/openomni/docs/ingress-engine.md
@@ -22,6 +22,16 @@ InboundEvent
 
 Only `plan` and `direct` modes exist. Parallel execution across plan steps is the caller's responsibility (typically through `SubagentRuntime` / `BackgroundManager`).
 
+### Persona Workforce Direction
+
+Ingress is the authority boundary for work entering the runtime.
+
+- **External inbound**: user, surface, or API submits work to a target persona.
+- **Internal inbound**: the Main Persona or an explicitly trusted manager persona submits new work back through ingress.
+- **Ordinary Sub Personas**: should return results or suggestions; they should not create new top-level inbound work by default.
+
+This authority model is target direction, not the full current implementation. When implemented, inbound authority checks should happen before work is projected into durable session history.
+
 ### IngressEngine API
 
 ```typescript
@@ -86,6 +96,7 @@ A single session spans plan → re-plan → direct interactions:
 - Same `surface` + `workspace` + `channel` → same session via `SurfaceKey`.
 - Re-plan: a second `mode: "plan"` call on the same session reads the previous plan from `Storage.PlanSubAdapter` (via `__OPENOMNI_PLANID__` marker) and combines with new user feedback.
 - Direct follow-up: `mode: "direct"` reads the flat session history and runs a single `ChatAgent`.
+- Future self-loop work should create child sessions instead of writing internal reasoning into the original user-facing session.
 
 ### Key Modules
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -45,6 +45,18 @@ src/
 - **Task types**: `Task.Info` / `Task.Run` / `Task.Status` / `Task.RunStatus` live in `task/index.ts`. These moved from `packages/openomni/src/storage/` so session and openomni can share them without a circular dep.
 - **Todo types**: `Todo.Info` / `Todo.Status` / `Todo.Priority` live in `todo/index.ts`. `Todo.Updated` is a `BusEvent.define()` descriptor published when a session's todo list changes.
 
+## FUTURE PERSONA CONTRACTS
+
+The persona workforce direction is documented in `docs/persona-workforce.md` and `docs/persona-runtime-roadmap.md`. Future schemas should live here when they become implementation work:
+
+- persona profile and lifecycle contracts;
+- inbound authority / actor role contracts;
+- self-loop session metadata;
+- distilled writeback records;
+- memory candidate records for Anamnesis ingestion.
+
+Keep these as protocol contracts only. Runtime policy and storage implementations belong in upper packages.
+
 ## ANTI-PATTERNS
 
 - Do NOT add runtime logic here — this package is schemas/types only.

--- a/packages/session/AGENTS.md
+++ b/packages/session/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/session
 
-Session lifecycle, message/part storage, event bus, snapshots, artifacts, event log, surface-key routing, and worker-run records. Depends only on `@openomni/protocol`.
+Session lifecycle, message/part storage, event bus, snapshots, artifacts, event log, surface-key routing, and worker-run records. Depends only on `@openomni/protocol`. In the persona workforce model, this package owns the durable substrate for original sessions, self-loop sessions, child persona sessions, and worker-run history.
 
 ## STRUCTURE
 
@@ -41,6 +41,7 @@ src/
 - **Snapshot.Provider**: Interface for capturing and restoring session message state. `Snapshot.Diff` reports added / removed / modified message IDs.
 - **WorkerRun**: Event-sourced via `Storage.Adapter.eventLog`. `WorkerRun.create()`, `WorkerRun.updateStatus()`, `WorkerRun.listBySession()`. State transitions (e.g. `waiting_input → running`) increment `resumeCount`. Used by `SubagentRuntime` / `BackgroundManager` to persist subagent runs.
 - **TTL / lazy deletion**: `Session.create({ ttlMs })` sets `expiresAt`; `Session.get()` and `.list()` check expiry and auto-delete.
+- **Persona session lineage**: `Session.createChild()` + `parentSessionId` + `spawnDepth` are the current foundation for original → self-loop → child persona trees. Future work should add explicit metadata conventions before adding new storage shapes.
 
 ## ANTI-PATTERNS
 
@@ -48,3 +49,4 @@ src/
 - Do NOT import internal paths from other packages — import from `@openomni/session` (index re-exports).
 - Do NOT persist ad-hoc subagent state alongside `Session`; use `WorkerRun` so it is event-sourced and replayable.
 - Do NOT call `Storage.get().todo` directly for writes that require bus event publication — go through `Todo.update()` instead. For read-only queries that don't require event notification, direct access is OK (or use `Todo.get()`).
+- Do NOT write raw self-loop transcripts back into the original user session. Store internal work in child sessions and let `openomni` decide what distilled result belongs in the original session.


### PR DESCRIPTION
## Summary

Defines OpenOmni's updated product direction as a personal AI workforce infrastructure centered on one Main Persona managing specialized Sub Personas. Documents controlled inbound authority, isolated self-loop sessions, SNS as the first domain persona, and the memory-ready path toward Anamnesis.

Fixes N/A
Relates to N/A

## Changes

- Add `docs/persona-workforce.md` with the Main Persona/Sub Persona model, three-layer execution, persona lifecycle, SNS domain strategy, and competitive positioning.
- Add ADR-005 to accept the persona workforce runtime direction and controlled inbound authority model.
- Refresh README and AGENTS.md so project entrypoints point to the new product direction and current coordinator dispatch path.
- Clarify the agent/session boundary in Golden Principles and ADRs as no durable session state ownership, with sanctioned observability usage.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [ ] `cli`
- [ ] `server`

Documentation-only change; no package runtime code is affected.

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

N/A

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

Tests are N/A because this PR only updates documentation. Type checking and dependency checks also passed in the pre-push hook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the product direction to a personal AI workforce with one Main Persona managing specialized Sub Personas, controlled inbound authority, self-loop sessions, and clean user-facing history. Adds a persona runtime roadmap and aligns package guides and observability to this model; SNS is the first domain persona.

- **Docs**
  - Added `docs/persona-workforce.md` and ADR‑005 defining the Main/Sub model, authority boundaries, three-layer execution, and session hygiene.
  - Added `docs/persona-runtime-roadmap.md` with staged contracts and phases; refreshed README/AGENTS with the product model, runtime path, and `CoordinatorLike.dispatch` for `direct`/`plan`.
  - Aligned guides to the workforce direction: `packages/openomni` (future home for authority, self-loops, writeback), ingress authority notes, `packages/session` persona lineage guidance, `packages/protocol` future persona contracts, observability for persona lineage/writeback; updated Golden Principles and ADRs 003/004.

<sup>Written for commit c22f20ee3f52fd2f971c0d48afed52c17f956c76. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

