### PR TITLE
feat(protocol,agent,openomni): universalize policy engine with registry, resolver, and dispatch points

### DIFF
--- a/apps/server/src/bootstrap/local-runner.ts
+++ b/apps/server/src/bootstrap/local-runner.ts
@@ -63,6 +63,7 @@ async function run(config: Config, request: Execution.Request): Promise<Executio
       createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
       ...buildWorkerMiddleware({
         permissions: request.permissions,
+        ...(request.policyPlan ? { policyPlan: request.policyPlan } : {}),
       }),
     ],
   });

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -153,6 +153,7 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
             createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
             ...buildWorkerMiddleware({
               permissions: request.permissions,
+              ...(request.policyPlan ? { policyPlan: request.policyPlan } : {}),
             }),
           ],
         });

--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -1,7 +1,7 @@
 import type { RunInput } from "@openomni/llm";
 import { Retry } from "@openomni/llm";
 import { AgentExecution, Operational } from "@openomni/protocol";
-import type { Hook, Message, Sink, Tool, TraceContext } from "@openomni/protocol";
+import type { Hook, Message, Policy, Sink, Tool, TraceContext } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import {
   checkBudget,
@@ -389,6 +389,50 @@ export async function buildTurn(
     : undefined;
 
   const system = await buildTurnSystemPrompt(state, config, engine);
+
+  // pre_tool_selection — policies can filter/modify tools exposed to LLM
+  const allTools = config.tools ?? [];
+  const catalogLabels: Policy.LabelEntry[] = [];
+  for (const [name, labels] of toolLabels) {
+    for (const label of labels) {
+      catalogLabels.push({ value: `${name}:${label}`, source: "tool_metadata" });
+    }
+  }
+  const toolSelectionVerdict = await engine.dispatch("pre_tool_selection", {
+    steps: state.steps,
+    usage: state.totalUsage,
+    turnCount: state.budgetState.turns,
+    isCompletion: false,
+    continuationCount: state.continuationCount,
+    elapsedMs: Date.now() - state.startTime,
+    messages: state.messages,
+    labels: catalogLabels,
+  });
+
+  let selectedTools = allTools;
+  if (toolSelectionVerdict.action === "transform") {
+    const input = toolSelectionVerdict.input as { tools?: unknown };
+    if (Array.isArray(input.tools)) {
+      const allowed = new Set(input.tools as string[]);
+      selectedTools = allTools.filter((t) => allowed.has(t.name));
+    }
+  } else if (toolSelectionVerdict.action === "abort") {
+    return {
+      type: "complete",
+      event: {
+        type: "complete",
+        result: {
+          text: state.lastAssistantText,
+          steps: state.steps,
+          usage: state.totalUsage,
+          finishReason: "stop",
+          guardAborted: true,
+          compactionCount: getCompactionCount(state),
+        },
+      },
+    };
+  }
+
   const turnUsage: TokenUsage = {
     inputTokens: 0,
     outputTokens: 0,
@@ -405,7 +449,7 @@ export async function buildTurn(
     turn: {
       runInput: {
         messages: state.messages,
-        tools: config.tools ?? [],
+        tools: selectedTools,
         system,
         signal: config.signal,
         model: providerModel,

--- a/packages/agent/src/core/policy/builtin/budget.ts
+++ b/packages/agent/src/core/policy/builtin/budget.ts
@@ -1,5 +1,5 @@
 import { checkBudget, describeBudgetRemaining } from "../../budget";
-import type { PolicyRegistration } from "../types";
+import type { PolicyFactory, PolicyRegistration } from "../types";
 
 export function createBudgetReassurancePolicy(): PolicyRegistration {
   let issued = false;
@@ -31,6 +31,11 @@ export function createBudgetReassurancePolicy(): PolicyRegistration {
   };
 }
 
+export const budgetReassuranceFactory: PolicyFactory = {
+  id: "policy:budget-reassurance",
+  create: () => createBudgetReassurancePolicy(),
+};
+
 export function createBudgetWarningPolicy(): PolicyRegistration {
   let issued = false;
   return {
@@ -60,3 +65,8 @@ export function createBudgetWarningPolicy(): PolicyRegistration {
     },
   };
 }
+
+export const budgetWarningFactory: PolicyFactory = {
+  id: "policy:budget-warning",
+  create: () => createBudgetWarningPolicy(),
+};

--- a/packages/agent/src/core/policy/builtin/compaction.ts
+++ b/packages/agent/src/core/policy/builtin/compaction.ts
@@ -1,5 +1,5 @@
 import { InMemoryCompactor } from "../../execution/compaction";
-import type { PolicyRegistration } from "../types";
+import type { PolicyFactory, PolicyRegistration } from "../types";
 import type { ChatAgentConfig } from "../../types";
 
 type CompactionConfig = NonNullable<ChatAgentConfig["compaction"]>;
@@ -43,3 +43,8 @@ export function createCompactionPolicy(config: CompactionConfig): PolicyRegistra
     },
   };
 }
+
+export const compactionFactory: PolicyFactory = {
+  id: "policy:compaction",
+  create: (config) => createCompactionPolicy(config as CompactionConfig),
+};

--- a/packages/agent/src/core/policy/builtin/idle-nudge.ts
+++ b/packages/agent/src/core/policy/builtin/idle-nudge.ts
@@ -1,4 +1,4 @@
-import type { PolicyRegistration } from "../types";
+import type { PolicyFactory, PolicyRegistration } from "../types";
 
 export interface IdleNudgeConfig {
   idleThresholdMs?: number;
@@ -52,3 +52,8 @@ export function createIdleNudgePolicy(config: IdleNudgeConfig = {}): PolicyRegis
     },
   };
 }
+
+export const idleNudgeFactory: PolicyFactory = {
+  id: "policy:idle-nudge",
+  create: (config) => createIdleNudgePolicy(config as IdleNudgeConfig),
+};

--- a/packages/agent/src/core/policy/builtin/index.ts
+++ b/packages/agent/src/core/policy/builtin/index.ts
@@ -1,11 +1,42 @@
-export { createBudgetReassurancePolicy, createBudgetWarningPolicy } from "./budget";
-export { createCompactionPolicy } from "./compaction";
-export { createMemoryPolicy } from "./memory";
-export { createPostToolPolicy } from "./post-tool";
+export {
+  createBudgetReassurancePolicy,
+  createBudgetWarningPolicy,
+  budgetReassuranceFactory,
+  budgetWarningFactory,
+} from "./budget";
+export { createCompactionPolicy, compactionFactory } from "./compaction";
+export { createMemoryPolicy, memoryFactory } from "./memory";
+export { createPostToolPolicy, postToolFactory } from "./post-tool";
 export type { PostToolEnricher } from "./post-tool";
-export { createPostTurnPolicy } from "./post-turn";
+export { createPostTurnPolicy, postTurnFactory } from "./post-turn";
 export type { PostTurnHandler } from "./post-turn";
-export { createIdleNudgePolicy } from "./idle-nudge";
+export { createIdleNudgePolicy, idleNudgeFactory } from "./idle-nudge";
 export type { IdleNudgeConfig } from "./idle-nudge";
-export { createToolPermissionPolicy } from "./tool-guard";
+export { createToolPermissionPolicy, toolPermissionFactory } from "./tool-guard";
 export type { ToolPermissionPolicyConfig } from "./tool-guard";
+
+import type { PolicyFactory, PolicyRegistry } from "../types";
+import { budgetReassuranceFactory, budgetWarningFactory } from "./budget";
+import { compactionFactory } from "./compaction";
+import { memoryFactory } from "./memory";
+import { postToolFactory } from "./post-tool";
+import { postTurnFactory } from "./post-turn";
+import { idleNudgeFactory } from "./idle-nudge";
+import { toolPermissionFactory } from "./tool-guard";
+
+export const builtinFactories: readonly PolicyFactory[] = [
+  budgetReassuranceFactory,
+  budgetWarningFactory,
+  compactionFactory,
+  memoryFactory,
+  postToolFactory,
+  postTurnFactory,
+  idleNudgeFactory,
+  toolPermissionFactory,
+];
+
+export function registerBuiltins(registry: PolicyRegistry): void {
+  for (const factory of builtinFactories) {
+    registry.register(factory.id, (config, runtime) => factory.create(config, runtime));
+  }
+}

--- a/packages/agent/src/core/policy/builtin/memory.ts
+++ b/packages/agent/src/core/policy/builtin/memory.ts
@@ -1,5 +1,5 @@
 import type { Memory } from "../../memory";
-import type { PolicyRegistration } from "../types";
+import type { PolicyFactory, PolicyRegistration } from "../types";
 import type { Message } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
@@ -50,3 +50,8 @@ export function createMemoryPolicy(memory: Memory): PolicyRegistration {
     },
   };
 }
+
+export const memoryFactory: PolicyFactory = {
+  id: "policy:memory",
+  create: (_config, runtime) => createMemoryPolicy(runtime.memory as Memory),
+};

--- a/packages/agent/src/core/policy/builtin/post-tool.ts
+++ b/packages/agent/src/core/policy/builtin/post-tool.ts
@@ -1,6 +1,6 @@
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import type { PolicyContext, PolicyRegistration } from "../types";
+import type { PolicyContext, PolicyFactory, PolicyRegistration } from "../types";
 
 export type PostToolEnricher = (ctx: PolicyContext) => string | null | Promise<string | null>;
 
@@ -34,3 +34,8 @@ export function createPostToolPolicy(enricher: PostToolEnricher): PolicyRegistra
     },
   };
 }
+
+export const postToolFactory: PolicyFactory = {
+  id: "policy:post-tool",
+  create: (config) => createPostToolPolicy(config as PostToolEnricher),
+};

--- a/packages/agent/src/core/policy/builtin/post-turn.ts
+++ b/packages/agent/src/core/policy/builtin/post-turn.ts
@@ -1,6 +1,6 @@
 import { Operational, type Hook } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import type { PolicyContext, PolicyRegistration } from "../types";
+import type { PolicyContext, PolicyFactory, PolicyRegistration } from "../types";
 
 export type PostTurnHandler = (ctx: PolicyContext) => Promise<Hook.Verdict> | Hook.Verdict;
 
@@ -25,3 +25,8 @@ export function createPostTurnPolicy(handler: PostTurnHandler): PolicyRegistrati
     },
   };
 }
+
+export const postTurnFactory: PolicyFactory = {
+  id: "policy:post-turn",
+  create: (config) => createPostTurnPolicy(config as PostTurnHandler),
+};

--- a/packages/agent/src/core/policy/builtin/tool-guard.ts
+++ b/packages/agent/src/core/policy/builtin/tool-guard.ts
@@ -1,7 +1,7 @@
 import { Operational, Policy } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import type { AgentEventEmitter } from "../../types";
-import type { PolicyRegistration } from "../types";
+import type { PolicyFactory, PolicyRegistration } from "../types";
 import { summarizeInput } from "../../execution/shared";
 
 const TOOL_CALL_ACTION = "tool.call";
@@ -74,3 +74,8 @@ export function createToolPermissionPolicy(config: ToolPermissionPolicyConfig): 
     },
   };
 }
+
+export const toolPermissionFactory: PolicyFactory = {
+  id: "policy:tool-permission",
+  create: (config) => createToolPermissionPolicy(config as ToolPermissionPolicyConfig),
+};

--- a/packages/agent/src/core/policy/engine.ts
+++ b/packages/agent/src/core/policy/engine.ts
@@ -4,6 +4,7 @@ import {
   PolicyEvent,
   type Hook,
   type Middleware,
+  type Policy,
   type TraceContext,
 } from "@openomni/protocol";
 import type { PolicyContext, PolicyRegistration } from "./types";
@@ -13,7 +14,7 @@ const CONTINUE: Hook.Verdict = { action: "continue" };
 type AuditVisibility = "internal" | "llm_reason" | "user_audit";
 
 export interface PolicyDecision {
-  readonly timing: Hook.Timing;
+  readonly timing: Policy.Timing;
   readonly name: string;
   readonly policyId: string;
   readonly verdict: Hook.Verdict["action"];
@@ -38,7 +39,7 @@ export interface PolicyEngineConfig {
   readonly audit?: PolicyAuditConfig | false;
 }
 
-function matchesTiming(reg: PolicyRegistration, timing: Hook.Timing): boolean {
+function matchesTiming(reg: PolicyRegistration, timing: Policy.Timing): boolean {
   return Array.isArray(reg.timing) ? reg.timing.includes(timing) : reg.timing === timing;
 }
 
@@ -51,7 +52,7 @@ function matchesScope(reg: PolicyRegistration, agentType: string | undefined): b
 
 function selectRegistrations(
   registrations: PolicyRegistration[],
-  timing: Hook.Timing,
+  timing: Policy.Timing,
   agentType: string | undefined,
 ): PolicyRegistration[] {
   return registrations
@@ -61,7 +62,7 @@ function selectRegistrations(
 
 export interface PolicyEngineInstance {
   register(reg: PolicyRegistration): void;
-  dispatch(timing: Hook.Timing, ctx: Omit<PolicyContext, "timing">): Promise<Hook.Verdict>;
+  dispatch(timing: Policy.Timing, ctx: Omit<PolicyContext, "timing">): Promise<Hook.Verdict>;
   dispatchSystemPrompt(ctx: Omit<PolicyContext, "timing">): Promise<Middleware.SystemPromptVerdict>;
 }
 
@@ -69,13 +70,13 @@ function isProduction(): boolean {
   return process.env.NODE_ENV === "production";
 }
 
-function warnKey(timing: Hook.Timing, name: string): string {
+function warnKey(timing: Policy.Timing, name: string): string {
   return `${timing}:${name}`;
 }
 
 function normalizeVerdict(
   verdict: Hook.Verdict,
-  timing: Hook.Timing,
+  timing: Policy.Timing,
   name: string,
   warnedMissingMetadata: Set<string>,
 ): Hook.Verdict {
@@ -112,7 +113,7 @@ function buildActor(traceContext: TraceContext.Type | undefined): Record<string,
   };
 }
 
-function resolveAction(timing: Hook.Timing): string {
+function resolveAction(timing: Policy.Timing): string {
   if (timing === "pre_tool_use" || timing === "post_tool_use") return "tool.call";
   return `middleware.${timing}`;
 }
@@ -181,7 +182,7 @@ function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
   }
 
   async function dispatch(
-    timing: Hook.Timing,
+    timing: Policy.Timing,
     ctx: Omit<PolicyContext, "timing">,
   ): Promise<Hook.Verdict> {
     const selected = selectRegistrations(registrations, timing, ctx.agentType);

--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -6,4 +6,6 @@ export type {
   PolicyEngineConfig,
   PolicyEngineInstance,
 } from "./engine";
+export { PolicyRegistry, defaultRegistry } from "./registry";
+export type { PolicyFactory, PolicyRegistryInstance, RuntimeContext } from "./registry";
 export * from "./builtin";

--- a/packages/agent/src/core/policy/registry.ts
+++ b/packages/agent/src/core/policy/registry.ts
@@ -1,0 +1,111 @@
+import { Operational, type Policy } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import {
+  createBudgetReassurancePolicy,
+  createBudgetWarningPolicy,
+  createCompactionPolicy,
+  createIdleNudgePolicy,
+  createMemoryPolicy,
+  createPostToolPolicy,
+  createPostTurnPolicy,
+  createToolPermissionPolicy,
+} from "./builtin";
+import type { PolicyRegistration } from "./types";
+
+export interface RuntimeContext {
+  readonly workspaceRoot?: string;
+  readonly sessionId?: string;
+  readonly runId?: string;
+  readonly agentName?: string;
+}
+
+export type PolicyFactory = (config: unknown, runtime: RuntimeContext) => PolicyRegistration;
+
+export interface PolicyRegistryInstance {
+  register(id: string, factory: PolicyFactory): void;
+  resolve(plan: Policy.PolicyPlan, runtime: RuntimeContext): PolicyRegistration[];
+  has(id: string): boolean;
+  list(): string[];
+}
+
+function publishOptionalPolicyMissing(id: string, runtime: RuntimeContext): void {
+  Bus.publish(Operational.Warn, {
+    traceId: runtime.runId ?? crypto.randomUUID(),
+    ...(runtime.sessionId !== undefined && { sessionId: runtime.sessionId }),
+    time: Date.now(),
+    component: "agent.policy.registry",
+    msg: "optional policy missing",
+    context: {
+      policyId: id,
+      ...(runtime.workspaceRoot !== undefined && { workspaceRoot: runtime.workspaceRoot }),
+      ...(runtime.agentName !== undefined && { agentName: runtime.agentName }),
+    },
+  });
+}
+
+function create(): PolicyRegistryInstance {
+  const factories = new Map<string, PolicyFactory>();
+
+  return {
+    register(id, factory) {
+      factories.set(id, factory);
+    },
+
+    resolve(plan, runtime) {
+      const registrations: PolicyRegistration[] = [];
+
+      for (const policy of plan.policies) {
+        const factory = factories.get(policy.id);
+        if (!factory) {
+          if (policy.required) {
+            throw new Error(`Required policy '${policy.id}' is not registered`);
+          }
+          publishOptionalPolicyMissing(policy.id, runtime);
+          continue;
+        }
+
+        registrations.push(factory(policy.config, runtime));
+      }
+
+      return registrations;
+    },
+
+    has(id) {
+      return factories.has(id);
+    },
+
+    list() {
+      return Array.from(factories.keys());
+    },
+  };
+}
+
+function defaultRegistry(): PolicyRegistryInstance {
+  const registry = create();
+
+  registry.register("builtin:budget-reassurance", () => createBudgetReassurancePolicy());
+  registry.register("builtin:budget-warning", () => createBudgetWarningPolicy());
+  registry.register("builtin:compaction", (config) =>
+    createCompactionPolicy(config as Parameters<typeof createCompactionPolicy>[0]),
+  );
+  registry.register("builtin:memory", (config) =>
+    createMemoryPolicy(config as Parameters<typeof createMemoryPolicy>[0]),
+  );
+  registry.register("builtin:post-tool", (config) =>
+    createPostToolPolicy(config as Parameters<typeof createPostToolPolicy>[0]),
+  );
+  registry.register("builtin:post-turn", (config) =>
+    createPostTurnPolicy(config as Parameters<typeof createPostTurnPolicy>[0]),
+  );
+  registry.register("builtin:idle-nudge", (config) =>
+    createIdleNudgePolicy(config as Parameters<typeof createIdleNudgePolicy>[0]),
+  );
+  registry.register("builtin:tool-permission", (config) =>
+    createToolPermissionPolicy(config as Parameters<typeof createToolPermissionPolicy>[0]),
+  );
+
+  return registry;
+}
+
+export const PolicyRegistry = { create };
+export { defaultRegistry };

--- a/packages/agent/src/core/policy/types.ts
+++ b/packages/agent/src/core/policy/types.ts
@@ -1,9 +1,16 @@
-import type { Hook, Middleware, Message, Messenger, TraceContext } from "@openomni/protocol";
+import type {
+  Hook,
+  Middleware,
+  Message,
+  Messenger,
+  TraceContext,
+  Policy,
+} from "@openomni/protocol";
 import type { AgentStep, TokenUsage, AgentBudget, AgentEventEmitter } from "../types";
 import type { BudgetState } from "../budget";
 
 export interface PolicyContext {
-  timing: Hook.Timing;
+  timing: Policy.Timing;
   steps: AgentStep[];
   usage: TokenUsage;
   turnCount: number;
@@ -22,13 +29,14 @@ export interface PolicyContext {
   budget?: AgentBudget;
   traceContext?: TraceContext.Type;
   envelope?: Messenger.MessageEnvelope;
+  labels?: Policy.LabelEntry[];
 }
 
 export type PolicyFn = (ctx: PolicyContext) => Promise<Hook.Verdict> | Hook.Verdict;
 
 export interface PolicyRegistration {
   name: string;
-  timing: Hook.Timing | Hook.Timing[];
+  timing: Policy.Timing | Policy.Timing[];
   priority: number;
   scope?: Middleware.Scope;
   failPolicy?: Middleware.FailPolicy;

--- a/packages/agent/src/core/policy/types.ts
+++ b/packages/agent/src/core/policy/types.ts
@@ -43,3 +43,20 @@ export interface PolicyRegistration {
   fn: PolicyFn;
   propagate?: boolean;
 }
+
+export type PolicyRuntimeContext = Record<string, unknown>;
+
+export interface PolicyFactory {
+  readonly id: string;
+  create(config: unknown, runtime: PolicyRuntimeContext): PolicyRegistration;
+}
+
+export interface PolicyRegistry {
+  register(
+    id: string,
+    factory: (config: unknown, runtime: Record<string, unknown>) => PolicyRegistration,
+  ): void;
+  resolve(plan: unknown, runtime: Record<string, unknown>): PolicyRegistration[];
+  has(id: string): boolean;
+  list(): string[];
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,7 +24,7 @@ export type {
   RuntimeAgentInstance,
   RuntimeInstanceStatus,
 } from "./core/runtime-context";
-export { PolicyEngine } from "./core/policy";
+export { PolicyEngine, defaultRegistry } from "./core/policy";
 export type {
   PolicyContext,
   PolicyFn,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,7 +24,7 @@ export type {
   RuntimeAgentInstance,
   RuntimeInstanceStatus,
 } from "./core/runtime-context";
-export { PolicyEngine, defaultRegistry } from "./core/policy";
+export { PolicyEngine, PolicyRegistry, defaultRegistry } from "./core/policy";
 export type {
   PolicyContext,
   PolicyFn,
@@ -33,6 +33,8 @@ export type {
   PolicyAuditConfig,
   PolicyEngineConfig,
   PolicyEngineInstance,
+  PolicyFactory,
+  PolicyRegistryInstance,
 } from "./core/policy";
 export { AgentRegistry } from "./runtime/index";
 export { SubagentTool } from "./runtime/index";

--- a/packages/agent/test/core/execution/tool-selection.test.ts
+++ b/packages/agent/test/core/execution/tool-selection.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "bun:test";
+import { Bus } from "@openomni/session";
+import { PolicyEngine } from "../../../src/core/policy";
+import { buildTurn, createStreamRunState } from "../../../src/core/execution/stream-helpers";
+import type { PolicyRegistration } from "../../../src/core/policy/types";
+import type { Tool, TraceContext } from "@openomni/protocol";
+import type { ChatAgentConfig, ChatAgentInput } from "../../../src/core/types";
+
+function makeTools(...names: string[]): Tool.Spec[] {
+  return names.map((name) => ({
+    name,
+    description: `tool ${name}`,
+    inputSchema: { type: "object", properties: {} },
+  }));
+}
+
+function makeLabeledTool(name: string, labels: string[]): Tool.Spec {
+  return {
+    name,
+    description: `tool ${name}`,
+    inputSchema: { type: "object", properties: {} },
+    labels,
+  };
+}
+
+function makeConfig(tools: Tool.Spec[]): ChatAgentConfig {
+  return {
+    model: { provider: "test", id: "test-model" },
+    tools,
+    systemPrompt: "test system prompt",
+  };
+}
+
+function makeTrace(): TraceContext.Type {
+  return { traceId: "trace-1", sessionId: "sess-1" };
+}
+
+function makeAgentBase() {
+  return { traceId: "trace-1", sessionId: "sess-1" };
+}
+
+function makeState() {
+  const input: ChatAgentInput = {
+    messages: [{ role: "user", content: "hello" }],
+  };
+  return createStreamRunState(input);
+}
+
+function filterPolicy(allowedTools: string[]): PolicyRegistration {
+  return {
+    name: "test-filter",
+    timing: "pre_tool_selection",
+    priority: 0,
+    fn: async () => ({
+      action: "transform" as const,
+      input: { tools: allowedTools },
+      reason: "test-filter",
+      policyId: "test-filter",
+    }),
+  };
+}
+
+function abortSelectionPolicy(reason: string): PolicyRegistration {
+  return {
+    name: "test-abort-selection",
+    timing: "pre_tool_selection",
+    priority: 0,
+    fn: async () => ({
+      action: "abort" as const,
+      reason,
+      policyId: "test-abort-selection",
+    }),
+  };
+}
+
+describe("pre_tool_selection dispatch", () => {
+  it("passes all tools through when no policy is registered", async () => {
+    Bus.reset();
+    const engine = PolicyEngine.create();
+    const tools = makeTools("bash", "read", "write");
+    const state = makeState();
+    const config = makeConfig(tools);
+
+    const result = await buildTurn(
+      state,
+      config,
+      engine,
+      { provider: "test", id: "test-model" },
+      undefined,
+      makeTrace(),
+      makeAgentBase(),
+    );
+
+    expect(result.type).toBe("ready");
+    if (result.type !== "ready") return;
+    expect(result.turn.runInput.tools).toHaveLength(3);
+    expect(result.turn.runInput.tools.map((t) => t.name)).toEqual(["bash", "read", "write"]);
+  });
+
+  it("filters tools when transform verdict specifies allowed tools", async () => {
+    Bus.reset();
+    const engine = PolicyEngine.create();
+    engine.register(filterPolicy(["bash", "write"]));
+
+    const tools = makeTools("bash", "read", "write");
+    const state = makeState();
+    const config = makeConfig(tools);
+
+    const result = await buildTurn(
+      state,
+      config,
+      engine,
+      { provider: "test", id: "test-model" },
+      undefined,
+      makeTrace(),
+      makeAgentBase(),
+    );
+
+    expect(result.type).toBe("ready");
+    if (result.type !== "ready") return;
+    expect(result.turn.runInput.tools).toHaveLength(2);
+    expect(result.turn.runInput.tools.map((t) => t.name)).toEqual(["bash", "write"]);
+  });
+
+  it("returns complete result when abort verdict is returned", async () => {
+    Bus.reset();
+    const engine = PolicyEngine.create();
+    engine.register(abortSelectionPolicy("tools-restricted"));
+
+    const tools = makeTools("bash", "read");
+    const state = makeState();
+    const config = makeConfig(tools);
+
+    const result = await buildTurn(
+      state,
+      config,
+      engine,
+      { provider: "test", id: "test-model" },
+      undefined,
+      makeTrace(),
+      makeAgentBase(),
+    );
+
+    expect(result.type).toBe("complete");
+    if (result.type !== "complete") return;
+    expect(result.event).toMatchObject({
+      type: "complete",
+      result: { guardAborted: true },
+    });
+  });
+
+  it("dispatches with tool catalog labels in context", async () => {
+    Bus.reset();
+    let capturedCtx: Record<string, unknown> | undefined;
+    const engine = PolicyEngine.create();
+    engine.register({
+      name: "capture-ctx",
+      timing: "pre_tool_selection",
+      priority: 0,
+      fn: async (ctx) => {
+        capturedCtx = ctx as unknown as Record<string, unknown>;
+        return { action: "continue" as const };
+      },
+    });
+
+    const tools = [
+      makeLabeledTool("bash", ["tool:bash", "capability.execute"]),
+      makeLabeledTool("read", ["tool:read", "capability.read"]),
+    ];
+    const state = makeState();
+    const config = makeConfig(tools);
+
+    await buildTurn(
+      state,
+      config,
+      engine,
+      { provider: "test", id: "test-model" },
+      undefined,
+      makeTrace(),
+      makeAgentBase(),
+    );
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx!.timing).toBe("pre_tool_selection");
+    const labels = capturedCtx!.labels as Array<{ value: string; source: string }>;
+    expect(labels.length).toBeGreaterThan(0);
+    expect(labels.some((l) => l.value.includes("bash"))).toBe(true);
+    expect(labels.every((l) => l.source === "tool_metadata")).toBe(true);
+  });
+
+  it("keeps all tools when transform verdict has no tools property", async () => {
+    Bus.reset();
+    const engine = PolicyEngine.create();
+    engine.register({
+      name: "transform-no-tools",
+      timing: "pre_tool_selection",
+      priority: 0,
+      fn: async () => ({
+        action: "transform" as const,
+        input: { someOtherKey: "value" },
+        reason: "test",
+        policyId: "test",
+      }),
+    });
+
+    const tools = makeTools("bash", "read", "write");
+    const state = makeState();
+    const config = makeConfig(tools);
+
+    const result = await buildTurn(
+      state,
+      config,
+      engine,
+      { provider: "test", id: "test-model" },
+      undefined,
+      makeTrace(),
+      makeAgentBase(),
+    );
+
+    expect(result.type).toBe("ready");
+    if (result.type !== "ready") return;
+    expect(result.turn.runInput.tools).toHaveLength(3);
+  });
+});

--- a/packages/agent/test/core/policy/builtin-snapshots.test.ts
+++ b/packages/agent/test/core/policy/builtin-snapshots.test.ts
@@ -1,0 +1,541 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Hook, Message } from "@openomni/protocol";
+import type { PolicyContext } from "../../../src/core/policy/types";
+import type { BudgetState } from "../../../src/core/budget";
+import type { Memory, MemoryResult } from "../../../src/core/memory";
+import {
+  createBudgetReassurancePolicy,
+  createBudgetWarningPolicy,
+} from "../../../src/core/policy/builtin/budget";
+import { createToolPermissionPolicy } from "../../../src/core/policy/builtin/tool-guard";
+import { createMemoryPolicy } from "../../../src/core/policy/builtin/memory";
+import { createCompactionPolicy } from "../../../src/core/policy/builtin/compaction";
+import { createPostToolPolicy } from "../../../src/core/policy/builtin/post-tool";
+import { createPostTurnPolicy } from "../../../src/core/policy/builtin/post-turn";
+import { createIdleNudgePolicy } from "../../../src/core/policy/builtin/idle-nudge";
+import { createUserMessage } from "../../../src/core/message-factory";
+
+type Inject = Extract<Hook.Verdict, { action: "inject" }>;
+type Abort = Extract<Hook.Verdict, { action: "abort" }>;
+type Transform = Extract<Hook.Verdict, { action: "transform" }>;
+
+function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
+  return {
+    timing: "pre_turn",
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
+function budgetState(overrides?: Partial<BudgetState>): BudgetState {
+  return {
+    startTime: Date.now(),
+    turns: 0,
+    toolCalls: 0,
+    toolRuntimeMs: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    ...overrides,
+  };
+}
+
+function testMessage(id: string): Message.WithParts {
+  return {
+    info: {
+      id,
+      sessionID: "test-session",
+      role: "user" as const,
+      time: { created: Date.now() },
+      agent: "test-agent",
+      model: { providerID: "test", modelID: "test" },
+      system: `Test message ${id}`,
+    },
+    parts: [
+      {
+        id: `part-${id}`,
+        sessionID: "test-session",
+        messageID: id,
+        type: "text" as const,
+        text: `Test message ${id}`,
+      },
+    ],
+  };
+}
+
+function mockMemory(results: MemoryResult[] = []): Memory {
+  return {
+    store: async () => undefined,
+    retrieve: async () => results,
+    clear: async () => undefined,
+  };
+}
+
+const originalNow = Date.now;
+function mockNow(ms: number): void {
+  Date.now = () => ms;
+}
+
+afterEach(() => {
+  Date.now = originalNow;
+});
+
+describe("snapshot: budget-reassurance", () => {
+  it("continue — below 0.6 threshold", async () => {
+    const mw = createBudgetReassurancePolicy();
+    const verdict = await mw.fn(
+      baseCtx({
+        budgetState: budgetState({ turns: 5 }),
+        budget: { maxTurns: 24 },
+      }),
+    );
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("inject — at 0.6 threshold", async () => {
+    const mw = createBudgetReassurancePolicy();
+    const verdict = await mw.fn(
+      baseCtx({
+        budgetState: budgetState({ turns: 15 }),
+        budget: { maxTurns: 24 },
+      }),
+    );
+    expect(verdict.action).toBe("inject");
+    const v = verdict as Inject;
+    expect(v.reason).toBe("budget_reassurance");
+    expect(v.policyId).toBe("builtin.budget.reassurance");
+    expect(v.message).toContain("[Budget Status]");
+    expect(v.message).toContain("Do NOT rush or skip tasks");
+  });
+
+  it("continue — fires only once (closure state)", async () => {
+    const mw = createBudgetReassurancePolicy();
+    const ctx = baseCtx({ budgetState: budgetState({ turns: 15 }), budget: { maxTurns: 24 } });
+    await mw.fn(ctx);
+    const second = await mw.fn(ctx);
+    expect(second).toEqual({ action: "continue" });
+  });
+
+  it("continue — no budgetState", async () => {
+    const mw = createBudgetReassurancePolicy();
+    const verdict = await mw.fn(baseCtx());
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: budget-warning", () => {
+  it("continue — below 0.8 threshold", async () => {
+    const mw = createBudgetWarningPolicy();
+    const verdict = await mw.fn(
+      baseCtx({
+        budgetState: budgetState({ turns: 10 }),
+        budget: { maxTurns: 24 },
+      }),
+    );
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("inject — at 0.8 threshold", async () => {
+    const mw = createBudgetWarningPolicy();
+    const verdict = await mw.fn(
+      baseCtx({
+        budgetState: budgetState({ turns: 20 }),
+        budget: { maxTurns: 24 },
+      }),
+    );
+    expect(verdict.action).toBe("inject");
+    const v = verdict as Inject;
+    expect(v.reason).toBe("budget_warning");
+    expect(v.policyId).toBe("builtin.budget.warning");
+    expect(v.message).toContain("[Budget Warning]");
+    expect(v.message).toContain("Wrap up your current task");
+  });
+
+  it("continue — fires only once", async () => {
+    const mw = createBudgetWarningPolicy();
+    const ctx = baseCtx({ budgetState: budgetState({ turns: 20 }), budget: { maxTurns: 24 } });
+    await mw.fn(ctx);
+    const second = await mw.fn(ctx);
+    expect(second).toEqual({ action: "continue" });
+  });
+
+  it("continue — no budgetState", async () => {
+    const mw = createBudgetWarningPolicy();
+    const verdict = await mw.fn(baseCtx());
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: tool-permission", () => {
+  it("continue — tool on allowlist", async () => {
+    const mw = createToolPermissionPolicy({
+      permission: { action: "tool.call", allowlist: ["read_file", "write_file"] },
+    });
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "pre_tool_use",
+        toolName: "read_file",
+        toolCallId: "call-1",
+        toolInput: { path: "/tmp/test" },
+      }),
+    );
+    expect(verdict.action).toBe("continue");
+  });
+
+  it("abort — tool not on allowlist", async () => {
+    const mw = createToolPermissionPolicy({
+      permission: { action: "tool.call", allowlist: ["read_file"] },
+    });
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "pre_tool_use",
+        toolName: "shell_exec",
+        toolCallId: "call-2",
+        toolInput: { cmd: "rm -rf /" },
+      }),
+    );
+    expect(verdict.action).toBe("abort");
+    const v = verdict as Abort;
+    expect(v.reason).toBe("allowlist_miss");
+    expect(v.policyId).toBe("guardrail.permission");
+  });
+
+  it("abort — tool on denylist", async () => {
+    const mw = createToolPermissionPolicy({
+      permission: { action: "tool.call", denylist: ["dangerous_tool"] },
+    });
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "pre_tool_use",
+        toolName: "dangerous_tool",
+        toolCallId: "call-3",
+        toolInput: {},
+      }),
+    );
+    expect(verdict.action).toBe("abort");
+    expect((verdict as Abort).reason).toBe("denylist");
+  });
+
+  it("continue — no toolName in context", async () => {
+    const mw = createToolPermissionPolicy({
+      permission: { action: "tool.call", allowlist: ["read_file"] },
+    });
+    const verdict = await mw.fn(baseCtx({ timing: "pre_tool_use" }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: memory", () => {
+  it("transform — memory results found", async () => {
+    const results: MemoryResult[] = [
+      { key: "k1", content: "user prefers dark mode", score: 0.9 },
+      { key: "k2", content: "user timezone is KST", score: 0.8 },
+    ];
+    const mw = createMemoryPolicy(mockMemory(results));
+    const userMsg = createUserMessage("what are my preferences?", "test");
+    const verdict = await mw.fn(baseCtx({ timing: "on_system_prompt", messages: [userMsg] }));
+
+    expect(verdict.action).toBe("transform");
+    const v = verdict as Transform;
+    expect((v.input as Record<string, unknown>).appendContext).toBe(
+      "[Memory Context]\n- user prefers dark mode\n- user timezone is KST",
+    );
+    expect(v.reason).toBe("memory_context_available");
+    expect(v.policyId).toBe("builtin.memory");
+  });
+
+  it("continue — no memory results", async () => {
+    const mw = createMemoryPolicy(mockMemory([]));
+    const userMsg = createUserMessage("hello", "test");
+    const verdict = await mw.fn(baseCtx({ timing: "on_system_prompt", messages: [userMsg] }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("continue — no messages in context", async () => {
+    const mw = createMemoryPolicy(mockMemory([{ key: "k1", content: "data", score: 1.0 }]));
+    const verdict = await mw.fn(baseCtx({ timing: "on_system_prompt" }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("continue — memory.retrieve throws", async () => {
+    const mem = mockMemory();
+    mem.retrieve = async () => {
+      throw new Error("service down");
+    };
+    const mw = createMemoryPolicy(mem);
+    const userMsg = createUserMessage("test", "test");
+    const verdict = await mw.fn(baseCtx({ timing: "on_system_prompt", messages: [userMsg] }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: compaction", () => {
+  it("continue — below token threshold", async () => {
+    const mw = createCompactionPolicy({ contextWindowTokens: 10000, thresholdRatio: 0.8 });
+    const messages = [testMessage("m1"), testMessage("m2")];
+    const verdict = await mw.fn(
+      baseCtx({
+        messages,
+        budgetState: budgetState({ totalInputTokens: 1000, totalOutputTokens: 500 }),
+      }),
+    );
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("transform — above token threshold", async () => {
+    const mw = createCompactionPolicy({
+      contextWindowTokens: 1000,
+      thresholdRatio: 0.8,
+      protectRecentMessages: 2,
+    });
+    const messages = Array.from({ length: 10 }, (_, i) => testMessage(`m${i}`));
+    const verdict = await mw.fn(
+      baseCtx({
+        messages,
+        budgetState: budgetState({ totalInputTokens: 7000, totalOutputTokens: 1000 }),
+      }),
+    );
+    expect(verdict.action).toBe("transform");
+    const v = verdict as Transform;
+    expect(v.reason).toBe("compaction_threshold_exceeded");
+    expect(v.policyId).toBe("builtin.compaction");
+    const compactedMsgs = (v.input as Record<string, unknown>).messages as unknown[];
+    expect(compactedMsgs.length).toBeLessThan(messages.length);
+  });
+
+  it("continue — no budgetState", async () => {
+    const mw = createCompactionPolicy({ contextWindowTokens: 1000, thresholdRatio: 0.8 });
+    const messages = Array.from({ length: 10 }, (_, i) => testMessage(`m${i}`));
+    const verdict = await mw.fn(baseCtx({ messages }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("continue — empty messages", async () => {
+    const mw = createCompactionPolicy({ contextWindowTokens: 1000, thresholdRatio: 0.8 });
+    const verdict = await mw.fn(
+      baseCtx({
+        messages: [],
+        budgetState: budgetState({ totalInputTokens: 9000, totalOutputTokens: 1000 }),
+      }),
+    );
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: post-tool", () => {
+  it("transform — enricher returns string, appended to existing output", async () => {
+    const mw = createPostToolPolicy(() => "enrichment");
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "post_tool_use",
+        toolName: "read_file",
+        toolCallId: "call-1",
+        toolOutput: "file contents here",
+      }),
+    );
+    expect(verdict.action).toBe("transform");
+    const v = verdict as Transform;
+    expect((v.input as Record<string, unknown>).output).toBe("file contents here\nenrichment");
+    expect(v.reason).toBe("post_tool_enrichment");
+    expect(v.policyId).toBe("builtin.post_tool");
+  });
+
+  it("continue — enricher returns null", async () => {
+    const mw = createPostToolPolicy(() => null);
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "post_tool_use",
+        toolName: "read_file",
+        toolOutput: "content",
+      }),
+    );
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("continue — enricher throws (error isolation)", async () => {
+    const mw = createPostToolPolicy(() => {
+      throw new Error("enricher boom");
+    });
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "post_tool_use",
+        toolName: "test-tool",
+        toolOutput: "content",
+      }),
+    );
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("transform — empty toolOutput uses enrichment only", async () => {
+    const mw = createPostToolPolicy(() => "standalone enrichment");
+    const verdict = await mw.fn(
+      baseCtx({
+        timing: "post_tool_use",
+        toolName: "test-tool",
+        toolOutput: "",
+      }),
+    );
+    expect(verdict.action).toBe("transform");
+    const v = verdict as Transform;
+    expect((v.input as Record<string, unknown>).output).toBe("standalone enrichment");
+  });
+});
+
+describe("snapshot: post-turn", () => {
+  it("inject — handler returns inject verdict", async () => {
+    const mw = createPostTurnPolicy(() => ({
+      action: "inject" as const,
+      message: "reminder to user",
+      reason: "turn_reminder",
+      policyId: "test.post_turn",
+    }));
+    const verdict = await mw.fn(baseCtx({ timing: "post_turn", turnCount: 3 }));
+    expect(verdict.action).toBe("inject");
+    const v = verdict as Inject;
+    expect(v.message).toBe("reminder to user");
+    expect(v.reason).toBe("turn_reminder");
+  });
+
+  it("continue — handler returns continue", async () => {
+    const mw = createPostTurnPolicy(() => ({ action: "continue" as const }));
+    const verdict = await mw.fn(baseCtx({ timing: "post_turn", turnCount: 1 }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("abort — handler returns abort", async () => {
+    const mw = createPostTurnPolicy(() => ({
+      action: "abort" as const,
+      reason: "max_turns_reached",
+    }));
+    const verdict = await mw.fn(baseCtx({ timing: "post_turn", turnCount: 10 }));
+    expect(verdict.action).toBe("abort");
+    expect((verdict as Abort).reason).toBe("max_turns_reached");
+  });
+
+  it("continue — handler throws (error isolation)", async () => {
+    const mw = createPostTurnPolicy(() => {
+      throw new Error("handler exploded");
+    });
+    const verdict = await mw.fn(baseCtx({ timing: "post_turn", turnCount: 1 }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: idle-nudge", () => {
+  it("continue — activity is recent", async () => {
+    mockNow(1000);
+    const mw = createIdleNudgePolicy({ idleThresholdMs: 60000 });
+    mockNow(30000);
+    const verdict = await mw.fn(baseCtx({ timing: "pre_turn" }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("inject — idle threshold exceeded", async () => {
+    mockNow(1000);
+    const mw = createIdleNudgePolicy({ idleThresholdMs: 60000 });
+    mockNow(70000);
+    const verdict = await mw.fn(baseCtx({ timing: "pre_turn" }));
+    expect(verdict.action).toBe("inject");
+    const v = verdict as Inject;
+    expect(v.message).toContain("[System]");
+    expect(v.message).toContain("idle for 69s");
+    expect(v.reason).toBe("idle_nudge");
+    expect(v.policyId).toBe("builtin.idle_nudge");
+  });
+
+  it("abort — maxNudges exceeded", async () => {
+    mockNow(0);
+    const mw = createIdleNudgePolicy({ idleThresholdMs: 1000, maxNudges: 2 });
+    mockNow(2000);
+    await mw.fn(baseCtx({ timing: "pre_turn" }));
+    mockNow(4000);
+    await mw.fn(baseCtx({ timing: "pre_turn" }));
+    mockNow(6000);
+    const verdict = await mw.fn(baseCtx({ timing: "pre_turn" }));
+    expect(verdict.action).toBe("abort");
+    const v = verdict as Abort;
+    expect(v.reason).toBe("stalled");
+    expect(v.policyId).toBe("builtin.idle_nudge");
+  });
+
+  it("continue — post_tool_use resets idle timer", async () => {
+    mockNow(0);
+    const mw = createIdleNudgePolicy({ idleThresholdMs: 60000 });
+    mockNow(65000);
+    await mw.fn(baseCtx({ timing: "post_tool_use" }));
+    mockNow(70000);
+    const verdict = await mw.fn(baseCtx({ timing: "pre_turn" }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+
+  it("continue — disabled when idleThresholdMs is -1", async () => {
+    mockNow(0);
+    const mw = createIdleNudgePolicy({ idleThresholdMs: -1 });
+    mockNow(999999);
+    const verdict = await mw.fn(baseCtx({ timing: "pre_turn" }));
+    expect(verdict).toEqual({ action: "continue" });
+  });
+});
+
+describe("snapshot: registration metadata", () => {
+  it("budget-reassurance: name, timing, priority", () => {
+    const mw = createBudgetReassurancePolicy();
+    expect(mw.name).toBe("builtin:budget-reassurance");
+    expect(mw.timing).toBe("pre_turn");
+    expect(mw.priority).toBe(10);
+  });
+
+  it("budget-warning: name, timing, priority", () => {
+    const mw = createBudgetWarningPolicy();
+    expect(mw.name).toBe("builtin:budget-warning");
+    expect(mw.timing).toBe("pre_turn");
+    expect(mw.priority).toBe(20);
+  });
+
+  it("tool-permission: name, timing, priority, failPolicy", () => {
+    const mw = createToolPermissionPolicy({ permission: { action: "tool.call" } });
+    expect(mw.name).toBe("builtin:tool-permission");
+    expect(mw.timing).toBe("pre_tool_use");
+    expect(mw.priority).toBe(0);
+    expect(mw.failPolicy).toBe("fail-closed");
+  });
+
+  it("memory: name, timing, priority", () => {
+    const mw = createMemoryPolicy(mockMemory());
+    expect(mw.name).toBe("builtin:memory");
+    expect(mw.timing).toBe("on_system_prompt");
+    expect(mw.priority).toBe(100);
+  });
+
+  it("compaction: name, timing, priority", () => {
+    const mw = createCompactionPolicy({ contextWindowTokens: 1000 });
+    expect(mw.name).toBe("builtin:compaction");
+    expect(mw.timing).toBe("post_compaction");
+    expect(mw.priority).toBe(900);
+  });
+
+  it("post-tool: name, timing, priority", () => {
+    const mw = createPostToolPolicy(() => null);
+    expect(mw.name).toBe("builtin:post-tool");
+    expect(mw.timing).toBe("post_tool_use");
+    expect(mw.priority).toBe(200);
+  });
+
+  it("post-turn: name, timing, priority", () => {
+    const mw = createPostTurnPolicy(() => ({ action: "continue" }));
+    expect(mw.name).toBe("builtin:post-turn");
+    expect(mw.timing).toBe("post_turn");
+    expect(mw.priority).toBe(250);
+  });
+
+  it("idle-nudge: name, timing (array), priority", () => {
+    const mw = createIdleNudgePolicy();
+    expect(mw.name).toBe("builtin:idle-nudge");
+    expect(mw.timing).toEqual(["pre_turn", "post_tool_use"]);
+    expect(mw.priority).toBe(300);
+  });
+});

--- a/packages/agent/test/core/policy/registry.test.ts
+++ b/packages/agent/test/core/policy/registry.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import { Operational, type Policy } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { PolicyRegistry, defaultRegistry } from "../../../src/core/policy";
+import type { PolicyFactory } from "../../../src/core/policy";
+
+const builtinPolicyIds = [
+  "builtin:budget-reassurance",
+  "builtin:budget-warning",
+  "builtin:compaction",
+  "builtin:memory",
+  "builtin:post-tool",
+  "builtin:post-turn",
+  "builtin:idle-nudge",
+  "builtin:tool-permission",
+];
+
+function plan(policies: Policy.PolicyPlan["policies"]): Policy.PolicyPlan {
+  return { policies, labels: [] };
+}
+
+describe("PolicyRegistry", () => {
+  it("defaultRegistry() has all builtins registered", () => {
+    const registry = defaultRegistry();
+
+    expect(registry.list()).toEqual(builtinPolicyIds);
+    for (const id of builtinPolicyIds) {
+      expect(registry.has(id)).toBe(true);
+    }
+  });
+
+  it("resolve() with a valid plan returns policy registrations", () => {
+    const registry = PolicyRegistry.create();
+    const factory: PolicyFactory = (config, runtime) => ({
+      name: `test:${runtime.agentName}:${(config as { mode: string }).mode}`,
+      timing: "pre_turn",
+      priority: 10,
+      fn: () => ({ action: "continue" }),
+    });
+    registry.register("test.policy", factory);
+
+    const registrations = registry.resolve(
+      plan([{ id: "test.policy", required: true, config: { mode: "strict" } }]),
+      { agentName: "primary" },
+    );
+
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0]?.name).toBe("test:primary:strict");
+  });
+
+  it("resolve() with a missing required policy throws", () => {
+    const registry = PolicyRegistry.create();
+
+    expect(() => registry.resolve(plan([{ id: "missing.policy", required: true }]), {})).toThrow(
+      "Required policy 'missing.policy' is not registered",
+    );
+  });
+
+  it("resolve() with a missing optional policy skips it and logs", async () => {
+    Bus.reset();
+    const events: unknown[] = [];
+    const unsubscribe = Bus.observe((event, payload) => {
+      if (event.name === Operational.Warn.name) events.push(payload);
+    });
+
+    try {
+      const registry = PolicyRegistry.create();
+      registry.register("present.policy", () => ({
+        name: "present.policy",
+        timing: "pre_turn",
+        priority: 10,
+        fn: () => ({ action: "continue" }),
+      }));
+
+      const registrations = registry.resolve(
+        plan([
+          { id: "missing.optional", required: false },
+          { id: "present.policy", required: true },
+        ]),
+        { sessionId: "session-1", runId: "run-1", agentName: "primary" },
+      );
+      await Promise.resolve();
+
+      expect(registrations).toHaveLength(1);
+      expect(registrations[0]?.name).toBe("present.policy");
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        traceId: "run-1",
+        sessionId: "session-1",
+        component: "agent.policy.registry",
+        msg: "optional policy missing",
+        context: { policyId: "missing.optional", agentName: "primary" },
+      });
+    } finally {
+      unsubscribe();
+      Bus.reset();
+    }
+  });
+});

--- a/packages/openomni/src/execution-runtime/middleware.test.ts
+++ b/packages/openomni/src/execution-runtime/middleware.test.ts
@@ -1,34 +1,94 @@
 import { describe, expect, it } from "bun:test";
+import type { Policy } from "@openomni/protocol";
 import { buildWorkerMiddleware } from "./middleware";
 
 describe("buildWorkerMiddleware", () => {
-  it("returns worker-owned registrations", () => {
-    const registrations = buildWorkerMiddleware({});
-    expect(registrations.map((r) => r.name)).toEqual([
-      "builtin:tool-permission",
-      "builtin:idle-nudge",
-    ]);
+  describe("backward compatibility (no policyPlan)", () => {
+    it("returns worker-owned registrations", () => {
+      const registrations = buildWorkerMiddleware({});
+      expect(registrations.map((r) => r.name)).toEqual([
+        "builtin:tool-permission",
+        "builtin:idle-nudge",
+      ]);
+    });
+
+    it("first registration is tool permission with fail-closed policy", () => {
+      const registrations = buildWorkerMiddleware({});
+      const toolPermission = registrations[0];
+      if (toolPermission == null) {
+        throw new Error("expected tool permission registration");
+      }
+      expect(toolPermission.name).toBe("builtin:tool-permission");
+      expect(toolPermission.failPolicy).toBe("fail-closed");
+    });
+
+    it("includes idle-nudge middleware", () => {
+      const registrations = buildWorkerMiddleware({});
+      const idleNudge = registrations.find((r) => r.name === "builtin:idle-nudge");
+      expect(idleNudge).toBeDefined();
+    });
+
+    it("passes permissions to tool permission middleware", () => {
+      const permissions = { action: "tool.call", allowlist: ["tool:read"] };
+      const registrations = buildWorkerMiddleware({ permissions });
+      expect(registrations[0]?.name).toBe("builtin:tool-permission");
+    });
   });
 
-  it("first registration is tool permission with fail-closed policy", () => {
-    const registrations = buildWorkerMiddleware({});
-    const toolPermission = registrations[0];
-    if (toolPermission == null) {
-      throw new Error("expected tool permission registration");
-    }
-    expect(toolPermission.name).toBe("builtin:tool-permission");
-    expect(toolPermission.failPolicy).toBe("fail-closed");
-  });
+  describe("policy plan path (with policyPlan)", () => {
+    it("accepts policyPlan in config", () => {
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call" } },
+          },
+        ],
+        labels: ["security", "audit"],
+        registryVersion: "1.0.0",
+      };
 
-  it("includes idle-nudge middleware", () => {
-    const registrations = buildWorkerMiddleware({});
-    const idleNudge = registrations.find((r) => r.name === "builtin:idle-nudge");
-    expect(idleNudge).toBeDefined();
-  });
+      const registrations = buildWorkerMiddleware({ policyPlan });
+      expect(registrations).toBeDefined();
+      expect(Array.isArray(registrations)).toBe(true);
+    });
 
-  it("passes permissions to tool permission middleware", () => {
-    const permissions = { action: "tool.call", allowlist: ["tool:read"] };
-    const registrations = buildWorkerMiddleware({ permissions });
-    expect(registrations[0]?.name).toBe("builtin:tool-permission");
+    it("resolves builtin policies from policyPlan via registry", () => {
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call" } },
+          },
+          { id: "builtin:idle-nudge", required: true, config: {} },
+        ],
+        labels: ["security"],
+      };
+
+      const registrations = buildWorkerMiddleware({ policyPlan });
+      expect(registrations.map((r) => r.name)).toEqual([
+        "builtin:tool-permission",
+        "builtin:idle-nudge",
+      ]);
+    });
+
+    it("ignores permissions when policyPlan is provided", () => {
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call" } },
+          },
+        ],
+        labels: ["security"],
+      };
+      const permissions = { action: "tool.call", allowlist: ["tool:read"] };
+
+      const registrations = buildWorkerMiddleware({ policyPlan, permissions });
+      expect(registrations.map((r) => r.name)).toEqual(["builtin:tool-permission"]);
+    });
   });
 });

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -1,16 +1,34 @@
-import { createIdleNudgePolicy, createToolPermissionPolicy } from "@openomni/agent";
+import {
+  createIdleNudgePolicy,
+  createToolPermissionPolicy,
+  defaultRegistry,
+} from "@openomni/agent";
 import type { PolicyRegistration } from "@openomni/agent";
 import type { Policy } from "@openomni/protocol";
 
 export interface WorkerMiddlewareConfig {
   permissions?: Policy.Permission;
+  policyPlan?: Policy.PolicyPlan;
 }
 
 export function buildWorkerMiddleware(config: WorkerMiddlewareConfig): PolicyRegistration[] {
+  if (config.policyPlan) {
+    return resolvePoliciesFromPlan(config.policyPlan);
+  }
+
+  return buildLegacyMiddleware(config.permissions);
+}
+
+function buildLegacyMiddleware(permissions?: Policy.Permission): PolicyRegistration[] {
   return [
     createToolPermissionPolicy({
-      permission: config.permissions ?? { action: "tool.call" },
+      permission: permissions ?? { action: "tool.call" },
     }),
     createIdleNudgePolicy(),
   ];
+}
+
+function resolvePoliciesFromPlan(plan: Policy.PolicyPlan): PolicyRegistration[] {
+  const registry = defaultRegistry();
+  return registry.resolve(plan, {});
 }

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -72,7 +72,13 @@ export {
 } from "./subagent";
 
 // Policy compatibility exports
-export { BackgroundLimitsPolicy } from "./policy";
+export { BackgroundLimitsPolicy, PolicyResolver } from "./policy";
+export type {
+  LabelMatcher,
+  PolicyResolverInstance,
+  PolicyResolverRule,
+  ResolverContext,
+} from "./policy";
 
 // Execution runtime
 export {

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -1,5 +1,5 @@
-import type { PolicyDecision } from "@openomni/agent";
-import { type Ingress, IngressEvent } from "@openomni/protocol";
+import { PolicyEngine, type PolicyDecision, type PolicyRegistration } from "@openomni/agent";
+import { type Ingress, type Policy, IngressEvent } from "@openomni/protocol";
 import { Bus, Storage, SurfaceKey, TraceContext } from "@openomni/session";
 import type { CoordinatorLike } from "./coordinator-like";
 import { IngressEventProjector } from "./event-projector";
@@ -9,8 +9,11 @@ import { IngressSessionResolver } from "./session-resolver";
 
 export type { CoordinatorLike };
 
+const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
 let _coordinator: CoordinatorLike | undefined;
 let _middlewareDecisionObserver: ((decision: PolicyDecision) => void | Promise<void>) | undefined;
+let _ingressPolicies: PolicyRegistration[] = [];
 
 export namespace IngressEngine {
   export function reset(): void {
@@ -19,6 +22,7 @@ export namespace IngressEngine {
     Bus.reset();
     _coordinator = undefined;
     _middlewareDecisionObserver = undefined;
+    _ingressPolicies = [];
   }
 
   export function setCoordinator(c: CoordinatorLike): void {
@@ -33,6 +37,10 @@ export namespace IngressEngine {
     observer: ((decision: PolicyDecision) => void | Promise<void>) | undefined,
   ): void {
     _middlewareDecisionObserver = observer;
+  }
+
+  export function registerIngressPolicy(reg: PolicyRegistration): void {
+    _ingressPolicies.push(reg);
   }
 
   export async function ingest(event: Ingress.InboundEvent): Promise<Ingress.IngressResult> {
@@ -58,6 +66,41 @@ export namespace IngressEngine {
       payloadLength,
       time: Date.now(),
     });
+
+    if (_ingressPolicies.length > 0) {
+      const engine = PolicyEngine.create({
+        traceContext: trace,
+        onDecision: _middlewareDecisionObserver,
+      });
+      for (const reg of _ingressPolicies) {
+        engine.register(reg);
+      }
+
+      const labels: Policy.LabelEntry[] = [
+        { value: `surface.${inboundEvent.surface}`, source: "system" },
+      ];
+      const actor = inboundEvent.meta?.actor;
+      if (actor && typeof actor === "object" && !Array.isArray(actor)) {
+        const role = String((actor as Record<string, unknown>).role ?? "");
+        if (role) labels.push({ value: `actor.${role}`, source: "system" });
+      }
+
+      const verdict = await engine.dispatch("pre_ingress", {
+        steps: [],
+        usage: emptyUsage,
+        turnCount: 0,
+        isCompletion: false,
+        continuationCount: 0,
+        elapsedMs: 0,
+        labels,
+        toolInput: { surface: inboundEvent.surface, mode: inboundEvent.mode },
+        traceContext: trace,
+      });
+
+      if (verdict.action !== "continue") {
+        throw new Error(verdict.reason ?? "pre_ingress policy aborted");
+      }
+    }
 
     const agentModel = inboundEvent.agent.model;
     const { session } = IngressSessionResolver.resolve(

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -43,6 +43,7 @@ export namespace IngressHandlers {
       credentials: undefined,
       budget: ctx.event.agent.budget,
       workspaceRoot: ctx.event.agent.toolConfig?.workspaceRoot,
+      policyPlan: ctx.event.agent.policyPlan,
       traceId: ctx.traceContext?.traceId,
     };
   }

--- a/packages/openomni/src/policy/index.ts
+++ b/packages/openomni/src/policy/index.ts
@@ -2,3 +2,10 @@ export { IngressAuthorityMiddleware } from "../ingress/middleware/ingress-author
 export { SubagentSpawnPolicyMiddleware } from "../subagent/middleware/subagent-spawn-policy";
 export { BackgroundLimitsPolicy } from "./background-limits";
 export { ToolRuntimePolicyMiddleware } from "../execution-runtime/tool/middleware/tool-runtime-policy";
+export { PolicyResolver } from "./resolver";
+export type {
+  LabelMatcher,
+  PolicyResolverInstance,
+  PolicyResolverRule,
+  ResolverContext,
+} from "./resolver";

--- a/packages/openomni/src/policy/resolver.ts
+++ b/packages/openomni/src/policy/resolver.ts
@@ -1,0 +1,95 @@
+import type { Policy } from "@openomni/protocol";
+
+const defaultPolicyIds = ["builtin:tool-permission", "builtin:idle-nudge"];
+
+type LabelInput = string | Policy.LabelEntry;
+
+export interface ResolverContext {
+  readonly actorLabels: readonly LabelInput[];
+  readonly agentLabels: readonly LabelInput[];
+  readonly runLabels: readonly LabelInput[];
+  readonly surfaceLabels: readonly LabelInput[];
+}
+
+export interface LabelMatcher {
+  readonly all?: readonly string[];
+  readonly any?: readonly string[];
+  readonly none?: readonly string[];
+}
+
+export interface PolicyResolverRule {
+  readonly match: LabelMatcher;
+  readonly policies: readonly string[];
+  readonly required?: boolean;
+}
+
+export interface PolicyResolverInstance {
+  resolve(context: ResolverContext): Policy.PolicyPlan;
+}
+
+function labelValue(label: LabelInput): string {
+  return typeof label === "string" ? label : label.value;
+}
+
+function uniqueLabels(context: ResolverContext): string[] {
+  const labels = new Set<string>();
+  for (const label of [
+    ...context.actorLabels,
+    ...context.agentLabels,
+    ...context.runLabels,
+    ...context.surfaceLabels,
+  ]) {
+    labels.add(labelValue(label));
+  }
+  return [...labels];
+}
+
+function hasAny(labels: ReadonlySet<string>, expected: readonly string[] | undefined): boolean {
+  return expected?.some((label) => labels.has(label)) ?? false;
+}
+
+function matchesLabels(matcher: LabelMatcher, labels: ReadonlySet<string>): boolean {
+  if (matcher.all?.some((label) => !labels.has(label))) return false;
+  if (matcher.any !== undefined && !hasAny(labels, matcher.any)) return false;
+  if (hasAny(labels, matcher.none)) return false;
+  return true;
+}
+
+function addPolicies(
+  plan: Map<string, Policy.PolicyPlan["policies"][number]>,
+  policyIds: readonly string[],
+  required: boolean,
+): void {
+  for (const id of policyIds) {
+    const existing = plan.get(id);
+    plan.set(id, { id, required: existing?.required || required });
+  }
+}
+
+class StaticPolicyResolver implements PolicyResolverInstance {
+  constructor(private readonly rules: readonly PolicyResolverRule[]) {}
+
+  resolve(context: ResolverContext): Policy.PolicyPlan {
+    const labels = uniqueLabels(context);
+    const labelSet = new Set(labels);
+    const policies = new Map<string, Policy.PolicyPlan["policies"][number]>();
+
+    addPolicies(policies, defaultPolicyIds, true);
+
+    for (const rule of this.rules) {
+      if (matchesLabels(rule.match, labelSet)) {
+        addPolicies(policies, rule.policies, rule.required ?? false);
+      }
+    }
+
+    return { policies: [...policies.values()], labels };
+  }
+}
+
+export namespace PolicyResolver {
+  export const DefaultPolicies = [...defaultPolicyIds];
+
+  export function create(rules: readonly PolicyResolverRule[] = []): PolicyResolverInstance {
+    return new StaticPolicyResolver(rules);
+  }
+}

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -1,5 +1,5 @@
-import type { ChatAgent } from "@openomni/agent";
-import { type Policy, type Message, Subagent } from "@openomni/protocol";
+import { PolicyEngine, type ChatAgent, type PolicyRegistration } from "@openomni/agent";
+import { type Hook, type Policy, type Message, Subagent } from "@openomni/protocol";
 import { Bus, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
 import { get as getAbortEntry, register as registerAbortController } from "./abort-registry";
 import { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-policy.js";
@@ -25,6 +25,54 @@ import {
   maybeCompactSendTranscript,
   runWithTranscript,
 } from "./transcript";
+
+const emptyDelegationUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+async function dispatchPreDelegation(input: {
+  middleware?: PolicyRegistration[];
+  childAgent: string;
+  parentSessionId?: string;
+  operation: string;
+  prompt: string;
+}): Promise<Hook.Verdict> {
+  if (!input.middleware?.length) return { action: "continue" };
+
+  const engine = PolicyEngine.create({ audit: false });
+  for (const reg of input.middleware) {
+    engine.register(reg);
+  }
+
+  return engine.dispatch("pre_delegation", {
+    steps: [],
+    usage: emptyDelegationUsage,
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    toolName: "subagent",
+    toolInput: {
+      operation: input.operation,
+      childAgent: input.childAgent,
+      prompt: input.prompt,
+      ...(input.parentSessionId !== undefined && { parentSessionId: input.parentSessionId }),
+    },
+    labels: [
+      { value: `actor.child:${input.childAgent}`, source: "system" as const },
+      ...(input.parentSessionId !== undefined
+        ? [{ value: `actor.parent:${input.parentSessionId}`, source: "system" as const }]
+        : []),
+    ],
+  });
+}
+
+function applyDelegationTransform(
+  config: { permissions?: Policy.Permission; softTimeoutMs?: number; hardTimeoutMs?: number },
+  input: Record<string, unknown>,
+): void {
+  if (input.permissions !== undefined) config.permissions = input.permissions as Policy.Permission;
+  if (typeof input.softTimeoutMs === "number") config.softTimeoutMs = input.softTimeoutMs;
+  if (typeof input.hardTimeoutMs === "number") config.hardTimeoutMs = input.hardTimeoutMs;
+}
 
 export namespace SubagentRuntime {
   export interface SpawnConfig extends RuntimeConfig {
@@ -94,7 +142,21 @@ export namespace SubagentRuntime {
     hardTimeoutMs?: number;
   }
 
-  export function spawn(config: SpawnConfig): Promise<RunResult> {
+  export async function spawn(config: SpawnConfig): Promise<RunResult> {
+    const verdict = await dispatchPreDelegation({
+      middleware: config.middleware,
+      childAgent: config.agentName,
+      parentSessionId: config.parentSessionId,
+      operation: "spawn",
+      prompt: config.prompt,
+    });
+    if (verdict.action === "abort") {
+      throw new Error(verdict.reason ?? "pre_delegation policy aborted spawn");
+    }
+    if (verdict.action === "transform") {
+      applyDelegationTransform(config, verdict.input);
+    }
+
     const session = createSpawnSession(config);
     void 0;
 
@@ -129,6 +191,20 @@ export namespace SubagentRuntime {
   }
 
   export async function spawnBackground(config: SpawnConfig): Promise<SpawnBackgroundResult> {
+    const verdict = await dispatchPreDelegation({
+      middleware: config.middleware,
+      childAgent: config.agentName,
+      parentSessionId: config.parentSessionId,
+      operation: "spawn_background",
+      prompt: config.prompt,
+    });
+    if (verdict.action === "abort") {
+      throw new Error(verdict.reason ?? "pre_delegation policy aborted spawn");
+    }
+    if (verdict.action === "transform") {
+      applyDelegationTransform(config, verdict.input);
+    }
+
     const session = createSpawnSession(config);
 
     const userMessage = createUserMessage(session.id, config.model);
@@ -163,6 +239,24 @@ export namespace SubagentRuntime {
   }
 
   export async function send(config: SendConfig): Promise<RunResult> {
+    const childMeta = Session.getWorkerMeta(config.sessionId);
+    const childAgent =
+      typeof childMeta?.agentName === "string" ? childMeta.agentName : config.sessionId;
+    const childSession = Session.get(config.sessionId);
+    const sendVerdict = await dispatchPreDelegation({
+      middleware: config.middleware,
+      childAgent,
+      parentSessionId: childSession?.parentSessionId,
+      operation: "send",
+      prompt: config.prompt,
+    });
+    if (sendVerdict.action === "abort") {
+      throw new Error(sendVerdict.reason ?? "pre_delegation policy aborted send");
+    }
+    if (sendVerdict.action === "transform") {
+      applyDelegationTransform(config, sendVerdict.input);
+    }
+
     const policy = await SubagentSpawnPolicyMiddleware.runPreSpawn({
       operation: "send",
       sessionId: config.sessionId,

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { PolicyDecision } from "@openomni/agent";
-import type { Ingress } from "@openomni/protocol";
+import type { PolicyDecision, PolicyRegistration } from "@openomni/agent";
+import type { Hook, Ingress } from "@openomni/protocol";
 import { Ingress as IngressNamespace } from "@openomni/protocol";
 import { Storage } from "@openomni/session";
 import {
@@ -260,5 +260,105 @@ describe("IngressEngine", () => {
     } finally {
       schema.safeParse = originalSafeParse;
     }
+  });
+
+  describe("pre_ingress policy dispatch", () => {
+    function makeEvent(overrides?: Partial<Ingress.InboundEvent>): Ingress.InboundEvent {
+      return {
+        id: "event-policy-1",
+        surface: "tui",
+        workspace: "/repo",
+        mode: "direct",
+        payload: "hello",
+        agent: { model: { provider: "anthropic", id: "claude-3-haiku-20240307" } },
+        ...overrides,
+      };
+    }
+
+    function abortPolicy(reason: string): PolicyRegistration {
+      return {
+        name: "test:ingress-abort",
+        timing: "pre_ingress",
+        priority: 0,
+        failPolicy: "fail-closed",
+        fn: () => ({ action: "abort" as const, policyId: "test.abort", reason }),
+      };
+    }
+
+    function continuePolicy(): PolicyRegistration {
+      return {
+        name: "test:ingress-continue",
+        timing: "pre_ingress",
+        priority: 0,
+        fn: () => ({ action: "continue" as const, policyId: "test.continue", reason: "ok" }),
+      };
+    }
+
+    it("aborts ingest when pre_ingress policy returns abort", async () => {
+      IngressEngine.registerIngressPolicy(abortPolicy("rate limit exceeded"));
+
+      const error = await catchError(IngressEngine.ingest(makeEvent()));
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("rate limit exceeded");
+    });
+
+    it("proceeds normally when pre_ingress policy returns continue", async () => {
+      testState.responseQueue.push("policy-ok response");
+      IngressEngine.registerIngressPolicy(continuePolicy());
+
+      const result = await IngressEngine.ingest(makeEvent());
+
+      expect(result.mode).toBe("direct");
+      expect(result.result.output).toBe("policy-ok response");
+    });
+
+    it("records pre_ingress decision through observer", async () => {
+      const decisions: PolicyDecision[] = [];
+      IngressEngine.setPolicyDecisionObserver((d) => {
+        decisions.push(d);
+      });
+      IngressEngine.registerIngressPolicy(abortPolicy("blocked"));
+
+      await catchError(IngressEngine.ingest(makeEvent()));
+
+      const ingressDecision = decisions.find((d) => d.timing === "pre_ingress");
+      expect(ingressDecision).toBeDefined();
+      expect(ingressDecision!.name).toBe("test:ingress-abort");
+      expect(ingressDecision!.verdict).toBe("abort");
+      expect(ingressDecision!.reason).toBe("blocked");
+    });
+
+    it("provides surface and actor labels to policy context", async () => {
+      let capturedLabels: unknown;
+      IngressEngine.registerIngressPolicy({
+        name: "test:label-capture",
+        timing: "pre_ingress",
+        priority: 0,
+        fn: (ctx) => {
+          capturedLabels = ctx.labels;
+          return { action: "continue" as const, policyId: "test.labels", reason: "captured" };
+        },
+      });
+      testState.responseQueue.push("ok");
+
+      await IngressEngine.ingest(
+        makeEvent({ surface: "slack", meta: { actor: { role: "user" } } }),
+      );
+
+      expect(capturedLabels).toEqual([
+        { value: "surface.slack", source: "system" },
+        { value: "actor.user", source: "system" },
+      ]);
+    });
+
+    it("skips dispatch when no ingress policies registered", async () => {
+      testState.responseQueue.push("no-policy response");
+
+      const result = await IngressEngine.ingest(makeEvent());
+
+      expect(result.mode).toBe("direct");
+      expect(result.result.output).toBe("no-policy response");
+    });
   });
 });

--- a/packages/openomni/test/policy/integration.test.ts
+++ b/packages/openomni/test/policy/integration.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "bun:test";
+import { PolicyEngine, defaultRegistry, type PolicyContext } from "@openomni/agent";
+import type { Policy } from "@openomni/protocol";
+import { buildWorkerMiddleware } from "../../src/execution-runtime/middleware";
+import { PolicyResolver } from "../../src/policy";
+
+function baseCtx(
+  overrides?: Partial<Omit<PolicyContext, "timing">>,
+): Omit<PolicyContext, "timing"> {
+  return {
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
+function labelEntries(labels: readonly string[]): Policy.LabelEntry[] {
+  return labels.map((value) => ({ value, source: "operator" }));
+}
+
+describe("policy pipeline integration", () => {
+  it("runs labels through resolver, plan, registry, engine dispatch, and verdict", async () => {
+    const resolver = PolicyResolver.create([
+      {
+        match: { all: ["surface.github"], any: ["agent.reviewer", "agent.coder"] },
+        policies: ["test:github-surface-guard"],
+        required: true,
+      },
+    ]);
+    const plan = resolver.resolve({
+      actorLabels: [{ value: "actor.owner", source: "operator" }],
+      agentLabels: [{ value: "agent.reviewer", source: "agent_profile" }],
+      runLabels: ["run.direct"],
+      surfaceLabels: ["surface.github"],
+    });
+
+    expect(plan.policies.map((policy) => policy.id)).toEqual([
+      "builtin:tool-permission",
+      "builtin:idle-nudge",
+      "test:github-surface-guard",
+    ]);
+    expect(plan.labels).toEqual(["actor.owner", "agent.reviewer", "run.direct", "surface.github"]);
+
+    const registry = defaultRegistry();
+    registry.register("test:github-surface-guard", () => ({
+      name: "test:github-surface-guard",
+      timing: "pre_turn",
+      priority: 0,
+      failPolicy: "fail-closed",
+      fn: (ctx) => {
+        const hasGitHubLabel =
+          ctx.labels?.some((label) => label.value === "surface.github") ?? false;
+        if (hasGitHubLabel) {
+          return {
+            action: "abort",
+            reason: "github_surface_requires_explicit_review_mode",
+            policyId: "test:github-surface-guard",
+          };
+        }
+        return { action: "continue" };
+      },
+    }));
+
+    const registrations = registry.resolve(plan, { agentName: "reviewer" });
+    expect(registrations.map((registration) => registration.name)).toContain(
+      "test:github-surface-guard",
+    );
+
+    const engine = PolicyEngine.create({ audit: false });
+    for (const registration of registrations) engine.register(registration);
+
+    const verdict = await engine.dispatch(
+      "pre_turn",
+      baseCtx({ agentType: "reviewer", labels: labelEntries(plan.labels) }),
+    );
+
+    expect(verdict).toEqual({
+      action: "abort",
+      reason: "github_surface_requires_explicit_review_mode",
+      policyId: "test:github-surface-guard",
+    });
+  });
+
+  it("denies write tools for a reviewer agent on GitHub", async () => {
+    const resolver = PolicyResolver.create([
+      {
+        match: { all: ["agent:reviewer", "surface:github"] },
+        policies: ["policy:github-review-readonly"],
+        required: true,
+      },
+    ]);
+    const plan = resolver.resolve({
+      actorLabels: ["actor:main"],
+      agentLabels: ["agent:reviewer"],
+      runLabels: ["run:review"],
+      surfaceLabels: ["surface:github"],
+    });
+
+    const registry = defaultRegistry();
+    registry.register("policy:github-review-readonly", () => ({
+      name: "policy:github-review-readonly",
+      timing: "pre_tool_use",
+      priority: -10,
+      failPolicy: "fail-closed",
+      fn: (ctx) => {
+        const isWriteTool = ctx.toolLabels?.includes("capability.write") ?? false;
+        if (isWriteTool) {
+          return {
+            action: "abort",
+            reason: "reviewer_read_only",
+            policyId: "policy:github-review-readonly",
+          };
+        }
+        return { action: "continue" };
+      },
+    }));
+
+    const engine = PolicyEngine.create({ audit: false });
+    for (const registration of registry.resolve(plan, { agentName: "reviewer" })) {
+      engine.register(registration);
+    }
+
+    const verdict = await engine.dispatch(
+      "pre_tool_use",
+      baseCtx({
+        agentType: "reviewer",
+        labels: labelEntries(plan.labels),
+        toolName: "github.create_review_comment",
+        toolCallId: "call-review-comment",
+        toolLabels: ["surface.github", "capability.write"],
+        toolInput: { body: "Please change this implementation." },
+      }),
+    );
+
+    expect(verdict).toEqual({
+      action: "abort",
+      reason: "reviewer_read_only",
+      policyId: "policy:github-review-readonly",
+    });
+  });
+
+  it("keeps permissions-only worker middleware working end-to-end", async () => {
+    const registrations = buildWorkerMiddleware({
+      permissions: { action: "tool.call", allowlist: ["github.read_issue"] },
+    });
+    const engine = PolicyEngine.create({ audit: false });
+    for (const registration of registrations) engine.register(registration);
+
+    const verdict = await engine.dispatch(
+      "pre_tool_use",
+      baseCtx({
+        toolName: "github.create_issue_comment",
+        toolCallId: "call-comment",
+        toolLabels: ["surface.github", "capability.write"],
+        toolInput: { body: "Looks good." },
+      }),
+    );
+
+    expect(verdict.action).toBe("abort");
+    expect("decision" in verdict ? verdict.decision : undefined).toBe("deny");
+    expect(verdict.reason).toBe("allowlist_miss");
+    expect(verdict.policyId).toBe("guardrail.permission");
+  });
+
+  it("fails closed when a required policy is not registered", () => {
+    const plan: Policy.PolicyPlan = {
+      policies: [{ id: "policy:missing-required", required: true }],
+      labels: ["agent:reviewer", "surface:github"],
+    };
+
+    expect(() => defaultRegistry().resolve(plan, { agentName: "reviewer" })).toThrow(
+      "Required policy 'policy:missing-required' is not registered",
+    );
+  });
+});

--- a/packages/openomni/test/policy/resolver.test.ts
+++ b/packages/openomni/test/policy/resolver.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { PolicyResolver } from "../../src/policy";
+
+describe("PolicyResolver", () => {
+  it("returns matching policies in a PolicyPlan", () => {
+    const resolver = PolicyResolver.create([
+      {
+        match: { all: ["actor.owner"], any: ["surface.discord", "surface.github"] },
+        policies: ["policy:trusted-surface"],
+        required: true,
+      },
+      {
+        match: { all: ["actor.guest"] },
+        policies: ["policy:guest"],
+      },
+    ]);
+
+    const plan = resolver.resolve({
+      actorLabels: ["actor.owner"],
+      agentLabels: ["agent.researcher"],
+      runLabels: ["run.direct"],
+      surfaceLabels: ["surface.github"],
+    });
+
+    expect(plan).toEqual({
+      policies: [
+        { id: "builtin:tool-permission", required: true },
+        { id: "builtin:idle-nudge", required: true },
+        { id: "policy:trusted-surface", required: true },
+      ],
+      labels: ["actor.owner", "agent.researcher", "run.direct", "surface.github"],
+    });
+  });
+
+  it("always includes default backward-compatible policies", () => {
+    const resolver = PolicyResolver.create([]);
+
+    const plan = resolver.resolve({
+      actorLabels: [],
+      agentLabels: [],
+      runLabels: [],
+      surfaceLabels: [],
+    });
+
+    expect(plan.policies).toEqual([
+      { id: "builtin:tool-permission", required: true },
+      { id: "builtin:idle-nudge", required: true },
+    ]);
+  });
+
+  it("matches all, any, and none label clauses", () => {
+    const resolver = PolicyResolver.create([
+      {
+        match: { all: ["actor.owner", "agent.coder"] },
+        policies: ["policy:all"],
+      },
+      {
+        match: { any: ["surface.telegram", "surface.github"] },
+        policies: ["policy:any"],
+      },
+      {
+        match: { none: ["risk.high"] },
+        policies: ["policy:none"],
+      },
+      {
+        match: { all: ["actor.owner"], none: ["risk.high"] },
+        policies: ["policy:blocked-by-none"],
+      },
+    ]);
+
+    const plan = resolver.resolve({
+      actorLabels: ["actor.owner"],
+      agentLabels: [{ value: "agent.coder", source: "agent_profile" }],
+      runLabels: ["risk.high"],
+      surfaceLabels: ["surface.github"],
+    });
+
+    expect(plan.policies.map((policy) => policy.id)).toEqual([
+      "builtin:tool-permission",
+      "builtin:idle-nudge",
+      "policy:all",
+      "policy:any",
+    ]);
+    expect(plan.labels).toEqual(["actor.owner", "agent.coder", "risk.high", "surface.github"]);
+  });
+});

--- a/packages/openomni/test/subagent/runtime.test.ts
+++ b/packages/openomni/test/subagent/runtime.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { ChatAgent, type AgentResult, type ChatAgentInput } from "@openomni/agent";
+import {
+  ChatAgent,
+  type AgentResult,
+  type ChatAgentInput,
+  type PolicyRegistration,
+} from "@openomni/agent";
 import { Subagent } from "@openomni/protocol";
 import { Bus, Session, Storage, WorkerRun } from "@openomni/session";
 import { SubagentRuntime } from "../../src/subagent/runtime";
@@ -290,6 +295,169 @@ describe("SubagentRuntime", () => {
 
     it("is a no-op for non-existent session", async () => {
       await SubagentRuntime.cancel({ sessionId: "nonexistent" });
+    });
+  });
+
+  describe("pre_delegation policy", () => {
+    const model = { provider: "anthropic", id: "claude-3-haiku-20240307" };
+
+    it("spawn aborts when pre_delegation policy returns abort", async () => {
+      const abortPolicy: PolicyRegistration = {
+        name: "test:block-delegation",
+        timing: "pre_delegation",
+        priority: 0,
+        fn: () => ({
+          action: "abort" as const,
+          reason: "delegation denied by test policy",
+          policyId: "test:block",
+        }),
+      };
+
+      const error = await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "blocked task",
+        prompt: "should not run",
+        model,
+        middleware: [abortPolicy],
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("delegation denied by test policy");
+    });
+
+    it("spawn proceeds when pre_delegation policy returns continue", async () => {
+      queueResult("allowed output");
+
+      const allowPolicy: PolicyRegistration = {
+        name: "test:allow-delegation",
+        timing: "pre_delegation",
+        priority: 0,
+        fn: () => ({
+          action: "continue" as const,
+          policyId: "test:allow",
+        }),
+      };
+
+      const result = await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "allowed task",
+        prompt: "do work",
+        model,
+        middleware: [allowPolicy],
+      });
+
+      expect(result.output).toBe("allowed output");
+    });
+
+    it("spawn applies transform constraints from pre_delegation verdict", async () => {
+      queueResult("transformed output");
+
+      const transformPolicy: PolicyRegistration = {
+        name: "test:transform-delegation",
+        timing: "pre_delegation",
+        priority: 0,
+        fn: () => ({
+          action: "transform" as const,
+          input: { softTimeoutMs: 5000, hardTimeoutMs: 10000 },
+          reason: "enforce timeout limits",
+          policyId: "test:transform",
+        }),
+      };
+
+      const config: Parameters<typeof SubagentRuntime.spawn>[0] = {
+        agentName: "worker",
+        title: "transformed task",
+        prompt: "do work",
+        model,
+        middleware: [transformPolicy],
+      };
+
+      const result = await SubagentRuntime.spawn(config);
+      expect(result.output).toBe("transformed output");
+      expect(config.softTimeoutMs).toBe(5000);
+      expect(config.hardTimeoutMs).toBe(10000);
+    });
+
+    it("pre_delegation receives parent/child agent labels", async () => {
+      queueResult("labeled output");
+      const parentSessionId = createParentSession();
+
+      let capturedLabels: unknown;
+      let capturedToolInput: unknown;
+      const capturePolicy: PolicyRegistration = {
+        name: "test:capture-ctx",
+        timing: "pre_delegation",
+        priority: 0,
+        fn: (ctx) => {
+          capturedLabels = ctx.labels;
+          capturedToolInput = ctx.toolInput;
+          return { action: "continue" as const, policyId: "test:capture" };
+        },
+      };
+
+      await SubagentRuntime.spawn({
+        parentSessionId,
+        agentName: "child-agent",
+        title: "labeled task",
+        prompt: "test labels",
+        model,
+        middleware: [capturePolicy],
+      });
+
+      expect(capturedToolInput).toEqual({
+        operation: "spawn",
+        childAgent: "child-agent",
+        prompt: "test labels",
+        parentSessionId,
+      });
+      expect(capturedLabels).toEqual([
+        { value: "actor.child:child-agent", source: "system" },
+        { value: `actor.parent:${parentSessionId}`, source: "system" },
+      ]);
+    });
+
+    it("send aborts when pre_delegation policy returns abort", async () => {
+      queueResult("spawned");
+      const spawned = await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "child",
+        prompt: "initial",
+        model,
+      });
+
+      const abortPolicy: PolicyRegistration = {
+        name: "test:block-send",
+        timing: "pre_delegation",
+        priority: 0,
+        fn: () => ({
+          action: "abort" as const,
+          reason: "send delegation denied",
+          policyId: "test:block-send",
+        }),
+      };
+
+      const error = await SubagentRuntime.send({
+        sessionId: spawned.sessionId,
+        prompt: "should not run",
+        model,
+        middleware: [abortPolicy],
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("send delegation denied");
+    });
+
+    it("spawn without middleware proceeds normally (no pre_delegation dispatch)", async () => {
+      queueResult("no middleware output");
+
+      const result = await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "no-middleware task",
+        prompt: "do work",
+        model,
+      });
+
+      expect(result.output).toBe("no middleware output");
     });
   });
 });

--- a/packages/protocol/src/execution/index.ts
+++ b/packages/protocol/src/execution/index.ts
@@ -29,6 +29,7 @@ const requestSchema = z.object({
   agentName: z.string().optional(),
   workspaceRoot: z.string().optional(),
   middleware: z.array(z.string()).optional(),
+  policyPlan: Policy.PolicyPlan.optional(),
   traceId: z.string().optional(),
 });
 

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -16,6 +16,7 @@ export namespace Ingress {
     tools: z.array(Tool.Spec).optional(),
     budget: z.object({ maxTurns: z.number().optional() }).optional(),
     permissions: Policy.Permission.optional(),
+    policyPlan: Policy.PolicyPlan.optional(),
     toolConfig: AgentToolConfigSchema.optional(),
   });
   // toolExecutor is a runtime callback — can't be expressed in Zod

--- a/packages/protocol/src/policy/index.ts
+++ b/packages/protocol/src/policy/index.ts
@@ -5,6 +5,24 @@ export namespace Policy {
   const MAX_INPUT_LENGTH = 10_000;
   const POLICY_ID = "guardrail.permission";
 
+  // Label source enumeration: where a label originates from
+  // Labels use source.category naming convention to prevent namespace collisions
+  // Examples: tool.filesystem, actor.owner, surface.github, risk.tier-2, capability.write
+  export const Label = {
+    Source: z.enum(["system", "tool_metadata", "agent_profile", "policy_rule", "operator"]),
+  } as const;
+
+  export type Label = {
+    Source: z.infer<typeof Label.Source>;
+  };
+
+  // Label entry: a labeled value with its source for audit and policy evaluation
+  export const LabelEntry = z.object({
+    value: z.string(),
+    source: Label.Source,
+  });
+  export type LabelEntry = z.infer<typeof LabelEntry>;
+
   export const PermissionDecision = z.enum(["allow", "deny", "require_approval"]);
   export type PermissionDecision = z.infer<typeof PermissionDecision>;
 
@@ -225,17 +243,8 @@ export namespace Policy {
     POST_RUN: "post_run",
     ON_ERROR: "on_error",
     PRE_INGRESS: "pre_ingress",
-    POST_INGRESS: "post_ingress",
-    PRE_DISPATCH: "pre_dispatch",
-    POST_DISPATCH: "post_dispatch",
     PRE_TOOL_SELECTION: "pre_tool_selection",
-    POST_TOOL_SELECTION: "post_tool_selection",
     PRE_DELEGATION: "pre_delegation",
-    POST_DELEGATION: "post_delegation",
-    PRE_MEMORY_ACCESS: "pre_memory_access",
-    POST_MEMORY_ACCESS: "post_memory_access",
-    PRE_ARTIFACT_WRITE: "pre_artifact_write",
-    POST_ARTIFACT_WRITE: "post_artifact_write",
   } as const;
 
   export type Timing = (typeof Timing)[keyof typeof Timing];
@@ -269,4 +278,89 @@ export namespace Policy {
     durationMs: z.number().optional(),
   });
   export type Decision = z.infer<typeof Decision>;
+
+  export const PolicyEffect = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("prompt.append_context"),
+      context: z.string(),
+    }),
+    z.object({
+      type: z.literal("prompt.inject_message"),
+      message: z.string(),
+      role: z.enum(["user", "assistant"]).optional(),
+    }),
+    z.object({
+      type: z.literal("tool.filter"),
+      toolPattern: z.string(),
+    }),
+    z.object({
+      type: z.literal("tool.rewrite_input"),
+      input: z.record(z.string(), z.unknown()),
+    }),
+    z.object({
+      type: z.literal("tool.require_approval"),
+      reason: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal("run.abort"),
+      reason: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal("run.continue_with_prompt"),
+      prompt: z.string(),
+    }),
+    z.object({
+      type: z.literal("run.retry_after"),
+      delayMs: z.number().int().min(0),
+      maxRetries: z.number().int().min(1).optional(),
+    }),
+    z.object({
+      type: z.literal("delegation.set_constraints"),
+      constraints: z.record(z.string(), z.unknown()),
+    }),
+    z.object({
+      type: z.literal("delegation.require_approval"),
+      reason: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal("audit.annotate"),
+      annotation: z.string(),
+      severity: z.enum(["info", "warning", "error"]).optional(),
+    }),
+  ]);
+  export type PolicyEffect = z.infer<typeof PolicyEffect>;
+
+  export const PolicyPoint = z.object({
+    point: z.enum(Object.values(Timing) as [string, ...string[]]),
+    allowedEffects: z.array(
+      z.enum([
+        "prompt.append_context",
+        "prompt.inject_message",
+        "tool.filter",
+        "tool.rewrite_input",
+        "tool.require_approval",
+        "run.abort",
+        "run.continue_with_prompt",
+        "run.retry_after",
+        "delegation.set_constraints",
+        "delegation.require_approval",
+        "audit.annotate",
+      ] as const),
+    ),
+    defaultFailPolicy: FailPolicy,
+  });
+  export type PolicyPoint = z.infer<typeof PolicyPoint>;
+
+  export const PolicyPlan = z.object({
+    policies: z.array(
+      z.object({
+        id: z.string().min(1),
+        required: z.boolean(),
+        config: z.record(z.string(), z.unknown()).optional(),
+      }),
+    ),
+    labels: z.array(z.string()),
+    registryVersion: z.string().optional(),
+  });
+  export type PolicyPlan = z.infer<typeof PolicyPlan>;
 }

--- a/packages/protocol/src/worker-bootstrap/index.ts
+++ b/packages/protocol/src/worker-bootstrap/index.ts
@@ -51,6 +51,7 @@ export namespace WorkerBootstrap {
     agents: RuntimeAgentDefinition.array(),
     toolCatalog: RuntimeToolCatalogEntry.array(),
     credentials: z.record(z.string()).optional(),
+    policyPlan: Policy.PolicyPlan.optional(),
   });
   export type Bootstrap = z.infer<typeof Bootstrap>;
 }


### PR DESCRIPTION
## Summary

Elevate PolicyEngine from a tool-permission-only guard to a universal label-driven policy middleware runtime. Adds PolicyRegistry (named factory store), PolicyResolver (labels → PolicyPlan), and dispatch points at ingress, delegation, and tool-selection layers — while preserving full backward compatibility with the existing permissions-based middleware path.

## Changes

- **protocol**: Add `PolicyPlan`, `PolicyEffect`, `PolicyPoint`, `Label.Source` schemas; audit `Policy.Timing` to 12 validated points (9 Hook.Timing + 3 new); add `policyPlan` field to `WorkerBootstrap`, `Execution.Request`, `Ingress.Agent`
- **agent**: Add `PolicyRegistry` with `defaultRegistry()` pre-populated with 8 builtins; migrate builtins to registry-registerable factories with static `id`; wire `pre_tool_selection` dispatch in stream-helpers before LLM run; export `PolicyRegistry` and related types from barrel
- **openomni**: Add `PolicyResolver` (labels → PolicyPlan with configurable rules + defaults); adapt `buildWorkerMiddleware()` with dual-path (policyPlan via registry / legacy compat); wire `pre_ingress` dispatch in `IngressEngine.ingest()`; wire `pre_delegation` dispatch in `SubagentRuntime.spawn()/send()/spawnBackground()`; export `PolicyResolver` and related types from barrel
- **server**: Propagate `policyPlan` through `worker-entry.ts` and `local-runner.ts` to `buildWorkerMiddleware()`
- **tests**: 41 snapshot tests for all 8 builtins (regression firewall), registry/resolver unit tests, ingress/delegation/tool-selection dispatch tests, full pipeline integration test (labels → plan → registry → engine → verdict)

## Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [x] `protocol`
- [ ] `session`
- [ ] `llm`
- [x] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the policy engine universal and label-driven across ingress, delegation, and tool selection. Adds a plan-based path with `PolicyRegistry` and `PolicyResolver` while keeping legacy permissions-only middleware working.

- **New Features**
  - `protocol`: Added `Policy.PolicyPlan`, `PolicyEffect`, `PolicyPoint`, and `Policy.LabelEntry`; added `policyPlan` to `Execution.Request`, `Ingress.Agent`, and `WorkerBootstrap`.
  - `agent`: Introduced `PolicyRegistry` with `defaultRegistry()` (8 built-ins); converted built-ins to factories; added `pre_tool_selection` dispatch to filter/abort tools before LLM runs; exported registry types.
  - `openomni`: Added `PolicyResolver` (labels → plan); `buildWorkerMiddleware()` now accepts `policyPlan` (falls back to legacy `permissions`); wired `pre_ingress` in `IngressEngine.ingest()` and `pre_delegation` in `SubagentRuntime.spawn()/send()/spawnBackground()`; exports for resolver.
  - `server`: Propagates `policyPlan` to worker middleware.
  - Backward compatible: If no `policyPlan` is provided, the existing permissions-based path is used.

- **Migration**
  - Optional: Build a plan with `PolicyResolver.create(rules).resolve({ actorLabels, agentLabels, runLabels, surfaceLabels })`.
  - Provide the plan via `Ingress.Agent.policyPlan` or `Execution.Request.policyPlan`; workers resolve policies with the default registry.
  - Register custom policies with `PolicyRegistry.create().register(id, factory)` or extend `defaultRegistry()`.
  - Add `labels` to `Tool.Spec` to enable `pre_tool_selection` filtering.

<sup>Written for commit e1ef4ab4a5bdf0dbe841ec151abaa4a4843c0652. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

