### PR TITLE
fix(openomni): abort timed-out tool executions

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -166,8 +166,11 @@ export async function main(): Promise<void> {
     workerScript,
     bootstrap,
     toolDispatcher,
-    askResident: async ({ workerId, sessionId, runId, question }) => {
+    askResident: async ({ workerId, sessionId, runId, question, signal }) => {
       const requestId = crypto.randomUUID();
+      if (signal?.aborted) {
+        return { requestId, accepted: false, error: "worker.ask_main aborted" };
+      }
       if (!model) {
         return { requestId, accepted: false, error: "worker.ask_main requires a configured model" };
       }
@@ -200,6 +203,7 @@ export async function main(): Promise<void> {
           runtime: {
             durableSessionId: mainSessionId,
             lifecycle: "active",
+            ...(signal ? { signal } : {}),
           },
           target: { kind: "resident" },
           meta: {

--- a/apps/server/src/execution/coordinator.ts
+++ b/apps/server/src/execution/coordinator.ts
@@ -35,9 +35,7 @@ export function buildToolDispatcher(providers: ToolProvider[]): Map<string, Tool
       if (dispatcher.has(canonicalName)) {
         throw new Error(`Duplicate tool in dispatcher: "${canonicalName}"`);
       }
-      dispatcher.set(canonicalName, (call, context) =>
-        context === undefined ? provider.execute(call) : provider.execute(call, context),
-      );
+      dispatcher.set(canonicalName, (call, context) => provider.execute(call, context));
     }
   }
 

--- a/apps/server/src/execution/coordinator.ts
+++ b/apps/server/src/execution/coordinator.ts
@@ -3,11 +3,17 @@ import {
   createWorkerManager,
   type AskMainParams,
   type AskMainResult,
+  type ToolCallContext,
   type WorkerManager,
   recoverInterruptedRuns as _recoverInterruptedRuns,
   type RecoveryResult,
 } from "@openomni/coordinator";
-import type { ToolProvider } from "@openomni/openomni";
+import type { ToolExecutionContext, ToolProvider } from "@openomni/openomni";
+
+export type ToolDispatchHandler = (
+  call: Tool.Call,
+  context?: ToolExecutionContext,
+) => Promise<Tool.Result>;
 
 export type CoordinatorConfig = {
   workerScript: string;
@@ -16,14 +22,12 @@ export type CoordinatorConfig = {
   workerIdleTimeoutMs?: number;
   socketDir?: string;
   bootstrap?: WorkerBootstrap.Bootstrap;
-  toolDispatcher?: Map<string, (call: Tool.Call) => Promise<Tool.Result>>;
+  toolDispatcher?: Map<string, ToolDispatchHandler>;
   askResident?: (params: AskMainParams) => Promise<AskMainResult>;
 };
 
-export function buildToolDispatcher(
-  providers: ToolProvider[],
-): Map<string, (call: Tool.Call) => Promise<Tool.Result>> {
-  const dispatcher = new Map<string, (call: Tool.Call) => Promise<Tool.Result>>();
+export function buildToolDispatcher(providers: ToolProvider[]): Map<string, ToolDispatchHandler> {
+  const dispatcher = new Map<string, ToolDispatchHandler>();
 
   for (const provider of providers) {
     for (const tool of provider.listTools()) {
@@ -31,7 +35,9 @@ export function buildToolDispatcher(
       if (dispatcher.has(canonicalName)) {
         throw new Error(`Duplicate tool in dispatcher: "${canonicalName}"`);
       }
-      dispatcher.set(canonicalName, (call) => provider.execute(call));
+      dispatcher.set(canonicalName, (call, context) =>
+        context === undefined ? provider.execute(call) : provider.execute(call, context),
+      );
     }
   }
 
@@ -68,7 +74,7 @@ export function createExecutionCoordinator(config: CoordinatorConfig): Execution
     bootstrap: config.bootstrap,
     onAskMain: config.askResident,
     onToolCall: toolDispatcher
-      ? async (params) => {
+      ? async (params, context?: ToolCallContext) => {
           const call: Tool.Call = {
             id: params.callId,
             tool: params.tool,
@@ -83,7 +89,7 @@ export function createExecutionCoordinator(config: CoordinatorConfig): Execution
               isError: true,
             };
           }
-          const result = await handler(call);
+          const result = await handler(call, context);
           return {
             id: result.id,
             toolCallId: result.toolCallId,

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -102,6 +102,10 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
       }, 0);
     }
   } else if (method === "worker.tool_call_settled") {
+    if (params?.authToken !== ipcAuthToken) {
+      respond({ acknowledged: false, error: "unauthorized coordinator request" });
+      return;
+    }
     if (typeof params?.workspaceRoot === "string" && typeof params.callId === "string") {
       WorkspaceLock.clearUnsafe(params.workspaceRoot, params.callId);
     }

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -102,14 +102,13 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
       }, 0);
     }
   } else if (method === "worker.tool_call_settled") {
-    if (params?.authToken !== ipcAuthToken) {
-      respond({ acknowledged: false, error: "unauthorized coordinator request" });
-      return;
-    }
-    if (typeof params?.workspaceRoot === "string" && typeof params.callId === "string") {
-      WorkspaceLock.clearUnsafe(params.workspaceRoot, params.callId);
-    }
-    respond({ acknowledged: true });
+    respond(
+      WorkerIpcHandlers.toolCallSettled({
+        params,
+        ipcAuthToken,
+        clearUnsafe: WorkspaceLock.clearUnsafe,
+      }),
+    );
   } else {
     respond({ ok: true });
   }

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -1,7 +1,7 @@
 import { createIpcServer } from "@openomni/coordinator";
 import { Operational } from "@openomni/protocol";
 import { initialize, Bus, BusPersistence } from "@openomni/session";
-import { BackgroundManager } from "@openomni/openomni";
+import { BackgroundManager, WorkspaceLock } from "@openomni/openomni";
 import { loadConfig } from "../config";
 import { WorkerBootstrapHandler } from "./worker-bootstrap-handler";
 import { resolveWorkerDbPath } from "./worker-runtime";
@@ -101,6 +101,11 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
         void shutdownWorker(0);
       }, 0);
     }
+  } else if (method === "worker.tool_call_settled") {
+    if (typeof params?.workspaceRoot === "string" && typeof params.callId === "string") {
+      WorkspaceLock.clearUnsafe(params.workspaceRoot, params.callId);
+    }
+    respond({ acknowledged: true });
   } else {
     respond({ ok: true });
   }

--- a/apps/server/src/execution/worker-internal-tools.ts
+++ b/apps/server/src/execution/worker-internal-tools.ts
@@ -5,7 +5,11 @@ import type { WorkerRunState } from "./worker-run-state";
 
 export namespace WorkerInternalTools {
   export const Server = z.custom<{
-    call(method: "worker.ask_main", params: Record<string, unknown>): Promise<unknown>;
+    call(
+      method: "worker.ask_main" | "worker.ask_main_cancel",
+      params: Record<string, unknown>,
+      timeoutMs?: number,
+    ): Promise<unknown>;
   }>(
     (value) =>
       typeof value === "object" &&
@@ -51,11 +55,21 @@ export namespace WorkerInternalTools {
       },
       source: "server",
       category: "delegation",
-      riskTier: 1,
-      isReadOnly: false,
+      labels: ["authority.read", "human-attention", "resident-consult"],
+      descriptor: {
+        id: "tool:server:ask_main",
+        kind: "tool",
+        source: { type: "server" },
+        labels: ["authority.read", "human-attention", "resident-consult"],
+        capabilities: ["resident.consult", "human-attention"],
+        effects: ["authority.request"],
+        risk: 0,
+      },
+      riskTier: 0,
+      isReadOnly: true,
       isDestructive: false,
       isConcurrencySafe: false,
-      async execute(call) {
+      async execute(call, context) {
         const question = readQuestion(call);
         if (!question) {
           return {
@@ -66,13 +80,46 @@ export namespace WorkerInternalTools {
           };
         }
 
-        const raw = await server.call("worker.ask_main", {
-          authToken: ipcAuthToken,
-          workerId,
-          sessionId,
-          runId,
-          question,
-        });
+        if (context?.signal?.aborted) return askMainAbortedResult(call);
+
+        const cancelAskMain = () => {
+          void server
+            .call(
+              "worker.ask_main_cancel",
+              {
+                authToken: ipcAuthToken,
+                workerId,
+                sessionId,
+                runId,
+                callId: call.id,
+              },
+              5_000,
+            )
+            .catch(() => undefined);
+        };
+        context?.signal?.addEventListener("abort", cancelAskMain, { once: true });
+
+        let raw: unknown;
+        const abort = abortRace(context?.signal);
+        try {
+          raw = await Promise.race([
+            server.call("worker.ask_main", {
+              authToken: ipcAuthToken,
+              workerId,
+              sessionId,
+              runId,
+              callId: call.id,
+              question,
+            }),
+            abort.promise,
+          ]);
+        } catch (error) {
+          if (isAbortError(error)) return askMainAbortedResult(call);
+          throw error;
+        } finally {
+          context?.signal?.removeEventListener("abort", cancelAskMain);
+          abort.cleanup();
+        }
         const response =
           raw && typeof raw === "object"
             ? (raw as { accepted?: unknown; output?: unknown; error?: unknown })
@@ -127,4 +174,49 @@ function readQuestion(call: Tool.Call): string {
   }
   const question = (call.input as { question?: unknown }).question;
   return typeof question === "string" ? question : "";
+}
+
+function askMainAbortedResult(call: Tool.Call): Tool.Result {
+  return {
+    id: crypto.randomUUID(),
+    toolCallId: call.id,
+    output: "worker.ask_main aborted",
+    isError: true,
+  };
+}
+
+function createAbortError(): Error {
+  const error = new Error("worker.ask_main aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function abortRace(signal: AbortSignal | undefined): {
+  readonly promise: Promise<never>;
+  readonly cleanup: () => void;
+} {
+  if (!signal) {
+    return {
+      promise: new Promise<never>(() => {
+        // The caller did not provide cancellation.
+      }),
+      cleanup: () => undefined,
+    };
+  }
+  if (signal.aborted)
+    return { promise: Promise.reject(createAbortError()), cleanup: () => undefined };
+  let cleanup: () => void = () => undefined;
+  const promise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  return { promise, cleanup };
 }

--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -174,8 +174,18 @@ export namespace WorkerIpcHandlers {
       return { acknowledged: false, error: "invalid worker.tool_call_settled params" };
     }
 
-    clearUnsafe(workspaceRoot, callId);
-    return { acknowledged: true };
+    try {
+      clearUnsafe(workspaceRoot, callId);
+      return { acknowledged: true };
+    } catch (error) {
+      return {
+        acknowledged: false,
+        error:
+          error instanceof Error
+            ? `failed to clear unsafe marker: ${error.message}`
+            : "failed to clear unsafe marker",
+      };
+    }
   }
 }
 

--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -27,6 +27,11 @@ export namespace WorkerIpcHandlers {
     readonly activeRuns: Pick<WorkerRunState.ReadableActiveRuns, "size">;
   }
 
+  export interface ToolCallSettledOptions extends Pick<SharedOptions, "ipcAuthToken"> {
+    readonly params: Record<string, unknown> | undefined;
+    readonly clearUnsafe: (workspaceRoot: string, callId: string) => void;
+  }
+
   export const CancelRunResponse = z.discriminatedUnion("cancelled", [
     z.object({
       cancelled: z.literal(true),
@@ -57,6 +62,15 @@ export namespace WorkerIpcHandlers {
     }),
   ]);
   export type ShutdownIdleResponse = z.infer<typeof ShutdownIdleResponse>;
+
+  export const ToolCallSettledResponse = z.discriminatedUnion("acknowledged", [
+    z.object({ acknowledged: z.literal(true) }),
+    z.object({
+      acknowledged: z.literal(false),
+      error: z.string(),
+    }),
+  ]);
+  export type ToolCallSettledResponse = z.infer<typeof ToolCallSettledResponse>;
 
   export function cancelRun(options: CancelRunOptions): CancelRunResponse {
     const { params, ipcAuthToken, activeRuns } = options;
@@ -145,6 +159,22 @@ export namespace WorkerIpcHandlers {
     if (activeRuns.size > 0) {
       return { acknowledged: false, error: "worker is busy" };
     }
+    return { acknowledged: true };
+  }
+
+  export function toolCallSettled(options: ToolCallSettledOptions): ToolCallSettledResponse {
+    const { params, ipcAuthToken, clearUnsafe } = options;
+    if (!isAuthorized(params, ipcAuthToken)) {
+      return { acknowledged: false, error: "unauthorized coordinator request" };
+    }
+
+    const workspaceRoot = readString(params, "workspaceRoot");
+    const callId = readString(params, "callId");
+    if (!workspaceRoot || !callId) {
+      return { acknowledged: false, error: "invalid worker.tool_call_settled params" };
+    }
+
+    clearUnsafe(workspaceRoot, callId);
     return { acknowledged: true };
   }
 }

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -19,6 +19,49 @@ import { buildWorkerInputMessages, createExecutionToolContext } from "./worker-r
 
 const WORKER_TOOL_CALL_IPC_TIMEOUT_MS = 5 * 60_000;
 
+function createToolCallAbortError(): Error {
+  const error = new Error("Tool call aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function abortableIpcCall<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal | undefined,
+  onAbort: () => void,
+): Promise<T> {
+  if (!signal) return operation();
+  if (signal.aborted) return Promise.reject(createToolCallAbortError());
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", handleAbort);
+    const finish = (complete: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      complete();
+    };
+    const handleAbort = () => {
+      onAbort();
+      finish(() => reject(createToolCallAbortError()));
+    };
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    let pending: Promise<T>;
+    try {
+      pending = operation();
+    } catch (error) {
+      finish(() => reject(error));
+      return;
+    }
+    pending.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}
+
 export interface WorkerRunIpcServer {
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   notify(method: string, params?: Record<string, unknown>): void;
@@ -135,20 +178,24 @@ export namespace WorkerRunner {
                 .call("worker.tool_call_cancel", { runId, sessionId, callId }, 5_000)
                 .catch(() => undefined);
             };
-            context?.signal?.addEventListener("abort", cancelToolCall, { once: true });
 
             try {
-              const raw = await server.call(
-                "worker.tool_call",
-                {
-                  runId,
-                  sessionId,
-                  callId,
-                  tool: toolName,
-                  input: toolArgs,
-                  ...(workspaceRoot ? { workspaceRoot } : {}),
-                },
-                WORKER_TOOL_CALL_IPC_TIMEOUT_MS,
+              const raw = await abortableIpcCall(
+                () =>
+                  server.call(
+                    "worker.tool_call",
+                    {
+                      runId,
+                      sessionId,
+                      callId,
+                      tool: toolName,
+                      input: toolArgs,
+                      ...(workspaceRoot ? { workspaceRoot } : {}),
+                    },
+                    WORKER_TOOL_CALL_IPC_TIMEOUT_MS,
+                  ),
+                context?.signal,
+                cancelToolCall,
               );
               return Tool.Result.parse(raw);
             } catch (error) {
@@ -159,8 +206,6 @@ export namespace WorkerRunner {
                 isError: true,
                 settlement: "unknown",
               };
-            } finally {
-              context?.signal?.removeEventListener("abort", cancelToolCall);
             }
           },
         );

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -17,6 +17,8 @@ import { WorkerInternalTools } from "./worker-internal-tools";
 import type { WorkerRunState } from "./worker-run-state";
 import { buildWorkerInputMessages, createExecutionToolContext } from "./worker-runtime";
 
+const WORKER_TOOL_CALL_IPC_TIMEOUT_MS = 5 * 60_000;
+
 export interface WorkerRunIpcServer {
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   notify(method: string, params?: Record<string, unknown>): void;
@@ -117,15 +119,49 @@ export namespace WorkerRunner {
 
         const mcpProxyProvider = ToolProxyProvider.create(
           bootstrap?.toolCatalog ?? [],
-          async (toolName, toolArgs) => {
-            const raw = await server.call("worker.tool_call", {
-              runId,
-              sessionId,
-              callId: crypto.randomUUID(),
-              tool: toolName,
-              input: toolArgs,
-            });
-            return Tool.Result.parse(raw);
+          async (toolName, toolArgs, context) => {
+            const callId = crypto.randomUUID();
+            if (context?.signal?.aborted) {
+              return {
+                id: callId,
+                toolCallId: callId,
+                output: "Tool call aborted",
+                isError: true,
+              };
+            }
+
+            const cancelToolCall = () => {
+              void server
+                .call("worker.tool_call_cancel", { runId, sessionId, callId }, 5_000)
+                .catch(() => undefined);
+            };
+            context?.signal?.addEventListener("abort", cancelToolCall, { once: true });
+
+            try {
+              const raw = await server.call(
+                "worker.tool_call",
+                {
+                  runId,
+                  sessionId,
+                  callId,
+                  tool: toolName,
+                  input: toolArgs,
+                  ...(workspaceRoot ? { workspaceRoot } : {}),
+                },
+                WORKER_TOOL_CALL_IPC_TIMEOUT_MS,
+              );
+              return Tool.Result.parse(raw);
+            } catch (error) {
+              return {
+                id: callId,
+                toolCallId: callId,
+                output: error instanceof Error ? error.message : String(error),
+                isError: true,
+                settlement: "unknown",
+              };
+            } finally {
+              context?.signal?.removeEventListener("abort", cancelToolCall);
+            }
           },
         );
 
@@ -184,9 +220,12 @@ export namespace WorkerRunner {
         const internalToolNames = new Set(
           internalTools.flatMap((tool) => [tool.spec.name, tool.spec.name.replace(/\./g, "_")]),
         );
-        const combinedToolExecutor = async (call: Tool.Call): Promise<Tool.Result> => {
-          if (internalToolNames.has(call.tool)) return internalToolExecutor(call);
-          if (toolExecutor) return toolExecutor(call);
+        const combinedToolExecutor = async (
+          call: Tool.Call,
+          context?: Tool.ExecutionContext,
+        ): Promise<Tool.Result> => {
+          if (internalToolNames.has(call.tool)) return internalToolExecutor(call, context);
+          if (toolExecutor) return toolExecutor(call, context);
           return {
             id: crypto.randomUUID(),
             toolCallId: call.id,

--- a/apps/server/src/execution/worker-runtime.ts
+++ b/apps/server/src/execution/worker-runtime.ts
@@ -55,7 +55,7 @@ export function createExecutionToolContext(
   availableTools: NativeTool[],
 ): {
   tools?: Execution.Request["tools"];
-  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  toolExecutor?: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
 } {
   if ((request.tools?.length ?? 0) === 0) {
     return {};

--- a/apps/server/src/tool/custom/provider.ts
+++ b/apps/server/src/tool/custom/provider.ts
@@ -1,5 +1,11 @@
 import type { Tool } from "@openomni/protocol";
-import type { NativeTool, ToolCategory, ToolProvider, ToolSource } from "@openomni/openomni";
+import type {
+  NativeTool,
+  ToolCategory,
+  ToolExecutionContext,
+  ToolProvider,
+  ToolSource,
+} from "@openomni/openomni";
 
 export class CustomToolProvider implements ToolProvider {
   readonly name = "custom";
@@ -61,8 +67,9 @@ export class CustomToolProvider implements ToolProvider {
     const extraDuplicates = extraTools.filter(
       (tool, i) => extraTools.findIndex((t) => t.spec.name === tool.spec.name) !== i,
     );
-    if (extraDuplicates.length > 0) {
-      throw new Error(`Duplicate custom tool name: ${extraDuplicates[0]!.spec.name}`);
+    const firstDuplicate = extraDuplicates[0];
+    if (firstDuplicate) {
+      throw new Error(`Duplicate custom tool name: ${firstDuplicate.spec.name}`);
     }
 
     this.tools = [...builtInTools, ...extraTools];
@@ -72,7 +79,7 @@ export class CustomToolProvider implements ToolProvider {
     return this.tools;
   }
 
-  execute(call: Tool.Call): Promise<Tool.Result> {
+  execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> {
     const tool = this.tools.find((t) => t.spec.name === call.tool);
     if (!tool) {
       return Promise.resolve({
@@ -82,6 +89,6 @@ export class CustomToolProvider implements ToolProvider {
         isError: true,
       });
     }
-    return tool.execute(call);
+    return context === undefined ? tool.execute(call) : tool.execute(call, context);
   }
 }

--- a/apps/server/src/tool/mcp/provider.ts
+++ b/apps/server/src/tool/mcp/provider.ts
@@ -3,16 +3,31 @@ import type { McpServerConfig, RuntimeResource, Tool } from "@openomni/protocol"
 import { Mcp, PolicyDecision, PolicyEvent, ToolExecution } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
 import { Bus, Storage } from "@openomni/session";
-import type { NativeTool, ToolCategory, ToolProvider } from "@openomni/openomni";
+import type {
+  NativeTool,
+  ToolCategory,
+  ToolExecutionContext,
+  ToolProvider,
+} from "@openomni/openomni";
 import { McpPrefixGuardMiddleware } from "./mcp-prefix-guard";
 
 const MCP_TOOL_ACTION = "mcp.tool.call";
+function createAbortError(): Error {
+  const error = new Error("MCP tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
 
 interface McpClientLike {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   listTools(): Promise<Tool.Spec[]>;
-  callTool(toolName: string, input: Record<string, unknown>, callId?: string): Promise<Tool.Result>;
+  callTool(
+    toolName: string,
+    input: Record<string, unknown>,
+    callId?: string,
+    context?: ToolExecutionContext,
+  ): Promise<Tool.Result>;
 }
 
 function uniqueLabels(labels: readonly string[]): string[] {
@@ -214,7 +229,10 @@ export class McpToolProvider implements ToolProvider {
             isDestructive: false,
             isConcurrencySafe: false,
             source: "mcp",
-            execute: (call) => client.callTool(call.tool, call.input, call.id),
+            execute: (call, context) => {
+              if (context?.signal?.aborted) return Promise.reject(createAbortError());
+              return client.callTool(call.tool, call.input, call.id, context);
+            },
           });
         }
       } catch (err) {
@@ -233,7 +251,7 @@ export class McpToolProvider implements ToolProvider {
     this.cachedTools = tools;
   }
 
-  async execute(call: Tool.Call): Promise<Tool.Result> {
+  async execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> {
     const guard = await McpPrefixGuardMiddleware.evaluatePreToolUse({
       call,
       tools: this.listTools(),
@@ -281,7 +299,9 @@ export class McpToolProvider implements ToolProvider {
     });
 
     const startTime = Date.now();
-    const result = await tool.execute({ ...call, tool: tool.spec.name });
+    const result = await (context === undefined
+      ? tool.execute({ ...call, tool: tool.spec.name })
+      : tool.execute({ ...call, tool: tool.spec.name }, context));
     const durationMs = Date.now() - startTime;
 
     Bus.publish(ToolExecution.Completed, {

--- a/apps/server/test/execution/tool-catalog.test.ts
+++ b/apps/server/test/execution/tool-catalog.test.ts
@@ -132,7 +132,7 @@ describe("tool catalog", () => {
     await dispatchWithFallback(dispatcher, call);
 
     expect(mcpProvider.execute).toHaveBeenCalledTimes(1);
-    expect(mcpProvider.execute).toHaveBeenCalledWith(call);
+    expect(mcpProvider.execute).toHaveBeenCalledWith(call, undefined);
   });
 
   it("server-source fixture tool is dispatched through the server provider", async () => {
@@ -144,7 +144,7 @@ describe("tool catalog", () => {
     await dispatchWithFallback(dispatcher, call);
 
     expect(serverProvider.execute).toHaveBeenCalledTimes(1);
-    expect(serverProvider.execute).toHaveBeenCalledWith(call);
+    expect(serverProvider.execute).toHaveBeenCalledWith(call, undefined);
   });
 
   it("dispatcher forwards execution context to providers", async () => {

--- a/apps/server/test/execution/tool-catalog.test.ts
+++ b/apps/server/test/execution/tool-catalog.test.ts
@@ -14,7 +14,7 @@ function makeTool(name: string, category?: ToolSelection.Category): NativeTool {
     isDestructive: false,
     isConcurrencySafe: false,
     category,
-    execute: mock(async (call: Tool.Call) => ({
+    execute: mock(async (call: Tool.Call, _context?: { signal?: AbortSignal }) => ({
       id: call.id,
       toolCallId: call.id,
       output: `${name} result`,
@@ -27,7 +27,7 @@ function makeProvider(name: string, tools: NativeTool[]): ToolProvider {
     name,
     category: "system",
     listTools: () => tools,
-    execute: mock(async (call: Tool.Call) => ({
+    execute: mock(async (call: Tool.Call, _context?: { signal?: AbortSignal }) => ({
       id: call.id,
       toolCallId: call.id,
       output: `${name} result`,
@@ -145,6 +145,18 @@ describe("tool catalog", () => {
 
     expect(serverProvider.execute).toHaveBeenCalledTimes(1);
     expect(serverProvider.execute).toHaveBeenCalledWith(call);
+  });
+
+  it("dispatcher forwards execution context to providers", async () => {
+    const provider = makeProvider("mock-provider", [makeTool("known_tool")]);
+    const dispatcher = buildToolDispatcher([provider]);
+    const controller = new AbortController();
+    const call: Tool.Call = { id: "call-ctx", tool: "known_tool", input: {} };
+
+    const result = await dispatcher.get("known_tool")?.(call, { signal: controller.signal });
+
+    expect(result?.output).toBe("mock-provider result");
+    expect(provider.execute).toHaveBeenCalledWith(call, { signal: controller.signal });
   });
 
   it("unknown tool name produces an isError result containing the tool name", async () => {

--- a/apps/server/test/execution/worker-full-stack.test.ts
+++ b/apps/server/test/execution/worker-full-stack.test.ts
@@ -6,11 +6,14 @@ import { Subagent } from "@openomni/protocol";
 import type { Execution, Ingress, Tool, WorkerBootstrap } from "@openomni/protocol";
 
 let capturedOnToolCall:
-  | ((params: {
-      callId: string;
-      tool: string;
-      input: Record<string, unknown>;
-    }) => Promise<{ id: string; toolCallId: string; output: string; isError?: boolean }>)
+  | ((
+      params: {
+        callId: string;
+        tool: string;
+        input: Record<string, unknown>;
+      },
+      context?: { signal?: AbortSignal },
+    ) => Promise<{ id: string; toolCallId: string; output: string; isError?: boolean }>)
   | undefined;
 
 let mockPoolDispatch: (
@@ -198,11 +201,14 @@ describe("builtin middleware — tool permission", () => {
 
 describe("MCP proxy — worker.tool_call routes to generic dispatcher", () => {
   test("onToolCall callback delegates to toolDispatcher handler", async () => {
-    const captured: Tool.Call[] = [];
+    const captured: Array<{ call: Tool.Call; signal?: AbortSignal }> = [];
 
-    const toolDispatcher = new Map<string, (call: Tool.Call) => Promise<Tool.Result>>();
-    toolDispatcher.set("myserver.read_file", async (call: Tool.Call): Promise<Tool.Result> => {
-      captured.push(call);
+    const toolDispatcher = new Map<
+      string,
+      (call: Tool.Call, context?: { signal?: AbortSignal }) => Promise<Tool.Result>
+    >();
+    toolDispatcher.set("myserver.read_file", async (call, context): Promise<Tool.Result> => {
+      captured.push({ call, signal: context?.signal });
       return {
         id: crypto.randomUUID(),
         toolCallId: call.id,
@@ -217,15 +223,20 @@ describe("MCP proxy — worker.tool_call routes to generic dispatcher", () => {
     if (!capturedOnToolCall) throw new Error("onToolCall not captured by mock");
 
     const callId = crypto.randomUUID();
-    const result = await capturedOnToolCall({
-      callId,
-      tool: "myserver.read_file",
-      input: { path: "/tmp/test.txt" },
-    });
+    const controller = new AbortController();
+    const result = await capturedOnToolCall(
+      {
+        callId,
+        tool: "myserver.read_file",
+        input: { path: "/tmp/test.txt" },
+      },
+      { signal: controller.signal },
+    );
 
     expect(captured).toHaveLength(1);
-    expect(captured[0].id).toBe(callId);
-    expect(captured[0].tool).toBe("myserver.read_file");
+    expect(captured[0]?.call.id).toBe(callId);
+    expect(captured[0]?.call.tool).toBe("myserver.read_file");
+    expect(captured[0]?.signal).toBe(controller.signal);
     expect(result.output).toBe("mcp-result");
   });
 });

--- a/apps/server/test/execution/worker-internal-tools.test.ts
+++ b/apps/server/test/execution/worker-internal-tools.test.ts
@@ -60,6 +60,23 @@ describe("worker internal tools", () => {
     });
   });
 
+  it("ask_main is workspace-read-only and explicitly labeled as resident consultation", () => {
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: mock(async () => ({ accepted: true, output: "unused" })) },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
+    });
+    const askMain = getTool(tools, "ask_main");
+
+    expect(askMain.riskTier).toBe(0);
+    expect(askMain.isReadOnly).toBe(true);
+    expect(askMain.labels).toContain("resident-consult");
+    expect(askMain.descriptor?.effects).toContain("authority.request");
+  });
+
   it("ask_main forwards the worker run context to the parent process", async () => {
     const serverCall = mock(async () => ({ accepted: true, output: "approved" }));
     const tools = WorkerInternalTools.create({
@@ -80,6 +97,7 @@ describe("worker internal tools", () => {
       workerId: "worker-1",
       sessionId: "session-1",
       runId: "run-1",
+      callId: "call-2",
       question: "Continue?",
     });
     expect(result).toMatchObject({
@@ -106,6 +124,80 @@ describe("worker internal tools", () => {
     expect(result).toMatchObject({
       toolCallId: "call-3",
       output: "no",
+      isError: true,
+    });
+  });
+
+  it("ask_main returns an abort result without starting when pre-aborted", async () => {
+    const serverCall = mock(async () => ({ accepted: true, output: "unused" }));
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: serverCall },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await getTool(tools, "ask_main").execute(
+      createCall("call-abort", "ask_main", { question: "Continue?" }),
+      { signal: controller.signal },
+    );
+
+    expect(serverCall).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      toolCallId: "call-abort",
+      output: "worker.ask_main aborted",
+      isError: true,
+    });
+  });
+
+  it("ask_main sends a cancel request when aborted while waiting", async () => {
+    const controller = new AbortController();
+    let resolveAsk: ((value: unknown) => void) | undefined;
+    const serverCall = mock((method: string) => {
+      if (method === "worker.ask_main") {
+        return new Promise<unknown>((resolve) => {
+          resolveAsk = resolve;
+        });
+      }
+      return Promise.resolve({ cancelled: true });
+    });
+    const tools = WorkerInternalTools.create({
+      runId: "run-1",
+      sessionId: "session-1",
+      server: { call: serverCall },
+      ipcAuthToken: "token",
+      workerId: "worker-1",
+      activeRuns: new Map<string, WorkerRunState.ActiveRun>(),
+    });
+
+    const resultPromise = getTool(tools, "ask_main").execute(
+      createCall("call-waiting", "ask_main", { question: "Continue?" }),
+      { signal: controller.signal },
+    );
+    await Bun.sleep(0);
+    controller.abort();
+
+    const result = await resultPromise;
+    resolveAsk?.({ accepted: true, output: "late" });
+
+    expect(serverCall).toHaveBeenCalledWith(
+      "worker.ask_main_cancel",
+      {
+        authToken: "token",
+        workerId: "worker-1",
+        sessionId: "session-1",
+        runId: "run-1",
+        callId: "call-waiting",
+      },
+      5_000,
+    );
+    expect(result).toMatchObject({
+      toolCallId: "call-waiting",
+      output: "worker.ask_main aborted",
       isError: true,
     });
   });

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -207,4 +207,19 @@ describe("worker IPC handlers", () => {
     expect(result).toEqual({ acknowledged: true });
     expect(cleared).toEqual([{ workspaceRoot: "/workspace", callId: "call-1" }]);
   });
+
+  it("rejects tool-settled notifications when clearing unsafe markers fails", () => {
+    const result = WorkerIpcHandlers.toolCallSettled({
+      params: { authToken: "token", workspaceRoot: "/workspace", callId: "call-1" },
+      ipcAuthToken: "token",
+      clearUnsafe: () => {
+        throw new Error("disk unavailable");
+      },
+    });
+
+    expect(result).toEqual({
+      acknowledged: false,
+      error: "failed to clear unsafe marker: disk unavailable",
+    });
+  });
 });

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -162,4 +162,49 @@ describe("worker IPC handlers", () => {
       }),
     ).toEqual({ acknowledged: true });
   });
+
+  it("rejects unauthorized tool-settled notifications without clearing unsafe markers", () => {
+    const cleared: Array<{ workspaceRoot: string; callId: string }> = [];
+
+    const result = WorkerIpcHandlers.toolCallSettled({
+      params: { authToken: "wrong", workspaceRoot: "/workspace", callId: "call-1" },
+      ipcAuthToken: "token",
+      clearUnsafe: (workspaceRoot, callId) => cleared.push({ workspaceRoot, callId }),
+    });
+
+    expect(result).toEqual({
+      acknowledged: false,
+      error: "unauthorized coordinator request",
+    });
+    expect(cleared).toEqual([]);
+  });
+
+  it("rejects malformed tool-settled notifications without acknowledging success", () => {
+    const cleared: Array<{ workspaceRoot: string; callId: string }> = [];
+
+    const result = WorkerIpcHandlers.toolCallSettled({
+      params: { authToken: "token", callId: "call-1" },
+      ipcAuthToken: "token",
+      clearUnsafe: (workspaceRoot, callId) => cleared.push({ workspaceRoot, callId }),
+    });
+
+    expect(result).toEqual({
+      acknowledged: false,
+      error: "invalid worker.tool_call_settled params",
+    });
+    expect(cleared).toEqual([]);
+  });
+
+  it("clears unsafe markers for authorized tool-settled notifications", () => {
+    const cleared: Array<{ workspaceRoot: string; callId: string }> = [];
+
+    const result = WorkerIpcHandlers.toolCallSettled({
+      params: { authToken: "token", workspaceRoot: "/workspace", callId: "call-1" },
+      ipcAuthToken: "token",
+      clearUnsafe: (workspaceRoot, callId) => cleared.push({ workspaceRoot, callId }),
+    });
+
+    expect(result).toEqual({ acknowledged: true });
+    expect(cleared).toEqual([{ workspaceRoot: "/workspace", callId: "call-1" }]);
+  });
 });

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -314,6 +314,101 @@ describe("WorkerRunner", () => {
     }
   });
 
+  it("aborts a proxied tool IPC wait without waiting for the full IPC timeout", async () => {
+    const responses: unknown[] = [];
+    const activeRuns = new Map<string, WorkerRunState.ActiveRun>();
+    const serverCalls: Array<{
+      method: string;
+      params?: Record<string, unknown>;
+      timeoutMs?: number;
+    }> = [];
+    let proxiedResult: Tool.Result | undefined;
+    const bootstrap: WorkerBootstrap.Bootstrap = {
+      configEpoch: "epoch-1",
+      agents: [],
+      toolCatalog: [
+        {
+          canonicalName: "mcp.server.slow_write",
+          exposedName: "mcp_server_slow_write",
+          source: "mcp",
+          category: "execution",
+          riskTier: 1,
+          spec: { name: "mcp.server.slow_write", inputSchema: {} },
+        },
+      ],
+    };
+    const request = createValidRequest();
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        {
+          ...request,
+          tools: [{ name: "mcp.server.slow_write", inputSchema: {} }],
+        },
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          activeRuns,
+          server: {
+            call(method, params, timeoutMs) {
+              serverCalls.push({ method, params, timeoutMs });
+              if (method === "worker.tool_call") {
+                activeRuns.get("run-1")?.controller.abort();
+                return new Promise<unknown>(() => undefined);
+              }
+              if (method === "worker.tool_call_cancel") {
+                return Promise.resolve({ cancelled: true, settlement: "unknown" });
+              }
+              throw new Error(`unexpected server call: ${method}`);
+            },
+            notify() {
+              // lifecycle notification
+            },
+          },
+          getBootstrap: () => bootstrap,
+          createAgent: (options) => ({
+            async run() {
+              if (!options.toolExecutor) throw new Error("tool executor missing");
+              proxiedResult = await options.toolExecutor(
+                {
+                  id: "agent-tool-call",
+                  tool: "mcp_server_slow_write",
+                  input: {},
+                },
+                { signal: options.signal },
+              );
+              return successfulResult;
+            },
+          }),
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    await responseReceived;
+
+    expect(proxiedResult).toMatchObject({
+      id: expect.any(String),
+      toolCallId: expect.any(String),
+      isError: true,
+    });
+    expect(proxiedResult?.output).toContain("aborted");
+    expect(serverCalls).toContainEqual(
+      expect.objectContaining({
+        method: "worker.tool_call_cancel",
+        params: expect.objectContaining({
+          runId: "run-1",
+          sessionId: "session-1",
+          callId: expect.any(String),
+        }),
+        timeoutMs: 5_000,
+      }),
+    );
+    expect(responses[0]).toMatchObject({ status: "cancelled" });
+  });
+
   it("reports failed runs and cleans active run state after agent errors", async () => {
     const responses: unknown[] = [];
     const notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -292,23 +292,26 @@ describe("WorkerRunner", () => {
       WorkerRunner.spawnRun(options);
     });
 
-    await responseReceived;
+    try {
+      await responseReceived;
 
-    expect(proxiedResult).toMatchObject({
-      id: expect.any(String),
-      toolCallId: expect.any(String),
-      output: "request timeout: worker.tool_call",
-      isError: true,
-      settlement: "unknown",
-    });
-    expect(serverCalls).toContainEqual(
-      expect.objectContaining({
-        method: "worker.tool_call",
-        timeoutMs: 300_000,
-      }),
-    );
-    expect(responses[0]).toMatchObject({ status: "succeeded" });
-    WorkspaceLock.clearUnsafe(workspaceRoot);
+      expect(proxiedResult).toMatchObject({
+        id: expect.any(String),
+        toolCallId: expect.any(String),
+        output: "request timeout: worker.tool_call",
+        isError: true,
+        settlement: "unknown",
+      });
+      expect(serverCalls).toContainEqual(
+        expect.objectContaining({
+          method: "worker.tool_call",
+          timeoutMs: 300_000,
+        }),
+      );
+      expect(responses[0]).toMatchObject({ status: "succeeded" });
+    } finally {
+      WorkspaceLock.clearUnsafe(workspaceRoot);
+    }
   });
 
   it("reports failed runs and cleans active run state after agent errors", async () => {

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentResult } from "@openomni/agent";
-import { BackgroundManager } from "@openomni/openomni";
+import { BackgroundManager, WorkspaceLock } from "@openomni/openomni";
+import type { Tool, WorkerBootstrap } from "@openomni/protocol";
 
 import type { WorkerRunState } from "../../src/execution/worker-run-state";
 import { WorkerRunner } from "../../src/execution/worker-runner";
@@ -226,6 +227,88 @@ describe("WorkerRunner", () => {
       },
     ]);
     expect(activeRuns.size).toBe(0);
+  });
+
+  it("returns unknown settlement for proxied tool IPC failures and uses an extended call timeout", async () => {
+    const responses: unknown[] = [];
+    const workspaceRoot = `/tmp/openomni-worker-runner-test-${crypto.randomUUID()}`;
+    const serverCalls: Array<{
+      method: string;
+      params?: Record<string, unknown>;
+      timeoutMs?: number;
+    }> = [];
+    let proxiedResult: Tool.Result | undefined;
+    const bootstrap: WorkerBootstrap.Bootstrap = {
+      configEpoch: "epoch-1",
+      agents: [],
+      toolCatalog: [
+        {
+          canonicalName: "mcp.server.write_file",
+          exposedName: "mcp_server_write_file",
+          source: "mcp",
+          category: "execution",
+          riskTier: 1,
+          spec: { name: "mcp.server.write_file", inputSchema: {} },
+        },
+      ],
+    };
+    const request = createValidRequest();
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        {
+          ...request,
+          tools: [{ name: "mcp.server.write_file", inputSchema: {} }],
+          toolConfig: { workspaceRoot },
+        },
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          server: {
+            async call(method, params, timeoutMs) {
+              serverCalls.push({ method, params, timeoutMs });
+              throw new Error("request timeout: worker.tool_call");
+            },
+            notify() {
+              // lifecycle notification
+            },
+          },
+          getBootstrap: () => bootstrap,
+          createAgent: (options) => ({
+            async run() {
+              if (!options.toolExecutor) throw new Error("tool executor missing");
+              proxiedResult = await options.toolExecutor({
+                id: "agent-tool-call",
+                tool: "mcp_server_write_file",
+                input: {},
+              });
+              return successfulResult;
+            },
+          }),
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    await responseReceived;
+
+    expect(proxiedResult).toMatchObject({
+      id: expect.any(String),
+      toolCallId: expect.any(String),
+      output: "request timeout: worker.tool_call",
+      isError: true,
+      settlement: "unknown",
+    });
+    expect(serverCalls).toContainEqual(
+      expect.objectContaining({
+        method: "worker.tool_call",
+        timeoutMs: 300_000,
+      }),
+    );
+    expect(responses[0]).toMatchObject({ status: "succeeded" });
+    WorkspaceLock.clearUnsafe(workspaceRoot);
   });
 
   it("reports failed runs and cleans active run state after agent errors", async () => {

--- a/apps/server/test/tool/mcp/provider.test.ts
+++ b/apps/server/test/tool/mcp/provider.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { PolicyEngine, type PolicyContext } from "@openomni/agent";
-import type { NativeTool } from "@openomni/openomni";
+import { createToolExecutor, WorkspaceLock, type NativeTool } from "@openomni/openomni";
 import type { RuntimeResource, Tool } from "@openomni/protocol";
 import { Mcp, PolicyDecision } from "@openomni/protocol";
 import { Bus, Session, Storage } from "@openomni/session";
@@ -126,6 +129,36 @@ describe("McpToolProvider", () => {
     });
   });
 
+  it("forwards execution context to resolved MCP tools", async () => {
+    const provider = new McpToolProvider();
+    let capturedSignal: AbortSignal | undefined;
+    const execute = mock(
+      async (call: Tool.Call, context?: { signal?: AbortSignal }): Promise<Tool.Result> => {
+        capturedSignal = context?.signal;
+        return { id: call.id, toolCallId: call.id, output: `${call.tool} ok` };
+      },
+    );
+    const tool: NativeTool = {
+      spec: { name: "search.query", description: "search.query tool", inputSchema: {} },
+      riskTier: 1,
+      isReadOnly: false,
+      isDestructive: false,
+      isConcurrencySafe: false,
+      source: "mcp",
+      execute,
+    };
+    seedProvider(provider, [tool], ["search"]);
+    const controller = new AbortController();
+
+    const result = await provider.execute(
+      { id: "call-context", tool: "search_query", input: { query: "hello" } },
+      { signal: controller.signal },
+    );
+
+    expect(result.output).toBe("search.query ok");
+    expect(capturedSignal).toBe(controller.signal);
+  });
+
   it("exposes MCP labels and descriptors on refreshed tools for agent policy dispatch", async () => {
     const client = makeClient();
     client.listTools.mockResolvedValueOnce([
@@ -148,6 +181,121 @@ describe("McpToolProvider", () => {
       kind: "tool",
       source: { type: "mcp", serverId: "search", remoteName: "search.query" },
     });
+  });
+
+  it("does not start direct MCP execution when context is already aborted", async () => {
+    const client = makeClient();
+    client.listTools.mockResolvedValueOnce([
+      { name: "search.query", description: "query", inputSchema: {} },
+    ]);
+    const provider = new McpToolProvider({ createClient: () => client.client });
+    await provider.addServer({ name: "search", transport: "stdio", command: "search-mcp" });
+    await provider.refreshTools();
+    const controller = new AbortController();
+    controller.abort(new Error("already cancelled"));
+
+    await expect(
+      provider.execute(
+        { id: "call-pre-abort", tool: "search.query", input: {} },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow("MCP tool execution aborted");
+    expect(client.callTool).not.toHaveBeenCalled();
+  });
+
+  it("keeps direct MCP execution pending after abort until the underlying call settles", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "openomni-mcp-abort-lock-"));
+    let settleCall: ((result: Tool.Result) => void) | undefined;
+    const client = makeClient();
+    client.listTools.mockResolvedValueOnce([
+      { name: "search.query", description: "query", inputSchema: {} },
+    ]);
+    client.callTool.mockImplementation(
+      async (toolName: string, _input: Record<string, unknown>, callId?: string) =>
+        await new Promise<Tool.Result>((resolve) => {
+          settleCall = () =>
+            resolve({
+              id: callId ?? crypto.randomUUID(),
+              toolCallId: callId ?? "call",
+              output: `${toolName} late`,
+            });
+        }),
+    );
+    const provider = new McpToolProvider({ createClient: () => client.client });
+
+    try {
+      await provider.addServer({ name: "search", transport: "stdio", command: "search-mcp" });
+      await provider.refreshTools();
+      const executor = createToolExecutor({
+        tools: provider.listTools(),
+        config: { workspaceRoot: workspace, timeoutMs: { tier1: 10 } },
+      });
+
+      const result = await executor({ id: "call-mcp", tool: "search.query", input: {} });
+      expect(result.isError).toBe(true);
+      expect(result.output).toBe("timeout after 10ms");
+
+      const blockedProbe = await WorkspaceLock.acquire(workspace, "probe-before-settle", 30).catch(
+        (error) => error,
+      );
+      expect(blockedProbe).toBeInstanceOf(Error);
+      expect((blockedProbe as Error).message).toContain("workspace lock timeout");
+
+      settleCall?.({ id: "late", toolCallId: "call-mcp", output: "late" });
+      await Bun.sleep(0);
+
+      await WorkspaceLock.acquire(workspace, "probe-after-settle", 50);
+      WorkspaceLock.release(workspace, "probe-after-settle");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("marks the workspace unsafe after MCP abort settlement grace when the call hangs", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "openomni-mcp-abort-grace-"));
+    const client = makeClient();
+    client.listTools.mockResolvedValueOnce([
+      { name: "search.query", description: "query", inputSchema: {} },
+    ]);
+    client.callTool.mockImplementation(
+      async () =>
+        await new Promise<Tool.Result>(() => {
+          // intentional: never resolves to exercise abort settlement grace
+        }),
+    );
+    const provider = new McpToolProvider({ createClient: () => client.client });
+
+    try {
+      await provider.addServer({ name: "search", transport: "stdio", command: "search-mcp" });
+      await provider.refreshTools();
+      const executor = createToolExecutor({
+        tools: provider.listTools(),
+        config: {
+          workspaceRoot: workspace,
+          timeoutMs: { tier1: 10 },
+          postTimeoutSettleGraceMs: 20,
+        },
+      });
+
+      const result = await executor({ id: "call-mcp-hung", tool: "search.query", input: {} });
+      expect(result.isError).toBe(true);
+      expect(result.output).toBe("timeout after 10ms");
+
+      const blockedProbe = await WorkspaceLock.acquire(workspace, "probe-before-grace", 5).catch(
+        (error) => error,
+      );
+      expect(blockedProbe).toBeInstanceOf(Error);
+
+      await Bun.sleep(40);
+      const unsafeProbe = await WorkspaceLock.acquire(workspace, "probe-after-grace", 50).catch(
+        (error) => error,
+      );
+      expect(unsafeProbe).toBeInstanceOf(Error);
+      expect((unsafeProbe as Error).message).toContain("workspace marked unsafe");
+      WorkspaceLock.clearUnsafe(workspace);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   });
 
   it("preserves the unknown-tool error for unknown MCP prefixes", async () => {

--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -548,6 +548,7 @@ export async function buildTurn(
           toolPolicyDecisions.push({ timing, decision });
         },
         traceContext: trace,
+        signal: config.signal,
       })
     : undefined;
 

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -16,7 +16,7 @@ type BlockedResultMetadata = {
 type BlockedToolResult = Tool.Result & { metadata?: BlockedResultMetadata };
 
 export interface ToolExecutorOptions {
-  toolExecutor: (call: Tool.Call) => Promise<Tool.Result>;
+  toolExecutor: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
   engine: PolicyEngineInstance;
   getContext?: () => {
     steps: AgentStep[];
@@ -29,6 +29,7 @@ export interface ToolExecutorOptions {
   onToolComplete?: (durationMs: number) => void;
   onDecision?: (timing: Policy.Timing, decision: Policy.PolicyDecision) => void | Promise<void>;
   traceContext?: TraceContext.Type;
+  signal?: AbortSignal;
 }
 
 function sourceFromLabels(
@@ -64,7 +65,7 @@ function toolDescriptor(
 
 export function createToolExecutor(
   options: ToolExecutorOptions,
-): (call: Tool.Call) => Promise<Tool.Result> {
+): (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result> {
   const {
     toolExecutor,
     engine,
@@ -74,6 +75,7 @@ export function createToolExecutor(
     onToolComplete,
     onDecision,
     traceContext,
+    signal,
   } = options;
   const traceId = traceContext?.traceId ?? crypto.randomUUID();
   const sessionId = traceContext?.sessionId ?? "";
@@ -133,7 +135,7 @@ export function createToolExecutor(
     return result;
   }
 
-  return async (call: Tool.Call): Promise<Tool.Result> => {
+  return async (call: Tool.Call, context?: Tool.ExecutionContext): Promise<Tool.Result> => {
     const ctx = getContext?.();
     const policyToolName = getPolicyToolName?.(call.tool) ?? call.tool;
     const usage = ctx?.usage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -203,7 +205,9 @@ export function createToolExecutor(
     const startMs = Date.now();
     let result: Tool.Result;
     try {
-      result = await toolExecutor(effectiveCall);
+      result = await toolExecutor(effectiveCall, {
+        signal: context?.signal ?? signal,
+      });
     } catch (err) {
       const durationMs = Date.now() - startMs;
       onToolComplete?.(durationMs);

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -18,7 +18,7 @@ export interface ChatAgentConfig {
   model: Model.Ref;
   budget?: AgentBudget;
   onStepFinish?: (step: AgentStep) => void | Promise<void>;
-  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  toolExecutor?: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
   signal?: AbortSignal;
   permissions?: Policy.Permission;
   compaction?: {

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -117,6 +117,7 @@ export class McpClient {
     name: string,
     args: Record<string, unknown>,
     toolCallId: string,
+    context?: { readonly signal?: AbortSignal },
   ): Promise<Tool.Result> {
     const traceId = randomUUID();
     const strippedName = name.startsWith(`${this.config.name}.`)
@@ -134,10 +135,14 @@ export class McpClient {
     });
 
     try {
-      const response = await this.client.callTool({
-        name: strippedName,
-        arguments: args,
-      });
+      const response = await this.client.callTool(
+        {
+          name: strippedName,
+          arguments: args,
+        },
+        undefined,
+        { signal: context?.signal },
+      );
 
       const _durationMs = Date.now() - startTime;
 

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -11,6 +11,7 @@ export interface SubagentRuntimeSpawnConfig {
   model: Model.Ref;
   systemPrompt?: string;
   middleware?: PolicyRegistration[];
+  signal?: AbortSignal;
 }
 
 export interface SubagentRuntimeSendConfig {
@@ -19,6 +20,7 @@ export interface SubagentRuntimeSendConfig {
   model: Model.Ref;
   systemPrompt?: string;
   middleware?: PolicyRegistration[];
+  signal?: AbortSignal;
 }
 
 export type SubagentRuntime = {
@@ -50,9 +52,13 @@ export interface SubagentToolOptions {
   };
 }
 
+export interface SubagentToolExecutionContext {
+  readonly signal?: AbortSignal;
+}
+
 export interface SubagentToolSpec {
   spec: Tool.Spec;
-  execute: (args: unknown) => Promise<Tool.Result>;
+  execute: (args: unknown, context?: SubagentToolExecutionContext) => Promise<Tool.Result>;
 }
 
 export namespace SubagentTool {
@@ -90,7 +96,10 @@ export namespace SubagentTool {
       },
     };
 
-    const execute = async (args: unknown): Promise<Tool.Result> => {
+    const execute = async (
+      args: unknown,
+      context?: SubagentToolExecutionContext,
+    ): Promise<Tool.Result> => {
       const { agentName, prompt, sessionId, background } = args as {
         agentName: string;
         prompt: string;
@@ -172,6 +181,7 @@ export namespace SubagentTool {
               model,
               systemPrompt: definition.systemPrompt,
               middleware: propagated.length > 0 ? propagated : undefined,
+              signal: context?.signal,
             })
           : await options.subagentRuntime.spawn({
               agentName,
@@ -180,6 +190,7 @@ export namespace SubagentTool {
               model,
               systemPrompt: definition.systemPrompt,
               middleware: propagated.length > 0 ? propagated : undefined,
+              signal: context?.signal,
             });
 
         return {

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -141,6 +141,14 @@ export namespace SubagentTool {
       const model = definition.model ?? options.defaultModel ?? DEFAULT_SUBAGENT_MODEL;
 
       if (background) {
+        if (context?.signal?.aborted) {
+          return {
+            id: crypto.randomUUID(),
+            toolCallId: "",
+            output: "subagent execution aborted",
+            isError: true,
+          };
+        }
         if (!options.backgroundManager) {
           return {
             id: crypto.randomUUID(),

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -283,6 +283,43 @@ it("uses toolExecutor when provided to execute tool calls", async () => {
   expect(result.finishReason).toBe("stop");
 });
 
+it("passes the agent abort signal to toolExecutor calls", async () => {
+  let capturedSignal: AbortSignal | undefined;
+  const controller = new AbortController();
+  const executor = async (_call: Tool.Call, context?: Tool.ExecutionContext) => {
+    capturedSignal = context?.signal;
+    return {
+      id: crypto.randomUUID(),
+      toolCallId: "call-1",
+      output: "signal captured",
+      isError: false,
+    };
+  };
+
+  mockRunFn = async (input, sink): Promise<Run.Outcome> => {
+    const call = createToolCall("call-1", "custom_tool");
+    if (!input.toolExecutor) throw new Error("expected tool executor");
+    const result = await input.toolExecutor(call);
+    sink.onToolCall(call);
+    sink.onToolResult(result);
+    sink.onMessage(createAssistantMessage("done"));
+    return createStopOutcome();
+  };
+
+  const agent = ChatAgent.create({
+    model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+    llm: mockLlm,
+    signal: controller.signal,
+    toolExecutor: executor,
+  });
+
+  await agent.run({
+    messages: [{ role: "user", content: "Use a tool" }],
+  });
+
+  expect(capturedSignal).toBe(controller.signal);
+});
+
 it("handles toolExecutor errors by setting isError: true", async () => {
   mockRunFn = async (input, sink): Promise<Run.Outcome> => {
     const call = createToolCall("call-1", "failing_tool");

--- a/packages/agent/test/helpers/mock-llm.ts
+++ b/packages/agent/test/helpers/mock-llm.ts
@@ -4,7 +4,11 @@ import type { ChatAgentConfig } from "../../src/core/types";
 export type MockLlmInput = {
   readonly messages?: readonly unknown[];
   readonly maxSteps?: number;
-  readonly toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  readonly signal?: AbortSignal;
+  readonly toolExecutor?: (
+    call: Tool.Call,
+    context?: Tool.ExecutionContext,
+  ) => Promise<Tool.Result>;
 };
 
 export type MockLlmFn = (input: MockLlmInput, sink: Sink) => Promise<Run.Outcome>;

--- a/packages/agent/test/runtime/tools/subagent-background.test.ts
+++ b/packages/agent/test/runtime/tools/subagent-background.test.ts
@@ -121,6 +121,38 @@ describe("SubagentTool background mode", () => {
     expect(result.output).toContain("background");
   });
 
+  it("does not launch background task when execution is already aborted", async () => {
+    resetState();
+    let launched = false;
+    const manager = {
+      ...createMockBackgroundManager(),
+      launch: async (input: unknown) => {
+        launched = true;
+        return createMockBackgroundManager().launch(input);
+      },
+    };
+    AgentRegistry.define(makeDefinition("test"));
+    const { execute } = SubagentTool.create({
+      backgroundManager: manager,
+      subagentRuntime: makeRuntime(),
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await execute(
+      {
+        agentName: "test",
+        prompt: "hello",
+        background: true,
+      },
+      { signal: controller.signal },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("aborted");
+    expect(launched).toBe(false);
+  });
+
   it("uses sync path when background is false", async () => {
     resetState();
     const { execute } = SubagentTool.create({ subagentRuntime: makeRuntime() });

--- a/packages/coordinator/src/index.ts
+++ b/packages/coordinator/src/index.ts
@@ -3,7 +3,14 @@ export type { RecoveryResult } from "./recovery";
 
 export { createIpcServer } from "./ipc";
 export { createWorkerPool } from "./worker-pool";
-export type { WorkerPool, WorkerPoolConfig, ToolCallParams, ToolCallResult } from "./worker-pool";
+export type {
+  WorkerPool,
+  WorkerPoolConfig,
+  ToolCallCancelParams,
+  ToolCallContext,
+  ToolCallParams,
+  ToolCallResult,
+} from "./worker-pool";
 export { createWorkerManager, OnDemandWorkerManager } from "./worker-manager";
 export type {
   AskMainParams,

--- a/packages/coordinator/src/worker-manager/index.ts
+++ b/packages/coordinator/src/worker-manager/index.ts
@@ -4,6 +4,8 @@ export {
   type WorkerManager,
   type WorkerManagerConfig,
   type WorkerManagerStats,
+  type ToolCallCancelParams,
+  type ToolCallContext,
   type ToolCallParams,
   type ToolCallResult,
   type AskMainParams,

--- a/packages/coordinator/src/worker-manager/manager.ts
+++ b/packages/coordinator/src/worker-manager/manager.ts
@@ -5,6 +5,8 @@ import {
   WorkerSupervisor,
   type AskMainParams,
   type AskMainResult,
+  type ToolCallCancelParams,
+  type ToolCallContext,
   type ToolCallParams,
   type ToolCallResult,
 } from "../worker-pool/supervisor";
@@ -15,7 +17,7 @@ const DEFAULT_IDLE_SHUTDOWN_MS = 600_000;
 const DEFAULT_SLOT_WAIT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_QUEUED_DISPATCHES = 100;
 
-export type { ToolCallParams, ToolCallResult };
+export type { ToolCallCancelParams, ToolCallContext, ToolCallParams, ToolCallResult };
 export type { AskMainParams, AskMainResult };
 
 export type WorkerManagerConfig = {
@@ -26,7 +28,7 @@ export type WorkerManagerConfig = {
   slotWaitTimeoutMs?: number;
   maxQueuedDispatches?: number;
   bootstrap?: WorkerBootstrap.Bootstrap;
-  onToolCall?: (params: ToolCallParams) => Promise<ToolCallResult>;
+  onToolCall?: (params: ToolCallParams, context?: ToolCallContext) => Promise<ToolCallResult>;
   onAskMain?: (params: AskMainParams) => Promise<AskMainResult>;
   onWorkerSnapshot?: (workerId: number, snapshot: WorkerBootstrap.WorkerSnapshot) => void;
 };

--- a/packages/coordinator/src/worker-pool/index.ts
+++ b/packages/coordinator/src/worker-pool/index.ts
@@ -2,6 +2,8 @@ export {
   createWorkerPool,
   type WorkerPool,
   type WorkerPoolConfig,
+  type ToolCallCancelParams,
+  type ToolCallContext,
   type ToolCallParams,
   type ToolCallResult,
 } from "./pool";

--- a/packages/coordinator/src/worker-pool/pool.ts
+++ b/packages/coordinator/src/worker-pool/pool.ts
@@ -1,5 +1,7 @@
 import {
   createWorkerManager,
+  type ToolCallCancelParams,
+  type ToolCallContext,
   type ToolCallParams,
   type ToolCallResult,
   type WorkerManager,
@@ -7,7 +9,7 @@ import {
 } from "../worker-manager";
 import type { WorkerManagerConfig } from "../worker-manager";
 
-export type { ToolCallParams, ToolCallResult };
+export type { ToolCallCancelParams, ToolCallContext, ToolCallParams, ToolCallResult };
 
 export type WorkerPoolConfig = Omit<WorkerManagerConfig, "maxActiveWorkers"> & {
   /** Legacy alias for maxActiveWorkers. */

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -193,7 +193,13 @@ export class WorkerSupervisor {
                       },
                       5_000,
                     )
-                    .catch(() => undefined);
+                    .catch((err) => {
+                      console.warn("worker.tool_call_settled notification failed", {
+                        callId: p.callId,
+                        workspaceRoot: active.workspaceRoot,
+                        error: err instanceof Error ? err.message : String(err),
+                      });
+                    });
                 });
               return;
             }

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -15,6 +15,17 @@ export type ToolCallParams = {
   callId: string;
   tool: string;
   input: Record<string, unknown>;
+  workspaceRoot?: string;
+};
+
+export type ToolCallCancelParams = {
+  runId: string;
+  sessionId: string;
+  callId: string;
+};
+
+export type ToolCallContext = {
+  readonly signal?: AbortSignal;
 };
 
 export type ToolCallResult = {
@@ -22,13 +33,16 @@ export type ToolCallResult = {
   toolCallId: string;
   output: string;
   isError?: boolean;
+  settlement?: "settled" | "unknown";
 };
 
 export type AskMainParams = {
   workerId: string;
   sessionId: string;
+  callId?: string;
   runId?: string;
   question: string;
+  signal?: AbortSignal;
 };
 
 export type AskMainResult = {
@@ -36,6 +50,15 @@ export type AskMainResult = {
   accepted: boolean;
   output?: string;
   error?: string;
+};
+
+type ActiveRequest = {
+  readonly runId?: string;
+  readonly sessionId: string;
+  readonly workspaceRoot?: string;
+  readonly controller: AbortController;
+  readonly respond: (result: unknown) => void;
+  completed: boolean;
 };
 
 export class WorkerSupervisor {
@@ -48,6 +71,8 @@ export class WorkerSupervisor {
   private generation = 0;
   private running = false;
   private stopping = false;
+  private readonly activeToolCalls = new Map<string, ActiveRequest>();
+  private readonly activeAskMainCalls = new Map<string, ActiveRequest>();
   readonly socketPath: string;
 
   constructor(
@@ -55,7 +80,10 @@ export class WorkerSupervisor {
     private readonly script: string,
     socketDir = "/tmp",
     private readonly bootstrap?: WorkerBootstrap.Bootstrap,
-    private readonly toolCallHandler?: (params: ToolCallParams) => Promise<ToolCallResult>,
+    private readonly toolCallHandler?: (
+      params: ToolCallParams,
+      context?: ToolCallContext,
+    ) => Promise<ToolCallResult>,
     private readonly snapshotHandler?: (
       workerId: number,
       snapshot: WorkerBootstrap.WorkerSnapshot,
@@ -107,18 +135,92 @@ export class WorkerSupervisor {
         const c = await connectIpcClient(this.socketPath, {
           connectTimeoutMs: 500,
           onRequest: (method, params, respond) => {
+            if (method === "worker.tool_call_cancel") {
+              const p = parseToolCallCancelParams(params);
+              if (!p) {
+                respond({ cancelled: false, error: "invalid worker.tool_call_cancel params" });
+                return;
+              }
+              const active = this.activeToolCalls.get(p.callId);
+              if (!active || active.runId !== p.runId || active.sessionId !== p.sessionId) {
+                respond({ cancelled: false });
+                return;
+              }
+              active.controller.abort();
+              this.respondAndForget(this.activeToolCalls, p.callId, active, {
+                id: p.callId,
+                toolCallId: p.callId,
+                output: "Tool call aborted",
+                isError: true,
+                settlement: "unknown",
+              });
+              respond({ cancelled: true, settlement: "unknown" });
+              return;
+            }
+
             if (method === "worker.tool_call" && toolCallHandler) {
               const p = params as ToolCallParams;
-              toolCallHandler(p)
-                .then((result) => respond(result))
+              const controller = new AbortController();
+              const active: ActiveRequest = {
+                runId: p.runId,
+                sessionId: p.sessionId,
+                ...(typeof p.workspaceRoot === "string" ? { workspaceRoot: p.workspaceRoot } : {}),
+                controller,
+                respond,
+                completed: false,
+              };
+              this.activeToolCalls.set(p.callId, active);
+              toolCallHandler(p, { signal: controller.signal })
+                .then((result) =>
+                  this.respondAndForget(this.activeToolCalls, p.callId, active, result),
+                )
                 .catch((err) =>
-                  respond({
+                  this.respondAndForget(this.activeToolCalls, p.callId, active, {
                     id: p.callId,
                     toolCallId: p.callId,
                     output: err instanceof Error ? err.message : String(err),
                     isError: true,
                   }),
-                );
+                )
+                .finally(() => {
+                  this.activeToolCalls.delete(p.callId);
+                  void c
+                    .call(
+                      "worker.tool_call_settled",
+                      {
+                        callId: p.callId,
+                        ...(active.workspaceRoot ? { workspaceRoot: active.workspaceRoot } : {}),
+                      },
+                      5_000,
+                    )
+                    .catch(() => undefined);
+                });
+              return;
+            }
+
+            if (method === "worker.ask_main_cancel") {
+              const p = parseAskMainCancelParams(params);
+              if (!p) {
+                respond({ cancelled: false, error: "invalid worker.ask_main_cancel params" });
+                return;
+              }
+              const callId = p.callId;
+              const active = this.activeAskMainCalls.get(callId);
+              if (
+                !active ||
+                active.sessionId !== p.sessionId ||
+                (active.runId ?? "") !== (p.runId ?? "")
+              ) {
+                respond({ cancelled: false });
+                return;
+              }
+              active.controller.abort();
+              this.respondAndForget(this.activeAskMainCalls, callId, active, {
+                requestId: callId,
+                accepted: false,
+                error: "worker.ask_main aborted",
+              });
+              respond({ cancelled: true, settlement: "unknown" });
               return;
             }
 
@@ -137,6 +239,10 @@ export class WorkerSupervisor {
                 return;
               }
               const sessionId = typeof params?.sessionId === "string" ? params.sessionId : "";
+              const callId =
+                typeof params?.callId === "string" && params.callId.length > 0
+                  ? params.callId
+                  : requestId;
               const question = typeof params?.question === "string" ? params.question : "";
               if (!this.askResidentHandler || !sessionId || !question) {
                 respond({
@@ -149,20 +255,38 @@ export class WorkerSupervisor {
                 return;
               }
 
+              const controller = new AbortController();
+              const runId = typeof params?.runId === "string" ? params.runId : undefined;
+              const active: ActiveRequest = {
+                ...(runId !== undefined && { runId }),
+                sessionId,
+                controller,
+                respond,
+                completed: false,
+              };
+              this.activeAskMainCalls.set(callId, active);
+
               this.askResidentHandler({
                 workerId: String(workerId),
                 sessionId,
-                ...(typeof params?.runId === "string" ? { runId: params.runId } : {}),
+                callId,
+                ...(runId !== undefined && { runId }),
                 question,
+                signal: controller.signal,
               })
-                .then((result: AskMainResult) => respond(result))
+                .then((result: AskMainResult) =>
+                  this.respondAndForget(this.activeAskMainCalls, callId, active, result),
+                )
                 .catch((err: unknown) =>
-                  respond({
+                  this.respondAndForget(this.activeAskMainCalls, callId, active, {
                     requestId,
                     accepted: false,
                     error: err instanceof Error ? err.message : String(err),
                   }),
-                );
+                )
+                .finally(() => {
+                  this.activeAskMainCalls.delete(callId);
+                });
               return;
             }
 
@@ -223,6 +347,18 @@ export class WorkerSupervisor {
     setTimeout(() => {
       if (!this.stopping) this.doStart();
     }, delay);
+  }
+
+  private respondAndForget(
+    activeRequests: Map<string, ActiveRequest>,
+    callId: string,
+    active: ActiveRequest,
+    result: unknown,
+  ): void {
+    if (active.completed) return;
+    active.completed = true;
+    active.respond(result);
+    activeRequests.delete(callId);
   }
 
   isActive(): boolean {
@@ -354,6 +490,30 @@ function buildWorkerEnv(source: NodeJS.ProcessEnv): Record<string, string> {
     if (value !== undefined) env[key] = value;
   }
   return env;
+}
+
+function parseToolCallCancelParams(
+  params: Record<string, unknown> | undefined,
+): ToolCallCancelParams | undefined {
+  if (!params) return undefined;
+  const { runId, sessionId, callId } = params;
+  if (typeof runId !== "string" || typeof sessionId !== "string" || typeof callId !== "string") {
+    return undefined;
+  }
+  return { runId, sessionId, callId };
+}
+
+function parseAskMainCancelParams(
+  params: Record<string, unknown> | undefined,
+): { runId?: string; sessionId: string; callId: string } | undefined {
+  if (!params) return undefined;
+  const { runId, sessionId, callId } = params;
+  if (typeof sessionId !== "string" || typeof callId !== "string") return undefined;
+  return {
+    ...(typeof runId === "string" ? { runId } : {}),
+    sessionId,
+    callId,
+  };
 }
 
 function isBootstrapAccepted(value: unknown): boolean {

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -188,6 +188,7 @@ export class WorkerSupervisor {
                     .call(
                       "worker.tool_call_settled",
                       {
+                        authToken,
                         callId: p.callId,
                         ...(active.workspaceRoot ? { workspaceRoot: active.workspaceRoot } : {}),
                       },
@@ -252,7 +253,7 @@ export class WorkerSupervisor {
               const question = typeof params?.question === "string" ? params.question : "";
               if (!this.askResidentHandler || !sessionId || !question) {
                 respond({
-                  requestId,
+                  requestId: callId,
                   accepted: false,
                   error: this.askResidentHandler
                     ? "worker.ask_main requires sessionId and question"

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -22,7 +22,7 @@ export interface RunInput {
   model?: Provider.Model;
   auth?: Auth.Info;
   allowAuthFallback?: boolean;
-  toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+  toolExecutor?: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
   toolChoice?: "auto" | "required" | "none";
   maxSteps?: number;
   providerOptions?: Record<string, unknown>;
@@ -96,7 +96,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
                 tool: spec.name,
                 input: args,
               };
-              const result = await input.toolExecutor?.(call);
+              const result = await input.toolExecutor?.(call, { signal: abortSignal });
               if (!result) return "";
               sink.onToolCall(call);
               sink.onToolResult(result);

--- a/packages/openomni/src/execution-runtime/index.ts
+++ b/packages/openomni/src/execution-runtime/index.ts
@@ -19,6 +19,7 @@ export type {
   CatalogEntry,
   NativeTool,
   ToolCategory,
+  ToolExecutionContext,
   ToolExecutorConfig,
   ToolExecutorContext,
   ToolMetaValue,

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.test.ts
@@ -67,6 +67,24 @@ describe("AgentToolProvider", () => {
     expect(result.output).toBe("helper-agent-result");
   });
 
+  it("execute forwards execution context to registered tools", async () => {
+    const provider = new AgentToolProvider();
+    let capturedSignal: AbortSignal | undefined;
+    provider.register({
+      ...makeTool("helper-agent"),
+      execute: async (call, context) => {
+        capturedSignal = context?.signal;
+        return { id: crypto.randomUUID(), toolCallId: call.id, output: "ok" };
+      },
+    });
+    const controller = new AbortController();
+
+    const result = await provider.execute(makeCall("helper-agent"), { signal: controller.signal });
+
+    expect(result.output).toBe("ok");
+    expect(capturedSignal).toBe(controller.signal);
+  });
+
   it("execute resolves underscore-to-dot alias for registered tools", async () => {
     const provider = new AgentToolProvider();
     provider.register(makeTool("my.agent.tool"));

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -1,6 +1,6 @@
 import type { SubagentToolOptions } from "@openomni/agent";
 import type { Tool } from "@openomni/protocol";
-import type { NativeTool, ToolCategory, ToolProvider } from "../types.js";
+import type { NativeTool, ToolCategory, ToolExecutionContext, ToolProvider } from "../types.js";
 import { createSubagentTool } from "./tools/subagent.js";
 
 export class AgentToolProvider implements ToolProvider {
@@ -22,7 +22,7 @@ export class AgentToolProvider implements ToolProvider {
     return [createSubagentTool(this.subagentOptions), ...this.extraTools];
   }
 
-  execute(call: Tool.Call): Promise<Tool.Result> {
+  execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> {
     const tool = this.listTools().find(
       (entry) => entry.spec.name === call.tool || entry.spec.name === call.tool.replace(/_/g, "."),
     );
@@ -34,6 +34,8 @@ export class AgentToolProvider implements ToolProvider {
         isError: true,
       });
     }
-    return tool.execute({ ...call, tool: tool.spec.name });
+    return context === undefined
+      ? tool.execute({ ...call, tool: tool.spec.name })
+      : tool.execute({ ...call, tool: tool.spec.name }, context);
   }
 }

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -18,6 +18,7 @@ export function createSubagentRuntime(): SubagentRuntimeInterface {
         model: config.model,
         systemPrompt: config.systemPrompt,
         middleware: config.middleware,
+        signal: config.signal,
       });
       const result = await agent.run({
         messages: [{ role: "user", content: config.prompt }],
@@ -34,6 +35,7 @@ export function createSubagentRuntime(): SubagentRuntimeInterface {
         model: config.model,
         systemPrompt: config.systemPrompt,
         middleware: config.middleware,
+        signal: config.signal,
       });
       const result = await agent.run({
         messages: [{ role: "user", content: config.prompt }],
@@ -152,6 +154,7 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         parentSessionId: cfg.parentSessionId,
         permissions,
         middleware: config.middleware,
+        signal: config.signal,
       });
       return { sessionId: result.sessionId, runId: result.runId, output: result.output };
     },
@@ -173,6 +176,7 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         toolExecutor: cfg.toolsRef.toolExecutor,
         permissions,
         middleware: config.middleware,
+        signal: config.signal,
       });
       return { sessionId: result.sessionId, runId: result.runId, output: result.output };
     },

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent.ts
@@ -15,8 +15,8 @@ export function createSubagentTool(options?: SubagentToolOptions): NativeTool {
     isDestructive: false,
     isConcurrencySafe: false,
     source: "agent",
-    async execute(call) {
-      const result = await tool.execute(call.input);
+    async execute(call, context) {
+      const result = await tool.execute(call.input, context);
       return { ...result, toolCallId: call.id };
     },
   };

--- a/packages/openomni/src/execution-runtime/tool/builtins/bash.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/bash.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { bashTool } from "./bash";
@@ -34,6 +34,34 @@ describe("bashTool", () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.output).toBe(`auth= db= home=${workspace}`);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("kills the subprocess when execution context is aborted", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "openomni-bash-abort-"));
+    const marker = join(workspace, "late-write.txt");
+    const controller = new AbortController();
+
+    try {
+      const tool = bashTool(workspace);
+      const resultPromise = tool.execute(
+        {
+          id: "call-abort",
+          tool: "bash",
+          input: { command: "(sleep 0.2; touch late-write.txt) & wait" },
+        },
+        { signal: controller.signal },
+      );
+
+      setTimeout(() => controller.abort(), 20);
+      const result = await resultPromise;
+      await Bun.sleep(300);
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toContain("Command aborted");
+      expect(existsSync(marker)).toBe(false);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }

--- a/packages/openomni/src/execution-runtime/tool/builtins/bash.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/bash.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { defineTool } from "../define.js";
 import { optionalPositiveNumber, optionalString, requireString } from "../shared/input.js";
 import { errorResult, fromError, successResult } from "../shared/result.js";
-import type { NativeTool } from "../types.js";
+import type { NativeTool, ToolExecutionContext } from "../types.js";
 import { BASH_PROMPT } from "./bash-prompt.js";
 import { isDestructiveCommand, isReadOnlyCommand, readCommandFromMeta } from "./bash-classify.js";
 
@@ -43,6 +43,17 @@ function resolveTimeout(input: Record<string, unknown>): number {
   return Math.min(value, MAX_TIMEOUT_MS);
 }
 
+function terminateProcessGroup(proc: { readonly pid: number; kill(): void }): void {
+  try {
+    process.kill(-proc.pid, "SIGTERM");
+    return;
+  } catch {
+    // Windows and non-detached fallback.
+  }
+
+  proc.kill();
+}
+
 function buildBashEnv(workspaceRoot: string | undefined): Record<string, string> {
   const env: Record<string, string> = {};
   for (const key of bashEnvKeys) {
@@ -78,48 +89,67 @@ export function bashTool(workspaceRoot?: string): NativeTool {
     isDestructive: (input) => isDestructiveCommand(readCommandFromMeta(input)),
     isConcurrencySafe: false,
     source: "system",
-    async execute(call) {
+    async execute(call, context?: ToolExecutionContext) {
       let timedOut = false;
+      let aborted = false;
 
       try {
         const command = requireString(call.input, "command");
         const cwd = resolveWorkingDirectory(workspaceRoot, optionalString(call.input, "workdir"));
         const timeoutMs = resolveTimeout(call.input);
 
+        if (context?.signal?.aborted) {
+          return errorResult(call, "Command aborted");
+        }
+
         const proc = Bun.spawn(["bash", "-lc", command], {
           cwd,
+          detached: true,
           env: buildBashEnv(workspaceRoot),
           stdout: "pipe",
           stderr: "pipe",
         });
 
+        const abortCommand = () => {
+          aborted = true;
+          terminateProcessGroup(proc);
+        };
+        context?.signal?.addEventListener("abort", abortCommand, { once: true });
+
         const timer = setTimeout(() => {
           timedOut = true;
-          proc.kill();
+          terminateProcessGroup(proc);
         }, timeoutMs);
 
-        const [stdout, stderr, exitCode] = await Promise.all([
-          new Response(proc.stdout).text(),
-          new Response(proc.stderr).text(),
-          proc.exited,
-        ]);
+        try {
+          const [stdout, stderr, exitCode] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+          ]);
 
-        clearTimeout(timer);
+          const output = [stdout, stderr]
+            .filter((chunk) => chunk.length > 0)
+            .join("\n")
+            .trim();
 
-        const output = [stdout, stderr]
-          .filter((chunk) => chunk.length > 0)
-          .join("\n")
-          .trim();
+          if (aborted) {
+            return errorResult(call, output || "Command aborted");
+          }
 
-        if (timedOut) {
-          return errorResult(call, output || `Command timed out after ${timeoutMs}ms`);
+          if (timedOut) {
+            return errorResult(call, output || `Command timed out after ${timeoutMs}ms`);
+          }
+
+          if (exitCode !== 0) {
+            return errorResult(call, output || `Command exited with code ${exitCode}`);
+          }
+
+          return successResult(call, output);
+        } finally {
+          clearTimeout(timer);
+          context?.signal?.removeEventListener("abort", abortCommand);
         }
-
-        if (exitCode !== 0) {
-          return errorResult(call, output || `Command exited with code ${exitCode}`);
-        }
-
-        return successResult(call, output);
       } catch (err) {
         return fromError(call, err);
       }

--- a/packages/openomni/src/execution-runtime/tool/builtins/grep.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/grep.ts
@@ -4,22 +4,79 @@ import { defineTool } from "../define.js";
 import { optionalBoolean, optionalString, requireString } from "../shared/input.js";
 import { errorResult, fromError, successResult } from "../shared/result.js";
 import { resolveContainedPath } from "../../filesystem/workspace-path.js";
-import type { NativeTool } from "../types.js";
+import type { NativeTool, ToolExecutionContext } from "../types.js";
 import { GREP_PROMPT } from "./grep-prompt.js";
 
 type MatchResult = { file: string; line: number; text: string };
 
 const MAX_MATCHES = 100;
 
+type PipeProcess = {
+  readonly stdout: ReadableStream<Uint8Array>;
+  readonly stderr: ReadableStream<Uint8Array>;
+  readonly exited: Promise<number | null>;
+  kill(): void;
+};
+
+function abortError(): Error {
+  const error = new Error("Tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+async function waitForProcess(
+  proc: PipeProcess,
+  signal?: AbortSignal,
+): Promise<readonly [string, string, number | null]> {
+  if (signal?.aborted) {
+    proc.kill();
+    throw abortError();
+  }
+
+  const abortProcess = () => proc.kill();
+  signal?.addEventListener("abort", abortProcess, { once: true });
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    if (signal?.aborted) {
+      throw abortError();
+    }
+
+    return [stdout, stderr, exitCode] as const;
+  } finally {
+    signal?.removeEventListener("abort", abortProcess);
+  }
+}
+
 function normalizeIncludePattern(include?: string): string | undefined {
   if (!include) return undefined;
   return include.includes("/") || include.startsWith("**/") ? include : `**/${include}`;
 }
 
-async function collectFiles(rootPath: string, include?: string): Promise<string[]> {
+async function collectFiles(
+  rootPath: string,
+  include?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  if (signal?.aborted) throw abortError();
   if (statSync(rootPath).isFile()) return [rootPath];
   const glob = new Bun.Glob(normalizeIncludePattern(include) ?? "**/*");
-  return Array.fromAsync(glob.scan({ cwd: rootPath, absolute: true, onlyFiles: true, dot: true }));
+  const files: string[] = [];
+  for await (const filePath of glob.scan({
+    cwd: rootPath,
+    absolute: true,
+    onlyFiles: true,
+    dot: true,
+  })) {
+    if (signal?.aborted) throw abortError();
+    files.push(filePath);
+  }
+  return files;
 }
 
 async function searchWithRg(
@@ -28,9 +85,10 @@ async function searchWithRg(
   rootPath: string,
   include?: string,
   ignoreCase?: boolean,
+  signal?: AbortSignal,
 ): Promise<Tool.Result> {
   const binary = Bun.which("rg");
-  if (!binary) return searchWithGrep(call, pattern, rootPath, include, ignoreCase);
+  if (!binary) return searchWithGrep(call, pattern, rootPath, include, ignoreCase, signal);
 
   const args = [
     "--json",
@@ -46,13 +104,9 @@ async function searchWithRg(
     rootPath,
   ];
   const proc = Bun.spawn([binary, ...args], { stdout: "pipe", stderr: "pipe" });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await waitForProcess(proc, signal);
 
-  if (exitCode > 1) {
+  if (exitCode !== null && exitCode > 1) {
     const output = [stdout, stderr].filter(Boolean).join("\n").trim();
     return errorResult(call, output || `rg exited with code ${exitCode}`);
   }
@@ -86,24 +140,22 @@ async function searchWithGrep(
   rootPath: string,
   include?: string,
   ignoreCase?: boolean,
+  signal?: AbortSignal,
 ): Promise<Tool.Result> {
   const binary = Bun.which("grep");
   if (!binary) return errorResult(call, "Neither rg nor grep is available");
 
   const matches: MatchResult[] = [];
-  const files = await collectFiles(rootPath, include);
+  const files = await collectFiles(rootPath, include, signal);
   const command = [binary, "-rnH", "-E", ...(ignoreCase ? ["-i"] : []), "-e", pattern, "--"];
 
   for (const filePath of files) {
+    if (signal?.aborted) throw abortError();
     if (matches.length >= MAX_MATCHES) break;
     const proc = Bun.spawn([...command, filePath], { stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await waitForProcess(proc, signal);
 
-    if (exitCode > 1) {
+    if (exitCode !== null && exitCode > 1) {
       const output = [stdout, stderr].filter(Boolean).join("\n").trim();
       return errorResult(call, output || `grep exited with code ${exitCode}`);
     }
@@ -139,7 +191,7 @@ export function createGrepTool(workspaceRoot: string): NativeTool {
     isReadOnly: true,
     isDestructive: false,
     isConcurrencySafe: true,
-    async execute(call) {
+    async execute(call, context?: ToolExecutionContext) {
       try {
         const pattern = requireString(call.input, "pattern");
         const targetPath = optionalString(call.input, "path") ?? ".";
@@ -147,7 +199,7 @@ export function createGrepTool(workspaceRoot: string): NativeTool {
         const ignoreCase = optionalBoolean(call.input, "ignoreCase");
         const resolved = resolveContainedPath(workspaceRoot, targetPath);
 
-        return await searchWithRg(call, pattern, resolved, include, ignoreCase);
+        return await searchWithRg(call, pattern, resolved, include, ignoreCase, context?.signal);
       } catch (err) {
         return fromError(call, err);
       }

--- a/packages/openomni/src/execution-runtime/tool/define.ts
+++ b/packages/openomni/src/execution-runtime/tool/define.ts
@@ -2,6 +2,7 @@ import type { RuntimeResource, Tool as ProtocolTool } from "@openomni/protocol";
 import type {
   ImplicitInputSource,
   NativeTool,
+  ToolExecutionContext,
   ToolMetaValue,
   ToolRiskTier,
   ToolSource,
@@ -34,6 +35,7 @@ export interface ToolDefinition<TInput = Record<string, unknown>> {
   readonly implicitInputs?: Readonly<Record<string, ImplicitInputSource>>;
   execute(
     call: ProtocolTool.Call & { input: TInput extends Record<string, unknown> ? TInput : never },
+    context?: ToolExecutionContext,
   ): Promise<ProtocolTool.Result>;
 }
 

--- a/packages/openomni/src/execution-runtime/tool/executor.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor.test.ts
@@ -145,6 +145,133 @@ describe("createToolExecutor", () => {
     expect(result.output).toBe("timeout after 10ms");
   });
 
+  it("does not invoke tools when execution context is already aborted", async () => {
+    let invoked = false;
+    const executor = createToolExecutor({
+      tools: [
+        makeTool("read", {
+          execute: async (call) => {
+            invoked = true;
+            return { id: "r1", toolCallId: call.id, output: "unexpected" };
+          },
+        }),
+      ],
+    });
+    const controller = new AbortController();
+    controller.abort(new Error("already cancelled"));
+
+    const result = await executor(makeCall("read"), { signal: controller.signal });
+
+    expect(invoked).toBe(false);
+    expect(result.toolCallId).toBe("call-1");
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe("Tool execution aborted");
+  });
+
+  it("keeps timeout authoritative when cooperative abort rejects immediately", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const { events, stop } = collectBusEvents();
+    const executor = createToolExecutor({
+      tools: [
+        makeTool("slow", {
+          execute: (_call, context) => {
+            const signal = context?.signal;
+            receivedSignal = signal;
+            return new Promise<Tool.Result>((_, reject) => {
+              signal?.addEventListener(
+                "abort",
+                () => {
+                  const error = new Error("cooperative abort");
+                  error.name = "AbortError";
+                  reject(error);
+                },
+                { once: true },
+              );
+            });
+          },
+        }),
+      ],
+      config: { timeoutMs: { tier0: 10 } },
+    });
+
+    try {
+      const result = await executor(makeCall("slow"));
+
+      expect(receivedSignal?.aborted).toBe(true);
+      expect(result.toolCallId).toBe("call-1");
+      expect(result.isError).toBe(true);
+      expect(result.output).toBe("timeout after 10ms");
+      expect(events.some((event) => event.name === "tool.execution.timed_out")).toBe(true);
+    } finally {
+      stop();
+    }
+  });
+
+  it("aborts cooperative native tools when executor timeout fires", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    let abortReason: unknown;
+    const executor = createToolExecutor({
+      tools: [
+        makeTool("slow", {
+          execute: async (_call, context) => {
+            const signal = context?.signal;
+            receivedSignal = signal;
+            return await new Promise<Tool.Result>((_, reject) => {
+              signal?.addEventListener(
+                "abort",
+                () => {
+                  abortReason = (signal as AbortSignal & { reason?: unknown }).reason;
+                  const error = new Error("cooperative abort");
+                  error.name = "AbortError";
+                  reject(error);
+                },
+                { once: true },
+              );
+            });
+          },
+        }),
+      ],
+      config: { timeoutMs: { tier0: 10 } },
+    });
+
+    const result = await executor(makeCall("slow"));
+
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(abortReason).toBeInstanceOf(ToolRuntimePolicyMiddleware.TimeoutError);
+    expect(result.toolCallId).toBe("call-1");
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe("timeout after 10ms");
+  });
+
+  it("returns abort promptly when the parent signal aborts before timeout", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    const executor = createToolExecutor({
+      tools: [
+        makeTool("slow", {
+          execute: (_call, context) => {
+            receivedSignal = context?.signal;
+            return new Promise<Tool.Result>(() => {
+              // intentional: non-cooperative tool ignores abort
+            });
+          },
+        }),
+      ],
+      config: { timeoutMs: { tier0: 1_000 }, postTimeoutSettleGraceMs: 10 },
+    });
+
+    const resultPromise = executor(makeCall("slow"), { signal: controller.signal });
+    await Bun.sleep(0);
+    controller.abort();
+    const result = await resultPromise;
+
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(result.toolCallId).toBe("call-1");
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe("Tool execution aborted");
+  });
+
   it("dispatches to a dotted-name tool via its underscore alias", async () => {
     const executor = createToolExecutor({
       tools: [makeTool("grep.search")],

--- a/packages/openomni/src/execution-runtime/tool/executor.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor.ts
@@ -1,4 +1,5 @@
 import {
+  Operational,
   PolicyDecision,
   PolicyEvent,
   ToolExecution,
@@ -10,11 +11,14 @@ import { ToolRuntimePolicyMiddleware } from "./middleware/tool-runtime-policy.js
 import type {
   ImplicitInputSource,
   NativeTool,
+  ToolExecutionContext,
   ToolExecutorConfig,
   ToolRuntimeContext,
 } from "./types.js";
+import { WorkspaceLock } from "../workspace-lock.js";
 
 const TOOL_CALL_ACTION = "tool.call";
+const DEFAULT_POST_TIMEOUT_SETTLE_GRACE_MS = 5_000;
 
 export interface ToolExecutorContext {
   tools: NativeTool[];
@@ -40,6 +44,16 @@ function createErrorResult(call: Tool.Call, message: string): Tool.Result {
   };
 }
 
+function createAbortError(): Error {
+  const error = new Error("Tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function hasUnknownSettlement(result: Tool.Result): boolean {
+  return result.settlement === "unknown";
+}
+
 function buildActor(runtime: ToolRuntimeContext | undefined): Record<string, unknown> {
   return {
     kind: "agent",
@@ -51,6 +65,39 @@ function buildActor(runtime: ToolRuntimeContext | undefined): Record<string, unk
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return (signal as AbortSignal & { reason?: unknown }).reason;
+}
+
+function linkAbortSignals(
+  localSignal: AbortSignal,
+  parentSignal: AbortSignal | undefined,
+): { signal: AbortSignal; cleanup: () => void } {
+  if (!parentSignal) return { signal: localSignal, cleanup: () => undefined };
+
+  const linked = new AbortController();
+  const forwardLocalAbort = () => {
+    if (!linked.signal.aborted) linked.abort(abortReason(localSignal));
+  };
+  const forwardParentAbort = () => {
+    if (!linked.signal.aborted) linked.abort(abortReason(parentSignal));
+  };
+
+  if (localSignal.aborted) forwardLocalAbort();
+  if (parentSignal.aborted) forwardParentAbort();
+
+  localSignal.addEventListener("abort", forwardLocalAbort, { once: true });
+  parentSignal.addEventListener("abort", forwardParentAbort, { once: true });
+
+  return {
+    signal: linked.signal,
+    cleanup: () => {
+      localSignal.removeEventListener("abort", forwardLocalAbort);
+      parentSignal.removeEventListener("abort", forwardParentAbort);
+    },
+  };
 }
 
 function summarizeInput(input: unknown): string {
@@ -109,13 +156,106 @@ function publishPolicyEvaluated(
   });
 }
 
+type ToolSettlementOutcome =
+  | { readonly settled: true; readonly output: string }
+  | {
+      readonly settled: false;
+      readonly clearWhenToolSettles: boolean;
+      readonly unsafeToken?: string;
+    };
+
+function waitForToolSettlement(
+  promise: Promise<Tool.Result>,
+  graceMs: number,
+): Promise<ToolSettlementOutcome> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const timer = globalThis.setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      resolve({ settled: false, clearWhenToolSettles: true });
+    }, graceMs);
+    const finish = (outcome: ToolSettlementOutcome) => {
+      if (resolved) return;
+      resolved = true;
+      globalThis.clearTimeout(timer);
+      resolve(outcome);
+    };
+
+    promise.then(
+      (result) => {
+        if (hasUnknownSettlement(result)) {
+          finish({
+            settled: false,
+            clearWhenToolSettles: false,
+            unsafeToken: result.toolCallId || result.id,
+          });
+          return;
+        }
+        finish({ settled: true, output: result.output });
+      },
+      (error: unknown) =>
+        finish({
+          settled: true,
+          output: error instanceof Error ? error.message : String(error),
+        }),
+    );
+  });
+}
+
+async function enforceTimeoutAndAbort<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+  onTimeout: (error: ToolRuntimePolicyMiddleware.TimeoutError) => void,
+): Promise<T> {
+  if (signal?.aborted) throw createAbortError();
+
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timeoutFired = false;
+    const cleanup = () => {
+      globalThis.clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const onAbort = () => finish(() => reject(createAbortError()));
+    const timer = globalThis.setTimeout(() => {
+      timeoutFired = true;
+      const error = new ToolRuntimePolicyMiddleware.TimeoutError(timeoutMs);
+      finish(() => reject(error));
+      try {
+        onTimeout(error);
+      } catch {
+        // Timeout rejection is authoritative; cleanup callbacks must not
+        // escape the timer turn as uncaught exceptions.
+      }
+    }, timeoutMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => finish(() => resolve(value)),
+      (error: unknown) => {
+        if (timeoutFired) return;
+        finish(() => reject(error));
+      },
+    );
+  });
+}
+
 export function createToolExecutor(
   ctx: ToolExecutorContext,
-): (call: Tool.Call) => Promise<Tool.Result> {
+): (call: Tool.Call, context?: ToolExecutionContext) => Promise<Tool.Result> {
   const dispatch = buildDispatchTable(ctx.tools);
   const config = ctx.config ?? {};
+  const postTimeoutSettleGraceMs =
+    config.postTimeoutSettleGraceMs ?? DEFAULT_POST_TIMEOUT_SETTLE_GRACE_MS;
   const { workspaceRoot } = config;
-  const lockOwnerId = crypto.randomUUID();
   const runtime = config.runtime;
 
   function eventBase() {
@@ -127,15 +267,24 @@ export function createToolExecutor(
     };
   }
 
-  return async (call: Tool.Call): Promise<Tool.Result> => {
+  return async (call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> => {
     const tool = dispatch.get(call.tool);
     if (!tool) {
       return createErrorResult(call, `Unknown tool: ${call.tool}`);
     }
 
+    if (context?.signal?.aborted) {
+      return createErrorResult(call, "Tool execution aborted");
+    }
+
     const originalName = tool.spec.name;
     const actionId = crypto.randomUUID();
     const actor = buildActor(runtime);
+    let cleanupAbortSignal: (() => void) | undefined;
+    const abortController = new AbortController();
+    const linkedAbort = linkAbortSignals(abortController.signal, context?.signal);
+    cleanupAbortSignal = linkedAbort.cleanup;
+    if (linkedAbort.signal.aborted) throw createAbortError();
 
     Bus.publish(PolicyEvent.ActionRequested, {
       ...eventBase(),
@@ -150,6 +299,64 @@ export function createToolExecutor(
     const dispatchedCall =
       originalName === enrichedCall.tool ? enrichedCall : { ...enrichedCall, tool: originalName };
     let policy: ToolRuntimePolicyMiddleware.PreToolResult | undefined;
+    let shouldEvaluatePostTool = false;
+    let postToolDeferred = false;
+    let postToolOutput: string | undefined;
+    let toolExecution: Promise<Tool.Result> | undefined;
+    const lockOwnerId = crypto.randomUUID();
+
+    function evaluatePostToolOnce(): void {
+      if (!policy || !shouldEvaluatePostTool || postToolDeferred) return;
+
+      shouldEvaluatePostTool = false;
+      const postDecision = ToolRuntimePolicyMiddleware.evaluatePostTool({
+        toolName: originalName,
+        toolCallId: call.id,
+        input: dispatchedCall.input,
+        output: postToolOutput,
+        handle: policy.handle,
+      });
+      publishPolicyEvaluated(eventBase(), actor, originalName, postDecision);
+    }
+
+    function deferPostToolUntilExecutionSettles(fallbackOutput: string): void {
+      if (!toolExecution || !policy || !shouldEvaluatePostTool || postToolDeferred) return;
+
+      postToolDeferred = true;
+      void waitForToolSettlement(toolExecution, postTimeoutSettleGraceMs).then((outcome) => {
+        if (outcome.settled) {
+          postToolOutput = outcome.output;
+        } else {
+          postToolOutput = fallbackOutput;
+          if (policy?.handle.workspaceRoot && policy.handle.lockAcquired) {
+            WorkspaceLock.markUnsafe(
+              policy.handle.workspaceRoot,
+              `tool "${originalName}" did not settle after timeout/abort grace`,
+              outcome.unsafeToken ?? call.id,
+            );
+            const unsafeWorkspace = policy.handle.workspaceRoot;
+            const unsafeToken = outcome.unsafeToken ?? call.id;
+            if (outcome.clearWhenToolSettles) {
+              void toolExecution
+                ?.finally(() => WorkspaceLock.clearUnsafe(unsafeWorkspace, unsafeToken))
+                .catch(() => undefined);
+            }
+          }
+          Bus.publish(Operational.Warn, {
+            ...eventBase(),
+            component: "executor",
+            msg: "timed-out tool did not settle before post-timeout grace elapsed",
+            context: {
+              toolName: originalName,
+              toolCallId: call.id,
+              graceMs: postTimeoutSettleGraceMs,
+            },
+          });
+        }
+        postToolDeferred = false;
+        evaluatePostToolOnce();
+      });
+    }
 
     try {
       policy = await ToolRuntimePolicyMiddleware.evaluatePreTool({
@@ -161,6 +368,7 @@ export function createToolExecutor(
         timeoutConfig: config.timeoutMs,
         workspaceRoot,
         lockOwnerId,
+        signal: linkedAbort.signal,
       });
 
       publishPolicyEvaluated(eventBase(), actor, originalName, policy.decision);
@@ -190,7 +398,10 @@ export function createToolExecutor(
         return result;
       }
 
+      shouldEvaluatePostTool = true;
       const startTime = Date.now();
+      if (linkedAbort.signal.aborted) throw createAbortError();
+
       Bus.publish(ToolExecution.Started, {
         ...eventBase(),
         actor,
@@ -198,20 +409,30 @@ export function createToolExecutor(
         toolName: originalName,
       });
 
-      const result = await ToolRuntimePolicyMiddleware.enforceTimeout(
-        tool.execute(dispatchedCall),
+      toolExecution = tool.execute(dispatchedCall, { signal: linkedAbort.signal });
+      const result = await enforceTimeoutAndAbort(
+        toolExecution,
         policy.handle.timeoutMs,
+        context?.signal,
+        (error) => abortController.abort(error),
       );
       const durationMs = Date.now() - startTime;
+      postToolOutput = result.output;
 
-      const postDecision = ToolRuntimePolicyMiddleware.evaluatePostTool({
-        toolName: originalName,
-        toolCallId: call.id,
-        input: dispatchedCall.input,
-        output: result.output,
-        handle: policy.handle,
-      });
-      publishPolicyEvaluated(eventBase(), actor, originalName, postDecision);
+      if (hasUnknownSettlement(result)) {
+        deferPostToolUntilExecutionSettles(result.output);
+        Bus.publish(ToolExecution.Completed, {
+          ...eventBase(),
+          actor,
+          toolCallId: call.id,
+          toolName: originalName,
+          durationMs,
+          isError: result.isError ?? false,
+        });
+        return result;
+      }
+
+      evaluatePostToolOnce();
 
       Bus.publish(ToolExecution.Completed, {
         ...eventBase(),
@@ -226,6 +447,7 @@ export function createToolExecutor(
       const message = error instanceof Error ? error.message : String(error);
       const isTimeout = error instanceof ToolRuntimePolicyMiddleware.TimeoutError;
       const isAbort = isAbortError(error);
+      postToolOutput = message;
 
       if (isTimeout && policy) {
         const timeoutMs = (error as ToolRuntimePolicyMiddleware.TimeoutError).timeoutMs;
@@ -237,15 +459,10 @@ export function createToolExecutor(
         });
       }
 
-      if (policy && !PolicyDecision.isBlocking(policy.decision)) {
-        const postDecision = ToolRuntimePolicyMiddleware.evaluatePostTool({
-          toolName: originalName,
-          toolCallId: call.id,
-          input: dispatchedCall.input,
-          output: message,
-          handle: policy.handle,
-        });
-        publishPolicyEvaluated(eventBase(), actor, originalName, postDecision);
+      if (isTimeout || isAbort) {
+        deferPostToolUntilExecutionSettles(message);
+      } else {
+        evaluatePostToolOnce();
       }
 
       const result = createErrorResult(call, message);
@@ -269,6 +486,9 @@ export function createToolExecutor(
         isError: true,
       });
       return result;
+    } finally {
+      cleanupAbortSignal?.();
+      evaluatePostToolOnce();
     }
   };
 }

--- a/packages/openomni/src/execution-runtime/tool/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/index.ts
@@ -11,6 +11,7 @@ export type {
   ImplicitInputSource,
   NativeTool,
   ToolCategory,
+  ToolExecutionContext,
   ToolExecutorConfig,
   ToolMetaValue,
   ToolProvider,

--- a/packages/openomni/src/execution-runtime/tool/mcp-proxy-provider.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/mcp-proxy-provider.test.ts
@@ -75,6 +75,33 @@ describe("ToolProxyProvider", () => {
     expect(result).toEqual(mockResult);
   });
 
+  it("execute forwards execution context to the proxy caller", async () => {
+    const controller = new AbortController();
+    const mockResult: Tool.Result = {
+      id: crypto.randomUUID(),
+      toolCallId: "call-1",
+      output: "file content",
+    };
+    const callTool = mock(
+      async (_name: string, _args: Record<string, unknown>, _context?: { signal?: AbortSignal }) =>
+        mockResult,
+    );
+
+    const provider = ToolProxyProvider.create([makeEntry()], callTool);
+    const tool = getTool(provider.listTools(), 0);
+
+    const result = await tool.execute(makeCall("filesystem.read_file", { path: "/tmp/test.txt" }), {
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual(mockResult);
+    expect(callTool).toHaveBeenCalledWith(
+      "filesystem.read_file",
+      { path: "/tmp/test.txt" },
+      { signal: controller.signal },
+    );
+  });
+
   it("returns empty list when no entries", () => {
     const callTool = mock(async () => ({ id: "r1", toolCallId: "c1", output: "" }));
     const provider = ToolProxyProvider.create([], callTool);

--- a/packages/openomni/src/execution-runtime/tool/middleware/tool-runtime-policy.ts
+++ b/packages/openomni/src/execution-runtime/tool/middleware/tool-runtime-policy.ts
@@ -76,6 +76,10 @@ export namespace ToolRuntimePolicyMiddleware {
     }
   }
 
+  export interface TimeoutOptions {
+    readonly onTimeout?: (error: TimeoutError) => void;
+  }
+
   export interface RuntimePolicyHandle {
     readonly timeoutMs: number;
     readonly lockOwnerId: string;
@@ -92,6 +96,7 @@ export namespace ToolRuntimePolicyMiddleware {
     readonly timeoutConfig?: ToolExecutorConfig["timeoutMs"];
     readonly workspaceRoot?: string;
     readonly lockOwnerId: string;
+    readonly signal?: AbortSignal;
     readonly traceContext?: TraceContext.Type;
     readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
   }
@@ -144,7 +149,7 @@ export namespace ToolRuntimePolicyMiddleware {
     }
 
     try {
-      await WorkspaceLock.acquire(ctx.workspaceRoot, ctx.lockOwnerId);
+      await WorkspaceLock.acquire(ctx.workspaceRoot, ctx.lockOwnerId, 30_000, ctx.signal);
       handle.lockAcquired = true;
       recordDecision(
         allowDecision("workspace lock acquired", [
@@ -154,6 +159,7 @@ export namespace ToolRuntimePolicyMiddleware {
       );
       return { decision: allowDecision("runtime policy evaluated"), handle };
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") throw error;
       const decision = abortDecision(error instanceof Error ? error.message : String(error));
       recordDecision(decision, ctx.onDecision);
       return { decision, handle };
@@ -172,12 +178,23 @@ export namespace ToolRuntimePolicyMiddleware {
     return allowDecision("runtime policy post-tool evaluated");
   }
 
-  export function enforceTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  export function enforceTimeout<T>(
+    promise: Promise<T>,
+    ms: number,
+    options: TimeoutOptions = {},
+  ): Promise<T> {
     return Promise.race([
       promise,
       new Promise<never>((_, reject) => {
         const timer = globalThis.setTimeout(() => {
-          reject(new TimeoutError(ms));
+          const error = new TimeoutError(ms);
+          reject(error);
+          try {
+            options.onTimeout?.(error);
+          } catch {
+            // Timeout rejection is authoritative; do not let cleanup callbacks
+            // escape the timer turn as uncaught exceptions.
+          }
         }, ms);
 
         promise.then(

--- a/packages/openomni/src/execution-runtime/tool/system/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/system/provider.ts
@@ -1,5 +1,5 @@
 import type { Tool } from "@openomni/protocol";
-import type { NativeTool, ToolCategory, ToolProvider } from "../types.js";
+import type { NativeTool, ToolCategory, ToolExecutionContext, ToolProvider } from "../types.js";
 import { bashTool } from "../builtins/bash.js";
 import { createEditTool } from "../builtins/edit.js";
 import { createGlobTool } from "../builtins/glob.js";
@@ -27,7 +27,7 @@ export class SystemToolProvider implements ToolProvider {
     return tools;
   }
 
-  execute(call: Tool.Call): Promise<Tool.Result> {
+  execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> {
     const tool = this.listTools().find(
       (entry) => entry.spec.name === call.tool || entry.spec.name === call.tool.replace(/_/g, "."),
     );
@@ -39,6 +39,8 @@ export class SystemToolProvider implements ToolProvider {
         isError: true,
       });
     }
-    return tool.execute({ ...call, tool: tool.spec.name });
+    return context === undefined
+      ? tool.execute({ ...call, tool: tool.spec.name })
+      : tool.execute({ ...call, tool: tool.spec.name }, context);
   }
 }

--- a/packages/openomni/src/execution-runtime/tool/tool-proxy-provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/tool-proxy-provider.ts
@@ -1,13 +1,17 @@
 import type { Tool } from "@openomni/protocol";
 import type { WorkerBootstrap } from "@openomni/protocol";
-import type { NativeTool } from "./types.js";
+import type { NativeTool, ToolExecutionContext } from "./types.js";
 
 type RuntimeToolCatalogEntry = WorkerBootstrap.RuntimeToolCatalogEntry;
 
 export namespace ToolProxyProvider {
   export function create(
     entries: RuntimeToolCatalogEntry[],
-    callTool: (toolName: string, args: Record<string, unknown>) => Promise<Tool.Result>,
+    callTool: (
+      toolName: string,
+      args: Record<string, unknown>,
+      context?: ToolExecutionContext,
+    ) => Promise<Tool.Result>,
   ): { listTools(): NativeTool[] } {
     const tools: NativeTool[] = entries.map((entry) => ({
       spec: entry.spec,
@@ -18,8 +22,10 @@ export namespace ToolProxyProvider {
       labels: entry.spec.labels,
       ...(entry.descriptor !== undefined && { descriptor: entry.descriptor }),
       source: entry.source,
-      execute: (call: Tool.Call): Promise<Tool.Result> =>
-        callTool(entry.canonicalName, call.input as Record<string, unknown>),
+      execute: (call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> =>
+        context === undefined
+          ? callTool(entry.canonicalName, call.input as Record<string, unknown>)
+          : callTool(entry.canonicalName, call.input as Record<string, unknown>, context),
     }));
 
     return {

--- a/packages/openomni/src/execution-runtime/tool/types.ts
+++ b/packages/openomni/src/execution-runtime/tool/types.ts
@@ -18,6 +18,8 @@ export interface ToolRuntimeContext {
   readonly workspaceRoot?: string;
 }
 
+export type ToolExecutionContext = Tool.ExecutionContext;
+
 export interface NativeTool {
   spec: Tool.Spec;
   riskTier: ToolRiskTier;
@@ -29,14 +31,14 @@ export interface NativeTool {
   source?: ToolSource;
   category?: ToolSelection.Category;
   implicitInputs?: Readonly<Record<string, ImplicitInputSource>>;
-  execute(call: Tool.Call): Promise<Tool.Result>;
+  execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result>;
 }
 
 export interface ToolProvider {
   readonly name: string;
   readonly category: ToolCategory;
   listTools(): NativeTool[];
-  execute(call: Tool.Call): Promise<Tool.Result>;
+  execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result>;
 }
 
 export interface ToolExecutorConfig {
@@ -48,4 +50,5 @@ export interface ToolExecutorConfig {
     tier1?: number;
     tier2?: number;
   };
+  postTimeoutSettleGraceMs?: number;
 }

--- a/packages/openomni/src/execution-runtime/workspace-lock.test.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Tool } from "@openomni/protocol";
 import { createToolExecutor } from "./tool/executor.js";
+import { bashTool } from "./tool/builtins/bash.js";
 import type { NativeTool } from "./tool/types.js";
 import { WorkspaceLock } from "./workspace-lock.js";
 
@@ -92,6 +96,33 @@ describe("WorkspaceLock", () => {
     expect(waiters).toHaveLength(0);
     WorkspaceLock.release(workspace, "owner");
   });
+
+  test("unsafe markers clear only for the matching token", async () => {
+    const workspace = makeWorkspace();
+
+    WorkspaceLock.markUnsafe(workspace, "unknown settlement", "call-a");
+    WorkspaceLock.clearUnsafe(workspace, "call-b");
+
+    const blocked = await WorkspaceLock.acquire(workspace, "probe-mismatch", 50).catch(
+      (error) => error,
+    );
+    expect(blocked).toBeInstanceOf(Error);
+    expect((blocked as Error).message).toContain("workspace marked unsafe");
+
+    WorkspaceLock.clearUnsafe(workspace, "call-a");
+    await WorkspaceLock.acquire(workspace, "probe-match", 50);
+    WorkspaceLock.release(workspace, "probe-match");
+  });
+
+  test("settlement token received before unsafe mark suppresses stale unsafe marker", async () => {
+    const workspace = makeWorkspace();
+
+    WorkspaceLock.clearUnsafe(workspace, "already-settled-call");
+    WorkspaceLock.markUnsafe(workspace, "late unknown settlement", "already-settled-call");
+
+    await WorkspaceLock.acquire(workspace, "probe-settled-first", 50);
+    WorkspaceLock.release(workspace, "probe-settled-first");
+  });
 });
 
 describe("createToolExecutor — workspace lock integration", () => {
@@ -164,16 +195,84 @@ describe("createToolExecutor — workspace lock integration", () => {
     WorkspaceLock.release(workspace, "probe");
   });
 
-  test("tier-1 tools release workspace lock after executor timeouts", async () => {
+  test("pre-aborted tier-1 tools do not acquire the workspace lock", async () => {
     const workspace = makeWorkspace();
+    await WorkspaceLock.acquire(workspace, "holder");
+    const controller = new AbortController();
+    controller.abort();
+    let executed = false;
     const executor = createToolExecutor({
       tools: [
         {
           ...makeTool("write", 1),
-          execute: () =>
-            new Promise<Tool.Result>(() => {
-              // intentional: never resolves to test timeout
-            }),
+          execute: async (call) => {
+            executed = true;
+            return { id: crypto.randomUUID(), toolCallId: call.id, output: "unexpected" };
+          },
+        },
+      ],
+      config: { workspaceRoot: workspace, timeoutMs: { tier1: 10 } },
+    });
+
+    try {
+      const result = await executor(
+        { id: "pre-aborted", tool: "write", input: {} },
+        { signal: controller.signal },
+      );
+      expect(result.isError).toBe(true);
+      expect(result.output).toBe("Tool execution aborted");
+      expect(executed).toBe(false);
+    } finally {
+      WorkspaceLock.release(workspace, "holder");
+    }
+  });
+
+  test("tier-1 tools abort promptly while waiting for the workspace lock", async () => {
+    const workspace = makeWorkspace();
+    await WorkspaceLock.acquire(workspace, "holder");
+    const controller = new AbortController();
+    let executed = false;
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: async (call) => {
+            executed = true;
+            return { id: crypto.randomUUID(), toolCallId: call.id, output: "unexpected" };
+          },
+        },
+      ],
+      config: { workspaceRoot: workspace },
+    });
+
+    try {
+      const resultPromise = executor(
+        { id: "abort-while-waiting", tool: "write", input: {} },
+        { signal: controller.signal },
+      );
+      await Bun.sleep(10);
+      controller.abort();
+      const result = await resultPromise;
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toBe("Tool execution aborted");
+      expect(executed).toBe(false);
+    } finally {
+      WorkspaceLock.release(workspace, "holder");
+    }
+  });
+
+  test("tier-1 tools keep the workspace lock until timed-out execution settles", async () => {
+    const workspace = makeWorkspace();
+    let settleTool: ((result: Tool.Result) => void) | undefined;
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: (call) =>
+            new Promise<Tool.Result>((resolve) => {
+              settleTool = resolve;
+            }).then((result) => ({ ...result, toolCallId: call.id })),
         },
       ],
       config: { workspaceRoot: workspace, timeoutMs: { tier1: 10 } },
@@ -183,7 +282,218 @@ describe("createToolExecutor — workspace lock integration", () => {
     expect(result.isError).toBe(true);
     expect(result.output).toBe("timeout after 10ms");
 
+    const blockedProbe = await WorkspaceLock.acquire(workspace, "probe-before-settle", 30).catch(
+      (error) => error,
+    );
+    expect(blockedProbe).toBeInstanceOf(Error);
+    expect((blockedProbe as Error).message).toContain("workspace lock timeout");
+
+    settleTool?.({ id: "late-result", toolCallId: "c4", output: "late" });
+    await Bun.sleep(0);
+
+    await WorkspaceLock.acquire(workspace, "probe-after-settle", 50);
+    WorkspaceLock.release(workspace, "probe-after-settle");
+  });
+
+  test("same executor cannot reenter workspace while a timed-out tool is settling", async () => {
+    const workspace = makeWorkspace();
+    let firstStarted = false;
+    let secondStarted = false;
+    let settleFirst: ((result: Tool.Result) => void) | undefined;
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: (call) => {
+            if (!firstStarted) {
+              firstStarted = true;
+              return new Promise<Tool.Result>((resolve) => {
+                settleFirst = resolve;
+              }).then((result) => ({ ...result, toolCallId: call.id }));
+            }
+            secondStarted = true;
+            return Promise.resolve({
+              id: crypto.randomUUID(),
+              toolCallId: call.id,
+              output: "second",
+            });
+          },
+        },
+      ],
+      config: { workspaceRoot: workspace, timeoutMs: { tier1: 10 } },
+    });
+
+    const first = await executor({ id: "c4-first", tool: "write", input: {} });
+    expect(first.output).toBe("timeout after 10ms");
+
+    let secondDone = false;
+    const second = executor({ id: "c4-second", tool: "write", input: {} }).then((result) => {
+      secondDone = true;
+      return result;
+    });
+    await Bun.sleep(20);
+    expect(secondStarted).toBe(false);
+    expect(secondDone).toBe(false);
+
+    settleFirst?.({ id: "late-result", toolCallId: "c4-first", output: "late" });
+    const secondResult = await second;
+    expect(secondStarted).toBe(true);
+    expect(secondResult.output).toBe("second");
+  });
+
+  test("tier-1 tools mark workspace unsafe after post-timeout settlement grace", async () => {
+    const workspace = makeWorkspace();
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: () => new Promise<Tool.Result>(() => undefined),
+        },
+      ],
+      config: { workspaceRoot: workspace, timeoutMs: { tier1: 10 }, postTimeoutSettleGraceMs: 20 },
+    });
+
+    const result = await executor({ id: "c4-grace", tool: "write", input: {} });
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe("timeout after 10ms");
+
+    const blockedProbe = await WorkspaceLock.acquire(workspace, "probe-before-grace", 5).catch(
+      (error) => error,
+    );
+    expect(blockedProbe).toBeInstanceOf(Error);
+    expect((blockedProbe as Error).message).toContain("workspace lock timeout");
+
+    await Bun.sleep(30);
+
+    const unsafeProbe = await WorkspaceLock.acquire(workspace, "probe-after-grace", 50).catch(
+      (error) => error,
+    );
+    expect(unsafeProbe).toBeInstanceOf(Error);
+    expect((unsafeProbe as Error).message).toContain("workspace marked unsafe");
+    WorkspaceLock.clearUnsafe(workspace);
+  });
+
+  test("tier-1 tools mark workspace unsafe when a proxy reports unknown settlement", async () => {
+    const workspace = makeWorkspace();
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: async (call) => ({
+            id: crypto.randomUUID(),
+            toolCallId: call.id,
+            output: "Tool call aborted",
+            isError: true,
+            settlement: "unknown",
+          }),
+        },
+      ],
+      config: { workspaceRoot: workspace, postTimeoutSettleGraceMs: 20 },
+    });
+
+    const result = await executor({ id: "c4-unknown", tool: "write", input: {} });
+    expect(result.isError).toBe(true);
+    expect(result.settlement).toBe("unknown");
+
+    const unsafeProbe = await WorkspaceLock.acquire(workspace, "probe-unknown", 50).catch(
+      (error) => error,
+    );
+    expect(unsafeProbe).toBeInstanceOf(Error);
+    expect((unsafeProbe as Error).message).toContain("workspace marked unsafe");
+    WorkspaceLock.clearUnsafe(workspace);
+  });
+
+  test("unknown-settlement unsafe marker clears only for the proxy call that reported it", async () => {
+    const workspace = makeWorkspace();
+    const proxyCallId = "proxy-call-id";
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: async () => ({
+            id: proxyCallId,
+            toolCallId: proxyCallId,
+            output: "Tool call aborted",
+            isError: true,
+            settlement: "unknown",
+          }),
+        },
+      ],
+      config: { workspaceRoot: workspace, postTimeoutSettleGraceMs: 20 },
+    });
+
+    await executor({ id: "agent-call-id", tool: "write", input: {} });
+    WorkspaceLock.clearUnsafe(workspace, "unrelated-call");
+
+    const blocked = await WorkspaceLock.acquire(workspace, "probe-wrong-call", 50).catch(
+      (error) => error,
+    );
+    expect(blocked).toBeInstanceOf(Error);
+    expect((blocked as Error).message).toContain("workspace marked unsafe");
+
+    WorkspaceLock.clearUnsafe(workspace, proxyCallId);
+    await WorkspaceLock.acquire(workspace, "probe-right-call", 50);
+    WorkspaceLock.release(workspace, "probe-right-call");
+  });
+
+  test("tier-1 tools release workspace lock after cooperative timeout aborts", async () => {
+    const workspace = makeWorkspace();
+    const executor = createToolExecutor({
+      tools: [
+        {
+          ...makeTool("write", 1),
+          execute: async (_call, context) => {
+            const signal = context?.signal;
+            return await new Promise<Tool.Result>((_, reject) => {
+              signal?.addEventListener(
+                "abort",
+                () => {
+                  const error = new Error("cooperative abort");
+                  error.name = "AbortError";
+                  reject(error);
+                },
+                { once: true },
+              );
+            });
+          },
+        },
+      ],
+      config: { workspaceRoot: workspace, timeoutMs: { tier1: 10 } },
+    });
+
+    const result = await executor({ id: "c5", tool: "write", input: {} });
+    expect(result.isError).toBe(true);
+    expect(result.output).toBe("timeout after 10ms");
+
     await WorkspaceLock.acquire(workspace, "probe", 50);
     WorkspaceLock.release(workspace, "probe");
+  });
+
+  test("aborts bash side effects before releasing the workspace lock after timeout", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "openomni-lock-bash-timeout-"));
+    const marker = join(workspace, "late-write.txt");
+
+    try {
+      const executor = createToolExecutor({
+        tools: [bashTool(workspace)],
+        config: { workspaceRoot: workspace, timeoutMs: { tier2: 20 } },
+      });
+
+      const result = await executor({
+        id: "c6",
+        tool: "bash",
+        input: { command: "(sleep 0.2; touch late-write.txt) & wait" },
+      });
+      await Bun.sleep(300);
+
+      expect(result.isError).toBe(true);
+      expect(result.output).toBe("timeout after 20ms");
+      expect(existsSync(marker)).toBe(false);
+
+      await WorkspaceLock.acquire(workspace, "probe", 50);
+      WorkspaceLock.release(workspace, "probe");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/openomni/src/execution-runtime/workspace-lock.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock.ts
@@ -1,29 +1,78 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 type Waiter = { runId: string; resolve: () => void; reject: (e: Error) => void };
 type LocalLock = { runId: string; depth: number; pending: boolean };
 type LockOwnerMeta = { runId: string; pid: number; acquiredAt: number };
+type UnsafeWorkspace = { reason: string; markedAt: number; token?: string };
 
 const active = new Map<string, LocalLock>();
 const queue = new Map<string, Waiter[]>();
+const unsafe = new Map<string, UnsafeWorkspace>();
+const settledUnsafeTokens = new Map<string, number>();
 const LOCK_ROOT = join(tmpdir(), "openomni-workspace-locks");
 const OWNER_FILE = "owner.json";
 const STALE_GRACE_MS = 1_000;
+const SETTLED_TOKEN_TTL_MS = 5 * 60_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function createAbortError(): Error {
+  const error = new Error("Tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
+function sleepAbortable(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (!signal) return sleep(ms);
+  throwIfAborted(signal);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 function lockPath(workspace: string): string {
-  const key = createHash("sha256").update(workspace).digest("hex");
-  return join(LOCK_ROOT, key);
+  return join(LOCK_ROOT, lockKey(workspace));
+}
+
+function lockKey(workspace: string): string {
+  return createHash("sha256").update(workspace).digest("hex");
+}
+
+function unsafeTokenKey(workspace: string, token: string): string {
+  return `${lockKey(workspace)}:${token}`;
+}
+
+function pruneSettledUnsafeTokens(): void {
+  const now = Date.now();
+  for (const [key, settledAt] of settledUnsafeTokens) {
+    if (now - settledAt >= SETTLED_TOKEN_TTL_MS) settledUnsafeTokens.delete(key);
+  }
 }
 
 function ownerFilePath(workspace: string): string {
   return join(lockPath(workspace), OWNER_FILE);
+}
+
+function unsafeFilePath(workspace: string): string {
+  return join(LOCK_ROOT, `${lockKey(workspace)}.unsafe.json`);
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -47,6 +96,18 @@ function readOwnerMeta(workspace: string): LockOwnerMeta | undefined {
   }
 }
 
+function readUnsafeMeta(workspace: string): UnsafeWorkspace | undefined {
+  const local = unsafe.get(workspace);
+  if (local) return local;
+  try {
+    const parsed = JSON.parse(readFileSync(unsafeFilePath(workspace), "utf-8")) as UnsafeWorkspace;
+    unsafe.set(workspace, parsed);
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
 function removeLockDir(workspace: string): void {
   rmSync(lockPath(workspace), { recursive: true, force: true });
 }
@@ -65,15 +126,22 @@ function shouldReapStaleLock(workspace: string): boolean {
   }
 }
 
-async function acquireExternal(workspace: string, runId: string, timeoutMs: number): Promise<void> {
+async function acquireExternal(
+  workspace: string,
+  runId: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
   mkdirSync(LOCK_ROOT, { recursive: true });
   const start = Date.now();
 
   for (;;) {
+    throwIfAborted(signal);
     try {
       const path = lockPath(workspace);
       mkdirSync(path);
       try {
+        throwIfAborted(signal);
         writeFileSync(
           join(path, OWNER_FILE),
           JSON.stringify({ runId, pid: process.pid, acquiredAt: Date.now() }),
@@ -101,7 +169,7 @@ async function acquireExternal(workspace: string, runId: string, timeoutMs: numb
       if (Date.now() - start >= timeoutMs) {
         throw new Error(`workspace lock timeout after ${timeoutMs}ms for "${workspace}"`);
       }
-      await sleep(25);
+      await sleepAbortable(25, signal);
     }
   }
 }
@@ -114,6 +182,12 @@ function releaseExternal(workspace: string, runId: string): void {
 }
 
 function wakeNextWaiter(workspace: string): void {
+  const unsafeState = readUnsafeMeta(workspace);
+  if (unsafeState) {
+    rejectWaiters(workspace, unsafeWorkspaceError(workspace, unsafeState));
+    return;
+  }
+
   const waiters = queue.get(workspace);
   if (!waiters || waiters.length === 0) {
     queue.delete(workspace);
@@ -128,12 +202,28 @@ function wakeNextWaiter(workspace: string): void {
   next.resolve();
 }
 
+function unsafeWorkspaceError(workspace: string, state: UnsafeWorkspace): Error {
+  return new Error(`workspace marked unsafe for "${workspace}": ${state.reason}`);
+}
+
+function rejectWaiters(workspace: string, error: Error): void {
+  const waiters = queue.get(workspace);
+  if (!waiters) return;
+  queue.delete(workspace);
+  for (const waiter of waiters) waiter.reject(error);
+}
+
 export namespace WorkspaceLock {
   export async function acquire(
     workspace: string,
     runId: string,
     timeoutMs = 30_000,
+    signal?: AbortSignal,
   ): Promise<void> {
+    throwIfAborted(signal);
+    const unsafeState = readUnsafeMeta(workspace);
+    if (unsafeState) throw unsafeWorkspaceError(workspace, unsafeState);
+
     const local = active.get(workspace);
     if (local && !local.pending && local.runId === runId) {
       local.depth++;
@@ -141,7 +231,11 @@ export namespace WorkspaceLock {
     }
 
     if (!local && (queue.get(workspace)?.length ?? 0) === 0) {
-      await acquireExternal(workspace, runId, timeoutMs);
+      await acquireExternal(workspace, runId, timeoutMs, signal);
+      if (signal?.aborted) {
+        releaseExternal(workspace, runId);
+        throw createAbortError();
+      }
       active.set(workspace, { runId, depth: 1, pending: false });
       return;
     }
@@ -163,15 +257,27 @@ export namespace WorkspaceLock {
         }
         reject(new Error(`workspace lock timeout after ${timeoutMs}ms for "${workspace}"`));
       }, timeoutMs);
+      const onAbort = () => {
+        const waiters = queue.get(workspace);
+        if (waiters) {
+          const idx = waiters.indexOf(entry);
+          if (idx !== -1) waiters.splice(idx, 1);
+          if (waiters.length === 0) queue.delete(workspace);
+        }
+        reject(createAbortError());
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
 
       const complete = entry.resolve;
       entry.resolve = () => {
         clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
         complete();
       };
       const fail = entry.reject;
       entry.reject = (error) => {
         clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
         fail(error);
       };
 
@@ -182,7 +288,13 @@ export namespace WorkspaceLock {
 
     const remaining = Math.max(0, timeoutMs - (Date.now() - start));
     try {
-      await acquireExternal(workspace, runId, remaining);
+      const unsafeState = readUnsafeMeta(workspace);
+      if (unsafeState) throw unsafeWorkspaceError(workspace, unsafeState);
+      await acquireExternal(workspace, runId, remaining, signal);
+      if (signal?.aborted) {
+        releaseExternal(workspace, runId);
+        throw createAbortError();
+      }
       active.set(workspace, { runId, depth: 1, pending: false });
     } catch (error) {
       const current = active.get(workspace);
@@ -205,5 +317,42 @@ export namespace WorkspaceLock {
     active.delete(workspace);
     releaseExternal(workspace, runId);
     wakeNextWaiter(workspace);
+  }
+
+  export function markUnsafe(workspace: string, reason: string, token?: string): void {
+    if (token !== undefined) {
+      pruneSettledUnsafeTokens();
+      if (settledUnsafeTokens.has(unsafeTokenKey(workspace, token))) return;
+    }
+
+    const state: UnsafeWorkspace = {
+      reason,
+      markedAt: Date.now(),
+      ...(token !== undefined ? { token } : {}),
+    };
+    unsafe.set(workspace, state);
+    mkdirSync(LOCK_ROOT, { recursive: true });
+    writeFileSync(unsafeFilePath(workspace), JSON.stringify(state), "utf-8");
+    rejectWaiters(workspace, unsafeWorkspaceError(workspace, state));
+  }
+
+  export function isUnsafe(workspace: string): boolean {
+    return readUnsafeMeta(workspace) !== undefined;
+  }
+
+  export function clearUnsafe(workspace: string, token?: string): void {
+    const state = readUnsafeMeta(workspace);
+    if (token !== undefined) {
+      pruneSettledUnsafeTokens();
+      settledUnsafeTokens.set(unsafeTokenKey(workspace, token), Date.now());
+      if (state?.token !== token) return;
+    }
+
+    unsafe.delete(workspace);
+    try {
+      unlinkSync(unsafeFilePath(workspace));
+    } catch {
+      // No unsafe marker exists.
+    }
   }
 }

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -110,6 +110,7 @@ export type {
   CatalogEntry,
   NativeTool,
   ToolCategory,
+  ToolExecutionContext,
   ToolExecutorConfig,
   ToolExecutorContext,
   ToolMetaValue,

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -345,6 +345,7 @@ export namespace IngressHandlers {
       sessionId: ctx.sessionId,
       event: ctx.event,
       traceContext: ctx.traceContext,
+      signal: (ctx.event.runtime as { signal?: AbortSignal } | undefined)?.signal,
     });
     const output = await dispatchWritebackCommit(ctx, residentResult.output);
     SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -189,24 +189,41 @@ export class ResidentRuntime {
     }
   }
 
-  private async acquireSlot(): Promise<void> {
+  private async acquireSlot(signal?: AbortSignal): Promise<void> {
+    throwIfAborted(signal);
     if (this.activeRuns < this.maxActive) {
       this.activeRuns++;
       return;
     }
     let timer: ReturnType<typeof setTimeout> | undefined;
     await new Promise<void>((resolve, reject) => {
-      const waiter = { resolve, reject };
+      const waiter = {
+        resolve: () => {
+          if (timer) clearTimeout(timer);
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        reject: (error: Error) => {
+          if (timer) clearTimeout(timer);
+          signal?.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      };
+      const onAbort = () => {
+        const index = this.waiters.indexOf(waiter);
+        if (index >= 0) this.waiters.splice(index, 1);
+        waiter.reject(createAbortError());
+      };
       this.waiters.push(waiter);
+      signal?.addEventListener("abort", onAbort, { once: true });
       timer = setTimeout(() => {
         const index = this.waiters.indexOf(waiter);
         if (index >= 0) this.waiters.splice(index, 1);
-        reject(
+        waiter.reject(
           new Error(`resident activation slot wait timed out after ${this.slotWaitTimeoutMs}ms`),
         );
       }, this.slotWaitTimeoutMs);
     });
-    if (timer) clearTimeout(timer);
   }
 
   private releaseSlot(): void {
@@ -256,8 +273,9 @@ export class ResidentRuntime {
   }
 
   private async runExclusive(ctx: ResidentRunContext): Promise<ResidentRunResult> {
-    await this.acquireSlot();
-    const activation = this.ensureActivation(ctx.sessionId);
+    let slotAcquired = false;
+    await this.acquireSlot(ctx.signal);
+    slotAcquired = true;
     const runId = crypto.randomUUID();
     const start = Date.now();
     const traceContext = {
@@ -267,6 +285,8 @@ export class ResidentRuntime {
     };
 
     try {
+      throwIfAborted(ctx.signal);
+      const activation = this.ensureActivation(ctx.sessionId);
       if (activation.idleTimer) clearTimeout(activation.idleTimer);
       activation.lifecycle = "hydrating";
       const messages = SessionBridge.buildDirectMessages(ctx.sessionId).filter(
@@ -298,6 +318,8 @@ export class ResidentRuntime {
         activationId: activation.activationId,
       };
     } catch (error) {
+      const activation = this.activations.get(ctx.sessionId);
+      if (!activation) throw error;
       activation.lastUsedAt = Date.now();
       this.scheduleIdleRelease(ctx.sessionId, activation);
       Bus.publish(IngressEvent.Failed, {
@@ -311,7 +333,7 @@ export class ResidentRuntime {
       });
       throw error;
     } finally {
-      this.releaseSlot();
+      if (slotAcquired) this.releaseSlot();
     }
   }
 }

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -15,6 +15,7 @@ export interface ResidentRunContext {
   readonly sessionId: string;
   readonly event: Ingress.ResolvedInboundEvent;
   readonly traceContext?: TraceContextProtocol.Type;
+  readonly signal?: AbortSignal;
 }
 
 export interface ResidentRunResult {
@@ -49,6 +50,43 @@ type SlotWaiter = { resolve: () => void; reject: (error: Error) => void };
 
 function defaultRunAgent(config: ChatAgentConfig, input: ChatAgentInput) {
   return ChatAgent.create(config).run(input);
+}
+
+function createAbortError(): Error {
+  const error = new Error("resident run aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
+function abortRace(signal: AbortSignal | undefined): {
+  readonly promise: Promise<never>;
+  readonly cleanup: () => void;
+} {
+  if (!signal) {
+    return {
+      promise: new Promise<never>(() => {
+        // No cancellation requested.
+      }),
+      cleanup: () => undefined,
+    };
+  }
+  if (signal.aborted) {
+    return { promise: Promise.reject(createAbortError()), cleanup: () => undefined };
+  }
+  let cleanup: () => void = () => undefined;
+  const promise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  return { promise, cleanup };
 }
 
 function extractAgentName(event: Ingress.ResolvedInboundEvent): string | undefined {
@@ -106,11 +144,22 @@ export class ResidentRuntime {
   }
 
   async run(ctx: ResidentRunContext): Promise<ResidentRunResult> {
+    throwIfAborted(ctx.signal);
     const activation = this.ensureActivation(ctx.sessionId);
     const previous = activation.queue;
-    const chained = previous.catch(() => undefined).then(() => this.runExclusive(ctx));
+    const chained = previous
+      .catch(() => undefined)
+      .then(() => {
+        throwIfAborted(ctx.signal);
+        return this.runExclusive(ctx);
+      });
     activation.queue = chained;
-    return chained;
+    const abort = abortRace(ctx.signal);
+    try {
+      return await Promise.race([chained, abort.promise]);
+    } finally {
+      abort.cleanup();
+    }
   }
 
   private ensureActivation(sessionId: string): ActivationRecord {
@@ -195,7 +244,10 @@ export class ResidentRuntime {
       budget: ctx.event.agent.budget,
       tools: ctx.event.agent.tools,
       permissions: ctx.event.agent.permissions,
-      toolExecutor: toolExecutor as ((call: Tool.Call) => Promise<Tool.Result>) | undefined,
+      toolExecutor: toolExecutor as
+        | ((call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>)
+        | undefined,
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
       middleware: buildWorkerMiddleware({
         permissions: ctx.event.agent.permissions,
         ...(ctx.event.agent.policyPlan ? { policyPlan: ctx.event.agent.policyPlan } : {}),

--- a/packages/openomni/test/resident/runtime.test.ts
+++ b/packages/openomni/test/resident/runtime.test.ts
@@ -120,3 +120,45 @@ test("ResidentRuntime reuses fallback traceId for agent input and completion eve
   expect(inputTraceId).toBeString();
   expect(completedTraceIds.at(-1)).toBe(inputTraceId);
 });
+
+test("ResidentRuntime does not start a queued run after it is aborted", async () => {
+  let releaseFirstRun!: () => void;
+  let firstRunStarted!: () => void;
+  const firstStarted = new Promise<void>((resolve) => {
+    firstRunStarted = resolve;
+  });
+  const firstCanFinish = new Promise<void>((resolve) => {
+    releaseFirstRun = resolve;
+  });
+  let runCount = 0;
+  const manager = ResidentRuntime.create({
+    runAgent: async () => {
+      runCount++;
+      if (runCount === 1) {
+        firstRunStarted();
+        await firstCanFinish;
+      }
+      return { text: "ok", finishReason: "stop" };
+    },
+  });
+
+  const firstRun = manager.run({ sessionId: "resident-queued-abort", event: makeEvent() });
+  await firstStarted;
+
+  const controller = new AbortController();
+  const secondRun = manager.run({
+    sessionId: "resident-queued-abort",
+    event: makeEvent(),
+    signal: controller.signal,
+  });
+
+  controller.abort();
+  const secondError = await secondRun.catch((error) => error);
+  expect(secondError).toBeInstanceOf(Error);
+  expect((secondError as Error).name).toBe("AbortError");
+
+  releaseFirstRun();
+  await firstRun;
+  await Bun.sleep(0);
+  expect(runCount).toBe(1);
+});

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -111,13 +111,13 @@ export namespace Ingress {
     .passthrough();
   // Runtime callbacks can't be expressed in Zod.
   export type AgentDef = z.infer<typeof AgentDefSchema> & {
-    toolExecutor?: (call: Tool.Call) => Promise<Tool.Result>;
+    toolExecutor?: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
     toolExecutorFactory?: (ctx: {
       sessionId: string;
       runId: string;
       agentName?: string;
       workspaceRoot?: string;
-    }) => (call: Tool.Call) => Promise<Tool.Result>;
+    }) => (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
   };
 
   const InboundEventBase = {

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -186,7 +186,7 @@ const methods = {
   },
   "worker.tool_call_settled": {
     params: z.object({
-      authToken: z.string(),
+      authToken: z.string().optional(),
       callId: z.string(),
       workspaceRoot: z.string().optional(),
     }),

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -186,10 +186,11 @@ const methods = {
   },
   "worker.tool_call_settled": {
     params: z.object({
+      authToken: z.string(),
       callId: z.string(),
       workspaceRoot: z.string().optional(),
     }),
-    result: z.object({ acknowledged: z.boolean() }),
+    result: z.object({ acknowledged: z.boolean(), error: z.string().optional() }),
   },
   "worker.state_update": {
     params: z.object({

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -150,13 +150,46 @@ const methods = {
       callId: z.string(),
       tool: z.string(),
       input: z.record(z.string(), z.unknown()),
+      workspaceRoot: z.string().optional(),
     }),
     result: z.object({
       id: z.string(),
       toolCallId: z.string(),
       output: z.string(),
       isError: z.boolean().optional(),
+      settlement: z.enum(["settled", "unknown"]).optional(),
     }),
+  },
+  "worker.tool_call_cancel": {
+    params: z.object({
+      runId: z.string(),
+      sessionId: z.string(),
+      callId: z.string(),
+    }),
+    result: z.object({
+      cancelled: z.boolean(),
+      settlement: z.enum(["settled", "unknown"]).optional(),
+      error: z.string().optional(),
+    }),
+  },
+  "worker.ask_main_cancel": {
+    params: z.object({
+      runId: z.string().optional(),
+      sessionId: z.string(),
+      callId: z.string(),
+    }),
+    result: z.object({
+      cancelled: z.boolean(),
+      settlement: z.enum(["settled", "unknown"]).optional(),
+      error: z.string().optional(),
+    }),
+  },
+  "worker.tool_call_settled": {
+    params: z.object({
+      callId: z.string(),
+      workspaceRoot: z.string().optional(),
+    }),
+    result: z.object({ acknowledged: z.boolean() }),
   },
   "worker.state_update": {
     params: z.object({

--- a/packages/protocol/src/tool/index.ts
+++ b/packages/protocol/src/tool/index.ts
@@ -83,11 +83,22 @@ export namespace Tool {
   });
   export type Call = z.infer<typeof Call>;
 
+  /**
+   * Per-call runtime context for tool execution callbacks. Cancellation is
+   * cooperative: executors pass an aborted signal before returning timeout or
+   * run-cancel results, and tools that start long-running work should stop their
+   * own side effects when it aborts.
+   */
+  export interface ExecutionContext {
+    readonly signal?: AbortSignal;
+  }
+
   export const Result = z.object({
     id: z.string(),
     toolCallId: z.string(),
     output: z.string(),
     isError: z.boolean().optional(),
+    settlement: z.enum(["settled", "unknown"]).optional(),
   });
   export type Result = z.infer<typeof Result>;
 

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -219,4 +219,21 @@ describe("Ipc.Methods param schemas", () => {
       }).success,
     ).toBe(true);
   });
+
+  test("worker.tool_call_settled requires coordinator auth token", () => {
+    expect(
+      Ipc.Methods["worker.tool_call_settled"].params.safeParse({
+        authToken: "token",
+        callId: "call-1",
+        workspaceRoot: "/workspace",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      Ipc.Methods["worker.tool_call_settled"].params.safeParse({
+        callId: "call-1",
+        workspaceRoot: "/workspace",
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -220,7 +220,7 @@ describe("Ipc.Methods param schemas", () => {
     ).toBe(true);
   });
 
-  test("worker.tool_call_settled requires coordinator auth token", () => {
+  test("worker.tool_call_settled accepts optional auth token for version-skew tolerance", () => {
     expect(
       Ipc.Methods["worker.tool_call_settled"].params.safeParse({
         authToken: "token",
@@ -234,6 +234,6 @@ describe("Ipc.Methods param schemas", () => {
         callId: "call-1",
         workspaceRoot: "/workspace",
       }).success,
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/script/lint-side-effects.ts
+++ b/script/lint-side-effects.ts
@@ -40,8 +40,9 @@ const rules: readonly SideEffectRule[] = [
   {
     ruleId: "tool-ledger-before-execute",
     filePath: "packages/openomni/src/execution-runtime/tool/executor.ts",
-    sideEffect: /tool\.execute\(dispatchedCall\)/g,
-    scopeStart: /return async \(call: Tool\.Call\): Promise<Tool\.Result> => \{/g,
+    sideEffect: /tool\.execute\(dispatchedCall(?:, \{ signal: linkedAbort\.signal \})?\)/g,
+    scopeStart:
+      /return async \(call: Tool\.Call(?:, context\?: ToolExecutionContext)?\): Promise<Tool\.Result> => \{/g,
     requiredBefore: [
       "Bus.publish(ToolExecution.Started, {",
       "toolCallId: call.id",
@@ -52,8 +53,9 @@ const rules: readonly SideEffectRule[] = [
   {
     ruleId: "mcp-ledger-before-execute",
     filePath: "apps/server/src/tool/mcp/provider.ts",
-    sideEffect: /tool\.execute\(\{ \.\.\.call, tool: tool\.spec\.name \}\)/g,
-    scopeStart: /async execute\(call: Tool\.Call\): Promise<Tool\.Result> \{/g,
+    sideEffect: /tool\.execute\(\{ \.\.\.call, tool: tool\.spec\.name \}(?:, context)?\)/g,
+    scopeStart:
+      /async execute\(call: Tool\.Call(?:, context\?: ToolExecutionContext)?\): Promise<Tool\.Result> \{/g,
     requiredBefore: ["Bus.publish(PolicyEvent.ActionRequested, {", "actionId", "tool.spec.name"],
     message: "MCP tool execution must be preceded by a mandatory action_requested ledger append",
   },


### PR DESCRIPTION
## Summary

Adds cooperative cancellation to tool execution paths and hardens workspace lock safety when a timed-out or cancelled tool may still have side effects in flight.

Fixes N/A
Relates to N/A

## Changes

- Thread `AbortSignal` through LLM, agent, native tool, provider, proxy, worker, subagent, and MCP execution boundaries.
- Cancel bash/grep subprocess work on timeout/abort and keep post-tool policy/lock release deferred until execution settlement or unsafe marking.
- Add `Tool.Result.settlement` so worker/proxy cancel acknowledgements can report unknown underlying settlement.
- Persist unsafe workspace markers and make them call-token-aware so only matching actual settlement can clear them.
- Validate worker cancel IPC parameters and make proxied IPC failures resolve as unknown settlement instead of ordinary safe errors.
- Propagate cancellation through `ask_main` resident consultation and document it as a read-only consultation tool.
- Add regression coverage for abort-aware locks, proxy unknown settlement, MCP hangs, subprocess cancellation, and worker IPC failure handling.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [x] `protocol`
- [x] `session`
- [x] `llm`
- [x] `agent`
- [x] `openomni`
- [x] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- `git diff --check`
- `bun run script/check-deps.ts`
- `bun run build`
- `bun run check-types`
- `bun run lint` (passes with 12 pre-existing warnings)
- `bun test` (2450 pass, 10 skip, 0 fail)
- Independent reviewer PASS

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cooperative cancellation across tool execution so timed-out or cancelled tools stop safely and workspaces stay protected until settlement. Propagates abort signals end-to-end, cancels subprocesses, and validates/cancels via new IPC to prevent late side effects.

- New Features
  - Threaded `AbortSignal` via `Tool.ExecutionContext` across LLM, agent, subagent, providers (`system`, `custom`, `agent`, `MCP`), proxy, workers, and `ask_main`; `askResident` now accepts `signal` and `ask_main` is read-only with resident-consult labels.
  - IPC: added `worker.tool_call_cancel`, `worker.ask_main_cancel`, and `worker.tool_call_settled`; extended tool-call timeout to 5m; coordinator exports `ToolCallCancelParams` and `ToolCallContext`.
  - Workspace safety: `Tool.Result.settlement` ("settled" | "unknown"); `WorkspaceLock` uses tokened unsafe markers and only matching settlements clear them; optional `postTimeoutSettleGraceMs` delays unlock after timeouts.

- Bug Fixes
  - Bash and grep terminate process groups on abort/timeout to prevent late writes.
  - Proxied/IPC failures and cancelled MCP calls return `settlement: "unknown"` to keep workspaces protected.
  - Worker cancellation/settlement feedback hardened: abortable IPC, strict param validation, and rejection of unauthorized or malformed `worker.tool_call_settled` notifications without clearing unsafe markers; subagent background and resident runs respect abort and do not start after cancellation.
  - Server reports unsafe marker cleanup failures when handling `worker.tool_call_settled`.

<sup>Written for commit 5f4267572a78a9041dda3dcc22c2aaf29436e49e. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/161?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-wide cooperative cancellation: abort signals propagate end-to-end for tool calls, agents/subagents, residents, MCP proxies, native tools, and IPC flows.
  * Per-call execution context and settlement state exposed; IPC supports cancel and settled notifications.
  * Workspace locking: abortable acquisition, unsafe-state marking/clearing, and settlement-aware behavior.
  * Built-in tools and subprocesses now honor aborts and terminate reliably.

* **Tests**
  * Expanded coverage for cancellation, timeouts, settlement, workspace unsafe flows, and IPC cancel/settled paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->