### PR TITLE
refactor(server,agent): consolidate runtime contracts

### DIFF
--- a/apps/server/src/agents/index.ts
+++ b/apps/server/src/agents/index.ts
@@ -10,3 +10,4 @@ export type {
   AgentFactory,
   AgentPromptMetadata,
 } from "./types";
+export { RuntimeAgentDefinition } from "./runtime-definition";

--- a/apps/server/src/agents/runtime-definition.ts
+++ b/apps/server/src/agents/runtime-definition.ts
@@ -1,0 +1,12 @@
+import { WorkerBootstrap } from "@openomni/protocol";
+import type { AgentDefinition } from "./types";
+
+export namespace RuntimeAgentDefinition {
+  // Sole server-to-worker agent egress boundary: protocol parsing projects the
+  // worker wire contract and intentionally strips server-only prompt metadata.
+  export function parse(definition: AgentDefinition): WorkerBootstrap.RuntimeAgentDefinition {
+    return WorkerBootstrap.RuntimeAgentDefinition.parse(definition);
+  }
+
+  export const create = parse;
+}

--- a/apps/server/src/agents/types.ts
+++ b/apps/server/src/agents/types.ts
@@ -1,17 +1,16 @@
-import type { AgentBudget, ChatAgentConfig } from "@openomni/agent";
-import type { Policy, ToolSelection } from "@openomni/protocol";
+import type { ChatAgentConfig } from "@openomni/agent";
+import type { WorkerBootstrap } from "@openomni/protocol";
 
-export interface AgentDefinition {
-  name: string;
-  description: string;
+type RuntimeAgentModel = NonNullable<WorkerBootstrap.RuntimeAgentDefinition["model"]>;
+type AssertRuntimeModelCompatible<T extends RuntimeAgentModel> = T;
+type _AgentDefinitionModelCompatibility = AssertRuntimeModelCompatible<ChatAgentConfig["model"]>;
+
+export type AgentDefinition = WorkerBootstrap.RuntimeAgentDefinition & {
   // Agent definitions may use an alias/latest model ID. The server resolves it
   // to a concrete provider model ID from models.dev before execution.
   model: ChatAgentConfig["model"];
   systemPrompt: string;
-  tools: ToolSelection.Selection;
-  budget?: AgentBudget;
-  permissions?: Policy.Permission;
-}
+};
 
 export type AgentFactory = () => AgentDefinition;
 

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -27,6 +27,7 @@ import { resolveModel } from "./providers";
 import { runRecovery } from "./recovery";
 import { installShutdownHandlers } from "./shutdown";
 import { createAllAgents, registerAgent } from "../agents";
+import { RuntimeAgentDefinition } from "../agents/runtime-definition";
 import { createResidentProfile } from "../profile/resident";
 
 function djb2Hash(s: string): string {
@@ -38,17 +39,7 @@ function djb2Hash(s: string): string {
 }
 
 async function assembleBootstrap(mcpProvider: McpToolProvider): Promise<WorkerBootstrap.Bootstrap> {
-  const agents = [...createAllAgents().values()].map(
-    (def): WorkerBootstrap.RuntimeAgentDefinition => ({
-      name: def.name,
-      description: def.description,
-      model: def.model,
-      systemPrompt: def.systemPrompt,
-      tools: def.tools,
-      permissions: def.permissions,
-      budget: def.budget,
-    }),
-  );
+  const agents = [...createAllAgents().values()].map(RuntimeAgentDefinition.create);
 
   const toolCatalog = mcpProvider.listTools().map(
     (tool): WorkerBootstrap.RuntimeToolCatalogEntry => ({

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -3,14 +3,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-
-type McpServerConfig = {
-  name: string;
-  transport: "stdio" | "sse" | "streamable-http";
-  command?: string;
-  args?: string[];
-  url?: string;
-};
+import { parseMcpServerConfigs, type McpServerConfig } from "./config/mcp-server-config";
+export type { McpServerConfig } from "./config/mcp-server-config";
 
 const DEFAULT_CONFIG_PATH = join(homedir(), ".openomni", "config.json");
 
@@ -19,7 +13,7 @@ interface RawConfig {
     root?: string;
   };
   mcp?: {
-    servers?: McpServerConfig[];
+    servers?: unknown;
   };
   server?: {
     port?: number;
@@ -74,7 +68,7 @@ function loadRaw(configPath: string): RawConfig {
   }
 }
 
-function resolve(raw: RawConfig): ServerConfig {
+function resolve(raw: RawConfig, configPath: string): ServerConfig {
   const defaultDbPath = join(homedir(), ".openomni", "storage.db");
   const workspaceRoot = raw.workspace?.root;
 
@@ -91,7 +85,10 @@ function resolve(raw: RawConfig): ServerConfig {
   return {
     workspace: workspaceRoot ? { root: workspaceRoot } : undefined,
     mcp: {
-      servers: raw.mcp?.servers ?? [],
+      servers: parseMcpServerConfigs(raw.mcp?.servers, {
+        source: "server-config",
+        configPath,
+      }),
     },
     server: {
       port: raw.server?.port ?? 3000,
@@ -120,7 +117,7 @@ function resolve(raw: RawConfig): ServerConfig {
 
 export function loadConfig(configPath = DEFAULT_CONFIG_PATH): ServerConfig {
   if (_config && _configPath === configPath) return _config;
-  _config = resolve(loadRaw(configPath));
+  _config = resolve(loadRaw(configPath), configPath);
   _configPath = configPath;
   return _config;
 }

--- a/apps/server/src/config/mcp-server-config.ts
+++ b/apps/server/src/config/mcp-server-config.ts
@@ -1,0 +1,84 @@
+import { McpConfig, Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { z } from "zod";
+
+export type McpServerConfig = McpConfig.ServerConfig;
+
+const MAX_ZOD_ISSUES_PER_ENTRY = 3;
+
+export const McpServerConfigParseOptionsSchema = z.object({
+  source: z.enum(["server-config", "project-config"]),
+  configPath: z.string().optional(),
+});
+export type McpServerConfigParseOptions = z.infer<typeof McpServerConfigParseOptionsSchema>;
+
+export function parseMcpServerConfigs(
+  value: unknown,
+  options: McpServerConfigParseOptions,
+): McpServerConfig[] {
+  const parseOptions = McpServerConfigParseOptionsSchema.parse(options);
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    publishInvalidMcpConfigWarning(parseOptions, [
+      { index: -1, error: "servers must be an array" },
+    ]);
+    return [];
+  }
+
+  const servers: McpServerConfig[] = [];
+  const rejected: Array<{
+    readonly index: number;
+    readonly name?: string;
+    readonly error: string;
+  }> = [];
+
+  value.forEach((entry, index) => {
+    const parsed = McpConfig.ServerConfig.safeParse(entry);
+    if (parsed.success) {
+      servers.push(parsed.data);
+      return;
+    }
+
+    rejected.push({
+      index,
+      ...readMcpServerName(entry),
+      error: parsed.error.issues
+        .slice(0, MAX_ZOD_ISSUES_PER_ENTRY)
+        .map((issue) => issue.message)
+        .join("; "),
+    });
+  });
+
+  if (rejected.length > 0) {
+    publishInvalidMcpConfigWarning(parseOptions, rejected);
+  }
+
+  return servers;
+}
+
+function publishInvalidMcpConfigWarning(
+  options: McpServerConfigParseOptions,
+  rejected: ReadonlyArray<{
+    readonly index: number;
+    readonly name?: string;
+    readonly error: string;
+  }>,
+): void {
+  Bus.publish(Operational.Warn, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    component: "server",
+    msg: "invalid mcp server config ignored",
+    context: {
+      source: options.source,
+      ...(options.configPath !== undefined && { configPath: options.configPath }),
+      rejected,
+    },
+  });
+}
+
+function readMcpServerName(entry: unknown): { readonly name?: string } {
+  if (entry === null || typeof entry !== "object") return {};
+  const name = (entry as { readonly name?: unknown }).name;
+  return typeof name === "string" ? { name } : {};
+}

--- a/apps/server/src/context/mcp-config.ts
+++ b/apps/server/src/context/mcp-config.ts
@@ -2,9 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import type { ServerConfig } from "../config.js";
-
-type McpServerConfig = ServerConfig["mcp"]["servers"][number];
+import { parseMcpServerConfigs, type McpServerConfig } from "../config/mcp-server-config";
 
 const discoverCache = new Map<string, { result: McpServerConfig[] | null }>();
 
@@ -37,17 +35,12 @@ export namespace McpConfigLoader {
     let result: McpServerConfig[] | null;
 
     if (Array.isArray(parsed)) {
-      result = parsed.filter(
-        (e): e is McpServerConfig =>
-          e !== null && typeof e === "object" && typeof (e as { name?: unknown }).name === "string",
-      );
-    } else if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      "servers" in parsed &&
-      Array.isArray((parsed as { servers: unknown }).servers)
-    ) {
-      result = (parsed as { servers: McpServerConfig[] }).servers;
+      result = parseMcpServerConfigs(parsed, { source: "project-config", configPath });
+    } else if (parsed !== null && typeof parsed === "object" && "servers" in parsed) {
+      result = parseMcpServerConfigs((parsed as { servers: unknown }).servers, {
+        source: "project-config",
+        configPath,
+      });
     } else {
       Bus.publish(Operational.Warn, {
         traceId: crypto.randomUUID(),

--- a/apps/server/src/execution/worker-heartbeat.ts
+++ b/apps/server/src/execution/worker-heartbeat.ts
@@ -15,7 +15,7 @@ export namespace WorkerHeartbeat {
   export const Server = z.object({
     call: z
       .function()
-      .args(z.literal("worker.heartbeat"), z.record(z.unknown()))
+      .args(z.literal("worker.heartbeat"), z.record(z.string(), z.unknown()))
       .returns(z.promise(z.unknown())),
   });
   export type Server = {

--- a/apps/server/src/tool/mcp/provider.ts
+++ b/apps/server/src/tool/mcp/provider.ts
@@ -368,16 +368,23 @@ function latestSession(): { readonly id: string } | undefined {
 }
 
 function summarizeServerConfig(config: McpServerConfig): Record<string, unknown> {
-  return {
+  const summary: Record<string, unknown> = {
     serverName: config.name,
     transport: config.transport,
-    ...(config.command !== undefined && { command: config.command }),
-    ...(config.url !== undefined && { url: config.url }),
-    ...(config.args !== undefined && { argsCount: config.args.length }),
     ...(config.timeout !== undefined && { timeout: config.timeout }),
     ...(config.retries !== undefined && { retries: config.retries }),
     ...(config.headers !== undefined && { headerNames: Object.keys(config.headers).sort() }),
   };
+
+  if (config.transport === "stdio") {
+    return {
+      ...summary,
+      command: config.command,
+      ...(config.args !== undefined && { argsCount: config.args.length }),
+    };
+  }
+
+  return { ...summary, url: config.url };
 }
 
 function lifecycleBase(audit: ResolvedLifecycleAudit) {

--- a/apps/server/test/agents/runtime-definition.test.ts
+++ b/apps/server/test/agents/runtime-definition.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { WorkerBootstrap } from "@openomni/protocol";
+import { RuntimeAgentDefinition } from "../../src/agents/runtime-definition";
+import type { AgentDefinition, AgentPromptMetadata } from "../../src/agents/types";
+
+describe("RuntimeAgentDefinition", () => {
+  it("serializes server agent definitions through the protocol runtime schema", () => {
+    const definition: AgentDefinition = {
+      name: "dev",
+      description: "Development agent",
+      model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+      systemPrompt: "Build carefully.",
+      tools: { categories: ["filesystem", "execution"] },
+      budget: { maxTurns: 4, maxToolCalls: 8 },
+    };
+
+    const runtime = RuntimeAgentDefinition.create(definition);
+
+    expect(runtime).toEqual(definition);
+    expect(WorkerBootstrap.RuntimeAgentDefinition.parse(runtime)).toEqual(runtime);
+  });
+
+  it("keeps prompt metadata out of the worker bootstrap contract", () => {
+    const metadata: AgentPromptMetadata = {
+      name: "dev",
+      description: "Development agent",
+      triggers: { slashCommand: "dev" },
+    };
+    const definitionWithMetadata = {
+      name: "dev",
+      description: metadata.description,
+      model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+      systemPrompt: "Build carefully.",
+      tools: { categories: ["filesystem"] },
+      metadata,
+    } as AgentDefinition & { metadata: AgentPromptMetadata };
+
+    const runtime = RuntimeAgentDefinition.create(definitionWithMetadata);
+
+    expect(runtime).toEqual({
+      name: "dev",
+      description: "Development agent",
+      model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+      systemPrompt: "Build carefully.",
+      tools: { categories: ["filesystem"] },
+    });
+    expect("metadata" in runtime).toBe(false);
+  });
+});

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { resetConfig, loadConfig } from "../src/config";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { resetConfig, loadConfig, type McpServerConfig } from "../src/config";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+async function flushBus(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe("config", () => {
   let tempDir: string;
@@ -17,11 +23,13 @@ describe("config", () => {
       WS_AUTH_TOKEN: process.env.WS_AUTH_TOKEN,
     };
     resetConfig();
+    Bus.reset();
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
     resetConfig();
+    Bus.reset();
     Object.entries(originalEnv).forEach(([key, value]) => {
       if (value === undefined) {
         delete process.env[key];
@@ -48,6 +56,90 @@ describe("config", () => {
     expect(config.discord.token).toBe("file-discord-token");
     expect(config.github.secret).toBe("file-github-secret");
     expect(config.server.wsToken).toBe("file-ws-token");
+  });
+
+  it("preserves protocol MCP server fields from the config file", () => {
+    const configPath = join(tempDir, "config.json");
+    const servers: McpServerConfig[] = [
+      {
+        name: "remote",
+        transport: "streamable-http",
+        url: "https://mcp.example.com",
+        headers: { Authorization: "Bearer file-token" },
+        timeout: 12_000,
+        retries: 2,
+      },
+    ];
+    writeFileSync(configPath, JSON.stringify({ mcp: { servers } }));
+
+    const config = loadConfig(configPath);
+    expect(config.mcp.servers).toEqual(servers);
+  });
+
+  it("drops invalid MCP server entries at the config boundary", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (payload) => warnings.push(payload));
+    const configPath = join(tempDir, "config.json");
+    const valid: McpServerConfig = {
+      name: "valid",
+      transport: "stdio",
+      command: "node",
+    };
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcp: {
+          servers: [valid, { name: "invalid", transport: "websocket", url: "ws://localhost" }],
+        },
+      }),
+    );
+
+    const config = loadConfig(configPath);
+    await flushBus();
+    unsubscribe();
+
+    expect(config.mcp.servers).toEqual([valid]);
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid mcp server config ignored",
+        context: expect.objectContaining({
+          source: "server-config",
+          configPath,
+          rejected: [
+            expect.objectContaining({
+              index: 1,
+              name: "invalid",
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("treats non-array MCP servers as empty at the config boundary", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (payload) => warnings.push(payload));
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcp: { servers: { name: "bad", transport: "stdio" } } }),
+    );
+
+    const config = loadConfig(configPath);
+    await flushBus();
+    unsubscribe();
+
+    expect(config.mcp.servers).toEqual([]);
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid mcp server config ignored",
+        context: expect.objectContaining({
+          source: "server-config",
+          configPath,
+          rejected: [expect.objectContaining({ index: -1, error: "servers must be an array" })],
+        }),
+      }),
+    );
   });
 
   it("uses env var when config file value is missing for telegram token", () => {

--- a/apps/server/test/context/mcp-config.test.ts
+++ b/apps/server/test/context/mcp-config.test.ts
@@ -2,17 +2,16 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import { McpConfigLoader } from "../../src/context/mcp-config";
-
-type McpServerConfig = {
-  name: string;
-  transport: "stdio" | "sse" | "streamable-http";
-  command?: string;
-  args?: string[];
-  url?: string;
-};
+import type { McpServerConfig } from "../../src/config";
 
 let tempRoot: string;
+
+async function flushBus(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 beforeAll(() => {
   tempRoot = realpathSync(mkdtempSync(join(tmpdir(), "mcp-config-test-")));
@@ -20,6 +19,11 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(tempRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  Bus.reset();
+  McpConfigLoader._resetCache();
 });
 
 describe("McpConfigLoader.discover", () => {
@@ -49,7 +53,14 @@ describe("McpConfigLoader.discover", () => {
     mkdirSync(openomniDir, { recursive: true });
 
     const servers: McpServerConfig[] = [
-      { name: "server-b", transport: "sse", url: "http://localhost:8080" },
+      {
+        name: "server-b",
+        transport: "sse",
+        url: "http://localhost:8080",
+        headers: { Authorization: "Bearer project-token" },
+        timeout: 5_000,
+        retries: 1,
+      },
     ];
     writeFileSync(join(openomniDir, "mcp.json"), JSON.stringify(servers), "utf-8");
 
@@ -64,6 +75,65 @@ describe("McpConfigLoader.discover", () => {
     writeFileSync(join(openomniDir, "mcp.json"), "{ not valid json", "utf-8");
 
     expect(McpConfigLoader.discover(dir)).toBeNull();
+  });
+
+  it("drops invalid server entries through the protocol MCP schema", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (payload) => warnings.push(payload));
+    const dir = join(tempRoot, "invalid-server-entry");
+    const openomniDir = join(dir, ".openomni");
+    const configPath = join(openomniDir, "mcp.json");
+    mkdirSync(openomniDir, { recursive: true });
+    const valid: McpServerConfig = { name: "valid", transport: "stdio", command: "node" };
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: [valid, { name: "bad", transport: "websocket", url: "ws://localhost" }],
+      }),
+      "utf-8",
+    );
+
+    expect(McpConfigLoader.discover(dir)).toEqual([valid]);
+    await flushBus();
+    unsubscribe();
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid mcp server config ignored",
+        context: expect.objectContaining({
+          source: "project-config",
+          configPath,
+          rejected: [expect.objectContaining({ index: 1, name: "bad" })],
+        }),
+      }),
+    );
+  });
+
+  it("routes non-array object-format servers through the shared parser", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (payload) => warnings.push(payload));
+    const dir = join(tempRoot, "object-format-non-array");
+    const openomniDir = join(dir, ".openomni");
+    const configPath = join(openomniDir, "mcp.json");
+    mkdirSync(openomniDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ servers: { name: "bad", transport: "stdio" } }),
+      "utf-8",
+    );
+
+    expect(McpConfigLoader.discover(dir)).toEqual([]);
+    await flushBus();
+    unsubscribe();
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid mcp server config ignored",
+        context: expect.objectContaining({
+          source: "project-config",
+          configPath,
+          rejected: [expect.objectContaining({ index: -1, error: "servers must be an array" })],
+        }),
+      }),
+    );
   });
 });
 
@@ -101,6 +171,22 @@ describe("McpConfigLoader.merge", () => {
     expect(overridden?.command).toBeUndefined();
   });
 
+  it("project overrides preserve protocol MCP fields", () => {
+    const conflictProject: McpServerConfig[] = [
+      {
+        name: "global-b",
+        transport: "streamable-http",
+        url: "https://override.example.com",
+        headers: { "x-project": "yes" },
+        timeout: 9_000,
+        retries: 3,
+      },
+    ];
+
+    const result = McpConfigLoader.merge(globalServers, conflictProject);
+    expect(result.find((s) => s.name === "global-b")).toEqual(conflictProject[0]);
+  });
+
   it("returns project servers when global is empty", () => {
     expect(McpConfigLoader.merge([], projectServers)).toEqual(projectServers);
   });
@@ -111,8 +197,6 @@ describe("McpConfigLoader.merge", () => {
 });
 
 describe("McpConfigLoader caching", () => {
-  afterEach(() => McpConfigLoader._resetCache());
-
   it("discover returns cached result on repeated calls", () => {
     const dir = join(tempRoot, "cache-repeat");
     const openomniDir = join(dir, ".openomni");
@@ -139,7 +223,7 @@ describe("McpConfigLoader caching", () => {
     mkdirSync(join(dir, ".openomni"), { recursive: true });
     writeFileSync(
       join(dir, ".openomni", "mcp.json"),
-      JSON.stringify([{ name: "late", transport: "stdio" }]),
+      JSON.stringify([{ name: "late", transport: "stdio", command: "node" }]),
     );
 
     const cached = McpConfigLoader.discover(dir);

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -1,7 +1,13 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  SSEClientTransport,
+  type SSEClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/sse.js";
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { randomUUID } from "node:crypto";
@@ -273,24 +279,84 @@ function attachMcpToolDescriptor(
   };
 }
 
+const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
+  initialReconnectionDelay: 1_000,
+  maxReconnectionDelay: 30_000,
+  reconnectionDelayGrowFactor: 1.5,
+} as const;
+
 function createTransport(config: McpServerConfig): Transport {
   switch (config.transport) {
-    case "stdio": {
-      if (!config.command) throw new Error("stdio transport requires command");
+    case "stdio":
       return new StdioClientTransport({
         command: config.command,
         args: config.args,
       });
-    }
-    case "sse": {
-      if (!config.url) throw new Error("sse transport requires url");
-      return new SSEClientTransport(new URL(config.url));
-    }
-    case "streamable-http": {
-      if (!config.url) throw new Error("streamable-http transport requires url");
-      return new StreamableHTTPClientTransport(new URL(config.url));
-    }
+    case "sse":
+      return new SSEClientTransport(new URL(config.url), sseTransportOptions(config));
+    case "streamable-http":
+      return new StreamableHTTPClientTransport(
+        new URL(config.url),
+        streamableHttpTransportOptions(config),
+      );
     default:
-      throw new Error(`Unknown transport: ${String(config.transport)}`);
+      throw new Error("Unknown transport");
   }
+}
+
+function sseTransportOptions(config: McpServerConfig): SSEClientTransportOptions | undefined {
+  const headers = config.headers;
+  if (headers === undefined) return undefined;
+
+  // The SSE SDK transport exposes header injection but not a retry option; only
+  // streamable-http can apply `config.retries` below.
+  return {
+    requestInit: { headers: { ...headers } },
+    eventSourceInit: { fetch: createSseHeaderFetch(headers) },
+  };
+}
+
+function streamableHttpTransportOptions(
+  config: McpServerConfig,
+): StreamableHTTPClientTransportOptions | undefined {
+  const requestInit = requestInitForHeaders(config);
+  const maxRetries = normalizeRetries(config.retries);
+  if (requestInit === undefined && maxRetries === undefined) return undefined;
+
+  return {
+    ...(requestInit !== undefined && { requestInit }),
+    ...(maxRetries !== undefined && {
+      reconnectionOptions: {
+        ...DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS,
+        maxRetries,
+      },
+    }),
+  };
+}
+
+function requestInitForHeaders(config: McpServerConfig): RequestInit | undefined {
+  if (config.headers === undefined) return undefined;
+  return { headers: { ...config.headers } };
+}
+
+type SseEventSourceFetch = NonNullable<
+  NonNullable<SSEClientTransportOptions["eventSourceInit"]>["fetch"]
+>;
+type FetchRequestInit = NonNullable<Parameters<typeof fetch>[1]>;
+
+function createSseHeaderFetch(headers: Record<string, string>): SseEventSourceFetch {
+  const headerSnapshot = { ...headers };
+  return ((url: string | URL, init?: Parameters<SseEventSourceFetch>[1]) => {
+    const mergedHeaders = new Headers(init?.headers as FetchRequestInit["headers"] | undefined);
+    for (const [name, value] of Object.entries(headerSnapshot)) {
+      mergedHeaders.set(name, value);
+    }
+
+    return fetch(url, { ...init, headers: mergedHeaders });
+  }) as SseEventSourceFetch;
+}
+
+function normalizeRetries(retries: number | undefined): number | undefined {
+  if (retries === undefined) return undefined;
+  return Number.isFinite(retries) && retries >= 0 ? Math.trunc(retries) : undefined;
 }

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -228,7 +228,128 @@ describe("McpClient request options", () => {
     expect(options?.timeout).toBe(5000);
     expect(options?.maxTotalTimeout).toBe(5000);
   });
+
+  test("passes configured headers to SSE transports", async () => {
+    const sdkClient = createTransportCaptureClient();
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "sse",
+        url: "https://example.test/mcp",
+        headers: { Authorization: "Bearer token" },
+      },
+      { client: sdkClient },
+    );
+
+    await client.connect();
+
+    const options = capturedHttpTransportOptions(sdkClient.transport());
+    expect(new Headers(options.requestInit?.headers).get("Authorization")).toBe("Bearer token");
+    expect(options.eventSourceFetch).toBeFunction();
+  });
+
+  test("SSE EventSource header fetch handles omitted init", async () => {
+    const sdkClient = createTransportCaptureClient();
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Array<{ readonly url: string | URL; readonly init?: RequestInit }> = [];
+    globalThis.fetch = (async (url, init) => {
+      fetchCalls.push({ url, init });
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    try {
+      const client = new McpClient(
+        {
+          name: "search-server",
+          transport: "sse",
+          url: "https://example.test/mcp",
+          headers: { Authorization: "Bearer token" },
+        },
+        { client: sdkClient },
+      );
+
+      await client.connect();
+
+      const eventSourceFetch = capturedHttpTransportOptions(sdkClient.transport()).eventSourceFetch;
+      expect(eventSourceFetch).toBeFunction();
+      await eventSourceFetch("https://example.test/mcp");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(new Headers(fetchCalls[0]?.init?.headers).get("Authorization")).toBe("Bearer token");
+  });
+
+  test("passes configured headers and retries to streamable HTTP transports", async () => {
+    const sdkClient = createTransportCaptureClient();
+    const client = new McpClient(
+      {
+        name: "search-server",
+        transport: "streamable-http",
+        url: "https://example.test/mcp",
+        headers: { "x-api-key": "secret" },
+        retries: 4,
+      },
+      { client: sdkClient },
+    );
+
+    await client.connect();
+
+    const options = capturedHttpTransportOptions(sdkClient.transport());
+    expect(new Headers(options.requestInit?.headers).get("x-api-key")).toBe("secret");
+    expect(options.reconnectionOptions?.maxRetries).toBe(4);
+  });
 });
+
+function createTransportCaptureClient(tools: McpToolStub[] = []): McpClientHandle & {
+  readonly transport: () => Transport | undefined;
+} {
+  let transport: Transport | undefined;
+  return {
+    connect: async (nextTransport) => {
+      transport = nextTransport;
+    },
+    close: async () => undefined,
+    listTools: async () => ({ tools }),
+    callTool: async () => {
+      throw new Error("callTool is not implemented by this test stub");
+    },
+    transport: () => transport,
+  };
+}
+
+interface CapturedHttpTransportOptions {
+  readonly eventSourceFetch?: (url: string | URL, init?: RequestInit) => Promise<Response>;
+  readonly requestInit?: RequestInit;
+  readonly reconnectionOptions?: { readonly maxRetries?: number };
+}
+
+// The MCP SDK accepts these options through public transport constructors, but
+// does not expose them through a public read API. These transport-option tests
+// therefore use guarded, documented white-box reads as the smallest connect-free
+// assertion point for verifying the options passed by McpClient.
+function capturedHttpTransportOptions(
+  transport: Transport | undefined,
+): CapturedHttpTransportOptions {
+  expect(transport).toBeDefined();
+  const captured = transport as TransportWithCapturedHttpOptions;
+  const eventSourceFetch = captured._eventSourceInit?.fetch;
+  return {
+    eventSourceFetch:
+      typeof eventSourceFetch === "function"
+        ? (eventSourceFetch as CapturedHttpTransportOptions["eventSourceFetch"])
+        : undefined,
+    requestInit: captured._requestInit,
+    reconnectionOptions: captured._reconnectionOptions,
+  };
+}
+
+type TransportWithCapturedHttpOptions = Transport & {
+  readonly _eventSourceInit?: { readonly fetch?: unknown };
+  readonly _requestInit?: RequestInit;
+  readonly _reconnectionOptions?: { readonly maxRetries?: number };
+};
 
 function createTransportStub(options: { readonly emitOnClose?: boolean } = {}): Transport & {
   readonly closeCalls: () => number;

--- a/packages/protocol/src/mcp/index.ts
+++ b/packages/protocol/src/mcp/index.ts
@@ -1,17 +1,38 @@
 import { z } from "zod";
 
 export namespace McpConfig {
-  export const ServerConfig = z.object({
+  const BaseServerConfig = z.object({
     name: z.string(),
-    transport: z.enum(["stdio", "sse", "streamable-http"]),
-    command: z.string().optional(),
-    args: z.string().array().optional(),
-    url: z.string().optional(),
     headers: z.record(z.string(), z.string()).optional(),
     /** Per-request timeout in milliseconds for MCP tool discovery and tool calls. */
-    timeout: z.number().optional(),
-    retries: z.number().optional(),
+    timeout: z.number().int().nonnegative().optional(),
+    retries: z.number().int().nonnegative().optional(),
   });
+
+  export const StdioServerConfig = BaseServerConfig.extend({
+    transport: z.literal("stdio"),
+    command: z.string().min(1),
+    args: z.string().array().optional(),
+  });
+  export type StdioServerConfig = z.infer<typeof StdioServerConfig>;
+
+  export const SseServerConfig = BaseServerConfig.extend({
+    transport: z.literal("sse"),
+    url: z.string().url(),
+  });
+  export type SseServerConfig = z.infer<typeof SseServerConfig>;
+
+  export const StreamableHttpServerConfig = BaseServerConfig.extend({
+    transport: z.literal("streamable-http"),
+    url: z.string().url(),
+  });
+  export type StreamableHttpServerConfig = z.infer<typeof StreamableHttpServerConfig>;
+
+  export const ServerConfig = z.discriminatedUnion("transport", [
+    StdioServerConfig,
+    SseServerConfig,
+    StreamableHttpServerConfig,
+  ]);
   export type ServerConfig = z.infer<typeof ServerConfig>;
 }
 

--- a/packages/protocol/test/mcp.test.ts
+++ b/packages/protocol/test/mcp.test.ts
@@ -37,6 +37,44 @@ describe("McpConfig.ServerConfig", () => {
       }),
     ).toThrow();
   });
+
+  test("rejects transport configs missing runtime-required fields", () => {
+    expect(() =>
+      McpConfig.ServerConfig.parse({
+        name: "stdio-missing-command",
+        transport: "stdio",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      McpConfig.ServerConfig.parse({
+        name: "http-missing-url",
+        transport: "streamable-http",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      McpConfig.ServerConfig.parse({
+        name: "http-invalid-url",
+        transport: "sse",
+        url: "not a url",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects invalid timeout and retry numbers", () => {
+    const base = {
+      name: "remote",
+      transport: "streamable-http" as const,
+      url: "https://example.com/mcp",
+    };
+
+    for (const field of ["timeout", "retries"] as const) {
+      for (const value of [-1, 0.5, Infinity, Number.NaN]) {
+        expect(() => McpConfig.ServerConfig.parse({ ...base, [field]: value })).toThrow();
+      }
+    }
+  });
 });
 
 describe("Mcp.ToolCompleted event", () => {


### PR DESCRIPTION
## Summary

Consolidate server/runtime contracts around protocol-owned schemas and carry MCP config fields through to runtime behavior.

Fixes #
Relates to #

## Changes

- Derive server MCP config entries from `McpConfig.ServerConfig` and validate global/project config through one protocol-schema boundary
- Preserve and warn on MCP config parsing behavior, including invalid entries and non-array `servers`
- Align server `AgentDefinition` with `WorkerBootstrap.RuntimeAgentDefinition` and centralize server-to-worker projection
- Normalize worker heartbeat parameter records to explicit string keys
- Apply MCP headers to SSE/streamable HTTP transports and streamable HTTP retries to reconnection options

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `llm`
- [x] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Validation

- `git diff --cached --check`
- `bunx biome check packages/agent/src/runtime/mcp/client.ts packages/agent/test/runtime/mcp/descriptor.test.ts apps/server/src/config.ts apps/server/src/config/mcp-server-config.ts apps/server/src/context/mcp-config.ts apps/server/src/agents/types.ts apps/server/src/agents/runtime-definition.ts apps/server/src/agents/index.ts apps/server/src/bootstrap/index.ts apps/server/src/execution/worker-heartbeat.ts apps/server/test/config.test.ts apps/server/test/context/mcp-config.test.ts apps/server/test/agents/runtime-definition.test.ts`
- `bun test packages/agent/test/runtime/mcp/descriptor.test.ts apps/server/test/config.test.ts apps/server/test/context/mcp-config.test.ts apps/server/test/agents/runtime-definition.test.ts apps/server/test/execution/worker-heartbeat.test.ts`
- `bun test` from `apps/server`
- `bun run check-types`
- `bun run build`
- `bun run script/check-deps.ts`
- pre-push dependency/type checks

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated server-to-runtime contracts using protocol-owned schemas and carried MCP config fields (headers, timeout, retries) through to runtime. This tightens validation, aligns agents with the `WorkerBootstrap` contract, and applies headers/retries in SSE and streamable HTTP transports.

- **Refactors**
  - Parse MCP servers via shared `parseMcpServerConfigs` using `McpConfig.ServerConfig`; drop invalid/non-array entries with `Operational.Warn` (includes `source` and optional `configPath`). Schema is now a discriminated union that requires `stdio.command`, valid `sse`/`streamable-http` URLs, and non-negative integer `timeout`/`retries`.
  - Project server `AgentDefinition` through `RuntimeAgentDefinition.create` to `WorkerBootstrap.RuntimeAgentDefinition` and strip server-only prompt metadata.
  - Normalize worker heartbeat to use string-keyed parameter records.

- **New Features**
  - Apply MCP `headers` to `sse` (via a header-injecting fetch) and `streamable-http` transports.
  - Honor MCP `retries` for `streamable-http` reconnection with sensible defaults.

<sup>Written for commit c4e2328bd45513c68ce16a96a699fc5471c84272. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/175?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP transports support configurable request headers and improved reconnection/retry options.

* **Improvements**
  * Safer MCP server config handling with normalized parsing, stricter transport-specific validation, and structured warnings for invalid entries.
  * Agent definitions are now normalized for the worker runtime during bootstrap.
  * Tighter validation for worker heartbeat payload keys.

* **Tests**
  * New tests covering agent runtime serialization, MCP config parsing/warnings, and transport header/retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->