### PR TITLE
fix(agent): preserve policy priority registration order

### DIFF
--- a/packages/agent/src/core/policy/engine.ts
+++ b/packages/agent/src/core/policy/engine.ts
@@ -63,8 +63,10 @@ function selectRegistrations(
   agentType: string | undefined,
 ): PolicyRegistration[] {
   return registrations
-    .filter((reg) => matchesTiming(reg, timing) && matchesScope(reg, agentType))
-    .sort((a, b) => a.priority - b.priority);
+    .map((reg, index) => ({ index, reg }))
+    .filter(({ reg }) => matchesTiming(reg, timing) && matchesScope(reg, agentType))
+    .sort((a, b) => a.reg.priority - b.reg.priority || a.index - b.index)
+    .map(({ reg }) => reg);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/agent/test/core/policy/engine-composition.test.ts
+++ b/packages/agent/test/core/policy/engine-composition.test.ts
@@ -134,6 +134,27 @@ describe("deny-wins composition", () => {
     expect(verdict.verdict).toBe("allow");
   });
 
+  it("executes equal-priority policies in registration order", async () => {
+    const engine = PolicyEngine.create();
+    const executed: string[] = [];
+
+    for (const name of ["first", "second", "third"]) {
+      engine.register({
+        name,
+        timing: "turn.start",
+        priority: 10,
+        fn: () => {
+          executed.push(name);
+          return allow();
+        },
+      });
+    }
+
+    await engine.dispatch("turn.start", baseCtx());
+
+    expect(executed).toEqual(["first", "second", "third"]);
+  });
+
   it("deny-wins across all Policy.Timing values", async () => {
     const timings: Policy.Timing[] = [
       "inbound.receive",


### PR DESCRIPTION
## Summary
- add an explicit registration-order tiebreaker for equal-priority policy registrations
- keep distinct-priority ordering unchanged
- cover the equal-priority execution contract with a focused test

## Validation
- git diff --check
- bun run script/check-deps.ts
- bun run build
- bun run lint (passes with 12 existing warnings)
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix equal-priority policy execution order by preserving registration order. No changes to different-priority behavior.

- **Bug Fixes**
  - Use registration index as a tiebreaker when priorities are equal.
  - Add a focused test to assert equal-priority execution runs in registration order.

<sup>Written for commit 190f05ff3c6ba4e76ccda9b659dc56c43682f5cd. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in policy registration ordering when multiple policies share equal priority—they now execute in the order they were registered instead of having unspecified tie-breaking behavior.

* **Tests**
  * Added test coverage verifying policy execution order for equal-priority registrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->