### PR TITLE
fix(agent): harden small correctness edges

### DIFF
--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -547,7 +547,9 @@ export async function buildTurn(
           elapsedMs: Date.now() - state.startTime,
           usage: state.totalUsage,
         }),
-        onDecision: (timing, decision) => toolPolicyDecisions.push({ timing, decision }),
+        onDecision: (timing, decision) => {
+          toolPolicyDecisions.push({ timing, decision });
+        },
         traceContext: trace,
       })
     : undefined;
@@ -945,7 +947,7 @@ export async function* handleError(
       error: normalizedError,
       willRetry: true,
     };
-    await Retry.agentSleep(backoffMs);
+    await Retry.agentSleep(backoffMs, config.signal);
     return { action: "retry", kind: "error", error: normalizedError, errorMessage: lastError };
   }
 

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -1,5 +1,5 @@
 import type { Policy, RuntimeResource, Tool, TraceContext } from "@openomni/protocol";
-import { PolicyDecision, ToolExecution } from "@openomni/protocol";
+import { Operational, PolicyDecision, ToolExecution } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import type { AgentStep, TokenUsage } from "../types";
 import type { PolicyEngineInstance } from "../policy";
@@ -27,7 +27,7 @@ export interface ToolExecutorOptions {
   getPolicyToolName?: (toolName: string) => string | undefined;
   getToolLabels?: (toolName: string) => string[] | undefined;
   onToolComplete?: (durationMs: number) => void;
-  onDecision?: (timing: Policy.Timing, decision: Policy.PolicyDecision) => void;
+  onDecision?: (timing: Policy.Timing, decision: Policy.PolicyDecision) => void | Promise<void>;
   traceContext?: TraceContext.Type;
 }
 
@@ -84,6 +84,30 @@ export function createToolExecutor(
     ...(traceContext?.agentName !== undefined && { actor: { agentName: traceContext.agentName } }),
   };
 
+  function publishDecisionObserverError(
+    timing: Policy.Timing,
+    decision: Policy.PolicyDecision,
+    err: unknown,
+  ): void {
+    Bus.publish(Operational.Warn, {
+      traceId,
+      time: Date.now(),
+      component: "agent.tool-executor",
+      msg: "onDecision observer error",
+      context: { timing, policyId: decision.policyId, error: String(err) },
+    });
+  }
+
+  function recordDecision(timing: Policy.Timing, decision: Policy.PolicyDecision): void {
+    try {
+      void Promise.resolve(onDecision?.(timing, decision)).catch((err) => {
+        publishDecisionObserverError(timing, decision, err);
+      });
+    } catch (err) {
+      publishDecisionObserverError(timing, decision, err);
+    }
+  }
+
   function publishBlocked(call: Tool.Call, toolName: string, reason: string): void {
     Bus.publish(ToolExecution.PermissionDenied, {
       ...eventBase,
@@ -128,7 +152,7 @@ export function createToolExecutor(
       resourceDescriptor: toolDescriptor(policyToolName, toolLabels),
     });
 
-    onDecision?.("invoke.prepare", preDecision);
+    recordDecision("invoke.prepare", preDecision);
 
     if (PolicyDecision.isBlocking(preDecision)) {
       const reason = PolicyDecision.reason(preDecision, "middleware");
@@ -219,7 +243,7 @@ export function createToolExecutor(
       resourceDescriptor: toolDescriptor(policyToolName, toolLabels),
     });
 
-    onDecision?.("invoke.result", postDecision);
+    recordDecision("invoke.result", postDecision);
     const postAbort = effectOf(postDecision, "run.abort");
     if (PolicyDecision.isBlocking(postDecision) && postAbort) {
       const reason = postAbort.reason ?? PolicyDecision.reason(postDecision, "middleware");

--- a/packages/agent/src/core/policy/engine.ts
+++ b/packages/agent/src/core/policy/engine.ts
@@ -402,13 +402,35 @@ function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
     });
   }
 
-  async function recordDecision(
+  function publishDecisionObserverError(
+    ctx: AuditDispatchContext,
+    decision: Policy.PolicyDecision,
+    err: unknown,
+  ): void {
+    const traceContext = ctx.traceContext ?? options.traceContext;
+    Bus.publish(Operational.Warn, {
+      traceId: traceContext?.traceId ?? crypto.randomUUID(),
+      time: Date.now(),
+      ...(traceContext?.sessionId !== undefined && { sessionId: traceContext.sessionId }),
+      component: "agent.policy",
+      msg: "onDecision observer error",
+      context: { timing: ctx.timing, policyId: decision.policyId, error: String(err) },
+    });
+  }
+
+  function recordDecision(
     reg: PolicyRegistration,
     ctx: AuditDispatchContext,
     decision: Policy.PolicyDecision,
-  ): Promise<Policy.PolicyDecision> {
+  ): Policy.PolicyDecision {
     publishPolicyEvent(decision, reg, ctx);
-    await options.onDecision?.(decision);
+    try {
+      void Promise.resolve(options.onDecision?.(decision)).catch((err) => {
+        publishDecisionObserverError(ctx, decision, err);
+      });
+    } catch (err) {
+      publishDecisionObserverError(ctx, decision, err);
+    }
     return decision;
   }
 
@@ -464,7 +486,7 @@ function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
         timing,
         ctx.resourceDescriptor,
       );
-      decisions.push(await recordDecision(reg, fullCtx, normalized));
+      decisions.push(recordDecision(reg, fullCtx, normalized));
 
       Bus.publish(Operational.Debug, {
         traceId: options.traceContext?.traceId ?? crypto.randomUUID(),

--- a/packages/agent/src/core/retry.ts
+++ b/packages/agent/src/core/retry.ts
@@ -142,8 +142,28 @@ export function shouldRetry(
 
 export const shouldAgentRetry = shouldRetry;
 
-export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, Math.max(0, Math.floor(ms))));
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(new Error("aborted"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      Math.max(0, Math.floor(ms)),
+    );
+
+    function onAbort(): void {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(new Error("aborted"));
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export const agentSleep = sleep;

--- a/packages/agent/test/core/execution/stream-helpers-dispatch.test.ts
+++ b/packages/agent/test/core/execution/stream-helpers-dispatch.test.ts
@@ -855,6 +855,44 @@ describe("handleError (error)", () => {
     expect(Date.now() - started).toBeGreaterThanOrEqual(15);
   });
 
+  it("does not sleep when retry delay is already aborted", async () => {
+    Bus.reset();
+    const engine = PolicyEngine.create();
+    engine.register({
+      name: "test-on-error-aborted-retry-delay",
+      timing: "error",
+      priority: 100,
+      fn: () =>
+        allow("test.aborted-retry-delay", "retry-after", [
+          { type: "run.retry_after", delayMs: 5_000 },
+        ]),
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const state = makeState();
+    const config = makeConfig({ signal: controller.signal });
+    const retryPolicy = {
+      maxAttempts: 3,
+      backoffMs: { initial: 0, multiplier: 1, max: 0 },
+    };
+
+    const started = Date.now();
+    const gen = handleError(
+      state,
+      engine,
+      config,
+      makeAgentBase(),
+      new Error("timeout while waiting"),
+      1,
+      retryPolicy,
+    );
+    await gen.next();
+
+    await expect(gen.next()).rejects.toThrow("aborted");
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
   it("applies run.retry_after maxRetries as a stricter retry ceiling", async () => {
     Bus.reset();
     const engine = PolicyEngine.create();

--- a/packages/agent/test/core/execution/tool-executor-verdicts.test.ts
+++ b/packages/agent/test/core/execution/tool-executor-verdicts.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { PolicyDecision, ToolExecution, type Policy, type Tool } from "@openomni/protocol";
+import {
+  Operational,
+  PolicyDecision,
+  ToolExecution,
+  type Policy,
+  type Tool,
+} from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { createToolExecutor } from "../../../src/core/execution/tool-executor";
 import { PolicyEngine, type PolicyRegistration } from "../../../src/core/policy";
@@ -537,6 +543,114 @@ describe("createToolExecutor effect application", () => {
       expect(invokeResultDecision).toBeDefined();
       expect(invokeResultDecision?.[1].verdict).toBe("deny");
       expect(invokeResultDecision?.[1].reasonCodes).toContain("post-deny");
+    });
+
+    it("isolates onDecision callback errors from tool execution", async () => {
+      Bus.reset();
+      const warnings: unknown[] = [];
+      const unsubscribe = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+      const engine = engineWithRegistrations([
+        {
+          name: "pre",
+          timing: "invoke.prepare",
+          priority: 0,
+          fn: () => PolicyDecision.allow({ policyId: "pre" }),
+        },
+      ]);
+      const executor = createToolExecutor({
+        engine,
+        onDecision: () => {
+          throw new Error("observer failed");
+        },
+        toolExecutor: async (call) => ({
+          id: "result-on-decision-error",
+          toolCallId: call.id,
+          output: "ok",
+        }),
+      });
+
+      try {
+        const result = await executor(makeCall("call-on-decision-error"));
+        await new Promise((resolve) => queueMicrotask(resolve));
+
+        expect(result.output).toBe("ok");
+        expect(warnings).toHaveLength(2);
+        expect(warnings[0]).toMatchObject({
+          component: "agent.tool-executor",
+          msg: "onDecision observer error",
+          context: {
+            timing: "invoke.prepare",
+            policyId: "agent.policy.composed",
+            error: "Error: observer failed",
+          },
+        });
+        expect(warnings[1]).toMatchObject({
+          component: "agent.tool-executor",
+          msg: "onDecision observer error",
+          context: {
+            timing: "invoke.result",
+            policyId: "agent.policy.composed",
+            error: "Error: observer failed",
+          },
+        });
+      } finally {
+        unsubscribe();
+        Bus.reset();
+      }
+    });
+
+    it("isolates async onDecision callback rejections from tool execution", async () => {
+      Bus.reset();
+      const warnings: unknown[] = [];
+      const unsubscribe = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+      const engine = engineWithRegistrations([
+        {
+          name: "pre",
+          timing: "invoke.prepare",
+          priority: 0,
+          fn: () => PolicyDecision.allow({ policyId: "pre" }),
+        },
+      ]);
+      const executor = createToolExecutor({
+        engine,
+        onDecision: async () => {
+          throw new Error("async observer failed");
+        },
+        toolExecutor: async (call) => ({
+          id: "result-async-on-decision-error",
+          toolCallId: call.id,
+          output: "ok",
+        }),
+      });
+
+      try {
+        const result = await executor(makeCall("call-async-on-decision-error"));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(result.output).toBe("ok");
+        expect(warnings).toHaveLength(2);
+        expect(warnings[0]).toMatchObject({
+          component: "agent.tool-executor",
+          msg: "onDecision observer error",
+          context: {
+            timing: "invoke.prepare",
+            policyId: "agent.policy.composed",
+            error: "Error: async observer failed",
+          },
+        });
+        expect(warnings[1]).toMatchObject({
+          component: "agent.tool-executor",
+          msg: "onDecision observer error",
+          context: {
+            timing: "invoke.result",
+            policyId: "agent.policy.composed",
+            error: "Error: async observer failed",
+          },
+        });
+      } finally {
+        unsubscribe();
+        Bus.reset();
+      }
     });
   });
 });

--- a/packages/agent/test/core/policy/engine.test.ts
+++ b/packages/agent/test/core/policy/engine.test.ts
@@ -433,6 +433,110 @@ describe("PolicyEngine", () => {
     }
   });
 
+  it("isolates onDecision observer errors from policy dispatch", async () => {
+    Bus.reset();
+    const warnings: unknown[] = [];
+    const unsub = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+    try {
+      const engine = PolicyEngine.create({
+        onDecision: () => {
+          throw new Error("observer failed");
+        },
+      });
+      engine.register({
+        name: "observer-isolation",
+        timing: "turn.finish",
+        priority: 100,
+        fn: () => PolicyDecision.allow({ policyId: "observer-isolation" }),
+      });
+
+      const decision = await engine.dispatch("turn.finish", {
+        ...baseCtx(),
+        traceContext: { traceId: "trace-observer", sessionId: "session-observer" },
+      });
+      await new Promise((resolve) => queueMicrotask(resolve));
+
+      expect(decision.verdict).toBe("allow");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({
+        traceId: "trace-observer",
+        sessionId: "session-observer",
+        component: "agent.policy",
+        msg: "onDecision observer error",
+        context: {
+          timing: "turn.finish",
+          policyId: "observer-isolation",
+          error: "Error: observer failed",
+        },
+      });
+    } finally {
+      unsub();
+      Bus.reset();
+    }
+  });
+
+  it("isolates async onDecision observer rejections from policy dispatch", async () => {
+    Bus.reset();
+    const warnings: unknown[] = [];
+    const unsub = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+    try {
+      const engine = PolicyEngine.create({
+        onDecision: async () => {
+          throw new Error("async observer failed");
+        },
+      });
+      engine.register({
+        name: "async-observer-isolation",
+        timing: "turn.finish",
+        priority: 100,
+        fn: () => PolicyDecision.allow({ policyId: "async-observer-isolation" }),
+      });
+
+      const decision = await engine.dispatch("turn.finish", baseCtx());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(decision.verdict).toBe("allow");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({
+        component: "agent.policy",
+        msg: "onDecision observer error",
+        context: {
+          timing: "turn.finish",
+          policyId: "async-observer-isolation",
+          error: "Error: async observer failed",
+        },
+      });
+    } finally {
+      unsub();
+      Bus.reset();
+    }
+  });
+
+  it("does not wait for async onDecision observers before returning decisions", async () => {
+    let observerStarted = false;
+    let releaseObserver: (() => void) | undefined;
+    const engine = PolicyEngine.create({
+      onDecision: async () => {
+        observerStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseObserver = resolve;
+        });
+      },
+    });
+    engine.register({
+      name: "observer-latency-isolation",
+      timing: "turn.finish",
+      priority: 100,
+      fn: () => PolicyDecision.allow({ policyId: "observer-latency-isolation" }),
+    });
+
+    const decision = await engine.dispatch("turn.finish", baseCtx());
+
+    expect(decision.verdict).toBe("allow");
+    expect(observerStarted).toBe(true);
+    releaseObserver?.();
+  });
+
   it("publishes PolicyEvent.Evaluated via Bus when session context is available", async () => {
     const published: unknown[] = [];
     const unsub = Bus.subscribe(PolicyEvent.Evaluated, (data) => {

--- a/packages/agent/test/core/retry.test.ts
+++ b/packages/agent/test/core/retry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { sleep } from "../../src/core/retry";
+
+describe("Retry.sleep", () => {
+  it("rejects immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const started = Date.now();
+
+    await expect(sleep(5_000, controller.signal)).rejects.toThrow("aborted");
+    expect(Date.now() - started).toBeLessThan(100);
+  });
+
+  it("rejects when the signal aborts during sleep", async () => {
+    const controller = new AbortController();
+
+    setTimeout(() => controller.abort(), 5);
+    const started = Date.now();
+
+    await expect(sleep(5_000, controller.signal)).rejects.toThrow("aborted");
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it("removes the abort listener after normal completion", async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const originalAddEventListener = signal.addEventListener.bind(signal);
+    const originalRemoveEventListener = signal.removeEventListener.bind(signal);
+    let added = 0;
+    let removed = 0;
+
+    signal.addEventListener = ((...args: Parameters<AbortSignal["addEventListener"]>) => {
+      added += 1;
+      return originalAddEventListener(...args);
+    }) as AbortSignal["addEventListener"];
+    signal.removeEventListener = ((...args: Parameters<AbortSignal["removeEventListener"]>) => {
+      removed += 1;
+      return originalRemoveEventListener(...args);
+    }) as AbortSignal["removeEventListener"];
+
+    await sleep(1, signal);
+
+    expect(added).toBe(1);
+    expect(removed).toBe(1);
+  });
+});

--- a/packages/coordinator/src/ipc/framing.test.ts
+++ b/packages/coordinator/src/ipc/framing.test.ts
@@ -21,6 +21,38 @@ describe("LineDecoder", () => {
     expect(dec.push(chunk)).toEqual([{ ok: true }]);
   });
 
+  test("preserves multibyte UTF-8 characters split across Uint8Array chunks", () => {
+    const dec = new LineDecoder();
+    const encoded = new TextEncoder().encode('{"text":"😀"}\n');
+    const emojiStart = encoded.findIndex((byte) => byte === 0xf0);
+    const split = emojiStart + 2;
+
+    expect(dec.push(encoded.slice(0, split))).toEqual([]);
+    expect(dec.push(encoded.slice(split))).toEqual([{ text: "😀" }]);
+  });
+
+  test("resets pending streaming decoder state before string chunks", () => {
+    const dec = new LineDecoder();
+    const encoder = new TextEncoder();
+    const prefix = encoder.encode('{"text":"');
+    const firstEmojiBytes = new Uint8Array(prefix.length + 2);
+    firstEmojiBytes.set(prefix);
+    firstEmojiBytes.set([0xf0, 0x9f], prefix.length);
+
+    expect(dec.push(firstEmojiBytes)).toEqual([]);
+    expect(dec.push('fallback"}\n')).toEqual([{ text: "fallback" }]);
+    expect(dec.push(encoder.encode('{"ok":true}\n'))).toEqual([{ ok: true }]);
+  });
+
+  test("keeps string chunks composable after Uint8Array frames", () => {
+    const dec = new LineDecoder();
+    const encoder = new TextEncoder();
+
+    expect(dec.push(encoder.encode('{"a":1}\n'))).toEqual([{ a: 1 }]);
+    expect(dec.push('{"b":')).toEqual([]);
+    expect(dec.push("2}\n")).toEqual([{ b: 2 }]);
+  });
+
   test("throws IpcProtocolError when buffer exceeds MAX_FRAME_BYTES", () => {
     const dec = new LineDecoder();
     // push slightly over the cap without a newline
@@ -39,6 +71,26 @@ describe("LineDecoder", () => {
     // buffer should be cleared — next valid push works normally
     const results = dec.push('{"recovered":true}\n');
     expect(results).toEqual([{ recovered: true }]);
+  });
+
+  test("resets streaming decoder state after oversized Uint8Array rejection", () => {
+    const dec = new LineDecoder();
+    const encoder = new TextEncoder();
+    const prefix = encoder.encode("x".repeat(MAX_FRAME_BYTES + 1));
+    const oversizedWithPartialUtf8 = new Uint8Array(prefix.length + 2);
+    oversizedWithPartialUtf8.set(prefix);
+    oversizedWithPartialUtf8.set([0xf0, 0x9f], prefix.length);
+
+    expect(() => dec.push(oversizedWithPartialUtf8)).toThrow(IpcProtocolError);
+    expect(dec.push(encoder.encode('{"ok":true}\n'))).toEqual([{ ok: true }]);
+  });
+
+  test("resets buffer after completed oversized frame rejection", () => {
+    const dec = new LineDecoder();
+    const oversizedLine = `${JSON.stringify({ data: "y".repeat(MAX_FRAME_BYTES) })}\npartial`;
+
+    expect(() => dec.push(oversizedLine)).toThrow(IpcProtocolError);
+    expect(dec.push('{"ok":true}\n')).toEqual([{ ok: true }]);
   });
 
   test("allows frames just under the cap", () => {

--- a/packages/coordinator/src/ipc/framing.ts
+++ b/packages/coordinator/src/ipc/framing.ts
@@ -1,7 +1,6 @@
 import { IpcProtocolError } from "./errors";
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 
 // 16 MiB — reject any single frame that exceeds this before unbounded growth
 export const MAX_FRAME_BYTES = 16 * 1024 * 1024;
@@ -12,15 +11,22 @@ export function encode(msg: unknown): Uint8Array {
 
 export class LineDecoder {
   private buffer = "";
+  private decoder = new TextDecoder();
 
   push(chunk: string | Uint8Array): unknown[] {
-    this.buffer += typeof chunk === "string" ? chunk : decoder.decode(chunk);
+    if (typeof chunk === "string") {
+      // String chunks cannot complete a pending byte sequence; discard stale decoder state.
+      this.decoder = new TextDecoder();
+      this.buffer += chunk;
+    } else {
+      this.buffer += this.decoder.decode(chunk, { stream: true });
+    }
 
     const lines = this.buffer.split("\n");
     this.buffer = lines.pop() ?? "";
 
     if (Buffer.byteLength(this.buffer, "utf-8") > MAX_FRAME_BYTES) {
-      this.buffer = "";
+      this.reset();
       throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
     }
 
@@ -28,6 +34,7 @@ export class LineDecoder {
       .filter((l) => l.trim())
       .map((l) => {
         if (Buffer.byteLength(l, "utf-8") > MAX_FRAME_BYTES) {
+          this.reset();
           throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
         }
         return JSON.parse(l);
@@ -36,5 +43,6 @@ export class LineDecoder {
 
   reset(): void {
     this.buffer = "";
+    this.decoder = new TextDecoder();
   }
 }

--- a/packages/session/src/bus/index.ts
+++ b/packages/session/src/bus/index.ts
@@ -69,8 +69,12 @@ export namespace Bus {
     };
     subs.add(subscription);
     const captured = subs;
+    const eventName = event.name;
     return () => {
       captured.delete(subscription);
+      if (captured.size === 0 && subscribers.get(eventName) === captured) {
+        subscribers.delete(eventName);
+      }
     };
   }
 
@@ -84,6 +88,24 @@ export namespace Bus {
   export function reset(): void {
     subscribers.clear();
     observers.clear();
+  }
+
+  /** Diagnostic counters for tests and runtime observability; not control-flow state. */
+  export function stats(): {
+    readonly subscriberEventCount: number;
+    readonly subscriberCount: number;
+    readonly observerCount: number;
+  } {
+    let subscriberCount = 0;
+    for (const subs of subscribers.values()) {
+      subscriberCount += subs.size;
+    }
+
+    return {
+      subscriberEventCount: subscribers.size,
+      subscriberCount,
+      observerCount: observers.size,
+    };
   }
 
   function matches(data: unknown, match: Record<string, unknown>): boolean {

--- a/packages/session/test/bus/async-dispatch.test.ts
+++ b/packages/session/test/bus/async-dispatch.test.ts
@@ -98,4 +98,26 @@ describe("Bus async dispatch", () => {
 
     expect(results).toEqual(["handler1", "handler2"]);
   });
+
+  it("removes empty subscriber sets after the last unsubscribe", async () => {
+    const event = BusEvent.define("test:cleanup", (s) => s);
+    const unsubscribe = Bus.subscribe(event, () => undefined);
+    expect(Bus.stats().subscriberEventCount).toBe(1);
+
+    unsubscribe();
+    expect(Bus.stats()).toEqual({
+      subscriberEventCount: 0,
+      subscriberCount: 0,
+      observerCount: 0,
+    });
+
+    let called = false;
+    Bus.subscribe(event, () => {
+      called = true;
+    });
+    Bus.publish(event, "data");
+    await new Promise((resolve) => queueMicrotask(resolve));
+
+    expect(called).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Hardens a small batch of correctness and reliability edges across agent execution, IPC framing, and session bus cleanup.

Fixes: N/A
Relates to: local audit G004 small correctness batch

## Changes

- Remove empty Bus subscriber entries after the final unsubscribe and expose diagnostic counters for tests/observability.
- Preserve split multibyte UTF-8 in IPC line decoding, reset decoder state on recovery paths, and cover mixed string/byte chunk behavior.
- Make retry sleep honor `AbortSignal` before and during retry backoff, and pass the run signal through `handleError` retry delays.
- Isolate policy/tool `onDecision` observer sync errors, async rejections, and policy observer latency from dispatch/execution.
- Add regression tests for each edge case.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [x] `session`
- [ ] `llm`
- [x] `agent`
- [ ] `openomni`
- [x] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md update not required; no architecture or package-boundary guidance changed

## Validation

- `bunx biome check ...` (changed files; existing non-null assertion warning in `stream-helpers-dispatch.test.ts`)
- `bun test packages/session/test/bus packages/coordinator/src/ipc/framing.test.ts`
- `(cd packages/agent && bun test test/core/retry.test.ts test/core/execution/stream-helpers-dispatch.test.ts test/core/policy/engine.test.ts test/core/execution/tool-executor-verdicts.test.ts)`
- `bun run check-types`
- `bun run build`
- pre-push `dep-check`
- pre-push `type-check`
