### PR TITLE
fix(protocol): dedupe shared runtime contracts

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/types.ts
+++ b/packages/openomni/src/execution-runtime/tool/types.ts
@@ -2,9 +2,8 @@ import type { Policy, RuntimeResource, Tool, ToolSelection } from "@openomni/pro
 
 export type ToolCategory = "system" | "agent" | "mcp";
 export type ToolMetaValue = boolean | ((input: unknown) => boolean);
-export type ToolSource = "system" | "mcp" | "agent" | "server";
-
-export type ToolRiskTier = 0 | 1 | 2 | 3;
+export type ToolSource = Tool.Source;
+export type ToolRiskTier = Tool.RiskTier;
 // Tier 0: read-only (read, glob, grep.search)
 // Tier 1: local write (write, edit)
 // Tier 2: bash — logged, future approval gate

--- a/packages/protocol/src/execution/execution.test.ts
+++ b/packages/protocol/src/execution/execution.test.ts
@@ -29,6 +29,8 @@ describe("Execution", () => {
       ],
       toolConfig: {
         systemTools: ["calculator"],
+        agentTools: ["delegate"],
+        mcpTools: ["search.query"],
         workspaceRoot: "/tmp",
       },
       permissions: {
@@ -47,6 +49,8 @@ describe("Execution", () => {
 
     const parsed = Execution.Request.parse(request);
     expect(parsed).toEqual(request);
+    expect(parsed.toolConfig?.agentTools).toEqual(["delegate"]);
+    expect(parsed.toolConfig?.mcpTools).toEqual(["search.query"]);
 
     const json = JSON.stringify(parsed);
     const reparsed = Execution.Request.parse(JSON.parse(json));

--- a/packages/protocol/src/execution/index.ts
+++ b/packages/protocol/src/execution/index.ts
@@ -14,14 +14,7 @@ const requestSchema = z.object({
   }),
   systemPrompt: z.string().optional(),
   tools: z.array(Tool.Spec).optional(),
-  toolConfig: z
-    .object({
-      systemTools: z.array(z.string()).optional(),
-      agentTools: z.array(z.string()).optional(),
-      mcpTools: z.array(z.string()).optional(),
-      workspaceRoot: z.string().optional(),
-    })
-    .optional(),
+  toolConfig: Tool.Config.optional(),
   permissions: Policy.Permission.optional(),
   credentials: z.record(z.string()).optional(),
   budget: AgentProfile.AgentBudget.optional(),

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -1,13 +1,7 @@
 import { z } from "zod";
+import { AgentProfile } from "../agent/index.js";
 import { Policy } from "../policy/index.js";
 import { Tool } from "../tool/index.js";
-
-const AgentToolConfigSchema = z.object({
-  systemTools: z.array(z.string()).optional(),
-  agentTools: z.array(z.string()).optional(),
-  mcpTools: z.array(z.string()).optional(),
-  workspaceRoot: z.string().optional(),
-});
 
 const ActorSchemaImpl = z
   .object({
@@ -108,10 +102,10 @@ export namespace Ingress {
       model: z.object({ provider: z.string(), id: z.string() }),
       systemPrompt: z.string().optional(),
       tools: z.array(Tool.Spec).optional(),
-      budget: z.object({ maxTurns: z.number().optional() }).optional(),
+      budget: AgentProfile.AgentBudget.optional(),
       permissions: Policy.Permission.optional(),
       policyPlan: Policy.PolicyPlan.optional(),
-      toolConfig: AgentToolConfigSchema.optional(),
+      toolConfig: Tool.Config.optional(),
     })
     .passthrough();
   // Runtime callbacks can't be expressed in Zod.

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Policy } from "../policy/index.js";
 import { WorkerBootstrap } from "../worker-bootstrap/index.js";
 
 const baseMessage = z.object({
@@ -10,7 +11,7 @@ const requestSchema = baseMessage.extend({
   type: z.literal("request"),
   id: z.string(),
   method: z.string(),
-  params: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
 });
 
 const responseSchema = baseMessage.extend({
@@ -29,9 +30,16 @@ const responseSchema = baseMessage.extend({
 const notificationSchema = baseMessage.extend({
   type: z.literal("notification"),
   method: z.string(),
-  params: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
 });
 
+/**
+ * Same-version internal method parameter contracts.
+ *
+ * The generic request envelope above intentionally stays permissive; these
+ * method schemas document and test the canonical params expected by current
+ * workers/coordinators.
+ */
 const methods = {
   "coordinator.spawn_run": {
     params: z.object({
@@ -43,12 +51,7 @@ const methods = {
       systemPrompt: z.string().optional(),
       // IronClaw capability injection — workers never read env vars for API keys
       credentials: z.record(z.string()).optional(),
-      permissions: z
-        .object({
-          denylist: z.array(z.string()).optional(),
-          allowlist: z.array(z.string()).optional(),
-        })
-        .optional(),
+      permissions: Policy.Permission.optional(),
       softTimeoutMs: z.number().optional(),
       hardTimeoutMs: z.number().optional(),
     }),
@@ -100,7 +103,7 @@ const methods = {
       runId: z.string(),
       sessionId: z.string(),
       tool: z.string(),
-      input: z.record(z.unknown()),
+      input: z.record(z.string(), z.unknown()),
     }),
     result: z.object({ allowed: z.boolean(), reason: z.string().optional() }),
   },
@@ -145,7 +148,7 @@ const methods = {
       sessionId: z.string(),
       callId: z.string(),
       tool: z.string(),
-      input: z.record(z.unknown()),
+      input: z.record(z.string(), z.unknown()),
     }),
     result: z.object({
       id: z.string(),
@@ -159,7 +162,7 @@ const methods = {
       runId: z.string(),
       sessionId: z.string(),
       event: z.string(),
-      data: z.record(z.unknown()).optional(),
+      data: z.record(z.string(), z.unknown()).optional(),
     }),
     result: z.null(),
   },

--- a/packages/protocol/src/notification/index.ts
+++ b/packages/protocol/src/notification/index.ts
@@ -18,7 +18,7 @@ export namespace Notification {
     artifactRefs: z.array(z.string()).optional(),
     conversationSessionId: z.string().optional(),
     deliveryHint: DeliveryMode.optional(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   });
   export type Request = z.infer<typeof Request>;
 

--- a/packages/protocol/src/tool/index.ts
+++ b/packages/protocol/src/tool/index.ts
@@ -1,6 +1,34 @@
 import { z } from "zod";
 
 export namespace Tool {
+  /**
+   * Compact runtime tool-catalog source discriminator.
+   *
+   * This intentionally does not replace RuntimeResource.Source policy provenance:
+   * richer source metadata stays on catalog-specific fields such as `mcpServer`
+   * or resource descriptors.
+   */
+  export const Source = z.enum(["system", "mcp", "agent", "server"]);
+  export type Source = z.infer<typeof Source>;
+
+  export const RiskTier = z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]);
+  export type RiskTier = z.infer<typeof RiskTier>;
+
+  /**
+   * Shared tool exposure config accepted at ingress and execution boundaries.
+   *
+   * `workspaceRoot` is the existing workspace selector for tool resolution; keep
+   * broader execution-environment settings on execution-level contracts instead
+   * of growing this shape.
+   */
+  export const Config = z.object({
+    systemTools: z.array(z.string()).optional(),
+    agentTools: z.array(z.string()).optional(),
+    mcpTools: z.array(z.string()).optional(),
+    workspaceRoot: z.string().optional(),
+  });
+  export type Config = z.infer<typeof Config>;
+
   export const StatePending = z.object({
     status: z.literal("pending"),
     input: z.record(z.string(), z.unknown()),

--- a/packages/protocol/src/worker-bootstrap/index.ts
+++ b/packages/protocol/src/worker-bootstrap/index.ts
@@ -24,9 +24,9 @@ export namespace WorkerBootstrap {
   export const RuntimeToolCatalogEntry = z.object({
     canonicalName: z.string(),
     exposedName: z.string(),
-    source: z.enum(["system", "agent", "mcp", "server"]),
+    source: Tool.Source,
     category: ToolSelection.Category,
-    riskTier: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+    riskTier: Tool.RiskTier,
     spec: Tool.Spec,
     descriptor: RuntimeResource.Descriptor.optional(),
     mcpServer: z.string().optional(),

--- a/packages/protocol/src/worker-bootstrap/worker-bootstrap.test.ts
+++ b/packages/protocol/src/worker-bootstrap/worker-bootstrap.test.ts
@@ -37,6 +37,36 @@ describe("WorkerBootstrap", () => {
     expect(parsed.riskTier).toEqual(2);
   });
 
+  test("RuntimeToolCatalogEntry rejects non-canonical source and risk tier", () => {
+    expect(
+      WorkerBootstrap.RuntimeToolCatalogEntry.safeParse({
+        canonicalName: "fs.read",
+        exposedName: "read_file",
+        source: "custom",
+        category: "filesystem",
+        riskTier: 0,
+        spec: {
+          name: "read_file",
+          inputSchema: {},
+        },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      WorkerBootstrap.RuntimeToolCatalogEntry.safeParse({
+        canonicalName: "fs.read",
+        exposedName: "read_file",
+        source: "system",
+        category: "filesystem",
+        riskTier: 4,
+        spec: {
+          name: "read_file",
+          inputSchema: {},
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   test("WorkerSnapshot round-trip parse", () => {
     const snapshot = {
       activeRuns: ["run1", "run2"],

--- a/packages/protocol/test/ingress.test.ts
+++ b/packages/protocol/test/ingress.test.ts
@@ -32,6 +32,9 @@ describe("AgentDef", () => {
       ],
       budget: {
         maxTurns: 10,
+        maxToolCalls: 20,
+        maxWallTimeMs: 30_000,
+        maxToolRuntimeMs: 5_000,
       },
       permissions: {
         action: "tool.call",
@@ -47,9 +50,40 @@ describe("AgentDef", () => {
     if (!tool) throw new Error("expected parsed tool");
     expect(tool.name).toBe("bash");
     expect(agent.budget?.maxTurns).toBe(10);
+    expect(agent.budget?.maxToolCalls).toBe(20);
+    expect(agent.budget?.maxWallTimeMs).toBe(30_000);
+    expect(agent.budget?.maxToolRuntimeMs).toBe(5_000);
     expect(agent.permissions?.action).toBe("tool.call");
     expect(agent.permissions?.allowlist).toEqual(["bash"]);
     expect(agent.toolConfig?.workspaceRoot).toBe("/workspace/openomni");
+  });
+
+  test("should parse full canonical budget fields through direct events", () => {
+    const event = Ingress.DirectEventSchema.parse({
+      id: "event-budget",
+      surface: "cli",
+      mode: "direct",
+      payload: "budgeted work",
+      agent: {
+        model: {
+          provider: "anthropic",
+          id: "claude-3-5-sonnet",
+        },
+        budget: {
+          maxTurns: 8,
+          maxToolCalls: 13,
+          maxWallTimeMs: 60_000,
+          maxToolRuntimeMs: 10_000,
+        },
+      },
+    });
+
+    expect(event.agent.budget).toEqual({
+      maxTurns: 8,
+      maxToolCalls: 13,
+      maxWallTimeMs: 60_000,
+      maxToolRuntimeMs: 10_000,
+    });
   });
 });
 

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -147,8 +147,36 @@ describe("Ipc.Methods param schemas", () => {
         prompt: "do work",
         model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
         credentials: { ANTHROPIC_API_KEY: "sk-test" },
+        permissions: {
+          action: "tool.call",
+          allowlist: ["read_file"],
+          denyLabels: ["risk.tier-3"],
+          inputRules: [
+            {
+              toolPattern: "write_file",
+              field: "path",
+              pattern: "^/workspace/",
+              action: "allow",
+            },
+          ],
+        },
       }).success,
     ).toBe(true);
+  });
+
+  test("coordinator.spawn_run rejects permission payloads without canonical action", () => {
+    expect(
+      Ipc.Methods["coordinator.spawn_run"].params.safeParse({
+        authToken: "token",
+        runId: "run-1",
+        sessionId: "sess-1",
+        prompt: "do work",
+        model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
+        permissions: {
+          allowlist: ["read_file"],
+        },
+      }).success,
+    ).toBe(false);
   });
 
   test("coordinator.spawn_run rejects missing required fields", () => {

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -1,6 +1,37 @@
 import { describe, test, expect } from "bun:test";
 import { Tool } from "../src/tool/index.js";
 
+describe("Tool shared contracts", () => {
+  test("parses tool config shared by execution and ingress", () => {
+    const config = Tool.Config.parse({
+      systemTools: ["read"],
+      agentTools: ["subagent"],
+      mcpTools: ["search.query"],
+      workspaceRoot: "/workspace",
+    });
+
+    expect(config.systemTools).toEqual(["read"]);
+    expect(config.agentTools).toEqual(["subagent"]);
+    expect(config.mcpTools).toEqual(["search.query"]);
+    expect(config.workspaceRoot).toBe("/workspace");
+  });
+
+  test("rejects invalid tool config shapes", () => {
+    expect(Tool.Config.safeParse({ systemTools: "read" }).success).toBe(false);
+    expect(Tool.Config.safeParse({ workspaceRoot: 42 }).success).toBe(false);
+  });
+
+  test("parses canonical tool source and risk tier contracts", () => {
+    expect(Tool.Source.parse("system")).toBe("system");
+    expect(Tool.Source.parse("server")).toBe("server");
+    expect(Tool.RiskTier.parse(0)).toBe(0);
+    expect(Tool.RiskTier.parse(3)).toBe(3);
+
+    expect(Tool.Source.safeParse("custom").success).toBe(false);
+    expect(Tool.RiskTier.safeParse(4).success).toBe(false);
+  });
+});
+
 describe("Tool.StatePending", () => {
   test("parses valid pending state with empty input", () => {
     const state = Tool.StatePending.parse({

--- a/packages/session/src/bus-persistence/query.ts
+++ b/packages/session/src/bus-persistence/query.ts
@@ -49,7 +49,7 @@ export namespace BusQuery {
     runId: z.string().optional().describe("Worker run ID if applicable"),
     eventType: z.string().describe("Event type name (e.g., 'agent.execution.started')"),
     category: z.string().describe("Event category"),
-    data: z.record(z.unknown()).describe("Event payload data"),
+    data: z.record(z.string(), z.unknown()).describe("Event payload data"),
     traceId: z.string().describe("Trace ID for correlation"),
     durationMs: z.number().optional().describe("Duration in milliseconds if applicable"),
     timeCreated: z.number().describe("Timestamp when event was created (ms since epoch)"),

--- a/packages/session/src/session/info.ts
+++ b/packages/session/src/session/info.ts
@@ -31,7 +31,7 @@ export const SessionInfo = z.object({
   messageCount: z.number().optional(),
   summary: z.string().optional(),
   projectId: z.string().optional(),
-  workerMeta: z.record(z.unknown()).optional(),
+  workerMeta: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type SessionInfo = z.infer<typeof SessionInfo>;


### PR DESCRIPTION
## Summary

Deduplicates shared runtime protocol contracts so ingress, execution, IPC, and worker bootstrap schemas use the same canonical definitions.

Fixes: N/A
Relates to: local audit G005 protocol contract dedupe

## Changes

- Add shared `Tool.Source`, `Tool.RiskTier`, and `Tool.Config` contracts in `@openomni/protocol`.
- Reuse `Tool.Config` from execution and ingress schemas, and reuse canonical `AgentProfile.AgentBudget` in ingress agent definitions.
- Align `coordinator.spawn_run` method-schema permissions with canonical `Policy.Permission` while keeping the generic IPC envelope permissive.
- Make protocol/session unknown record contracts explicit with `z.record(z.string(), z.unknown())`.
- Derive runtime `ToolSource` and `ToolRiskTier` aliases from protocol while keeping runtime-only `ToolCategory` local.
- Add schema coverage for shared tool contracts, canonical ingress budgets, IPC permissions, and worker bootstrap catalog validation.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [x] `protocol`
- [x] `session`
- [ ] `llm`
- [ ] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

<!-- If breaking, explain what consumers need to change: -->

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md update not required; package-boundary guidance remains accurate

## Validation

- `bunx biome check ...` (changed files)
- `bun run check-types`
- `bun run build`
- `bun run script/check-deps.ts`
- `bun test packages/protocol/test packages/protocol/src/worker-bootstrap/worker-bootstrap.test.ts packages/protocol/src/execution/execution.test.ts`
- `bun test packages/session/test/session/info.test.ts packages/session/test/bus-persistence/query.test.ts`
- `bun test`
- pre-push `dep-check`
- pre-push `type-check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates shared runtime tool contracts and aligns tool, budget, and permission schemas across ingress, execution, IPC, and worker bootstrap in `@openomni/protocol`. This reduces drift and strengthens validation while keeping generic IPC envelopes permissive.

- **Refactors**
  - Added canonical `Tool.Source`, `Tool.RiskTier`, and `Tool.Config` in `@openomni/protocol`; reused in execution and ingress, and derived in `openomni` runtime types.
  - Standardized budgets to `AgentProfile.AgentBudget` in ingress; expanded execution tests to cover `agentTools`/`mcpTools`.
  - Aligned IPC method schemas (e.g., `coordinator.spawn_run`) to `Policy.Permission`; tightened unknown maps to `z.record(z.string(), z.unknown())` across IPC, notifications, session info, and bus query.
  - Updated worker bootstrap catalog to use canonical tool types; added tests for invalid source/risk tier and shared tool config coverage.

<sup>Written for commit 5f818598f3fd39a65619b738b28e40523b509f16. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/151?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized tool configuration schemas with canonical source types and risk tier definitions.

* **Bug Fixes**
  * Improved validation for record fields to enforce string keys, preventing invalid data structures.

* **Chores**
  * Consolidated tool type definitions across protocol packages for consistency.
  * Updated validation schemas to reference centralized, canonical definitions instead of inline specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->