### PR TITLE
fix(server): enforce coordinator-only llm runtime

### DIFF
--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -15,7 +15,7 @@ src/
 ├── bootstrap/
 │   ├── index.ts          # main() — wires storage, tool providers, model, channels, server, recovery, shutdown
 │   ├── channels.ts       # createChannelAdapters() — Discord / Telegram / GitHub / WebSocket setup + triggers
-│   ├── local-runner.ts   # LocalRunner.create() — in-process CoordinatorLike for OPENOMNI_MODE=local
+│   ├── local-runner.ts   # Disabled stub; OpenOmni requires coordinator execution
 │   ├── providers.ts      # resolveModel() — picks a default LLM model from stored credentials
 │   ├── mcp.ts            # connectMcpServers() — fires up each configured MCP server
 │   ├── recovery.ts       # runRecovery() — resumes incomplete sessions on startup
@@ -60,9 +60,9 @@ src/
 
 ## BOOT SEQUENCE (`bootstrap/index.ts`)
 
-Two execution modes are selected by `OPENOMNI_MODE` env var:
+OpenOmni always runs inbound execution through the coordinator. `OPENOMNI_MODE=local` is disabled and fails during bootstrap.
 
-**Coordinator mode** (default):
+**Coordinator mode**:
 1. `loadConfig()` — read env + config files.
 2. `initialize({ dbPath })` — bootstrap `@openomni/session` SQLite storage.
 3. Create tool providers: `SystemToolProvider`, `AgentToolProvider`, `McpToolProvider`, `CustomToolProvider`.
@@ -77,9 +77,7 @@ Two execution modes are selected by `OPENOMNI_MODE` env var:
 12. `runRecovery(routingHandler, coordinator, traceId)` — resume sessions interrupted before last shutdown.
 13. `installShutdownHandlers({ channels, server, mcpProvider, coordinator })` — graceful stop on SIGINT / SIGTERM.
 
-**Local mode** (`OPENOMNI_MODE=local`):
-- Skips worker pool; uses `LocalRunner.create(...)` as the `CoordinatorLike`.
-- `LocalRunner` runs `ChatAgent` in-process via `bootstrap/local-runner.ts`.
+**Local mode** (`OPENOMNI_MODE=local`): disabled. Do not add in-process `ChatAgent` execution paths.
 
 ## MESSAGE FLOW
 

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -19,7 +19,6 @@ import { createRouter } from "../server/routes";
 import { McpToolProvider } from "../tool/mcp";
 import { CustomToolProvider } from "../tool/custom";
 import { createChannelAdapters } from "./channels";
-import { LocalRunner } from "./local-runner";
 import { connectMcpServers } from "./mcp";
 import { resolveModel } from "./providers";
 import { runRecovery } from "./recovery";
@@ -101,6 +100,9 @@ function createRoutingHandler(
 
 export async function main(): Promise<void> {
   const config = loadConfig();
+  if (process.env.OPENOMNI_MODE === "local") {
+    throw new Error("OPENOMNI_MODE=local is disabled; OpenOmni requires coordinator mode");
+  }
 
   mkdirSync(dirname(config.storage.dbPath), { recursive: true });
   initialize({ dbPath: config.storage.dbPath });
@@ -118,39 +120,20 @@ export async function main(): Promise<void> {
   };
   await connectMcpServers({ ...config, mcp: mergedMcpConfig }, mcpProvider);
 
-  const isLocalMode = process.env.OPENOMNI_MODE === "local";
-
   let coordinator: ReturnType<typeof createExecutionCoordinator> | undefined;
 
-  if (isLocalMode) {
-    Bus.publish(Operational.Info, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "server",
-      msg: "server running in local mode (no worker pool)",
-    });
-    const localRunner = LocalRunner.create({
-      systemProvider,
-      agentProvider,
-      mcpProvider,
-      customProvider,
-      workspaceRoot: config.workspace?.root,
-    });
-    IngressEngine.setCoordinator(localRunner);
-  } else {
-    Bus.publish(Operational.Info, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "server",
-      msg: "server running in coordinator mode",
-    });
-    const workerScript = new URL("../execution/worker-entry.ts", import.meta.url).pathname;
-    const bootstrap = await assembleBootstrap(mcpProvider);
-    const toolDispatcher = buildToolDispatcher([mcpProvider]);
-    coordinator = createExecutionCoordinator({ workerScript, bootstrap, toolDispatcher });
-    await coordinator.waitUntilReady();
-    IngressEngine.setCoordinator(coordinator);
-  }
+  Bus.publish(Operational.Info, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    component: "server",
+    msg: "server running in coordinator mode",
+  });
+  const workerScript = new URL("../execution/worker-entry.ts", import.meta.url).pathname;
+  const bootstrap = await assembleBootstrap(mcpProvider);
+  const toolDispatcher = buildToolDispatcher([mcpProvider]);
+  coordinator = createExecutionCoordinator({ workerScript, bootstrap, toolDispatcher });
+  await coordinator.waitUntilReady();
+  IngressEngine.setCoordinator(coordinator);
 
   const hasAnyChannel = Boolean(
     config.telegram.token || config.github.secret || config.discord.token,
@@ -241,7 +224,7 @@ export async function main(): Promise<void> {
   });
 
   const traceId = crypto.randomUUID();
-  const mode = isLocalMode ? "local" : "coordinator";
+  const mode = "coordinator";
   await runRecovery(routingHandler, coordinator, traceId);
 
   Bus.publish(Operational.BootstrapCompleted, {

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -130,7 +130,12 @@ export async function main(): Promise<void> {
   });
   const workerScript = new URL("../execution/worker-entry.ts", import.meta.url).pathname;
   const bootstrap = await assembleBootstrap(mcpProvider);
-  const toolDispatcher = buildToolDispatcher([mcpProvider]);
+  const toolDispatcher = buildToolDispatcher([
+    systemProvider,
+    agentProvider,
+    mcpProvider,
+    customProvider,
+  ]);
   coordinator = createExecutionCoordinator({ workerScript, bootstrap, toolDispatcher });
   await coordinator.waitUntilReady();
   IngressEngine.setCoordinator(coordinator);

--- a/apps/server/src/bootstrap/local-runner.ts
+++ b/apps/server/src/bootstrap/local-runner.ts
@@ -1,16 +1,6 @@
-import { ChatAgent } from "@openomni/agent";
-import type { Execution } from "@openomni/protocol";
-import {
-  type AgentToolProvider,
-  SessionBridge,
-  SystemToolProvider,
-  buildWorkerMiddleware,
-  type CoordinatorLike,
-} from "@openomni/openomni";
+import type { AgentToolProvider, SystemToolProvider, CoordinatorLike } from "@openomni/openomni";
 import type { McpToolProvider } from "../tool/mcp";
 import type { CustomToolProvider } from "../tool/custom";
-import { createExecutionToolContext } from "../execution/worker-runtime";
-import { createContextMiddleware } from "../context/index";
 
 type Config = {
   readonly systemProvider: SystemToolProvider;
@@ -22,53 +12,11 @@ type Config = {
 
 export namespace LocalRunner {
   export function create(config: Config): CoordinatorLike {
+    void config;
     return {
-      dispatch: (_sessionTreeId, request) => run(config, request),
+      dispatch: async () => {
+        throw new Error("LocalRunner is disabled; use coordinator execution");
+      },
     };
   }
-}
-
-async function run(config: Config, request: Execution.Request): Promise<Execution.Result> {
-  const messages = SessionBridge.buildDirectMessages(request.sessionId).filter(
-    (m): m is { role: "user"; content: string } | { role: "assistant"; content: string } =>
-      m.role === "user" || m.role === "assistant",
-  );
-
-  const workspaceRoot =
-    request.workspaceRoot ?? request.toolConfig?.workspaceRoot ?? config.workspaceRoot;
-  const systemProvider = new SystemToolProvider(workspaceRoot);
-
-  const availableTools = [
-    ...systemProvider.listTools(),
-    ...config.agentProvider.listTools(),
-    ...config.mcpProvider.listTools(),
-    ...(config.customProvider?.listTools() ?? []),
-  ];
-
-  const { tools, toolExecutor } = createExecutionToolContext(request, availableTools);
-
-  const agent = ChatAgent.create({
-    model: request.model,
-    systemPrompt: request.systemPrompt,
-    budget: request.budget,
-    tools,
-    toolExecutor,
-    middleware: [
-      createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
-      ...buildWorkerMiddleware({
-        permissions: request.permissions,
-        ...(request.policyPlan ? { policyPlan: request.policyPlan } : {}),
-      }),
-    ],
-  });
-
-  const runResult = await agent.run({ messages });
-
-  return {
-    runId: request.runId,
-    sessionId: request.sessionId,
-    status: "succeeded",
-    output: runResult.text,
-    finishReason: runResult.finishReason,
-  };
 }

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -56,8 +56,8 @@ BusPersistence.start();
 
 let workerBootstrap: WorkerBootstrap.Bootstrap | null = null;
 const activeRunIds = new Set<string>();
-let resolveBootstrapReady = () => undefined;
-let rejectBootstrapReady = (_error: Error) => undefined;
+let resolveBootstrapReady: () => void = () => undefined;
+let rejectBootstrapReady: (_error: Error) => void = () => undefined;
 const bootstrapReady = new Promise<void>((resolve, reject) => {
   resolveBootstrapReady = resolve;
   rejectBootstrapReady = reject;

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -259,7 +259,7 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
         });
         const runResult = await agent.run({
           messages,
-          traceContext: { traceId: request.traceId ?? crypto.randomUUID(), sessionId, runId },
+          traceContext: { traceId, sessionId, runId },
         });
 
         server.notify("worker.run_completed", {

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -1,8 +1,9 @@
 import { ChatAgent, AgentRegistry } from "@openomni/agent";
+import type { Auth } from "@openomni/llm";
 import { createIpcServer } from "@openomni/coordinator";
-import { Execution, Tool, WorkerBootstrap } from "@openomni/protocol";
+import { Execution, Subagent, Tool, WorkerBootstrap } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
-import { initialize, Bus } from "@openomni/session";
+import { initialize, Bus, BusPersistence } from "@openomni/session";
 import {
   AgentToolProvider,
   BackgroundManager,
@@ -17,9 +18,15 @@ import { loadConfig } from "../config";
 import { createExecutionToolContext, resolveWorkerDbPath } from "./worker-runtime";
 import { createContextMiddleware } from "../context/index";
 
-const args = process.argv.slice(2);
-const workerId = args[args.indexOf("--worker-id") + 1] ?? "unknown";
-const socketPath = args[args.indexOf("--socket") + 1];
+function readCliArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const workerId = readCliArg("--worker-id") ?? "unknown";
+const socketPath = readCliArg("--socket");
+const ipcAuthToken = process.env.OPENOMNI_WORKER_IPC_TOKEN;
+delete process.env.OPENOMNI_WORKER_IPC_TOKEN;
 
 if (!socketPath) {
   Bus.publish(Operational.Error, {
@@ -31,22 +38,117 @@ if (!socketPath) {
   process.exit(1);
 }
 
+if (!ipcAuthToken) {
+  Bus.publish(Operational.Error, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    component: "server",
+    msg: "worker-entry: missing IPC auth token",
+  });
+  process.exit(1);
+}
+
 const config = loadConfig();
 initialize({
   dbPath: resolveWorkerDbPath(config),
 });
+BusPersistence.start();
 
 let workerBootstrap: WorkerBootstrap.Bootstrap | null = null;
 const activeRunIds = new Set<string>();
+let resolveBootstrapReady = () => undefined;
+let rejectBootstrapReady = (_error: Error) => undefined;
+const bootstrapReady = new Promise<void>((resolve, reject) => {
+  resolveBootstrapReady = resolve;
+  rejectBootstrapReady = reject;
+});
 
 const backgroundManager = BackgroundManager.create({
   maxConcurrentPerAgent: 3,
   maxConcurrentTotal: 10,
   maxDepth: 3,
+  resolveAuth: resolveBootstrapAuth,
+  allowAuthFallback: false,
 });
 
-const server = createIpcServer(socketPath, (method, params, respond) => {
-  if (method === "coordinator.spawn_run") {
+function resolveBootstrapAuth(provider: string): Auth.Info | undefined {
+  const credentials = workerBootstrap?.credentials;
+  if (!credentials) return undefined;
+
+  const prefix = provider.toUpperCase();
+  const apiKey = credentials[`${prefix}_API_KEY`];
+  const baseURL = credentials[`${prefix}_BASE_URL`];
+
+  if (baseURL) {
+    return { type: "proxy", baseURL, ...(apiKey ? { apiKey } : {}) };
+  }
+  if (apiKey) {
+    return { type: "api", key: apiKey };
+  }
+  return undefined;
+}
+
+const server = createIpcServer(socketPath, (method, params, respond, _notify, connectionId) => {
+  if (method === "coordinator.bootstrap") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({ ok: false, error: "unauthorized" });
+      return;
+    }
+
+    try {
+      const bootstrap = WorkerBootstrap.Bootstrap.parse(params.bootstrap);
+      workerBootstrap = bootstrap;
+      const agentDefs = bootstrap.agents.map((agent) => ({
+        name: agent.name,
+        description: agent.description,
+        model: agent.model,
+        systemPrompt: agent.systemPrompt,
+        tools: agent.tools.allow ?? [],
+        permissions: agent.permissions,
+        budget: agent.budget,
+      }));
+      AgentRegistry.replaceAll(agentDefs);
+      server.useConnection(connectionId);
+      resolveBootstrapReady();
+      server.notify("worker.bootstrap_ready", { workerId, authToken: ipcAuthToken });
+      Bus.publish(Operational.Info, {
+        traceId: crypto.randomUUID(),
+        time: Date.now(),
+        component: "server",
+        msg: "worker bootstrap received",
+        context: {
+          workerId,
+          agents: bootstrap.agents.length,
+          mcpTools: bootstrap.toolCatalog.length,
+        },
+      });
+      respond({ ok: true });
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      rejectBootstrapReady(error);
+      respond({ ok: false, error: error.message });
+      Bus.publish(Operational.Error, {
+        traceId: crypto.randomUUID(),
+        time: Date.now(),
+        component: "server",
+        msg: "worker bootstrap failed",
+        context: {
+          workerId,
+          err: error.message,
+        },
+      });
+    }
+  } else if (method === "coordinator.spawn_run") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({
+        runId: typeof params?.runId === "string" ? params.runId : "unknown",
+        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
+        status: "failed",
+        error: "unauthorized coordinator request",
+      });
+      return;
+    }
+
     let request: Execution.Request;
     try {
       request = Execution.Request.parse(params);
@@ -63,10 +165,19 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
     const { runId, sessionId } = request;
 
     (async () => {
+      const traceId = request.traceId ?? crypto.randomUUID();
       activeRunIds.add(runId);
       server.notify("worker.run_started", { runId, sessionId });
+      Bus.publish(Subagent.Events.WorkerRunStarted, {
+        traceId,
+        sessionId,
+        runId,
+        time: Date.now(),
+        payload: { sessionId, runId, title: request.prompt.slice(0, 80) },
+      });
 
       try {
+        await bootstrapReady;
         const messages = SessionBridge.buildDirectMessages(sessionId).filter(
           (m): m is { role: "user"; content: string } | { role: "assistant"; content: string } =>
             m.role === "user" || m.role === "assistant",
@@ -102,6 +213,8 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
             toolsRef,
             catalogRef,
             agentDefinitionsRef,
+            resolveAuth: resolveBootstrapAuth,
+            allowAuthFallback: false,
             parentSessionId: sessionId,
             parentPermissions: request.permissions,
           }),
@@ -130,6 +243,8 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
 
         const agent = ChatAgent.create({
           model: request.model,
+          auth: resolveBootstrapAuth(request.model.provider),
+          allowAuthFallback: false,
           systemPrompt: request.systemPrompt,
           budget: request.budget,
           tools,
@@ -144,9 +259,7 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
         });
         const runResult = await agent.run({
           messages,
-          ...(request.traceId
-            ? { traceContext: { traceId: request.traceId, sessionId, runId } }
-            : {}),
+          traceContext: { traceId: request.traceId ?? crypto.randomUUID(), sessionId, runId },
         });
 
         server.notify("worker.run_completed", {
@@ -154,6 +267,13 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
           sessionId,
           status: "succeeded",
           output: runResult.text,
+        });
+        Bus.publish(Subagent.Events.WorkerRunCompleted, {
+          traceId,
+          sessionId,
+          runId,
+          time: Date.now(),
+          payload: { sessionId, runId, status: "succeeded" },
         });
 
         respond({
@@ -164,24 +284,36 @@ const server = createIpcServer(socketPath, (method, params, respond) => {
           finishReason: runResult.finishReason,
         });
       } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
         server.notify("worker.run_completed", {
           runId,
           sessionId,
           status: "failed",
-          error: err instanceof Error ? err.message : String(err),
+          error: errorMessage,
+        });
+        Bus.publish(Subagent.Events.WorkerRunFailed, {
+          traceId,
+          sessionId,
+          runId,
+          time: Date.now(),
+          payload: { sessionId, runId, error: errorMessage },
         });
 
         respond({
           runId,
           sessionId,
           status: "failed",
-          error: err instanceof Error ? err.message : String(err),
+          error: errorMessage,
         });
       } finally {
         activeRunIds.delete(runId);
       }
     })();
   } else if (method === "coordinator.cancel_run") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({ cancelled: false, error: "unauthorized coordinator request" });
+      return;
+    }
     respond({ cancelled: true });
   } else {
     respond({ ok: true });
@@ -202,6 +334,7 @@ setInterval(() => {
   server
     .call("worker.heartbeat", {
       workerId,
+      authToken: ipcAuthToken,
       activeRunIds: [...activeRunIds],
       memoryRssMb: process.memoryUsage().rss / 1024 / 1024,
       snapshot,
@@ -211,48 +344,9 @@ setInterval(() => {
     });
 }, HEARTBEAT_INTERVAL_MS);
 
-(async () => {
-  try {
-    const raw = await server.call("worker.ready", { workerId, pid: process.pid });
-    const bootstrap = WorkerBootstrap.Bootstrap.parse(raw);
-    workerBootstrap = bootstrap;
-    // Convert RuntimeAgentDefinition back to AgentProfile.Definition for registry
-    const agentDefs = bootstrap.agents.map((agent) => ({
-      name: agent.name,
-      description: agent.description,
-      model: agent.model,
-      systemPrompt: agent.systemPrompt,
-      tools: agent.tools.allow ?? [],
-      permissions: agent.permissions,
-      budget: agent.budget,
-    }));
-    AgentRegistry.replaceAll(agentDefs);
-    Bus.publish(Operational.Info, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "server",
-      msg: "worker bootstrap received",
-      context: {
-        workerId,
-        agents: bootstrap.agents.length,
-        mcpTools: bootstrap.toolCatalog.length,
-      },
-    });
-  } catch (err) {
-    Bus.publish(Operational.Error, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "server",
-      msg: "worker bootstrap failed",
-      context: {
-        workerId,
-        err: err instanceof Error ? err.message : String(err),
-      },
-    });
-  }
-})();
-
-process.on("SIGTERM", () => {
+process.on("SIGTERM", async () => {
+  await BusPersistence.flush();
+  BusPersistence.stop();
   server.close();
   process.exit(0);
 });

--- a/apps/server/test/context/integration.test.ts
+++ b/apps/server/test/context/integration.test.ts
@@ -44,17 +44,40 @@ describe("context barrel export", () => {
   });
 });
 
-describe("local-runner wiring", () => {
+describe("local-runner disabled", () => {
   const localRunnerSrc = readFileSync(join(serverSrc, "bootstrap/local-runner.ts"), "utf-8");
 
-  it("imports createContextMiddleware from context/index", () => {
-    expect(localRunnerSrc).toContain("createContextMiddleware");
-    expect(localRunnerSrc).toContain("../context/index");
+  it("fails instead of running in process", () => {
+    expect(localRunnerSrc).toContain("LocalRunner is disabled");
+    expect(localRunnerSrc).not.toContain("ChatAgent.create");
   });
 
-  it("uses createContextMiddleware in middleware array", () => {
-    expect(localRunnerSrc).toContain("createContextMiddleware(");
-    expect(localRunnerSrc).toContain("...buildWorkerMiddleware(");
+  it("rejects dispatch calls", async () => {
+    const { LocalRunner } = await import("../../src/bootstrap/local-runner");
+    const { SystemToolProvider, AgentToolProvider } = await import("@openomni/openomni");
+    const { McpToolProvider } = await import("../../src/tool/mcp");
+    const { CustomToolProvider } = await import("../../src/tool/custom");
+
+    const runner = LocalRunner.create({
+      systemProvider: new SystemToolProvider(),
+      agentProvider: new AgentToolProvider(),
+      mcpProvider: new McpToolProvider(),
+      customProvider: new CustomToolProvider(),
+    });
+
+    try {
+      await runner.dispatch("session", {
+        runId: "run",
+        sessionId: "session",
+        mode: "direct",
+        prompt: "hello",
+        model: { provider: "test", id: "test" },
+      });
+      expect.unreachable("LocalRunner dispatch should fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("LocalRunner is disabled; use coordinator execution");
+    }
   });
 });
 

--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -35,6 +35,7 @@ export interface StreamAgentBase {
 }
 
 export interface StreamRunState {
+  readonly sessionId: string;
   budgetState: BudgetState;
   messages: Message.WithParts[];
   lastAssistantText: string;
@@ -94,6 +95,7 @@ export type ErrorDecision =
 export function createStreamRunState(input: ChatAgentInput): StreamRunState {
   const sessionId = input.traceContext?.sessionId ?? "stream-engine";
   return {
+    sessionId,
     budgetState: createBudgetState(),
     messages: toMessagesWithParts(input.messages, sessionId),
     lastAssistantText: "",
@@ -179,9 +181,9 @@ function replacementMessages(decision: Policy.PolicyDecision): Message.WithParts
 function applyPromptMessageEffects(state: StreamRunState, decision: Policy.PolicyDecision): void {
   for (const effect of decision.effects) {
     if (effect.type === "prompt.inject_message") {
-      state.messages.push(createUserMessage(effect.message, "stream-engine"));
+      state.messages.push(createUserMessage(effect.message, state.sessionId));
     } else if (effect.type === "prompt.append_context") {
-      state.messages.push(createUserMessage(effect.context, "stream-engine"));
+      state.messages.push(createUserMessage(effect.context, state.sessionId));
     }
   }
 }
@@ -228,7 +230,7 @@ function publishDenyDiagnostic(
     },
   });
   config.eventEmitter?.emit("agent.policy.deny", {
-    sessionId: "stream-engine",
+    sessionId: state.sessionId,
     time: Date.now(),
     timing,
     reason,
@@ -420,7 +422,7 @@ export function emitTurnStart(
   agentBase: StreamAgentBase,
 ): void {
   config.eventEmitter?.emit("agent.turn.start", {
-    sessionId: "stream-engine",
+    sessionId: state.sessionId,
     time: Date.now(),
     turnIndex: state.budgetState.turns,
   });
@@ -438,7 +440,7 @@ export function emitTurnComplete(
   turnUsage: TokenUsage,
 ): void {
   config.eventEmitter?.emit("agent.turn.complete", {
-    sessionId: "stream-engine",
+    sessionId: state.sessionId,
     time: Date.now(),
     turnIndex: state.turnIndex,
     usage: {
@@ -765,8 +767,8 @@ export async function* handleStop(
   if (!PolicyDecision.isBlocking(postTurnDecision) && continuationPrompts.length > 0) {
     const parentID = state.messages.at(-1)?.info.id ?? "";
     state.messages.push(
-      createAssistantMessage(state.lastAssistantText, parentID, "stream-engine"),
-      ...continuationPrompts.map((prompt) => createUserMessage(prompt, "stream-engine")),
+      createAssistantMessage(state.lastAssistantText, parentID, state.sessionId),
+      ...continuationPrompts.map((prompt) => createUserMessage(prompt, state.sessionId)),
     );
     const blocked = await applyPostCompaction(state, engine, config, agentBase, true);
     if (blocked) {
@@ -925,7 +927,7 @@ export async function* handleError(
   if (Retry.shouldAgentRetry(effectiveRetryPolicy, retryReason, attempt)) {
     const backoffMs = retryEffect?.delayMs ?? Retry.calculateAgentBackoffMs(retryPolicy, attempt);
     config.eventEmitter?.emit("agent.error.retry", {
-      sessionId: "stream-engine",
+      sessionId: state.sessionId,
       time: Date.now(),
       attempt,
       maxAttempts: effectiveRetryPolicy.maxAttempts,

--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -92,9 +92,10 @@ export type ErrorDecision =
   | ({ action: "throw"; errorMessage: string } & Extract<TurnDecision, { kind: "error" }>);
 
 export function createStreamRunState(input: ChatAgentInput): StreamRunState {
+  const sessionId = input.traceContext?.sessionId ?? "stream-engine";
   return {
     budgetState: createBudgetState(),
-    messages: toMessagesWithParts(input.messages, "stream-engine"),
+    messages: toMessagesWithParts(input.messages, sessionId),
     lastAssistantText: "",
     steps: [],
     totalUsage: {
@@ -599,10 +600,16 @@ export async function buildTurn(
         system,
         signal: config.signal,
         model: providerModel,
+        auth: config.auth,
+        allowAuthFallback: config.allowAuthFallback,
         toolExecutor: hookedExecutor,
         toolChoice: configuredToolChoice,
         maxSteps: config.budget?.maxToolCalls ?? 24,
         providerOptions: config.providerOptions,
+        trace: {
+          traceId: trace.traceId,
+          ...(trace.runId !== undefined && { runId: trace.runId }),
+        },
       },
       trackingSink,
       turnUsage,

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -44,6 +44,8 @@ export interface ChatAgentConfig {
   memory?: Memory;
   eventEmitter?: AgentEventEmitter;
   providerOptions?: Record<string, unknown>;
+  auth?: RunInput["auth"];
+  allowAuthFallback?: RunInput["allowAuthFallback"];
   middleware?: PolicyRegistration[];
   context?: AgentRuntimeContext;
   llm?: {

--- a/packages/coordinator/src/ipc/server.ts
+++ b/packages/coordinator/src/ipc/server.ts
@@ -59,10 +59,22 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
     if (activeConnectionId) {
       const active = connections.get(activeConnectionId)?.socket;
       if (active) return active;
-      activeConnectionId = undefined;
+      return undefined;
     }
     const first = connections.values().next();
     return first.done ? undefined : first.value.socket;
+  }
+
+  function removeConnection(id: string, reason: string): void {
+    connections.delete(id);
+    if (id === activeConnectionId) {
+      failAllPending(new IpcConnectionError(reason));
+      return;
+    }
+    if (connections.size === 0) {
+      activeConnectionId = undefined;
+      failAllPending(new IpcConnectionError(reason));
+    }
   }
 
   function failAllPending(err: Error): void {
@@ -173,20 +185,12 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
       },
       close(socket: BunSocket) {
         const id = (socket.data as unknown as SocketData).id;
-        connections.delete(id);
-        if (connections.size === 0) {
-          activeConnectionId = undefined;
-          failAllPending(new IpcConnectionError("socket closed"));
-        }
+        removeConnection(id, "socket closed");
       },
       error(socket: BunSocket, _err: Error) {
         const id = (socket.data as unknown as SocketData).id;
-        connections.delete(id);
         void socket;
-        if (connections.size === 0) {
-          activeConnectionId = undefined;
-          failAllPending(new IpcConnectionError("socket error"));
-        }
+        removeConnection(id, "socket error");
       },
     },
   });

--- a/packages/coordinator/src/ipc/server.ts
+++ b/packages/coordinator/src/ipc/server.ts
@@ -14,12 +14,14 @@ export type RequestHandler = (
   params: Record<string, unknown> | undefined,
   respond: (result: unknown) => void,
   notify: (method: string, params?: Record<string, unknown>) => void,
+  connectionId: string,
 ) => void;
 
 export interface IpcServer {
   readonly socketPath: string;
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   notify(method: string, params?: Record<string, unknown>): void;
+  useConnection(id: string): void;
   close(): void;
 }
 
@@ -51,8 +53,14 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
   const connections = new Map<string, { socket: BunSocket; decoder: LineDecoder }>();
   const pending = new Map<string, PendingRequest>();
   let connCounter = 0;
+  let activeConnectionId: string | undefined;
 
   function getActiveSocket(): BunSocket | undefined {
+    if (activeConnectionId) {
+      const active = connections.get(activeConnectionId)?.socket;
+      if (active) return active;
+      activeConnectionId = undefined;
+    }
     const first = connections.values().next();
     return first.done ? undefined : first.value.socket;
   }
@@ -126,7 +134,13 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
               socket.write(encode(Ipc.createNotification(method, params)));
             };
             try {
-              handler(parsed.method, parsed.params, respond, notify);
+              handler(
+                parsed.method,
+                parsed.params,
+                respond,
+                notify,
+                (socket.data as unknown as SocketData).id,
+              );
             } catch (err) {
               socket.write(
                 encode(
@@ -146,6 +160,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
                 parsed.params,
                 () => undefined,
                 () => undefined,
+                (socket.data as unknown as SocketData).id,
               );
             } catch (error) {
               console.warn(
@@ -160,6 +175,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
         const id = (socket.data as unknown as SocketData).id;
         connections.delete(id);
         if (connections.size === 0) {
+          activeConnectionId = undefined;
           failAllPending(new IpcConnectionError("socket closed"));
         }
       },
@@ -168,6 +184,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
         connections.delete(id);
         void socket;
         if (connections.size === 0) {
+          activeConnectionId = undefined;
           failAllPending(new IpcConnectionError("socket error"));
         }
       },
@@ -196,6 +213,9 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
       if (sock) {
         sock.write(encode(Ipc.createNotification(method, params)));
       }
+    },
+    useConnection(id) {
+      if (connections.has(id)) activeConnectionId = id;
     },
     close() {
       failAllPending(new IpcConnectionError("server closed"));

--- a/packages/coordinator/src/worker-pool/pool.ts
+++ b/packages/coordinator/src/worker-pool/pool.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { WorkerBootstrap } from "@openomni/protocol";
 import { SessionRouting } from "./session-routing";
 import { WorkerSupervisor, type ToolCallParams, type ToolCallResult } from "./supervisor";
@@ -23,7 +25,7 @@ export type WorkerPool = {
 
 export function createWorkerPool(config: WorkerPoolConfig): WorkerPool {
   const size = config.size ?? 8;
-  const socketDir = config.socketDir ?? "/tmp";
+  const socketDir = createPrivateSocketDir(config.socketDir ?? "/tmp");
 
   const workers: WorkerSupervisor[] = Array.from(
     { length: size },
@@ -67,6 +69,14 @@ export function createWorkerPool(config: WorkerPoolConfig): WorkerPool {
     },
     async shutdown() {
       await Promise.all(workers.map((w) => w.stop()));
+      fs.rmSync(socketDir, { recursive: true, force: true });
     },
   };
+}
+
+function createPrivateSocketDir(baseDir: string): string {
+  fs.mkdirSync(baseDir, { recursive: true, mode: 0o700 });
+  const dir = fs.mkdtempSync(path.join(baseDir, "openomni-workers-"));
+  fs.chmodSync(dir, 0o700);
+  return dir;
 }

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -137,7 +137,6 @@ export class WorkerSupervisor {
         if (!isBootstrapAccepted(bootstrapResult)) {
           throw new Error("worker bootstrap rejected");
         }
-        this.bootstrapped = true;
         if (!this.stopping && this.running) {
           this.client = c;
         } else {

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -27,6 +27,8 @@ export type ToolCallResult = {
 export class WorkerSupervisor {
   private proc: Subprocess | null = null;
   private client: IpcClient | null = null;
+  private bootstrapped = false;
+  private readonly authToken = crypto.randomUUID();
   private restartCount = 0;
   private restartWindowStart = 0;
   private running = false;
@@ -50,15 +52,18 @@ export class WorkerSupervisor {
 
   private doStart(): void {
     this.running = true;
+    this.bootstrapped = false;
     this.proc = Bun.spawn(
-      ["bun", this.script, "--worker-id", String(this.id), "--socket", this.socketPath],
+      ["bun", this.script, "--", "--worker-id", String(this.id), "--socket", this.socketPath],
       {
+        env: { ...buildWorkerEnv(process.env), OPENOMNI_WORKER_IPC_TOKEN: this.authToken },
         stdout: "pipe",
         stderr: "pipe",
       },
     );
     this.proc.exited.then(() => {
       this.running = false;
+      this.bootstrapped = false;
       const prev = this.client;
       this.client = null;
       prev?.close();
@@ -74,6 +79,7 @@ export class WorkerSupervisor {
     const toolCallHandler = this.toolCallHandler;
     const snapshotHandler = this.snapshotHandler;
     const workerId = this.id;
+    const authToken = this.authToken;
 
     while (Date.now() < deadline && !this.stopping && this.running) {
       if (!fs.existsSync(this.socketPath)) {
@@ -83,14 +89,7 @@ export class WorkerSupervisor {
       try {
         const c = await connectIpcClient(this.socketPath, {
           connectTimeoutMs: 500,
-          onRequest(method, params, respond) {
-            if (method === "worker.ready") {
-              respond(
-                bootstrap ?? { configEpoch: "", agents: [], toolCatalog: [], credentials: {} },
-              );
-              return;
-            }
-
+          onRequest: (method, params, respond) => {
             if (method === "worker.tool_call" && toolCallHandler) {
               const p = params as ToolCallParams;
               toolCallHandler(p)
@@ -116,7 +115,29 @@ export class WorkerSupervisor {
 
             respond(null);
           },
+          onNotification: (method, params) => {
+            if (method === "worker.bootstrap_ready" && params?.authToken === authToken) {
+              this.bootstrapped = true;
+            }
+          },
         });
+        const bootstrapResult = await c.call(
+          "coordinator.bootstrap",
+          {
+            authToken,
+            bootstrap: bootstrap ?? {
+              configEpoch: "",
+              agents: [],
+              toolCatalog: [],
+              credentials: {},
+            },
+          },
+          5000,
+        );
+        if (!isBootstrapAccepted(bootstrapResult)) {
+          throw new Error("worker bootstrap rejected");
+        }
+        this.bootstrapped = true;
         if (!this.stopping && this.running) {
           this.client = c;
         } else {
@@ -157,7 +178,7 @@ export class WorkerSupervisor {
   }
 
   isReady(): boolean {
-    return this.client?.connected === true;
+    return this.client?.connected === true && this.bootstrapped;
   }
 
   async waitReady(timeoutMs = 10_000): Promise<void> {
@@ -179,7 +200,11 @@ export class WorkerSupervisor {
       Math.max(budget?.maxWallTimeMs ?? 300_000, 300_000) + 30_000,
       MAX_DISPATCH_TIMEOUT_MS,
     );
-    return c.call("coordinator.spawn_run", { runId, ...params }, timeoutMs);
+    return c.call(
+      "coordinator.spawn_run",
+      { authToken: this.authToken, runId, ...params },
+      timeoutMs,
+    );
   }
 
   forceKill(): void {
@@ -200,4 +225,32 @@ export class WorkerSupervisor {
     this.proc = null;
     this.running = false;
   }
+}
+
+const workerEnvKeys = new Set([
+  "PATH",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "BUN_INSTALL",
+  "NODE_ENV",
+  "CI",
+  "OPENOMNI_DB_PATH",
+  "OPENOMNI_MODELS_URL",
+  "OPENOMNI_MODELS_PATH",
+  "OPENOMNI_DISABLE_MODELS_FETCH",
+  "OPENOMNI_WORKER_ENV_FIXTURE",
+]);
+
+function buildWorkerEnv(source: NodeJS.ProcessEnv): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of workerEnvKeys) {
+    const value = source[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+function isBootstrapAccepted(value: unknown): boolean {
+  return value !== null && typeof value === "object" && (value as { ok?: unknown }).ok === true;
 }

--- a/packages/coordinator/test/harness/worker-fixture.ts
+++ b/packages/coordinator/test/harness/worker-fixture.ts
@@ -1,11 +1,22 @@
 import { createIpcServer } from "../../src/ipc";
 
-const args = process.argv.slice(2);
-const workerId = args[args.indexOf("--worker-id") + 1] ?? "fixture";
-const socketPath = args[args.indexOf("--socket") + 1];
+function readCliArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const workerId = readCliArg("--worker-id") ?? "fixture";
+const socketPath = readCliArg("--socket");
+const ipcAuthToken = process.env.OPENOMNI_WORKER_IPC_TOKEN;
+delete process.env.OPENOMNI_WORKER_IPC_TOKEN;
 
 if (!socketPath) {
   console.error("worker-fixture: missing --socket argument");
+  process.exit(1);
+}
+
+if (!ipcAuthToken) {
+  console.error("worker-fixture: missing IPC auth token");
   process.exit(1);
 }
 
@@ -13,19 +24,51 @@ function asNumber(value: unknown, fallback = 0): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
-const server = createIpcServer(socketPath, (method, params, respond) => {
+const server = createIpcServer(socketPath, (method, params, respond, _notify, connectionId) => {
+  if (method === "coordinator.bootstrap") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({ ok: false, error: "unauthorized" });
+      return;
+    }
+    server.useConnection(connectionId);
+    server.notify("worker.bootstrap_ready", { workerId, authToken: ipcAuthToken });
+    respond({ ok: true });
+    return;
+  }
+
   if (method === "coordinator.spawn_run") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({
+        runId: typeof params?.runId === "string" ? params.runId : "unknown",
+        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
+        status: "failed",
+        error: "unauthorized coordinator request",
+      });
+      return;
+    }
     const runId = typeof params?.runId === "string" ? params.runId : "unknown";
     const sessionId = typeof params?.sessionId === "string" ? params.sessionId : "unknown";
     const delayMs = asNumber(params?.delayMs, 0);
+    const envName = typeof params?.envName === "string" ? params.envName : undefined;
 
     setTimeout(() => {
-      respond({ accepted: true, workerId, runId, sessionId, delayMs });
+      respond({
+        accepted: true,
+        workerId,
+        runId,
+        sessionId,
+        delayMs,
+        envValue: envName ? process.env[envName] : undefined,
+      });
     }, delayMs);
     return;
   }
 
   if (method === "coordinator.cancel_run") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({ cancelled: false, error: "unauthorized coordinator request" });
+      return;
+    }
     respond({ cancelled: true });
     return;
   }

--- a/packages/coordinator/test/worker-pool/dispatch.test.ts
+++ b/packages/coordinator/test/worker-pool/dispatch.test.ts
@@ -69,6 +69,19 @@ describe("worker pool dispatch", () => {
     expect(stats.idle).toBe(0);
   });
 
+  test("creates a private per-pool socket directory", () => {
+    const entries = fs.readdirSync(socketDir, { withFileTypes: true });
+    const privateDirs = entries.filter(
+      (entry) => entry.isDirectory() && entry.name.startsWith("openomni-workers-"),
+    );
+    expect(privateDirs).toHaveLength(1);
+    const privateDir = privateDirs[0];
+    if (!privateDir) throw new Error("private socket directory missing");
+
+    const mode = fs.statSync(`${socketDir}/${privateDir.name}`).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
   test("dispatch with budget.maxWallTimeMs=120_000 passes timeout=150_000 to IPC", async () => {
     const result = await pool.dispatch("session-budget-1", "run-budget-1", {
       delayMs: 10,
@@ -84,5 +97,68 @@ describe("worker pool dispatch", () => {
       prompt: "test",
     });
     expect((result as Record<string, unknown>).accepted).toBe(true);
+  });
+
+  test("workers inherit runtime environment updates", async () => {
+    const previousDiscordToken = process.env.DISCORD_BOT_TOKEN;
+    const previousAuthFile = process.env.OPENOMNI_AUTH_FILE;
+    const previousHome = process.env.HOME;
+    process.env.OPENOMNI_WORKER_ENV_FIXTURE = "runtime-value";
+    process.env.OPENOMNI_AUTH_FILE = "/tmp/openomni-secret-auth.json";
+    process.env.HOME = "/tmp/openomni-secret-home";
+    process.env.DISCORD_BOT_TOKEN = "secret-token";
+    const envSocketDir = `${socketDir}-env`;
+    fs.mkdirSync(envSocketDir, { recursive: true });
+    const envPool = createWorkerPool({
+      size: 1,
+      workerScript: WORKER_ENTRY,
+      socketDir: envSocketDir,
+    });
+    try {
+      await envPool.waitUntilReady(15_000);
+      const result = await envPool.dispatch("session-env", "run-env", {
+        prompt: "test",
+        envName: "OPENOMNI_WORKER_ENV_FIXTURE",
+      });
+      expect((result as Record<string, unknown>).envValue).toBe("runtime-value");
+      const secretResult = await envPool.dispatch("session-env", "run-secret", {
+        prompt: "test",
+        envName: "DISCORD_BOT_TOKEN",
+      });
+      expect((secretResult as Record<string, unknown>).envValue).toBeUndefined();
+      const authTokenResult = await envPool.dispatch("session-env", "run-auth-token", {
+        prompt: "test",
+        envName: "OPENOMNI_WORKER_IPC_TOKEN",
+      });
+      expect((authTokenResult as Record<string, unknown>).envValue).toBeUndefined();
+      const authFileResult = await envPool.dispatch("session-env", "run-auth-file", {
+        prompt: "test",
+        envName: "OPENOMNI_AUTH_FILE",
+      });
+      expect((authFileResult as Record<string, unknown>).envValue).toBeUndefined();
+      const homeResult = await envPool.dispatch("session-env", "run-home", {
+        prompt: "test",
+        envName: "HOME",
+      });
+      expect((homeResult as Record<string, unknown>).envValue).toBeUndefined();
+    } finally {
+      await envPool.shutdown();
+      delete process.env.OPENOMNI_WORKER_ENV_FIXTURE;
+      if (previousAuthFile === undefined) {
+        delete process.env.OPENOMNI_AUTH_FILE;
+      } else {
+        process.env.OPENOMNI_AUTH_FILE = previousAuthFile;
+      }
+      if (previousDiscordToken === undefined) {
+        delete process.env.DISCORD_BOT_TOKEN;
+      } else {
+        process.env.DISCORD_BOT_TOKEN = previousDiscordToken;
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
   });
 });

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -21,11 +21,12 @@ export interface RunInput {
   signal?: AbortSignal;
   model?: Provider.Model;
   auth?: Auth.Info;
+  allowAuthFallback?: boolean;
   toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
   toolChoice?: "auto" | "required" | "none";
   maxSteps?: number;
   providerOptions?: Record<string, unknown>;
-  trace?: { traceId?: string };
+  trace?: { traceId?: string; runId?: string };
 }
 
 export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
@@ -65,7 +66,9 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   if (model) {
     createStream = async (streamInput) => {
       const ai = await import("ai");
-      const auth = input.auth ?? (await Auth.get(model.providerID));
+      const auth =
+        input.auth ??
+        (input.allowAuthFallback === false ? undefined : await Auth.get(model.providerID));
       if (!auth) {
         throw new Error(
           `No authentication found for provider: ${model.providerID}. Configure provider credentials or use a proxy auth provider first.`,
@@ -178,6 +181,9 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   }
 
   const resolvedModel = model ?? ({} as Provider.Model);
+  const traceId = input.trace?.traceId ?? crypto.randomUUID();
+  const provider = model?.providerID ?? "default";
+  const modelId = model?.id ?? "default";
 
   const processor = Processor.create({
     assistantMessage,
@@ -186,15 +192,18 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
     abort: abortSignal,
     sink,
     createStream,
+    trace: {
+      traceId,
+      sessionId: sessionID,
+      ...(input.trace?.runId !== undefined && { runId: input.trace.runId }),
+      provider,
+    },
   });
-
-  const traceId = input.trace?.traceId ?? crypto.randomUUID();
-  const provider = model?.providerID ?? "default";
-  const modelId = model?.id ?? "default";
 
   Bus.publish(LlmCall.Started, {
     traceId,
     sessionId: sessionID,
+    ...(input.trace?.runId !== undefined && { runId: input.trace.runId }),
     provider,
     model: modelId,
     messageCount: messages.length,
@@ -218,6 +227,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
     Bus.publish(LlmCall.Completed, {
       traceId,
       sessionId: sessionID,
+      ...(input.trace?.runId !== undefined && { runId: input.trace.runId }),
       provider,
       model: modelId,
       durationMs,

--- a/packages/llm/src/session/processor.ts
+++ b/packages/llm/src/session/processor.ts
@@ -1,4 +1,11 @@
-import { Operational, type Message, type Run, type Sink, type Tool } from "@openomni/protocol";
+import {
+  LlmCall,
+  Operational,
+  type Message,
+  type Run,
+  type Sink,
+  type Tool,
+} from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { TokenTracker } from "../token";
 import { Retry } from "./retry";
@@ -37,6 +44,7 @@ export namespace Processor {
     sink?: Sink;
     onToolCall?: (part: Message.ToolPart) => Promise<ToolResult>;
     createStream?: (input: StreamInput) => Promise<Stream>;
+    trace?: { traceId: string; sessionId: string; runId?: string; provider?: string };
   }
 
   export interface ProcessorInfo {
@@ -65,6 +73,7 @@ export namespace Processor {
       sink: configuredSink = createNoopSink(),
       onToolCall,
       createStream = defaultStream,
+      trace,
     } = options;
 
     const sink = createProjectedSink(configuredSink, sessionID);
@@ -416,6 +425,29 @@ export namespace Processor {
               if (retryReason !== undefined) {
                 attempt++;
                 const delayMs = Retry.delay(attempt, APIError.isInstance(e) ? e : undefined);
+                if (trace) {
+                  Bus.publish(LlmCall.RetryDecided, {
+                    traceId: trace.traceId,
+                    sessionId: trace.sessionId,
+                    ...(trace.runId !== undefined && { runId: trace.runId }),
+                    attempt,
+                    maxAttempts: Number.MAX_SAFE_INTEGER,
+                    reason: retryReason,
+                    backoffMs: delayMs,
+                    time: Date.now(),
+                  });
+
+                  if (retryReason === "Too Many Requests" || retryReason === "Rate Limited") {
+                    Bus.publish(LlmCall.RateLimited, {
+                      traceId: trace.traceId,
+                      sessionId: trace.sessionId,
+                      ...(trace.runId !== undefined && { runId: trace.runId }),
+                      provider: trace.provider ?? model.providerID,
+                      retryAfterMs: delayMs,
+                      time: Date.now(),
+                    });
+                  }
+                }
 
                 publishStatus({
                   type: "retry",
@@ -481,7 +513,11 @@ export namespace Processor {
     return {
       onMessage(message) {
         sink.onMessage(message);
-        publish("sink.message", { payload: message });
+        publish("sink.message", {
+          role: message.info.role,
+          messageId: message.info.id,
+          partCount: message.parts.length,
+        });
       },
 
       onToolCall(call: Tool.Call) {
@@ -489,7 +525,7 @@ export namespace Processor {
         publish("sink.tool.started", {
           toolCallId: call.id,
           toolName: call.tool,
-          args: call.input,
+          inputSummary: summarizeRecord(call.input),
         });
       },
 
@@ -497,20 +533,25 @@ export namespace Processor {
         sink.onToolResult(result);
         publish("sink.tool.completed", {
           toolCallId: result.toolCallId,
-          output: result.output,
+          outputLength: result.output.length,
           isError: result.isError,
         });
       },
 
       onSnapshot(snapshot: Run.Snapshot) {
         sink.onSnapshot(snapshot);
-        publish("sink.snapshot", { payload: snapshot });
+        publish("sink.snapshot", { stateType: String(snapshot.state.type ?? "unknown") });
       },
 
       flush() {
         return Promise.resolve();
       },
     };
+  }
+
+  function summarizeRecord(input: Record<string, unknown>): string {
+    const keys = Object.keys(input).sort();
+    return keys.length === 0 ? "empty" : keys.join(",");
   }
 
   function createNoopSink(): Sink {

--- a/packages/llm/src/session/retry.ts
+++ b/packages/llm/src/session/retry.ts
@@ -112,7 +112,7 @@ export namespace Retry {
     maxAttempts?: number;
     signal?: AbortSignal;
     initialDelay?: number;
-    trace?: { traceId: string; sessionId: string; provider?: string };
+    trace?: { traceId: string; sessionId: string; runId?: string; provider?: string };
   }
 
   export async function withRetry<T>(fn: () => Promise<T>, options?: WithRetryOptions): Promise<T> {
@@ -153,11 +153,12 @@ export namespace Retry {
           const delayMs = delay(attempt, e, initialDelay);
 
           if (options?.trace) {
-            const { traceId, sessionId, provider = "unknown" } = options.trace;
+            const { traceId, sessionId, runId, provider = "unknown" } = options.trace;
 
             Bus.publish(LlmCall.RetryDecided, {
               traceId,
               sessionId,
+              ...(runId !== undefined && { runId }),
               attempt,
               maxAttempts,
               reason: retryReason,
@@ -171,6 +172,7 @@ export namespace Retry {
               Bus.publish(LlmCall.RateLimited, {
                 traceId,
                 sessionId,
+                ...(runId !== undefined && { runId }),
                 provider,
                 retryAfterMs: delayMs,
                 time: Date.now(),

--- a/packages/llm/test/run.test.ts
+++ b/packages/llm/test/run.test.ts
@@ -1,5 +1,9 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import type { Message, Run, Sink, Tool } from "@openomni/protocol";
+import { Auth } from "../src/auth";
 
 const TEST_PROVIDER_ID = "__test_run__";
 let run: typeof import("../src/run").run;
@@ -61,6 +65,10 @@ describe("run", () => {
         capturedSnapshots.push(snapshot);
       },
     };
+  });
+
+  afterEach(() => {
+    aiCapture.__openomniAiStreamArgs = undefined;
   });
 
   test("accepts RunInput with required fields", () => {
@@ -145,6 +153,36 @@ describe("run", () => {
       expect(outcome.error.message).toContain("no-auth-provider-xyz");
     }
     expect(capturedToolCalls.length).toBe(0);
+  });
+
+  test("does not read stored auth when fallback is disabled", async () => {
+    const authFile = join(tmpdir(), `openomni-run-auth-${crypto.randomUUID()}.json`);
+
+    try {
+      await Auth.withFile(authFile, async () => {
+        await Auth.set("stored-auth-provider", testAuth);
+
+        const outcome = await run(
+          {
+            messages: [],
+            tools: [],
+            allowAuthFallback: false,
+            model: {
+              id: "claude-3-haiku",
+              providerID: "stored-auth-provider",
+              name: "Test Model",
+              api: { npm: "@ai-sdk/anthropic" },
+            },
+          },
+          mockSink,
+        );
+
+        expect(outcome.type).toBe("error");
+        expect(aiCapture.__openomniAiStreamArgs).toBeUndefined();
+      });
+    } finally {
+      rmSync(authFile, { force: true });
+    }
   });
 
   test("returns aborted outcome when signal is aborted before run", async () => {

--- a/packages/llm/test/session/processor.test.ts
+++ b/packages/llm/test/session/processor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, beforeEach } from "bun:test";
-import { Operational, type Run, type Sink, type Tool } from "@openomni/protocol";
+import { LlmCall, Operational, type Run, type Sink, type Tool } from "@openomni/protocol";
 import { Bus, Storage } from "@openomni/session";
 import { Processor } from "../../src/session/processor";
 import type { Message } from "../../src/session";
@@ -15,14 +15,7 @@ type OperationalInfoPayload = {
   context?: Record<string, unknown>;
 };
 
-interface EventLogRow {
-  id: number;
-  type: string;
-  status: string;
-  data: string;
-}
-
-function configureEventLogSession(sessionId: string, rows: EventLogRow[]): void {
+function configureSession(sessionId: string): void {
   const messages = new Map<string, Message.Info>();
   const parts = new Map<string, Message.Part>();
   const now = Date.now();
@@ -77,27 +70,6 @@ function configureEventLogSession(sessionId: string, rows: EventLogRow[]): void 
         return parts.delete(partID);
       },
     },
-    eventLog: {
-      append(rowSessionId, type, data) {
-        if (rowSessionId !== sessionId) return rows.length;
-        const id = rows.length + 1;
-        rows.push({ id, type, status: "pending", data });
-        return id;
-      },
-      replay(rowSessionId) {
-        return rowSessionId === sessionId ? rows : [];
-      },
-      listIncomplete(rowSessionId) {
-        return rowSessionId === sessionId ? rows : [];
-      },
-      markComplete(_rowSessionId, eventId) {
-        const row = rows.find((item) => item.id === eventId);
-        if (row) row.status = "completed";
-      },
-      listIncompleteSessions() {
-        return rows.some((row) => row.status !== "completed") ? [sessionId] : [];
-      },
-    },
   });
 }
 
@@ -146,6 +118,7 @@ describe("Processor", () => {
   });
 
   afterEach(() => {
+    Bus.reset();
     Storage.reset();
   });
 
@@ -460,7 +433,7 @@ describe("Processor", () => {
       const snapshots: Run.Snapshot[] = [];
       const messages: Message.WithParts[] = [];
 
-      configureEventLogSession("session-456", []);
+      configureSession("session-456");
 
       const sink: Sink = {
         onMessage(message) {
@@ -528,11 +501,11 @@ describe("Processor", () => {
       expect(toolStarted?.context).toMatchObject({
         toolCallId: "call-1",
         toolName: "lookup",
-        args: { q: "x" },
+        inputSummary: "q",
       });
       expect(toolCompleted?.context).toMatchObject({
         toolCallId: "call-1",
-        output: "ok",
+        outputLength: 2,
       });
 
       unsub();
@@ -601,6 +574,63 @@ describe("Processor", () => {
 
       expect(result).toBeDefined();
       expect(attemptCount).toBe(2);
+    });
+
+    test("publishes structured retry and rate-limit events", async () => {
+      let attemptCount = 0;
+      const retries: Array<{ runId?: string; reason: string; backoffMs: number }> = [];
+      const rateLimits: Array<{ runId?: string; provider: string; retryAfterMs: number }> = [];
+      const unsubRetry = Bus.subscribe(LlmCall.RetryDecided, (event) => {
+        retries.push(event);
+      });
+      const unsubRateLimit = Bus.subscribe(LlmCall.RateLimited, (event) => {
+        rateLimits.push(event);
+      });
+
+      const processor = Processor.create({
+        assistantMessage: mockAssistantMessage,
+        sessionID: "session-456",
+        model: mockModel,
+        abort: abortController.signal,
+        trace: {
+          traceId: "trace-processor-retry",
+          sessionId: "session-456",
+          runId: "run-processor-retry",
+          provider: "anthropic",
+        },
+        createStream: async () => ({
+          fullStream: (async function* () {
+            attemptCount++;
+            if (attemptCount === 1) {
+              throw new APIError({
+                message: JSON.stringify({
+                  type: "error",
+                  error: { type: "too_many_requests" },
+                }),
+                isRetryable: true,
+              });
+            }
+            yield { type: "finish" };
+          })(),
+        }),
+      });
+
+      await processor.process({ messages: [], model: mockModel, system: "" });
+      unsubRetry();
+      unsubRateLimit();
+
+      expect(retries).toHaveLength(1);
+      expect(retries[0]).toMatchObject({
+        runId: "run-processor-retry",
+        reason: "Too Many Requests",
+      });
+      expect(retries[0]?.backoffMs).toBeGreaterThan(0);
+      expect(rateLimits).toHaveLength(1);
+      expect(rateLimits[0]).toMatchObject({
+        runId: "run-processor-retry",
+        provider: "anthropic",
+        retryAfterMs: retries[0]?.backoffMs,
+      });
     });
 
     test("handles non-retryable errors", async () => {

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
@@ -49,6 +49,11 @@ function makeRuntime(selection: ToolSelection.Selection) {
     parentSessionId: "parent-session",
     catalogRef: { catalog },
     agentDefinitionsRef: { definitions },
+    resolveAuth: (provider) =>
+      provider === "anthropic"
+        ? { type: "proxy", baseURL: "http://localhost:8317/v1", apiKey: "proxy" }
+        : undefined,
+    allowAuthFallback: false,
   });
 }
 
@@ -83,6 +88,31 @@ describe("createWorkerSubagentRuntime", () => {
     expect(spawnSpy.mock.calls[0]?.[0].tools?.map((tool: { name: string }) => tool.name)).toEqual([
       "read",
     ]);
+  });
+
+  test("spawn passes provider auth from the worker bootstrap", async () => {
+    const runtime = makeRuntime({ all: true });
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "anthropic", id: "claude-haiku-4-5-20251001" },
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy.mock.calls[0]?.[0].auth).toEqual({
+      type: "proxy",
+      baseURL: "http://localhost:8317/v1",
+      apiKey: "proxy",
+    });
+    expect(spawnSpy.mock.calls[0]?.[0].allowAuthFallback).toBe(false);
   });
 
   test("send resolves tools from the child session metadata and depth", async () => {
@@ -121,12 +151,18 @@ describe("createWorkerSubagentRuntime", () => {
     await runtime.send({
       sessionId: grandchild.id,
       prompt: "continue",
-      model: { provider: "test", id: "model" },
+      model: { provider: "anthropic", id: "claude-haiku-4-5-20251001" },
     });
 
     expect(sendSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy.mock.calls[0]?.[0].tools?.map((tool: { name: string }) => tool.name)).toEqual([
       "read",
     ]);
+    expect(sendSpy.mock.calls[0]?.[0].auth).toEqual({
+      type: "proxy",
+      baseURL: "http://localhost:8317/v1",
+      apiKey: "proxy",
+    });
+    expect(sendSpy.mock.calls[0]?.[0].allowAuthFallback).toBe(false);
   });
 });

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -89,6 +89,8 @@ type WorkerRuntimeConfig = {
   // Lazily resolved alongside toolsRef — used to compute depth-filtered child tool sets.
   catalogRef?: { catalog?: CatalogEntry[] };
   agentDefinitionsRef?: { definitions?: Map<string, RuntimeAgentDefinition> };
+  resolveAuth?: (provider: string) => ChatAgentConfig["auth"];
+  allowAuthFallback?: ChatAgentConfig["allowAuthFallback"];
 };
 
 function resolveChildDefinition(
@@ -142,6 +144,8 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         title: config.title,
         prompt: config.prompt,
         model: config.model,
+        auth: cfg.resolveAuth?.(config.model.provider),
+        allowAuthFallback: cfg.allowAuthFallback,
         systemPrompt: config.systemPrompt,
         tools: childTools,
         toolExecutor: cfg.toolsRef.toolExecutor,
@@ -162,6 +166,8 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         sessionId: config.sessionId,
         prompt: config.prompt,
         model: config.model,
+        auth: cfg.resolveAuth?.(config.model.provider),
+        allowAuthFallback: cfg.allowAuthFallback,
         systemPrompt: config.systemPrompt,
         tools: resolveChildTools(cfg, childDefinition, depth),
         toolExecutor: cfg.toolsRef.toolExecutor,

--- a/packages/openomni/src/execution-runtime/tool/builtins/bash.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/bash.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bashTool } from "./bash";
+
+describe("bashTool", () => {
+  const originalAuthFile = process.env.OPENOMNI_AUTH_FILE;
+  const originalDbPath = process.env.OPENOMNI_DB_PATH;
+  const originalHome = process.env.HOME;
+
+  afterEach(() => {
+    restoreEnv("OPENOMNI_AUTH_FILE", originalAuthFile);
+    restoreEnv("OPENOMNI_DB_PATH", originalDbPath);
+    restoreEnv("HOME", originalHome);
+  });
+
+  test("scrubs auth paths from subprocess environment", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "openomni-bash-env-"));
+    process.env.OPENOMNI_AUTH_FILE = "/tmp/openomni-secret-auth.json";
+    process.env.OPENOMNI_DB_PATH = "/tmp/openomni-secret.db";
+    process.env.HOME = "/tmp/openomni-secret-home";
+
+    try {
+      const tool = bashTool(workspace);
+      const result = await tool.execute({
+        id: "call-1",
+        tool: "bash",
+        input: {
+          command:
+            'printf \'auth=%s db=%s home=%s\' "$OPENOMNI_AUTH_FILE" "$OPENOMNI_DB_PATH" "$HOME"',
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.output).toBe(`auth= db= home=${workspace}`);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/packages/openomni/src/execution-runtime/tool/builtins/bash.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/bash.ts
@@ -11,6 +11,8 @@ export { isReadOnlyCommand, isDestructiveCommand };
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 600_000;
 
+const bashEnvKeys = ["PATH", "TMPDIR", "TEMP", "TMP", "BUN_INSTALL"];
+
 interface BashInput {
   command: string;
   workdir?: string;
@@ -39,6 +41,16 @@ function resolveTimeout(input: Record<string, unknown>): number {
   const value = optionalPositiveNumber(input, "timeoutMs");
   if (value === undefined) return DEFAULT_TIMEOUT_MS;
   return Math.min(value, MAX_TIMEOUT_MS);
+}
+
+function buildBashEnv(workspaceRoot: string | undefined): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of bashEnvKeys) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  env.HOME = workspaceRoot ? resolve(workspaceRoot) : process.cwd();
+  return env;
 }
 
 export function bashTool(workspaceRoot?: string): NativeTool {
@@ -76,6 +88,7 @@ export function bashTool(workspaceRoot?: string): NativeTool {
 
         const proc = Bun.spawn(["bash", "-lc", command], {
           cwd,
+          env: buildBashEnv(workspaceRoot),
           stdout: "pipe",
           stderr: "pipe",
         });

--- a/packages/openomni/src/execution-runtime/tool/executor.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor.ts
@@ -53,6 +53,14 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
+function summarizeInput(input: unknown): string {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return typeof input;
+  }
+  const keys = Object.keys(input).sort();
+  return keys.length === 0 ? "empty" : keys.join(",");
+}
+
 function resolveImplicitValue(
   source: ImplicitInputSource,
   runtime: ToolRuntimeContext,
@@ -135,7 +143,7 @@ export function createToolExecutor(
       actor,
       action: TOOL_CALL_ACTION,
       resource: originalName,
-      context: { input: call.input },
+      context: { inputSummary: summarizeInput(call.input) },
     });
 
     const enrichedCall = injectImplicitInputs(call, tool, runtime);
@@ -196,7 +204,7 @@ export function createToolExecutor(
       );
       const durationMs = Date.now() - startTime;
 
-      const postDecision = await ToolRuntimePolicyMiddleware.evaluatePostTool({
+      const postDecision = ToolRuntimePolicyMiddleware.evaluatePostTool({
         toolName: originalName,
         toolCallId: call.id,
         input: dispatchedCall.input,
@@ -230,7 +238,7 @@ export function createToolExecutor(
       }
 
       if (policy && !PolicyDecision.isBlocking(policy.decision)) {
-        const postDecision = await ToolRuntimePolicyMiddleware.evaluatePostTool({
+        const postDecision = ToolRuntimePolicyMiddleware.evaluatePostTool({
           toolName: originalName,
           toolCallId: call.id,
           input: dispatchedCall.input,

--- a/packages/openomni/src/subagent/background-manager.test.ts
+++ b/packages/openomni/src/subagent/background-manager.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { PolicyDecision } from "@openomni/protocol";
+import { PolicyDecision, PolicyEvent } from "@openomni/protocol";
 import { SqliteStorageAdapter } from "@openomni/session/src/storage/sqlite-storage";
-import { Storage } from "@openomni/session";
+import { Bus, Storage } from "@openomni/session";
 import { BackgroundStore } from "./background-store";
 import { BackgroundManager } from "./background-manager";
 import { BackgroundLimitsMiddleware } from "./middleware/background-limits";
@@ -49,6 +49,7 @@ function mockSpawnBackground(): void {
 afterEach(() => {
   spawnBackgroundSpy?.mockRestore();
   spawnBackgroundSpy = undefined;
+  Bus.reset();
 });
 
 describe("BackgroundStore — SQLite persistence", () => {
@@ -240,6 +241,34 @@ describe("BackgroundManager — launch limit policy", () => {
     }
   });
 
+  it("passes resolved provider auth to background subagent runs", async () => {
+    const manager = BackgroundManager.create({
+      allowAuthFallback: false,
+      resolveAuth: (provider) =>
+        provider === "anthropic"
+          ? { type: "proxy", baseURL: "http://localhost:8317/v1", apiKey: "proxy" }
+          : undefined,
+    });
+    try {
+      const task = await manager.launch({
+        ...makeLaunchInput(),
+        model: { provider: "anthropic", id: "claude-haiku-4-5-20251001" },
+      });
+
+      expect(task.status).toBe("running");
+      expect(spawnBackgroundSpy).toHaveBeenCalledTimes(1);
+      expect(spawnBackgroundSpy.mock.calls[0]?.[0].auth).toEqual({
+        type: "proxy",
+        baseURL: "http://localhost:8317/v1",
+        apiKey: "proxy",
+      });
+      expect(spawnBackgroundSpy.mock.calls[0]?.[0].allowAuthFallback).toBe(false);
+      await manager.cancel(task.id);
+    } finally {
+      manager.dispose();
+    }
+  });
+
   it("returns policy metadata on non-continue verdicts", async () => {
     const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchInput(),
@@ -258,6 +287,41 @@ describe("BackgroundManager — launch limit policy", () => {
     expect(PolicyDecision.reason(result.verdict)).toBe(
       "max concurrent tasks per agent (0) exceeded",
     );
+  });
+
+  it("emits durable audit events for background launch limits", async () => {
+    const composed: Array<{
+      action: string;
+      resource: string;
+      sessionId: string;
+      pointId?: string;
+      verdict: string;
+    }> = [];
+    const unsubscribe = Bus.subscribe(PolicyEvent.DecisionComposed, (event) => {
+      composed.push(event);
+    });
+
+    await BackgroundLimitsMiddleware.evaluatePreLaunch({
+      input: makeLaunchInput(),
+      activeTasks: [],
+      activeCount: 0,
+      pendingQueueSize: 0,
+      maxConcurrentPerAgent: 3,
+      maxConcurrentTotal: 10,
+      maxDepth: 5,
+      maxDescendants: 10,
+      maxQueueSize: 100,
+    });
+    unsubscribe();
+
+    expect(composed).toHaveLength(1);
+    expect(composed[0]).toMatchObject({
+      action: "delegation.background.launch",
+      resource: "agent.test-agent",
+      sessionId: "parent-session-1",
+      pointId: "delegation.background.pre",
+      verdict: "allow",
+    });
   });
 
   it("treats background launch deny verdict as terminal", async () => {

--- a/packages/openomni/src/subagent/background-manager.test.ts
+++ b/packages/openomni/src/subagent/background-manager.test.ts
@@ -269,6 +269,24 @@ describe("BackgroundManager — launch limit policy", () => {
     }
   });
 
+  it("cleans up active state when auth resolution fails", async () => {
+    const manager = BackgroundManager.create({
+      resolveAuth: () => {
+        throw new Error("auth unavailable");
+      },
+    });
+    try {
+      const task = await manager.launch(makeLaunchInput());
+
+      expect(task.status).toBe("failed");
+      expect(task.error).toBe("auth unavailable");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 1 });
+      expect(spawnBackgroundSpy).not.toHaveBeenCalled();
+    } finally {
+      manager.dispose();
+    }
+  });
+
   it("returns policy metadata on non-continue verdicts", async () => {
     const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchInput(),

--- a/packages/openomni/src/subagent/background-manager.ts
+++ b/packages/openomni/src/subagent/background-manager.ts
@@ -10,6 +10,7 @@ import { startSweep, stopSweep } from "./abort-registry";
 import { BackgroundStore } from "./background-store.js";
 import { BackgroundLimitsMiddleware } from "./middleware/background-limits.js";
 import { SubagentRuntime } from "./runtime.js";
+import type { RuntimeConfig } from "./transcript.js";
 
 type LaunchInput = {
   agentName: string;
@@ -26,6 +27,8 @@ type Config = {
   maxDescendants?: number;
   taskTtlMs?: number;
   maxQueueSize?: number;
+  resolveAuth?: (provider: string) => RuntimeConfig["auth"];
+  allowAuthFallback?: RuntimeConfig["allowAuthFallback"];
   onTaskComplete?: (result: Subagent.BackgroundTaskResult) => void;
 };
 
@@ -64,6 +67,8 @@ export const BackgroundManager = {
     const maxDescendants = config?.maxDescendants ?? 10;
     const taskTtlMs = config?.taskTtlMs ?? 1_800_000;
     const maxQueueSize = config?.maxQueueSize ?? 100;
+    const resolveAuth = config?.resolveAuth;
+    const allowAuthFallback = config?.allowAuthFallback;
     const onTaskComplete = config?.onTaskComplete;
 
     const tasks = new Map<string, Subagent.BackgroundTask>();
@@ -157,6 +162,8 @@ export const BackgroundManager = {
         prompt: input.prompt,
         title: input.prompt.slice(0, 50),
         model: input.model,
+        auth: resolveAuth?.(input.model.provider),
+        allowAuthFallback,
         signal: controller.signal,
       }).then(
         ({ sessionId, runId }) => {

--- a/packages/openomni/src/subagent/background-manager.ts
+++ b/packages/openomni/src/subagent/background-manager.ts
@@ -157,156 +157,160 @@ export const BackgroundManager = {
       const controller = new AbortController();
       controllers.set(id, controller);
 
-      return SubagentRuntime.spawnBackground({
-        agentName: input.agentName,
-        prompt: input.prompt,
-        title: input.prompt.slice(0, 50),
-        model: input.model,
-        auth: resolveAuth?.(input.model.provider),
-        allowAuthFallback,
-        signal: controller.signal,
-      }).then(
-        ({ sessionId, runId }) => {
-          const running: Subagent.BackgroundTask = {
-            ...task,
-            status: "running",
-            sessionId,
-            runId,
-            startedAt: Date.now(),
-          };
-          tasks.set(id, running);
-          BackgroundStore.persist(running);
+      return Promise.resolve()
+        .then(() =>
+          SubagentRuntime.spawnBackground({
+            agentName: input.agentName,
+            prompt: input.prompt,
+            title: input.prompt.slice(0, 50),
+            model: input.model,
+            auth: resolveAuth?.(input.model.provider),
+            allowAuthFallback,
+            signal: controller.signal,
+          }),
+        )
+        .then(
+          ({ sessionId, runId }) => {
+            const running: Subagent.BackgroundTask = {
+              ...task,
+              status: "running",
+              sessionId,
+              runId,
+              startedAt: Date.now(),
+            };
+            tasks.set(id, running);
+            BackgroundStore.persist(running);
 
-          const runUnsubs: Array<() => void> = [];
-          const cleanupRunSubs = () => runUnsubs.forEach((u) => u());
-          taskUnsubs.set(id, cleanupRunSubs);
+            const runUnsubs: Array<() => void> = [];
+            const cleanupRunSubs = () => runUnsubs.forEach((u) => u());
+            taskUnsubs.set(id, cleanupRunSubs);
 
-          runUnsubs.push(
-            Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
-              if (data.payload.sessionId !== sessionId) return;
-              cleanupRunSubs();
-              taskUnsubs.delete(id);
+            runUnsubs.push(
+              Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
+                if (data.payload.sessionId !== sessionId) return;
+                cleanupRunSubs();
+                taskUnsubs.delete(id);
 
-              const current = tasks.get(id);
-              if (!current || current.status === "cancelled") {
-                activeCount--;
-                drainQueue();
-                return;
-              }
-
-              activeCount--;
-
-              const completed: Subagent.BackgroundTask = {
-                ...current,
-                status: "completed",
-                completedAt: Date.now(),
-              };
-              tasks.set(id, completed);
-
-              let output: string | undefined;
-              try {
-                const msgs = Session.getMessages(sessionId);
-                const lastAssistant = [...msgs].reverse().find((m) => m.role === "assistant");
-                if (lastAssistant) {
-                  const parts = Session.getParts(lastAssistant.id);
-                  output =
-                    parts
-                      .filter((p): p is Message.TextPart => p.type === "text")
-                      .map((p) => p.text)
-                      .filter(Boolean)
-                      .join("\n") || undefined;
+                const current = tasks.get(id);
+                if (!current || current.status === "cancelled") {
+                  activeCount--;
+                  drainQueue();
+                  return;
                 }
-              } catch {
-                // session may have been cleaned up
-              }
-              const result: Subagent.BackgroundTaskResult = {
-                taskId: id,
-                status: "completed",
-                output,
-              };
-              results.set(id, result);
-              BackgroundStore.persist(completed, output);
-              onTaskComplete?.(result);
 
-              Bus.publish(Subagent.Events.BackgroundTaskCompleted, {
-                traceId: crypto.randomUUID(),
-                time: Date.now(),
-                payload: { taskId: id, status: "completed" as const, sessionId },
-              });
-
-              drainQueue();
-            }),
-          );
-
-          runUnsubs.push(
-            Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
-              if (data.payload.sessionId !== sessionId) return;
-              cleanupRunSubs();
-              taskUnsubs.delete(id);
-
-              const current = tasks.get(id);
-              if (!current || current.status === "cancelled") {
                 activeCount--;
+
+                const completed: Subagent.BackgroundTask = {
+                  ...current,
+                  status: "completed",
+                  completedAt: Date.now(),
+                };
+                tasks.set(id, completed);
+
+                let output: string | undefined;
+                try {
+                  const msgs = Session.getMessages(sessionId);
+                  const lastAssistant = [...msgs].reverse().find((m) => m.role === "assistant");
+                  if (lastAssistant) {
+                    const parts = Session.getParts(lastAssistant.id);
+                    output =
+                      parts
+                        .filter((p): p is Message.TextPart => p.type === "text")
+                        .map((p) => p.text)
+                        .filter(Boolean)
+                        .join("\n") || undefined;
+                  }
+                } catch {
+                  // session may have been cleaned up
+                }
+                const result: Subagent.BackgroundTaskResult = {
+                  taskId: id,
+                  status: "completed",
+                  output,
+                };
+                results.set(id, result);
+                BackgroundStore.persist(completed, output);
+                onTaskComplete?.(result);
+
+                Bus.publish(Subagent.Events.BackgroundTaskCompleted, {
+                  traceId: crypto.randomUUID(),
+                  time: Date.now(),
+                  payload: { taskId: id, status: "completed" as const, sessionId },
+                });
+
                 drainQueue();
-                return;
-              }
+              }),
+            );
 
-              activeCount--;
+            runUnsubs.push(
+              Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
+                if (data.payload.sessionId !== sessionId) return;
+                cleanupRunSubs();
+                taskUnsubs.delete(id);
 
-              const failed: Subagent.BackgroundTask = {
-                ...current,
-                status: "failed",
-                completedAt: Date.now(),
-                error: data.payload.error ?? "unknown error",
-              };
-              tasks.set(id, failed);
-              BackgroundStore.persist(failed);
+                const current = tasks.get(id);
+                if (!current || current.status === "cancelled") {
+                  activeCount--;
+                  drainQueue();
+                  return;
+                }
 
-              const result: Subagent.BackgroundTaskResult = { taskId: id, status: "failed" };
-              results.set(id, result);
-              onTaskComplete?.(result);
+                activeCount--;
 
-              Bus.publish(Subagent.Events.BackgroundTaskFailed, {
-                traceId: crypto.randomUUID(),
-                time: Date.now(),
-                payload: { taskId: id, error: data.payload.error ?? "unknown error" },
-              });
+                const failed: Subagent.BackgroundTask = {
+                  ...current,
+                  status: "failed",
+                  completedAt: Date.now(),
+                  error: data.payload.error ?? "unknown error",
+                };
+                tasks.set(id, failed);
+                BackgroundStore.persist(failed);
 
-              drainQueue();
-            }),
-          );
+                const result: Subagent.BackgroundTaskResult = { taskId: id, status: "failed" };
+                results.set(id, result);
+                onTaskComplete?.(result);
 
-          Bus.publish(Subagent.Events.BackgroundTaskLaunched, {
-            traceId: crypto.randomUUID(),
-            time: Date.now(),
-            payload: {
-              taskId: id,
-              agentName: input.agentName,
-              parentSessionId: input.parentSessionId,
-              status: "running" as const,
-            },
-          });
-        },
-        (err) => {
-          controllers.delete(id);
-          activeCount--;
-          const failed: Subagent.BackgroundTask = {
-            ...task,
-            status: "failed",
-            completedAt: Date.now(),
-            error: err instanceof Error ? err.message : String(err),
-          };
-          tasks.set(id, failed);
-          BackgroundStore.persist(failed);
-          Bus.publish(Subagent.Events.BackgroundTaskFailed, {
-            traceId: crypto.randomUUID(),
-            time: Date.now(),
-            payload: { taskId: id, error: failed.error },
-          });
+                Bus.publish(Subagent.Events.BackgroundTaskFailed, {
+                  traceId: crypto.randomUUID(),
+                  time: Date.now(),
+                  payload: { taskId: id, error: data.payload.error ?? "unknown error" },
+                });
 
-          drainQueue();
-        },
-      );
+                drainQueue();
+              }),
+            );
+
+            Bus.publish(Subagent.Events.BackgroundTaskLaunched, {
+              traceId: crypto.randomUUID(),
+              time: Date.now(),
+              payload: {
+                taskId: id,
+                agentName: input.agentName,
+                parentSessionId: input.parentSessionId,
+                status: "running" as const,
+              },
+            });
+          },
+          (err) => {
+            controllers.delete(id);
+            activeCount--;
+            const failed: Subagent.BackgroundTask = {
+              ...task,
+              status: "failed",
+              completedAt: Date.now(),
+              error: err instanceof Error ? err.message : String(err),
+            };
+            tasks.set(id, failed);
+            BackgroundStore.persist(failed);
+            Bus.publish(Subagent.Events.BackgroundTaskFailed, {
+              traceId: crypto.randomUUID(),
+              time: Date.now(),
+              payload: { taskId: id, error: failed.error },
+            });
+
+            drainQueue();
+          },
+        );
     }
 
     async function launch(input: LaunchInput): Promise<Subagent.BackgroundTask> {

--- a/packages/openomni/src/subagent/consultation.ts
+++ b/packages/openomni/src/subagent/consultation.ts
@@ -13,6 +13,8 @@ import {
 
 type ConsultationConfig = {
   model: RuntimeModel;
+  auth?: ChatAgentConfig["auth"];
+  allowAuthFallback?: ChatAgentConfig["allowAuthFallback"];
   systemPrompt?: string;
   tools?: ChatAgentConfig["tools"];
   toolExecutor?: ChatAgentConfig["toolExecutor"];
@@ -22,6 +24,8 @@ type ConsultationConfig = {
 function createRuntimeAgent(config: ConsultationConfig) {
   return ChatAgent.create({
     model: config.model,
+    auth: config.auth,
+    allowAuthFallback: config.allowAuthFallback,
     systemPrompt: config.systemPrompt,
     tools: config.tools,
     budget: config.budget,

--- a/packages/openomni/src/subagent/middleware/background-limits.ts
+++ b/packages/openomni/src/subagent/middleware/background-limits.ts
@@ -15,6 +15,17 @@ type BackgroundPolicyContext = Parameters<ReturnType<typeof PolicyEngine.create>
   readonly resourceDescriptor?: RuntimeResource.Descriptor;
 };
 
+function createBackgroundLaunchDescriptor(agentName: string): RuntimeResource.Descriptor {
+  return {
+    id: "worker:agent:background_launch",
+    kind: "worker",
+    source: { type: "agent", agentId: agentName },
+    labels: ["source.agent", "delegation.background"],
+    capabilities: ["delegation.background"],
+    effects: ["session.create"],
+  };
+}
+
 interface LaunchRequest {
   readonly agentName: string;
   readonly prompt: string;
@@ -361,10 +372,20 @@ export namespace BackgroundLimitsMiddleware {
       maxDescendants: ctx.maxDescendants,
       maxQueueSize: ctx.maxQueueSize,
     };
+    const traceContext = ctx.traceContext ?? {
+      traceId: crypto.randomUUID(),
+      sessionId: ctx.input.parentSessionId,
+    };
+    const resourceDescriptor =
+      ctx.resourceDescriptor ?? createBackgroundLaunchDescriptor(ctx.input.agentName);
     const engine = PolicyEngine.create({
-      traceContext: ctx.traceContext,
+      traceContext,
       onDecision: ctx.onDecision,
-      audit: false,
+      audit: {
+        sessionId: traceContext.sessionId,
+        action: "delegation.background.launch",
+        resource: `agent.${ctx.input.agentName}`,
+      },
     });
 
     for (const registration of registrations(state)) {
@@ -379,7 +400,7 @@ export namespace BackgroundLimitsMiddleware {
       continuationCount: 0,
       elapsedMs: 0,
       toolName: "subagent",
-      toolLabels: ctx.resourceDescriptor?.labels,
+      toolLabels: resourceDescriptor.labels,
       toolInput: {
         operation: "background.launch",
         agentName: ctx.input.agentName,
@@ -388,8 +409,8 @@ export namespace BackgroundLimitsMiddleware {
         activeCount: ctx.activeCount,
         pendingQueueSize: ctx.pendingQueueSize,
       },
-      traceContext: ctx.traceContext,
-      ...(ctx.resourceDescriptor !== undefined && { resourceDescriptor: ctx.resourceDescriptor }),
+      traceContext,
+      resourceDescriptor,
     };
 
     const verdict = await engine.dispatch("invoke.prepare", policyContext);

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -45,6 +45,11 @@ type ResourcePolicyContext = Omit<PolicyContext, "timing"> & {
 
 type PreDelegationOperation = "spawn" | "spawn_background" | "send";
 
+function createDelegationTrace(parentSessionId: string | undefined) {
+  if (parentSessionId === undefined) return undefined;
+  return { traceId: crypto.randomUUID(), sessionId: parentSessionId };
+}
+
 function createSubagentDescriptor(
   childAgent: string,
   operation: PreDelegationOperation,
@@ -95,7 +100,18 @@ async function dispatchPreDelegation(input: {
     });
   }
 
-  const engine = PolicyEngine.create({ audit: false });
+  const traceContext = createDelegationTrace(input.parentSessionId);
+  const engine = PolicyEngine.create({
+    traceContext,
+    audit:
+      traceContext === undefined
+        ? false
+        : {
+            sessionId: traceContext.sessionId,
+            action: `delegation.${input.operation}`,
+            resource: `agent.${input.childAgent}`,
+          },
+  });
   for (const reg of input.middleware) {
     engine.register(reg);
   }
@@ -123,6 +139,7 @@ async function dispatchPreDelegation(input: {
         : []),
     ],
     resourceDescriptor,
+    traceContext,
   };
 
   return engine.dispatch("invoke.prepare", policyContext);

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -14,6 +14,8 @@ import {
 
 export type RuntimeConfig = {
   model: RuntimeModel;
+  auth?: ChatAgentConfig["auth"];
+  allowAuthFallback?: ChatAgentConfig["allowAuthFallback"];
   systemPrompt?: string;
   tools?: ChatAgentConfig["tools"];
   toolExecutor?: ChatAgentConfig["toolExecutor"];
@@ -81,6 +83,8 @@ export async function runWithTranscript(
 ): Promise<Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>> {
   const agent = ChatAgent.create({
     model: config.model,
+    auth: config.auth,
+    allowAuthFallback: config.allowAuthFallback,
     systemPrompt: config.systemPrompt,
     tools: config.tools,
     budget: config.budget,

--- a/packages/openomni/test/subagent/runtime.test.ts
+++ b/packages/openomni/test/subagent/runtime.test.ts
@@ -5,7 +5,7 @@ import {
   type ChatAgentInput,
   type PolicyRegistration,
 } from "@openomni/agent";
-import { PolicyDecision, Subagent } from "@openomni/protocol";
+import { PolicyDecision, PolicyEvent, Subagent } from "@openomni/protocol";
 import { Bus, Session, Storage, WorkerRun } from "@openomni/session";
 import { SubagentRuntime } from "../../src/subagent/runtime";
 
@@ -470,6 +470,45 @@ describe("SubagentRuntime", () => {
         { value: "actor.child:child-agent", source: "system" },
         { value: `actor.parent:${parentSessionId}`, source: "system" },
       ]);
+    });
+
+    it("emits durable audit events for parent-scoped delegation policy", async () => {
+      queueResult("audited output");
+      const parentSessionId = createParentSession();
+      const composed: Array<{
+        action: string;
+        resource: string;
+        sessionId: string;
+        pointId?: string;
+      }> = [];
+      const unsubscribe = Bus.subscribe(PolicyEvent.DecisionComposed, (event) => {
+        composed.push(event);
+      });
+
+      const allowPolicy: PolicyRegistration = {
+        name: "test:audit-delegation",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: () => PolicyDecision.allow({ policyId: "test:audit-delegation" }),
+      };
+
+      await SubagentRuntime.spawn({
+        parentSessionId,
+        agentName: "child-agent",
+        title: "audited task",
+        prompt: "audit this",
+        model,
+        middleware: [allowPolicy],
+      });
+      unsubscribe();
+
+      expect(composed).toHaveLength(1);
+      expect(composed[0]).toMatchObject({
+        action: "delegation.spawn",
+        resource: "agent.child-agent",
+        sessionId: parentSessionId,
+        pointId: "delegation.subagent.pre",
+      });
     });
 
     it("send aborts when invoke.prepare policy returns abort", async () => {

--- a/packages/protocol/src/event/llm.ts
+++ b/packages/protocol/src/event/llm.ts
@@ -4,6 +4,7 @@ import { BusEvent } from "../bus/index.js";
 const Base = z.object({
   traceId: z.string(),
   sessionId: z.string(),
+  runId: z.string().optional(),
   time: z.number(),
 });
 

--- a/packages/protocol/src/ipc/AGENTS.md
+++ b/packages/protocol/src/ipc/AGENTS.md
@@ -18,10 +18,12 @@ Defines the locked-in wire contract between the coordinator process and worker p
 
 | Method | Direction | Description |
 |--------|-----------|-------------|
+| `coordinator.bootstrap` | Coordinator → Worker | Authenticate the supervisor connection and deliver worker bootstrap config. |
 | `coordinator.spawn_run` | Coordinator → Worker | Spawn a new agent run on the worker. Injects credentials and permissions. |
 | `coordinator.cancel_run` | Coordinator → Worker | Cancel an in-progress run by runId. |
 | `coordinator.check_permission` | Coordinator → Worker (reply) | Response to worker's tool permission query. |
-| `worker.ready` | Worker → Coordinator | Worker process has started and is ready to accept runs. |
+| `worker.ready` | Worker → Coordinator | Legacy worker startup signal; current runtime uses `coordinator.bootstrap`. |
+| `worker.bootstrap_ready` | Worker → Coordinator | Worker authenticated bootstrap is applied and runs may be accepted. |
 | `worker.heartbeat` | Worker → Coordinator | Periodic liveness + resource report. |
 | `worker.run_started` | Worker → Coordinator | Notify that a run has begun execution. |
 | `worker.run_completed` | Worker → Coordinator | Notify run terminal state (succeeded/failed/cancelled/interrupted). |

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -35,6 +35,7 @@ const notificationSchema = baseMessage.extend({
 const methods = {
   "coordinator.spawn_run": {
     params: z.object({
+      authToken: z.string(),
       runId: z.string(),
       sessionId: z.string(),
       prompt: z.string(),
@@ -54,8 +55,12 @@ const methods = {
     result: z.object({ accepted: z.boolean() }),
   },
   "coordinator.cancel_run": {
-    params: z.object({ runId: z.string(), sessionId: z.string() }),
-    result: z.object({ cancelled: z.boolean() }),
+    params: z.object({ authToken: z.string(), runId: z.string(), sessionId: z.string() }),
+    result: z.object({ cancelled: z.boolean(), error: z.string().optional() }),
+  },
+  "coordinator.bootstrap": {
+    params: z.object({ authToken: z.string(), bootstrap: WorkerBootstrap.Bootstrap }),
+    result: z.object({ ok: z.boolean(), error: z.string().optional() }),
   },
   // Central tool permission enforcement — workers ask coordinator before executing any tool
   "coordinator.check_permission": {
@@ -74,8 +79,13 @@ const methods = {
       bootstrap: WorkerBootstrap.Bootstrap.optional(),
     }),
   },
+  "worker.bootstrap_ready": {
+    params: z.object({ workerId: z.string(), authToken: z.string() }),
+    result: z.null(),
+  },
   "worker.heartbeat": {
     params: z.object({
+      authToken: z.string(),
       workerId: z.string(),
       activeRunIds: z.array(z.string()),
       memoryRssMb: z.number(),

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { WorkerBootstrap } from "../worker-bootstrap/index.js";
 
 const baseMessage = z.object({
-  v: z.literal(1),
+  v: z.literal(2),
   id: z.string().optional(),
 });
 
@@ -150,22 +150,24 @@ export namespace Ipc {
   export type Response = z.infer<typeof responseSchema>;
   export type Notification = z.infer<typeof notificationSchema>;
 
+  const version = 2;
+
   export function createRequest(method: string, params?: Record<string, unknown>): Request {
-    return { v: 1, type: "request", id: crypto.randomUUID(), method, params };
+    return { v: version, type: "request", id: crypto.randomUUID(), method, params };
   }
 
   export function createResponse(id: string, result: unknown): Response {
-    return { v: 1, type: "response", id, result };
+    return { v: version, type: "response", id, result };
   }
 
   export function createErrorResponse(id: string, code: number, message: string): Response {
-    return { v: 1, type: "response", id, error: { code, message } };
+    return { v: version, type: "response", id, error: { code, message } };
   }
 
   export function createNotification(
     method: string,
     params?: Record<string, unknown>,
   ): Notification {
-    return { v: 1, type: "notification", method, params };
+    return { v: version, type: "notification", method, params };
   }
 }

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -4,7 +4,7 @@ import { Ipc } from "../../src/index.js";
 describe("Ipc.Request", () => {
   test("parse round-trip", () => {
     const raw = {
-      v: 1,
+      v: 2,
       type: "request",
       id: "req-1",
       method: "worker.ready",
@@ -16,7 +16,7 @@ describe("Ipc.Request", () => {
   });
 
   test("rejects missing id", () => {
-    expect(Ipc.Request.safeParse({ v: 1, type: "request", method: "worker.ready" }).success).toBe(
+    expect(Ipc.Request.safeParse({ v: 2, type: "request", method: "worker.ready" }).success).toBe(
       false,
     );
   });
@@ -24,7 +24,7 @@ describe("Ipc.Request", () => {
   test("rejects wrong version", () => {
     expect(
       Ipc.Request.safeParse({
-        v: 2,
+        v: 1,
         type: "request",
         id: "req-1",
         method: "worker.ready",
@@ -35,7 +35,7 @@ describe("Ipc.Request", () => {
   test("rejects wrong type", () => {
     expect(
       Ipc.Request.safeParse({
-        v: 1,
+        v: 2,
         type: "notification",
         id: "req-1",
         method: "worker.ready",
@@ -46,7 +46,7 @@ describe("Ipc.Request", () => {
 
 describe("Ipc.Response", () => {
   test("parse round-trip with result", () => {
-    const raw = { v: 1, type: "response", id: "req-1", result: { accepted: true } };
+    const raw = { v: 2, type: "response", id: "req-1", result: { accepted: true } };
     const parsed = Ipc.Response.parse(raw);
     const reparsed = Ipc.Response.parse(JSON.parse(JSON.stringify(parsed)));
     expect(reparsed).toEqual(parsed);
@@ -54,7 +54,7 @@ describe("Ipc.Response", () => {
 
   test("parse round-trip with error", () => {
     const raw = {
-      v: 1,
+      v: 2,
       type: "response",
       id: "req-1",
       error: { code: 2000, message: "method not found" },
@@ -65,14 +65,14 @@ describe("Ipc.Response", () => {
   });
 
   test("rejects missing id", () => {
-    expect(Ipc.Response.safeParse({ v: 1, type: "response", result: null }).success).toBe(false);
+    expect(Ipc.Response.safeParse({ v: 2, type: "response", result: null }).success).toBe(false);
   });
 });
 
 describe("Ipc.Notification", () => {
   test("parse round-trip", () => {
     const raw = {
-      v: 1,
+      v: 2,
       type: "notification",
       method: "worker.state_update",
       params: { runId: "run-1", sessionId: "sess-1", event: "turn_start" },
@@ -83,7 +83,7 @@ describe("Ipc.Notification", () => {
   });
 
   test("rejects missing method", () => {
-    expect(Ipc.Notification.safeParse({ v: 1, type: "notification" }).success).toBe(false);
+    expect(Ipc.Notification.safeParse({ v: 2, type: "notification" }).success).toBe(false);
   });
 });
 
@@ -92,7 +92,7 @@ describe("Ipc helpers", () => {
     const req = Ipc.createRequest("worker.ready", { workerId: "w1", pid: 42 });
     expect(Ipc.Request.safeParse(req).success).toBe(true);
     expect(req.type).toBe("request");
-    expect(req.v).toBe(1);
+    expect(req.v).toBe(2);
     expect(typeof req.id).toBe("string");
     expect(req.method).toBe("worker.ready");
   });
@@ -100,7 +100,7 @@ describe("Ipc helpers", () => {
   test("createRequest without params", () => {
     const req = Ipc.createRequest("coordinator.cancel_run");
     expect(Ipc.Request.safeParse(req).success).toBe(true);
-    expect(req.params).toBeUndefined();
+    expect(req.params).toBe(undefined);
   });
 
   test("createResponse produces valid response", () => {
@@ -116,7 +116,7 @@ describe("Ipc helpers", () => {
     expect(Ipc.Response.safeParse(res).success).toBe(true);
     expect(res.error?.code).toBe(2000);
     expect(res.error?.message).toBe("method not found");
-    expect(res.result).toBeUndefined();
+    expect(res.result).toBe(undefined);
   });
 
   test("createNotification produces valid notification", () => {
@@ -133,7 +133,7 @@ describe("Ipc helpers", () => {
   test("createNotification without params", () => {
     const notif = Ipc.createNotification("ping");
     expect(Ipc.Notification.safeParse(notif).success).toBe(true);
-    expect(notif.params).toBeUndefined();
+    expect(notif.params).toBe(undefined);
   });
 });
 
@@ -141,6 +141,7 @@ describe("Ipc.Methods param schemas", () => {
   test("coordinator.spawn_run params valid", () => {
     expect(
       Ipc.Methods["coordinator.spawn_run"].params.safeParse({
+        authToken: "token",
         runId: "run-1",
         sessionId: "sess-1",
         prompt: "do work",
@@ -183,6 +184,7 @@ describe("Ipc.Methods param schemas", () => {
   test("worker.heartbeat params valid", () => {
     expect(
       Ipc.Methods["worker.heartbeat"].params.safeParse({
+        authToken: "token",
         workerId: "w1",
         activeRunIds: ["run-1", "run-2"],
         memoryRssMb: 256,

--- a/packages/session/src/bus-persistence/index.ts
+++ b/packages/session/src/bus-persistence/index.ts
@@ -247,7 +247,10 @@ function numberFromRecord(
 }
 
 function toRecord(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
+  return value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
     ? (value as Record<string, unknown>)
     : undefined;
 }

--- a/packages/session/src/bus-persistence/index.ts
+++ b/packages/session/src/bus-persistence/index.ts
@@ -84,6 +84,12 @@ export namespace BusPersistence {
     state?.unsubscribe();
     state = undefined;
   }
+
+  export async function flush(): Promise<void> {
+    await new Promise((resolve) => queueMicrotask(resolve));
+    const pending = state ? [...state.chains.values()] : [];
+    await Promise.allSettled(pending);
+  }
 }
 
 interface PersistInput {
@@ -95,7 +101,9 @@ interface PersistInput {
 
 async function persist(input: PersistInput): Promise<void> {
   const db = getDatabase();
-  const data = JSON.stringify(input.payload === undefined ? null : input.payload);
+  const data = JSON.stringify(
+    redactForPersistence(input.payload === undefined ? null : input.payload),
+  );
   const traceId = getTraceField(input.payload, "traceId") ?? crypto.randomUUID();
   const runId = getTraceField(input.payload, "runId");
   const durationMs = getNumberTraceField(input.payload, "durationMs");
@@ -115,6 +123,39 @@ async function persist(input: PersistInput): Promise<void> {
     durationMs ?? null,
     timeCreated,
   );
+}
+
+const sensitiveKeyPattern =
+  /authorization|cookie|credential|password|secret|token|api[_-]?key|access[_-]?key/i;
+const rawBodyKeyPattern =
+  /^(args|command|content|err|error|input|messages|newString|oldString|output|payload|prompt|systemPrompt|text)$/i;
+
+function redactForPersistence(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactForPersistence(item));
+  }
+  const record = toRecord(value);
+  if (!record) return value;
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(record)) {
+    if (sensitiveKeyPattern.test(key)) {
+      redacted[key] = "[redacted]";
+    } else if (rawBodyKeyPattern.test(key)) {
+      redacted[key] = summarizeValue(item);
+    } else {
+      redacted[key] = redactForPersistence(item);
+    }
+  }
+  return redacted;
+}
+
+function summarizeValue(value: unknown): unknown {
+  if (typeof value === "string") return { type: "string", length: value.length };
+  if (Array.isArray(value)) return { type: "array", length: value.length };
+  const record = toRecord(value);
+  if (record) return { type: "object", keys: Object.keys(record).sort() };
+  return value;
 }
 
 function getDatabase(): Database {
@@ -231,13 +272,14 @@ function writeOperationalToStdout(eventName: string, payload: unknown): void {
 
   const rec = toRecord(payload);
   const ctx = rec ? toRecord(rec.context) : undefined;
+  const redactedCtx = redactForPersistence(ctx) as Record<string, unknown> | undefined;
   const line = JSON.stringify({
     ts: rec?.time ?? Date.now(),
     level,
     pid: process.pid,
     component: rec?.component ?? "unknown",
     msg: rec?.msg ?? "",
-    ...ctx,
+    ...redactedCtx,
   });
   process.stdout.write(`${line}\n`);
 }

--- a/packages/session/src/session/index.ts
+++ b/packages/session/src/session/index.ts
@@ -335,7 +335,10 @@ export namespace Session {
   export function addPart(messageID: string, part: Message.Part): void {
     const adapter = Storage.getAdapter();
     adapter.part.set(messageID, part);
-    Bus.publish(Event.Updated, { info: adapter.session.get(messageID)! });
+    const session = adapter.session.get(part.sessionID);
+    if (session) {
+      Bus.publish(Event.Updated, { info: session });
+    }
   }
 
   export function getParts(messageID: string): Message.Part[] {

--- a/packages/session/test/bus-persistence/bus-persistence.test.ts
+++ b/packages/session/test/bus-persistence/bus-persistence.test.ts
@@ -219,6 +219,7 @@ describe("BusPersistence", () => {
         prompt: "summarize private user request",
         systemPrompt: "internal instruction text",
         messages: [{ role: "user", content: "secret prompt" }],
+        generatedAt: new Date("2026-05-16T00:00:00.000Z"),
       },
     });
     await BusPersistence.flush();
@@ -233,6 +234,7 @@ describe("BusPersistence", () => {
         prompt: unknown;
         systemPrompt: unknown;
         messages: unknown;
+        generatedAt: string;
       };
     };
     expect(data.context.apiKey).toBe("[redacted]");
@@ -243,5 +245,6 @@ describe("BusPersistence", () => {
     expect(data.context.prompt).toEqual({ type: "string", length: 30 });
     expect(data.context.systemPrompt).toEqual({ type: "string", length: 25 });
     expect(data.context.messages).toEqual({ type: "array", length: 1 });
+    expect(data.context.generatedAt).toBe("2026-05-16T00:00:00.000Z");
   });
 });

--- a/packages/session/test/bus-persistence/bus-persistence.test.ts
+++ b/packages/session/test/bus-persistence/bus-persistence.test.ts
@@ -192,4 +192,56 @@ describe("BusPersistence", () => {
 
     expect(rows()).toHaveLength(1);
   });
+
+  test("redacts sensitive and raw payload fields before persistence", async () => {
+    const session = createSession();
+    const event = BusEvent.define(
+      "policy.action.requested",
+      z.object({
+        sessionId: z.string(),
+        traceId: z.string(),
+        time: z.number(),
+        context: z.record(z.string(), z.unknown()),
+      }),
+    );
+
+    BusPersistence.start();
+    Bus.publish(event, {
+      sessionId: session.id,
+      traceId: "trace-redact",
+      time: Date.now(),
+      context: {
+        apiKey: "secret",
+        credentials: { anthropic: "sk-secret" },
+        error: "provider failed with prompt text and token secret",
+        err: "raw stack includes api key",
+        input: { command: "printenv DISCORD_BOT_TOKEN" },
+        prompt: "summarize private user request",
+        systemPrompt: "internal instruction text",
+        messages: [{ role: "user", content: "secret prompt" }],
+      },
+    });
+    await BusPersistence.flush();
+
+    const data = JSON.parse((await waitForRows(1))[0].data) as {
+      context: {
+        apiKey: string;
+        credentials: string;
+        error: unknown;
+        err: unknown;
+        input: unknown;
+        prompt: unknown;
+        systemPrompt: unknown;
+        messages: unknown;
+      };
+    };
+    expect(data.context.apiKey).toBe("[redacted]");
+    expect(data.context.credentials).toBe("[redacted]");
+    expect(data.context.error).toEqual({ type: "string", length: 49 });
+    expect(data.context.err).toEqual({ type: "string", length: 26 });
+    expect(data.context.input).toEqual({ type: "object", keys: ["command"] });
+    expect(data.context.prompt).toEqual({ type: "string", length: 30 });
+    expect(data.context.systemPrompt).toEqual({ type: "string", length: 25 });
+    expect(data.context.messages).toEqual({ type: "array", length: 1 });
+  });
 });

--- a/packages/session/test/session/metadata-hooks.test.ts
+++ b/packages/session/test/session/metadata-hooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import type { Message } from "@openomni/protocol";
+import { Bus } from "../../src/bus";
 import { Session } from "../../src/session";
 import { Storage } from "../../src/storage/storage";
 import "../../src/storage/initialize";
@@ -42,6 +43,16 @@ function makeAssistantMessage(
       cache: { read: 0, write: 0 },
     },
     ...overrides,
+  };
+}
+
+function makeTextPart(sessionID: string, messageID: string): Message.TextPart {
+  return {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID,
+    type: "text",
+    text: "hello",
   };
 }
 
@@ -177,6 +188,30 @@ describe("Session.addMessage metadata hooks", () => {
       expect(updated?.time.updated).toBeGreaterThanOrEqual(originalUpdated);
       expect(updated?.time.updated).toBeGreaterThanOrEqual(before);
       expect(updated?.time.updated).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("part updates", () => {
+    test("publishes the owning session when adding a part", async () => {
+      const session = Session.create({
+        title: "Test",
+        model: { providerID: "test", modelID: "test-model" },
+      });
+      const message = makeUserMessage(session.id);
+      Session.addMessage(session.id, message);
+
+      const updated = new Promise<{ id: string }>((resolve) => {
+        const unsubscribe = Bus.subscribe(Session.Event.Updated, (payload) => {
+          if (payload.info.id !== session.id) return;
+          unsubscribe();
+          resolve({ id: payload.info.id });
+        });
+      });
+
+      Session.addPart(message.id, makeTextPart(session.id, message.id));
+
+      const info = await updated;
+      expect(info.id).toBe(session.id);
     });
   });
 


### PR DESCRIPTION
## Summary

Enforces coordinator-only LLM execution by disabling local runtime paths, hardening worker IPC/auth boundaries, and making policy/LLM observability durable without persisting raw sensitive payloads.

Fixes #
Relates to #

## Changes

- Disable local execution mode and route runtime work through coordinator-managed workers only.
- Authenticate worker IPC bootstrap/spawn/cancel calls, isolate worker sockets, and avoid leaking host auth or home environment into workers/tools.
- Propagate explicit runtime auth through direct, foreground subagent, and background subagent LLM paths with fallback disabled.
- Emit durable policy audit events for subagent/background delegation and structured LLM retry/rate-limit events with run IDs.
- Redact prompt/message/tool payloads before bus persistence and add regression coverage for auth, policy audit, lifecycle, and redaction behavior.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [x] `protocol`
- [x] `session`
- [x] `llm`
- [x] `agent`
- [x] `openomni`
- [x] `coordinator`
- [x] `server`

## Breaking Changes

- [ ] No breaking changes
- [x] Yes — describe migration path below

Local execution mode is intentionally disabled. Runtime callers must use coordinator-backed direct execution and provide worker bootstrap credentials instead of relying on local auth file/env/home fallback.

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force all LLM execution through coordinator-managed workers and remove local mode. Add authenticated IPC bootstrap with protocol v2, pinned connections, private sockets, and durable, redacted observability with run IDs.

- Bug Fixes
  - Bumped IPC to v2: added `coordinator.bootstrap` and `worker.bootstrap_ready`; require `authToken` on `spawn_run` and `cancel_run`; pin the authenticated connection.
  - Preserved worker isolation: per-pool 0700 socket dirs and cleanup on shutdown; pass one-time IPC token via env.
  - Kept stream processing session-scoped by using the session ID for message context.
  - Improved bus persistence redaction and added structured retry events with optional `runId`; fixed `Session.addPart` to publish updates on the owning session.
  - Cleaned up background subagent runs when provider auth resolution fails; pass explicit auth to foreground/background subagents; scrubbed `bash` tool env and set workspace `HOME`.

- Migration
  - Remove any use of `OPENOMNI_MODE=local`; all execution goes through the coordinator.
  - Ensure coordinator and workers use IPC v2 and include the per-worker `authToken` for `spawn_run`/`cancel_run`.
  - Provide bootstrap credentials for each model provider and do not rely on local auth files or `HOME`; if you used implicit provider auth, configure keys in the bootstrap.

<sup>Written for commit b881529e428ee595f74a9911ec8e51b4b53db3f9. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Infrastructure**
  * Local (in-process) execution disabled; execution now requires coordinator mode with authenticated worker handshakes and restricted worker envs
  * Added redaction of sensitive fields before event persistence; flushable persistence

* **Observability & Auditing**
  * Tracing extended with runId and sessionId; durable audit events for background launches and delegation
  * Event payloads now include compact summaries for tool inputs/outputs

* **Behavior**
  * Bash tool runs with a scrubbed, workspace-rooted environment
  * Session part additions now publish session-updated events reliably

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->