### PR TITLE
fix(agent): apply mcp request timeouts

### DIFF
--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { randomUUID } from "node:crypto";
 import type { McpServerConfig, RuntimeResource, Tool } from "@openomni/protocol";
@@ -45,7 +46,7 @@ export class McpClient {
       transport = this.createTransport(this.config);
       closeTracker = trackTransportCloseRequests(transport);
       await this.client.connect(transport);
-      const tools = await this.client.listTools();
+      const tools = await this.client.listTools(undefined, requestOptions(this.config));
       this.connected = true;
 
       const toolCount = tools.tools.length;
@@ -106,8 +107,8 @@ export class McpClient {
     }
   }
 
-  async listTools(): Promise<Tool.Spec[]> {
-    const response = await this.client.listTools();
+  async listTools(context?: { readonly signal?: AbortSignal }): Promise<Tool.Spec[]> {
+    const response = await this.client.listTools(undefined, requestOptions(this.config, context));
     return response.tools.map((t) =>
       attachMcpToolDescriptor(convertMcpTool(t, this.config.name), this.config.name, t.name),
     );
@@ -141,7 +142,7 @@ export class McpClient {
           arguments: args,
         },
         undefined,
-        { signal: context?.signal },
+        requestOptions(this.config, context),
       );
 
       const _durationMs = Date.now() - startTime;
@@ -172,6 +173,26 @@ export class McpClient {
   get serverName(): string {
     return this.config.name;
   }
+}
+
+function requestOptions(
+  config: McpServerConfig,
+  context?: { readonly signal?: AbortSignal },
+): RequestOptions | undefined {
+  const timeout = normalizeTimeout(config.timeout);
+  if (context?.signal === undefined && timeout === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(context?.signal !== undefined && { signal: context.signal }),
+    ...(timeout !== undefined && { timeout, maxTotalTimeout: timeout }),
+  };
+}
+
+function normalizeTimeout(timeout: number | undefined): number | undefined {
+  if (timeout === undefined) return undefined;
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : undefined;
 }
 
 interface TransportCloseTracker {

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { Operational, type RuntimeResource, type Tool } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
@@ -22,6 +23,29 @@ function createStubClient(tools: McpToolStub[]): McpClientHandle {
     callTool: async () => {
       throw new Error("callTool is not implemented by this test stub");
     },
+  };
+}
+
+function createRequestOptionsCaptureClient(tools: McpToolStub[] = []): McpClientHandle & {
+  readonly listOptions: () => Array<RequestOptions | undefined>;
+  readonly callOptions: () => Array<RequestOptions | undefined>;
+} {
+  const capturedListOptions: Array<RequestOptions | undefined> = [];
+  const capturedCallOptions: Array<RequestOptions | undefined> = [];
+
+  return {
+    connect: async () => undefined,
+    close: async () => undefined,
+    listTools: async (_params, options) => {
+      capturedListOptions.push(options);
+      return { tools };
+    },
+    callTool: async (_params, _resultSchema, options) => {
+      capturedCallOptions.push(options);
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+    listOptions: () => capturedListOptions,
+    callOptions: () => capturedCallOptions,
   };
 }
 
@@ -81,6 +105,128 @@ describe("McpClient tool descriptors", () => {
       serverId: "search-server",
       remoteName: "search",
     });
+  });
+});
+
+describe("McpClient request options", () => {
+  test("preserves SDK defaults when neither timeout nor signal is configured", async () => {
+    const sdkClient = createRequestOptionsCaptureClient([{ name: "search" }]);
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+      },
+      { client: sdkClient },
+    );
+
+    await client.listTools();
+
+    expect(sdkClient.listOptions()[0]).toBeUndefined();
+  });
+
+  test("passes abort signal without requiring a timeout override", async () => {
+    const sdkClient = createRequestOptionsCaptureClient([{ name: "search" }]);
+    const signal = new AbortController().signal;
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+      },
+      { client: sdkClient },
+    );
+
+    await client.listTools({ signal });
+
+    const options = sdkClient.listOptions()[0];
+    expect(options?.signal).toBe(signal);
+    expect(options?.timeout).toBeUndefined();
+    expect(options?.maxTotalTimeout).toBeUndefined();
+  });
+
+  test("ignores non-positive timeout overrides", async () => {
+    const sdkClient = createRequestOptionsCaptureClient([{ name: "search" }]);
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+        timeout: 0,
+      },
+      { client: sdkClient },
+    );
+
+    await client.listTools();
+
+    expect(sdkClient.listOptions()[0]).toBeUndefined();
+  });
+
+  test("passes configured timeout to initial tool discovery during connect", async () => {
+    const sdkClient = createRequestOptionsCaptureClient();
+    const client = new McpClient(
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+        timeout: 1234,
+      },
+      {
+        client: sdkClient,
+        createTransport: () => createTransportStub(),
+      },
+    );
+
+    await client.connect();
+
+    const options = sdkClient.listOptions()[0];
+    expect(options?.timeout).toBe(1234);
+    expect(options?.maxTotalTimeout).toBe(1234);
+  });
+
+  test("passes configured timeout and abort signal to listTools", async () => {
+    const sdkClient = createRequestOptionsCaptureClient([{ name: "search" }]);
+    const signal = new AbortController().signal;
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+        timeout: 2500,
+      },
+      { client: sdkClient },
+    );
+
+    await client.listTools({ signal });
+
+    const options = sdkClient.listOptions()[0];
+    expect(options?.signal).toBe(signal);
+    expect(options?.timeout).toBe(2500);
+    expect(options?.maxTotalTimeout).toBe(2500);
+  });
+
+  test("passes configured timeout and abort signal to callTool", async () => {
+    const sdkClient = createRequestOptionsCaptureClient();
+    const signal = new AbortController().signal;
+    const client = new McpClient(
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "mcp-server-filesystem",
+        timeout: 5000,
+      },
+      { client: sdkClient },
+    );
+
+    const result = await client.callTool("filesystem.read_file", { path: "README.md" }, "call-1", {
+      signal,
+    });
+
+    expect(result.output).toBe("ok");
+    const options = sdkClient.callOptions()[0];
+    expect(options?.signal).toBe(signal);
+    expect(options?.timeout).toBe(5000);
+    expect(options?.maxTotalTimeout).toBe(5000);
   });
 });
 

--- a/packages/protocol/src/mcp/index.ts
+++ b/packages/protocol/src/mcp/index.ts
@@ -8,6 +8,7 @@ export namespace McpConfig {
     args: z.string().array().optional(),
     url: z.string().optional(),
     headers: z.record(z.string(), z.string()).optional(),
+    /** Per-request timeout in milliseconds for MCP tool discovery and tool calls. */
     timeout: z.number().optional(),
     retries: z.number().optional(),
   });


### PR DESCRIPTION
## Summary
- forward MCP server timeout settings to connect-time tool discovery, listTools, and callTool requests
- preserve SDK defaults when no timeout or signal is configured and ignore non-positive timeout overrides
- document MCP timeout units and cover request-option forwarding paths

## Validation
- git diff --check
- bun run script/check-deps.ts
- bun run build
- bun run lint (passes with 12 existing warnings)
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply per-request MCP timeouts and cancellation by forwarding configured timeouts and abort signals to tool discovery and tool calls. Prevents indefinite requests while preserving SDK defaults when timeouts aren’t set.

- **Bug Fixes**
  - Forward `McpServerConfig.timeout` to connect-time discovery, listTools, and callTool as `RequestOptions` (`timeout` and `maxTotalTimeout`).
  - Preserve SDK defaults when no timeout or signal is provided; ignore non-positive timeouts.
  - Accept and pass through optional `AbortSignal` for listTools and callTool.
  - Document timeout units (ms) in `packages/protocol`.
  - Add tests to verify request-option forwarding.

<sup>Written for commit 0edca17e1fd2532fe1cd076ade12579831fa4de1. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/169?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tool discovery and tool calls now support cancellation via abort signals
  * Configurable timeouts are properly applied to MCP operations for improved control and reliability

* **Tests**
  * Added comprehensive test coverage for MCP request options handling and timeout behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->