### PR TITLE
refactor(server): split worker runner

### DIFF
--- a/apps/server/src/execution/coordinator.ts
+++ b/apps/server/src/execution/coordinator.ts
@@ -106,6 +106,10 @@ export function createExecutionCoordinator(config: CoordinatorConfig): Execution
         throw new Error("Execution coordinator is draining");
       }
 
+      if (activeRuns.has(request.runId)) {
+        throw new Error(`run already active: ${request.runId}`);
+      }
+
       activeRuns.add(request.runId);
 
       try {

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -1,29 +1,15 @@
-import { ChatAgent, AgentRegistry } from "@openomni/agent";
+import { AgentRegistry } from "@openomni/agent";
 import type { Auth } from "@openomni/llm";
 import { createIpcServer } from "@openomni/coordinator";
-import { Execution, Subagent, Tool, WorkerBootstrap } from "@openomni/protocol";
-import { Operational } from "@openomni/protocol";
+import { Operational, WorkerBootstrap } from "@openomni/protocol";
 import { initialize, Bus, BusPersistence } from "@openomni/session";
-import {
-  AgentToolProvider,
-  BackgroundManager,
-  ToolProxyProvider,
-  SystemToolProvider,
-  buildToolCatalog,
-  buildWorkerMiddleware,
-  createToolExecutor,
-  createWorkerSubagentRuntime,
-} from "@openomni/openomni";
+import { BackgroundManager } from "@openomni/openomni";
 import { loadConfig } from "../config";
-import {
-  buildWorkerInputMessages,
-  createExecutionToolContext,
-  resolveWorkerDbPath,
-} from "./worker-runtime";
-import { createContextMiddleware } from "../context/index";
+import { resolveWorkerDbPath } from "./worker-runtime";
 import { WorkerHeartbeat } from "./worker-heartbeat";
-import { WorkerInternalTools } from "./worker-internal-tools";
 import { WorkerIpcHandlers } from "./worker-ipc-handlers";
+import type { WorkerRunState } from "./worker-run-state";
+import { WorkerRunner } from "./worker-runner";
 
 function readCliArg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -62,7 +48,7 @@ initialize({
 BusPersistence.start();
 
 let workerBootstrap: WorkerBootstrap.Bootstrap | null = null;
-const activeRuns = new Map<string, WorkerIpcHandlers.ActiveRun>();
+const activeRuns: WorkerRunState.ActiveRunRegistry = new Map();
 let resolveBootstrapReady: () => void = () => undefined;
 let rejectBootstrapReady: (_error: Error) => void = () => undefined;
 const bootstrapReady = new Promise<void>((resolve, reject) => {
@@ -153,266 +139,19 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
       });
     }
   } else if (method === "coordinator.spawn_run") {
-    if (params?.authToken !== ipcAuthToken) {
-      respond({
-        runId: typeof params?.runId === "string" ? params.runId : "unknown",
-        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
-        status: "failed",
-        error: "unauthorized coordinator request",
-      });
-      return;
-    }
-
-    let request: Execution.Request;
-    try {
-      request = Execution.Request.parse(params);
-    } catch (err) {
-      respond({
-        runId: typeof params?.runId === "string" ? params.runId : "unknown",
-        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
-        status: "failed",
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return;
-    }
-
-    const { runId, sessionId } = request;
-
-    (async () => {
-      const traceId = request.traceId ?? crypto.randomUUID();
-      const controller = new AbortController();
-      activeRuns.set(runId, { sessionId, controller, inbox: [] });
-      server.notify("worker.run_started", { runId, sessionId });
-      Bus.publish(Subagent.Events.WorkerRunStarted, {
-        traceId,
-        sessionId,
-        runId,
-        time: Date.now(),
-        payload: { sessionId, runId, title: request.prompt.slice(0, 80) },
-      });
-
-      try {
-        await bootstrapReady;
-        const messages = buildWorkerInputMessages(sessionId, request.prompt);
-        const workspaceRoot =
-          request.workspaceRoot ?? request.toolConfig?.workspaceRoot ?? config.workspace?.root;
-        const systemProvider = new SystemToolProvider(workspaceRoot);
-
-        const mcpProxyProvider = ToolProxyProvider.create(
-          workerBootstrap?.toolCatalog ?? [],
-          async (toolName, toolArgs) => {
-            const raw = await server.call("worker.tool_call", {
-              runId,
-              sessionId,
-              callId: crypto.randomUUID(),
-              tool: toolName,
-              input: toolArgs,
-            });
-            return Tool.Result.parse(raw);
-          },
-        );
-
-        const toolsRef: Parameters<typeof createWorkerSubagentRuntime>[0]["toolsRef"] = {};
-        const catalogRef: { catalog?: ReturnType<typeof buildToolCatalog> } = {};
-        const agentDefinitionsRef: {
-          definitions?: Map<string, WorkerBootstrap.RuntimeAgentDefinition>;
-        } = {
-          definitions: new Map((workerBootstrap?.agents ?? []).map((agent) => [agent.name, agent])),
-        };
-
-        const agentProvider = new AgentToolProvider({
-          subagentRuntime: createWorkerSubagentRuntime({
-            toolsRef,
-            catalogRef,
-            agentDefinitionsRef,
-            resolveAuth: resolveBootstrapAuth,
-            allowAuthFallback: false,
-            parentSessionId: sessionId,
-            parentPermissions: request.permissions,
-          }),
-          delegationContext: {
-            depth: 0,
-            maxDepth: 3,
-            visitedAgents: new Set([request.agentName ?? "dev"]),
-            parentAbort: controller.signal,
-          },
-          backgroundManager,
-        });
-
-        const systemTools = systemProvider.listTools();
-        const agentTools = agentProvider.listTools();
-        const proxyTools = mcpProxyProvider.listTools();
-        const availableTools = [...systemTools, ...agentTools, ...proxyTools];
-        const internalTools = WorkerInternalTools.create({
-          runId,
-          sessionId,
-          server,
-          ipcAuthToken,
-          workerId,
-          activeRuns,
-        });
-        const { tools, toolExecutor } = createExecutionToolContext(request, availableTools);
-        const internalToolExecutor = createToolExecutor({
-          tools: internalTools,
-          config: {
-            workspaceRoot,
-            runtime: {
-              sessionId,
-              runId,
-              agentName: request.agentName,
-              workspaceRoot,
-            },
-          },
-        });
-        const internalToolNames = new Set(
-          internalTools.flatMap((tool) => [tool.spec.name, tool.spec.name.replace(/\./g, "_")]),
-        );
-        const combinedToolExecutor = async (call: Tool.Call): Promise<Tool.Result> => {
-          if (internalToolNames.has(call.tool)) return internalToolExecutor(call);
-          if (toolExecutor) return toolExecutor(call);
-          return {
-            id: crypto.randomUUID(),
-            toolCallId: call.id,
-            output: `Unknown worker tool: ${call.tool}`,
-            isError: true,
-          };
-        };
-        const exposedTools = [
-          ...(tools ?? []),
-          ...internalTools.map((tool) => ({
-            ...tool.spec,
-            name: tool.spec.name.replace(/\./g, "_"),
-          })),
-        ];
-
-        toolsRef.tools = exposedTools;
-        toolsRef.toolExecutor = combinedToolExecutor;
-        catalogRef.catalog = buildToolCatalog([
-          { tools: systemTools, source: "system" },
-          { tools: agentTools, source: "agent" },
-          { tools: proxyTools, source: "mcp" },
-        ]);
-
-        const agent = ChatAgent.create({
-          model: request.model,
-          auth: resolveBootstrapAuth(request.model.provider),
-          allowAuthFallback: false,
-          signal: controller.signal,
-          budget: request.budget,
-          systemPrompt: [
-            request.systemPrompt,
-            "Worker runtime tools: use ask_main when you need Resident guidance or approval; use check_inbox to read live messages delivered while this run is active.",
-          ]
-            .filter(Boolean)
-            .join("\n\n"),
-          tools: exposedTools,
-          toolExecutor: combinedToolExecutor,
-          middleware: [
-            createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
-            ...buildWorkerMiddleware({
-              permissions: request.permissions,
-              ...(request.policyPlan ? { policyPlan: request.policyPlan } : {}),
-            }),
-          ],
-        });
-        const runResult = await agent.run({
-          messages,
-          traceContext: { traceId, sessionId, runId },
-        });
-        if (controller.signal.aborted) {
-          server.notify("worker.run_completed", {
-            runId,
-            sessionId,
-            status: "cancelled",
-          });
-          Bus.publish(Subagent.Events.WorkerSessionCancelled, {
-            traceId,
-            sessionId,
-            runId,
-            time: Date.now(),
-            payload: { sessionId, runId },
-          });
-
-          respond({
-            runId,
-            sessionId,
-            status: "cancelled",
-            error: "cancelled by coordinator",
-          });
-          return;
-        }
-
-        server.notify("worker.run_completed", {
-          runId,
-          sessionId,
-          status: "succeeded",
-          output: runResult.text,
-        });
-        Bus.publish(Subagent.Events.WorkerRunCompleted, {
-          traceId,
-          sessionId,
-          runId,
-          time: Date.now(),
-          payload: { sessionId, runId, status: "succeeded" },
-        });
-
-        respond({
-          runId,
-          sessionId,
-          status: "succeeded",
-          output: runResult.text,
-          finishReason: runResult.finishReason,
-        });
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        const wasCancelled = controller.signal.aborted;
-        if (wasCancelled) {
-          server.notify("worker.run_completed", {
-            runId,
-            sessionId,
-            status: "cancelled",
-            error: errorMessage,
-          });
-          Bus.publish(Subagent.Events.WorkerSessionCancelled, {
-            traceId,
-            sessionId,
-            runId,
-            time: Date.now(),
-            payload: { sessionId, runId },
-          });
-
-          respond({
-            runId,
-            sessionId,
-            status: "cancelled",
-            error: errorMessage,
-          });
-          return;
-        }
-        server.notify("worker.run_completed", {
-          runId,
-          sessionId,
-          status: "failed",
-          error: errorMessage,
-        });
-        Bus.publish(Subagent.Events.WorkerRunFailed, {
-          traceId,
-          sessionId,
-          runId,
-          time: Date.now(),
-          payload: { sessionId, runId, error: errorMessage },
-        });
-
-        respond({
-          runId,
-          sessionId,
-          status: "failed",
-          error: errorMessage,
-        });
-      } finally {
-        activeRuns.delete(runId);
-      }
-    })();
+    WorkerRunner.spawnRun({
+      params,
+      ipcAuthToken,
+      workerId,
+      server,
+      activeRuns,
+      bootstrapReady,
+      backgroundManager,
+      defaultWorkspaceRoot: config.workspace?.root,
+      getBootstrap: () => workerBootstrap,
+      resolveAuth: resolveBootstrapAuth,
+      respond,
+    });
   } else if (method === "coordinator.cancel_run") {
     respond(WorkerIpcHandlers.cancelRun({ params, ipcAuthToken, activeRuns }));
   } else if (method === "worker.deliver_message") {

--- a/apps/server/src/execution/worker-internal-tools.ts
+++ b/apps/server/src/execution/worker-internal-tools.ts
@@ -1,11 +1,9 @@
 import type { NativeTool } from "@openomni/openomni";
 import type { Tool } from "@openomni/protocol";
 import { z } from "zod";
+import type { WorkerRunState } from "./worker-run-state";
 
 export namespace WorkerInternalTools {
-  export const InboxRun = z.object({ inbox: z.array(z.string()) });
-  export type InboxRun = z.infer<typeof InboxRun>;
-
   export const Server = z.custom<{
     call(method: "worker.ask_main", params: Record<string, unknown>): Promise<unknown>;
   }>(
@@ -17,7 +15,7 @@ export namespace WorkerInternalTools {
   );
   export type Server = z.infer<typeof Server>;
 
-  export const ActiveRuns = z.custom<Pick<Map<string, InboxRun>, "get">>(
+  export const ActiveRuns = z.custom<WorkerRunState.InboxReadableActiveRuns>(
     (value) =>
       typeof value === "object" &&
       value !== null &&

--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -1,18 +1,11 @@
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { z } from "zod";
+import type { WorkerRunState } from "./worker-run-state";
 
 const DEFAULT_MAX_INBOX_MESSAGES = 100;
 
 export namespace WorkerIpcHandlers {
-  export interface ActiveRun {
-    readonly sessionId: string;
-    readonly controller: AbortController;
-    readonly inbox: string[];
-  }
-
-  export type ActiveRuns = Pick<Map<string, ActiveRun>, "get" | "entries" | "size">;
-
   export interface SharedOptions {
     readonly ipcAuthToken: string;
     readonly workerId: string;
@@ -21,17 +14,17 @@ export namespace WorkerIpcHandlers {
 
   export interface CancelRunOptions extends Pick<SharedOptions, "ipcAuthToken"> {
     readonly params: Record<string, unknown> | undefined;
-    readonly activeRuns: Pick<ActiveRuns, "get">;
+    readonly activeRuns: Pick<WorkerRunState.ReadableActiveRuns, "get">;
   }
 
   export interface DeliverMessageOptions extends SharedOptions {
     readonly params: Record<string, unknown> | undefined;
-    readonly activeRuns: Pick<ActiveRuns, "entries">;
+    readonly activeRuns: Pick<WorkerRunState.ActiveRunRegistry, "entries">;
   }
 
   export interface ShutdownIdleOptions extends Pick<SharedOptions, "ipcAuthToken"> {
     readonly params: Record<string, unknown> | undefined;
-    readonly activeRuns: Pick<ActiveRuns, "size">;
+    readonly activeRuns: Pick<WorkerRunState.ReadableActiveRuns, "size">;
   }
 
   export const CancelRunResponse = z.discriminatedUnion("cancelled", [
@@ -113,7 +106,15 @@ export namespace WorkerIpcHandlers {
       };
     }
 
-    const [activeRunId, run] = matches[0] as [string, ActiveRun];
+    const match = matches[0];
+    if (!match) {
+      return {
+        accepted: false,
+        error: `run not active for session: ${sessionId}`,
+      };
+    }
+
+    const [activeRunId, run] = match;
     run.inbox.push(message);
     while (run.inbox.length > maxInboxMessages) {
       run.inbox.shift();

--- a/apps/server/src/execution/worker-run-state.ts
+++ b/apps/server/src/execution/worker-run-state.ts
@@ -1,0 +1,11 @@
+export namespace WorkerRunState {
+  export interface ActiveRun {
+    readonly sessionId: string;
+    readonly controller: AbortController;
+    readonly inbox: string[];
+  }
+
+  export type ActiveRunRegistry = Map<string, ActiveRun>;
+  export type ReadableActiveRuns = Pick<ActiveRunRegistry, "get" | "entries" | "size">;
+  export type InboxReadableActiveRuns = Pick<ActiveRunRegistry, "get">;
+}

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -1,0 +1,345 @@
+import { ChatAgent } from "@openomni/agent";
+import type { Auth } from "@openomni/llm";
+import {
+  AgentToolProvider,
+  type BackgroundManager,
+  SystemToolProvider,
+  ToolProxyProvider,
+  buildToolCatalog,
+  buildWorkerMiddleware,
+  createToolExecutor,
+  createWorkerSubagentRuntime,
+} from "@openomni/openomni";
+import { Execution, Subagent, Tool, type WorkerBootstrap } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { createContextMiddleware } from "../context/index";
+import { WorkerInternalTools } from "./worker-internal-tools";
+import type { WorkerRunState } from "./worker-run-state";
+import { buildWorkerInputMessages, createExecutionToolContext } from "./worker-runtime";
+
+export interface WorkerRunIpcServer {
+  call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
+  notify(method: string, params?: Record<string, unknown>): void;
+}
+
+export namespace WorkerRunner {
+  type ChatAgentOptions = Parameters<typeof ChatAgent.create>[0];
+  type WorkerAgent = Pick<ReturnType<typeof ChatAgent.create>, "run">;
+
+  export interface Environment {
+    readonly ipcAuthToken: string;
+    readonly workerId: string;
+    readonly server: WorkerRunIpcServer;
+    readonly activeRuns: WorkerRunState.ActiveRunRegistry;
+    readonly bootstrapReady: Promise<void>;
+    readonly backgroundManager: ReturnType<typeof BackgroundManager.create>;
+    readonly defaultWorkspaceRoot: string | undefined;
+    readonly getBootstrap: () => WorkerBootstrap.Bootstrap | null;
+    readonly resolveAuth: (provider: string) => Auth.Info | undefined;
+    readonly createAgent?: (options: ChatAgentOptions) => WorkerAgent;
+  }
+
+  export interface SpawnRunOptions extends Environment {
+    readonly params: Record<string, unknown> | undefined;
+    readonly respond: (result: unknown) => void;
+  }
+
+  export function spawnRun(options: SpawnRunOptions): void {
+    const {
+      params,
+      ipcAuthToken,
+      workerId,
+      server,
+      activeRuns,
+      bootstrapReady,
+      backgroundManager,
+      defaultWorkspaceRoot,
+      getBootstrap,
+      resolveAuth,
+      respond,
+      createAgent = ChatAgent.create,
+    } = options;
+
+    if (params?.authToken !== ipcAuthToken) {
+      respond({
+        runId: typeof params?.runId === "string" ? params.runId : "unknown",
+        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
+        status: "failed",
+        error: "unauthorized coordinator request",
+      });
+      return;
+    }
+
+    let request: Execution.Request;
+    try {
+      request = Execution.Request.parse(params);
+    } catch (err) {
+      respond({
+        runId: typeof params?.runId === "string" ? params.runId : "unknown",
+        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
+        status: "failed",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    const { runId, sessionId } = request;
+    if (activeRuns.has(runId)) {
+      respond({
+        runId,
+        sessionId,
+        status: "failed",
+        error: `run already active: ${runId}`,
+      });
+      return;
+    }
+
+    (async () => {
+      const traceId = request.traceId ?? crypto.randomUUID();
+      const controller = new AbortController();
+
+      try {
+        activeRuns.set(runId, { sessionId, controller, inbox: [] });
+        server.notify("worker.run_started", { runId, sessionId });
+        Bus.publish(Subagent.Events.WorkerRunStarted, {
+          traceId,
+          sessionId,
+          runId,
+          time: Date.now(),
+          payload: { sessionId, runId, title: request.prompt.slice(0, 80) },
+        });
+        await bootstrapReady;
+        const bootstrap = getBootstrap();
+        const messages = buildWorkerInputMessages(sessionId, request.prompt);
+        const workspaceRoot =
+          request.workspaceRoot ?? request.toolConfig?.workspaceRoot ?? defaultWorkspaceRoot;
+        const systemProvider = new SystemToolProvider(workspaceRoot);
+
+        const mcpProxyProvider = ToolProxyProvider.create(
+          bootstrap?.toolCatalog ?? [],
+          async (toolName, toolArgs) => {
+            const raw = await server.call("worker.tool_call", {
+              runId,
+              sessionId,
+              callId: crypto.randomUUID(),
+              tool: toolName,
+              input: toolArgs,
+            });
+            return Tool.Result.parse(raw);
+          },
+        );
+
+        const toolsRef: Parameters<typeof createWorkerSubagentRuntime>[0]["toolsRef"] = {};
+        const catalogRef: { catalog?: ReturnType<typeof buildToolCatalog> } = {};
+        const agentDefinitionsRef: {
+          definitions?: Map<string, WorkerBootstrap.RuntimeAgentDefinition>;
+        } = {
+          definitions: new Map((bootstrap?.agents ?? []).map((agent) => [agent.name, agent])),
+        };
+
+        const agentProvider = new AgentToolProvider({
+          subagentRuntime: createWorkerSubagentRuntime({
+            toolsRef,
+            catalogRef,
+            agentDefinitionsRef,
+            resolveAuth,
+            allowAuthFallback: false,
+            parentSessionId: sessionId,
+            parentPermissions: request.permissions,
+          }),
+          delegationContext: {
+            depth: 0,
+            maxDepth: 3,
+            visitedAgents: new Set([request.agentName ?? "dev"]),
+            parentAbort: controller.signal,
+          },
+          backgroundManager,
+        });
+
+        const systemTools = systemProvider.listTools();
+        const agentTools = agentProvider.listTools();
+        const proxyTools = mcpProxyProvider.listTools();
+        const availableTools = [...systemTools, ...agentTools, ...proxyTools];
+        const internalTools = WorkerInternalTools.create({
+          runId,
+          sessionId,
+          server,
+          ipcAuthToken,
+          workerId,
+          activeRuns,
+        });
+        const { tools, toolExecutor } = createExecutionToolContext(request, availableTools);
+        const internalToolExecutor = createToolExecutor({
+          tools: internalTools,
+          config: {
+            workspaceRoot,
+            runtime: {
+              sessionId,
+              runId,
+              agentName: request.agentName,
+              workspaceRoot,
+            },
+          },
+        });
+        const internalToolNames = new Set(
+          internalTools.flatMap((tool) => [tool.spec.name, tool.spec.name.replace(/\./g, "_")]),
+        );
+        const combinedToolExecutor = async (call: Tool.Call): Promise<Tool.Result> => {
+          if (internalToolNames.has(call.tool)) return internalToolExecutor(call);
+          if (toolExecutor) return toolExecutor(call);
+          return {
+            id: crypto.randomUUID(),
+            toolCallId: call.id,
+            output: `Unknown worker tool: ${call.tool}`,
+            isError: true,
+          };
+        };
+        const exposedTools = [
+          ...(tools ?? []),
+          ...internalTools.map((tool) => ({
+            ...tool.spec,
+            name: tool.spec.name.replace(/\./g, "_"),
+          })),
+        ];
+
+        toolsRef.tools = exposedTools;
+        toolsRef.toolExecutor = combinedToolExecutor;
+        catalogRef.catalog = buildToolCatalog([
+          { tools: systemTools, source: "system" },
+          { tools: agentTools, source: "agent" },
+          { tools: proxyTools, source: "mcp" },
+        ]);
+
+        const agent = createAgent({
+          model: request.model,
+          auth: resolveAuth(request.model.provider),
+          allowAuthFallback: false,
+          signal: controller.signal,
+          budget: request.budget,
+          systemPrompt: [
+            request.systemPrompt,
+            "Worker runtime tools: use ask_main when you need Resident guidance or approval; use check_inbox to read live messages delivered while this run is active.",
+          ]
+            .filter(Boolean)
+            .join("\n\n"),
+          tools: exposedTools,
+          toolExecutor: combinedToolExecutor,
+          middleware: [
+            createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
+            ...buildWorkerMiddleware({
+              permissions: request.permissions,
+              ...(request.policyPlan ? { policyPlan: request.policyPlan } : {}),
+            }),
+          ],
+        });
+        const runResult = await agent.run({
+          messages,
+          traceContext: { traceId, sessionId, runId },
+        });
+        if (controller.signal.aborted) {
+          notifyWorkerRunCompleted(server, {
+            runId,
+            sessionId,
+            status: "cancelled",
+          });
+          Bus.publish(Subagent.Events.WorkerSessionCancelled, {
+            traceId,
+            sessionId,
+            runId,
+            time: Date.now(),
+            payload: { sessionId, runId },
+          });
+
+          respond({
+            runId,
+            sessionId,
+            status: "cancelled",
+            error: "cancelled by coordinator",
+          });
+          return;
+        }
+
+        notifyWorkerRunCompleted(server, {
+          runId,
+          sessionId,
+          status: "succeeded",
+          output: runResult.text,
+        });
+        Bus.publish(Subagent.Events.WorkerRunCompleted, {
+          traceId,
+          sessionId,
+          runId,
+          time: Date.now(),
+          payload: { sessionId, runId, status: "succeeded" },
+        });
+
+        respond({
+          runId,
+          sessionId,
+          status: "succeeded",
+          output: runResult.text,
+          finishReason: runResult.finishReason,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        const wasCancelled = controller.signal.aborted;
+        if (wasCancelled) {
+          notifyWorkerRunCompleted(server, {
+            runId,
+            sessionId,
+            status: "cancelled",
+            error: errorMessage,
+          });
+          Bus.publish(Subagent.Events.WorkerSessionCancelled, {
+            traceId,
+            sessionId,
+            runId,
+            time: Date.now(),
+            payload: { sessionId, runId },
+          });
+
+          respond({
+            runId,
+            sessionId,
+            status: "cancelled",
+            error: errorMessage,
+          });
+          return;
+        }
+        notifyWorkerRunCompleted(server, {
+          runId,
+          sessionId,
+          status: "failed",
+          error: errorMessage,
+        });
+        Bus.publish(Subagent.Events.WorkerRunFailed, {
+          traceId,
+          sessionId,
+          runId,
+          time: Date.now(),
+          payload: { sessionId, runId, error: errorMessage },
+        });
+
+        respond({
+          runId,
+          sessionId,
+          status: "failed",
+          error: errorMessage,
+        });
+      } finally {
+        activeRuns.delete(runId);
+      }
+    })();
+  }
+}
+
+function notifyWorkerRunCompleted(
+  server: WorkerRunIpcServer,
+  params: Record<string, unknown>,
+): void {
+  try {
+    server.notify("worker.run_completed", params);
+  } catch {
+    // Preserve coordinator response and active-run cleanup if notification fails.
+  }
+}

--- a/apps/server/test/context/integration.test.ts
+++ b/apps/server/test/context/integration.test.ts
@@ -82,16 +82,16 @@ describe("local-runner disabled", () => {
 });
 
 describe("worker-entry wiring", () => {
-  const workerEntrySrc = readFileSync(join(serverSrc, "execution/worker-entry.ts"), "utf-8");
+  const workerRunnerSrc = readFileSync(join(serverSrc, "execution/worker-runner.ts"), "utf-8");
 
-  it("imports createContextMiddleware from context/index", () => {
-    expect(workerEntrySrc).toContain("createContextMiddleware");
-    expect(workerEntrySrc).toContain("../context/index");
+  it("worker runner imports createContextMiddleware from context/index", () => {
+    expect(workerRunnerSrc).toContain("createContextMiddleware");
+    expect(workerRunnerSrc).toContain("../context/index");
   });
 
-  it("uses createContextMiddleware in middleware array", () => {
-    expect(workerEntrySrc).toContain("createContextMiddleware(");
-    expect(workerEntrySrc).toContain("...buildWorkerMiddleware(");
+  it("worker runner uses createContextMiddleware in middleware array", () => {
+    expect(workerRunnerSrc).toContain("createContextMiddleware(");
+    expect(workerRunnerSrc).toContain("...buildWorkerMiddleware(");
   });
 });
 

--- a/apps/server/test/execution/coordinator.test.ts
+++ b/apps/server/test/execution/coordinator.test.ts
@@ -129,4 +129,40 @@ describe("ExecutionCoordinator", () => {
 
     await shutdown;
   });
+
+  test("rejects duplicate run ids without clearing the original active run", async () => {
+    const coordinator = createExecutionCoordinator({
+      workerScript: "unused-in-test",
+      workerCount: 1,
+    });
+
+    const firstRun = coordinator.dispatch(
+      "tree-1",
+      makeRequest({
+        runId: "run-1",
+        sessionId: "session-1",
+        prompt: "long",
+        delayMs: 150,
+      } as never),
+    );
+
+    expect(coordinator.getStats().activeRuns).toBe(1);
+
+    await expect(
+      coordinator.dispatch(
+        "tree-2",
+        makeRequest({ runId: "run-1", sessionId: "session-2", prompt: "duplicate" }),
+      ),
+    ).rejects.toThrow("run already active: run-1");
+
+    expect(coordinator.getStats().activeRuns).toBe(1);
+
+    await expect(firstRun).resolves.toMatchObject({
+      runId: "run-1",
+      sessionId: "session-1",
+      status: "succeeded",
+    });
+
+    expect(coordinator.getStats().activeRuns).toBe(0);
+  });
 });

--- a/apps/server/test/execution/worker-internal-tools.test.ts
+++ b/apps/server/test/execution/worker-internal-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 
 import type { Tool } from "@openomni/protocol";
 import { WorkerInternalTools } from "../../src/execution/worker-internal-tools";
+import type { WorkerRunState } from "../../src/execution/worker-run-state";
 
 function createCall(id: string, tool: string, input: Tool.Call["input"] = {}): Tool.Call {
   return { id, tool, input };
@@ -26,7 +27,7 @@ describe("worker internal tools", () => {
       server: { call: mock(async () => ({ accepted: true, output: "unused" })) },
       ipcAuthToken: "token",
       workerId: "worker-1",
-      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
     });
 
     const result = await getTool(tools, "ask_main").execute(createCall("call-1", "ask_main", {}));
@@ -45,7 +46,7 @@ describe("worker internal tools", () => {
       server: { call: mock(async () => ({ accepted: true, output: "unused" })) },
       ipcAuthToken: "token",
       workerId: "worker-1",
-      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
     });
 
     const result = await getTool(tools, "ask_main").execute(
@@ -67,7 +68,7 @@ describe("worker internal tools", () => {
       server: { call: serverCall },
       ipcAuthToken: "token",
       workerId: "worker-1",
-      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
     });
 
     const result = await getTool(tools, "ask_main").execute(
@@ -95,7 +96,7 @@ describe("worker internal tools", () => {
       server: { call: mock(async () => ({ accepted: false, error: "no" })) },
       ipcAuthToken: "token",
       workerId: "worker-1",
-      activeRuns: new Map<string, WorkerInternalTools.InboxRun>(),
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
     });
 
     const result = await getTool(tools, "ask_main").execute(
@@ -110,10 +111,12 @@ describe("worker internal tools", () => {
   });
 
   it("check_inbox drains queued messages for the active run", async () => {
-    const activeRuns = new Map<string, WorkerInternalTools.InboxRun>([
+    const activeRuns = new Map<string, WorkerRunState.ActiveRun>([
       [
         "run-1",
         {
+          sessionId: "session-1",
+          controller: new AbortController(),
           inbox: ["hello", "world"],
         },
       ],

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
 import { WorkerIpcHandlers } from "../../src/execution/worker-ipc-handlers";
+import type { WorkerRunState } from "../../src/execution/worker-run-state";
 
-function createRun(sessionId: string, inbox: string[] = []): WorkerIpcHandlers.ActiveRun {
+function createRun(sessionId: string, inbox: string[] = []): WorkerRunState.ActiveRun {
   return { sessionId, controller: new AbortController(), inbox };
 }
 

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentResult } from "@openomni/agent";
+import { BackgroundManager } from "@openomni/openomni";
+
+import type { WorkerRunState } from "../../src/execution/worker-run-state";
+import { WorkerRunner } from "../../src/execution/worker-runner";
+
+const successfulResult: AgentResult = {
+  text: "done",
+  steps: [],
+  usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+  finishReason: "stop",
+};
+
+function createSpawnOptions(
+  params: Record<string, unknown> | undefined,
+  respond: (result: unknown) => void,
+  overrides: Partial<WorkerRunner.Environment> = {},
+): WorkerRunner.SpawnRunOptions {
+  const activeRuns = overrides.activeRuns ?? new Map();
+  return {
+    params,
+    ipcAuthToken: "token",
+    workerId: "worker-1",
+    server: {
+      async call() {
+        throw new Error("unexpected server call");
+      },
+      notify() {
+        throw new Error("unexpected server notification");
+      },
+    },
+    activeRuns,
+    bootstrapReady: Promise.resolve(),
+    backgroundManager: BackgroundManager.create({
+      maxConcurrentPerAgent: 1,
+      maxConcurrentTotal: 1,
+      maxDepth: 1,
+      resolveAuth: () => undefined,
+      allowAuthFallback: false,
+    }),
+    defaultWorkspaceRoot: undefined,
+    getBootstrap: () => null,
+    resolveAuth: () => undefined,
+    respond,
+    ...overrides,
+  };
+}
+
+function createValidRequest(): Record<string, unknown> {
+  return {
+    authToken: "token",
+    runId: "run-1",
+    sessionId: "session-1",
+    mode: "direct",
+    prompt: "hello",
+    model: { provider: "test", id: "test" },
+  };
+}
+
+describe("WorkerRunner", () => {
+  it("rejects unauthorized spawn requests without starting a run", () => {
+    const responses: unknown[] = [];
+    const options = createSpawnOptions(
+      {
+        authToken: "wrong",
+        runId: "run-1",
+        sessionId: "session-1",
+      },
+      (result) => responses.push(result),
+    );
+
+    WorkerRunner.spawnRun(options);
+
+    expect(responses).toEqual([
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        status: "failed",
+        error: "unauthorized coordinator request",
+      },
+    ]);
+    expect(options.activeRuns.size).toBe(0);
+  });
+
+  it("rejects malformed spawn requests before starting a run", () => {
+    const responses: unknown[] = [];
+    const options = createSpawnOptions(
+      {
+        authToken: "token",
+        runId: "run-1",
+        sessionId: "session-1",
+      },
+      (result) => responses.push(result),
+    );
+
+    WorkerRunner.spawnRun(options);
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      runId: "run-1",
+      sessionId: "session-1",
+      status: "failed",
+    });
+    expect(options.activeRuns.size).toBe(0);
+  });
+
+  it("rejects duplicate run ids without replacing the active run", () => {
+    const responses: unknown[] = [];
+    const existingRun: WorkerRunState.ActiveRun = {
+      sessionId: "session-1",
+      controller: new AbortController(),
+      inbox: ["existing"],
+    };
+    const activeRuns = new Map([["run-1", existingRun]]);
+    const options = createSpawnOptions(createValidRequest(), (result) => responses.push(result), {
+      activeRuns,
+    });
+
+    WorkerRunner.spawnRun(options);
+
+    expect(responses).toEqual([
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        status: "failed",
+        error: "run already active: run-1",
+      },
+    ]);
+    expect(activeRuns.get("run-1")).toBe(existingRun);
+  });
+
+  it("reports failed runs and cleans state when start notification fails", async () => {
+    const responses: unknown[] = [];
+    const activeRuns = new Map();
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        createValidRequest(),
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          activeRuns,
+          server: {
+            async call() {
+              throw new Error("unexpected server call");
+            },
+            notify() {
+              throw new Error("notify failed");
+            },
+          },
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    await responseReceived;
+
+    expect(responses).toEqual([
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        status: "failed",
+        error: "notify failed",
+      },
+    ]);
+    expect(activeRuns.size).toBe(0);
+  });
+
+  it("runs valid spawn requests and cleans active run state after success", async () => {
+    const responses: unknown[] = [];
+    const notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];
+    const activeRuns = new Map();
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        createValidRequest(),
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          activeRuns,
+          server: {
+            async call() {
+              throw new Error("unexpected server call");
+            },
+            notify(method, params) {
+              notifications.push({ method, params });
+            },
+          },
+          createAgent: () => ({
+            async run(input) {
+              expect(activeRuns.get("run-1")?.sessionId).toBe("session-1");
+              expect(input.traceContext).toEqual({
+                traceId: expect.any(String),
+                sessionId: "session-1",
+                runId: "run-1",
+              });
+              return successfulResult;
+            },
+          }),
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    await responseReceived;
+
+    expect(responses).toEqual([
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        status: "succeeded",
+        output: "done",
+        finishReason: "stop",
+      },
+    ]);
+    expect(notifications).toEqual([
+      { method: "worker.run_started", params: { runId: "run-1", sessionId: "session-1" } },
+      {
+        method: "worker.run_completed",
+        params: { runId: "run-1", sessionId: "session-1", status: "succeeded", output: "done" },
+      },
+    ]);
+    expect(activeRuns.size).toBe(0);
+  });
+
+  it("reports failed runs and cleans active run state after agent errors", async () => {
+    const responses: unknown[] = [];
+    const notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];
+    const activeRuns = new Map();
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        createValidRequest(),
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          activeRuns,
+          server: {
+            async call() {
+              throw new Error("unexpected server call");
+            },
+            notify(method, params) {
+              notifications.push({ method, params });
+            },
+          },
+          createAgent: () => ({
+            async run() {
+              throw new Error("agent failed");
+            },
+          }),
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    await responseReceived;
+
+    expect(responses).toEqual([
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        status: "failed",
+        error: "agent failed",
+      },
+    ]);
+    expect(notifications).toEqual([
+      { method: "worker.run_started", params: { runId: "run-1", sessionId: "session-1" } },
+      {
+        method: "worker.run_completed",
+        params: {
+          runId: "run-1",
+          sessionId: "session-1",
+          status: "failed",
+          error: "agent failed",
+        },
+      },
+    ]);
+    expect(activeRuns.size).toBe(0);
+  });
+});

--- a/packages/coordinator/src/worker-manager/manager.ts
+++ b/packages/coordinator/src/worker-manager/manager.ts
@@ -100,6 +100,9 @@ export class OnDemandWorkerManager implements WorkerManager {
     if (this.stopping) {
       throw new Error("worker manager is shutting down");
     }
+    if (this.activeRuns.has(runId)) {
+      throw new Error(`run already active: ${runId}`);
+    }
 
     const activeRun: ActiveRun = { sessionId };
     this.activeRuns.set(runId, activeRun);

--- a/packages/coordinator/test/worker-manager/manager.test.ts
+++ b/packages/coordinator/test/worker-manager/manager.test.ts
@@ -158,6 +158,86 @@ describe("on-demand WorkerManager", () => {
     });
   });
 
+  test("rejects duplicate run ids across concurrent sessions before worker delivery", async () => {
+    manager = createWorkerManager({
+      workerScript: WORKER_ENTRY,
+      socketDir: makeSocketDir("dup-diff"),
+      maxActiveWorkers: 2,
+      idleShutdownMs: 1_000,
+    });
+
+    const first = manager.dispatch("duplicate-session-a", "run-duplicate", {
+      delayMs: 100,
+      prompt: "test",
+    });
+    await expect(
+      manager.dispatch("duplicate-session-b", "run-duplicate", {
+        delayMs: 100,
+        prompt: "test",
+      }),
+    ).rejects.toThrow("run already active: run-duplicate");
+
+    await expect(first).resolves.toMatchObject({
+      runId: "run-duplicate",
+      sessionId: "duplicate-session-a",
+    });
+  });
+
+  test("rejects duplicate run ids for the same session while the original is active", async () => {
+    manager = createWorkerManager({
+      workerScript: WORKER_ENTRY,
+      socketDir: makeSocketDir("dup-same"),
+      maxActiveWorkers: 1,
+      idleShutdownMs: 1_000,
+    });
+
+    const first = manager.dispatch("duplicate-session", "run-duplicate-same-session", {
+      delayMs: 100,
+      prompt: "test",
+    });
+    await waitFor(() => manager?.getStats().activeRuns === 1);
+
+    await expect(
+      manager.dispatch("duplicate-session", "run-duplicate-same-session", {
+        prompt: "test",
+      }),
+    ).rejects.toThrow("run already active: run-duplicate-same-session");
+    expect(manager.getStats().activeRuns).toBe(1);
+
+    await first;
+  });
+
+  test("duplicate run rejection preserves cancellation for the original run", async () => {
+    process.env.OPENOMNI_WORKER_BOOTSTRAP_DELAY_MS = "250";
+    manager = createWorkerManager({
+      workerScript: WORKER_ENTRY,
+      socketDir: makeSocketDir("dup-cancel"),
+      maxActiveWorkers: 1,
+      idleShutdownMs: 1_000,
+    });
+
+    const original = manager.dispatch("duplicate-cancel-session", "run-duplicate-cancel", {
+      prompt: "test",
+    });
+    await waitFor(() => manager?.getStats().activeRuns === 1);
+
+    await expect(
+      manager.dispatch("other-session", "run-duplicate-cancel", {
+        prompt: "test",
+      }),
+    ).rejects.toThrow("run already active: run-duplicate-cancel");
+    await expect(manager.cancelRun("run-duplicate-cancel")).resolves.toMatchObject({
+      cancelled: true,
+      runId: "run-duplicate-cancel",
+      sessionId: "duplicate-cancel-session",
+    });
+    await expect(original).resolves.toMatchObject({
+      status: "cancelled",
+      runId: "run-duplicate-cancel",
+      sessionId: "duplicate-cancel-session",
+    });
+  });
+
   test("times out queued dispatches when all workers stay busy", async () => {
     manager = createWorkerManager({
       workerScript: WORKER_ENTRY,


### PR DESCRIPTION
## Summary

Split worker spawn-run execution out of the worker entrypoint into a dedicated runner module while preserving lifecycle behavior. This keeps the entrypoint focused on process setup and IPC routing, centralizes active-run state, and hardens duplicate-run accounting at the worker, manager, and coordinator boundaries.

Fixes #
Relates to #

## Changes

- Add `WorkerRunner.spawnRun()` for `coordinator.spawn_run` handling.
- Add `worker-run-state.ts` as the neutral active-run state contract used by runner, IPC handlers, and internal tools.
- Keep `worker-entry.ts` responsible for bootstrap/setup and delegate spawn-run handling to the runner.
- Reject duplicate active `runId`s before replacing worker, manager, or coordinator run state.
- Keep worker run-start side effects inside guarded cleanup and make terminal worker notifications best-effort so cleanup and responses still run.
- Add regression tests for unauthorized/malformed requests, duplicate run IDs, notification-failure cleanup, success cleanup, and failure cleanup.
- Retarget existing context wiring checks to the new runner module.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [x] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

Validation:

- `git diff --check`
- `bun run build`
- `bun run check-types`
- `bun run script/check-deps.ts`
- `bun run lint`
- `bun test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized worker run execution via a dedicated runner with clearer lifecycle events and notifications.

* **Bug Fixes**
  * Reject duplicate run IDs early to prevent concurrent duplicate executions.
  * Stronger validation and clearer error reporting for spawn/startup and coordinator-triggered runs.

* **Refactor**
  * Internal run-state and active-run handling consolidated into a shared run-state model.

* **Tests**
  * Expanded tests for spawn failures, duplicate-run scenarios, cancellation, and run completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->