### PR TITLE
refactor(server): split worker heartbeat

### DIFF
--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -21,6 +21,7 @@ import {
   resolveWorkerDbPath,
 } from "./worker-runtime";
 import { createContextMiddleware } from "../context/index";
+import { WorkerHeartbeat } from "./worker-heartbeat";
 import { WorkerInternalTools } from "./worker-internal-tools";
 
 const MAX_INBOX_MESSAGES = 100;
@@ -500,29 +501,13 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
   }
 });
 
-const HEARTBEAT_INTERVAL_MS = 15_000;
-
-setInterval(() => {
-  const snapshot: WorkerBootstrap.WorkerSnapshot = {
-    activeRuns: [...activeRuns.keys()],
-    backgroundTasks: [],
-    lastHeartbeat: Date.now(),
-    memoryRss: process.memoryUsage().rss / 1024 / 1024,
-    configEpoch: workerBootstrap?.configEpoch ?? "",
-  };
-
-  server
-    .call("worker.heartbeat", {
-      workerId,
-      authToken: ipcAuthToken,
-      activeRunIds: [...activeRuns.keys()],
-      memoryRssMb: process.memoryUsage().rss / 1024 / 1024,
-      snapshot,
-    })
-    .catch(() => {
-      // heartbeat failure is non-fatal; supervisor may not be connected yet
-    });
-}, HEARTBEAT_INTERVAL_MS);
+WorkerHeartbeat.start({
+  workerId,
+  ipcAuthToken,
+  server,
+  getActiveRunIds: () => [...activeRuns.keys()],
+  getConfigEpoch: () => workerBootstrap?.configEpoch ?? "",
+});
 
 process.on("SIGTERM", async () => {
   await shutdownWorker(0);

--- a/apps/server/src/execution/worker-heartbeat.ts
+++ b/apps/server/src/execution/worker-heartbeat.ts
@@ -12,16 +12,15 @@ export namespace WorkerHeartbeat {
   });
   export type SnapshotInput = z.infer<typeof SnapshotInput>;
 
-  export const Server = z.custom<{
+  export const Server = z.object({
+    call: z
+      .function()
+      .args(z.literal("worker.heartbeat"), z.record(z.unknown()))
+      .returns(z.promise(z.unknown())),
+  });
+  export type Server = {
     call(method: "worker.heartbeat", params: Record<string, unknown>): Promise<unknown>;
-  }>(
-    (value) =>
-      typeof value === "object" &&
-      value !== null &&
-      "call" in value &&
-      typeof value.call === "function",
-  );
-  export type Server = z.infer<typeof Server>;
+  };
 
   export const Options = z.object({
     workerId: z.string(),
@@ -33,7 +32,8 @@ export namespace WorkerHeartbeat {
     readMemoryRssMb: z.custom<() => number>((value) => typeof value === "function").optional(),
     nowMs: z.custom<() => number>((value) => typeof value === "function").optional(),
   });
-  export type Options = z.infer<typeof Options>;
+  type ParsedOptions = z.infer<typeof Options>;
+  export type Options = Omit<ParsedOptions, "server"> & { server: Server };
 
   export function createSnapshot(input: SnapshotInput): WorkerBootstrap.WorkerSnapshot {
     const { activeRunIds, configEpoch, memoryRssMb, lastHeartbeat } = SnapshotInput.parse(input);

--- a/apps/server/src/execution/worker-heartbeat.ts
+++ b/apps/server/src/execution/worker-heartbeat.ts
@@ -1,0 +1,95 @@
+import type { WorkerBootstrap } from "@openomni/protocol";
+import { z } from "zod";
+
+const DEFAULT_INTERVAL_MS = 15_000;
+
+export namespace WorkerHeartbeat {
+  export const SnapshotInput = z.object({
+    activeRunIds: z.array(z.string()),
+    configEpoch: z.string(),
+    memoryRssMb: z.number(),
+    lastHeartbeat: z.number(),
+  });
+  export type SnapshotInput = z.infer<typeof SnapshotInput>;
+
+  export const Server = z.custom<{
+    call(method: "worker.heartbeat", params: Record<string, unknown>): Promise<unknown>;
+  }>(
+    (value) =>
+      typeof value === "object" &&
+      value !== null &&
+      "call" in value &&
+      typeof value.call === "function",
+  );
+  export type Server = z.infer<typeof Server>;
+
+  export const Options = z.object({
+    workerId: z.string(),
+    ipcAuthToken: z.string(),
+    server: Server,
+    getActiveRunIds: z.custom<() => string[]>((value) => typeof value === "function"),
+    getConfigEpoch: z.custom<() => string>((value) => typeof value === "function"),
+    intervalMs: z.number().int().positive().optional(),
+    readMemoryRssMb: z.custom<() => number>((value) => typeof value === "function").optional(),
+    nowMs: z.custom<() => number>((value) => typeof value === "function").optional(),
+  });
+  export type Options = z.infer<typeof Options>;
+
+  export function createSnapshot(input: SnapshotInput): WorkerBootstrap.WorkerSnapshot {
+    const { activeRunIds, configEpoch, memoryRssMb, lastHeartbeat } = SnapshotInput.parse(input);
+    return {
+      activeRuns: activeRunIds,
+      backgroundTasks: [],
+      lastHeartbeat,
+      memoryRss: memoryRssMb,
+      configEpoch,
+    };
+  }
+
+  export async function send(options: Options): Promise<void> {
+    await sendParsed(Options.parse(options));
+  }
+
+  export function start(options: Options): ReturnType<typeof setInterval> {
+    const parsed = Options.parse(options);
+    return setInterval(() => {
+      void sendParsed(parsed);
+    }, parsed.intervalMs ?? DEFAULT_INTERVAL_MS);
+  }
+}
+
+async function sendParsed(options: WorkerHeartbeat.Options): Promise<void> {
+  const {
+    workerId,
+    ipcAuthToken,
+    server,
+    getActiveRunIds,
+    getConfigEpoch,
+    readMemoryRssMb = defaultMemoryRssMb,
+    nowMs = Date.now,
+  } = options;
+  const activeRunIds = getActiveRunIds();
+  const memoryRssMb = readMemoryRssMb();
+  const snapshot = WorkerHeartbeat.createSnapshot({
+    activeRunIds,
+    lastHeartbeat: nowMs(),
+    memoryRssMb,
+    configEpoch: getConfigEpoch(),
+  });
+
+  await server
+    .call("worker.heartbeat", {
+      workerId,
+      authToken: ipcAuthToken,
+      activeRunIds,
+      memoryRssMb,
+      snapshot,
+    })
+    .catch(() => {
+      // heartbeat failure is non-fatal; supervisor may not be connected yet
+    });
+}
+
+function defaultMemoryRssMb(): number {
+  return process.memoryUsage().rss / 1024 / 1024;
+}

--- a/apps/server/test/execution/worker-heartbeat.test.ts
+++ b/apps/server/test/execution/worker-heartbeat.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import { WorkerHeartbeat } from "../../src/execution/worker-heartbeat";
+
+describe("worker heartbeat", () => {
+  it("creates worker snapshots from active run state", () => {
+    const snapshot = WorkerHeartbeat.createSnapshot({
+      activeRunIds: ["run-1", "run-2"],
+      configEpoch: "epoch-1",
+      memoryRssMb: 12.5,
+      lastHeartbeat: 123,
+    });
+
+    expect(snapshot).toEqual({
+      activeRuns: ["run-1", "run-2"],
+      backgroundTasks: [],
+      lastHeartbeat: 123,
+      memoryRss: 12.5,
+      configEpoch: "epoch-1",
+    });
+  });
+
+  it("sends heartbeat payloads", async () => {
+    const serverCall = mock(async () => ({ ok: true }));
+
+    await WorkerHeartbeat.send({
+      workerId: "worker-1",
+      ipcAuthToken: "token",
+      server: { call: serverCall },
+      getActiveRunIds: () => ["run-1"],
+      getConfigEpoch: () => "epoch-1",
+      readMemoryRssMb: () => 10,
+      nowMs: () => 123,
+    });
+
+    expect(serverCall).toHaveBeenCalledTimes(1);
+    expect(serverCall).toHaveBeenCalledWith("worker.heartbeat", {
+      workerId: "worker-1",
+      authToken: "token",
+      activeRunIds: ["run-1"],
+      memoryRssMb: 10,
+      snapshot: {
+        activeRuns: ["run-1"],
+        backgroundTasks: [],
+        lastHeartbeat: 123,
+        memoryRss: 10,
+        configEpoch: "epoch-1",
+      },
+    });
+  });
+
+  it("ignores supervisor send failures", async () => {
+    const serverCall = mock(async () => {
+      throw new Error("not connected yet");
+    });
+
+    await expect(
+      WorkerHeartbeat.send({
+        workerId: "worker-1",
+        ipcAuthToken: "token",
+        server: { call: serverCall },
+        getActiveRunIds: () => ["run-1"],
+        getConfigEpoch: () => "epoch-1",
+        readMemoryRssMb: () => 10,
+        nowMs: () => 123,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Splits worker heartbeat snapshot and send handling out of the worker entrypoint while preserving supervisor heartbeat behavior.

Fixes #
Relates to #

## Changes
- Add a focused worker heartbeat module for snapshot construction and heartbeat sending.
- Replace the inline worker-entry heartbeat interval with `WorkerHeartbeat.start(...)`.
- Add direct tests for snapshot shape, heartbeat payloads, and non-fatal supervisor send failures.

## Type
- [x] refactor
- [x] tests

## Affected Packages
- [x] server

## Breaking Changes
- [x] No breaking changes

## Checklist
- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Existing tests cover the refactor path
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md update not required; no public API or architecture contract changed

## Validation
- `bun run build`
- `bun run check-types`
- `bun run script/check-deps.ts`
- `bun run lint` (passes with existing warnings)
- `bun test`
- `bun test apps/server/test/execution/worker-heartbeat.test.ts apps/server/test/execution/worker-internal-tools.test.ts apps/server/test/execution/worker-runtime.test.ts apps/server/test/execution/worker-full-stack.test.ts apps/server/test/execution/coordinator.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split worker heartbeat into a dedicated module to simplify the worker entrypoint while preserving supervisor behavior. Replaced the inline interval with WorkerHeartbeat.start(...).

- **Refactors**
  - Extracted snapshot/send/start to apps/server/src/execution/worker-heartbeat.ts.
  - worker-entry.ts now calls WorkerHeartbeat.start(...) with workerId, auth token, server, and state getters; interval defaults to 15s and is configurable; time/memory readers are injectable for tests.
  - Behavior unchanged: payload stays the same and supervisor send failures remain non-fatal. Added tests for snapshot shape, payloads, and failure handling.

<sup>Written for commit c68b2eec96a4c6a8aabe45b150ae2b6537f5b288. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker heartbeat logic reorganized into a dedicated module for clearer, more maintainable background reporting.

* **Tests**
  * Added tests covering heartbeat snapshot creation, single-send behavior, and resilient handling when server calls fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->