### PR TITLE
fix(coordinator): escalate worker shutdown

### DIFF
--- a/packages/coordinator/src/worker-pool/supervisor.test.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.test.ts
@@ -1,6 +1,18 @@
-import { describe, test, expect, mock } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import type { IpcClient } from "../ipc/client";
 import { WorkerSupervisor } from "./supervisor";
+
+const originalStopGraceMs = process.env.OPENOMNI_WORKER_STOP_GRACE_MS;
+
+afterEach(() => {
+  if (originalStopGraceMs === undefined) {
+    delete process.env.OPENOMNI_WORKER_STOP_GRACE_MS;
+  } else {
+    process.env.OPENOMNI_WORKER_STOP_GRACE_MS = originalStopGraceMs;
+  }
+});
 
 describe("WorkerSupervisor dispatch timeout ceiling", () => {
   function createTestSupervisor(mockClient: IpcClient): WorkerSupervisor {
@@ -98,5 +110,103 @@ describe("WorkerSupervisor dispatch timeout ceiling", () => {
 
     // Math.max(300_000, 300_000) + 30_000 = 330_000
     expect(capturedTimeoutMs).toBe(330_000);
+  });
+});
+
+describe("WorkerSupervisor stop", () => {
+  function createStopSupervisor(proc: {
+    kill: (signal: NodeJS.Signals) => void;
+    exited: Promise<number>;
+  }): WorkerSupervisor {
+    const supervisor = Object.create(WorkerSupervisor.prototype) as WorkerSupervisor;
+    Reflect.set(supervisor, "id", 0);
+    Reflect.set(supervisor, "proc", proc);
+    Reflect.set(supervisor, "running", true);
+    Reflect.set(supervisor, "client", {
+      connected: true,
+      call: mock(async () => ({})),
+      close: mock(() => undefined),
+    } satisfies IpcClient);
+    return supervisor;
+  }
+
+  test("escalates from SIGTERM to SIGKILL when the worker ignores graceful shutdown", async () => {
+    process.env.OPENOMNI_WORKER_STOP_GRACE_MS = "1";
+
+    const warnings: Array<{ msg: string; context?: Record<string, unknown> }> = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (event) => {
+      warnings.push(event);
+    });
+    let resolveExit!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    const signals: NodeJS.Signals[] = [];
+    const proc = {
+      exited,
+      kill: mock((signal: NodeJS.Signals) => {
+        signals.push(signal);
+        if (signal === "SIGKILL") resolveExit(137);
+      }),
+    };
+
+    try {
+      await createStopSupervisor(proc).stop();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "worker did not stop within grace period; sending SIGKILL",
+        context: { workerId: 0, graceMs: 1 },
+      }),
+    );
+  });
+
+  test("does not send SIGKILL when the worker exits during the graceful window", async () => {
+    process.env.OPENOMNI_WORKER_STOP_GRACE_MS = "50";
+
+    let resolveExit!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    const signals: NodeJS.Signals[] = [];
+    const proc = {
+      exited,
+      kill: mock((signal: NodeJS.Signals) => {
+        signals.push(signal);
+        if (signal === "SIGTERM") resolveExit(0);
+      }),
+    };
+
+    await createStopSupervisor(proc).stop();
+
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  test("treats an empty grace env var as unset instead of immediate escalation", async () => {
+    process.env.OPENOMNI_WORKER_STOP_GRACE_MS = "";
+
+    let resolveExit!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    const signals: NodeJS.Signals[] = [];
+    const proc = {
+      exited,
+      kill: mock((signal: NodeJS.Signals) => {
+        signals.push(signal);
+        if (signal === "SIGTERM") {
+          setTimeout(() => resolveExit(0), 1);
+        }
+      }),
+    };
+
+    await createStopSupervisor(proc).stop();
+
+    expect(signals).toEqual(["SIGTERM"]);
   });
 });

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import type { Subprocess } from "bun";
-import type { WorkerBootstrap } from "@openomni/protocol";
+import { Operational, type WorkerBootstrap } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import { connectIpcClient, type IpcClient } from "../ipc/client";
 
 const MAX_RESTARTS_PER_WINDOW = 10;
@@ -8,6 +9,7 @@ const RESTART_WINDOW_MS = 60_000;
 const MAX_BACKOFF_MS = 30_000;
 const WORKER_CONNECT_TIMEOUT_MS = 10_000;
 const MAX_DISPATCH_TIMEOUT_MS = 600_000;
+const DEFAULT_WORKER_STOP_GRACE_MS = 5_000;
 
 export type ToolCallParams = {
   runId: string;
@@ -465,12 +467,48 @@ export class WorkerSupervisor {
     const c = this.client;
     this.client = null;
     c?.close();
-    if (this.proc && this.running) {
-      this.proc.kill("SIGTERM");
-      await this.proc.exited;
+    const proc = this.proc;
+    if (proc && this.running) {
+      proc.kill("SIGTERM");
+      const graceMs = workerStopGraceMs();
+      if ((await waitForWorkerExit(proc, graceMs)) === "timeout") {
+        Bus.publish(Operational.Warn, {
+          traceId: crypto.randomUUID(),
+          time: Date.now(),
+          component: "coordinator.worker",
+          msg: "worker did not stop within grace period; sending SIGKILL",
+          context: { workerId: this.id, graceMs },
+        });
+        proc.kill("SIGKILL");
+        await proc.exited;
+      }
     }
     this.proc = null;
     this.running = false;
+  }
+}
+
+function workerStopGraceMs(): number {
+  const raw = process.env.OPENOMNI_WORKER_STOP_GRACE_MS;
+  if (!raw) return DEFAULT_WORKER_STOP_GRACE_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_WORKER_STOP_GRACE_MS;
+}
+
+async function waitForWorkerExit(
+  proc: Pick<Subprocess, "exited">,
+  timeoutMs: number,
+): Promise<"exited" | "timeout"> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      proc.exited.then(() => "exited" as const),
+      new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => resolve("timeout"), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## Summary

Bounds coordinator worker shutdown by escalating from `SIGTERM` to `SIGKILL` when a worker does not exit within the grace window.

Fixes N/A
Relates to N/A

## Changes

- Add a worker stop grace window (`OPENOMNI_WORKER_STOP_GRACE_MS`, default 5000ms).
- Escalate `WorkerSupervisor.stop()` from `SIGTERM` to `SIGKILL` after the grace window.
- Publish a structured operational warning when escalation is required.
- Add regression coverage for graceful exit, forced escalation, and empty grace-env fallback.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [x] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- `git diff --check`
- `bun run script/check-deps.ts`
- `bun run check-types`
- `bun run build`
- `bun run lint` (passes with 12 pre-existing warnings)
- `bun test` (2462 pass, 10 skip, 0 fail)

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures stuck `coordinator` workers terminate by escalating shutdown from `SIGTERM` to `SIGKILL` after a grace window. The grace period is configurable and a structured warning is emitted when escalation occurs.

- **Bug Fixes**
  - Escalate `WorkerSupervisor.stop()` to `SIGKILL` if the worker doesn’t exit within the grace window.
  - Add `OPENOMNI_WORKER_STOP_GRACE_MS` (default 5000 ms); empty value is treated as unset.
  - Publish `Operational.Warn` on the `@openomni/session` `Bus` with `{ workerId, graceMs }` when escalation happens.
  - Add tests for graceful exit, forced escalation, and empty-env fallback.

<sup>Written for commit 3a328306c2e2df17c7d5ff1e2bdc38ea0e77d94e. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workers now emit warnings when failing to stop within the shutdown grace period, improving system reliability and shutdown observability.

* **Tests**
  * Expanded test coverage for worker shutdown timeout behavior and escalation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->