### PR TITLE
refactor(coordinator,session): reuse protocol worker contracts

### DIFF
--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import type { Subprocess } from "bun";
-import { Operational, type WorkerBootstrap } from "@openomni/protocol";
+import { Operational, type Tool, type WorkerBootstrap } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { connectIpcClient, type IpcClient } from "../ipc/client";
 
@@ -30,13 +30,7 @@ export type ToolCallContext = {
   readonly signal?: AbortSignal;
 };
 
-export type ToolCallResult = {
-  id: string;
-  toolCallId: string;
-  output: string;
-  isError?: boolean;
-  settlement?: "settled" | "unknown";
-};
+export type ToolCallResult = Tool.Result;
 
 export type AskMainParams = {
   workerId: string;

--- a/packages/coordinator/test/worker-pool/contract-alias.test.ts
+++ b/packages/coordinator/test/worker-pool/contract-alias.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import type { Tool } from "@openomni/protocol";
+import type { ToolCallResult } from "../../src/index";
+
+type IsExact<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2
+    ? true
+    : false
+  : false;
+
+type AssertExact<A, B> = IsExact<A, B> extends true ? true : never;
+
+const toolCallResultIsProtocolResult: AssertExact<ToolCallResult, Tool.Result> = true;
+
+describe("worker pool public contracts", () => {
+  test("ToolCallResult intentionally tracks the protocol Tool.Result contract", () => {
+    expect(toolCallResultIsProtocolResult).toBe(true);
+  });
+});

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -5,7 +5,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.contract-test.json",
     "lint": "bunx biome check ./src",
     "test": "bun test",
     "bench": "bun run bench/index.ts"

--- a/packages/session/src/worker-run/index.ts
+++ b/packages/session/src/worker-run/index.ts
@@ -4,15 +4,7 @@ import { WorkerRunStateStore } from "./state-store.js";
 
 // Subagent execution lifecycle per session, kept separate from user-facing work items.
 
-export type WorkerRunStatus =
-  | "queued"
-  | "starting"
-  | "running"
-  | "waiting_input"
-  | "succeeded"
-  | "failed"
-  | "cancelled"
-  | "interrupted";
+export type WorkerRunStatus = Subagent.WorkerRunStatus;
 
 export interface WorkerRunRecord {
   runId: string;

--- a/packages/session/test/worker-run/contract-alias.test.ts
+++ b/packages/session/test/worker-run/contract-alias.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import type { Subagent } from "@openomni/protocol";
+import type { WorkerRunStatus } from "../../src/index";
+
+type IsExact<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2
+    ? true
+    : false
+  : false;
+
+type AssertExact<A, B> = IsExact<A, B> extends true ? true : never;
+
+const workerRunStatusIsProtocolStatus: AssertExact<WorkerRunStatus, Subagent.WorkerRunStatus> =
+  true;
+
+describe("WorkerRun public contracts", () => {
+  test("WorkerRunStatus intentionally tracks the protocol Subagent.WorkerRunStatus contract", () => {
+    expect(workerRunStatusIsProtocolStatus).toBe(true);
+  });
+});

--- a/packages/session/tsconfig.contract-test.json
+++ b/packages/session/tsconfig.contract-test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test/worker-run/contract-alias.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Reuse the protocol-owned worker/tool contracts from coordinator and session public aliases, removing duplicated local unions/shape definitions while preserving existing exported type names.

Fixes #
Relates to #

## Changes

- Replace coordinator `ToolCallResult` local shape with `Tool.Result` from `@openomni/protocol`
- Replace session `WorkerRunStatus` local union with `Subagent.WorkerRunStatus` from `@openomni/protocol`
- Add typechecked alias contract tests so future protocol drift is intentional and visible
- Wire the session alias contract test into `check-types`

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [x] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [x] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- `git diff --check`
- `bunx biome check packages/coordinator/src/worker-pool/supervisor.ts packages/session/src/worker-run/index.ts packages/coordinator/test/worker-pool/contract-alias.test.ts packages/session/test/worker-run/contract-alias.test.ts packages/session/package.json packages/session/tsconfig.contract-test.json`
- `bun test packages/coordinator/test/worker-pool/contract-alias.test.ts packages/session/test/worker-run/contract-alias.test.ts packages/session/test/worker-run/worker-run.test.ts packages/session/test/worker-run/state-store.test.ts packages/coordinator/test/recovery/crash.test.ts`
- `bun run check-types`
- `bun test`
- `bun run script/check-deps.ts` via pre-push hook

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped coordinator and session worker/tool contracts by reusing `@openomni/protocol` types while keeping existing exported names. No behavior change.

- **Refactors**
  - Coordinator: `ToolCallResult` now aliases `Tool.Result` from `@openomni/protocol` (removed local shape).
  - Session: `WorkerRunStatus` now aliases `Subagent.WorkerRunStatus` from `@openomni/protocol` (removed local union).
  - Added type-checked alias contract tests; session `check-types` runs an extra `tsconfig.contract-test.json`.

<sup>Written for commit 750b431f80f246ab0d6aba64e988f721be569302. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/174?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions to align with protocol specifications.

* **Tests**
  * Added contract tests to verify type consistency across packages.

* **Chores**
  * Enhanced TypeScript build configuration to support contract validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->