### PR TITLE
refactor(server): split worker internal tools

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,7 +16,8 @@
     "@openomni/protocol": "workspace:*",
     "@openomni/session": "workspace:*",
     "gray-matter": "^4.0.3",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -13,7 +13,6 @@ import {
   buildWorkerMiddleware,
   createToolExecutor,
   createWorkerSubagentRuntime,
-  type NativeTool,
 } from "@openomni/openomni";
 import { loadConfig } from "../config";
 import {
@@ -22,8 +21,15 @@ import {
   resolveWorkerDbPath,
 } from "./worker-runtime";
 import { createContextMiddleware } from "../context/index";
+import { WorkerInternalTools } from "./worker-internal-tools";
 
 const MAX_INBOX_MESSAGES = 100;
+
+interface WorkerActiveRun {
+  readonly sessionId: string;
+  readonly controller: AbortController;
+  readonly inbox: string[];
+}
 
 function readCliArg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -62,10 +68,7 @@ initialize({
 BusPersistence.start();
 
 let workerBootstrap: WorkerBootstrap.Bootstrap | null = null;
-const activeRuns = new Map<
-  string,
-  { sessionId: string; controller: AbortController; inbox: string[] }
->();
+const activeRuns = new Map<string, WorkerActiveRun>();
 let resolveBootstrapReady: () => void = () => undefined;
 let rejectBootstrapReady: (_error: Error) => void = () => undefined;
 const bootstrapReady = new Promise<void>((resolve, reject) => {
@@ -103,94 +106,6 @@ function resolveBootstrapAuth(provider: string): Auth.Info | undefined {
     return { type: "api", key: apiKey };
   }
   return undefined;
-}
-
-function createWorkerInternalTools(runId: string, sessionId: string): NativeTool[] {
-  const askMain: NativeTool = {
-    spec: {
-      name: "ask_main",
-      description:
-        "Ask the Resident for guidance, approval, or missing context. Blocks until Resident answers.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          question: { type: "string", description: "Question or decision request for Resident" },
-        },
-        required: ["question"],
-      },
-    },
-    source: "server",
-    category: "delegation",
-    riskTier: 1,
-    isReadOnly: false,
-    isDestructive: false,
-    isConcurrencySafe: false,
-    async execute(call) {
-      const question =
-        call.input && typeof call.input === "object" && "question" in call.input
-          ? String((call.input as { question?: unknown }).question ?? "")
-          : "";
-      if (!question) {
-        return {
-          id: crypto.randomUUID(),
-          toolCallId: call.id,
-          output: "ask_main requires a question",
-          isError: true,
-        };
-      }
-
-      const raw = await server.call("worker.ask_main", {
-        authToken: ipcAuthToken,
-        workerId,
-        sessionId,
-        runId,
-        question,
-      });
-      const response =
-        raw && typeof raw === "object"
-          ? (raw as { accepted?: unknown; output?: unknown; error?: unknown })
-          : undefined;
-      const accepted = response?.accepted === true;
-      const output = accepted
-        ? String(response?.output ?? "")
-        : String(response?.error ?? "worker.ask_main was rejected");
-      return {
-        id: crypto.randomUUID(),
-        toolCallId: call.id,
-        output,
-        ...(accepted ? {} : { isError: true }),
-      };
-    },
-  };
-
-  const checkInbox: NativeTool = {
-    spec: {
-      name: "check_inbox",
-      description:
-        "Fetch live messages delivered by Resident/User while this worker run is active.",
-      inputSchema: {
-        type: "object",
-        properties: {},
-      },
-    },
-    source: "server",
-    category: "delegation",
-    riskTier: 0,
-    isReadOnly: false,
-    isDestructive: false,
-    isConcurrencySafe: false,
-    async execute(call) {
-      const active = activeRuns.get(runId);
-      const messages = active?.inbox.splice(0) ?? [];
-      return {
-        id: crypto.randomUUID(),
-        toolCallId: call.id,
-        output: JSON.stringify({ messages, count: messages.length }),
-      };
-    },
-  };
-
-  return [askMain, checkInbox];
 }
 
 const server = createIpcServer(socketPath, (method, params, respond, _notify, connectionId) => {
@@ -334,7 +249,14 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
         const agentTools = agentProvider.listTools();
         const proxyTools = mcpProxyProvider.listTools();
         const availableTools = [...systemTools, ...agentTools, ...proxyTools];
-        const internalTools = createWorkerInternalTools(runId, sessionId);
+        const internalTools = WorkerInternalTools.create({
+          runId,
+          sessionId,
+          server,
+          ipcAuthToken,
+          workerId,
+          activeRuns,
+        });
         const { tools, toolExecutor } = createExecutionToolContext(request, availableTools);
         const internalToolExecutor = createToolExecutor({
           tools: internalTools,

--- a/apps/server/src/execution/worker-internal-tools.ts
+++ b/apps/server/src/execution/worker-internal-tools.ts
@@ -1,0 +1,132 @@
+import type { NativeTool } from "@openomni/openomni";
+import type { Tool } from "@openomni/protocol";
+import { z } from "zod";
+
+export namespace WorkerInternalTools {
+  export const InboxRun = z.object({ inbox: z.array(z.string()) });
+  export type InboxRun = z.infer<typeof InboxRun>;
+
+  export const Server = z.custom<{
+    call(method: "worker.ask_main", params: Record<string, unknown>): Promise<unknown>;
+  }>(
+    (value) =>
+      typeof value === "object" &&
+      value !== null &&
+      "call" in value &&
+      typeof value.call === "function",
+  );
+  export type Server = z.infer<typeof Server>;
+
+  export const ActiveRuns = z.custom<Pick<Map<string, InboxRun>, "get">>(
+    (value) =>
+      typeof value === "object" &&
+      value !== null &&
+      "get" in value &&
+      typeof value.get === "function",
+  );
+  export type ActiveRuns = z.infer<typeof ActiveRuns>;
+
+  export const Options = z.object({
+    runId: z.string(),
+    sessionId: z.string(),
+    server: Server,
+    ipcAuthToken: z.string(),
+    workerId: z.string(),
+    activeRuns: ActiveRuns,
+  });
+  export type Options = z.infer<typeof Options>;
+
+  export function create(options: Options): NativeTool[] {
+    const { runId, sessionId, server, ipcAuthToken, workerId, activeRuns } = Options.parse(options);
+    const askMain: NativeTool = {
+      spec: {
+        name: "ask_main",
+        description:
+          "Ask the Resident for guidance, approval, or missing context. Blocks until Resident answers.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            question: { type: "string", description: "Question or decision request for Resident" },
+          },
+          required: ["question"],
+        },
+      },
+      source: "server",
+      category: "delegation",
+      riskTier: 1,
+      isReadOnly: false,
+      isDestructive: false,
+      isConcurrencySafe: false,
+      async execute(call) {
+        const question = readQuestion(call);
+        if (!question) {
+          return {
+            id: crypto.randomUUID(),
+            toolCallId: call.id,
+            output: "ask_main requires a question",
+            isError: true,
+          };
+        }
+
+        const raw = await server.call("worker.ask_main", {
+          authToken: ipcAuthToken,
+          workerId,
+          sessionId,
+          runId,
+          question,
+        });
+        const response =
+          raw && typeof raw === "object"
+            ? (raw as { accepted?: unknown; output?: unknown; error?: unknown })
+            : undefined;
+        const accepted = response?.accepted === true;
+        const output = accepted
+          ? String(response?.output ?? "")
+          : String(response?.error ?? "worker.ask_main was rejected");
+        return {
+          id: crypto.randomUUID(),
+          toolCallId: call.id,
+          output,
+          ...(accepted ? {} : { isError: true }),
+        };
+      },
+    };
+
+    const checkInbox: NativeTool = {
+      spec: {
+        name: "check_inbox",
+        description:
+          "Fetch live messages delivered by Resident/User while this worker run is active.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      source: "server",
+      category: "delegation",
+      riskTier: 0,
+      isReadOnly: false,
+      isDestructive: false,
+      isConcurrencySafe: false,
+      async execute(call) {
+        const active = activeRuns.get(runId);
+        const messages = active?.inbox.splice(0) ?? [];
+        return {
+          id: crypto.randomUUID(),
+          toolCallId: call.id,
+          output: JSON.stringify({ messages, count: messages.length }),
+        };
+      },
+    };
+
+    return [askMain, checkInbox];
+  }
+}
+
+function readQuestion(call: Tool.Call): string {
+  if (!call.input || typeof call.input !== "object" || !("question" in call.input)) {
+    return "";
+  }
+  const question = (call.input as { question?: unknown }).question;
+  return typeof question === "string" ? question : "";
+}

--- a/apps/server/test/execution/worker-internal-tools.test.ts
+++ b/apps/server/test/execution/worker-internal-tools.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { Tool } from "@openomni/protocol";
+import { WorkerInternalTools } from "../../src/execution/worker-internal-tools";
+
+function createCall(id: string, tool: string, input: Tool.Call["input"] = {}): Tool.Call {
+  return { id, tool, input };
+}
+
+function getTool(
+  tools: ReturnType<typeof WorkerInternalTools.create>,
+  name: string,
+): ReturnType<typeof WorkerInternalTools.create>[number] {
+  const tool = tools.find((candidate) => candidate.spec.name === name);
+  if (!tool) {
+    throw new Error(`Expected worker internal tool ${name}`);
+  }
+  return tool;
+}
+
+describe("worker internal tools", () => {
+  it("ask_main requires a question", async () => {
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: mock(async () => ({ accepted: true, output: "unused" })) },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+    });
+
+    const result = await getTool(tools, "ask_main").execute(createCall("call-1", "ask_main", {}));
+
+    expect(result).toMatchObject({
+      toolCallId: "call-1",
+      output: "ask_main requires a question",
+      isError: true,
+    });
+  });
+
+  it("ask_main rejects non-string question payloads", async () => {
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: mock(async () => ({ accepted: true, output: "unused" })) },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+    });
+
+    const result = await getTool(tools, "ask_main").execute(
+      createCall("call-invalid", "ask_main", { question: { text: "Continue?" } }),
+    );
+
+    expect(result).toMatchObject({
+      toolCallId: "call-invalid",
+      output: "ask_main requires a question",
+      isError: true,
+    });
+  });
+
+  it("ask_main forwards the worker run context to the parent process", async () => {
+    const serverCall = mock(async () => ({ accepted: true, output: "approved" }));
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: serverCall },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+    });
+
+    const result = await getTool(tools, "ask_main").execute(
+      createCall("call-2", "ask_main", { question: "Continue?" }),
+    );
+
+    expect(serverCall).toHaveBeenCalledWith("worker.ask_main", {
+      authToken: "token",
+      workerId: "worker-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      question: "Continue?",
+    });
+    expect(result).toMatchObject({
+      toolCallId: "call-2",
+      output: "approved",
+    });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("ask_main returns rejected parent responses as tool errors", async () => {
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: mock(async () => ({ accepted: false, error: "no" })) },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+    });
+
+    const result = await getTool(tools, "ask_main").execute(
+      createCall("call-3", "ask_main", { question: "Go?" }),
+    );
+
+    expect(result).toMatchObject({
+      toolCallId: "call-3",
+      output: "no",
+      isError: true,
+    });
+  });
+
+  it("check_inbox drains queued messages for the active run", async () => {
+    const activeRuns = new Map<string, WorkerInternalTools.InboxRun>([
+      [
+        "run-1",
+        {
+          inbox: ["hello", "world"],
+        },
+      ],
+    ]);
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: mock(async () => ({ accepted: true, output: "unused" })) },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns,
+    });
+
+    const result = await getTool(tools, "check_inbox").execute(createCall("call-4", "check_inbox"));
+
+    expect(result).toMatchObject({
+      toolCallId: "call-4",
+      output: JSON.stringify({ messages: ["hello", "world"], count: 2 }),
+    });
+    expect(activeRuns.get("run-1")?.inbox).toEqual([]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@openomni/session": "workspace:*",
         "gray-matter": "^4.0.3",
         "hono": "^4.0.0",
+        "zod": "^3.22.4",
       },
       "devDependencies": {
         "@types/bun": "latest",


### PR DESCRIPTION
## Summary
Splits worker-only internal tool construction out of the worker entrypoint while preserving IPC run handling behavior.

Fixes #
Relates to #

## Changes
- Add a focused worker internal tools module for `ask_main` and `check_inbox`.
- Keep the full active-run lifecycle shape local to the worker entrypoint while exposing only the inbox contract to the helper.
- Add direct tests for `ask_main` request handling and `check_inbox` drain behavior.

## Type
- [x] refactor
- [x] tests

## Affected Packages
- [x] server

## Breaking Changes
- [x] No breaking changes

## Checklist
- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Existing tests cover the refactor path
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md update not required; no public API or architecture contract changed

## Validation
- `bun run build`
- `bun run check-types`
- `bun run script/check-deps.ts`
- `bun run lint` (passes with existing warnings)
- `bun test`
- `bun test apps/server/test/execution/worker-internal-tools.test.ts apps/server/test/execution/worker-runtime.test.ts apps/server/test/execution/worker-full-stack.test.ts apps/server/test/execution/coordinator.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split worker-only internal tools out of the worker entrypoint to simplify the worker runtime while keeping IPC run handling unchanged. Adds a dedicated `WorkerInternalTools.create` with input validation and direct tests for `ask_main` and `check_inbox`.

- **Refactors**
  - Introduced `apps/server/src/execution/worker-internal-tools.ts` exporting `WorkerInternalTools.create` for `ask_main` and `check_inbox` (validates options with `zod`).
  - `worker-entry` now imports the helper and passes `runId`, `sessionId`, `workerId`, `ipcAuthToken`, `server`, and `activeRuns`; the entry keeps the active-run lifecycle only.

- **Dependencies**
  - Added `zod` to `apps/server`.

<sup>Written for commit 15aa88c2f0c2752feb9ae7fb31bc6af739f9c568. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated worker internal tools into a dedicated, reusable module and improved run-tracking for more reliable worker coordination.

* **New Features**
  * Added worker-facing "ask" and "check inbox" capabilities to enable message forwarding and inbox draining.

* **Tests**
  * Added tests covering message validation, forwarding behavior, error propagation, and inbox draining.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->