### PR TITLE
feat(openomni): reject stale file edits by hash

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/builtins/edit-prompt.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/edit-prompt.ts
@@ -1,3 +1,4 @@
 export const EDIT_PROMPT = `Replace an exact substring in a file within the workspace.
 oldString must already exist in the file and must differ from newString.
-Default behavior replaces the first occurrence; set replaceAll=true to replace every match.`;
+Default behavior replaces the first occurrence; set replaceAll=true to replace every match.
+Set expectedFileHash to the current file SHA-256 hash to reject stale edits.`;

--- a/packages/openomni/src/execution-runtime/tool/builtins/edit.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/edit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import type { Tool } from "@openomni/protocol";
+import { createEditTool } from "./edit.js";
+
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function withWorkspace(fn: (workspace: string) => Promise<void>): Promise<void> {
+  const workspace = join(import.meta.dir, ".edit-test-fixture");
+  await mkdir(workspace, { recursive: true });
+  try {
+    await fn(workspace);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+function call(input: Record<string, unknown>): Tool.Call {
+  return { id: "call-1", tool: "edit", input };
+}
+
+describe("createEditTool", () => {
+  it("edits when expectedFileHash matches the current file", async () => {
+    await withWorkspace(async (workspace) => {
+      const target = join(workspace, "file.txt");
+      const original = "hello world\n";
+      await Bun.write(target, original);
+
+      const tool = createEditTool(workspace);
+      const result = await tool.execute(
+        call({
+          path: "file.txt",
+          oldString: "world",
+          newString: "openomni",
+          expectedFileHash: await sha256Hex(original),
+        }),
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(await Bun.file(target).text()).toBe("hello openomni\n");
+    });
+  });
+
+  it("rejects edits when expectedFileHash does not match", async () => {
+    await withWorkspace(async (workspace) => {
+      const target = join(workspace, "file.txt");
+      const original = "hello world\n";
+      await Bun.write(target, original);
+
+      const tool = createEditTool(workspace);
+      const result = await tool.execute(
+        call({
+          path: "file.txt",
+          oldString: "world",
+          newString: "openomni",
+          expectedFileHash: await sha256Hex("stale content\n"),
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toContain("File hash mismatch");
+      expect(await Bun.file(target).text()).toBe(original);
+    });
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/builtins/edit.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/edit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Tool } from "@openomni/protocol";
 import { createEditTool } from "./edit.js";
@@ -10,8 +11,7 @@ async function sha256Hex(text: string): Promise<string> {
 }
 
 async function withWorkspace(fn: (workspace: string) => Promise<void>): Promise<void> {
-  const workspace = join(import.meta.dir, ".edit-test-fixture");
-  await mkdir(workspace, { recursive: true });
+  const workspace = await mkdtemp(join(tmpdir(), "openomni-edit-test-"));
   try {
     await fn(workspace);
   } finally {
@@ -63,6 +63,28 @@ describe("createEditTool", () => {
 
       expect(result.isError).toBe(true);
       expect(result.output).toContain("File hash mismatch");
+      expect(await Bun.file(target).text()).toBe(original);
+    });
+  });
+
+  it("rejects malformed expectedFileHash values", async () => {
+    await withWorkspace(async (workspace) => {
+      const target = join(workspace, "file.txt");
+      const original = "hello world\n";
+      await Bun.write(target, original);
+
+      const tool = createEditTool(workspace);
+      const result = await tool.execute(
+        call({
+          path: "file.txt",
+          oldString: "world",
+          newString: "openomni",
+          expectedFileHash: "not-a-sha256",
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toContain("expectedFileHash must be a lowercase SHA-256 hex digest");
       expect(await Bun.file(target).text()).toBe(original);
     });
   });

--- a/packages/openomni/src/execution-runtime/tool/builtins/edit.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/edit.ts
@@ -74,6 +74,13 @@ export function createEditTool(workspaceRoot: string) {
           return errorResult(call, `Path does not exist: ${filePath}`);
         }
 
+        if (expectedFileHash !== undefined && !isSha256Hex(expectedFileHash)) {
+          return errorResult(
+            call,
+            "Invalid input: expectedFileHash must be a lowercase SHA-256 hex digest",
+          );
+        }
+
         const original = await file.text();
         if (expectedFileHash !== undefined) {
           const actualFileHash = await sha256Hex(original);
@@ -109,4 +116,8 @@ export function createEditTool(workspaceRoot: string) {
 async function sha256Hex(text: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function isSha256Hex(value: string): boolean {
+  return /^[0-9a-f]{64}$/.test(value);
 }

--- a/packages/openomni/src/execution-runtime/tool/builtins/edit.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/edit.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../define.js";
-import { optionalBoolean, requireString } from "../shared/input.js";
+import { optionalBoolean, optionalString, requireString } from "../shared/input.js";
 import { errorResult, fromError, successResult } from "../shared/result.js";
 import { resolveContainedPath } from "../../filesystem/workspace-path.js";
 import { EDIT_PROMPT } from "./edit-prompt.js";
@@ -27,7 +27,13 @@ function replaceMany(
 }
 
 export function createEditTool(workspaceRoot: string) {
-  return defineTool<{ path: string; oldString: string; newString: string; replaceAll?: boolean }>({
+  return defineTool<{
+    path: string;
+    oldString: string;
+    newString: string;
+    replaceAll?: boolean;
+    expectedFileHash?: string;
+  }>({
     name: "edit",
     description: "Replace exact text in a file",
     prompt: EDIT_PROMPT,
@@ -38,6 +44,10 @@ export function createEditTool(workspaceRoot: string) {
         oldString: { type: "string", description: "Text to replace" },
         newString: { type: "string", description: "Replacement text" },
         replaceAll: { type: "boolean", description: "Replace all occurrences" },
+        expectedFileHash: {
+          type: "string",
+          description: "Expected SHA-256 hash of the current file",
+        },
       },
       required: ["path", "oldString", "newString"],
     },
@@ -51,6 +61,7 @@ export function createEditTool(workspaceRoot: string) {
         const oldString = requireString(call.input, "oldString");
         const newString = requireString(call.input, "newString");
         const replaceAll = optionalBoolean(call.input, "replaceAll") ?? false;
+        const expectedFileHash = optionalString(call.input, "expectedFileHash");
 
         if (oldString === newString) {
           return errorResult(call, "Invalid input: oldString and newString must be different");
@@ -64,6 +75,16 @@ export function createEditTool(workspaceRoot: string) {
         }
 
         const original = await file.text();
+        if (expectedFileHash !== undefined) {
+          const actualFileHash = await sha256Hex(original);
+          if (actualFileHash !== expectedFileHash) {
+            return errorResult(
+              call,
+              `File hash mismatch for ${filePath}: expected ${expectedFileHash}, got ${actualFileHash}`,
+            );
+          }
+        }
+
         if (!original.includes(oldString)) {
           return errorResult(call, `oldString not found in file: ${filePath}`);
         }
@@ -83,4 +104,9 @@ export function createEditTool(workspaceRoot: string) {
       }
     },
   });
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }


### PR DESCRIPTION
## Summary

Adds an optional SHA-256 file hash guard to the built-in edit tool so stale file edits are rejected before writing.

Fixes N/A
Relates to N/A

## Changes

- Add optional `expectedFileHash` input to the `edit` tool.
- Reject edits when the current file hash differs from the provided expected hash.
- Document the new input in the edit prompt and add direct tool tests.

## Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed

AGENTS.md update is not required; this extends an existing tool input contract without changing package ownership or architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional SHA-256 hash guard to the `openomni` `edit` tool to prevent stale edits. Validates `expectedFileHash` (lowercase hex), rejects mismatches before writing, and updates the tool prompt and tests.

<sup>Written for commit d4ff5297b034250b8daa06b72d043f865b556f15. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit tool accepts an optional file hash to validate the file state and reject stale edits when the hash doesn't match.

* **Documentation**
  * Updated user-facing guidance explaining file-hash validation and default replacement behavior (including replace-all option).

* **Tests**
  * Added tests verifying correct behavior for matching/non-matching hashes and reporting an error for malformed hash input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->