### PR TITLE
fix(llm): bound provider caches with lru

### DIFF
--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -185,7 +185,14 @@ export namespace Provider {
   }
 }
 
-export { getSDK, getLanguage, CODEX_ALLOWED_MODELS } from "./provider";
+export {
+  getSDK,
+  getLanguage,
+  CODEX_ALLOWED_MODELS,
+  ProviderCache,
+  PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES,
+  PROVIDER_SDK_CACHE_MAX_ENTRIES,
+} from "./provider";
 
 export { ModelsDev } from "../model";
 

--- a/packages/llm/src/provider/provider.ts
+++ b/packages/llm/src/provider/provider.ts
@@ -26,6 +26,8 @@ const BUNDLED_PROVIDERS: Record<string, (options: SdkOptions) => ProviderSDK> = 
 
 const SDK_CACHE = new Map<string, ProviderSDK>();
 const LANGUAGE_CACHE = new Map<string, LanguageModel>();
+export const PROVIDER_SDK_CACHE_MAX_ENTRIES = 64;
+export const PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES = 256;
 
 type CustomModelLoader = (
   sdk: ProviderSDK,
@@ -59,7 +61,7 @@ const CUSTOM_LOADERS: Record<string, () => CustomLoaderResult> = {
 
 export function getSDK(model: Provider.Model, auth: Auth.Info): ProviderSDK {
   const cacheKey = `${model.providerID}:${model.api?.npm ?? ""}:${JSON.stringify(auth)}`;
-  const cached = SDK_CACHE.get(cacheKey);
+  const cached = getCached(SDK_CACHE, cacheKey);
   if (cached) return cached;
 
   const npm = model.api?.npm ?? "@ai-sdk/openai";
@@ -91,19 +93,19 @@ export function getSDK(model: Provider.Model, auth: Auth.Info): ProviderSDK {
       baseURL,
       apiKey: sdkOptions.apiKey,
     });
-    SDK_CACHE.set(cacheKey, sdk);
+    setCached(SDK_CACHE, cacheKey, sdk, PROVIDER_SDK_CACHE_MAX_ENTRIES);
     return sdk;
   }
 
   const sdk = factory(sdkOptions);
-  SDK_CACHE.set(cacheKey, sdk);
+  setCached(SDK_CACHE, cacheKey, sdk, PROVIDER_SDK_CACHE_MAX_ENTRIES);
   return sdk;
 }
 
 export function getLanguage(model: Provider.Model, auth: Auth.Info): LanguageModel {
   const modelID = model.api?.id ?? model.id;
   const cacheKey = `${model.providerID}:${model.api?.npm ?? ""}:${modelID}:${JSON.stringify(auth)}`;
-  const cached = LANGUAGE_CACHE.get(cacheKey);
+  const cached = getCached(LANGUAGE_CACHE, cacheKey);
   if (cached) return cached;
 
   const sdk = getSDK(model, auth);
@@ -112,9 +114,44 @@ export function getLanguage(model: Provider.Model, auth: Auth.Info): LanguageMod
   const custom = customLoader ? customLoader() : undefined;
 
   const languageModel = resolveLanguageModel(sdk, modelID, providerID, auth, custom);
-  LANGUAGE_CACHE.set(cacheKey, languageModel);
+  setCached(LANGUAGE_CACHE, cacheKey, languageModel, PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES);
   return languageModel;
 }
+
+function getCached<T>(cache: Map<string, T>, key: string): T | undefined {
+  const cached = cache.get(key);
+  if (cached === undefined) return undefined;
+  cache.delete(key);
+  cache.set(key, cached);
+  return cached;
+}
+
+function setCached<T>(cache: Map<string, T>, key: string, value: T, maxEntries: number): void {
+  if (cache.has(key)) {
+    cache.delete(key);
+  }
+  cache.set(key, value);
+
+  while (cache.size > maxEntries) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) return;
+    cache.delete(oldestKey);
+  }
+}
+
+export const ProviderCache = {
+  clear(): void {
+    SDK_CACHE.clear();
+    LANGUAGE_CACHE.clear();
+  },
+
+  stats(): { sdkEntries: number; languageEntries: number } {
+    return {
+      sdkEntries: SDK_CACHE.size,
+      languageEntries: LANGUAGE_CACHE.size,
+    };
+  },
+};
 
 function resolveLanguageModel(
   sdk: ProviderSDK,

--- a/packages/llm/test/provider/provider-cache.test.ts
+++ b/packages/llm/test/provider/provider-cache.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { Auth } from "../../src/auth";
-import { getLanguage, getSDK, type Provider } from "../../src/provider/index";
+import {
+  getLanguage,
+  getSDK,
+  ProviderCache,
+  PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES,
+  PROVIDER_SDK_CACHE_MAX_ENTRIES,
+  type Provider,
+} from "../../src/provider/index";
 
 function makeAnthropicModel(id = "claude-sonnet-4-20250514"): Provider.Model {
   return {
@@ -25,6 +32,10 @@ function makeOpenAIModel(id = "gpt-4o"): Provider.Model {
 }
 
 describe("provider caches", () => {
+  beforeEach(() => {
+    ProviderCache.clear();
+  });
+
   test("reuses SDK for the same provider and auth", () => {
     const auth: Auth.Info = { type: "api", key: "sk-test" };
 
@@ -73,5 +84,43 @@ describe("provider caches", () => {
     const second = getLanguage(makeOpenAIModel(), { type: "api", key: "sk-test-2" });
 
     expect(first).not.toBe(second);
+  });
+
+  test("evicts least-recently-used SDK entries after the cache limit", () => {
+    const model = makeOpenAIModel();
+    const firstAuth: Auth.Info = { type: "api", key: "sk-lru-0" };
+    const first = getSDK(model, firstAuth);
+
+    for (let i = 1; i <= PROVIDER_SDK_CACHE_MAX_ENTRIES; i++) {
+      getSDK(model, { type: "api", key: `sk-lru-${i}` });
+    }
+
+    expect(ProviderCache.stats().sdkEntries).toBe(PROVIDER_SDK_CACHE_MAX_ENTRIES);
+    expect(getSDK(model, firstAuth)).not.toBe(first);
+  });
+
+  test("touching an SDK cache entry keeps it across eviction", () => {
+    const model = makeOpenAIModel();
+    const firstAuth: Auth.Info = { type: "api", key: "sk-touch-0" };
+    const first = getSDK(model, firstAuth);
+
+    for (let i = 1; i < PROVIDER_SDK_CACHE_MAX_ENTRIES; i++) {
+      getSDK(model, { type: "api", key: `sk-touch-${i}` });
+    }
+    expect(getSDK(model, firstAuth)).toBe(first);
+    getSDK(model, { type: "api", key: "sk-touch-evict" });
+
+    expect(ProviderCache.stats().sdkEntries).toBe(PROVIDER_SDK_CACHE_MAX_ENTRIES);
+    expect(getSDK(model, firstAuth)).toBe(first);
+  });
+
+  test("bounds language model cache entries", () => {
+    const auth: Auth.Info = { type: "proxy", baseURL: "http://localhost:8317" };
+
+    for (let i = 0; i <= PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES; i++) {
+      getLanguage(makeAnthropicModel(`claude-lru-${i}`), auth);
+    }
+
+    expect(ProviderCache.stats().languageEntries).toBe(PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES);
   });
 });


### PR DESCRIPTION
## Summary
- bound provider SDK and language-model caches with LRU eviction
- expose provider cache clear/stats helpers and cache-size constants
- cover SDK eviction, touch promotion, and language cache bounds

## Validation
- git diff --check
- bun run script/check-deps.ts
- bun run build
- bun run lint (passes with 12 existing warnings)
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the provider SDK and language-model caches with LRU eviction to prevent unbounded growth and lower memory usage. Exposed simple cache controls for clearing and introspection.

- **Bug Fixes**
  - Added LRU bounds to caches: `PROVIDER_SDK_CACHE_MAX_ENTRIES = 64`, `PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES = 256`.
  - Promotes entries on access and evicts the oldest when limits are exceeded.

- **New Features**
  - Exposed `ProviderCache.clear()` and `ProviderCache.stats()`.
  - Exported `PROVIDER_SDK_CACHE_MAX_ENTRIES` and `PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES`.
  - Tests cover SDK eviction, touch promotion, and language cache limits.

<sup>Written for commit 90503e6b6bde295ee9837370a2657cdf6bba806e. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/167?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache management capabilities with size limits and monitoring.
  * Introduced utility to clear caches and view cache statistics.

* **Tests**
  * Expanded test coverage for cache eviction and boundary behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->