### PR TITLE
fix(session): harden sqlite migrations

### DIFF
--- a/packages/session/src/storage/drizzle/db.ts
+++ b/packages/session/src/storage/drizzle/db.ts
@@ -1,34 +1,24 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import * as schema from "./schema";
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { Migration } from "../migration-runner";
 
 export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
 
 const MIGRATION_DIR = join(import.meta.dir, "../../../migration");
 
 function applyMigrations(sqlite: Database): void {
-  sqlite.exec("CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY)");
-
-  const migrations = [
-    "0001_initial/migration.sql",
-    "0002_pragma_fk_indices/migration.sql",
-    "0003_new_tables/migration.sql",
-    "0004_message_status/migration.sql",
+  // Drizzle storage is legacy bootstrap code and only has schema definitions for the
+  // original core session tables; keep its migration list intentionally bounded.
+  const migrations: Migration.Definition[] = [
+    { name: "0001_initial/migration.sql" },
+    { name: "0002_pragma_fk_indices/migration.sql" },
+    { name: "0003_new_tables/migration.sql" },
+    { name: "0004_message_status/migration.sql", compatApplied: hasMessageStatusColumn },
   ];
 
-  for (const migration of migrations) {
-    const applied = sqlite.query("SELECT 1 FROM _migrations WHERE name = ?").get(migration);
-    if (applied) continue;
-    if (migration === "0004_message_status/migration.sql" && hasMessageStatusColumn(sqlite)) {
-      sqlite.exec(`INSERT INTO _migrations (name) VALUES ('${migration}')`);
-      continue;
-    }
-    const migrationSql = readFileSync(join(MIGRATION_DIR, migration), "utf-8");
-    sqlite.exec(migrationSql);
-    sqlite.exec(`INSERT INTO _migrations (name) VALUES ('${migration}')`);
-  }
+  Migration.applyOrdered(sqlite, MIGRATION_DIR, migrations);
 }
 
 function hasMessageStatusColumn(sqlite: Database): boolean {
@@ -39,17 +29,22 @@ function hasMessageStatusColumn(sqlite: Database): boolean {
 export function createDb(dbPath: string): { db: DrizzleDb; sqlite: Database } {
   const sqlite = new Database(dbPath);
 
-  sqlite.exec("PRAGMA journal_mode = WAL");
-  sqlite.exec("PRAGMA synchronous = NORMAL");
-  sqlite.exec("PRAGMA busy_timeout = 5000");
-  sqlite.exec("PRAGMA cache_size = -64000");
-  sqlite.exec("PRAGMA mmap_size = 268435456");
-  sqlite.exec("PRAGMA temp_store = MEMORY");
-  sqlite.exec("PRAGMA foreign_keys = ON");
-  sqlite.exec("PRAGMA wal_autocheckpoint = 1000");
+  try {
+    sqlite.exec("PRAGMA journal_mode = WAL");
+    sqlite.exec("PRAGMA synchronous = NORMAL");
+    sqlite.exec("PRAGMA busy_timeout = 5000");
+    sqlite.exec("PRAGMA cache_size = -64000");
+    sqlite.exec("PRAGMA mmap_size = 268435456");
+    sqlite.exec("PRAGMA temp_store = MEMORY");
+    sqlite.exec("PRAGMA foreign_keys = ON");
+    sqlite.exec("PRAGMA wal_autocheckpoint = 1000");
 
-  applyMigrations(sqlite);
+    applyMigrations(sqlite);
 
-  const db = drizzle(sqlite, { schema });
-  return { db, sqlite };
+    const db = drizzle(sqlite, { schema });
+    return { db, sqlite };
+  } catch (err) {
+    sqlite.close();
+    throw err;
+  }
 }

--- a/packages/session/src/storage/migration-runner.ts
+++ b/packages/session/src/storage/migration-runner.ts
@@ -1,0 +1,58 @@
+import type { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+
+export namespace Migration {
+  export const Definition = z.object({
+    name: z.string(),
+    compatApplied: z.function().args(z.custom<Database>()).returns(z.boolean()).optional(),
+    compatInsert: z.enum(["insert", "insertOrIgnore"]).optional(),
+  });
+
+  export type Definition = z.infer<typeof Definition>;
+
+  export function applyOrdered(db: Database, migrationDir: string, migrations: Definition[]): void {
+    db.exec("CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY)");
+
+    for (const migration of migrations.map((item) => Definition.parse(item))) {
+      applyMigration(db, migrationDir, migration);
+    }
+  }
+}
+
+function applyMigration(db: Database, migrationDir: string, migration: Migration.Definition): void {
+  db.exec("BEGIN IMMEDIATE TRANSACTION");
+  try {
+    const applied = db.query("SELECT 1 FROM _migrations WHERE name = ?").get(migration.name);
+    if (!applied) {
+      if (migration.compatApplied?.(db)) {
+        insertMigrationMarker(db, migration.name, migration.compatInsert ?? "insert");
+      } else {
+        const sql = readFileSync(join(migrationDir, migration.name), "utf-8");
+        db.exec(sql);
+        insertMigrationMarker(db, migration.name, "insert");
+      }
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    try {
+      db.exec("ROLLBACK");
+    } catch (_rollbackErr) {
+      void _rollbackErr;
+    }
+    throw err;
+  }
+}
+
+function insertMigrationMarker(
+  db: Database,
+  migrationName: string,
+  conflictMode: "insert" | "insertOrIgnore",
+): void {
+  const sql =
+    conflictMode === "insertOrIgnore"
+      ? "INSERT OR IGNORE INTO _migrations (name) VALUES (?)"
+      : "INSERT INTO _migrations (name) VALUES (?)";
+  db.query(sql).run(migrationName);
+}

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -1,24 +1,28 @@
 import { Database } from "bun:sqlite";
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Message, WorkItem, type Storage as ProtocolStorage } from "@openomni/protocol";
 import { getPartStartTime } from "./part-time";
 import type { SessionInfo } from "../session/info";
 import type { WorkerRunStateStore } from "../worker-run/state-store";
+import { Migration } from "./migration-runner";
 import type { Storage } from "./storage";
 
 const MIGRATION_DIR = join(import.meta.dir, "../../migration");
 
-const ORDERED_MIGRATIONS = [
-  "0001_initial/migration.sql",
-  "0002_pragma_fk_indices/migration.sql",
-  "0003_new_tables/migration.sql",
-  "0004_message_status/migration.sql",
-  "0005_background_task/migration.sql",
-  "0006_task_plan_todo/migration.sql",
-  "0007_todo_fk_idempotency_idx/migration.sql",
-  "0008_unified_observability/migration.sql",
-  "0009_work_item/migration.sql",
+const ORDERED_MIGRATIONS: Migration.Definition[] = [
+  { name: "0001_initial/migration.sql" },
+  { name: "0002_pragma_fk_indices/migration.sql" },
+  { name: "0003_new_tables/migration.sql" },
+  {
+    name: "0004_message_status/migration.sql",
+    compatApplied: hasMessageStatusColumn,
+    compatInsert: "insertOrIgnore",
+  },
+  { name: "0005_background_task/migration.sql" },
+  { name: "0006_task_plan_todo/migration.sql" },
+  { name: "0007_todo_fk_idempotency_idx/migration.sql" },
+  { name: "0008_unified_observability/migration.sql" },
+  { name: "0009_work_item/migration.sql" },
 ];
 
 function applyPragmas(db: Database): void {
@@ -33,22 +37,7 @@ function applyPragmas(db: Database): void {
 }
 
 function applyMigrations(db: Database): void {
-  db.exec("CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY)");
-
-  for (const name of ORDERED_MIGRATIONS) {
-    const applied = db.query("SELECT 1 FROM _migrations WHERE name = ?").get(name);
-    if (applied) continue;
-
-    // 0004 compat: if status column already exists (from an older migration path), skip DDL
-    if (name === "0004_message_status/migration.sql" && hasMessageStatusColumn(db)) {
-      db.exec(`INSERT OR IGNORE INTO _migrations (name) VALUES ('${name}')`);
-      continue;
-    }
-
-    const sql = readFileSync(join(MIGRATION_DIR, name), "utf-8");
-    db.exec(sql);
-    db.exec(`INSERT INTO _migrations (name) VALUES ('${name}')`);
-  }
+  Migration.applyOrdered(db, MIGRATION_DIR, ORDERED_MIGRATIONS);
 }
 
 function hasMessageStatusColumn(db: Database): boolean {
@@ -61,8 +50,13 @@ export class SqliteStorageAdapter implements Storage.Adapter {
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
-    applyPragmas(this.db);
-    applyMigrations(this.db);
+    try {
+      applyPragmas(this.db);
+      applyMigrations(this.db);
+    } catch (err) {
+      this.db.close();
+      throw err;
+    }
   }
 
   session = {

--- a/packages/session/test/storage/drizzle-db.test.ts
+++ b/packages/session/test/storage/drizzle-db.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { createDb } from "../../src/storage/drizzle/db";
+
+function tempDbPath(): string {
+  return join(tmpdir(), `test-drizzle-db-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function removeSqliteFiles(path: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(`${path}${suffix}`);
+    } catch (_err) {
+      void _err;
+    }
+  }
+}
+
+describe("drizzle createDb migrations", () => {
+  let dbPath = "";
+
+  afterEach(() => {
+    removeSqliteFiles(dbPath);
+  });
+
+  test("failed migration rolls back DDL and migration marker", () => {
+    dbPath = tempDbPath();
+
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE _migrations (name TEXT PRIMARY KEY);
+      INSERT INTO _migrations (name) VALUES ('0001_initial/migration.sql');
+      INSERT INTO _migrations (name) VALUES ('0002_pragma_fk_indices/migration.sql');
+      INSERT INTO _migrations (name) VALUES ('0003_new_tables/migration.sql');
+      CREATE TABLE message (id TEXT PRIMARY KEY);
+    `);
+    db.close();
+
+    expect(() => createDb(dbPath)).toThrow();
+
+    const checkDb = new Database(dbPath);
+    try {
+      const columns = checkDb.query("PRAGMA table_info(message)").all() as Array<{ name: string }>;
+      expect(columns.map((row) => row.name)).not.toContain("status");
+      expect(
+        checkDb
+          .query("SELECT name FROM _migrations WHERE name = ?")
+          .get("0004_message_status/migration.sql"),
+      ).toBeNull();
+    } finally {
+      checkDb.close();
+    }
+  });
+});

--- a/packages/session/test/storage/sqlite-storage.test.ts
+++ b/packages/session/test/storage/sqlite-storage.test.ts
@@ -103,6 +103,16 @@ function tempDbPath(): string {
   return join(tmpdir(), `test-sqlite-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
 }
 
+function removeSqliteFiles(path: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(`${path}${suffix}`);
+    } catch (_err) {
+      void _err;
+    }
+  }
+}
+
 function storageDb(adapter: SqliteStorageAdapter): Database {
   return (adapter as unknown as { db: Database }).db;
 }
@@ -134,11 +144,7 @@ describe("SqliteStorageAdapter", () => {
     } catch (_err) {
       void _err;
     }
-    try {
-      unlinkSync(dbPath);
-    } catch (_err) {
-      void _err;
-    }
+    removeSqliteFiles(dbPath);
   });
 
   describe("PRAGMA verification", () => {
@@ -230,6 +236,43 @@ describe("SqliteStorageAdapter", () => {
       const adapter2 = new SqliteStorageAdapter(dbPath);
       expect(adapter2.session.get("s1")).toBeDefined();
       adapter2.close();
+    });
+
+    test("failed migration does not leave partially applied schema behind", () => {
+      adapter.close();
+      removeSqliteFiles(dbPath);
+
+      const db = new Database(dbPath);
+      db.exec("CREATE TABLE _migrations (name TEXT PRIMARY KEY)");
+      for (const name of [
+        "0001_initial/migration.sql",
+        "0002_pragma_fk_indices/migration.sql",
+        "0003_new_tables/migration.sql",
+        "0004_message_status/migration.sql",
+        "0005_background_task/migration.sql",
+        "0006_task_plan_todo/migration.sql",
+      ]) {
+        db.query("INSERT INTO _migrations (name) VALUES (?)").run(name);
+      }
+      db.close();
+
+      expect(() => new SqliteStorageAdapter(dbPath)).toThrow();
+
+      const checkDb = new Database(dbPath);
+      try {
+        expect(
+          checkDb
+            .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'todo_new'")
+            .get(),
+        ).toBeNull();
+        expect(
+          checkDb
+            .query("SELECT name FROM _migrations WHERE name = ?")
+            .get("0007_todo_fk_idempotency_idx/migration.sql"),
+        ).toBeNull();
+      } finally {
+        checkDb.close();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Hardens SQLite migration application so each migration's schema changes and `_migrations` marker are committed atomically. Also shares the migration runner between the primary SQLite adapter and the legacy Drizzle bootstrap path.

Fixes #
Relates to #

## Changes

- Add a shared migration runner that performs the applied check, migration SQL, and marker insert inside one `BEGIN IMMEDIATE` transaction.
- Preserve the existing `0004_message_status` compatibility behavior while making the Drizzle migration scope explicit.
- Close SQLite handles if adapter/bootstrap initialization fails during pragmas or migrations.
- Add rollback regression coverage for both the primary SQLite adapter and the Drizzle bootstrap path.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [x] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

## Validation

- `bunx biome check packages/session/src/storage/migration-runner.ts packages/session/src/storage/sqlite-storage.ts packages/session/src/storage/drizzle/db.ts packages/session/test/storage/sqlite-storage.test.ts packages/session/test/storage/drizzle-db.test.ts`
- `bun test packages/session/test/storage/sqlite-storage.test.ts packages/session/test/storage/drizzle-db.test.ts`
- `bun run check-types`
- `bun run build`
- `bun test packages/session/test`
- `bun test`
- `bun run script/check-deps.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes SQLite migrations atomic and rollback-safe to prevent partial schema or stray markers. Uses a shared `Migration` runner across the primary adapter and the legacy Drizzle bootstrap in `session`.

- **Bug Fixes**
  - Run each migration (DDL + `_migrations` marker) in a single `BEGIN IMMEDIATE` transaction via `Migration.applyOrdered`.
  - Bound Drizzle bootstrap migrations to 0001–0004 and preserved `0004_message_status` compatibility; `INSERT OR IGNORE` is used only in the primary adapter.
  - Closed SQLite handles on init errors during pragmas or migrations in both adapters.
  - Added regression tests that simulate failures and verify rollbacks, including cleanup of `-wal`/`-shm` files.

<sup>Written for commit 4606fea14b094ad52c9dcef373b07ee1bf9033f8. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and standardized database migration execution with compatibility checks for legacy migrations.

* **Bug Fixes**
  * Improved error handling during migration startup to ensure DB connections are closed and partial changes are rolled back.
  * Ensures migration markers and schema remain consistent after failures.

* **Tests**
  * Added tests for migration failure scenarios and enhanced cleanup of SQLite sidecar files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->