### PR TITLE
fix(openomni): repair background cancellation accounting

### DIFF
--- a/packages/openomni/src/subagent/background-manager.test.ts
+++ b/packages/openomni/src/subagent/background-manager.test.ts
@@ -8,6 +8,13 @@ import { BackgroundLimitsMiddleware } from "./middleware/background-limits";
 import { SubagentRuntime } from "./runtime";
 
 let spawnBackgroundSpy: ReturnType<typeof spyOn> | undefined;
+let cancelSpy: ReturnType<typeof spyOn> | undefined;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+};
 
 function makeTask(id: string): import("@openomni/protocol").Subagent.BackgroundTask {
   return {
@@ -46,9 +53,25 @@ function mockSpawnBackground(): void {
   });
 }
 
+function createDeferred<T>(): Deferred<T> {
+  let resolve: Deferred<T>["resolve"] = () => {
+    throw new Error("deferred resolve called before initialization");
+  };
+  let reject: Deferred<T>["reject"] = () => {
+    throw new Error("deferred reject called before initialization");
+  };
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 afterEach(() => {
   spawnBackgroundSpy?.mockRestore();
   spawnBackgroundSpy = undefined;
+  cancelSpy?.mockRestore();
+  cancelSpy = undefined;
   Bus.reset();
 });
 
@@ -282,6 +305,106 @@ describe("BackgroundManager — launch limit policy", () => {
       expect(task.error).toBe("auth unavailable");
       expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 1 });
       expect(spawnBackgroundSpy).not.toHaveBeenCalled();
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("preserves cancelled task state when spawn fails after cancellation", async () => {
+    const deferred = createDeferred<{ sessionId: string; runId: string }>();
+    spawnBackgroundSpy?.mockRestore();
+    spawnBackgroundSpy = spyOn(SubagentRuntime, "spawnBackground").mockImplementation(
+      () => deferred.promise,
+    );
+    const manager = BackgroundManager.create();
+
+    try {
+      const launchPromise = manager.launch(makeLaunchInput());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const task = manager.listByParent("parent-session-1")[0];
+      expect(task?.status).toBe("pending");
+      expect(manager.stats()).toEqual({ active: 1, pending: 0, total: 1 });
+      if (!task) throw new Error("expected launched task");
+
+      await manager.cancel(task.id);
+      expect(manager.getTask(task.id)?.status).toBe("cancelled");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 1 });
+
+      deferred.reject(new Error("spawn failed after cancel"));
+      const result = await launchPromise;
+
+      expect(result.status).toBe("cancelled");
+      expect(result.error).toBeUndefined();
+      expect(manager.getTask(task.id)?.status).toBe("cancelled");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 1 });
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("does not resurrect a cleaned cancelled task when spawn fails late", async () => {
+    const deferred = createDeferred<{ sessionId: string; runId: string }>();
+    spawnBackgroundSpy?.mockRestore();
+    spawnBackgroundSpy = spyOn(SubagentRuntime, "spawnBackground").mockImplementation(
+      () => deferred.promise,
+    );
+    const manager = BackgroundManager.create({ taskTtlMs: 0 });
+
+    try {
+      const launchPromise = manager.launch(makeLaunchInput());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const task = manager.listByParent("parent-session-1")[0];
+      expect(task?.status).toBe("pending");
+      if (!task) throw new Error("expected launched task");
+
+      await manager.cancel(task.id);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      manager.cleanup();
+      expect(manager.getTask(task.id)).toBeUndefined();
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 0 });
+
+      deferred.reject(new Error("spawn failed after cleanup"));
+      await launchPromise;
+
+      expect(manager.getTask(task.id)).toBeUndefined();
+      expect(manager.getResult(task.id)).toBeUndefined();
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 0 });
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("preserves cancelled task state when spawn resolves after cancellation", async () => {
+    const deferred = createDeferred<{ sessionId: string; runId: string }>();
+    spawnBackgroundSpy?.mockRestore();
+    spawnBackgroundSpy = spyOn(SubagentRuntime, "spawnBackground").mockImplementation(
+      () => deferred.promise,
+    );
+    cancelSpy = spyOn(SubagentRuntime, "cancel").mockResolvedValue();
+    const manager = BackgroundManager.create();
+
+    try {
+      const launchPromise = manager.launch(makeLaunchInput());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const task = manager.listByParent("parent-session-1")[0];
+      expect(task?.status).toBe("pending");
+      expect(manager.stats()).toEqual({ active: 1, pending: 0, total: 1 });
+      if (!task) throw new Error("expected launched task");
+
+      await manager.cancel(task.id);
+      expect(manager.getTask(task.id)?.status).toBe("cancelled");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 1 });
+
+      deferred.resolve({ sessionId: "late-session", runId: "late-run" });
+      const result = await launchPromise;
+
+      expect(result.status).toBe("cancelled");
+      expect(manager.getTask(task.id)?.status).toBe("cancelled");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 1 });
+      expect(cancelSpy).toHaveBeenCalledWith({ sessionId: "late-session", runId: "late-run" });
     } finally {
       manager.dispose();
     }

--- a/packages/openomni/src/subagent/background-manager.ts
+++ b/packages/openomni/src/subagent/background-manager.ts
@@ -78,8 +78,9 @@ export const BackgroundManager = {
 
     type QueuedItem = { input: LaunchInput; id: string };
     const pendingQueue: QueuedItem[] = [];
-    // Tracks spawning + running tasks synchronously (incremented before async spawn)
+    // Tracks spawning + running tasks synchronously before async spawn completes.
     let activeCount = 0;
+    const activeTaskIds = new Set<string>();
     let launchLock: Promise<void> = Promise.resolve();
 
     for (const interrupted of BackgroundStore.loadInterrupted()) {
@@ -144,16 +145,23 @@ export const BackgroundManager = {
         // task may have been cancelled while queued
         if (!task || task.status !== "pending") continue;
 
-        activeCount++;
-        spawnTask(next.id, next.input, task);
+        markActive(next.id);
+        spawnTask(next.id, next.input);
       }
     }
 
-    function spawnTask(
-      id: string,
-      input: LaunchInput,
-      task: Subagent.BackgroundTask,
-    ): Promise<void> {
+    function markActive(taskId: string): void {
+      if (activeTaskIds.has(taskId)) return;
+      activeTaskIds.add(taskId);
+      activeCount++;
+    }
+
+    function releaseActive(taskId: string): void {
+      if (!activeTaskIds.delete(taskId)) return;
+      activeCount--;
+    }
+
+    function spawnTask(id: string, input: LaunchInput): Promise<void> {
       const controller = new AbortController();
       controllers.set(id, controller);
 
@@ -170,9 +178,22 @@ export const BackgroundManager = {
           }),
         )
         .then(
-          ({ sessionId, runId }) => {
+          async ({ sessionId, runId }) => {
+            const currentTask = tasks.get(id);
+            if (!currentTask || currentTask.status === "cancelled") {
+              try {
+                await SubagentRuntime.cancel({ sessionId, runId });
+              } catch {
+                // The run may already be terminal; local background accounting still needs cleanup.
+              }
+              controllers.delete(id);
+              releaseActive(id);
+              drainQueue();
+              return;
+            }
+
             const running: Subagent.BackgroundTask = {
-              ...task,
+              ...currentTask,
               status: "running",
               sessionId,
               runId,
@@ -187,18 +208,20 @@ export const BackgroundManager = {
 
             runUnsubs.push(
               Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
-                if (data.payload.sessionId !== sessionId) return;
+                if (data.payload.sessionId !== sessionId || data.payload.runId !== runId) return;
                 cleanupRunSubs();
                 taskUnsubs.delete(id);
 
                 const current = tasks.get(id);
                 if (!current || current.status === "cancelled") {
-                  activeCount--;
+                  controllers.delete(id);
+                  releaseActive(id);
                   drainQueue();
                   return;
                 }
 
-                activeCount--;
+                controllers.delete(id);
+                releaseActive(id);
 
                 const completed: Subagent.BackgroundTask = {
                   ...current,
@@ -244,18 +267,20 @@ export const BackgroundManager = {
 
             runUnsubs.push(
               Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
-                if (data.payload.sessionId !== sessionId) return;
+                if (data.payload.sessionId !== sessionId || data.payload.runId !== runId) return;
                 cleanupRunSubs();
                 taskUnsubs.delete(id);
 
                 const current = tasks.get(id);
                 if (!current || current.status === "cancelled") {
-                  activeCount--;
+                  controllers.delete(id);
+                  releaseActive(id);
                   drainQueue();
                   return;
                 }
 
-                activeCount--;
+                controllers.delete(id);
+                releaseActive(id);
 
                 const failed: Subagent.BackgroundTask = {
                   ...current,
@@ -293,9 +318,16 @@ export const BackgroundManager = {
           },
           (err) => {
             controllers.delete(id);
-            activeCount--;
+            releaseActive(id);
+
+            const current = tasks.get(id);
+            if (!current || current.status === "cancelled") {
+              drainQueue();
+              return;
+            }
+
             const failed: Subagent.BackgroundTask = {
-              ...task,
+              ...current,
               status: "failed",
               completedAt: Date.now(),
               error: err instanceof Error ? err.message : String(err),
@@ -348,11 +380,12 @@ export const BackgroundManager = {
 
         if (policy.shouldQueue) {
           pendingQueue.push({ input, id });
-          return task;
+          drainQueue();
+          return tasks.get(id) ?? task;
         }
 
-        activeCount++;
-        await spawnTask(id, input, task);
+        markActive(id);
+        await spawnTask(id, input);
         return tasks.get(id) ?? task;
       });
     }
@@ -371,6 +404,7 @@ export const BackgroundManager = {
       controllers.get(taskId)?.abort();
       taskUnsubs.get(taskId)?.();
       taskUnsubs.delete(taskId);
+      controllers.delete(taskId);
       const cancelled: Subagent.BackgroundTask = {
         ...task,
         status: "cancelled",
@@ -378,12 +412,15 @@ export const BackgroundManager = {
       };
       tasks.set(taskId, cancelled);
       BackgroundStore.persist(cancelled);
+      releaseActive(taskId);
 
       Bus.publish(Subagent.Events.BackgroundTaskCancelled, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         payload: { taskId },
       });
+
+      drainQueue();
 
       return true;
     }

--- a/packages/openomni/test/subagent/background-queue.test.ts
+++ b/packages/openomni/test/subagent/background-queue.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { type AgentResult, type ChatAgentInput, ChatAgent } from "@openomni/agent";
 import { Bus, Storage } from "@openomni/session";
 import { BackgroundManager } from "../../src/subagent/background-manager";
+import { BackgroundLimitsMiddleware } from "../../src/subagent/middleware/background-limits";
 import { SubagentRuntime } from "../../src/subagent/runtime";
 
 const model = { provider: "anthropic", id: "claude-3-haiku-20240307" };
@@ -13,8 +14,12 @@ type Deferred<T> = {
 };
 
 function createDeferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (error: Error) => void;
+  let resolve: Deferred<T>["resolve"] = () => {
+    throw new Error("deferred resolve called before initialization");
+  };
+  let reject: Deferred<T>["reject"] = () => {
+    throw new Error("deferred reject called before initialization");
+  };
   const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
@@ -31,8 +36,19 @@ function makeAgentResult(text = "done"): AgentResult {
   };
 }
 
+async function waitFor(predicate: () => boolean, message: string, timeoutMs = 500): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 let createSpy: ReturnType<typeof spyOn> | undefined;
 let spawnSpy: ReturnType<typeof spyOn> | undefined;
+let policySpy: ReturnType<typeof spyOn> | undefined;
 
 beforeEach(() => {
   Storage.reset();
@@ -43,6 +59,7 @@ beforeEach(() => {
 afterEach(() => {
   createSpy?.mockRestore();
   spawnSpy?.mockRestore();
+  policySpy?.mockRestore();
   Bus.reset();
 });
 
@@ -255,5 +272,128 @@ describe("BackgroundManager bounded queue", () => {
 
     expect(manager.stats().pending).toBe(0);
     manager.dispose();
+  });
+
+  it("drains a queued launch when cancellation frees capacity before enqueue", async () => {
+    const deferred = createDeferred<AgentResult>();
+    let callCount = 0;
+    createSpy = spyOn(ChatAgent, "create").mockImplementation(
+      () =>
+        ({
+          run: async (_input: ChatAgentInput) => {
+            if (callCount++ === 0) return deferred.promise;
+            return makeAgentResult();
+          },
+        }) as ReturnType<typeof ChatAgent.create>,
+    );
+
+    const parentSessionId = crypto.randomUUID();
+    const manager = BackgroundManager.create({
+      maxConcurrentTotal: 1,
+      maxConcurrentPerAgent: 10,
+      maxDescendants: 10,
+    });
+    try {
+      const running = await manager.launch({
+        agentName: "worker",
+        prompt: "running",
+        model,
+        parentSessionId,
+      });
+      await waitFor(
+        () => manager.getTask(running.id)?.status === "running",
+        "expected first task to start running",
+      );
+
+      const evaluatePreLaunch = BackgroundLimitsMiddleware.evaluatePreLaunch;
+      policySpy = spyOn(BackgroundLimitsMiddleware, "evaluatePreLaunch").mockImplementation(
+        async (ctx) => {
+          const result = await evaluatePreLaunch(ctx);
+          if (ctx.input.prompt === "queued") {
+            await manager.cancel(running.id);
+          }
+          return result;
+        },
+      );
+
+      const queued = await manager.launch({
+        agentName: "worker",
+        prompt: "queued",
+        model,
+        parentSessionId,
+      });
+
+      await waitFor(
+        () => manager.getTask(queued.id)?.status === "completed",
+        "expected queued task to drain after cancellation freed capacity",
+      );
+      expect(manager.getTask(running.id)?.status).toBe("cancelled");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 2 });
+    } finally {
+      deferred.resolve(makeAgentResult());
+      await Promise.resolve();
+      manager.dispose();
+    }
+  });
+
+  it("cancelled running task releases capacity and drains the queue immediately", async () => {
+    const deferred = createDeferred<AgentResult>();
+    let callCount = 0;
+    createSpy = spyOn(ChatAgent, "create").mockImplementation(
+      () =>
+        ({
+          run: async (_input: ChatAgentInput) => {
+            if (callCount++ === 0) return deferred.promise;
+            return makeAgentResult();
+          },
+        }) as ReturnType<typeof ChatAgent.create>,
+    );
+
+    const parentSessionId = crypto.randomUUID();
+    const manager = BackgroundManager.create({
+      maxConcurrentTotal: 1,
+      maxConcurrentPerAgent: 10,
+      maxDescendants: 10,
+    });
+    try {
+      const running = await manager.launch({
+        agentName: "worker",
+        prompt: "running",
+        model,
+        parentSessionId,
+      });
+      const queued = await manager.launch({
+        agentName: "worker",
+        prompt: "queued",
+        model,
+        parentSessionId,
+      });
+
+      await waitFor(
+        () => manager.getTask(queued.id)?.status === "pending",
+        "expected second task to remain pending while capacity is saturated",
+      );
+      expect(manager.stats()).toEqual({ active: 1, pending: 1, total: 2 });
+      expect(manager.getTask(queued.id)?.status).toBe("pending");
+
+      await manager.cancel(running.id);
+      await waitFor(
+        () => manager.getTask(queued.id)?.status === "completed",
+        "expected queued task to complete after cancellation drained the queue",
+      );
+
+      expect(manager.getTask(running.id)?.status).toBe("cancelled");
+      expect(manager.getTask(queued.id)?.status).toBe("completed");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 2 });
+
+      deferred.resolve(makeAgentResult());
+      await Promise.resolve();
+      expect(manager.getTask(running.id)?.status).toBe("cancelled");
+      expect(manager.stats()).toEqual({ active: 0, pending: 0, total: 2 });
+    } finally {
+      deferred.resolve(makeAgentResult());
+      await Promise.resolve();
+      manager.dispose();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Repairs background task cancellation accounting so cancelling an active background task releases logical capacity, drains queued work, and preserves cancelled state across late spawn or worker-run races.

Relates to audit follow-up: background cancellation accounting.

## Changes

- Track active background tasks by task id to make capacity release idempotent.
- Drain the pending queue after cancellation and after enqueueing when capacity may have opened during policy evaluation.
- Preserve `cancelled` as terminal for late spawn resolve/reject and worker completion/failure events.
- Match worker-run lifecycle events by both `sessionId` and `runId`.
- Add regression coverage for active cancellation queue drain, cancel-before-enqueue races, and late spawn settle after cancellation/cleanup.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- [x] `git diff --check`
- [x] `bunx biome check packages/openomni/src/subagent/background-manager.ts packages/openomni/src/subagent/background-manager.test.ts packages/openomni/test/subagent/background-queue.test.ts`
- [x] `bun test packages/openomni/src/subagent/background-manager.test.ts packages/openomni/test/subagent/background-queue.test.ts packages/openomni/test/subagent/background-integration.test.ts`
- [x] `bun run check-types`
- [x] `bun run build`
- [x] `bun test`
- [x] `bun run script/check-deps.ts`

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md not required: no public API or architecture change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs background task cancellation in `openomni` so cancelling a running or in-flight task frees capacity immediately, drains queued launches, and keeps the cancelled state across late spawn outcomes and worker-event races.

- **Bug Fixes**
  - Track active tasks by ID and release capacity idempotently; clean up controllers reliably.
  - Drain the queue on cancel and immediately after enqueue (when policy queues) to start work as soon as capacity opens.
  - If spawn resolves after cancellation, proactively cancel the late run via runtime; if spawn rejects late, keep the task cancelled; never resurrect cleaned tasks.
  - Match worker lifecycle events by both `sessionId` and `runId`; ignore mismatches.
  - Add tests for late spawn resolve/reject after cancel, cleanup non-resurrection, cancel-before-enqueue, and immediate drain when cancellation frees capacity.

<sup>Written for commit 89f9392a0e186646c20362bf09a76994c6758a59. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task cancellation so cancelled tasks never resurrect, free capacity immediately, and keep manager stats accurate.
  * Fixed spawn/queue edge cases to avoid double-counting active tasks and to handle late failures/resolutions without corrupting state.
* **Tests**
  * Added edge-case tests verifying cancellation, queue draining, capacity freeing, and correct stats after late resolutions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->