### PR TITLE
fix(llm): reject pre-aborted retry sleep

### DIFF
--- a/packages/llm/src/session/retry.ts
+++ b/packages/llm/src/session/retry.ts
@@ -9,6 +9,10 @@ export namespace Retry {
   export const RETRY_MAX_DELAY = 2_147_483_647;
 
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+
     return new Promise((resolve, reject) => {
       const abortHandler = () => {
         clearTimeout(timeout);

--- a/packages/llm/test/session/retry.test.ts
+++ b/packages/llm/test/session/retry.test.ts
@@ -57,6 +57,23 @@ describe("Retry", () => {
       }
     });
 
+    test("rejects immediately when signal is already aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const start = Date.now();
+
+      try {
+        await Retry.sleep(5000, controller.signal);
+        expect.unreachable("Should have thrown AbortError");
+      } catch (e) {
+        expect(e).toBeInstanceOf(DOMException);
+        expect((e as DOMException).name).toBe("AbortError");
+      }
+
+      expect(Date.now() - start).toBeLessThan(100);
+    });
+
     test("caps delay at RETRY_MAX_DELAY", async () => {
       const controller = new AbortController();
       // Request a delay larger than RETRY_MAX_DELAY


### PR DESCRIPTION
## Summary

Reject retry sleep immediately when the provided abort signal is already aborted.

Fixes N/A
Relates to N/A

## Changes

- Add a pre-abort guard to `Retry.sleep()` so callers do not arm a timer after cancellation has already happened.
- Add regression coverage for already-aborted retry sleeps returning an `AbortError` immediately.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [x] `llm`
- [ ] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- `git diff --check`
- `bun run script/check-deps.ts`
- `bun run check-types`
- `bun run build`
- `bun run lint` (passes with 12 pre-existing warnings)
- `bun test` (2459 pass, 10 skip, 0 fail)

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `Retry.sleep()` in `llm` reject immediately when the provided `AbortSignal` is already aborted. This avoids arming timers after cancellation and returns an `AbortError` right away.

- **Bug Fixes**
  - Add pre-abort guard to `Retry.sleep()` to throw immediately on an already-aborted signal.
  - Add regression test to ensure immediate `AbortError` with no delay.

<sup>Written for commit 7a1fd441edae2d74c65b094fbfb0052a25f2628f. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved abort signal handling to respond immediately when already aborted, eliminating unnecessary delays in operation cancellation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->