### PR TITLE
fix(openomni): claim ingress surface sessions atomically

### DIFF
--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -90,27 +90,9 @@ export namespace IngressSessionResolver {
         isNew = false;
       } else {
         const surfaceKey = extractSurfaceKey(event);
-        const existingSessionId = SurfaceKey.lookup(surfaceKey);
-
-        if (existingSessionId) {
-          const existing = Session.get(existingSessionId);
-          if (existing) {
-            session = existing;
-            isNew = false;
-          } else {
-            // Stale entry — session was deleted, create new
-            session = Session.create({
-              title: `Session from ${event.surface}`,
-              model: defaultModel,
-            });
-            SurfaceKey.register(surfaceKey, session.id);
-            isNew = true;
-          }
-        } else {
-          session = Session.create({ title: `Session from ${event.surface}`, model: defaultModel });
-          SurfaceKey.register(surfaceKey, session.id);
-          isNew = true;
-        }
+        const resolved = resolveResidentSurfaceSession(surfaceKey, event.surface, defaultModel);
+        session = resolved.session;
+        isNew = resolved.isNew;
       }
     }
 
@@ -126,5 +108,52 @@ export namespace IngressSessionResolver {
     }
 
     return { session, isNew };
+  }
+
+  function resolveResidentSurfaceSession(
+    surfaceKey: string,
+    surface: string,
+    defaultModel: ModelConfig,
+  ): ResolveResult {
+    let staleSessionId: string | undefined;
+    let lastOwnerSessionId: string | undefined;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const existingSessionId = SurfaceKey.lookup(surfaceKey);
+      if (existingSessionId) {
+        const existing = Session.get(existingSessionId);
+        if (existing) return { session: existing, isNew: false };
+        staleSessionId = existingSessionId;
+      } else {
+        staleSessionId = undefined;
+      }
+
+      // Optimistically create a candidate and keep it only if the surface-key
+      // claim succeeds; losing candidates are removed below.
+      const candidate = Session.create({
+        title: `Session from ${surface}`,
+        model: defaultModel,
+      });
+      let ownerSessionId: string;
+      try {
+        ownerSessionId = SurfaceKey.claim(surfaceKey, candidate.id, staleSessionId);
+      } catch (err) {
+        Session.remove(candidate.id);
+        throw err;
+      }
+      lastOwnerSessionId = ownerSessionId;
+      if (ownerSessionId === candidate.id) {
+        return { session: candidate, isNew: true };
+      }
+
+      Session.remove(candidate.id);
+      const owner = Session.get(ownerSessionId);
+      if (owner) return { session: owner, isNew: false };
+      staleSessionId = ownerSessionId;
+    }
+
+    throw new Error(
+      `unable to resolve surface key owner after 3 attempts: ${surfaceKey} lastOwner=${lastOwnerSessionId ?? "unknown"}`,
+    );
   }
 }

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -128,6 +128,59 @@ describe("IngressSessionResolver", () => {
       expect(result1.session.id).toBe(result2.session.id);
     });
 
+    it("returns a concurrent surface key owner instead of clobbering it", () => {
+      const event = {
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+      };
+      const key = IngressSessionResolver.extractSurfaceKey(event);
+      const competing = Session.create({
+        title: "competing",
+        model: { providerID: "test", modelID: "fixture" },
+      });
+
+      const surfaceKey = Storage.get().surfaceKey;
+      if (!surfaceKey?.claim) throw new Error("surfaceKey claim adapter missing");
+      const originalClaim = surfaceKey.claim.bind(surfaceKey);
+      surfaceKey.claim = (claimKey, _candidateSessionId, expectedSessionId) => {
+        expect(claimKey).toBe(key);
+        return originalClaim(claimKey, competing.id, expectedSessionId);
+      };
+
+      try {
+        const result = IngressSessionResolver.resolve(event);
+
+        expect(result.isNew).toBe(false);
+        expect(result.session.id).toBe(competing.id);
+        expect(SurfaceKey.lookup(key)).toBe(competing.id);
+        expect(Session.list().map((session) => session.id)).toEqual([competing.id]);
+      } finally {
+        surfaceKey.claim = originalClaim;
+      }
+    });
+
+    it("removes the candidate session if claiming the surface key fails", () => {
+      const event = {
+        surface: "slack",
+        workspace: "team-a",
+        channel: "C123",
+      };
+      const surfaceKey = Storage.get().surfaceKey;
+      if (!surfaceKey?.claim) throw new Error("surfaceKey claim adapter missing");
+      const originalClaim = surfaceKey.claim.bind(surfaceKey);
+      surfaceKey.claim = () => {
+        throw new Error("claim failed");
+      };
+
+      try {
+        expect(() => IngressSessionResolver.resolve(event)).toThrow("claim failed");
+        expect(Session.list()).toEqual([]);
+      } finally {
+        surfaceKey.claim = originalClaim;
+      }
+    });
+
     it("creates different sessions for different surface keys", () => {
       const event1 = {
         surface: "slack",

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -248,6 +248,42 @@ export class SqliteStorageAdapter implements Storage.Adapter {
         .run(key, sessionId, Date.now());
     },
 
+    claim: (key: string, sessionId: string, expectedSessionId?: string): string => {
+      const now = Date.now();
+      this.db.exec("BEGIN IMMEDIATE TRANSACTION");
+      try {
+        if (expectedSessionId !== undefined) {
+          this.db
+            .query(
+              `UPDATE surface_key
+               SET session_id = ?, time_created = ?
+               WHERE key = ? AND session_id = ?`,
+            )
+            .run(sessionId, now, key, expectedSessionId);
+        }
+
+        this.db
+          .query(
+            `INSERT OR IGNORE INTO surface_key (key, session_id, time_created)
+             VALUES (?, ?, ?)`,
+          )
+          .run(key, sessionId, now);
+
+        const row = this.db.query("SELECT session_id FROM surface_key WHERE key = ?").get(key) as {
+          session_id: string;
+        } | null;
+        this.db.exec("COMMIT");
+        return row?.session_id ?? sessionId;
+      } catch (err) {
+        try {
+          this.db.exec("ROLLBACK");
+        } catch (_rollbackErr) {
+          void _rollbackErr;
+        }
+        throw err;
+      }
+    },
+
     lookup: (key: string): string | undefined => {
       const row = this.db.query("SELECT session_id FROM surface_key WHERE key = ?").get(key) as {
         session_id: string;

--- a/packages/session/src/storage/storage.ts
+++ b/packages/session/src/storage/storage.ts
@@ -36,6 +36,7 @@ export namespace Storage {
 
     surfaceKey?: {
       register(key: string, sessionId: string): void;
+      claim(key: string, sessionId: string, expectedSessionId?: string): string;
       lookup(key: string): string | undefined;
       delete(key: string): void;
       listBySession?(sessionId: string): string[];

--- a/packages/session/src/surface-key/index.ts
+++ b/packages/session/src/surface-key/index.ts
@@ -142,6 +142,24 @@ export namespace SurfaceKey {
   }
 
   /**
+   * Attempt to claim a surfaceKey for a session without clobbering a concurrent owner.
+   * With expectedSessionId, replaces only if the current owner still equals it.
+   * Without expectedSessionId, inserts only when the key is absent.
+   * Returns the session ID that owns the key after the claim attempt.
+   */
+  export function claim(key: string, sessionId: string, expectedSessionId?: string): string {
+    if (!validateFormat(key)) {
+      throw new Error(
+        `Invalid surfaceKey format: "${key}". Must include surface type prefix (e.g., "slack:...")`,
+      );
+    }
+
+    const surfaceKey = Storage.get().surfaceKey;
+    if (!surfaceKey) return sessionId;
+    return surfaceKey.claim(key, sessionId, expectedSessionId);
+  }
+
+  /**
    * Unregister a surfaceKey.
    * @param key - The surfaceKey to unregister
    * @returns true if key was found and removed, false otherwise

--- a/packages/session/test/surface-key.test.ts
+++ b/packages/session/test/surface-key.test.ts
@@ -184,6 +184,30 @@ describe("SurfaceKey", () => {
       expect(SurfaceKey.listBySession(sessionId2)).toContain(key);
     });
 
+    test("claim returns existing owner without overwriting it", () => {
+      const key = "slack:workspaceA:channel:C123";
+      seedSession("session-1");
+      seedSession("session-2");
+      SurfaceKey.register(key, "session-1");
+
+      const owner = SurfaceKey.claim(key, "session-2");
+
+      expect(owner).toBe("session-1");
+      expect(SurfaceKey.lookup(key)).toBe("session-1");
+    });
+
+    test("claim can replace an expected owner", () => {
+      const key = "slack:workspaceA:channel:C123";
+      seedSession("session-1");
+      seedSession("session-2");
+      SurfaceKey.register(key, "session-1");
+
+      const owner = SurfaceKey.claim(key, "session-2", "session-1");
+
+      expect(owner).toBe("session-2");
+      expect(SurfaceKey.lookup(key)).toBe("session-2");
+    });
+
     test("maintains bidirectional consistency", () => {
       const sessionId = "session-123";
       const key1 = "slack:workspaceA:channel:C123";


### PR DESCRIPTION
## Summary
- add a conditional surface-key claim operation for SQLite-backed session routing
- make resident ingress resolution keep the winning surface-key owner instead of overwriting concurrent claims
- cover claim semantics and concurrent-owner resolver behavior with focused tests

## Validation
- git diff --check
- bun run script/check-deps.ts
- bun run build
- bun run lint (passes with 12 existing warnings)
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ingress session ownership claims atomic and safe for SQLite-backed surface keys. Prevents duplicate sessions and preserves a single winner under concurrent claims.

- **Bug Fixes**
  - Added `SurfaceKey.claim(key, sessionId, expectedSessionId?)` to conditionally claim without overwriting; returns the final owner.
  - Implemented transactional `claim` in the SQLite adapter with conditional UPDATE and INSERT OR IGNORE for atomicity.
  - Updated resolver to optimistically create a candidate, claim the key, keep the winner, remove losers, clear the candidate on claim failure, handle stale owners, and retry up to 3 times.
  - Added focused tests for claim semantics, concurrent owner resolution, and candidate cleanup on claim failure.

- **Migration**
  - If you provide a custom `Storage.Adapter.surfaceKey`, implement `claim(key, sessionId, expectedSessionId?)`.

<sup>Written for commit 15b2cffe6d6dafff6ec54e9008b725850d47d335. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session resolution to more reliably handle concurrent surface-key ownership attempts with retries and safe-claim semantics.
  * Added a storage-level claim operation for surface keys to prevent conflicting session ownership and produce deterministic outcomes.

* **Tests**
  * Added tests for concurrent claim handling and ownership collision scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->