### PR TITLE
refactor(server): split worker bootstrap handling

### DIFF
--- a/apps/server/src/execution/worker-bootstrap-handler.ts
+++ b/apps/server/src/execution/worker-bootstrap-handler.ts
@@ -1,0 +1,137 @@
+import { AgentRegistry } from "@openomni/agent";
+import type { Auth } from "@openomni/llm";
+import { Operational, WorkerBootstrap } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+export namespace WorkerBootstrapHandler {
+  export interface ServerPort {
+    useConnection(id: string): void;
+    notify(method: string, params?: Record<string, unknown>): void;
+  }
+
+  export interface State {
+    readonly ready: Promise<void>;
+    getBootstrap(): WorkerBootstrap.Bootstrap | null;
+    resolveAuth(provider: string): Auth.Info | undefined;
+  }
+
+  export interface CreateStateOptions {
+    readonly onBootstrap?: (bootstrap: WorkerBootstrap.Bootstrap) => void;
+  }
+
+  export interface HandleOptions {
+    readonly params: Record<string, unknown> | undefined;
+    readonly ipcAuthToken: string;
+    readonly workerId: string;
+    readonly server: ServerPort;
+    readonly connectionId: string;
+    readonly respond: (result: unknown) => void;
+    readonly state: MutableState;
+  }
+
+  export interface MutableState extends State {
+    setBootstrap(bootstrap: WorkerBootstrap.Bootstrap): void;
+    markReady(): void;
+    rejectReady(error: Error): void;
+  }
+
+  export function createState(options: CreateStateOptions = {}): MutableState {
+    let bootstrap: WorkerBootstrap.Bootstrap | null = null;
+    let resolveReady: () => void = () => undefined;
+    let rejectReady: (_error: Error) => void = () => undefined;
+
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+
+    return {
+      ready,
+      getBootstrap: () => bootstrap,
+      resolveAuth: (provider) => resolveBootstrapAuth(bootstrap, provider),
+      setBootstrap(nextBootstrap) {
+        bootstrap = nextBootstrap;
+        options.onBootstrap?.(nextBootstrap);
+      },
+      markReady() {
+        resolveReady();
+      },
+      rejectReady,
+    } satisfies MutableState;
+  }
+
+  export function handleBootstrap(options: HandleOptions): void {
+    if (options.params?.authToken !== options.ipcAuthToken) {
+      options.respond({ ok: false, error: "unauthorized" });
+      return;
+    }
+
+    try {
+      const bootstrap = WorkerBootstrap.Bootstrap.parse(options.params.bootstrap);
+      options.state.setBootstrap(bootstrap);
+      AgentRegistry.replaceAll(
+        bootstrap.agents.map((agent) => ({
+          name: agent.name,
+          description: agent.description,
+          model: agent.model,
+          systemPrompt: agent.systemPrompt,
+          tools: agent.tools.allow ?? [],
+          permissions: agent.permissions,
+          budget: agent.budget,
+        })),
+      );
+      options.server.useConnection(options.connectionId);
+      options.state.markReady();
+      options.server.notify("worker.bootstrap_ready", {
+        workerId: options.workerId,
+        authToken: options.ipcAuthToken,
+      });
+      Bus.publish(Operational.Info, {
+        traceId: crypto.randomUUID(),
+        time: Date.now(),
+        component: "server",
+        msg: "worker bootstrap received",
+        context: {
+          workerId: options.workerId,
+          agents: bootstrap.agents.length,
+          mcpTools: bootstrap.toolCatalog.length,
+        },
+      });
+      options.respond({ ok: true });
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      options.state.rejectReady(error);
+      options.respond({ ok: false, error: error.message });
+      Bus.publish(Operational.Error, {
+        traceId: crypto.randomUUID(),
+        time: Date.now(),
+        component: "server",
+        msg: "worker bootstrap failed",
+        context: {
+          workerId: options.workerId,
+          err: error.message,
+        },
+      });
+    }
+  }
+
+  function resolveBootstrapAuth(
+    bootstrap: WorkerBootstrap.Bootstrap | null,
+    provider: string,
+  ): Auth.Info | undefined {
+    const credentials = bootstrap?.credentials;
+    if (!credentials) return undefined;
+
+    const prefix = provider.toUpperCase();
+    const apiKey = credentials[`${prefix}_API_KEY`];
+    const baseURL = credentials[`${prefix}_BASE_URL`];
+
+    if (baseURL) {
+      return { type: "proxy", baseURL, ...(apiKey ? { apiKey } : {}) };
+    }
+    if (apiKey) {
+      return { type: "api", key: apiKey };
+    }
+    return undefined;
+  }
+}

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -1,10 +1,9 @@
-import { AgentRegistry } from "@openomni/agent";
-import type { Auth } from "@openomni/llm";
 import { createIpcServer } from "@openomni/coordinator";
-import { Operational, WorkerBootstrap } from "@openomni/protocol";
+import { Operational } from "@openomni/protocol";
 import { initialize, Bus, BusPersistence } from "@openomni/session";
 import { BackgroundManager } from "@openomni/openomni";
 import { loadConfig } from "../config";
+import { WorkerBootstrapHandler } from "./worker-bootstrap-handler";
 import { resolveWorkerDbPath } from "./worker-runtime";
 import { WorkerHeartbeat } from "./worker-heartbeat";
 import { WorkerIpcHandlers } from "./worker-ipc-handlers";
@@ -47,20 +46,14 @@ initialize({
 });
 BusPersistence.start();
 
-let workerBootstrap: WorkerBootstrap.Bootstrap | null = null;
 const activeRuns: WorkerRunState.ActiveRunRegistry = new Map();
-let resolveBootstrapReady: () => void = () => undefined;
-let rejectBootstrapReady: (_error: Error) => void = () => undefined;
-const bootstrapReady = new Promise<void>((resolve, reject) => {
-  resolveBootstrapReady = resolve;
-  rejectBootstrapReady = reject;
-});
+const workerBootstrapState = WorkerBootstrapHandler.createState();
 
 const backgroundManager = BackgroundManager.create({
   maxConcurrentPerAgent: 3,
   maxConcurrentTotal: 10,
   maxDepth: 3,
-  resolveAuth: resolveBootstrapAuth,
+  resolveAuth: workerBootstrapState.resolveAuth,
   allowAuthFallback: false,
 });
 
@@ -71,73 +64,17 @@ async function shutdownWorker(exitCode: number): Promise<never> {
   process.exit(exitCode);
 }
 
-function resolveBootstrapAuth(provider: string): Auth.Info | undefined {
-  const credentials = workerBootstrap?.credentials;
-  if (!credentials) return undefined;
-
-  const prefix = provider.toUpperCase();
-  const apiKey = credentials[`${prefix}_API_KEY`];
-  const baseURL = credentials[`${prefix}_BASE_URL`];
-
-  if (baseURL) {
-    return { type: "proxy", baseURL, ...(apiKey ? { apiKey } : {}) };
-  }
-  if (apiKey) {
-    return { type: "api", key: apiKey };
-  }
-  return undefined;
-}
-
 const server = createIpcServer(socketPath, (method, params, respond, _notify, connectionId) => {
   if (method === "coordinator.bootstrap") {
-    if (params?.authToken !== ipcAuthToken) {
-      respond({ ok: false, error: "unauthorized" });
-      return;
-    }
-
-    try {
-      const bootstrap = WorkerBootstrap.Bootstrap.parse(params.bootstrap);
-      workerBootstrap = bootstrap;
-      const agentDefs = bootstrap.agents.map((agent) => ({
-        name: agent.name,
-        description: agent.description,
-        model: agent.model,
-        systemPrompt: agent.systemPrompt,
-        tools: agent.tools.allow ?? [],
-        permissions: agent.permissions,
-        budget: agent.budget,
-      }));
-      AgentRegistry.replaceAll(agentDefs);
-      server.useConnection(connectionId);
-      resolveBootstrapReady();
-      server.notify("worker.bootstrap_ready", { workerId, authToken: ipcAuthToken });
-      Bus.publish(Operational.Info, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "server",
-        msg: "worker bootstrap received",
-        context: {
-          workerId,
-          agents: bootstrap.agents.length,
-          mcpTools: bootstrap.toolCatalog.length,
-        },
-      });
-      respond({ ok: true });
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      rejectBootstrapReady(error);
-      respond({ ok: false, error: error.message });
-      Bus.publish(Operational.Error, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "server",
-        msg: "worker bootstrap failed",
-        context: {
-          workerId,
-          err: error.message,
-        },
-      });
-    }
+    WorkerBootstrapHandler.handleBootstrap({
+      params,
+      ipcAuthToken,
+      workerId,
+      server,
+      connectionId,
+      respond,
+      state: workerBootstrapState,
+    });
   } else if (method === "coordinator.spawn_run") {
     WorkerRunner.spawnRun({
       params,
@@ -145,11 +82,11 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
       workerId,
       server,
       activeRuns,
-      bootstrapReady,
+      bootstrapReady: workerBootstrapState.ready,
       backgroundManager,
       defaultWorkspaceRoot: config.workspace?.root,
-      getBootstrap: () => workerBootstrap,
-      resolveAuth: resolveBootstrapAuth,
+      getBootstrap: workerBootstrapState.getBootstrap,
+      resolveAuth: workerBootstrapState.resolveAuth,
       respond,
     });
   } else if (method === "coordinator.cancel_run") {
@@ -174,7 +111,7 @@ WorkerHeartbeat.start({
   ipcAuthToken,
   server,
   getActiveRunIds: () => [...activeRuns.keys()],
-  getConfigEpoch: () => workerBootstrap?.configEpoch ?? "",
+  getConfigEpoch: () => workerBootstrapState.getBootstrap()?.configEpoch ?? "",
 });
 
 process.on("SIGTERM", async () => {
@@ -188,5 +125,3 @@ Bus.publish(Operational.Info, {
   msg: "worker started",
   context: { workerId, pid: process.pid, socketPath },
 });
-
-export { workerBootstrap };

--- a/apps/server/test/execution/worker-bootstrap-handler.test.ts
+++ b/apps/server/test/execution/worker-bootstrap-handler.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { AgentRegistry } from "@openomni/agent";
+import { z } from "zod";
+
+import { WorkerBootstrapHandler } from "../../src/execution/worker-bootstrap-handler";
+
+const NotificationRecord = z.object({
+  method: z.string(),
+  params: z.record(z.string(), z.unknown()).optional(),
+});
+type NotificationRecord = z.infer<typeof NotificationRecord>;
+
+function createServer() {
+  const usedConnections: string[] = [];
+  const notifications: NotificationRecord[] = [];
+
+  return {
+    usedConnections,
+    notifications,
+    server: {
+      useConnection(id: string) {
+        usedConnections.push(id);
+      },
+      notify(method: string, params?: Record<string, unknown>) {
+        notifications.push({ method, params });
+      },
+    } satisfies WorkerBootstrapHandler.ServerPort,
+  };
+}
+
+describe("worker bootstrap handler", () => {
+  afterEach(() => {
+    AgentRegistry.clear();
+  });
+
+  it("rejects unauthorized bootstrap requests without mutating state", () => {
+    const state = WorkerBootstrapHandler.createState();
+    const { server, usedConnections, notifications } = createServer();
+    const responses: unknown[] = [];
+
+    WorkerBootstrapHandler.handleBootstrap({
+      params: { authToken: "wrong", bootstrap: {} },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      server,
+      connectionId: "conn-1",
+      respond: (result) => responses.push(result),
+      state,
+    });
+
+    expect(responses).toEqual([{ ok: false, error: "unauthorized" }]);
+    expect(state.getBootstrap()).toBeNull();
+    expect(state.resolveAuth("openai")).toBeUndefined();
+    expect(usedConnections).toEqual([]);
+    expect(notifications).toEqual([]);
+  });
+
+  it("stores valid bootstrap data, marks readiness, and exposes scoped auth", async () => {
+    let mirroredEpoch: string | undefined;
+    const state = WorkerBootstrapHandler.createState({
+      onBootstrap: (bootstrap) => {
+        mirroredEpoch = bootstrap.configEpoch;
+      },
+    });
+    const { server, usedConnections, notifications } = createServer();
+    const responses: unknown[] = [];
+
+    WorkerBootstrapHandler.handleBootstrap({
+      params: {
+        authToken: "token",
+        bootstrap: {
+          configEpoch: "epoch-1",
+          agents: [
+            {
+              name: "planner",
+              description: "Plans work",
+              systemPrompt: "Plan carefully",
+              tools: { allow: ["read"] },
+            },
+          ],
+          toolCatalog: [],
+          credentials: {
+            OPENAI_API_KEY: "openai-key",
+            ANTHROPIC_BASE_URL: "https://anthropic.example",
+            ANTHROPIC_API_KEY: "anthropic-key",
+          },
+        },
+      },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      server,
+      connectionId: "conn-1",
+      respond: (result) => responses.push(result),
+      state,
+    });
+
+    await state.ready;
+
+    expect(responses).toEqual([{ ok: true }]);
+    expect(state.getBootstrap()?.configEpoch).toBe("epoch-1");
+    expect(AgentRegistry.get("planner")).toMatchObject({
+      name: "planner",
+      description: "Plans work",
+      systemPrompt: "Plan carefully",
+      tools: ["read"],
+    });
+    expect(mirroredEpoch).toBe("epoch-1");
+    expect(state.resolveAuth("openai")).toEqual({ type: "api", key: "openai-key" });
+    expect(state.resolveAuth("anthropic")).toEqual({
+      type: "proxy",
+      baseURL: "https://anthropic.example",
+      apiKey: "anthropic-key",
+    });
+    expect(usedConnections).toEqual(["conn-1"]);
+    expect(notifications).toEqual([
+      {
+        method: "worker.bootstrap_ready",
+        params: { workerId: "worker-1", authToken: "token" },
+      },
+    ]);
+  });
+
+  it("reports parse failures and rejects readiness", async () => {
+    const state = WorkerBootstrapHandler.createState();
+    const { server } = createServer();
+    const responses: unknown[] = [];
+
+    WorkerBootstrapHandler.handleBootstrap({
+      params: {
+        authToken: "token",
+        bootstrap: { configEpoch: "epoch-1", agents: "not-an-array", toolCatalog: [] },
+      },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      server,
+      connectionId: "conn-1",
+      respond: (result) => responses.push(result),
+      state,
+    });
+
+    await expect(state.ready).rejects.toThrow();
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({ ok: false });
+    expect(state.getBootstrap()).toBeNull();
+  });
+
+  it("does not mark readiness when connection activation fails", async () => {
+    const state = WorkerBootstrapHandler.createState();
+    const responses: unknown[] = [];
+
+    WorkerBootstrapHandler.handleBootstrap({
+      params: {
+        authToken: "token",
+        bootstrap: { configEpoch: "epoch-1", agents: [], toolCatalog: [] },
+      },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      server: {
+        useConnection() {
+          throw new Error("connection closed");
+        },
+        notify() {
+          expect.unreachable("bootstrap_ready should not be sent after activation fails");
+        },
+      },
+      connectionId: "conn-1",
+      respond: (result) => responses.push(result),
+      state,
+    });
+
+    await expect(state.ready).rejects.toThrow("connection closed");
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({ ok: false, error: "connection closed" });
+  });
+});


### PR DESCRIPTION
## Summary

Split worker bootstrap handling out of the worker entrypoint into a dedicated handler module while preserving behavior. This keeps `worker-entry.ts` focused on process setup and IPC routing, and gives bootstrap parsing, readiness, agent registry loading, and credential resolution focused coverage.

Fixes #
Relates to #

## Changes

- Add `WorkerBootstrapHandler` for `coordinator.bootstrap` request handling.
- Move bootstrap readiness state and provider credential resolution into the bootstrap handler.
- Keep `worker-entry.ts` responsible for process setup, IPC routing, heartbeat, and shutdown wiring.
- Read heartbeat config epoch from the bootstrap state object directly.
- Add regression tests for unauthorized bootstrap requests, successful bootstrap/auth resolution, agent registry loading, and parse failures.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

Validation:

- `git diff --check`
- `bun run build`
- `bun run check-types`
- `bun run script/check-deps.ts`
- `bun run lint`
- `bun test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split worker bootstrap logic into a dedicated `WorkerBootstrapHandler`, keeping `worker-entry.ts` focused on IPC, heartbeat, and shutdown. The handler now validates auth, parses bootstrap, resolves provider auth (API or proxy), updates the agent registry, claims the connection, and handles Operational logging.

- **Refactors**
  - Added `WorkerBootstrapHandler` with `createState` (ready, `getBootstrap`, `resolveAuth`, optional `onBootstrap`) and `handleBootstrap`.
  - `worker-entry.ts` delegates bootstrap, spawn-run dependencies, and heartbeat `configEpoch` to handler state; `BackgroundManager` uses the handler’s `resolveAuth`.
  - Handler validates IPC auth, updates `AgentRegistry`, claims the IPC connection, sends `worker.bootstrap_ready`, and publishes `Operational.Info/Error`.
  - Added tests for unauthorized requests, successful bootstrap/auth (API and proxy), agent registry loading, parse failures, and connection activation failure.

<sup>Written for commit 0050f60a1abb30abd3eb1a627d7b2138811e2278. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized worker bootstrap handling and state management for clearer startup flow and readiness coordination.
  * Delegated bootstrap responsibilities away from the entrypoint to streamline initialization.
* **Bug Fixes**
  * Improved handling of unauthorized or malformed bootstrap requests; startup readiness now reliably rejects on failure.
  * Ensures server notifications and connection activation occur only after successful bootstrap.
* **Tests**
  * Added tests covering successful bootstrap, failure paths, auth resolution, readiness and notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->