### PR TITLE
fix(agent): clean up failed mcp connections

### DIFF
--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -2,25 +2,40 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { randomUUID } from "node:crypto";
 import type { McpServerConfig, RuntimeResource, Tool } from "@openomni/protocol";
 import { Mcp, Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { convertMcpTool, convertMcpResult } from "./convert";
 
+/** @internal Test-oriented seam for replacing the underlying MCP SDK client. */
+export type McpClientHandle = Pick<Client, "connect" | "close" | "listTools" | "callTool">;
+/** @internal Test-oriented seam for replacing the underlying MCP transport factory. */
+export type McpTransportFactory = (config: McpServerConfig) => Transport;
+
+/** @internal Constructor dependencies are intended for tests and package-internal adapters. */
+export interface McpClientDependencies {
+  readonly client?: McpClientHandle;
+  readonly createTransport?: McpTransportFactory;
+}
+
 export class McpClient {
-  private client: Client;
+  private client: McpClientHandle;
   private config: McpServerConfig;
+  private createTransport: McpTransportFactory;
   private connected = false;
 
-  constructor(config: McpServerConfig) {
+  constructor(config: McpServerConfig, dependencies: McpClientDependencies = {}) {
     this.config = config;
-    this.client = new Client({ name: "openomni-agent", version: "0.1.0" });
+    this.client = dependencies.client ?? new Client({ name: "openomni-agent", version: "0.1.0" });
+    this.createTransport = dependencies.createTransport ?? createTransport;
   }
 
   async connect(): Promise<void> {
     const traceId = randomUUID();
-    const transport = createTransport(this.config);
+    const transport = this.createTransport(this.config);
+    const closeTracker = trackTransportCloseRequests(transport);
     const transportType =
       this.config.transport === "streamable-http"
         ? ("streamable-http" as const)
@@ -42,13 +57,19 @@ export class McpClient {
       });
     } catch (err) {
       this.connected = false;
+      const cleanupError = await cleanupFailedConnection(this.client, transport, closeTracker);
+      const context: Record<string, unknown> = { serverName: this.config.name };
+      if (cleanupError) {
+        context.cleanupError = String(cleanupError);
+      }
+
       Bus.publish(Operational.Error, {
         traceId,
         time: Date.now(),
         component: "agent.mcp",
         msg: "MCP connection failed",
         error: String(err),
-        context: { serverName: this.config.name },
+        context,
       });
       throw err;
     }
@@ -144,6 +165,51 @@ export class McpClient {
   }
 }
 
+interface TransportCloseTracker {
+  readonly isClosed: () => boolean;
+}
+
+function trackTransportCloseRequests(transport: Transport): TransportCloseTracker {
+  let closeRequested = false;
+  const close = transport.close.bind(transport);
+  // Wrap this freshly created transport so cleanup can tell whether the SDK
+  // client actually attempted to close it, independent of onclose callback timing.
+  transport.close = async () => {
+    closeRequested = true;
+    await close();
+  };
+
+  return {
+    isClosed: () => closeRequested,
+  };
+}
+
+async function cleanupFailedConnection(
+  client: McpClientHandle,
+  transport: Transport,
+  closeTracker: TransportCloseTracker,
+): Promise<unknown | undefined> {
+  let cleanupError: unknown;
+  try {
+    await client.close();
+  } catch (err) {
+    cleanupError = err;
+  }
+
+  // The SDK client normally owns and closes the transport after connect() starts.
+  // If close() failed before it reached the transport, close it directly while
+  // still preserving the original connection error for callers.
+  if (!closeTracker.isClosed()) {
+    try {
+      await transport.close();
+    } catch (err) {
+      cleanupError ??= err;
+    }
+  }
+
+  return cleanupError;
+}
+
 type McpToolSpec = Tool.Spec & {
   readonly descriptor: RuntimeResource.Descriptor;
 };
@@ -177,7 +243,7 @@ function attachMcpToolDescriptor(
   };
 }
 
-function createTransport(config: McpServerConfig) {
+function createTransport(config: McpServerConfig): Transport {
   switch (config.transport) {
     case "stdio": {
       if (!config.command) throw new Error("stdio transport requires command");

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -34,14 +34,16 @@ export class McpClient {
 
   async connect(): Promise<void> {
     const traceId = randomUUID();
-    const transport = this.createTransport(this.config);
-    const closeTracker = trackTransportCloseRequests(transport);
+    let transport: Transport | undefined;
+    let closeTracker: TransportCloseTracker | undefined;
     const transportType =
       this.config.transport === "streamable-http"
         ? ("streamable-http" as const)
         : (this.config.transport as "stdio" | "sse" | "http");
 
     try {
+      transport = this.createTransport(this.config);
+      closeTracker = trackTransportCloseRequests(transport);
       await this.client.connect(transport);
       const tools = await this.client.listTools();
       this.connected = true;
@@ -57,7 +59,9 @@ export class McpClient {
       });
     } catch (err) {
       this.connected = false;
-      const cleanupError = await cleanupFailedConnection(this.client, transport, closeTracker);
+      const cleanupError = transport
+        ? await cleanupFailedConnection(this.client, transport, closeTracker)
+        : undefined;
       const context: Record<string, unknown> = { serverName: this.config.name };
       if (cleanupError) {
         context.cleanupError = String(cleanupError);
@@ -187,7 +191,7 @@ function trackTransportCloseRequests(transport: Transport): TransportCloseTracke
 async function cleanupFailedConnection(
   client: McpClientHandle,
   transport: Transport,
-  closeTracker: TransportCloseTracker,
+  closeTracker?: TransportCloseTracker,
 ): Promise<unknown | undefined> {
   let cleanupError: unknown;
   try {
@@ -199,7 +203,7 @@ async function cleanupFailedConnection(
   // The SDK client normally owns and closes the transport after connect() starts.
   // If close() failed before it reached the transport, close it directly while
   // still preserving the original connection error for callers.
-  if (!closeTracker.isClosed()) {
+  if (!closeTracker?.isClosed()) {
     try {
       await transport.close();
     } catch (err) {

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import type { RuntimeResource, Tool } from "@openomni/protocol";
-import { McpClient } from "../../../src/runtime/mcp/client";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { Operational, type RuntimeResource, type Tool } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { McpClient, type McpClientHandle } from "../../../src/runtime/mcp/client";
 
 interface McpToolStub {
   readonly name: string;
@@ -8,39 +10,39 @@ interface McpToolStub {
   readonly inputSchema?: Record<string, unknown>;
 }
 
-interface ListToolsClientStub {
-  listTools(): Promise<{ tools: McpToolStub[] }>;
-}
-
-interface McpClientInternals {
-  client: ListToolsClientStub;
-}
-
 type ToolSpecWithDescriptor = Tool.Spec & {
   readonly descriptor?: RuntimeResource.Descriptor;
 };
 
-function stubListTools(client: McpClient, tools: McpToolStub[]): void {
-  const internals = client as unknown as McpClientInternals;
-  internals.client = {
+function createStubClient(tools: McpToolStub[]): McpClientHandle {
+  return {
+    connect: async () => undefined,
+    close: async () => undefined,
     listTools: async () => ({ tools }),
+    callTool: async () => {
+      throw new Error("callTool is not implemented by this test stub");
+    },
   };
 }
 
 describe("McpClient tool descriptors", () => {
   test("attaches RuntimeResource descriptors to listed MCP tools", async () => {
-    const client = new McpClient({
-      name: "filesystem",
-      transport: "stdio",
-      command: "mcp-server-filesystem",
-    });
-    stubListTools(client, [
+    const client = new McpClient(
       {
-        name: "write_file",
-        description: "Write a file",
-        inputSchema: { type: "object", properties: { path: { type: "string" } } },
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
       },
-    ]);
+      {
+        client: createStubClient([
+          {
+            name: "write_file",
+            description: "Write a file",
+            inputSchema: { type: "object", properties: { path: { type: "string" } } },
+          },
+        ]),
+      },
+    );
 
     const [tool] = (await client.listTools()) as ToolSpecWithDescriptor[];
 
@@ -61,12 +63,14 @@ describe("McpClient tool descriptors", () => {
   });
 
   test("uses the remote MCP tool name in descriptor source metadata", async () => {
-    const client = new McpClient({
-      name: "search-server",
-      transport: "sse",
-      url: "https://example.test/mcp",
-    });
-    stubListTools(client, [{ name: "search" }]);
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+      },
+      { client: createStubClient([{ name: "search" }]) },
+    );
 
     const [tool] = (await client.listTools()) as ToolSpecWithDescriptor[];
 
@@ -77,5 +81,198 @@ describe("McpClient tool descriptors", () => {
       serverId: "search-server",
       remoteName: "search",
     });
+  });
+});
+
+function createTransportStub(options: { readonly emitOnClose?: boolean } = {}): Transport & {
+  readonly closeCalls: () => number;
+} {
+  let closeCalls = 0;
+
+  const transport: Transport & { readonly closeCalls: () => number } = {
+    start: async () => undefined,
+    send: async () => undefined,
+    close: async () => {
+      closeCalls += 1;
+      if (options.emitOnClose !== false) {
+        transport.onclose?.();
+      }
+    },
+    closeCalls: () => closeCalls,
+  };
+
+  return transport;
+}
+
+function createConnectableStubClient(options: {
+  readonly connectError?: Error;
+  readonly listToolsError?: Error;
+  readonly closeError?: Error;
+  readonly closeTransport?: boolean;
+}): McpClientHandle & { readonly closeCalls: () => number } {
+  let transport: Transport | undefined;
+  let closeCalls = 0;
+
+  return {
+    connect: async (nextTransport) => {
+      transport = nextTransport;
+      if (options.connectError) {
+        throw options.connectError;
+      }
+    },
+    close: async () => {
+      closeCalls += 1;
+      if (options.closeError) {
+        throw options.closeError;
+      }
+      if (options.closeTransport !== false) {
+        await transport?.close();
+      }
+    },
+    listTools: async () => {
+      if (options.listToolsError) {
+        throw options.listToolsError;
+      }
+      return { tools: [] };
+    },
+    callTool: async () => {
+      throw new Error("callTool is not implemented by this test stub");
+    },
+    closeCalls: () => closeCalls,
+  };
+}
+
+describe("McpClient connection cleanup", () => {
+  test("closes the MCP transport when client.connect fails", async () => {
+    const connectError = new Error("connect failed");
+    const sdkClient = createConnectableStubClient({ connectError });
+    const transport = createTransportStub();
+    const client = new McpClient(
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+      },
+      {
+        client: sdkClient,
+        createTransport: () => transport,
+      },
+    );
+
+    await expect(client.connect()).rejects.toBe(connectError);
+
+    expect(sdkClient.closeCalls()).toBe(1);
+    expect(transport.closeCalls()).toBe(1);
+  });
+
+  test("closes the MCP transport when initial tool discovery fails", async () => {
+    const listToolsError = new Error("tools/list failed");
+    const sdkClient = createConnectableStubClient({ listToolsError });
+    const transport = createTransportStub();
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+      },
+      {
+        client: sdkClient,
+        createTransport: () => transport,
+      },
+    );
+
+    await expect(client.connect()).rejects.toBe(listToolsError);
+
+    expect(sdkClient.closeCalls()).toBe(1);
+    expect(transport.closeCalls()).toBe(1);
+  });
+
+  test("falls back to closing the transport directly if the client cleanup does not close it", async () => {
+    const connectError = new Error("connect failed");
+    const sdkClient = createConnectableStubClient({
+      connectError,
+      closeTransport: false,
+    });
+    const transport = createTransportStub();
+    const client = new McpClient(
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+      },
+      {
+        client: sdkClient,
+        createTransport: () => transport,
+      },
+    );
+
+    await expect(client.connect()).rejects.toBe(connectError);
+
+    expect(sdkClient.closeCalls()).toBe(1);
+    expect(transport.closeCalls()).toBe(1);
+  });
+
+  test("reports cleanup failures without masking the original connection error", async () => {
+    const connectError = new Error("connect failed");
+    const closeError = new Error("cleanup failed");
+    const sdkClient = createConnectableStubClient({ connectError, closeError });
+    const transport = createTransportStub();
+    const observedErrors: Array<{
+      readonly error?: string;
+      readonly context?: Record<string, unknown>;
+    }> = [];
+    const unsubscribe = Bus.observe((event, payload) => {
+      if (event.name === Operational.Error.name) {
+        observedErrors.push(
+          payload as { readonly error?: string; readonly context?: Record<string, unknown> },
+        );
+      }
+    });
+    const client = new McpClient(
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+      },
+      {
+        client: sdkClient,
+        createTransport: () => transport,
+      },
+    );
+
+    try {
+      await expect(client.connect()).rejects.toBe(connectError);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      unsubscribe();
+    }
+
+    expect(sdkClient.closeCalls()).toBe(1);
+    expect(transport.closeCalls()).toBe(1);
+    expect(observedErrors).toHaveLength(1);
+    expect(observedErrors[0]?.error).toBe("Error: connect failed");
+    expect(observedErrors[0]?.context?.cleanupError).toBe("Error: cleanup failed");
+  });
+
+  test("does not double-close when the client closes a transport that omits onclose", async () => {
+    const connectError = new Error("connect failed");
+    const sdkClient = createConnectableStubClient({ connectError });
+    const transport = createTransportStub({ emitOnClose: false });
+    const client = new McpClient(
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+      },
+      {
+        client: sdkClient,
+        createTransport: () => transport,
+      },
+    );
+
+    await expect(client.connect()).rejects.toBe(connectError);
+
+    expect(sdkClient.closeCalls()).toBe(1);
+    expect(transport.closeCalls()).toBe(1);
   });
 });

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -217,20 +217,29 @@ describe("McpClient connection cleanup", () => {
     const closeError = new Error("cleanup failed");
     const sdkClient = createConnectableStubClient({ connectError, closeError });
     const transport = createTransportStub();
+    const serverName = "filesystem-cleanup-error";
     const observedErrors: Array<{
+      readonly component?: string;
       readonly error?: string;
       readonly context?: Record<string, unknown>;
     }> = [];
     const unsubscribe = Bus.observe((event, payload) => {
-      if (event.name === Operational.Error.name) {
-        observedErrors.push(
-          payload as { readonly error?: string; readonly context?: Record<string, unknown> },
-        );
+      const errorPayload = payload as {
+        readonly component?: string;
+        readonly error?: string;
+        readonly context?: Record<string, unknown>;
+      };
+      if (
+        event.name === Operational.Error.name &&
+        errorPayload.component === "agent.mcp" &&
+        errorPayload.context?.serverName === serverName
+      ) {
+        observedErrors.push(errorPayload);
       }
     });
     const client = new McpClient(
       {
-        name: "filesystem",
+        name: serverName,
         transport: "stdio",
         command: "mcp-server-filesystem",
       },
@@ -250,8 +259,59 @@ describe("McpClient connection cleanup", () => {
     expect(sdkClient.closeCalls()).toBe(1);
     expect(transport.closeCalls()).toBe(1);
     expect(observedErrors).toHaveLength(1);
+    expect(observedErrors[0]?.component).toBe("agent.mcp");
     expect(observedErrors[0]?.error).toBe("Error: connect failed");
     expect(observedErrors[0]?.context?.cleanupError).toBe("Error: cleanup failed");
+  });
+
+  test("reports transport factory failures through operational errors", async () => {
+    const createError = new Error("transport factory failed");
+    const serverName = "factory-failure";
+    const observedErrors: Array<{
+      readonly component?: string;
+      readonly error?: string;
+      readonly context?: Record<string, unknown>;
+    }> = [];
+    const unsubscribe = Bus.observe((event, payload) => {
+      const errorPayload = payload as {
+        readonly component?: string;
+        readonly error?: string;
+        readonly context?: Record<string, unknown>;
+      };
+      if (
+        event.name === Operational.Error.name &&
+        errorPayload.component === "agent.mcp" &&
+        errorPayload.context?.serverName === serverName
+      ) {
+        observedErrors.push(errorPayload);
+      }
+    });
+    const client = new McpClient(
+      {
+        name: serverName,
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+      },
+      {
+        client: createStubClient([]),
+        createTransport: () => {
+          throw createError;
+        },
+      },
+    );
+
+    try {
+      await expect(client.connect()).rejects.toBe(createError);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      unsubscribe();
+    }
+
+    expect(observedErrors).toHaveLength(1);
+    expect(observedErrors[0]?.component).toBe("agent.mcp");
+    expect(observedErrors[0]?.error).toBe("Error: transport factory failed");
+    expect(observedErrors[0]?.context?.serverName).toBe(serverName);
+    expect(observedErrors[0]?.context?.cleanupError).toBeUndefined();
   });
 
   test("does not double-close when the client closes a transport that omits onclose", async () => {


### PR DESCRIPTION
## Summary
- close partially initialized MCP clients/transports when connect or initial tool discovery fails
- preserve the original connection error while surfacing cleanup failures in operational error context
- add focused MCP client lifecycle regression tests for connect failure, discovery failure, cleanup failure, and missing onclose behavior

## Validation
- `bunx biome check packages/agent/src/runtime/mcp/client.ts packages/agent/test/runtime/mcp/descriptor.test.ts`
- `bun test packages/agent/test/runtime/mcp/descriptor.test.ts`
- `bun run check-types`
- `bun run build`
- `(cd packages/agent && bun test)`
- pre-push hook: dependency check + type check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cleanup of failed MCP connections. We now properly close partially initialized clients/transports and keep the original error while surfacing cleanup issues.

- **Bug Fixes**
  - Close MCP client and transport on connect or discovery failure.
  - Track whether the client initiated transport close; close directly if not, and avoid double-close when `onclose` is missing.
  - Preserve the original error; include cleanup failures in `Operational.Error`, and surface transport factory failures. Added lifecycle tests and injectable `McpClientHandle`/transport factory.

<sup>Written for commit 2f0e4638c8b7c49b7e96472f9b880da595179296. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/149?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP connection error handling with clearer error reports and preserved original errors.
  * Ensured reliable cleanup of transport and SDK resources to prevent leaks when connections or tool discovery fail.
* **Tests**
  * Added tests covering connection cleanup, failure modes, and tool discovery to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->