### PR TITLE
fix(agent): replace unsafe stream assertions

### DIFF
--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -122,7 +122,7 @@ export async function* streamAgent(
         if (outcome.type === "aborted") throw new Error("aborted");
         if (outcome.type === "error") throw new Error(outcome.error.message);
         const _exhaustive: never = outcome;
-        throw new Error(`Unknown outcome type: ${(_exhaustive as { type?: string }).type}`);
+        throw new Error(`Unknown outcome type: ${unknownOutcomeType(_exhaustive)}`);
       }
     } catch (error) {
       const decision = yield* handleError(
@@ -145,4 +145,13 @@ export async function* streamAgent(
   }
 
   throw new Error(lastError || "Max retry attempts exceeded");
+}
+
+function unknownOutcomeType(value: unknown): string {
+  if (typeof value !== "object" || value === null || !("type" in value)) {
+    return "unknown";
+  }
+
+  const type = value.type;
+  return typeof type === "string" ? type : "unknown";
 }

--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -150,7 +150,7 @@ export function buildPolicyEngine(
 export function resolveToolChoice(
   config: ChatAgentConfig,
 ): "auto" | "required" | "none" | undefined {
-  return (config as ChatAgentConfig & { toolChoice?: "auto" | "required" | "none" }).toolChoice;
+  return config.toolChoice;
 }
 
 export function assertToolExecutor(config: ChatAgentConfig): void {
@@ -259,13 +259,12 @@ function createGuardCompleteEvent(
 function buildToolLabelMap(tools: ChatAgentConfig["tools"]): Map<string, string[]> {
   const labels = new Map<string, string[]>();
   for (const tool of tools ?? []) {
-    const labelledTool = tool as typeof tool & { labels?: string[] };
-    if (!labelledTool.labels || labelledTool.labels.length === 0) continue;
-    labels.set(tool.name, labelledTool.labels);
-    const canonical = labelledTool.labels.find((label) => label.startsWith("tool:"))?.slice(5);
-    if (canonical) labels.set(canonical, labelledTool.labels);
+    if (!tool.labels || tool.labels.length === 0) continue;
+    labels.set(tool.name, tool.labels);
+    const canonical = tool.labels.find((label) => label.startsWith("tool:"))?.slice(5);
+    if (canonical) labels.set(canonical, tool.labels);
     const dotted = tool.name.replace(/_/g, ".");
-    if (dotted !== tool.name) labels.set(dotted, labelledTool.labels);
+    if (dotted !== tool.name) labels.set(dotted, tool.labels);
   }
   return labels;
 }
@@ -401,12 +400,13 @@ export async function dispatchModelResponse(
     try {
       applyMessageReplacementEffect(state, decision);
     } catch (error) {
+      const reason = errorMessage(error);
       publishDenyDiagnostic(
         "model.response",
         PolicyDecision.deny({
           policyId: "agent.policy.composed",
-          reasonCodes: [(error as Error).message],
-          effects: [{ type: "run.abort", reason: (error as Error).message }],
+          reasonCodes: [reason],
+          effects: [{ type: "run.abort", reason }],
         }),
         state,
         config,
@@ -635,7 +635,7 @@ export function createTrackingSink(
   return {
     onMessage: (message: Message.WithParts) => {
       if (message.info.role === "assistant") {
-        const tokens = (message.info as Message.AssistantMessage).tokens;
+        const tokens = message.info.tokens;
         const deltaInput = tokens.input - prevInputTokens;
         const deltaOutput = tokens.output - prevOutputTokens;
         prevInputTokens = tokens.input;
@@ -742,12 +742,13 @@ export async function* handleStop(
     try {
       applyMessageReplacementEffect(state, postTurnDecision);
     } catch (error) {
+      const reason = errorMessage(error);
       publishDenyDiagnostic(
         "turn.finish",
         PolicyDecision.deny({
           policyId: "agent.policy.composed",
-          reasonCodes: [(error as Error).message],
-          effects: [{ type: "run.abort", reason: (error as Error).message }],
+          reasonCodes: [reason],
+          effects: [{ type: "run.abort", reason }],
         }),
         state,
         config,
@@ -1035,12 +1036,13 @@ async function applyPostCompaction(
   try {
     messages = replacementMessages(compactionDecision);
   } catch (error) {
+    const reason = errorMessage(error);
     publishDenyDiagnostic(
       "completion.prepare",
       PolicyDecision.deny({
         policyId: "agent.policy.composed",
-        reasonCodes: [(error as Error).message],
-        effects: [{ type: "run.abort", reason: (error as Error).message }],
+        reasonCodes: [reason],
+        effects: [{ type: "run.abort", reason }],
       }),
       state,
       config,
@@ -1066,4 +1068,8 @@ async function applyPostCompaction(
 
 function getCompactionCount(state: StreamRunState): number | undefined {
   return state.compactionCount > 0 ? state.compactionCount : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -34,6 +34,7 @@ export interface ChatAgentConfig {
   providerOptions?: Record<string, unknown>;
   auth?: RunInput["auth"];
   allowAuthFallback?: RunInput["allowAuthFallback"];
+  toolChoice?: "auto" | "required" | "none";
   middleware?: PolicyRegistration[];
   context?: AgentRuntimeContext;
   llm?: {


### PR DESCRIPTION
## Summary
- add the missing optional ChatAgentConfig.toolChoice field instead of casting around it
- rely on existing Tool.Spec labels and assistant-message narrowing in stream helpers
- replace unsafe error casts and unreachable outcome casts with runtime-safe helpers

## Validation
- git diff --check
- bun run script/check-deps.ts
- bun run build
- bun run lint (passes with 12 existing warnings)
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe casts in the agent streaming path with runtime-safe helpers and proper types. Adds optional tool choice to config and improves error handling to prevent crashes and produce clearer diagnostics.

- **Bug Fixes**
  - Added optional `toolChoice` to `ChatAgentConfig`; simplified `resolveToolChoice` (no cast).
  - Used `tool.labels` to build the label map; support canonical and dotted names.
  - Narrowed assistant messages in tracking sink; removed token cast.
  - Replaced unreachable outcome cast with `unknownOutcomeType(...)` in stream engine.
  - Added `errorMessage(...)` to safely extract error text for deny diagnostics.

<sup>Written for commit 2c92c2e2b049b9b8858a2a63d92cac03e2b6e465. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/168?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `toolChoice` configuration option to control tool usage behavior with "auto", "required", or "none" modes.

* **Bug Fixes**
  * Improved error message clarity when unexpected outcome types occur.
  * Enhanced error handling consistency across stream execution helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->