### PR TITLE
fix(coordinator): guard recovery status updates

### DIFF
--- a/packages/coordinator/src/recovery/index.ts
+++ b/packages/coordinator/src/recovery/index.ts
@@ -15,17 +15,18 @@ export async function recoverInterruptedRuns(): Promise<RecoveryResult> {
     );
 
     for (const run of incompleteRuns) {
-      // starting → running is the only valid transition before → interrupted
-      if (run.status === "starting") {
-        await WorkerRun.updateStatus(session.id, run.runId, "running");
-      }
+      const interrupted = await WorkerRun.updateStatusIfCurrent(
+        session.id,
+        run.runId,
+        { status: run.status, timeUpdated: run.timeUpdated },
+        "interrupted",
+        {
+          endedAt: Date.now(),
+          error: "coordinator restarted: run interrupted",
+        },
+      );
 
-      await WorkerRun.updateStatus(session.id, run.runId, "interrupted", {
-        endedAt: Date.now(),
-        error: "coordinator restarted: run interrupted",
-      });
-
-      recovered.push(session.id);
+      if (interrupted) recovered.push(session.id);
     }
   }
 

--- a/packages/coordinator/test/recovery/crash.test.ts
+++ b/packages/coordinator/test/recovery/crash.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { Bus, Storage, WorkerRun } from "@openomni/session";
+import { Bus, Storage, WorkerRun, WorkerRunStateStore } from "@openomni/session";
 import { Subagent } from "@openomni/protocol";
 import { recoverInterruptedRuns } from "../../src/recovery";
 
@@ -62,7 +62,7 @@ describe("recoverInterruptedRuns", () => {
     expect(result.sessions).toEqual(["s1"]);
   });
 
-  test("marks starting runs as interrupted via running transition", async () => {
+  test("marks starting runs as interrupted", async () => {
     seedSession("s2");
     await seedRunAtStatus("s2", "r2", "starting");
 
@@ -138,6 +138,55 @@ describe("recoverInterruptedRuns", () => {
     expect(result.recovered).toBe(0);
     const run = await WorkerRun.get("s5", "r5");
     expect(run?.status).toBe("queued");
+  });
+
+  test("skips runs changed by an active writer after the recovery scan", async () => {
+    seedSession("s-active");
+    await seedRunAtStatus("s-active", "r-active", "running");
+
+    const workerRunState = Storage.get().workerRunState;
+    if (!workerRunState) throw new Error("workerRunState adapter missing");
+
+    const listBySession = workerRunState.listBySession.bind(workerRunState);
+    let changedAfterScan = false;
+    workerRunState.listBySession = (sessionId) => {
+      const rows = listBySession(sessionId);
+      if (sessionId === "s-active" && !changedAfterScan) {
+        changedAfterScan = true;
+        WorkerRunStateStore.updateStatus(sessionId, "r-active", "succeeded");
+      }
+      return rows;
+    };
+
+    const result = await recoverInterruptedRuns();
+
+    const run = await WorkerRun.get("s-active", "r-active");
+    expect(run?.status).toBe("succeeded");
+    expect(result.recovered).toBe(0);
+    expect(result.sessions).toEqual([]);
+  });
+
+  test("status precondition rejects runs touched without a status change", async () => {
+    seedSession("s-touch");
+    await seedRunAtStatus("s-touch", "r-touch", "running");
+
+    const scanned = WorkerRunStateStore.get("s-touch", "r-touch");
+    expect(scanned?.status).toBe("running");
+    if (!scanned) throw new Error("r-touch not found before active write");
+    WorkerRunStateStore.updateStatus("s-touch", "r-touch", "running");
+
+    const interrupted = await WorkerRun.updateStatusIfCurrent(
+      "s-touch",
+      "r-touch",
+      { status: scanned.status, timeUpdated: scanned.timeUpdated },
+      "interrupted",
+      { endedAt: Date.now(), error: "stale recovery update" },
+    );
+
+    const run = await WorkerRun.get("s-touch", "r-touch");
+    expect(run?.status).toBe("running");
+    expect(run?.timeUpdated).toBeGreaterThan(scanned.timeUpdated);
+    expect(interrupted).toBe(false);
   });
 
   test("deduplicates sessions in result when multiple runs recovered from same session", async () => {

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -413,10 +413,45 @@ export class SqliteStorageAdapter implements Storage.Adapter {
                  WHEN status = 'waiting_input' AND ? = 'running' THEN resume_count + 1
                  ELSE resume_count
                END,
-               time_updated = ?
+               time_updated = MAX(?, time_updated + 1)
            WHERE session_id = ? AND run_id = ?`,
         )
         .run(status, extra?.error ?? null, status, Date.now(), sessionId, runId);
+      return result.changes > 0;
+    },
+
+    updateStatusIfCurrent: (
+      sessionId: string,
+      runId: string,
+      expected: WorkerRunStateStore.StatusPrecondition,
+      status: WorkerRunStateStore.Status,
+      extra?: WorkerRunStateStore.StatusExtra,
+    ): boolean => {
+      const result = this.db
+        .query(
+          `UPDATE worker_run_state
+           SET status = ?,
+               error = COALESCE(?, error),
+               resume_count = CASE
+                 WHEN status = 'waiting_input' AND ? = 'running' THEN resume_count + 1
+                 ELSE resume_count
+               END,
+               time_updated = MAX(?, time_updated + 1)
+           WHERE session_id = ?
+             AND run_id = ?
+             AND status = ?
+             AND time_updated = ?`,
+        )
+        .run(
+          status,
+          extra?.error ?? null,
+          status,
+          Date.now(),
+          sessionId,
+          runId,
+          expected.status,
+          expected.timeUpdated,
+        );
       return result.changes > 0;
     },
 

--- a/packages/session/src/worker-run/index.ts
+++ b/packages/session/src/worker-run/index.ts
@@ -27,6 +27,7 @@ export interface WorkerRunRecord {
   lastMessageId?: string;
   error?: string;
   resumeCount: number;
+  timeUpdated: number;
 }
 
 type WorkerRunStatusExtra = {
@@ -103,6 +104,7 @@ function toWorkerRunRecord(record: WorkerRunStateStore.Record): WorkerRunRecord 
     lastMessageId: extras?.lastMessageId,
     error: record.error,
     resumeCount: record.resumeCount,
+    timeUpdated: record.timeUpdated,
   };
 }
 
@@ -171,5 +173,34 @@ export namespace WorkerRun {
     if (current.status !== status) {
       publishLifecycleEvent(sessionId, current, status, extra?.error);
     }
+  }
+
+  export async function updateStatusIfCurrent(
+    sessionId: string,
+    runId: string,
+    expected: WorkerRunStateStore.StatusPrecondition,
+    status: WorkerRunStatus,
+    extra?: WorkerRunStatusExtra,
+  ): Promise<boolean> {
+    const current = WorkerRunStateStore.get(sessionId, runId);
+    const updated = WorkerRunStateStore.updateStatusIfCurrent(sessionId, runId, expected, status, {
+      error: extra?.error,
+    });
+    if (!updated) return false;
+
+    if (extra?.endedAt !== undefined || extra?.lastMessageId !== undefined) {
+      const key = extraKey(sessionId, runId);
+      const previous = runExtras.get(key);
+      runExtras.set(key, {
+        endedAt: extra.endedAt ?? previous?.endedAt,
+        lastMessageId: extra.lastMessageId ?? previous?.lastMessageId,
+      });
+    }
+
+    if (current && expected.status !== status) {
+      publishLifecycleEvent(sessionId, toWorkerRunRecord(current), status, extra?.error);
+    }
+
+    return true;
   }
 }

--- a/packages/session/src/worker-run/state-store.ts
+++ b/packages/session/src/worker-run/state-store.ts
@@ -1,4 +1,5 @@
-import type { Subagent } from "@openomni/protocol";
+import { Subagent } from "@openomni/protocol";
+import { z } from "zod";
 import { Storage } from "../storage/storage";
 
 const transitions: Record<Subagent.WorkerRunStatus, readonly Subagent.WorkerRunStatus[]> = {
@@ -55,9 +56,22 @@ export namespace WorkerRunStateStore {
     readonly error?: string;
   }
 
+  export const StatusPrecondition = z.object({
+    status: Subagent.WorkerRunStatus,
+    timeUpdated: z.number(),
+  });
+  export type StatusPrecondition = z.infer<typeof StatusPrecondition>;
+
   export interface Adapter {
     create(sessionId: string, record: CreateRecord): void;
     updateStatus(sessionId: string, runId: string, status: Status, extra?: StatusExtra): boolean;
+    updateStatusIfCurrent(
+      sessionId: string,
+      runId: string,
+      expected: StatusPrecondition,
+      status: Status,
+      extra?: StatusExtra,
+    ): boolean;
     get(sessionId: string, runId: string): Record | undefined;
     listBySession(sessionId: string): Record[];
     listByStatus(status: Status): Record[];
@@ -85,6 +99,22 @@ export namespace WorkerRunStateStore {
       throw new Error(`Invalid worker run status transition from ${current.status} to ${status}`);
     }
     adapter.updateStatus(sessionId, runId, status, extra);
+  }
+
+  export function updateStatusIfCurrent(
+    sessionId: string,
+    runId: string,
+    expected: StatusPrecondition,
+    status: Status,
+    extra?: StatusExtra,
+  ): boolean {
+    const parsedExpected = StatusPrecondition.parse(expected);
+    if (!isValidTransition(parsedExpected.status, status)) {
+      throw new Error(
+        `Invalid worker run status transition from ${parsedExpected.status} to ${status}`,
+      );
+    }
+    return requireAdapter().updateStatusIfCurrent(sessionId, runId, parsedExpected, status, extra);
   }
 
   export function get(sessionId: string, runId: string): Record | undefined {


### PR DESCRIPTION
## Summary

Guards crash recovery against clobbering worker-run rows that were updated after the recovery scan.

Fixes N/A
Relates to N/A

## Changes

- Add a status/timestamp precondition for worker-run state updates.
- Make worker-run `time_updated` monotonic so same-millisecond writes still invalidate stale preconditions.
- Use conditional recovery updates and count only rows actually interrupted by recovery.
- Add regression coverage for rows changed after the recovery scan and same-status active writes.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [x] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [x] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- `git diff --check`
- `bun run script/check-deps.ts`
- `bun run check-types`
- `bun run build`
- `bun run lint` (passes with 12 pre-existing warnings)
- `bun test` (2464 pass, 10 skip, 0 fail)

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard crash recovery to avoid clobbering active worker runs. Recovery updates are conditional on the scanned status and timestamp, and `time_updated` is monotonic across writes.

- **Bug Fixes**
  - Use `WorkerRun.updateStatusIfCurrent(...)` in `coordinator` recovery; only mark `interrupted` when status/time match the scan.
  - Remove the forced `starting → running` step during recovery.
  - Make SQLite updates monotonic and guarded by status/time (`MAX(now, time_updated + 1)` with `WHERE status AND time_updated`) to reject stale writes.
  - Count recovered sessions only when an update succeeds.
  - Add regression tests for post-scan changes, same-status touches, and session deduping in `@openomni/session`.

<sup>Written for commit e0da262db4bbc8b4b848067a57266aec9fecd955. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable recovery: interrupted runs are only marked when the update is safe, avoiding overwrites from concurrent writers; run timestamps now progress monotonically to prevent regressions.

* **Tests**
  * Added regression tests for concurrent update/race scenarios and for conditional update preconditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->