### PR TITLE
feat(agent): preserve reserve tokens before compaction

### DIFF
--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -4,6 +4,8 @@ import { Bus } from "@openomni/session";
 export interface CompactionOptions {
   contextWindowTokens: number;
   thresholdRatio?: number;
+  reserveTokens?: number;
+  reserveRatio?: number;
   protectRecentMessages?: number;
   onSummarize?: (messages: Message.WithParts[]) => Promise<string>;
 }
@@ -19,8 +21,7 @@ const DEFAULT_PROTECT_RECENT = 6;
 
 export namespace InMemoryCompactor {
   export function shouldCompact(totalTokens: number, options: CompactionOptions): boolean {
-    const threshold =
-      options.contextWindowTokens * (options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO);
+    const threshold = resolveThresholdTokens(options);
     return totalTokens >= threshold;
   }
 
@@ -65,6 +66,20 @@ export namespace InMemoryCompactor {
       removedCount: toRemove.length,
     };
   }
+}
+
+function resolveThresholdTokens(options: CompactionOptions): number {
+  const ratioThreshold =
+    options.contextWindowTokens * (options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO);
+  const reserveTokens = resolveReserveTokens(options);
+  if (reserveTokens === undefined) return ratioThreshold;
+  return Math.min(ratioThreshold, Math.max(0, options.contextWindowTokens - reserveTokens));
+}
+
+function resolveReserveTokens(options: CompactionOptions): number | undefined {
+  if (options.reserveTokens !== undefined) return options.reserveTokens;
+  if (options.reserveRatio !== undefined) return options.contextWindowTokens * options.reserveRatio;
+  return undefined;
 }
 
 function buildSummaryMessage(summaryText: string): Message.WithParts {

--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -73,13 +73,17 @@ function resolveThresholdTokens(options: CompactionOptions): number {
     options.contextWindowTokens * (options.thresholdRatio ?? DEFAULT_THRESHOLD_RATIO);
   const reserveTokens = resolveReserveTokens(options);
   if (reserveTokens === undefined) return ratioThreshold;
-  return Math.min(ratioThreshold, Math.max(0, options.contextWindowTokens - reserveTokens));
+  return Math.min(ratioThreshold, options.contextWindowTokens - reserveTokens);
 }
 
 function resolveReserveTokens(options: CompactionOptions): number | undefined {
-  if (options.reserveTokens !== undefined) return options.reserveTokens;
-  if (options.reserveRatio !== undefined) return options.contextWindowTokens * options.reserveRatio;
-  return undefined;
+  const reserveTokens =
+    options.reserveTokens ??
+    (options.reserveRatio === undefined
+      ? undefined
+      : options.contextWindowTokens * options.reserveRatio);
+  if (reserveTokens === undefined || !Number.isFinite(reserveTokens)) return undefined;
+  return Math.min(options.contextWindowTokens, Math.max(0, reserveTokens));
 }
 
 function buildSummaryMessage(summaryText: string): Message.WithParts {

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -38,6 +38,8 @@ export interface ChatAgentConfig {
   compaction?: {
     contextWindowTokens: number;
     thresholdRatio?: number;
+    reserveTokens?: number;
+    reserveRatio?: number;
     protectRecentMessages?: number;
     onSummarize?: (messages: Message.WithParts[]) => Promise<string>;
   };

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, it } from "bun:test";
 import type { Message } from "@openomni/protocol";
 import { InMemoryCompactor } from "../../../src/core/execution/compaction";
 
+let idCounter = 0;
+
+function nextId(prefix: string): string {
+  idCounter += 1;
+  return `${prefix}-${idCounter}`;
+}
+
 function makeUserMessage(text: string): Message.WithParts {
-  const id = crypto.randomUUID();
+  const id = nextId("user-message");
   const sessionID = "test";
   const info: Message.UserMessage = {
     id,
@@ -14,7 +21,7 @@ function makeUserMessage(text: string): Message.WithParts {
     model: { providerID: "", modelID: "" },
   };
   const part: Message.TextPart = {
-    id: crypto.randomUUID(),
+    id: nextId("user-part"),
     sessionID,
     messageID: id,
     type: "text",
@@ -24,7 +31,7 @@ function makeUserMessage(text: string): Message.WithParts {
 }
 
 function makeAssistantMessage(text: string): Message.WithParts {
-  const id = crypto.randomUUID();
+  const id = nextId("assistant-message");
   const sessionID = "test";
   const info: Message.AssistantMessage = {
     id,
@@ -40,7 +47,7 @@ function makeAssistantMessage(text: string): Message.WithParts {
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
   };
   const part: Message.TextPart = {
-    id: crypto.randomUUID(),
+    id: nextId("assistant-part"),
     sessionID,
     messageID: id,
     type: "text",
@@ -74,6 +81,36 @@ describe("InMemoryCompactor", () => {
         InMemoryCompactor.shouldCompact(400, {
           contextWindowTokens: 1000,
           thresholdRatio: 0.5,
+        }),
+      ).toBe(false);
+    });
+
+    it("compacts early when reserveTokens would be consumed", () => {
+      expect(
+        InMemoryCompactor.shouldCompact(751, {
+          contextWindowTokens: 1000,
+          reserveTokens: 250,
+        }),
+      ).toBe(true);
+      expect(
+        InMemoryCompactor.shouldCompact(749, {
+          contextWindowTokens: 1000,
+          reserveTokens: 250,
+        }),
+      ).toBe(false);
+    });
+
+    it("compacts early when reserveRatio would be consumed", () => {
+      expect(
+        InMemoryCompactor.shouldCompact(701, {
+          contextWindowTokens: 1000,
+          reserveRatio: 0.3,
+        }),
+      ).toBe(true);
+      expect(
+        InMemoryCompactor.shouldCompact(699, {
+          contextWindowTokens: 1000,
+          reserveRatio: 0.3,
         }),
       ).toBe(false);
     });

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -114,6 +114,39 @@ describe("InMemoryCompactor", () => {
         }),
       ).toBe(false);
     });
+
+    it("prefers reserveTokens over reserveRatio", () => {
+      expect(
+        InMemoryCompactor.shouldCompact(751, {
+          contextWindowTokens: 1000,
+          reserveTokens: 250,
+          reserveRatio: 0.5,
+        }),
+      ).toBe(true);
+      expect(
+        InMemoryCompactor.shouldCompact(749, {
+          contextWindowTokens: 1000,
+          reserveTokens: 250,
+          reserveRatio: 0.5,
+        }),
+      ).toBe(false);
+    });
+
+    it("normalizes out-of-range reserve values", () => {
+      expect(
+        InMemoryCompactor.shouldCompact(999, {
+          contextWindowTokens: 1000,
+          thresholdRatio: 1,
+          reserveTokens: -100,
+        }),
+      ).toBe(false);
+      expect(
+        InMemoryCompactor.shouldCompact(0, {
+          contextWindowTokens: 1000,
+          reserveTokens: 1200,
+        }),
+      ).toBe(true);
+    });
   });
 
   describe("compact", () => {

--- a/packages/agent/test/core/policy/builtin/compaction.test.ts
+++ b/packages/agent/test/core/policy/builtin/compaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Message } from "@openomni/protocol";
 import { createCompactionPolicy } from "../../../../src/core/policy/builtin/compaction";
 import type { PolicyContext } from "../../../../src/core/policy";
+import type { BudgetState } from "../../../../src/core/budget";
 import { effectOf } from "../../../helpers/policy-decision";
 
 function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
@@ -40,6 +41,17 @@ function createTestMessage(id: string): Message.WithParts {
   };
 }
 
+function budgetState(inputTokens: number, outputTokens: number): BudgetState {
+  return {
+    startTime: Date.now(),
+    turns: 1,
+    toolCalls: 0,
+    toolRuntimeMs: 0,
+    totalInputTokens: inputTokens,
+    totalOutputTokens: outputTokens,
+  };
+}
+
 describe("createCompactionPolicy", () => {
   it("continues when below threshold", async () => {
     const middleware = createCompactionPolicy({
@@ -50,7 +62,7 @@ describe("createCompactionPolicy", () => {
     const messages = [createTestMessage("msg1"), createTestMessage("msg2")];
     const ctx = baseCtx({
       messages,
-      budgetState: { turns: 1, totalInputTokens: 1000, totalOutputTokens: 500 },
+      budgetState: budgetState(1000, 500),
     });
 
     const verdict = await middleware.fn(ctx);
@@ -68,7 +80,29 @@ describe("createCompactionPolicy", () => {
     const messages = Array.from({ length: 10 }, (_, i) => createTestMessage(`msg${i}`));
     const ctx = baseCtx({
       messages,
-      budgetState: { turns: 1, totalInputTokens: 7000, totalOutputTokens: 1000 },
+      budgetState: budgetState(7000, 1000),
+    });
+
+    const verdict = await middleware.fn(ctx);
+
+    expect(verdict.verdict).toBe("allow");
+    const replacement = effectOf(verdict, "run.replace_messages");
+    expect(replacement).toBeDefined();
+    expect(replacement?.messages.length).toBeLessThan(messages.length);
+  });
+
+  it("transforms when reserve budget is reached before ratio threshold", async () => {
+    const middleware = createCompactionPolicy({
+      contextWindowTokens: 1000,
+      thresholdRatio: 0.95,
+      reserveTokens: 250,
+      protectRecentMessages: 2,
+    });
+
+    const messages = Array.from({ length: 10 }, (_, i) => createTestMessage(`msg${i}`));
+    const ctx = baseCtx({
+      messages,
+      budgetState: budgetState(700, 60),
     });
 
     const verdict = await middleware.fn(ctx);
@@ -80,9 +114,9 @@ describe("createCompactionPolicy", () => {
   });
 
   it("emits compaction event when compacting", async () => {
-    const events: Array<{ name: string; data: unknown }> = [];
+    const events: Array<{ name: string; data: Record<string, unknown> }> = [];
     const mockEmitter = {
-      emit: (name: string, data: unknown) => {
+      emit: (name: string, data: Record<string, unknown>) => {
         events.push({ name, data });
       },
     };
@@ -96,17 +130,19 @@ describe("createCompactionPolicy", () => {
     const messages = Array.from({ length: 10 }, (_, i) => createTestMessage(`msg${i}`));
     const ctx = baseCtx({
       messages,
-      budgetState: { turns: 1, totalInputTokens: 7000, totalOutputTokens: 1000 },
-      eventEmitter: mockEmitter as unknown as Parameters<typeof baseCtx>[0]["eventEmitter"],
+      budgetState: budgetState(7000, 1000),
+      eventEmitter: mockEmitter,
     });
 
     const verdict = await middleware.fn(ctx);
 
     expect(verdict.verdict).toBe("allow");
     expect(events.length).toBe(1);
-    expect(events[0].name).toBe("agent.compaction");
-    expect(events[0].data.messagesBefore).toBe(10);
-    expect(events[0].data.messagesAfter).toBeLessThan(10);
+    const event = events[0];
+    if (!event) throw new Error("expected compaction event");
+    expect(event.name).toBe("agent.compaction");
+    expect(event.data.messagesBefore).toBe(10);
+    expect(event.data.messagesAfter).toBeLessThan(10);
   });
 
   it("continues when no messages in context", async () => {
@@ -117,7 +153,7 @@ describe("createCompactionPolicy", () => {
 
     const ctx = baseCtx({
       messages: undefined,
-      budgetState: { turns: 1, totalInputTokens: 7000, totalOutputTokens: 1000 },
+      budgetState: budgetState(7000, 1000),
     });
 
     const verdict = await middleware.fn(ctx);
@@ -133,7 +169,7 @@ describe("createCompactionPolicy", () => {
 
     const ctx = baseCtx({
       messages: [],
-      budgetState: { turns: 1, totalInputTokens: 7000, totalOutputTokens: 1000 },
+      budgetState: budgetState(7000, 1000),
     });
 
     const verdict = await middleware.fn(ctx);


### PR DESCRIPTION
## Summary

Adds reserve-token based compaction thresholds so agent runs can compact before consuming the model context budget reserved for future output.

Fixes N/A
Relates to N/A

## Changes

- Add optional `reserveTokens` and `reserveRatio` compaction settings.
- Resolve the effective compaction threshold as the earlier of ratio threshold and reserve budget threshold.
- Add unit and policy coverage for reserve-triggered compaction.

## Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [x] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed

AGENTS.md update is not required; this extends an existing optional configuration shape without changing package ownership or architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves a token reserve during compaction so runs compact before using tokens needed for future model output.

- **New Features**
  - Adds optional `reserveTokens` and `reserveRatio` to `agent` compaction config.
  - Compaction threshold is min(ratio threshold, `contextWindowTokens - resolved reserve`).
  - Adds unit and policy tests for reserve-triggered compaction and event emission.
  - Default behavior unchanged when reserve settings are not provided.

- **Bug Fixes**
  - Normalizes reserve values (clamps to [0, context window], ignores non-finite) and prefers `reserveTokens` over `reserveRatio` to ensure consistent thresholds.

<sup>Written for commit e9ca427f4c3bca29149add12981abfab492a055d. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional token-reservation controls to agent compaction configuration (reserveTokens, reserveRatio) for finer control over usable context during compaction.

* **Tests**
  * Expanded compaction tests to cover reserveTokens/reserveRatio precedence, out-of-range normalization, and early-compaction scenarios.
  * Made test IDs deterministic and introduced a budget-state helper for clearer, more robust assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->