### PR TITLE
test(session): cover reliability edge cases

### DIFF
--- a/packages/openomni/test/profile/profile.test.ts
+++ b/packages/openomni/test/profile/profile.test.ts
@@ -23,6 +23,23 @@ async function withTempDir(fn: (dir: string) => Promise<void>) {
   }
 }
 
+type ProfilePolicyContext = Parameters<
+  ReturnType<typeof Profile.createMiddleware>[number]["fn"]
+>[0];
+
+function policyContext(overrides: Partial<ProfilePolicyContext> = {}): ProfilePolicyContext {
+  return {
+    timing: "context.prepare",
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
 function expectAllow(decision: Policy.PolicyDecision, policyId = "profile"): void {
   expect(decision).toEqual(PolicyDecision.allow({ policyId }));
 }
@@ -53,7 +70,7 @@ describe("Profile", () => {
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
         const [soul, user, memory] = registrations;
 
-        const soulVerdict = await soul.fn({} as any);
+        const soulVerdict = await soul.fn(policyContext());
         expectEffect(
           soulVerdict,
           {
@@ -63,7 +80,7 @@ describe("Profile", () => {
           "profile.soul",
         );
 
-        const userVerdict = await user.fn({} as any);
+        const userVerdict = await user.fn(policyContext());
         expectEffect(
           userVerdict,
           {
@@ -73,7 +90,7 @@ describe("Profile", () => {
           "profile.user",
         );
 
-        const memoryVerdict = await memory.fn({} as any);
+        const memoryVerdict = await memory.fn(policyContext());
         expectEffect(
           memoryVerdict,
           {
@@ -95,7 +112,7 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const userVerdict = await registrations[1].fn({} as any);
+        const userVerdict = await registrations[1].fn(policyContext());
 
         expectEffect(
           userVerdict,
@@ -117,7 +134,7 @@ describe("Profile", () => {
         await createFixture(dir, "test-agent", {});
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const userVerdict = await registrations[1].fn({} as any);
+        const userVerdict = await registrations[1].fn(policyContext());
 
         expectEffect(
           userVerdict,
@@ -137,7 +154,7 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const userVerdict = await registrations[1].fn({} as any);
+        const userVerdict = await registrations[1].fn(policyContext());
 
         expectEffect(
           userVerdict,
@@ -154,7 +171,7 @@ describe("Profile", () => {
       await withTempDir(async (dir) => {
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
         for (const reg of registrations) {
-          const verdict = await reg.fn({} as any);
+          const verdict = await reg.fn(policyContext());
           expectAllow(verdict);
         }
       });
@@ -167,17 +184,17 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const soulVerdict = await registrations[0].fn({} as any);
+        const soulVerdict = await registrations[0].fn(policyContext());
         expectEffect(
           soulVerdict,
           { type: "prompt.inject_message", message: "═══ PERSONA IDENTITY ═══\nSoul content only" },
           "profile.soul",
         );
 
-        const userVerdict = await registrations[1].fn({} as any);
+        const userVerdict = await registrations[1].fn(policyContext());
         expectAllow(userVerdict);
 
-        const memoryVerdict = await registrations[2].fn({} as any);
+        const memoryVerdict = await registrations[2].fn(policyContext());
         expectAllow(memoryVerdict);
       });
     });
@@ -189,7 +206,7 @@ describe("Profile", () => {
           homeRoot: dir,
         });
         for (const reg of registrations) {
-          const verdict = await reg.fn({} as any);
+          const verdict = await reg.fn(policyContext());
           expectAllow(verdict);
         }
       });
@@ -199,7 +216,7 @@ describe("Profile", () => {
       await withTempDir(async (dir) => {
         const registrations = Profile.createMiddleware({ agentName: "..", homeRoot: dir });
         for (const reg of registrations) {
-          const verdict = await reg.fn({} as any);
+          const verdict = await reg.fn(policyContext());
           expectAllow(verdict);
         }
       });
@@ -215,7 +232,7 @@ describe("Profile", () => {
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
         for (const reg of registrations) {
-          const verdict = await reg.fn({} as any);
+          const verdict = await reg.fn(policyContext());
           expectAllow(verdict);
         }
       });
@@ -273,13 +290,13 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const soulVerdict = await registrations[0].fn({} as any);
+        const soulVerdict = await registrations[0].fn(policyContext());
         expect(soulVerdict.effects[0]).toMatchObject({ type: "prompt.inject_message" });
 
-        const userVerdict = await registrations[1].fn({} as any);
+        const userVerdict = await registrations[1].fn(policyContext());
         expect(userVerdict.effects[0]).toMatchObject({ type: "prompt.append_context" });
 
-        const memoryVerdict = await registrations[2].fn({} as any);
+        const memoryVerdict = await registrations[2].fn(policyContext());
         expect(memoryVerdict.effects[0]).toMatchObject({ type: "prompt.append_context" });
       });
     });
@@ -291,7 +308,7 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const verdict = await registrations[2].fn({} as any);
+        const verdict = await registrations[2].fn(policyContext());
 
         expectEffect(
           verdict,
@@ -311,7 +328,7 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const verdict = await registrations[2].fn({} as any);
+        const verdict = await registrations[2].fn(policyContext());
         expectAllow(verdict);
       });
     });
@@ -325,12 +342,12 @@ describe("Profile", () => {
         });
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const first = await registrations[0].fn({} as any);
+        const first = await registrations[0].fn(policyContext());
 
         const soulPath = join(dir, ".openomni", "profiles", "test-agent", "SOUL.md");
         await Bun.write(soulPath, "modified soul");
 
-        const second = await registrations[0].fn({} as any);
+        const second = await registrations[0].fn(policyContext());
         expect(second).toEqual(first);
         expectEffect(
           second,
@@ -347,7 +364,7 @@ describe("Profile", () => {
         });
 
         const first = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const firstVerdict = await first[0].fn({} as any);
+        const firstVerdict = await first[0].fn(policyContext());
         expectEffect(
           firstVerdict,
           { type: "prompt.inject_message", message: "═══ PERSONA IDENTITY ═══\nversion one" },
@@ -358,7 +375,7 @@ describe("Profile", () => {
         await Bun.write(soulPath, "version two");
 
         const second = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
-        const secondVerdict = await second[0].fn({} as any);
+        const secondVerdict = await second[0].fn(policyContext());
         expectEffect(
           secondVerdict,
           { type: "prompt.inject_message", message: "═══ PERSONA IDENTITY ═══\nversion two" },
@@ -376,12 +393,12 @@ describe("Profile", () => {
 
         const registrations = Profile.createMiddleware({ agentName: "test-agent", homeRoot: dir });
 
-        await registrations[0].fn({} as any);
+        await registrations[0].fn(policyContext());
 
         const memoryPath = join(dir, ".openomni", "profiles", "test-agent", "MEMORY.md");
         await Bun.write(memoryPath, "updated memory");
 
-        const memoryVerdict = await registrations[2].fn({} as any);
+        const memoryVerdict = await registrations[2].fn(policyContext());
         expectEffect(
           memoryVerdict,
           {

--- a/packages/session/test/session/lineage.test.ts
+++ b/packages/session/test/session/lineage.test.ts
@@ -101,4 +101,23 @@ describe("Session lineage APIs", () => {
       state: "busy",
     });
   });
+
+  test("createChild rejects missing parents without creating a child", () => {
+    expect(() =>
+      Session.createChild({
+        parentSessionId: "missing-parent",
+        title: "Orphan",
+        model: { providerID: "test", modelID: "orphan-model" },
+      }),
+    ).toThrow("Parent session not found: missing-parent");
+
+    expect(Session.list()).toEqual([]);
+    expect(Session.listChildren("missing-parent")).toEqual([]);
+  });
+
+  test("updateWorkerMeta on a missing session is a no-op", () => {
+    expect(() => Session.updateWorkerMeta("missing-session", { lane: "worker-1" })).not.toThrow();
+    expect(Session.getWorkerMeta("missing-session")).toBeUndefined();
+    expect(Session.list()).toEqual([]);
+  });
 });

--- a/packages/session/test/session/resume.test.ts
+++ b/packages/session/test/session/resume.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { Message } from "@openomni/protocol";
+import { Session } from "../../src/session";
+import { Storage } from "../../src/storage/storage";
+import "../../src/storage/initialize";
+
+function createSession() {
+  return Session.create({
+    title: "Resume",
+    model: { providerID: "test", modelID: "test-model" },
+  });
+}
+
+function userMessage(sessionID: string, id: string, created: number): Message.UserMessage {
+  return {
+    id,
+    sessionID,
+    role: "user",
+    time: { created },
+    agent: "test-agent",
+    model: { providerID: "test", modelID: "test-model" },
+  };
+}
+
+function assistantMessage(
+  sessionID: string,
+  id: string,
+  created: number,
+  parentID = "user-1",
+): Message.AssistantMessage {
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created },
+    parentID,
+    modelID: "test-model",
+    providerID: "test",
+    agent: "test-agent",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: {
+      input: 1,
+      output: 2,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+function textPart(
+  sessionID: string,
+  messageID: string,
+  id: string,
+  text: string,
+): Message.TextPart {
+  return {
+    id,
+    sessionID,
+    messageID,
+    type: "text",
+    text,
+    time: { start: 0 },
+  };
+}
+
+describe("Session resume and abandon APIs", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  test("resume recovers assistant text messages with stable sequence metadata", async () => {
+    const session = createSession();
+    const user = userMessage(session.id, "user-1", Date.UTC(2026, 0, 1));
+    const assistantOne = assistantMessage(session.id, "assistant-1", Date.UTC(2026, 0, 2));
+    const assistantEmpty = assistantMessage(session.id, "assistant-empty", Date.UTC(2026, 0, 3));
+    const assistantTwo = assistantMessage(session.id, "assistant-2", Date.UTC(2026, 0, 4));
+
+    Session.addMessage(session.id, user);
+    Session.addMessage(session.id, assistantOne);
+    Session.addPart(
+      assistantOne.id,
+      textPart(session.id, assistantOne.id, "assistant-1-text-1", "first"),
+    );
+    Session.addPart(
+      assistantOne.id,
+      textPart(session.id, assistantOne.id, "assistant-1-text-2", "second"),
+    );
+    Session.addMessage(session.id, assistantEmpty);
+    Session.addMessage(session.id, assistantTwo);
+    Session.addPart(
+      assistantTwo.id,
+      textPart(session.id, assistantTwo.id, "assistant-2-text-1", "third"),
+    );
+
+    await expect(Session.resume(session.id)).resolves.toEqual([
+      {
+        role: "assistant",
+        text: "first\nsecond",
+        timestamp: new Date(Date.UTC(2026, 0, 2)).toISOString(),
+        sequence: 1,
+        turnIndex: 0,
+      },
+      {
+        role: "assistant",
+        text: "third",
+        timestamp: new Date(Date.UTC(2026, 0, 4)).toISOString(),
+        sequence: 2,
+        turnIndex: 1,
+      },
+    ]);
+  });
+
+  test("suspend and abandon report existence and remove session data", async () => {
+    const session = createSession();
+    const user = userMessage(session.id, "user-abandon", Date.UTC(2026, 0, 1));
+    const assistant = assistantMessage(session.id, "assistant-1", Date.UTC(2026, 0, 2), user.id);
+    Session.addMessage(session.id, user);
+    Session.addMessage(session.id, assistant);
+    Session.addPart(assistant.id, textPart(session.id, assistant.id, "text-1", "persisted"));
+
+    await expect(Session.suspend(session.id)).resolves.toBe(true);
+    await expect(Session.suspend("missing-session")).resolves.toBe(false);
+
+    await expect(Session.abandon(session.id)).resolves.toBe(true);
+    expect(Session.get(session.id)).toBeUndefined();
+    expect(Session.getMessages(session.id)).toEqual([]);
+    expect(Session.getParts(assistant.id)).toEqual([]);
+    await expect(Session.abandon(session.id)).resolves.toBe(false);
+  });
+});

--- a/packages/session/test/snapshot/snapshot.test.ts
+++ b/packages/session/test/snapshot/snapshot.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { Message } from "@openomni/protocol";
+import { Session } from "../../src/session";
+import { Snapshot } from "../../src/snapshot";
+import { Storage } from "../../src/storage/storage";
+import "../../src/storage/initialize";
+
+function createSession() {
+  return Session.create({
+    title: "Snapshot",
+    model: { providerID: "test", modelID: "test-model" },
+  });
+}
+
+function userMessage(sessionID: string, id: string, created: number): Message.UserMessage {
+  return {
+    id,
+    sessionID,
+    role: "user",
+    time: { created },
+    agent: "test-agent",
+    model: { providerID: "test", modelID: "test-model" },
+  };
+}
+
+function textPart(
+  sessionID: string,
+  messageID: string,
+  id: string,
+  text: string,
+): Message.TextPart {
+  return {
+    id,
+    sessionID,
+    messageID,
+    type: "text",
+    text,
+    time: { start: 0 },
+  };
+}
+
+function addMessageWithText(sessionID: string, messageID: string, text: string, created = 1): void {
+  const message = userMessage(sessionID, messageID, created);
+  Session.addMessage(sessionID, message);
+  Session.addPart(messageID, textPart(sessionID, messageID, `${messageID}-text`, text));
+}
+
+describe("Snapshot provider", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    Snapshot.reset();
+  });
+
+  test("restore replaces current messages and parts with the tracked snapshot", () => {
+    const session = createSession();
+    addMessageWithText(session.id, "tracked", "original", 1);
+    const snapshotID = Snapshot.track(session.id);
+
+    Session.addPart("tracked", textPart(session.id, "tracked", "tracked-extra", "mutated"));
+    addMessageWithText(session.id, "later", "remove me", 2);
+
+    Snapshot.restore(session.id, snapshotID);
+
+    expect(Session.getMessages(session.id).map((message) => message.id)).toEqual(["tracked"]);
+    expect(Session.getParts("tracked").map((part) => part.id)).toEqual(["tracked-text"]);
+    expect(Session.getParts("later")).toEqual([]);
+  });
+
+  test("diff reports structural added, removed, and part-count modified messages", () => {
+    const session = createSession();
+    addMessageWithText(session.id, "kept", "kept", 1);
+    addMessageWithText(session.id, "removed", "removed", 2);
+    const snapshotID = Snapshot.track(session.id);
+
+    Session.addPart("kept", textPart(session.id, "kept", "kept-extra", "new part"));
+
+    // Provider-level diff is structural today: message ID membership plus part count.
+    // Remove directly through the adapter to exercise the missing-message path
+    // without adding a production deletion API just for this fixture.
+    Storage.getAdapter().message.remove(session.id, "removed");
+    addMessageWithText(session.id, "added", "added", 3);
+
+    expect(Snapshot.diff(session.id, snapshotID)).toEqual({
+      added: ["added"],
+      removed: ["removed"],
+      modified: ["kept"],
+    });
+  });
+
+  test("empty snapshots restore by clearing messages added later", () => {
+    const session = createSession();
+    const snapshotID = Snapshot.track(session.id);
+
+    addMessageWithText(session.id, "later", "remove me", 1);
+
+    expect(Snapshot.diff(session.id, snapshotID)).toEqual({
+      added: ["later"],
+      removed: [],
+      modified: [],
+    });
+
+    Snapshot.restore(session.id, snapshotID);
+
+    expect(Session.getMessages(session.id)).toEqual([]);
+    expect(Session.getParts("later")).toEqual([]);
+  });
+
+  test("missing snapshots throw for restore and diff", () => {
+    const session = createSession();
+
+    expect(() => Snapshot.restore(session.id, "missing-snapshot")).toThrow(
+      "Snapshot not found: missing-snapshot",
+    );
+    expect(() => Snapshot.diff(session.id, "missing-snapshot")).toThrow(
+      "Snapshot not found: missing-snapshot",
+    );
+  });
+});

--- a/packages/session/test/storage/wal-checkpoint.test.ts
+++ b/packages/session/test/storage/wal-checkpoint.test.ts
@@ -1,9 +1,53 @@
-import { describe, expect, test, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { Operational } from "@openomni/protocol";
 import { unlinkSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Bus } from "../../src/bus";
 import { WalMaintenance } from "../../src/storage/wal-maintenance";
+
+type CheckpointResult = { busy: number; log: number; checkpointed: number };
+
+function makeCheckpointDb(result: CheckpointResult): Database {
+  return {
+    query(sql: string) {
+      expect(sql).toBe("PRAGMA wal_checkpoint(RESTART)");
+      return {
+        get: () => result,
+      };
+    },
+  } as unknown as Database;
+}
+
+function makeFailingCheckpointDb(error: Error): Database {
+  return {
+    query(sql: string) {
+      expect(sql).toBe("PRAGMA wal_checkpoint(RESTART)");
+      throw error;
+    },
+  } as unknown as Database;
+}
+
+function waitForWarning(): Promise<{
+  component: string;
+  msg: string;
+  context?: Record<string, unknown>;
+}> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error("Timed out waiting for WAL warning"));
+    }, 500);
+
+    const unsubscribe = Bus.subscribe(Operational.Warn, (event) => {
+      if (event.component !== "storage.wal") return;
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(event);
+    });
+  });
+}
 
 function makeTempDb(): { db: Database; path: string } {
   const path = join(tmpdir(), `wal-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
@@ -25,11 +69,16 @@ describe("WalMaintenance", () => {
   const handles: ReturnType<typeof WalMaintenance.start>[] = [];
   const dbs: Array<{ db: Database; path: string }> = [];
 
+  beforeEach(() => {
+    Bus.reset();
+  });
+
   afterEach(() => {
     for (const h of handles) h.stop();
     handles.length = 0;
     for (const { db, path } of dbs) cleanup(db, path);
     dbs.length = 0;
+    Bus.reset();
   });
 
   test("start() returns a handle with stop()", () => {
@@ -90,5 +139,31 @@ describe("WalMaintenance", () => {
 
     const after = fixture.db.query("SELECT COUNT(*) as n FROM items").get() as { n: number };
     expect(after.n).toBe(snapshot.n);
+  });
+
+  test("publishes a warning when checkpoint reports busy pages", async () => {
+    const handle = WalMaintenance.start(makeCheckpointDb({ busy: 2, log: 7, checkpointed: 5 }), {
+      intervalMs: 10,
+    });
+    handles.push(handle);
+
+    await expect(waitForWarning()).resolves.toMatchObject({
+      component: "storage.wal",
+      msg: "WAL checkpoint had busy pages",
+      context: { busy: 2, log: 7, checkpointed: 5 },
+    });
+  });
+
+  test("publishes a warning when checkpoint query fails", async () => {
+    const handle = WalMaintenance.start(makeFailingCheckpointDb(new Error("db closed")), {
+      intervalMs: 10,
+    });
+    handles.push(handle);
+
+    await expect(waitForWarning()).resolves.toMatchObject({
+      component: "storage.wal",
+      msg: "WAL checkpoint failed",
+      context: { error: "Error: db closed" },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds targeted regression coverage for session reliability edges, snapshot behavior, WAL checkpoint warnings, and profile policy fixture typing.

Fixes #
Relates to #

## Changes

- Replace profile middleware test `as any` calls with a typed policy-context fixture derived from the registration callback.
- Cover missing-parent child session behavior, missing-session worker metadata updates, resume recovery, suspend/abandon behavior, and message/part cleanup.
- Add snapshot restore/diff tests for structural added/removed/modified paths, empty snapshots, and missing snapshot errors.
- Extend WAL checkpoint tests to assert busy-page and query-failure warning publication with isolated bus state.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [x] `session`
- [ ] `llm`
- [ ] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

## Validation

- `bun run build`
- `bun run check-types`
- `bun run script/check-deps.ts`
- `bun run lint` (passes with existing warnings)
- `bun test`
- Targeted test subset for changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds targeted tests for session reliability and storage edges. Covers resume/abandon flows, snapshot restore/diff, WAL checkpoint warnings, and typed profile policy fixtures in `session` and `openomni`.

- **Tests**
  - Lineage: reject `createChild` with missing parent (no child created); `updateWorkerMeta` is a no-op on missing sessions.
  - Resume: recovers assistant text with stable sequence and turn indices.
  - Suspend/abandon: report existence via booleans and remove messages/parts.
  - Snapshot: restore replaces current state; diff reports added/removed/modified; empty snapshot clears; missing snapshot throws.
  - WAL: publishes `Operational.Warn` for busy pages and query failures with isolated `Bus` state.
  - Profile: replace `as any` with a typed policy-context fixture derived from `Profile.createMiddleware`.

<sup>Written for commit c94cf3109ceab9361d7c5ff409b71ae1618b0c32. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for session lineage, resume, and snapshot functionality to validate edge cases including invalid parent sessions, session suspension, snapshot restoration, and error handling.
  * Improved profile policy middleware testing with typed context structures for consistency and reliability.
  * Added event bus assertion support for WAL maintenance warnings to enhance storage integrity monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->