### PR TITLE
feat(openomni,server): add profile system for SOUL/USER/MEMORY prompt injection

### DIFF
--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -145,7 +145,7 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
           tools,
           toolExecutor,
           middleware: [
-            ...Profile.createMiddleware({ agentName: request.agentName ?? "default" }),
+            ...Profile.createMiddleware({ agentName: request.agentName ?? "dev" }),
             createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
             ...buildWorkerMiddleware({
               permissions: request.permissions,

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -5,6 +5,7 @@ import { initialize, Log } from "@openomni/session";
 import {
   AgentToolProvider,
   BackgroundManager,
+  Profile,
   ToolProxyProvider,
   SessionBridge,
   SystemToolProvider,
@@ -144,6 +145,7 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
           tools,
           toolExecutor,
           middleware: [
+            ...Profile.createMiddleware({ agentName: request.agentName ?? "default" }),
             createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
             ...buildWorkerMiddleware({
               permissions: request.permissions,

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -63,6 +63,9 @@ export type {
   RuntimeToolTarget,
 } from "./extension";
 
+// Profile system
+export { Profile } from "./profile";
+
 // Subagent runtime
 export {
   SubagentRuntime,

--- a/packages/openomni/src/profile/guidance.ts
+++ b/packages/openomni/src/profile/guidance.ts
@@ -1,0 +1,20 @@
+export const MEMORY_GUIDANCE = `
+Memory entries must be declarative facts, not instructions.
+
+Good: "User prefers concise responses"
+Good: "User's primary language is Korean"
+Good: "Project uses Bun runtime instead of Node"
+Bad:  "Always respond concisely"
+Bad:  "Use Korean when talking to user"
+
+What to save:
+- User corrections and explicit preferences (highest value)
+- Stable personal context (name, role, timezone, tools)
+- Project-specific facts the user has shared
+
+What NOT to save:
+- Task progress or session outcomes
+- Completed-work logs or TODO state
+- Procedures, workflows, or step-by-step instructions
+- Anything that changes between sessions
+`.trim();

--- a/packages/openomni/src/profile/index.ts
+++ b/packages/openomni/src/profile/index.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { MEMORY_GUIDANCE } from "./guidance";
 
 const PROFILES_DIR = ".openomni/profiles";
-const SAFE_NAME = /^[A-Za-z0-9._-]+$/;
+const SAFE_NAME = /^[A-Za-z0-9_-]+$/;
 
 export namespace Profile {
   export const MiddlewareConfigSchema = z.object({

--- a/packages/openomni/src/profile/index.ts
+++ b/packages/openomni/src/profile/index.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+import { Log } from "@openomni/session";
+import type { MiddlewareRegistration } from "@openomni/agent";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { MEMORY_GUIDANCE } from "./guidance";
+
+const PROFILES_DIR = ".openomni/profiles";
+const SAFE_NAME = /^[A-Za-z0-9._-]+$/;
+
+export namespace Profile {
+  export const MiddlewareConfigSchema = z.object({
+    agentName: z.string(),
+    homeRoot: z.string().optional(),
+  });
+  export type MiddlewareConfig = z.infer<typeof MiddlewareConfigSchema>;
+
+  export function createMiddleware(config: MiddlewareConfig): MiddlewareRegistration[] {
+    const home = config.homeRoot ?? homedir();
+    const agent = sanitizeName(config.agentName);
+
+    return [
+      createSoulRegistration(home, agent),
+      createUserRegistration(home, agent),
+      createMemoryRegistration(home, agent),
+    ];
+  }
+}
+
+function sanitizeName(name: string): string {
+  return SAFE_NAME.test(name) ? name : "";
+}
+
+function resolveProfilePath(homeRoot: string, agentName: string, file: string): string {
+  return join(homeRoot, PROFILES_DIR, agentName, file);
+}
+
+async function loadFile(path: string): Promise<string> {
+  try {
+    const file = Bun.file(path);
+    if (!(await file.exists())) return "";
+    return await file.text();
+  } catch (error) {
+    Log.warn("profile: failed to read file", { path, error });
+    return "";
+  }
+}
+
+async function loadSoul(homeRoot: string, agentName: string): Promise<string> {
+  if (!agentName) return "";
+  return loadFile(resolveProfilePath(homeRoot, agentName, "SOUL.md"));
+}
+
+async function loadUser(homeRoot: string, agentName: string): Promise<string> {
+  const globalPath = join(homeRoot, PROFILES_DIR, "USER.md");
+  const agentPath = agentName ? resolveProfilePath(homeRoot, agentName, "USER.md") : "";
+
+  const parts: string[] = [];
+  const global = await loadFile(globalPath);
+  if (global) parts.push(global);
+
+  if (agentPath) {
+    const agent = await loadFile(agentPath);
+    if (agent) parts.push(agent);
+  }
+
+  return parts.join("\n\n");
+}
+
+async function loadMemory(homeRoot: string, agentName: string): Promise<string> {
+  if (!agentName) return "";
+  return loadFile(resolveProfilePath(homeRoot, agentName, "MEMORY.md"));
+}
+
+function renderSoul(content: string): string {
+  return `═══ PERSONA IDENTITY ═══\n${content}`;
+}
+
+function renderUser(content: string): string {
+  return `═══ USER PROFILE ═══\n${content}`;
+}
+
+function renderMemory(content: string): string {
+  return `═══ DECLARATIVE MEMORY ═══\n${MEMORY_GUIDANCE}\n\n${content}`;
+}
+
+function createSoulRegistration(homeRoot: string, agentName: string): MiddlewareRegistration {
+  let snapshot: string | null = null;
+
+  return {
+    name: "profile:soul",
+    timing: "on_system_prompt",
+    priority: 25,
+    failPolicy: "fail-open",
+    fn: async () => {
+      try {
+        if (snapshot === null) snapshot = await loadSoul(homeRoot, agentName);
+        if (!snapshot) return { action: "continue" };
+        return { action: "transform", input: { prependContext: renderSoul(snapshot) } };
+      } catch (error) {
+        Log.warn("profile:soul middleware failed", { error });
+        return { action: "continue" };
+      }
+    },
+  };
+}
+
+function createUserRegistration(homeRoot: string, agentName: string): MiddlewareRegistration {
+  let snapshot: string | null = null;
+
+  return {
+    name: "profile:user",
+    timing: "on_system_prompt",
+    priority: 30,
+    failPolicy: "fail-open",
+    fn: async () => {
+      try {
+        if (snapshot === null) snapshot = await loadUser(homeRoot, agentName);
+        if (!snapshot) return { action: "continue" };
+        return { action: "transform", input: { appendContext: renderUser(snapshot) } };
+      } catch (error) {
+        Log.warn("profile:user middleware failed", { error });
+        return { action: "continue" };
+      }
+    },
+  };
+}
+
+function createMemoryRegistration(homeRoot: string, agentName: string): MiddlewareRegistration {
+  let snapshot: string | null = null;
+
+  return {
+    name: "profile:memory",
+    timing: "on_system_prompt",
+    priority: 35,
+    failPolicy: "fail-open",
+    fn: async () => {
+      try {
+        if (snapshot === null) snapshot = await loadMemory(homeRoot, agentName);
+        if (!snapshot) return { action: "continue" };
+        return { action: "transform", input: { appendContext: renderMemory(snapshot) } };
+      } catch (error) {
+        Log.warn("profile:memory middleware failed", { error });
+        return { action: "continue" };
+      }
+    },
+  };
+}

--- a/packages/openomni/test/profile/profile.test.ts
+++ b/packages/openomni/test/profile/profile.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Profile } from "../../src/profile";
+import { MEMORY_GUIDANCE } from "../../src/profile/guidance";
+
+async function createFixture(homeRoot: string, agentName: string, files: Record<string, string>) {
+  const agentDir = join(homeRoot, ".openomni", "profiles", agentName);
+  await mkdir(agentDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    await Bun.write(join(agentDir, name), content);
+  }
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await mkdtemp(join(tmpdir(), "profile-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+}
+
+describe("Profile", () => {
+  describe("loader", () => {
+    it("loads all three files when present", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "You are a helpful assistant.",
+          "USER.md": "Name: Alice",
+          "MEMORY.md": "User prefers dark mode",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const [soul, user, memory] = registrations;
+
+        const soulVerdict = await soul.fn({} as any);
+        expect(soulVerdict).toEqual({
+          action: "transform",
+          input: { prependContext: "═══ PERSONA IDENTITY ═══\nYou are a helpful assistant." },
+        });
+
+        const userVerdict = await user.fn({} as any);
+        expect(userVerdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext: `\u2550\u2550\u2550 USER PROFILE \u2550\u2550\u2550\nName: Alice`,
+          },
+        });
+
+        const memoryVerdict = await memory.fn({} as any);
+        expect(memoryVerdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext: `\u2550\u2550\u2550 DECLARATIVE MEMORY \u2550\u2550\u2550\n${MEMORY_GUIDANCE}\n\nUser prefers dark mode`,
+          },
+        });
+      });
+    });
+
+    it("merges global USER.md with agent-specific USER.md", async () => {
+      await withTempDir(async (dir) => {
+        const profilesDir = join(dir, ".openomni", "profiles");
+        await mkdir(profilesDir, { recursive: true });
+        await Bun.write(join(profilesDir, "USER.md"), "Global preferences");
+        await createFixture(dir, "test-agent", {
+          "USER.md": "Agent-specific prefs",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const userVerdict = await registrations[1].fn({} as any);
+
+        expect(userVerdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext:
+              "\u2550\u2550\u2550 USER PROFILE \u2550\u2550\u2550\nGlobal preferences\n\nAgent-specific prefs",
+          },
+        });
+      });
+    });
+
+    it("uses global USER.md only when agent-specific is absent", async () => {
+      await withTempDir(async (dir) => {
+        const profilesDir = join(dir, ".openomni", "profiles");
+        await mkdir(profilesDir, { recursive: true });
+        await Bun.write(join(profilesDir, "USER.md"), "Global only");
+        await createFixture(dir, "test-agent", {});
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const userVerdict = await registrations[1].fn({} as any);
+
+        expect(userVerdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext: "\u2550\u2550\u2550 USER PROFILE \u2550\u2550\u2550\nGlobal only",
+          },
+        });
+      });
+    });
+
+    it("uses agent-specific USER.md only when global is absent", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "USER.md": "Agent only",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const userVerdict = await registrations[1].fn({} as any);
+
+        expect(userVerdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext: "\u2550\u2550\u2550 USER PROFILE \u2550\u2550\u2550\nAgent only",
+          },
+        });
+      });
+    });
+
+    it("returns continue for missing files in empty directory", async () => {
+      await withTempDir(async (dir) => {
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        for (const reg of registrations) {
+          const verdict = await reg.fn({} as any);
+          expect(verdict).toEqual({ action: "continue" });
+        }
+      });
+    });
+
+    it("loads only SOUL.md when others are absent", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "Soul content only",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const soulVerdict = await registrations[0].fn({} as any);
+        expect(soulVerdict).toEqual({
+          action: "transform",
+          input: { prependContext: "═══ PERSONA IDENTITY ═══\nSoul content only" },
+        });
+
+        const userVerdict = await registrations[1].fn({} as any);
+        expect(userVerdict).toEqual({ action: "continue" });
+
+        const memoryVerdict = await registrations[2].fn({} as any);
+        expect(memoryVerdict).toEqual({ action: "continue" });
+      });
+    });
+
+    it("sanitizes invalid agent name and returns empty content", async () => {
+      await withTempDir(async (dir) => {
+        const registrations = Profile.createMiddleware({
+          agentName: "../etc/passwd",
+          homeRoot: dir,
+        });
+        for (const reg of registrations) {
+          const verdict = await reg.fn({} as any);
+          expect(verdict).toEqual({ action: "continue" });
+        }
+      });
+    });
+
+    it("treats empty files as empty strings", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "",
+          "USER.md": "",
+          "MEMORY.md": "",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        for (const reg of registrations) {
+          const verdict = await reg.fn({} as any);
+          expect(verdict).toEqual({ action: "continue" });
+        }
+      });
+    });
+  });
+
+  describe("middleware registration", () => {
+    it("returns exactly 3 registrations", () => {
+      const registrations = Profile.createMiddleware({
+        agentName: "test",
+        homeRoot: "/tmp/nonexistent",
+      });
+      expect(registrations).toHaveLength(3);
+    });
+
+    it("assigns correct names", () => {
+      const registrations = Profile.createMiddleware({
+        agentName: "test",
+        homeRoot: "/tmp/nonexistent",
+      });
+      expect(registrations.map((r) => r.name)).toEqual([
+        "profile:soul",
+        "profile:user",
+        "profile:memory",
+      ]);
+    });
+
+    it("assigns priorities 25, 30, 35", () => {
+      const registrations = Profile.createMiddleware({
+        agentName: "test",
+        homeRoot: "/tmp/nonexistent",
+      });
+      expect(registrations.map((r) => r.priority)).toEqual([25, 30, 35]);
+    });
+
+    it("all have on_system_prompt timing and fail-open policy", () => {
+      const registrations = Profile.createMiddleware({
+        agentName: "test",
+        homeRoot: "/tmp/nonexistent",
+      });
+      for (const reg of registrations) {
+        expect(reg.timing).toBe("on_system_prompt");
+        expect(reg.failPolicy).toBe("fail-open");
+      }
+    });
+  });
+
+  describe("middleware behavior", () => {
+    it("soul uses prependContext, user and memory use appendContext", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "soul",
+          "USER.md": "user",
+          "MEMORY.md": "memory",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const soulVerdict = await registrations[0].fn({} as any);
+        expect(soulVerdict).toHaveProperty("input.prependContext");
+
+        const userVerdict = await registrations[1].fn({} as any);
+        expect(userVerdict).toHaveProperty("input.appendContext");
+
+        const memoryVerdict = await registrations[2].fn({} as any);
+        expect(memoryVerdict).toHaveProperty("input.appendContext");
+      });
+    });
+
+    it("includes MEMORY_GUIDANCE in memory output only when content exists", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "MEMORY.md": "User likes TypeScript",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const verdict = await registrations[2].fn({} as any);
+
+        expect(verdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext: `\u2550\u2550\u2550 DECLARATIVE MEMORY \u2550\u2550\u2550\n${MEMORY_GUIDANCE}\n\nUser likes TypeScript`,
+          },
+        });
+      });
+    });
+
+    it("omits memory middleware when MEMORY.md is empty", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "MEMORY.md": "",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const verdict = await registrations[2].fn({} as any);
+        expect(verdict).toEqual({ action: "continue" });
+      });
+    });
+  });
+
+  describe("frozen snapshot", () => {
+    it("returns same result after underlying file changes", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "original soul",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const first = await registrations[0].fn({} as any);
+
+        const soulPath = join(dir, ".openomni", "profiles", "test-agent", "SOUL.md");
+        await Bun.write(soulPath, "modified soul");
+
+        const second = await registrations[0].fn({} as any);
+        expect(second).toEqual(first);
+        expect(second).toEqual({
+          action: "transform",
+          input: { prependContext: "═══ PERSONA IDENTITY ═══\noriginal soul" },
+        });
+      });
+    });
+
+    it("new middleware instance picks up file changes", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "version one",
+        });
+
+        const first = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const firstVerdict = await first[0].fn({} as any);
+        expect(firstVerdict).toEqual({
+          action: "transform",
+          input: { prependContext: "═══ PERSONA IDENTITY ═══\nversion one" },
+        });
+
+        const soulPath = join(dir, ".openomni", "profiles", "test-agent", "SOUL.md");
+        await Bun.write(soulPath, "version two");
+
+        const second = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+        const secondVerdict = await second[0].fn({} as any);
+        expect(secondVerdict).toEqual({
+          action: "transform",
+          input: { prependContext: "═══ PERSONA IDENTITY ═══\nversion two" },
+        });
+      });
+    });
+
+    it("snapshot is per-registration, not shared across all three", async () => {
+      await withTempDir(async (dir) => {
+        await createFixture(dir, "test-agent", {
+          "SOUL.md": "soul content",
+          "MEMORY.md": "memory content",
+        });
+
+        const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
+
+        await registrations[0].fn({} as any);
+
+        const memoryPath = join(dir, ".openomni", "profiles", "test-agent", "MEMORY.md");
+        await Bun.write(memoryPath, "updated memory");
+
+        const memoryVerdict = await registrations[2].fn({} as any);
+        expect(memoryVerdict).toEqual({
+          action: "transform",
+          input: {
+            appendContext: `\u2550\u2550\u2550 DECLARATIVE MEMORY \u2550\u2550\u2550\n${MEMORY_GUIDANCE}\n\nupdated memory`,
+          },
+        });
+      });
+    });
+  });
+});

--- a/packages/openomni/test/profile/profile.test.ts
+++ b/packages/openomni/test/profile/profile.test.ts
@@ -162,6 +162,16 @@ describe("Profile", () => {
       });
     });
 
+    it("sanitizes dot-dot segment and returns empty content", async () => {
+      await withTempDir(async (dir) => {
+        const registrations = Profile.createMiddleware({ agentName: "..", homeRoot: dir });
+        for (const reg of registrations) {
+          const verdict = await reg.fn({} as any);
+          expect(verdict).toEqual({ action: "continue" });
+        }
+      });
+    });
+
     it("treats empty files as empty strings", async () => {
       await withTempDir(async (dir) => {
         await createFixture(dir, "test-agent", {


### PR DESCRIPTION
## Summary

Add a file-based profile system that loads SOUL.md, USER.md, and MEMORY.md from `~/.openomni/profiles/` and injects them into agent system prompts via middleware.

- **SOUL.md**: persona identity injected as `prependContext` (priority 25)
- **USER.md**: user preferences injected as `appendContext` (priority 30), with hierarchical merge (global + agent-specific)
- **MEMORY.md**: declarative memory injected as `appendContext` (priority 35), only when content exists

Frozen snapshot pattern: profile content is cached on first `on_system_prompt` call and reused for the session lifetime, preserving LLM prefix cache.

## Changes

- `packages/openomni/src/profile/index.ts` — Profile namespace (types + loader + middleware factory + rendering)
- `packages/openomni/src/profile/guidance.ts` — MEMORY_GUIDANCE constant
- `packages/openomni/src/index.ts` — Profile re-export
- `apps/server/src/execution/worker-entry.ts` — Wire profile middleware into ChatAgent
- `packages/openomni/test/profile/profile.test.ts` — 18 tests covering loader, middleware, frozen snapshot, edge cases

## Type

- [x] `feat` — New feature or capability

## Affected Packages

- [x] `openomni`
- [x] `server`

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] `bun run check-types` passes
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added (test file uses `{} as any` for middleware context param only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a file-based profile system that injects `SOUL.md`, `USER.md`, and `MEMORY.md` into agent system prompts via middleware, and hardens agent name handling to prevent path traversal. Wired into the `server` worker so agents get persona, preferences, and memory without extra setup.

- New Features
  - Loads profiles from `~/.openomni/profiles/<agent>/` with optional global `USER.md` at `~/.openomni/profiles/USER.md`.
  - SOUL uses prependContext (priority 25). USER uses appendContext (priority 30) with global + agent merge. MEMORY uses appendContext (priority 35) only if content exists.
  - Per-middleware frozen snapshot caches content for the session to preserve LLM prefix cache; new instances pick up file changes.
  - MEMORY includes guidance to keep entries declarative facts.
  - `Profile` API exported from `openomni`; `server` wires `Profile.createMiddleware({ agentName })` into the ChatAgent chain.

- Bug Fixes
  - Block path traversal by sanitizing `agentName` to `[A-Za-z0-9_-]+`; invalid names disable agent-specific files while keeping global `USER.md` support.

<sup>Written for commit 04b93a3a6d74c9ce3068aac6ad9716fc2c246241. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

