### PR TITLE
fix(agent,openomni): restore policy engine with Bus observability

### DIFF
--- a/packages/agent/src/core/index.ts
+++ b/packages/agent/src/core/index.ts
@@ -30,3 +30,15 @@ export type {
   MiddlewareEngineConfig,
   MiddlewareEngineInstance,
 } from "./middleware";
+export { PolicyEngine } from "./policy";
+export type {
+  PolicyAuditConfig,
+  PolicyContext,
+  PolicyDecision,
+  PolicyEngineConfig,
+  PolicyEngineInstance,
+  PolicyFn,
+  PolicyRegistration,
+  PolicySystemPromptVerdict,
+  PolicyVerdict,
+} from "./policy";

--- a/packages/agent/src/core/policy/builtin/budget.ts
+++ b/packages/agent/src/core/policy/builtin/budget.ts
@@ -1,0 +1,62 @@
+import { checkBudget, describeBudgetRemaining } from "../../budget";
+import type { PolicyRegistration } from "../types";
+
+export function createBudgetReassuranceMiddleware(): PolicyRegistration {
+  let issued = false;
+  return {
+    name: "builtin:budget-reassurance",
+    timing: "pre_turn",
+    priority: 10,
+    fn: (ctx) => {
+      if (issued || !ctx.budgetState) return { action: "continue" };
+      const status = checkBudget(ctx.budgetState, ctx.budget);
+      if (status === "reassurance") {
+        issued = true;
+        const remaining = describeBudgetRemaining(ctx.budgetState, ctx.budget);
+        ctx.eventEmitter?.emit("agent.budget.reassurance", {
+          sessionId: "chat-agent",
+          time: Date.now(),
+          remaining,
+          threshold: ctx.budget?.reassuranceThreshold ?? 0.6,
+        });
+        return {
+          action: "inject",
+          message: `[Budget Status] ${remaining}. You have plenty of budget remaining. Do NOT rush or skip tasks. Complete your work thoroughly.`,
+          reason: "budget_reassurance",
+          policyId: "builtin.budget.reassurance",
+        };
+      }
+      return { action: "continue" };
+    },
+  };
+}
+
+export function createBudgetWarningMiddleware(): PolicyRegistration {
+  let issued = false;
+  return {
+    name: "builtin:budget-warning",
+    timing: "pre_turn",
+    priority: 20,
+    fn: (ctx) => {
+      if (issued || !ctx.budgetState) return { action: "continue" };
+      const status = checkBudget(ctx.budgetState, ctx.budget);
+      if (status === "warning") {
+        issued = true;
+        const remaining = describeBudgetRemaining(ctx.budgetState, ctx.budget);
+        ctx.eventEmitter?.emit("agent.budget.warning", {
+          sessionId: "chat-agent",
+          time: Date.now(),
+          remaining,
+          threshold: ctx.budget?.warningThreshold ?? 0.8,
+        });
+        return {
+          action: "inject",
+          message: `[Budget Warning] ${remaining}. Wrap up your current task and provide a summary.`,
+          reason: "budget_warning",
+          policyId: "builtin.budget.warning",
+        };
+      }
+      return { action: "continue" };
+    },
+  };
+}

--- a/packages/agent/src/core/policy/builtin/compaction.ts
+++ b/packages/agent/src/core/policy/builtin/compaction.ts
@@ -1,0 +1,45 @@
+import { InMemoryCompactor } from "../../execution/compaction";
+import type { PolicyRegistration } from "../types";
+import type { ChatAgentConfig } from "../../types";
+
+type CompactionConfig = NonNullable<ChatAgentConfig["compaction"]>;
+
+export function createCompactionMiddleware(config: CompactionConfig): PolicyRegistration {
+  return {
+    name: "builtin:compaction",
+    timing: "post_compaction",
+    priority: 900,
+    fn: async (ctx) => {
+      if (!ctx.messages || ctx.messages.length === 0) {
+        return { action: "continue" };
+      }
+      if (!ctx.budgetState) {
+        return { action: "continue" };
+      }
+
+      const totalTokens = ctx.budgetState.totalInputTokens + ctx.budgetState.totalOutputTokens;
+      if (!InMemoryCompactor.shouldCompact(totalTokens, config)) {
+        return { action: "continue" };
+      }
+
+      const result = await InMemoryCompactor.compact(ctx.messages, config);
+      if (!result.compacted) {
+        return { action: "continue" };
+      }
+
+      ctx.eventEmitter?.emit("agent.compaction", {
+        sessionId: "chat-agent",
+        time: Date.now(),
+        messagesBefore: ctx.messages.length,
+        messagesAfter: result.messages.length,
+      });
+
+      return {
+        action: "transform",
+        input: { messages: result.messages },
+        reason: "compaction_threshold_exceeded",
+        policyId: "builtin.compaction",
+      };
+    },
+  };
+}

--- a/packages/agent/src/core/policy/builtin/idle-nudge.ts
+++ b/packages/agent/src/core/policy/builtin/idle-nudge.ts
@@ -1,0 +1,54 @@
+import type { PolicyRegistration } from "../types";
+
+export interface IdleNudgeConfig {
+  idleThresholdMs?: number;
+  maxNudges?: number;
+}
+
+export function createIdleNudgeMiddleware(config: IdleNudgeConfig = {}): PolicyRegistration {
+  const idleThresholdMs = config.idleThresholdMs ?? 60000;
+  const maxNudges = config.maxNudges ?? 3;
+
+  let lastProgressAt = Date.now();
+  let nudgeCount = 0;
+  let lastTurnCount = -1;
+
+  return {
+    name: "builtin:idle-nudge",
+    timing: ["pre_turn", "post_tool_use"],
+    priority: 300,
+    fn: (ctx) => {
+      if (ctx.timing === "post_tool_use") {
+        lastProgressAt = Date.now();
+        return { action: "continue" };
+      }
+
+      const turnCount = ctx.turnCount ?? 0;
+      if (turnCount === 0 && lastTurnCount > 0) {
+        lastProgressAt = Date.now();
+        nudgeCount = 0;
+      }
+      lastTurnCount = turnCount;
+
+      if (idleThresholdMs === -1) return { action: "continue" };
+
+      const idleMs = Date.now() - lastProgressAt;
+      if (idleMs <= idleThresholdMs) return { action: "continue" };
+
+      if (nudgeCount >= maxNudges) {
+        return { action: "abort", reason: "stalled", policyId: "builtin.idle_nudge" };
+      }
+
+      nudgeCount++;
+      lastProgressAt = Date.now();
+
+      const idleSecs = Math.round(idleMs / 1000);
+      return {
+        action: "inject",
+        message: `[System] You have been idle for ${idleSecs}s. Report your current status: what are you working on, what is blocking you, and what is your next action. If you are stuck, say so explicitly.`,
+        reason: "idle_nudge",
+        policyId: "builtin.idle_nudge",
+      };
+    },
+  };
+}

--- a/packages/agent/src/core/policy/builtin/index.ts
+++ b/packages/agent/src/core/policy/builtin/index.ts
@@ -1,0 +1,10 @@
+export { createBudgetReassuranceMiddleware, createBudgetWarningMiddleware } from "./budget";
+export { createCompactionMiddleware } from "./compaction";
+export { createPostToolMiddleware } from "./post-tool";
+export type { PostToolEnricher } from "./post-tool";
+export { createPostTurnMiddleware } from "./post-turn";
+export type { PostTurnHandler } from "./post-turn";
+export { createIdleNudgeMiddleware } from "./idle-nudge";
+export type { IdleNudgeConfig } from "./idle-nudge";
+export { createToolGuardMiddleware } from "./tool-guard";
+export type { ToolGuardMiddlewareConfig } from "./tool-guard";

--- a/packages/agent/src/core/policy/builtin/post-tool.ts
+++ b/packages/agent/src/core/policy/builtin/post-tool.ts
@@ -1,0 +1,36 @@
+import type { PolicyContext, PolicyRegistration } from "../types";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+export type PostToolEnricher = (ctx: PolicyContext) => string | null | Promise<string | null>;
+
+export function createPostToolMiddleware(enricher: PostToolEnricher): PolicyRegistration {
+  return {
+    name: "builtin:post-tool",
+    timing: "post_tool_use",
+    priority: 200,
+    fn: async (ctx) => {
+      let addition: string | null;
+      try {
+        addition = await enricher(ctx);
+      } catch (error) {
+        Bus.publish(Operational.Debug, {
+          traceId: ctx.traceContext?.traceId ?? crypto.randomUUID(),
+          time: Date.now(),
+          component: "agent.policy.post-tool",
+          msg: "post-tool enricher failed",
+          context: { error: String(error) },
+        });
+        return { action: "continue" };
+      }
+      if (!addition) return { action: "continue" };
+      const base = ctx.toolOutput ?? "";
+      return {
+        action: "transform",
+        input: { output: base ? `${base}\n${addition}` : addition },
+        reason: "post_tool_enrichment",
+        policyId: "builtin.post_tool",
+      };
+    },
+  };
+}

--- a/packages/agent/src/core/policy/builtin/post-turn.ts
+++ b/packages/agent/src/core/policy/builtin/post-turn.ts
@@ -1,0 +1,27 @@
+import type { PolicyContext, PolicyRegistration, PolicyVerdict } from "../types";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+export type PostTurnHandler = (ctx: PolicyContext) => Promise<PolicyVerdict> | PolicyVerdict;
+
+export function createPostTurnMiddleware(handler: PostTurnHandler): PolicyRegistration {
+  return {
+    name: "builtin:post-turn",
+    timing: "post_turn",
+    priority: 250,
+    fn: async (ctx) => {
+      try {
+        return await handler(ctx);
+      } catch (error) {
+        Bus.publish(Operational.Debug, {
+          traceId: ctx.traceContext?.traceId ?? crypto.randomUUID(),
+          time: Date.now(),
+          component: "agent.policy.post-turn",
+          msg: "post-turn handler failed",
+          context: { error: String(error) },
+        });
+        return { action: "continue" };
+      }
+    },
+  };
+}

--- a/packages/agent/src/core/policy/builtin/tool-guard.ts
+++ b/packages/agent/src/core/policy/builtin/tool-guard.ts
@@ -1,0 +1,120 @@
+import { Operational, type Guardrail } from "@openomni/protocol";
+import type { AgentEventEmitter, AgentStep, StepGuardContext, StepGuardVerdict } from "../../types";
+import type { PolicyRegistration } from "../types";
+import { Bus } from "@openomni/session";
+import { ToolGuard } from "../../tool-guard";
+import { summarizeInput } from "../../execution/shared";
+
+export interface ToolGuardMiddlewareConfig {
+  permission: Guardrail.Permission;
+  stepGuard?: (
+    step: AgentStep,
+    context: StepGuardContext,
+  ) => Promise<StepGuardVerdict> | StepGuardVerdict;
+  eventEmitter?: AgentEventEmitter;
+  source?: string;
+  onToolBlocked?: (toolCallId: string, toolName: string, reason: string) => void;
+}
+
+export function createToolGuardMiddleware(config: ToolGuardMiddlewareConfig): PolicyRegistration {
+  return {
+    name: "builtin:tool-guard",
+    timing: "pre_tool_use",
+    priority: 0,
+    failPolicy: "fail-closed",
+    fn: async (ctx) => {
+      const toolName = ctx.toolName;
+      const toolInput = ctx.toolInput;
+      if (!toolName) return { action: "continue" };
+
+      let verdict: Guardrail.EvaluationResult;
+      try {
+        verdict = ToolGuard.evaluate(toolName, toolInput ?? {}, config.permission);
+      } catch (error) {
+        Bus.publish(Operational.Debug, {
+          traceId: ctx.traceContext?.traceId ?? crypto.randomUUID(),
+          time: Date.now(),
+          component: "agent.policy.tool-guard",
+          msg: "tool guard evaluation failed",
+          context: { toolName, error: String(error) },
+        });
+        return {
+          action: "abort",
+          reason: "tool_guard_evaluation_failed",
+          policyId: "guardrail.permission",
+        };
+      }
+
+      if (verdict.action === "continue") {
+        config.eventEmitter?.emit("tool.execution.started", {
+          sessionId: config.source,
+          time: Date.now(),
+          toolCallId: ctx.toolCallId,
+          toolName,
+          inputSummary: summarizeInput(toolInput ?? {}),
+        });
+        return verdict;
+      }
+
+      if (verdict.decision !== "require_approval") {
+        config.eventEmitter?.emit("tool.execution.permission_denied", {
+          sessionId: config.source,
+          time: Date.now(),
+          toolCallId: ctx.toolCallId,
+          toolName,
+          reason: verdict.reason,
+        });
+        config.onToolBlocked?.(ctx.toolCallId ?? "", toolName, verdict.reason);
+        return verdict;
+      }
+
+      if (config.stepGuard) {
+        const input = toolInput ?? {};
+        const syntheticStep = {
+          type: "tool-call" as const,
+          content: `Tool "${toolName}" requires approval`,
+          toolCalls: [{ id: ctx.toolCallId ?? "", tool: toolName, input }],
+        };
+        const guardContext: StepGuardContext = {
+          steps: ctx.steps ?? [],
+          usage: ctx.usage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          turnCount: ctx.turnCount ?? 0,
+          isCompletion: false,
+          continuationCount: 0,
+          elapsedMs: ctx.elapsedMs ?? 0,
+        };
+        try {
+          const guardVerdict = await config.stepGuard(syntheticStep, guardContext);
+          if (guardVerdict.action === "continue") {
+            config.eventEmitter?.emit("tool.execution.started", {
+              sessionId: config.source,
+              time: Date.now(),
+              toolCallId: ctx.toolCallId,
+              toolName,
+              inputSummary: summarizeInput(input),
+            });
+            return { action: "continue", reason: verdict.reason, policyId: verdict.policyId };
+          }
+        } catch (error) {
+          Bus.publish(Operational.Debug, {
+            traceId: ctx.traceContext?.traceId ?? crypto.randomUUID(),
+            time: Date.now(),
+            component: "agent.policy.tool-guard",
+            msg: "tool guard evaluation failed",
+            context: { toolName, error: String(error) },
+          });
+        }
+      }
+
+      config.eventEmitter?.emit("tool.execution.permission_denied", {
+        sessionId: config.source,
+        time: Date.now(),
+        toolCallId: ctx.toolCallId,
+        toolName,
+        reason: verdict.reason,
+      });
+      config.onToolBlocked?.(ctx.toolCallId ?? "", toolName, verdict.reason);
+      return verdict;
+    },
+  };
+}

--- a/packages/agent/src/core/policy/engine.ts
+++ b/packages/agent/src/core/policy/engine.ts
@@ -1,0 +1,470 @@
+import { Bus } from "@openomni/session";
+import {
+  Operational,
+  PolicyEvent,
+  type Guardrail,
+  type Policy,
+  type TraceContext,
+} from "@openomni/protocol";
+import type {
+  PolicyContext,
+  PolicyEngineInstance,
+  PolicyRegistration,
+  PolicySystemPromptVerdict,
+  PolicyVerdict,
+} from "./types";
+
+const CONTINUE: Policy.Verdict = { action: "continue" };
+const POLICY_ID = "guardrail.permission";
+const MAX_REGEX_PATTERN_LENGTH = 200;
+const MAX_INPUT_LENGTH = 10_000;
+
+type AuditVisibility = "internal" | "llm_reason" | "user_audit";
+type EventVerdict = "continue" | "skip" | "abort" | "retry" | "transform" | "inject";
+
+export interface PolicyDecision {
+  readonly timing: Policy.Timing;
+  readonly label: string;
+  readonly policyId: string;
+  readonly verdict: PolicyVerdict;
+  readonly reason?: string;
+  readonly durationMs: number;
+  readonly traceContext?: TraceContext.Type;
+  readonly envelope?: PolicyContext["envelope"];
+}
+
+export interface PolicyAuditConfig {
+  readonly enabled?: boolean;
+  readonly sessionId?: string;
+  readonly actor?: Record<string, unknown>;
+  readonly action?: string;
+  readonly resource?: string;
+  readonly visibility?: AuditVisibility;
+  readonly parentActionId?: string;
+}
+
+export interface PolicyEngineConfig {
+  readonly onDecision?: (decision: PolicyDecision) => void | Promise<void>;
+  readonly traceContext?: TraceContext.Type;
+  readonly audit?: PolicyAuditConfig | false;
+}
+
+function matchesTiming(reg: PolicyRegistration, timing: Policy.Timing): boolean {
+  return Array.isArray(reg.timing) ? reg.timing.includes(timing) : reg.timing === timing;
+}
+
+function matchesScope(reg: PolicyRegistration, agentType: string | undefined): boolean {
+  const allowed = reg.scope?.agentType;
+  if (!allowed || allowed.length === 0) return true;
+  if (!agentType) return false;
+  return allowed.includes(agentType);
+}
+
+function selectRegistrations(
+  registrations: PolicyRegistration[],
+  timing: Policy.Timing,
+  agentType: string | undefined,
+): PolicyRegistration[] {
+  return registrations
+    .filter((reg) => matchesTiming(reg, timing) && matchesScope(reg, agentType))
+    .sort((a, b) => a.priority - b.priority);
+}
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function warnKey(timing: Policy.Timing, label: string): string {
+  return `${timing}:${label}`;
+}
+
+function normalizeVerdict(
+  verdict: PolicyVerdict,
+  timing: Policy.Timing,
+  label: string,
+  warnedMissingMetadata: Set<string>,
+): PolicyVerdict {
+  const missingReason = verdict.action !== "continue" && !verdict.reason;
+  const missingPolicyId = !verdict.policyId;
+
+  if (missingReason && !isProduction()) {
+    throw new Error(`Policy ${label} returned ${verdict.action} without reason at ${timing}`);
+  }
+
+  if (isProduction() && (missingReason || missingPolicyId)) {
+    const key = warnKey(timing, label);
+    if (!warnedMissingMetadata.has(key)) {
+      warnedMissingMetadata.add(key);
+      Bus.publish(Operational.Warn, {
+        traceId: crypto.randomUUID(),
+        time: Date.now(),
+        component: "agent.policy",
+        msg: "policy verdict missing metadata",
+        context: { timing, label, verdict: verdict.action, missingReason, missingPolicyId },
+      });
+    }
+  }
+
+  return isProduction() && missingPolicyId ? { ...verdict, policyId: "unknown" } : verdict;
+}
+
+function buildActor(traceContext: TraceContext.Type | undefined): Record<string, unknown> {
+  return {
+    kind: "agent",
+    ...(traceContext?.agentName !== undefined && { name: traceContext.agentName }),
+    ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
+    ...(traceContext?.taskId !== undefined && { taskId: traceContext.taskId }),
+  };
+}
+
+function resolveAction(timing: Policy.Timing, ctx: PolicyContext): string {
+  if (ctx.action) return ctx.action;
+  if (timing === "pre_tool_use" || timing === "post_tool_use") return "tool.call";
+  return `policy.${timing}`;
+}
+
+function resolveResource(reg: PolicyRegistration, ctx: PolicyContext): string {
+  return ctx.resource ?? ctx.toolName ?? reg.name;
+}
+
+function resolveEventReason(decision: PolicyDecision): string {
+  if (decision.reason) return decision.reason;
+  if (decision.verdict.reason) return decision.verdict.reason;
+  return decision.verdict.action === "continue" ? "continue" : "unspecified";
+}
+
+function toEventVerdict(action: PolicyVerdict["action"]): EventVerdict {
+  if (action === "deny") return "abort";
+  return action;
+}
+
+function matchesPattern(resource: string, pattern: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith(".*")) return resource.startsWith(`${pattern.slice(0, -2)}.`);
+  return resource === pattern;
+}
+
+// reject patterns with obvious backtracking risks: nested quantifiers like (a+)+, (a*)*
+const BACKTRACK_RISK = /([+*]|\{\d)[+*?]|\([^)]*[+*][^)]*\)[+*]/;
+
+function matchesInputField(
+  input: Record<string, unknown> | undefined,
+  field: string,
+  pattern: string,
+): boolean {
+  if (pattern.length > MAX_REGEX_PATTERN_LENGTH) return false;
+  if (BACKTRACK_RISK.test(pattern)) return false;
+
+  const raw = String(input?.[field] ?? "");
+  const value = raw.length > MAX_INPUT_LENGTH ? raw.slice(0, MAX_INPUT_LENGTH) : raw;
+
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function permissionVerdict(
+  decision: Policy.PermissionDecision,
+  reason: string,
+  matchedPattern?: string,
+): Guardrail.EvaluationResult {
+  const action: Extract<Guardrail.EvaluationResult["action"], "continue" | "abort"> =
+    decision === "allow" ? "continue" : "abort";
+  return matchedPattern === undefined
+    ? { action, decision, reason, policyId: POLICY_ID }
+    : { action, decision, reason, policyId: POLICY_ID, matchedPattern };
+}
+
+function evaluatePermission(
+  permission: Policy.Permission | undefined,
+  request: Policy.EvaluationRequest,
+): Guardrail.EvaluationResult {
+  if (!permission) return permissionVerdict("allow", "default_allow");
+  if (permission.action !== request.action) return permissionVerdict("deny", "action_mismatch");
+
+  const inputRules = [...(permission.inputRules ?? [])].sort(
+    (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
+  );
+
+  for (const rule of inputRules) {
+    if (
+      matchesPattern(request.resource, rule.toolPattern) &&
+      matchesInputField(request.input, rule.field, rule.pattern)
+    ) {
+      return permissionVerdict(
+        rule.action,
+        rule.reason ?? `input_rule_${rule.action}`,
+        rule.toolPattern,
+      );
+    }
+  }
+
+  const deniedBy = permission.denylist?.find((pattern) =>
+    matchesPattern(request.resource, pattern),
+  );
+  if (deniedBy) return permissionVerdict("deny", "denylist", deniedBy);
+
+  const requiresApprovalBy = permission.requireApproval?.find((pattern) =>
+    matchesPattern(request.resource, pattern),
+  );
+  if (requiresApprovalBy) {
+    return permissionVerdict("require_approval", "require_approval", requiresApprovalBy);
+  }
+
+  if (permission.allowlist !== undefined) {
+    const allowedBy = permission.allowlist.find((pattern) =>
+      matchesPattern(request.resource, pattern),
+    );
+
+    if (allowedBy) return permissionVerdict("allow", "allowlist", allowedBy);
+
+    return permissionVerdict(
+      "deny",
+      permission.allowlist.length === 0 ? "allowlist_empty" : "allowlist_miss",
+    );
+  }
+
+  return permissionVerdict("allow", "default_allow");
+}
+
+function cloneRegistration(reg: PolicyRegistration): PolicyRegistration {
+  return {
+    ...reg,
+    timing: Array.isArray(reg.timing) ? [...reg.timing] : reg.timing,
+    ...(reg.scope !== undefined && {
+      scope: {
+        ...reg.scope,
+        ...(reg.scope.agentType !== undefined && { agentType: [...reg.scope.agentType] }),
+      },
+    }),
+  };
+}
+
+function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
+  const registrations: PolicyRegistration[] = [];
+  const warnedMissingMetadata = new Set<string>();
+  let frozen = false;
+
+  function isAuditEnabled(): boolean {
+    if (options.audit === false) return false;
+    return options.audit?.enabled ?? true;
+  }
+
+  function publishPolicyEvent(
+    decision: PolicyDecision,
+    reg: PolicyRegistration,
+    ctx: PolicyContext,
+  ): void {
+    if (!isAuditEnabled()) return;
+
+    const audit = options.audit === false ? undefined : options.audit;
+    const traceContext = decision.traceContext;
+    const traceId = traceContext?.traceId;
+    const sessionId = audit?.sessionId ?? traceContext?.sessionId;
+    if (!sessionId || !traceId) return;
+
+    Bus.publish(PolicyEvent.Evaluated, {
+      traceId,
+      sessionId,
+      ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
+      time: Date.now(),
+      policyId: decision.policyId,
+      actor: audit?.actor ?? ctx.actor ?? buildActor(traceContext),
+      action: audit?.action ?? resolveAction(decision.timing, ctx),
+      resource: audit?.resource ?? resolveResource(reg, ctx),
+      verdict: toEventVerdict(decision.verdict.action),
+      reason: resolveEventReason(decision),
+      beforeSideEffect: {
+        timing: decision.timing,
+        label: decision.label,
+        durationMs: decision.durationMs,
+        visibility: audit?.visibility ?? "internal",
+        ...(audit?.parentActionId !== undefined && { parentActionId: audit.parentActionId }),
+      },
+    });
+  }
+
+  async function recordDecision(
+    reg: PolicyRegistration,
+    ctx: PolicyContext,
+    verdict: PolicyVerdict,
+    durationMs: number,
+  ): Promise<PolicyVerdict> {
+    const normalized = normalizeVerdict(verdict, ctx.timing, reg.name, warnedMissingMetadata);
+    const traceContext = ctx.traceContext ?? options.traceContext;
+    const decision: PolicyDecision = {
+      timing: ctx.timing,
+      label: reg.name,
+      policyId: normalized.policyId ?? "unknown",
+      verdict: normalized,
+      durationMs,
+      ...(normalized.reason !== undefined && { reason: normalized.reason }),
+      ...(traceContext !== undefined && { traceContext }),
+      ...(ctx.envelope !== undefined && { envelope: ctx.envelope }),
+    };
+
+    publishPolicyEvent(decision, reg, ctx);
+    await options.onDecision?.(decision);
+    return normalized;
+  }
+
+  async function dispatch<T = unknown>(
+    timing: Policy.Timing,
+    ctx: Omit<PolicyContext<T>, "timing">,
+  ): Promise<PolicyVerdict> {
+    const selected = selectRegistrations(registrations, timing, ctx.agentType);
+    const fullCtx = { ...ctx, timing } as PolicyContext<T>;
+
+    for (const reg of selected) {
+      let verdict: PolicyVerdict;
+      const startTime = Date.now();
+      try {
+        verdict = await reg.fn(fullCtx);
+      } catch (err) {
+        const durationMs = Date.now() - startTime;
+        const failPolicy = reg.failPolicy ?? "fail-open";
+        Bus.publish(Operational.Warn, {
+          traceId:
+            fullCtx.traceContext?.traceId ?? options.traceContext?.traceId ?? crypto.randomUUID(),
+          time: Date.now(),
+          component: "agent.policy",
+          msg: "policy error",
+          context: { timing, name: reg.name, error: String(err), failPolicy, durationMs },
+        });
+        if (failPolicy === "fail-closed") {
+          return recordDecision(
+            reg,
+            fullCtx,
+            { action: "abort", reason: "policy-error", policyId: reg.name },
+            durationMs,
+          );
+        }
+        continue;
+      }
+
+      const durationMs = Date.now() - startTime;
+      verdict = await recordDecision(reg, fullCtx, verdict, durationMs);
+      Bus.publish(Operational.Debug, {
+        traceId:
+          fullCtx.traceContext?.traceId ?? options.traceContext?.traceId ?? crypto.randomUUID(),
+        time: Date.now(),
+        component: "agent.policy",
+        msg: "policy dispatch",
+        context: { timing, name: reg.name, verdict: verdict.action, durationMs },
+      });
+
+      if (verdict.action !== "continue") {
+        return verdict;
+      }
+    }
+
+    return CONTINUE;
+  }
+
+  async function dispatchSystemPrompt<T = unknown>(
+    ctx: Omit<PolicyContext<T>, "timing">,
+  ): Promise<PolicySystemPromptVerdict> {
+    const selected = selectRegistrations(registrations, "on_system_prompt", ctx.agentType);
+    const fullCtx = { ...ctx, timing: "on_system_prompt" } as PolicyContext<T>;
+
+    let systemPrompt: string | undefined;
+    const prependParts: string[] = [];
+    const appendParts: string[] = [];
+
+    for (const reg of selected) {
+      let verdict: PolicyVerdict;
+      const startTime = Date.now();
+      try {
+        verdict = await reg.fn(fullCtx);
+      } catch (err) {
+        const durationMs = Date.now() - startTime;
+        const failPolicy = reg.failPolicy ?? "fail-open";
+        Bus.publish(Operational.Warn, {
+          traceId:
+            fullCtx.traceContext?.traceId ?? options.traceContext?.traceId ?? crypto.randomUUID(),
+          time: Date.now(),
+          component: "agent.policy",
+          msg: "policy error",
+          context: {
+            timing: "on_system_prompt",
+            name: reg.name,
+            error: String(err),
+            failPolicy,
+            durationMs,
+          },
+        });
+        if (failPolicy === "fail-closed") {
+          throw err;
+        }
+        continue;
+      }
+
+      const durationMs = Date.now() - startTime;
+      verdict = await recordDecision(reg, fullCtx, verdict, durationMs);
+      Bus.publish(Operational.Debug, {
+        traceId:
+          fullCtx.traceContext?.traceId ?? options.traceContext?.traceId ?? crypto.randomUUID(),
+        time: Date.now(),
+        component: "agent.policy",
+        msg: "policy dispatch",
+        context: {
+          timing: "on_system_prompt",
+          name: reg.name,
+          verdict: verdict.action,
+          durationMs,
+        },
+      });
+
+      if (verdict.action === "transform") {
+        const input = verdict.input as {
+          systemPrompt?: unknown;
+          prependContext?: unknown;
+          appendContext?: unknown;
+        };
+        if (systemPrompt === undefined && typeof input.systemPrompt === "string") {
+          systemPrompt = input.systemPrompt;
+        }
+        if (typeof input.prependContext === "string") {
+          prependParts.push(input.prependContext);
+        }
+        if (typeof input.appendContext === "string") {
+          appendParts.push(input.appendContext);
+        }
+      } else if (verdict.action === "inject") {
+        appendParts.push(verdict.message);
+      }
+    }
+
+    const result: PolicySystemPromptVerdict = {};
+    if (systemPrompt !== undefined) result.systemPrompt = systemPrompt;
+    if (prependParts.length > 0) result.prependContext = prependParts.join("\n\n");
+    if (appendParts.length > 0) result.appendContext = appendParts.join("\n\n");
+    return result;
+  }
+
+  const instance: PolicyEngineInstance = {
+    register(policy) {
+      if (frozen) {
+        throw new Error("PolicyEngine is frozen; register() cannot be called after freeze()");
+      }
+      registrations.push(policy as PolicyRegistration);
+      return instance;
+    },
+    freeze() {
+      frozen = true;
+      return instance;
+    },
+    dispatch,
+    dispatchSystemPrompt,
+    evaluatePermission,
+    deriveChildPolicies() {
+      return registrations.filter((reg) => reg.propagate === true).map(cloneRegistration);
+    },
+  };
+
+  return instance;
+}
+
+export const PolicyEngine = { create, evaluatePermission };

--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -1,0 +1,15 @@
+export { PolicyEngine } from "./engine";
+export type {
+  PolicyAuditConfig,
+  PolicyDecision,
+  PolicyEngineConfig,
+} from "./engine";
+export type {
+  PolicyContext,
+  PolicyEngineInstance,
+  PolicyFn,
+  PolicyRegistration,
+  PolicySystemPromptVerdict,
+  PolicyVerdict,
+} from "./types";
+export * from "./builtin";

--- a/packages/agent/src/core/policy/types.ts
+++ b/packages/agent/src/core/policy/types.ts
@@ -1,0 +1,66 @@
+import type { Guardrail, Message, Messenger, Policy, TraceContext } from "@openomni/protocol";
+import type { AgentBudget, AgentEventEmitter, AgentStep, TokenUsage } from "../types";
+import type { BudgetState } from "../budget";
+
+export type PolicyVerdict = Policy.Verdict | Guardrail.EvaluationResult;
+
+export interface PolicyContext<T = unknown> {
+  timing: Policy.Timing;
+  action?: string;
+  resource?: string;
+  input?: Record<string, unknown>;
+  actor?: Record<string, unknown>;
+  resourceMeta?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  data?: T;
+  tools?: readonly string[];
+  agentType?: string;
+  traceContext?: TraceContext.Type;
+  envelope?: Messenger.MessageEnvelope;
+  steps?: AgentStep[];
+  usage?: TokenUsage;
+  turnCount?: number;
+  isCompletion?: boolean;
+  continuationCount?: number;
+  elapsedMs?: number;
+  toolName?: string;
+  toolCallId?: string;
+  toolInput?: Record<string, unknown>;
+  toolOutput?: string;
+  messages?: Message.WithParts[];
+  budgetState?: BudgetState;
+  eventEmitter?: AgentEventEmitter;
+  budget?: AgentBudget;
+}
+
+export type PolicyFn<T = unknown> = (
+  ctx: PolicyContext<T>,
+) => Promise<PolicyVerdict> | PolicyVerdict;
+
+export interface PolicyRegistration<T = unknown> extends Policy.Definition {
+  fn: PolicyFn<T>;
+  propagate?: boolean;
+}
+
+export interface PolicySystemPromptVerdict {
+  systemPrompt?: string;
+  prependContext?: string;
+  appendContext?: string;
+}
+
+export interface PolicyEngineInstance {
+  register<T = unknown>(policy: PolicyRegistration<T>): PolicyEngineInstance;
+  freeze(): PolicyEngineInstance;
+  dispatch<T = unknown>(
+    timing: Policy.Timing,
+    ctx: Omit<PolicyContext<T>, "timing">,
+  ): Promise<PolicyVerdict>;
+  dispatchSystemPrompt<T = unknown>(
+    ctx: Omit<PolicyContext<T>, "timing">,
+  ): Promise<PolicySystemPromptVerdict>;
+  evaluatePermission(
+    permission: Policy.Permission | undefined,
+    request: Policy.EvaluationRequest,
+  ): Guardrail.EvaluationResult;
+  deriveChildPolicies(): PolicyRegistration[];
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,4 @@
-// Agent package public API — ChatAgent only
+// Agent package public API
 export { ChatAgent } from "./core/chat-agent";
 export type { ChatAgentInstance } from "./core/chat-agent";
 export type {
@@ -39,6 +39,18 @@ export type {
   MiddlewareEngineConfig,
   MiddlewareEngineInstance,
 } from "./core/middleware";
+export { PolicyEngine } from "./core/policy";
+export type {
+  PolicyAuditConfig,
+  PolicyContext,
+  PolicyDecision,
+  PolicyEngineConfig,
+  PolicyEngineInstance,
+  PolicyFn,
+  PolicyRegistration,
+  PolicySystemPromptVerdict,
+  PolicyVerdict,
+} from "./core/policy";
 export { AgentRegistry } from "./runtime/index";
 export { SubagentTool } from "./runtime/index";
 export type { SubagentToolOptions } from "./runtime/index";

--- a/packages/agent/test/core/policy/engine.test.ts
+++ b/packages/agent/test/core/policy/engine.test.ts
@@ -1,0 +1,799 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Operational, PolicyEvent, type Guardrail } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { PolicyEngine } from "../../../src/core/policy";
+import type { PolicyContext, PolicyDecision } from "../../../src/core/policy";
+
+function baseCtx(): Omit<PolicyContext, "timing"> {
+  return {};
+}
+
+function env(): Record<string, string | undefined> {
+  return (globalThis as unknown as { process: { env: Record<string, string | undefined> } }).process
+    .env;
+}
+
+async function expectRejectsWith(promise: Promise<unknown>, message: string): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(message);
+    return;
+  }
+  throw new Error(`Expected promise to reject with ${message}`);
+}
+
+describe("PolicyEngine", () => {
+  it("returns continue when no policies are registered", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const verdict = await engine.dispatch("pre_turn", baseCtx());
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("executes policies in priority order (ascending)", async () => {
+    const order: number[] = [];
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "third",
+      timing: "pre_turn",
+      priority: 300,
+      fn: () => {
+        order.push(300);
+        return { action: "continue", reason: "ok", policyId: "p.third" };
+      },
+    });
+    engine.register({
+      name: "first",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => {
+        order.push(100);
+        return { action: "continue", reason: "ok", policyId: "p.first" };
+      },
+    });
+    engine.register({
+      name: "second",
+      timing: "pre_turn",
+      priority: 200,
+      fn: () => {
+        order.push(200);
+        return { action: "continue", reason: "ok", policyId: "p.second" };
+      },
+    });
+
+    await engine.dispatch("pre_turn", baseCtx());
+    expect(order).toEqual([100, 200, 300]);
+  });
+
+  it("short-circuits on first non-continue verdict", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const third = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.third",
+    }));
+    engine.register({
+      name: "a",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => ({ action: "continue", reason: "ok", policyId: "p.a" }),
+    });
+    engine.register({
+      name: "b",
+      timing: "pre_turn",
+      priority: 200,
+      fn: () => ({ action: "abort", reason: "blocked", policyId: "p.b" }),
+    });
+    engine.register({ name: "c", timing: "pre_turn", priority: 300, fn: third });
+
+    const verdict = await engine.dispatch("pre_turn", baseCtx());
+    expect(verdict.action).toBe("abort");
+    expect(third).toHaveBeenCalledTimes(0);
+  });
+
+  it("skip verdict stops the chain", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const after = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.after",
+    }));
+    engine.register({
+      name: "skipper",
+      timing: "pre_tool_use",
+      priority: 100,
+      fn: () => ({ action: "skip", reason: "not allowed", policyId: "p.skipper" }),
+    });
+    engine.register({ name: "after", timing: "pre_tool_use", priority: 200, fn: after });
+
+    const verdict = await engine.dispatch("pre_tool_use", baseCtx());
+    expect(verdict.action).toBe("skip");
+    expect(after).toHaveBeenCalledTimes(0);
+  });
+
+  it("retry verdict stops the chain", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "retrier",
+      timing: "on_error",
+      priority: 100,
+      fn: () => ({ action: "retry", reason: "transient", policyId: "p.retrier" }),
+    });
+
+    const verdict = await engine.dispatch("on_error", baseCtx());
+    expect(verdict.action).toBe("retry");
+  });
+
+  it("fail-open: policy error is swallowed and chain continues", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const after = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.after",
+    }));
+    engine.register({
+      name: "boom",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => {
+        throw new Error("kaboom");
+      },
+    });
+    engine.register({ name: "after", timing: "pre_turn", priority: 200, fn: after });
+
+    const verdict = await engine.dispatch("pre_turn", baseCtx());
+    expect(verdict).toEqual({ action: "continue" });
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+
+  it("fail-closed: policy error aborts immediately", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const after = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.after",
+    }));
+    engine.register({
+      name: "boom",
+      timing: "pre_turn",
+      priority: 100,
+      failPolicy: "fail-closed",
+      fn: () => {
+        throw new Error("kaboom");
+      },
+    });
+    engine.register({ name: "after", timing: "pre_turn", priority: 200, fn: after });
+
+    const verdict = await engine.dispatch("pre_turn", baseCtx());
+    expect(verdict.action).toBe("abort");
+    expect(after).toHaveBeenCalledTimes(0);
+  });
+
+  it("scope filtering: only runs policies matching agentType", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const scoped = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.scoped",
+    }));
+    const unscoped = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.unscoped",
+    }));
+    engine.register({
+      name: "scoped",
+      timing: "pre_turn",
+      priority: 100,
+      scope: { agentType: ["subagent"] },
+      fn: scoped,
+    });
+    engine.register({ name: "unscoped", timing: "pre_turn", priority: 200, fn: unscoped });
+
+    await engine.dispatch("pre_turn", { ...baseCtx(), agentType: "primary" });
+
+    expect(scoped).toHaveBeenCalledTimes(0);
+    expect(unscoped).toHaveBeenCalledTimes(1);
+  });
+
+  it("scope filtering: runs scoped policy when agentType matches", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const scoped = mock(() => ({
+      action: "continue" as const,
+      reason: "ok",
+      policyId: "p.scoped",
+    }));
+    engine.register({
+      name: "scoped",
+      timing: "pre_turn",
+      priority: 100,
+      scope: { agentType: ["subagent", "reviewer"] },
+      fn: scoped,
+    });
+
+    await engine.dispatch("pre_turn", { ...baseCtx(), agentType: "reviewer" });
+    expect(scoped).toHaveBeenCalledTimes(1);
+  });
+
+  it("freeze prevents further registration", () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "pre-freeze",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => ({ action: "continue", reason: "ok", policyId: "p.pre" }),
+    });
+    engine.freeze();
+
+    expect(() =>
+      engine.register({
+        name: "post-freeze",
+        timing: "pre_turn",
+        priority: 200,
+        fn: () => ({ action: "continue", reason: "ok", policyId: "p.post" }),
+      }),
+    ).toThrow("PolicyEngine is frozen");
+  });
+
+  it("deriveChildPolicies returns only propagated registrations as clones", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const fnA = () => ({ action: "continue" as const, reason: "ok", policyId: "p.a" });
+    const fnB = () => ({ action: "continue" as const, reason: "ok", policyId: "p.b" });
+
+    engine.register({
+      name: "propagated",
+      timing: "pre_turn",
+      priority: 100,
+      propagate: true,
+      scope: { agentType: ["subagent"] },
+      fn: fnA,
+    });
+    engine.register({
+      name: "local-only",
+      timing: "pre_turn",
+      priority: 200,
+      fn: fnB,
+    });
+
+    const children = engine.deriveChildPolicies();
+    expect(children).toHaveLength(1);
+    const child = children.at(0);
+    expect(child?.name).toBe("propagated");
+    expect(child?.fn).toBe(fnA);
+
+    child?.scope?.agentType?.push("mutant");
+    const children2 = engine.deriveChildPolicies();
+    expect(children2.at(0)?.scope?.agentType).toEqual(["subagent"]);
+  });
+
+  it("dispatchSystemPrompt composes transform and inject verdicts", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "prompt-a",
+      timing: "on_system_prompt",
+      priority: 100,
+      fn: () => ({
+        action: "transform",
+        input: { systemPrompt: "BASE_PROMPT", appendContext: "ctx-a" },
+        reason: "prompt-a",
+        policyId: "p.prompt-a",
+      }),
+    });
+    engine.register({
+      name: "prompt-b",
+      timing: "on_system_prompt",
+      priority: 200,
+      fn: () => ({
+        action: "transform",
+        input: { systemPrompt: "IGNORED", prependContext: "pre-b", appendContext: "ctx-b" },
+        reason: "prompt-b",
+        policyId: "p.prompt-b",
+      }),
+    });
+    engine.register({
+      name: "injector",
+      timing: "on_system_prompt",
+      priority: 300,
+      fn: () => ({
+        action: "inject",
+        message: "injected-msg",
+        reason: "injector",
+        policyId: "p.injector",
+      }),
+    });
+
+    const result = await engine.dispatchSystemPrompt(baseCtx());
+    expect(result.systemPrompt).toBe("BASE_PROMPT");
+    expect(result.prependContext).toBe("pre-b");
+    expect(result.appendContext).toBe("ctx-a\n\nctx-b\n\ninjected-msg");
+  });
+
+  it("dispatchSystemPrompt returns empty object when no transforms", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "noop",
+      timing: "on_system_prompt",
+      priority: 100,
+      fn: () => ({ action: "continue", reason: "pass", policyId: "p.noop" }),
+    });
+
+    const result = await engine.dispatchSystemPrompt(baseCtx());
+    expect(result).toEqual({});
+  });
+
+  it("onDecision callback receives correct decision metadata", async () => {
+    const decisions: PolicyDecision[] = [];
+    const engine = PolicyEngine.create({
+      audit: false,
+      onDecision: (d) => {
+        decisions.push(d);
+      },
+    });
+    engine.register({
+      name: "test-policy",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => ({ action: "abort", reason: "blocked", policyId: "test.block" }),
+    });
+
+    await engine.dispatch("pre_turn", baseCtx());
+
+    expect(decisions).toHaveLength(1);
+    const decision = decisions.at(0);
+    expect(decision?.timing).toBe("pre_turn");
+    expect(decision?.label).toBe("test-policy");
+    expect(decision?.policyId).toBe("test.block");
+    expect(decision?.verdict.action).toBe("abort");
+    expect(decision?.reason).toBe("blocked");
+    expect(typeof decision?.durationMs).toBe("number");
+  });
+
+  it("onDecision fires for every policy in chain (not just terminal)", async () => {
+    const decisions: PolicyDecision[] = [];
+    const engine = PolicyEngine.create({
+      audit: false,
+      onDecision: (d) => {
+        decisions.push(d);
+      },
+    });
+    engine.register({
+      name: "first",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => ({ action: "continue", policyId: "p.first" }),
+    });
+    engine.register({
+      name: "second",
+      timing: "pre_turn",
+      priority: 200,
+      fn: () => ({ action: "abort", reason: "stop", policyId: "p.second" }),
+    });
+
+    await engine.dispatch("pre_turn", baseCtx());
+    expect(decisions).toHaveLength(2);
+    expect(decisions.map((decision) => decision.label)).toEqual(["first", "second"]);
+  });
+
+  it("runs policy at multiple timings when timing is an array", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const fn = mock(() => ({ action: "continue" as const, reason: "ok", policyId: "p.multi" }));
+    engine.register({
+      name: "multi",
+      timing: ["pre_turn", "post_turn"],
+      priority: 100,
+      fn,
+    });
+
+    await engine.dispatch("pre_turn", baseCtx());
+    await engine.dispatch("post_turn", baseCtx());
+    await engine.dispatch("on_error", baseCtx());
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws in dev when non-continue verdict lacks reason", async () => {
+    const prev = env().NODE_ENV;
+    env().NODE_ENV = "development";
+    try {
+      const engine = PolicyEngine.create({ audit: false });
+      engine.register({
+        name: "no-reason",
+        timing: "pre_turn",
+        priority: 100,
+        fn: () => ({ action: "abort" }),
+      });
+
+      await expectRejectsWith(
+        engine.dispatch("pre_turn", baseCtx()),
+        "Policy no-reason returned abort without reason at pre_turn",
+      );
+    } finally {
+      if (prev === undefined) delete env().NODE_ENV;
+      else env().NODE_ENV = prev;
+    }
+  });
+
+  it("tags unknown policyId in production and warns once", async () => {
+    const prev = env().NODE_ENV;
+    env().NODE_ENV = "production";
+    const warnings: unknown[] = [];
+    const unsub = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+    try {
+      const decisions: PolicyDecision[] = [];
+      const engine = PolicyEngine.create({
+        audit: false,
+        onDecision: (d) => {
+          decisions.push(d);
+        },
+      });
+      engine.register({
+        name: "prod-no-meta",
+        timing: "pre_turn",
+        priority: 100,
+        fn: () => ({ action: "abort" }),
+      });
+
+      const v1 = await engine.dispatch("pre_turn", baseCtx());
+      const v2 = await engine.dispatch("pre_turn", baseCtx());
+
+      expect(v1).toEqual({ action: "abort", policyId: "unknown" });
+      expect(v2).toEqual({ action: "abort", policyId: "unknown" });
+      await Promise.resolve();
+      expect(warnings).toHaveLength(1);
+    } finally {
+      unsub();
+      Bus.reset();
+      if (prev === undefined) delete env().NODE_ENV;
+      else env().NODE_ENV = prev;
+    }
+  });
+
+  describe("evaluatePermission", () => {
+    const engine = PolicyEngine.create({ audit: false });
+
+    it("returns allow when permission is undefined (default allow)", () => {
+      const result = engine.evaluatePermission(undefined, {
+        action: "tool.call",
+        resource: "shell",
+      });
+      expect(result.action).toBe("continue");
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toBe("default_allow");
+    });
+
+    it("returns a result assignable to the legacy Guardrail evaluation result", () => {
+      const result: Guardrail.EvaluationResult = engine.evaluatePermission(undefined, {
+        action: "tool.call",
+        resource: "shell",
+      });
+
+      expect(result.policyId).toBe("guardrail.permission");
+    });
+
+    it("evaluates representative permission inputs correctly", () => {
+      const permission = {
+        action: "tool.call",
+        allowlist: ["safe.*"],
+        denylist: ["safe.blocked"],
+        requireApproval: ["safe.review"],
+        inputRules: [
+          {
+            toolPattern: "safe.*",
+            field: "text",
+            pattern: "secret",
+            action: "deny" as const,
+            priority: 10,
+          },
+        ],
+      };
+
+      const allowed = engine.evaluatePermission(permission, {
+        action: "tool.call",
+        resource: "safe.echo",
+        input: { text: "hello" },
+      });
+      expect(allowed.decision).toBe("allow");
+      expect(allowed.reason).toBe("allowlist");
+
+      const inputDenied = engine.evaluatePermission(permission, {
+        action: "tool.call",
+        resource: "safe.echo",
+        input: { text: "secret" },
+      });
+      expect(inputDenied.decision).toBe("deny");
+
+      const denylistBlocked = engine.evaluatePermission(permission, {
+        action: "tool.call",
+        resource: "safe.blocked",
+        input: {},
+      });
+      expect(denylistBlocked.decision).toBe("deny");
+      expect(denylistBlocked.reason).toBe("denylist");
+
+      const approvalRequired = engine.evaluatePermission(permission, {
+        action: "tool.call",
+        resource: "safe.review",
+        input: {},
+      });
+      expect(approvalRequired.decision).toBe("require_approval");
+
+      const actionMismatch = engine.evaluatePermission(permission, {
+        action: "other",
+        resource: "safe.echo",
+        input: {},
+      });
+      expect(actionMismatch.decision).toBe("deny");
+      expect(actionMismatch.reason).toBe("action_mismatch");
+    });
+
+    it("returns deny when action does not match permission action", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call" },
+        { action: "file.write", resource: "shell" },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toBe("action_mismatch");
+    });
+
+    it("allows resource in allowlist", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", allowlist: ["shell", "grep"] },
+        { action: "tool.call", resource: "shell" },
+      );
+      expect(result.action).toBe("continue");
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toBe("allowlist");
+      expect(result.matchedPattern).toBe("shell");
+    });
+
+    it("denies resource in denylist even when in allowlist", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", allowlist: ["shell", "grep"], denylist: ["shell"] },
+        { action: "tool.call", resource: "shell" },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toBe("denylist");
+    });
+
+    it("returns require_approval for matching requireApproval pattern", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", requireApproval: ["shell"] },
+        { action: "tool.call", resource: "shell" },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("require_approval");
+      expect(result.reason).toBe("require_approval");
+    });
+
+    it("denies resource not in allowlist (allowlist_miss)", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", allowlist: ["grep", "find"] },
+        { action: "tool.call", resource: "shell" },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toBe("allowlist_miss");
+    });
+
+    it("denies when allowlist is empty", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", allowlist: [] },
+        { action: "tool.call", resource: "shell" },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toBe("allowlist_empty");
+    });
+
+    it("allows by default when no lists defined", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call" },
+        { action: "tool.call", resource: "shell" },
+      );
+      expect(result.action).toBe("continue");
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toBe("default_allow");
+    });
+
+    it("matches wildcard patterns in allowlist", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", allowlist: ["*"] },
+        { action: "tool.call", resource: "anything" },
+      );
+      expect(result.action).toBe("continue");
+      expect(result.decision).toBe("allow");
+      expect(result.matchedPattern).toBe("*");
+    });
+
+    it("matches prefix wildcard in denylist (e.g. fs.*)", () => {
+      const result = engine.evaluatePermission(
+        { action: "tool.call", denylist: ["fs.*"] },
+        { action: "tool.call", resource: "fs.write" },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("deny");
+      expect(result.matchedPattern).toBe("fs.*");
+    });
+
+    it("inputRules take precedence over deny/allow lists", () => {
+      const result = engine.evaluatePermission(
+        {
+          action: "tool.call",
+          allowlist: ["shell"],
+          inputRules: [
+            {
+              toolPattern: "shell",
+              field: "command",
+              pattern: "rm\\s+-rf",
+              action: "deny",
+              reason: "dangerous_command",
+              priority: 0,
+            },
+          ],
+        },
+        { action: "tool.call", resource: "shell", input: { command: "rm -rf /" } },
+      );
+      expect(result.action).toBe("abort");
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toBe("dangerous_command");
+    });
+
+    it("inputRules respect priority order (higher first)", () => {
+      const result = engine.evaluatePermission(
+        {
+          action: "tool.call",
+          inputRules: [
+            {
+              toolPattern: "shell",
+              field: "command",
+              pattern: ".*",
+              action: "deny",
+              reason: "catch_all",
+              priority: 0,
+            },
+            {
+              toolPattern: "shell",
+              field: "command",
+              pattern: "echo",
+              action: "allow",
+              reason: "safe_echo",
+              priority: 10,
+            },
+          ],
+        },
+        { action: "tool.call", resource: "shell", input: { command: "echo hello" } },
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toBe("safe_echo");
+    });
+  });
+
+  it("dispatchSystemPrompt fail-closed rethrows error", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "boom",
+      timing: "on_system_prompt",
+      priority: 100,
+      failPolicy: "fail-closed",
+      fn: () => {
+        throw new Error("system-prompt-crash");
+      },
+    });
+
+    await expectRejectsWith(engine.dispatchSystemPrompt(baseCtx()), "system-prompt-crash");
+  });
+
+  it("dispatchSystemPrompt fail-open skips errored policy and continues", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "boom",
+      timing: "on_system_prompt",
+      priority: 100,
+      fn: () => {
+        throw new Error("ignored");
+      },
+    });
+    engine.register({
+      name: "ok",
+      timing: "on_system_prompt",
+      priority: 200,
+      fn: () => ({
+        action: "inject",
+        message: "survived",
+        reason: "ok",
+        policyId: "p.ok",
+      }),
+    });
+
+    const result = await engine.dispatchSystemPrompt(baseCtx());
+    expect(result.appendContext).toBe("survived");
+  });
+
+  it("async policy functions are awaited", async () => {
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register({
+      name: "async-policy",
+      timing: "pre_turn",
+      priority: 100,
+      fn: async () => {
+        await Promise.resolve().then(() => undefined);
+        return { action: "abort", reason: "async-block", policyId: "p.async" };
+      },
+    });
+
+    const verdict = await engine.dispatch("pre_turn", baseCtx());
+    expect(verdict.action).toBe("abort");
+  });
+
+  it("freeze returns the engine for chaining", () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const result = engine.freeze();
+    expect(result).toBe(engine);
+  });
+
+  it("register returns the engine for chaining", () => {
+    const engine = PolicyEngine.create({ audit: false });
+    const result = engine.register({
+      name: "chain-test",
+      timing: "pre_turn",
+      priority: 100,
+      fn: () => ({ action: "continue", reason: "ok", policyId: "p.chain" }),
+    });
+    expect(result).toBe(engine);
+  });
+
+  it("publishes PolicyEvent.Evaluated via Bus when session context is available", async () => {
+    const published: unknown[] = [];
+    const unsub = Bus.subscribe(PolicyEvent.Evaluated, (data) => {
+      published.push(data);
+    });
+
+    try {
+      const engine = PolicyEngine.create({
+        traceContext: {
+          traceId: "trace-policy-engine",
+          sessionId: "sess-policy-engine",
+          runId: "run-policy-engine",
+          agentName: "policy-engine-agent",
+        },
+      });
+      engine.register({
+        name: "policy-check",
+        timing: "pre_tool_use",
+        priority: 100,
+        fn: () => ({
+          action: "abort",
+          reason: "blocked_by_policy_engine",
+          policyId: "test.policy-engine",
+        }),
+      });
+
+      await engine.dispatch("pre_tool_use", { toolName: "shell" });
+      await Promise.resolve();
+
+      expect(published).toHaveLength(1);
+      expect(published[0]).toMatchObject({
+        traceId: "trace-policy-engine",
+        sessionId: "sess-policy-engine",
+        runId: "run-policy-engine",
+        policyId: "test.policy-engine",
+        actor: { kind: "agent", name: "policy-engine-agent", runId: "run-policy-engine" },
+        action: "tool.call",
+        resource: "shell",
+        verdict: "abort",
+        reason: "blocked_by_policy_engine",
+        beforeSideEffect: {
+          timing: "pre_tool_use",
+          label: "policy-check",
+          visibility: "internal",
+        },
+      });
+    } finally {
+      unsub();
+      Bus.reset();
+    }
+  });
+});

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -71,6 +71,9 @@ export {
   BackgroundManager,
 } from "./subagent";
 
+// Policy compatibility exports
+export { BackgroundLimitsMiddleware } from "./policy";
+
 // Execution runtime
 export {
   AgentToolProvider,

--- a/packages/openomni/src/policy/background-limits.ts
+++ b/packages/openomni/src/policy/background-limits.ts
@@ -1,0 +1,284 @@
+import {
+  MiddlewareEngine,
+  type MiddlewareDecision,
+  type MiddlewareRegistration,
+} from "@openomni/agent";
+import {
+  Operational,
+  type Hook,
+  type Middleware,
+  type Subagent,
+  type TraceContext,
+} from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+interface LaunchRequest {
+  readonly agentName: string;
+  readonly prompt: string;
+  readonly model: { readonly provider: string; readonly id: string };
+  readonly parentSessionId: string;
+  readonly depth?: number;
+}
+
+interface BackgroundLimitState {
+  readonly input: LaunchRequest;
+  readonly depth: number;
+  readonly activeTasks: readonly Subagent.BackgroundTask[];
+  readonly activeCount: number;
+  readonly pendingQueueSize: number;
+  readonly maxConcurrentPerAgent: number;
+  readonly maxConcurrentTotal: number;
+  readonly maxDepth: number;
+  readonly maxDescendants: number;
+  readonly maxQueueSize: number;
+  shouldQueue?: boolean;
+}
+
+function continueVerdict(policyId: string, reason: string): Hook.Verdict {
+  return { action: "continue", policyId, reason };
+}
+
+function denyVerdict(reason: string): Hook.Verdict {
+  return { action: "abort", reason };
+}
+
+function createPerAgentLimit(state: BackgroundLimitState): MiddlewareRegistration {
+  return {
+    ...BackgroundLimitsMiddleware.PerAgent,
+    failPolicy: "fail-closed",
+    fn: () => {
+      const count = state.activeTasks.filter((t) => t.agentName === state.input.agentName).length;
+      if (count >= state.maxConcurrentPerAgent) {
+        Bus.publish(Operational.Warn, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          component: "openomni.policy.background-limits",
+          msg: "background.limit.per-agent",
+          context: {
+            agentName: state.input.agentName,
+            count,
+            limit: state.maxConcurrentPerAgent,
+          },
+        });
+        return denyVerdict(
+          `max concurrent tasks per agent (${state.maxConcurrentPerAgent}) exceeded`,
+        );
+      }
+
+      return continueVerdict("background.per-agent-limit", "per-agent capacity available");
+    },
+  };
+}
+
+function createDepthLimit(state: BackgroundLimitState): MiddlewareRegistration {
+  return {
+    ...BackgroundLimitsMiddleware.Depth,
+    failPolicy: "fail-closed",
+    fn: () => {
+      if (state.depth > state.maxDepth) {
+        Bus.publish(Operational.Warn, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          component: "openomni.policy.background-limits",
+          msg: "background.limit.depth",
+          context: {
+            agentName: state.input.agentName,
+            depth: state.depth,
+            limit: state.maxDepth,
+          },
+        });
+        return denyVerdict(`max depth (${state.maxDepth}) exceeded`);
+      }
+
+      return continueVerdict("background.depth-limit", "depth within limit");
+    },
+  };
+}
+
+function createDescendantLimit(state: BackgroundLimitState): MiddlewareRegistration {
+  return {
+    ...BackgroundLimitsMiddleware.Descendants,
+    failPolicy: "fail-closed",
+    fn: () => {
+      const count = state.activeTasks.filter(
+        (t) => t.parentSessionId === state.input.parentSessionId,
+      ).length;
+      if (count >= state.maxDescendants) {
+        Bus.publish(Operational.Warn, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          component: "openomni.policy.background-limits",
+          msg: "background.limit.descendants",
+          context: {
+            parentSessionId: state.input.parentSessionId,
+            count,
+            limit: state.maxDescendants,
+          },
+        });
+        return denyVerdict(`max descendants (${state.maxDescendants}) from same parent exceeded`);
+      }
+
+      return continueVerdict("background.descendant-limit", "descendant capacity available");
+    },
+  };
+}
+
+function createTotalLimit(state: BackgroundLimitState): MiddlewareRegistration {
+  return {
+    ...BackgroundLimitsMiddleware.Total,
+    failPolicy: "fail-closed",
+    fn: () => {
+      state.shouldQueue = state.activeCount >= state.maxConcurrentTotal;
+      if (state.shouldQueue) {
+        return continueVerdict(
+          "background.total-limit",
+          "total concurrency saturated; queue required",
+        );
+      }
+
+      return continueVerdict("background.total-limit", "total concurrency capacity available");
+    },
+  };
+}
+
+function createQueueLimit(state: BackgroundLimitState): MiddlewareRegistration {
+  return {
+    ...BackgroundLimitsMiddleware.Queue,
+    failPolicy: "fail-closed",
+    fn: () => {
+      if (!state.shouldQueue) {
+        return continueVerdict("background.limit.queue", "queue capacity not required");
+      }
+
+      if (state.pendingQueueSize >= state.maxQueueSize) {
+        Bus.publish(Operational.Warn, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          component: "openomni.policy.background-limits",
+          msg: "background.limit.queue-full",
+          context: {
+            agentName: state.input.agentName,
+            queueSize: state.pendingQueueSize,
+            limit: state.maxQueueSize,
+          },
+        });
+        return denyVerdict(`queue full (max ${state.maxQueueSize})`);
+      }
+
+      return continueVerdict("background.queue-limit", "queue capacity available");
+    },
+  };
+}
+
+export namespace BackgroundLimitsMiddleware {
+  export const PerAgent = {
+    name: "background:per-agent-limit",
+    timing: "pre_tool_use",
+    priority: 0,
+    failPolicy: "fail-closed",
+  } satisfies Middleware.Definition;
+
+  export const Depth = {
+    name: "background:depth-limit",
+    timing: "pre_tool_use",
+    priority: 10,
+    failPolicy: "fail-closed",
+  } satisfies Middleware.Definition;
+
+  export const Descendants = {
+    name: "background:descendant-limit",
+    timing: "pre_tool_use",
+    priority: 20,
+    failPolicy: "fail-closed",
+  } satisfies Middleware.Definition;
+
+  export const Total = {
+    name: "background:total-limit",
+    timing: "pre_tool_use",
+    priority: 30,
+    failPolicy: "fail-closed",
+  } satisfies Middleware.Definition;
+
+  export const Queue = {
+    name: "background:queue-limit",
+    timing: "pre_tool_use",
+    priority: 40,
+    failPolicy: "fail-closed",
+  } satisfies Middleware.Definition;
+
+  export interface PreLaunchContext {
+    readonly input: LaunchRequest;
+    readonly activeTasks: readonly Subagent.BackgroundTask[];
+    readonly activeCount: number;
+    readonly pendingQueueSize: number;
+    readonly maxConcurrentPerAgent: number;
+    readonly maxConcurrentTotal: number;
+    readonly maxDepth: number;
+    readonly maxDescendants: number;
+    readonly maxQueueSize: number;
+    readonly traceContext?: TraceContext.Type;
+    readonly onDecision?: (decision: MiddlewareDecision) => void | Promise<void>;
+  }
+
+  export interface PreLaunchResult {
+    readonly verdict: Hook.Verdict;
+    readonly shouldQueue: boolean;
+  }
+
+  export function registrations(state: BackgroundLimitState): MiddlewareRegistration[] {
+    return [
+      createPerAgentLimit(state),
+      createDepthLimit(state),
+      createDescendantLimit(state),
+      createTotalLimit(state),
+      createQueueLimit(state),
+    ];
+  }
+
+  export async function evaluatePreLaunch(ctx: PreLaunchContext): Promise<PreLaunchResult> {
+    const state: BackgroundLimitState = {
+      input: ctx.input,
+      depth: ctx.input.depth ?? 0,
+      activeTasks: ctx.activeTasks,
+      activeCount: ctx.activeCount,
+      pendingQueueSize: ctx.pendingQueueSize,
+      maxConcurrentPerAgent: ctx.maxConcurrentPerAgent,
+      maxConcurrentTotal: ctx.maxConcurrentTotal,
+      maxDepth: ctx.maxDepth,
+      maxDescendants: ctx.maxDescendants,
+      maxQueueSize: ctx.maxQueueSize,
+    };
+    const engine = MiddlewareEngine.create({
+      traceContext: ctx.traceContext,
+      onDecision: ctx.onDecision,
+      audit: false,
+    });
+
+    for (const registration of registrations(state)) {
+      engine.register(registration);
+    }
+
+    const verdict = await engine.dispatch("pre_tool_use", {
+      steps: [],
+      usage: emptyUsage,
+      turnCount: 0,
+      isCompletion: false,
+      continuationCount: 0,
+      elapsedMs: 0,
+      toolName: "subagent",
+      toolInput: {
+        operation: "background.launch",
+        agentName: ctx.input.agentName,
+        parentSessionId: ctx.input.parentSessionId,
+        depth: ctx.input.depth ?? 0,
+        activeCount: ctx.activeCount,
+        pendingQueueSize: ctx.pendingQueueSize,
+      },
+      traceContext: ctx.traceContext,
+    });
+
+    return { verdict, shouldQueue: state.shouldQueue ?? false };
+  }
+}

--- a/packages/openomni/src/policy/index.ts
+++ b/packages/openomni/src/policy/index.ts
@@ -1,0 +1,4 @@
+export { IngressAuthorityMiddleware } from "../ingress/middleware/ingress-authority";
+export { SubagentSpawnPolicyMiddleware } from "../subagent/middleware/subagent-spawn-policy";
+export { BackgroundLimitsMiddleware } from "./background-limits";
+export { ToolRuntimePolicyMiddleware } from "../execution-runtime/tool/middleware/tool-runtime-policy";


### PR DESCRIPTION
## Summary

Restore policy engine files that were accidentally deleted during #131 merge, migrated from EventLog/Log to Bus-based observability.

PR #131 (unified observability) was rebased onto main after PR #130 (policy engine) was merged. The conflict resolution via `git apply --3way` incorrectly deleted the policy engine files because they imported `EventLog` and `Log` which were removed in the observability PR.

## Changes

- Restore `packages/agent/src/core/policy/` (engine, types, builtins, index)
- Restore `packages/openomni/src/policy/` (background-limits, index)
- Restore `packages/agent/test/core/policy/engine.test.ts`
- Restore `docs/policy-architecture-*.md`
- Migrate all `EventLog.append()` → `Bus.publish(PolicyEvent.Evaluated, ...)`
- Migrate all `Log.warn/debug()` → `Bus.publish(Operational.Warn/Debug, ...)`
- Remove `ExecutionEvent` type references (replaced with `AuditVisibility`)

## Type

- [x] `fix` — Bug fix

## Affected Packages

- [x] `agent`
- [x] `openomni`

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the policy engine and moves observability to the `Bus`, fixing a merge regression and re-enabling policy enforcement and auditing across `agent` and `openomni`. Also restores OpenOmni background limits policy and re-exports to keep downstream imports stable.

- **Bug Fixes**
  - Restored `PolicyEngine` with `Bus`-backed auditing and system-prompt dispatch; re-exposed policy APIs from `agent` and `openomni`.
  - Brought back built-ins: budget reassurance/warning, compaction, idle-nudge, post-tool, post-turn, and tool-guard (permission checks).
  - Restored OpenOmni background limits policy and compatibility exports (`openomni/src/policy`, `openomni/src/index.ts`).
  - Reinstated the policy engine test suite updated for `Bus` observability.

- **Refactors**
  - Migrated `EventLog.append()` to `Bus.publish(PolicyEvent.Evaluated, ...)`.
  - Replaced `Log.warn/debug()` with `Bus.publish(Operational.Warn/Debug, ...)`.
  - Added structured `PolicyDecision` auditing with trace propagation and child-policy derivation.

<sup>Written for commit dfd5ee31e9d2d7766a3d3e6c6d9f200cb79d46f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

