### PR TITLE
refactor(server): split worker ipc handlers

### DIFF
--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -23,14 +23,7 @@ import {
 import { createContextMiddleware } from "../context/index";
 import { WorkerHeartbeat } from "./worker-heartbeat";
 import { WorkerInternalTools } from "./worker-internal-tools";
-
-const MAX_INBOX_MESSAGES = 100;
-
-interface WorkerActiveRun {
-  readonly sessionId: string;
-  readonly controller: AbortController;
-  readonly inbox: string[];
-}
+import { WorkerIpcHandlers } from "./worker-ipc-handlers";
 
 function readCliArg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -69,7 +62,7 @@ initialize({
 BusPersistence.start();
 
 let workerBootstrap: WorkerBootstrap.Bootstrap | null = null;
-const activeRuns = new Map<string, WorkerActiveRun>();
+const activeRuns = new Map<string, WorkerIpcHandlers.ActiveRun>();
 let resolveBootstrapReady: () => void = () => undefined;
 let rejectBootstrapReady: (_error: Error) => void = () => undefined;
 const bootstrapReady = new Promise<void>((resolve, reject) => {
@@ -421,81 +414,17 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
       }
     })();
   } else if (method === "coordinator.cancel_run") {
-    if (params?.authToken !== ipcAuthToken) {
-      respond({ cancelled: false, error: "unauthorized coordinator request" });
-      return;
-    }
-    const runId = typeof params?.runId === "string" ? params.runId : undefined;
-    const sessionId = typeof params?.sessionId === "string" ? params.sessionId : undefined;
-    const active = runId ? activeRuns.get(runId) : undefined;
-    if (!runId || !active || (sessionId && active.sessionId !== sessionId)) {
-      respond({ cancelled: false, error: `run not active: ${runId ?? "unknown"}` });
-      return;
-    }
-    active.controller.abort(new Error("cancelled by coordinator"));
-    respond({ cancelled: true, runId, sessionId: active.sessionId });
+    respond(WorkerIpcHandlers.cancelRun({ params, ipcAuthToken, activeRuns }));
   } else if (method === "worker.deliver_message") {
-    if (params?.authToken !== ipcAuthToken) {
-      respond({ accepted: false, error: "unauthorized coordinator request" });
-      return;
-    }
-    const sessionId = typeof params?.sessionId === "string" ? params.sessionId : undefined;
-    const runId = typeof params?.runId === "string" ? params.runId : undefined;
-    const message = typeof params?.message === "string" ? params.message : undefined;
-    const matches = sessionId
-      ? [...activeRuns.entries()].filter(
-          ([activeRunId, run]) =>
-            run.sessionId === sessionId && (runId === undefined || activeRunId === runId),
-        )
-      : [];
-    if (!sessionId || !message || matches.length === 0) {
-      respond({
-        accepted: false,
-        error: `run not active for session: ${sessionId ?? "unknown"}`,
-      });
-      return;
-    }
-    if (!runId && matches.length > 1) {
-      respond({
-        accepted: false,
-        error: `multiple active runs for session: ${sessionId}`,
-      });
-      return;
-    }
-    const [activeRunId, run] = matches[0]!;
-    if (run.inbox.length >= MAX_INBOX_MESSAGES) {
-      run.inbox.shift();
-    }
-    run.inbox.push(message);
-    Bus.publish(Operational.Info, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "server",
-      msg: "live worker message delivered to active worker inbox",
-      context: {
-        workerId,
-        sessionId,
-        runId: activeRunId,
-        bytes: message.length,
-        inboxDepth: run.inbox.length,
-      },
-    });
-    respond({
-      accepted: true,
-    });
+    respond(WorkerIpcHandlers.deliverMessage({ params, ipcAuthToken, workerId, activeRuns }));
   } else if (method === "worker.shutdown_idle") {
-    if (params?.authToken !== ipcAuthToken) {
-      respond({ acknowledged: false, error: "unauthorized coordinator request" });
-      return;
+    const result = WorkerIpcHandlers.canShutdownIdle({ params, ipcAuthToken, activeRuns });
+    respond(result);
+    if (result.acknowledged) {
+      setTimeout(() => {
+        void shutdownWorker(0);
+      }, 0);
     }
-    if (activeRuns.size > 0) {
-      respond({ acknowledged: false, error: "worker is busy" });
-      return;
-    }
-    respond({ acknowledged: true });
-    setTimeout(() => {
-      void shutdownWorker(0);
-    }, 0);
   } else {
     respond({ ok: true });
   }

--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -1,0 +1,143 @@
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+const DEFAULT_MAX_INBOX_MESSAGES = 100;
+
+export namespace WorkerIpcHandlers {
+  export interface ActiveRun {
+    readonly sessionId: string;
+    readonly controller: AbortController;
+    readonly inbox: string[];
+  }
+
+  export type ActiveRuns = Pick<Map<string, ActiveRun>, "get" | "entries" | "size">;
+
+  export interface SharedOptions {
+    readonly ipcAuthToken: string;
+    readonly workerId: string;
+    readonly maxInboxMessages?: number;
+  }
+
+  export interface CancelRunOptions extends Pick<SharedOptions, "ipcAuthToken"> {
+    readonly params: Record<string, unknown> | undefined;
+    readonly activeRuns: Pick<ActiveRuns, "get">;
+  }
+
+  export interface DeliverMessageOptions extends SharedOptions {
+    readonly params: Record<string, unknown> | undefined;
+    readonly activeRuns: Pick<ActiveRuns, "entries">;
+  }
+
+  export interface ShutdownIdleOptions extends Pick<SharedOptions, "ipcAuthToken"> {
+    readonly params: Record<string, unknown> | undefined;
+    readonly activeRuns: Pick<ActiveRuns, "size">;
+  }
+
+  export type CancelRunResponse = {
+    readonly cancelled: boolean;
+    readonly runId?: string;
+    readonly sessionId?: string;
+    readonly error?: string;
+  };
+
+  export type DeliverMessageResponse = {
+    readonly accepted: boolean;
+    readonly error?: string;
+  };
+
+  export type ShutdownIdleResponse = {
+    readonly acknowledged: boolean;
+    readonly error?: string;
+  };
+
+  export function cancelRun(options: CancelRunOptions): CancelRunResponse {
+    const { params, ipcAuthToken, activeRuns } = options;
+    if (!isAuthorized(params, ipcAuthToken)) {
+      return { cancelled: false, error: "unauthorized coordinator request" };
+    }
+
+    const runId = readString(params, "runId");
+    const sessionId = readString(params, "sessionId");
+    const active = runId ? activeRuns.get(runId) : undefined;
+    if (!runId || !active || (sessionId && active.sessionId !== sessionId)) {
+      return { cancelled: false, error: `run not active: ${runId ?? "unknown"}` };
+    }
+
+    active.controller.abort(new Error("cancelled by coordinator"));
+    return { cancelled: true, runId, sessionId: active.sessionId };
+  }
+
+  export function deliverMessage(options: DeliverMessageOptions): DeliverMessageResponse {
+    const { params, ipcAuthToken, workerId, activeRuns } = options;
+    const maxInboxMessages = options.maxInboxMessages ?? DEFAULT_MAX_INBOX_MESSAGES;
+
+    if (!isAuthorized(params, ipcAuthToken)) {
+      return { accepted: false, error: "unauthorized coordinator request" };
+    }
+
+    const sessionId = readString(params, "sessionId");
+    const runId = readString(params, "runId");
+    const message = readString(params, "message");
+    const matches = sessionId
+      ? [...activeRuns.entries()].filter(
+          ([activeRunId, run]) =>
+            run.sessionId === sessionId && (runId === undefined || activeRunId === runId),
+        )
+      : [];
+
+    if (!sessionId || !message || matches.length === 0) {
+      return {
+        accepted: false,
+        error: `run not active for session: ${sessionId ?? "unknown"}`,
+      };
+    }
+    if (!runId && matches.length > 1) {
+      return {
+        accepted: false,
+        error: `multiple active runs for session: ${sessionId}`,
+      };
+    }
+
+    const [activeRunId, run] = matches[0] as [string, ActiveRun];
+    if (run.inbox.length >= maxInboxMessages) {
+      run.inbox.shift();
+    }
+    run.inbox.push(message);
+
+    Bus.publish(Operational.Info, {
+      traceId: crypto.randomUUID(),
+      time: Date.now(),
+      component: "server",
+      msg: "live worker message delivered to active worker inbox",
+      context: {
+        workerId,
+        sessionId,
+        runId: activeRunId,
+        bytes: message.length,
+        inboxDepth: run.inbox.length,
+      },
+    });
+
+    return { accepted: true };
+  }
+
+  export function canShutdownIdle(options: ShutdownIdleOptions): ShutdownIdleResponse {
+    const { params, ipcAuthToken, activeRuns } = options;
+    if (!isAuthorized(params, ipcAuthToken)) {
+      return { acknowledged: false, error: "unauthorized coordinator request" };
+    }
+    if (activeRuns.size > 0) {
+      return { acknowledged: false, error: "worker is busy" };
+    }
+    return { acknowledged: true };
+  }
+}
+
+function isAuthorized(params: Record<string, unknown> | undefined, ipcAuthToken: string): boolean {
+  return params?.authToken === ipcAuthToken;
+}
+
+function readString(params: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = params?.[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -1,5 +1,6 @@
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
+import { z } from "zod";
 
 const DEFAULT_MAX_INBOX_MESSAGES = 100;
 
@@ -33,22 +34,36 @@ export namespace WorkerIpcHandlers {
     readonly activeRuns: Pick<ActiveRuns, "size">;
   }
 
-  export type CancelRunResponse = {
-    readonly cancelled: boolean;
-    readonly runId?: string;
-    readonly sessionId?: string;
-    readonly error?: string;
-  };
+  export const CancelRunResponse = z.discriminatedUnion("cancelled", [
+    z.object({
+      cancelled: z.literal(true),
+      runId: z.string(),
+      sessionId: z.string(),
+    }),
+    z.object({
+      cancelled: z.literal(false),
+      error: z.string(),
+    }),
+  ]);
+  export type CancelRunResponse = z.infer<typeof CancelRunResponse>;
 
-  export type DeliverMessageResponse = {
-    readonly accepted: boolean;
-    readonly error?: string;
-  };
+  export const DeliverMessageResponse = z.discriminatedUnion("accepted", [
+    z.object({ accepted: z.literal(true) }),
+    z.object({
+      accepted: z.literal(false),
+      error: z.string(),
+    }),
+  ]);
+  export type DeliverMessageResponse = z.infer<typeof DeliverMessageResponse>;
 
-  export type ShutdownIdleResponse = {
-    readonly acknowledged: boolean;
-    readonly error?: string;
-  };
+  export const ShutdownIdleResponse = z.discriminatedUnion("acknowledged", [
+    z.object({ acknowledged: z.literal(true) }),
+    z.object({
+      acknowledged: z.literal(false),
+      error: z.string(),
+    }),
+  ]);
+  export type ShutdownIdleResponse = z.infer<typeof ShutdownIdleResponse>;
 
   export function cancelRun(options: CancelRunOptions): CancelRunResponse {
     const { params, ipcAuthToken, activeRuns } = options;

--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -84,7 +84,7 @@ export namespace WorkerIpcHandlers {
 
   export function deliverMessage(options: DeliverMessageOptions): DeliverMessageResponse {
     const { params, ipcAuthToken, workerId, activeRuns } = options;
-    const maxInboxMessages = options.maxInboxMessages ?? DEFAULT_MAX_INBOX_MESSAGES;
+    const maxInboxMessages = normalizeMaxInboxMessages(options.maxInboxMessages);
 
     if (!isAuthorized(params, ipcAuthToken)) {
       return { accepted: false, error: "unauthorized coordinator request" };
@@ -114,10 +114,10 @@ export namespace WorkerIpcHandlers {
     }
 
     const [activeRunId, run] = matches[0] as [string, ActiveRun];
-    if (run.inbox.length >= maxInboxMessages) {
+    run.inbox.push(message);
+    while (run.inbox.length > maxInboxMessages) {
       run.inbox.shift();
     }
-    run.inbox.push(message);
 
     Bus.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
@@ -146,6 +146,18 @@ export namespace WorkerIpcHandlers {
     }
     return { acknowledged: true };
   }
+}
+
+function normalizeMaxInboxMessages(value: number | undefined): number {
+  if (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 1
+  ) {
+    return value;
+  }
+  return DEFAULT_MAX_INBOX_MESSAGES;
 }
 
 function isAuthorized(params: Record<string, unknown> | undefined, ipcAuthToken: string): boolean {

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -99,7 +99,8 @@ describe("worker IPC handlers", () => {
   });
 
   it("falls back to the default inbox cap for invalid numeric caps", () => {
-    const run = createRun("session-1", ["existing"]);
+    const seedInbox = Array.from({ length: 100 }, (_, index) => `message-${index}`);
+    const run = createRun("session-1", seedInbox);
     const activeRuns = new Map([["run-1", run]]);
 
     const result = WorkerIpcHandlers.deliverMessage({
@@ -111,7 +112,9 @@ describe("worker IPC handlers", () => {
     });
 
     expect(result).toEqual({ accepted: true });
-    expect(run.inbox).toEqual(["existing", "new"]);
+    expect(run.inbox).toHaveLength(100);
+    expect(run.inbox[0]).toBe("message-1");
+    expect(run.inbox.at(-1)).toBe("new");
   });
 
   it("rejects ambiguous session-only delivery when multiple runs are active", () => {

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -83,7 +83,7 @@ describe("worker IPC handlers", () => {
   });
 
   it("delivers messages to a matching active run and caps inbox depth", () => {
-    const run = createRun("session-1", ["older", "old"]);
+    const run = createRun("session-1", ["oldest", "older", "old"]);
     const activeRuns = new Map([["run-1", run]]);
 
     const result = WorkerIpcHandlers.deliverMessage({
@@ -96,6 +96,22 @@ describe("worker IPC handlers", () => {
 
     expect(result).toEqual({ accepted: true });
     expect(run.inbox).toEqual(["old", "new"]);
+  });
+
+  it("falls back to the default inbox cap for invalid numeric caps", () => {
+    const run = createRun("session-1", ["existing"]);
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.deliverMessage({
+      params: { authToken: "token", sessionId: "session-1", runId: "run-1", message: "new" },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns,
+      maxInboxMessages: Number.NaN,
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(run.inbox).toEqual(["existing", "new"]);
   });
 
   it("rejects ambiguous session-only delivery when multiple runs are active", () => {

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+
+import { WorkerIpcHandlers } from "../../src/execution/worker-ipc-handlers";
+
+function createRun(sessionId: string, inbox: string[] = []): WorkerIpcHandlers.ActiveRun {
+  return { sessionId, controller: new AbortController(), inbox };
+}
+
+describe("worker IPC handlers", () => {
+  it("rejects unauthorized cancel requests without aborting the active run", () => {
+    const run = createRun("session-1");
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.cancelRun({
+      params: { authToken: "wrong", runId: "run-1" },
+      ipcAuthToken: "token",
+      activeRuns,
+    });
+
+    expect(result).toEqual({ cancelled: false, error: "unauthorized coordinator request" });
+    expect(run.controller.signal.aborted).toBe(false);
+  });
+
+  it("aborts matching active runs", () => {
+    const run = createRun("session-1");
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.cancelRun({
+      params: { authToken: "token", runId: "run-1", sessionId: "session-1" },
+      ipcAuthToken: "token",
+      activeRuns,
+    });
+
+    expect(result).toEqual({ cancelled: true, runId: "run-1", sessionId: "session-1" });
+    expect(run.controller.signal.aborted).toBe(true);
+  });
+
+  it("rejects cancel requests when session id does not match", () => {
+    const run = createRun("session-1");
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.cancelRun({
+      params: { authToken: "token", runId: "run-1", sessionId: "other-session" },
+      ipcAuthToken: "token",
+      activeRuns,
+    });
+
+    expect(result).toEqual({ cancelled: false, error: "run not active: run-1" });
+    expect(run.controller.signal.aborted).toBe(false);
+  });
+
+  it("rejects unauthorized message delivery without mutating the inbox", () => {
+    const run = createRun("session-1", ["existing"]);
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.deliverMessage({
+      params: { authToken: "wrong", sessionId: "session-1", runId: "run-1", message: "new" },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns,
+    });
+
+    expect(result).toEqual({ accepted: false, error: "unauthorized coordinator request" });
+    expect(run.inbox).toEqual(["existing"]);
+  });
+
+  it("rejects message delivery when an explicit run id does not match", () => {
+    const run = createRun("session-1", []);
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.deliverMessage({
+      params: { authToken: "token", sessionId: "session-1", runId: "missing", message: "new" },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns,
+    });
+
+    expect(result).toEqual({
+      accepted: false,
+      error: "run not active for session: session-1",
+    });
+    expect(run.inbox).toEqual([]);
+  });
+
+  it("delivers messages to a matching active run and caps inbox depth", () => {
+    const run = createRun("session-1", ["older", "old"]);
+    const activeRuns = new Map([["run-1", run]]);
+
+    const result = WorkerIpcHandlers.deliverMessage({
+      params: { authToken: "token", sessionId: "session-1", runId: "run-1", message: "new" },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns,
+      maxInboxMessages: 2,
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(run.inbox).toEqual(["old", "new"]);
+  });
+
+  it("rejects ambiguous session-only delivery when multiple runs are active", () => {
+    const activeRuns = new Map([
+      ["run-1", createRun("session-1")],
+      ["run-2", createRun("session-1")],
+    ]);
+
+    const result = WorkerIpcHandlers.deliverMessage({
+      params: { authToken: "token", sessionId: "session-1", message: "hello" },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns,
+    });
+
+    expect(result).toEqual({
+      accepted: false,
+      error: "multiple active runs for session: session-1",
+    });
+  });
+
+  it("reports idle shutdown readiness only when authorized and idle", () => {
+    expect(
+      WorkerIpcHandlers.canShutdownIdle({
+        params: { authToken: "wrong" },
+        ipcAuthToken: "token",
+        activeRuns: new Map(),
+      }),
+    ).toEqual({ acknowledged: false, error: "unauthorized coordinator request" });
+
+    expect(
+      WorkerIpcHandlers.canShutdownIdle({
+        params: { authToken: "token" },
+        ipcAuthToken: "token",
+        activeRuns: new Map([["run-1", createRun("session-1")]]),
+      }),
+    ).toEqual({ acknowledged: false, error: "worker is busy" });
+
+    expect(
+      WorkerIpcHandlers.canShutdownIdle({
+        params: { authToken: "token" },
+        ipcAuthToken: "token",
+        activeRuns: new Map(),
+      }),
+    ).toEqual({ acknowledged: true });
+  });
+});


### PR DESCRIPTION
## Summary
Splits worker control IPC handling out of the worker entrypoint while preserving cancellation, inbox delivery, and idle shutdown behavior.

Fixes #
Relates to #

## Changes
- Add a focused worker IPC handler module for cancel, message delivery, and idle shutdown decisions.
- Keep process shutdown scheduling in the worker entrypoint while delegating handler response construction.
- Add tests for auth rejection, run/session matching, inbox capping, ambiguous delivery, and idle shutdown readiness.

## Type
- [x] refactor
- [x] tests

## Affected Packages
- [x] server

## Breaking Changes
- [x] No breaking changes

## Checklist
- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Existing tests cover the refactor path
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md update not required; no public API or architecture contract changed

## Validation
- `bun run build`
- `bun run check-types`
- `bun run script/check-deps.ts`
- `bun run lint` (passes with existing warnings)
- `bun test`
- `bun test apps/server/test/execution/worker-ipc-handlers.test.ts apps/server/test/execution/worker-heartbeat.test.ts apps/server/test/execution/worker-internal-tools.test.ts apps/server/test/execution/worker-runtime.test.ts apps/server/test/execution/worker-full-stack.test.ts apps/server/test/execution/coordinator.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split worker control IPC into a dedicated `WorkerIpcHandlers` module to simplify the worker entrypoint while keeping cancellation, live message delivery, and idle shutdown behavior.

- **Refactors**
  - Added `worker-ipc-handlers.ts` with `cancelRun`, `deliverMessage`, and `canShutdownIdle`; responses are discriminated unions validated with `zod`. Preserves delivery logging and supports a configurable `maxInboxMessages` with normalization and fallback.
  - Entrypoint now delegates to handlers and schedules idle shutdown after acknowledgement. Tests cover auth, run/session matching, ambiguous session delivery, inbox capping (including invalid caps), and idle readiness.

<sup>Written for commit c1a5a08c2bc81d42e08dd23dc92ac64ec20ddf35. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/158?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized IPC handlers for coordinator requests: run cancellation, message delivery, and idle-shutdown checks.

* **Refactor**
  * Moved inline worker request logic into shared handlers with unified context and authorization gating.

* **Behavior**
  * Safer cancellation flows, bounded inbox enqueueing with oldest-message eviction, and explicit idle-shutdown acknowledgement.

* **Tests**
  * Added tests covering authorization, run/session resolution, inbox capping, cancellation, and idle-shutdown responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->