### PR TITLE
fix(llm): share model status contract

### DIFF
--- a/packages/llm/src/model/index.ts
+++ b/packages/llm/src/model/index.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { Model as ProtocolModel } from "@openomni/protocol";
 import { lazy } from "../util/lazy";
 
 const DEFAULT_CACHE_DIR = join(homedir(), ".openomni");
 const DEFAULT_CACHE_PATH = join(DEFAULT_CACHE_DIR, "models.json");
 
 export namespace ModelsDev {
-  export const ModelStatus = z.enum(["alpha", "beta", "deprecated", "active"]);
+  export const ModelStatus = ProtocolModel.Status;
   export type ModelStatus = z.infer<typeof ModelStatus>;
 
   export const Model = z.object({

--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Model as ProtocolModel } from "@openomni/protocol";
 import { ProviderError } from "../error";
 import { ModelsDev } from "../model";
 import { fromModelsDevProvider, filterModels } from "./provider";
@@ -72,7 +73,7 @@ export namespace Provider {
         output: z.number().optional(),
       })
       .optional(),
-    status: ModelsDev.ModelStatus.optional(),
+    status: ProtocolModel.Status.optional(),
     options: z.record(z.string(), z.any()).optional(),
     headers: z.record(z.string(), z.string()).optional(),
     release_date: z.string().optional(),

--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -1,4 +1,4 @@
-import type { Model } from "@openomni/protocol";
+import { Model } from "@openomni/protocol";
 import type { SDKMessage } from "../session/convert";
 import type { Provider } from "../provider/index";
 
@@ -110,10 +110,12 @@ export namespace ProviderTransform {
     variant?: string,
   ): Record<string, unknown> {
     if (!variant) return {};
-    if ("providerID" in model || "capabilities" in model) {
-      return variants(model as Provider.Model)[variant] ?? {};
+    if (isProviderModel(model)) {
+      return variants(model)[variant] ?? {};
     }
-    const providerName = (model as Model.Ref).provider;
+    if (!Model.isRef(model)) return {};
+
+    const providerName = model.provider;
     const npm =
       providerName === "anthropic"
         ? "@ai-sdk/anthropic"
@@ -121,13 +123,19 @@ export namespace ProviderTransform {
           ? "@ai-sdk/openai"
           : undefined;
     if (!npm) return {};
-    const syntheticModel = {
-      id: (model as Model.Ref).id,
+    const syntheticModel: Provider.Model = {
+      id: model.id,
+      providerID: model.provider,
+      name: model.id,
       api: { npm },
       capabilities: { reasoning: true },
       limit: { output: 64_000 },
-    } as unknown as Provider.Model;
+    };
     return variants(syntheticModel)[variant] ?? {};
+  }
+
+  function isProviderModel(model: Provider.Model | Model.Ref): model is Provider.Model {
+    return "providerID" in model;
   }
 
   function normalizeAnthropic(msgs: SDKMessage[], model: NormalizeOptions): SDKMessage[] {

--- a/packages/llm/test/model/models.test.ts
+++ b/packages/llm/test/model/models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Model } from "@openomni/protocol";
 import { ModelsDev } from "../../src/model";
 
 describe("ModelsDev", () => {
@@ -99,6 +100,7 @@ describe("ModelsDev", () => {
     it("should reuse the same model status schema for provider models", () => {
       const result = ModelsDev.ModelStatus.safeParse("active");
       expect(result.success).toBe(true);
+      expect(ModelsDev.ModelStatus).toBe(Model.Status);
     });
 
     it("should validate Model with variants", () => {

--- a/packages/llm/test/transform/transform.test.ts
+++ b/packages/llm/test/transform/transform.test.ts
@@ -421,6 +421,22 @@ describe("ProviderTransform.resolveVariant", () => {
     expect(result.reasoningSummary).toBe("auto");
   });
 
+  test("resolveVariant with openai model ref uses the shared model ref guard", () => {
+    const result = ProviderTransform.resolveVariant({ provider: "openai", id: "o4-mini" }, "low");
+
+    expect(result.reasoningEffort).toBe("low");
+    expect(result.reasoningSummary).toBe("auto");
+  });
+
+  test("resolveVariant with anthropic model ref returns thinking options", () => {
+    const result = ProviderTransform.resolveVariant(
+      { provider: "anthropic", id: "claude-sonnet-4-20250514" },
+      "high",
+    );
+
+    expect((result.thinking as Record<string, unknown>).type).toBe("enabled");
+  });
+
   test("resolveVariant with non-reasoning model returns empty object", () => {
     const model: Provider.Model = {
       id: "gpt-4o",

--- a/packages/protocol/src/model/index.ts
+++ b/packages/protocol/src/model/index.ts
@@ -1,9 +1,16 @@
 import { z } from "zod";
 
 export namespace Model {
+  export const Status = z.enum(["alpha", "beta", "deprecated", "active"]);
+  export type Status = z.infer<typeof Status>;
+
   export const Ref = z.object({
     provider: z.string(),
     id: z.string(),
   });
   export type Ref = z.infer<typeof Ref>;
+
+  export function isRef(value: unknown): value is Ref {
+    return Ref.safeParse(value).success;
+  }
 }

--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -167,6 +167,16 @@ describe("acceptance (documents current behavior)", () => {
       provider: "openai",
       id: "gpt-4o",
     }));
+  it("recognizes model refs with the shared guard", () => {
+    expect(Model.isRef({ provider: "openai", id: "gpt-4o" })).toBe(true);
+    expect(Model.isRef({ providerID: "openai", id: "gpt-4o" })).toBe(false);
+  });
+  it("exposes shared model status values", () => {
+    for (const status of ["alpha", "beta", "deprecated", "active"] as const) {
+      expect(Model.Status.parse(status)).toBe(status);
+    }
+    expect(Model.Status.safeParse("unknown").success).toBe(false);
+  });
   it("keeps AgentProfile.ModelRef as a compatibility alias", () =>
     expect(AgentProfile.ModelRef.parse({ provider: "openai", id: "gpt-4o" })).toEqual({
       provider: "openai",


### PR DESCRIPTION
## Summary
- move model status values into the shared protocol model contract
- reuse the shared status contract from llm model/provider schemas
- add a shared Model.Ref guard and use it in variant resolution instead of casts

## Validation
- git diff --check
- bun run script/check-deps.ts
- bun run build
- bun run lint (passes with 12 existing warnings)
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes model status in `@openomni/protocol` and updates `llm` to use the shared contract. Adds a `Model.isRef` guard and uses it in variant resolution for safer handling of model refs.

- **Refactors**
  - Move status enum to `Model.Status` in `@openomni/protocol` and reuse it in `llm` model/provider schemas.
  - Replace ad-hoc checks/casts in `resolveVariant` with `Model.isRef`; keep provider models narrowed via `providerID`.
  - For `openai` and `anthropic` refs, create a minimal synthetic provider model to resolve variants consistently.

<sup>Written for commit 95317a28280c8dcf6c72142d9e30a0d19f2c6f5d. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized model status definitions to use a shared protocol-based schema instead of local definitions.
  * Enhanced variant resolution to intelligently handle both provider models and model references, with automatic synthetic model generation for references.

* **Tests**
  * Added test coverage for model reference validation and status schema alignment across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->