### PR TITLE
refactor(server,openomni): propagate per-agent policy plans

### DIFF
--- a/apps/server/src/execution/worker-bootstrap-handler.ts
+++ b/apps/server/src/execution/worker-bootstrap-handler.ts
@@ -77,6 +77,7 @@ export namespace WorkerBootstrapHandler {
           systemPrompt: agent.systemPrompt,
           tools: agent.tools.allow ?? [],
           permissions: agent.permissions,
+          policyPlan: agent.policyPlan,
           budget: agent.budget,
         })),
       );

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -7,6 +7,7 @@ import {
   ToolProxyProvider,
   buildToolCatalog,
   buildWorkerMiddleware,
+  buildWorkerChildRuntimeConfig,
   createToolExecutor,
   createWorkerSubagentRuntime,
 } from "@openomni/openomni";
@@ -218,23 +219,51 @@ export namespace WorkerRunner {
           definitions: new Map((bootstrap?.agents ?? []).map((agent) => [agent.name, agent])),
         };
 
+        const workerSubagentConfig: Parameters<typeof createWorkerSubagentRuntime>[0] = {
+          toolsRef,
+          catalogRef,
+          agentDefinitionsRef,
+          resolveAuth,
+          allowAuthFallback: false,
+          parentSessionId: sessionId,
+          parentPermissions: request.permissions,
+          parentPolicyPlan: request.policyPlan,
+        };
+        const scopedBackgroundManager: ReturnType<typeof BackgroundManager.create> = {
+          launch(input: Parameters<typeof backgroundManager.launch>[0]) {
+            const childRuntime = buildWorkerChildRuntimeConfig(workerSubagentConfig, {
+              agentName: input.agentName,
+              depth: input.depth ?? 1,
+              middleware: input.middleware,
+            });
+            return backgroundManager.launch({
+              ...input,
+              systemPrompt: childRuntime.systemPrompt,
+              tools: childRuntime.tools,
+              toolExecutor: childRuntime.toolExecutor,
+              permissions: childRuntime.permissions,
+              middleware: childRuntime.middleware,
+              childMiddleware: childRuntime.childMiddleware,
+            });
+          },
+          getTask: (taskId) => backgroundManager.getTask(taskId),
+          getResult: (taskId) => backgroundManager.getResult(taskId),
+          cancel: (taskId) => backgroundManager.cancel(taskId),
+          listByParent: (parentSessionId) => backgroundManager.listByParent(parentSessionId),
+          cleanup: () => backgroundManager.cleanup(),
+          stats: () => backgroundManager.stats(),
+          dispose: () => backgroundManager.dispose(),
+        };
+
         const agentProvider = new AgentToolProvider({
-          subagentRuntime: createWorkerSubagentRuntime({
-            toolsRef,
-            catalogRef,
-            agentDefinitionsRef,
-            resolveAuth,
-            allowAuthFallback: false,
-            parentSessionId: sessionId,
-            parentPermissions: request.permissions,
-          }),
+          subagentRuntime: createWorkerSubagentRuntime(workerSubagentConfig),
           delegationContext: {
             depth: 0,
             maxDepth: 3,
             visitedAgents: new Set([request.agentName ?? "dev"]),
             parentAbort: controller.signal,
           },
-          backgroundManager,
+          backgroundManager: scopedBackgroundManager,
         });
 
         const systemTools = systemProvider.listTools();

--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -57,6 +57,7 @@ function buildAgentDefFromEntries(
     tools: specs,
     budget: definition.budget,
     permissions: definition.permissions,
+    policyPlan: definition.policyPlan,
     toolConfig: {
       workspaceRoot: deps.workspaceRoot,
     },

--- a/apps/server/test/agents/runtime-definition.test.ts
+++ b/apps/server/test/agents/runtime-definition.test.ts
@@ -11,6 +11,10 @@ describe("RuntimeAgentDefinition", () => {
       model: { provider: "anthropic", id: "claude-sonnet-4-6" },
       systemPrompt: "Build carefully.",
       tools: { categories: ["filesystem", "execution"] },
+      policyPlan: {
+        policies: [{ id: "builtin:tool-permission", required: true }],
+        labels: ["dev-runtime"],
+      },
       budget: { maxTurns: 4, maxToolCalls: 8 },
     };
 

--- a/apps/server/test/execution/worker-bootstrap-handler.test.ts
+++ b/apps/server/test/execution/worker-bootstrap-handler.test.ts
@@ -76,6 +76,10 @@ describe("worker bootstrap handler", () => {
               description: "Plans work",
               systemPrompt: "Plan carefully",
               tools: { allow: ["read"] },
+              policyPlan: {
+                policies: [{ id: "builtin:tool-permission", required: true }],
+                labels: ["planner"],
+              },
             },
           ],
           toolCatalog: [],
@@ -103,6 +107,10 @@ describe("worker bootstrap handler", () => {
       description: "Plans work",
       systemPrompt: "Plan carefully",
       tools: ["read"],
+      policyPlan: {
+        policies: [{ id: "builtin:tool-permission", required: true }],
+        labels: ["planner"],
+      },
     });
     expect(mirroredEpoch).toBe("epoch-1");
     expect(state.resolveAuth("openai")).toEqual({ type: "api", key: "openai-key" });

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { AgentRegistry } from "@openomni/agent";
 import type { AgentResult } from "@openomni/agent";
 import { BackgroundManager, WorkspaceLock } from "@openomni/openomni";
 import type { Tool, WorkerBootstrap } from "@openomni/protocol";
@@ -311,6 +312,125 @@ describe("WorkerRunner", () => {
       expect(responses[0]).toMatchObject({ status: "succeeded" });
     } finally {
       WorkspaceLock.clearUnsafe(workspaceRoot);
+    }
+  });
+
+  it("enriches background subagent launches with child runtime policy config", async () => {
+    const responses: unknown[] = [];
+    const notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];
+    const launched: Array<Record<string, unknown>> = [];
+    const bootstrap: WorkerBootstrap.Bootstrap = {
+      configEpoch: "epoch-1",
+      toolCatalog: [],
+      agents: [
+        {
+          name: "child",
+          description: "child",
+          model: { provider: "test", id: "child" },
+          tools: { all: true },
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["read"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+      ],
+    };
+    AgentRegistry.define({
+      name: "child",
+      description: "child",
+      model: { provider: "test", id: "child" },
+    });
+    const backgroundManager = {
+      async launch(input: Record<string, unknown>) {
+        launched.push(input);
+        return {
+          id: "bg_test",
+          agentName: "child",
+          prompt: "background work",
+          status: "running",
+          parentSessionId: "session-1",
+          queuedAt: Date.now(),
+          depth: 0,
+        };
+      },
+      getTask: () => undefined,
+      getResult: () => undefined,
+      cancel: async () => false,
+      listByParent: () => [],
+      cleanup: () => undefined,
+      stats: () => ({ active: 0, pending: 0, total: 0 }),
+      dispose: () => undefined,
+    } as unknown as ReturnType<typeof BackgroundManager.create>;
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        {
+          ...createValidRequest(),
+          tools: [{ name: "subagent", inputSchema: {} }],
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["read"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          backgroundManager,
+          getBootstrap: () => bootstrap,
+          server: {
+            async call() {
+              throw new Error("unexpected server call");
+            },
+            notify(method, params) {
+              notifications.push({ method, params });
+            },
+          },
+          createAgent: (options) => ({
+            async run() {
+              if (!options.toolExecutor) throw new Error("tool executor missing");
+              const result = await options.toolExecutor({
+                id: "agent-tool-call",
+                tool: "subagent",
+                input: { agentName: "child", prompt: "background work", background: true },
+              });
+              expect(result.isError).not.toBe(true);
+              return successfulResult;
+            },
+          }),
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    try {
+      await responseReceived;
+
+      expect(responses[0]).toMatchObject({ status: "succeeded" });
+      expect(launched).toHaveLength(1);
+      expect(launched[0]).toMatchObject({
+        agentName: "child",
+        parentSessionId: expect.any(String),
+      });
+      expect(launched[0].permissions).toBeUndefined();
+      const childMiddleware = launched[0].childMiddleware;
+      expect(Array.isArray(childMiddleware)).toBe(true);
+      expect(childMiddleware as unknown[]).not.toHaveLength(0);
+    } finally {
+      AgentRegistry.clear();
     }
   });
 

--- a/apps/server/test/ingress-bridge.test.ts
+++ b/apps/server/test/ingress-bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { Adapter, Tool } from "@openomni/protocol";
 import type { NativeTool, ToolProvider } from "@openomni/openomni";
+import { agentMetadata, getAgentDefinition, registerAgent } from "../src/agents";
 import { buildAgentDef, buildInboundEvent } from "../src/ingress/bridge";
 
 function makeTool(name: string): NativeTool {
@@ -77,5 +78,41 @@ describe("ingress bridge tool surfaces", () => {
       "read",
       "subagent",
     ]);
+  });
+
+  it("propagates per-agent policy plans into ingress agent definitions", () => {
+    const originalDev = getAgentDefinition("dev");
+    const originalDevMeta = agentMetadata.get("dev");
+    if (!originalDev || !originalDevMeta) {
+      throw new Error("expected dev agent fixture");
+    }
+
+    try {
+      registerAgent(
+        () => ({
+          name: "dev",
+          description: "Policy test agent",
+          model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+          systemPrompt: "Follow the policy plan.",
+          tools: { categories: ["filesystem"] },
+          permissions: { action: "tool.call", allowlist: ["read"] },
+          policyPlan: {
+            policies: [{ id: "builtin:tool-permission", required: true }],
+            labels: ["policy-dev"],
+          },
+        }),
+        { name: "dev", description: "Policy test agent" },
+      );
+
+      const workerAgent = buildAgentDef("dev", deps);
+
+      expect(workerAgent.permissions).toEqual({ action: "tool.call", allowlist: ["read"] });
+      expect(workerAgent.policyPlan).toEqual({
+        policies: [{ id: "builtin:tool-permission", required: true }],
+        labels: ["policy-dev"],
+      });
+    } finally {
+      registerAgent(() => originalDev, originalDevMeta);
+    }
   });
 });

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -45,6 +45,7 @@ export interface SubagentToolOptions {
       model: Model.Ref;
       parentSessionId: string;
       depth?: number;
+      middleware?: PolicyRegistration[];
     }) => Promise<Subagent.BackgroundTask>;
     getTask: (taskId: string) => Subagent.BackgroundTask | undefined;
     getResult: (taskId: string) => Subagent.BackgroundTaskResult | undefined;
@@ -139,6 +140,7 @@ export namespace SubagentTool {
       }
 
       const model = definition.model ?? options.defaultModel ?? DEFAULT_SUBAGENT_MODEL;
+      const propagated = options.middleware?.filter((m) => m.propagate === true) ?? [];
 
       if (background) {
         if (context?.signal?.aborted) {
@@ -162,6 +164,7 @@ export namespace SubagentTool {
           prompt,
           model,
           parentSessionId: sessionId ?? `anon_${crypto.randomUUID().slice(0, 8)}`,
+          middleware: propagated.length > 0 ? propagated : undefined,
         });
         if (task.status === "failed") {
           return {
@@ -178,8 +181,6 @@ export namespace SubagentTool {
           isError: false,
         };
       }
-
-      const propagated = options.middleware?.filter((m) => m.propagate === true) ?? [];
 
       try {
         const result = sessionId

--- a/packages/openomni/src/execution-runtime/index.ts
+++ b/packages/openomni/src/execution-runtime/index.ts
@@ -7,6 +7,7 @@ export {
   SystemToolProvider,
   Tool,
   buildToolCatalog,
+  buildWorkerChildRuntimeConfig,
   createToolExecutor,
   createWorkerSubagentRuntime,
   defineTool,

--- a/packages/openomni/src/execution-runtime/middleware.test.ts
+++ b/packages/openomni/src/execution-runtime/middleware.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from "bun:test";
 import type { Policy } from "@openomni/protocol";
 import { buildWorkerMiddleware } from "./middleware";
 
+function invokeTool(
+  registration: ReturnType<typeof buildWorkerMiddleware>[number] | undefined,
+  toolName: string,
+) {
+  return registration?.fn({
+    timing: "invoke.prepare",
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    toolName,
+  });
+}
+
 describe("buildWorkerMiddleware", () => {
   describe("backward compatibility (no policyPlan)", () => {
     it("returns worker-owned registrations", () => {
@@ -74,13 +90,12 @@ describe("buildWorkerMiddleware", () => {
       ]);
     });
 
-    it("ignores permissions when policyPlan is provided", () => {
+    it("preserves legacy permissions when policyPlan omits tool permission config", async () => {
       const policyPlan: Policy.PolicyPlan = {
         policies: [
           {
             id: "builtin:tool-permission",
             required: true,
-            config: { permission: { action: "tool.call" } },
           },
         ],
         labels: ["security"],
@@ -89,6 +104,60 @@ describe("buildWorkerMiddleware", () => {
 
       const registrations = buildWorkerMiddleware({ policyPlan, permissions });
       expect(registrations.map((r) => r.name)).toEqual(["builtin:tool-permission"]);
+      await expect(invokeTool(registrations[0], "tool:read")).resolves.toMatchObject({
+        verdict: "allow",
+      });
+      await expect(invokeTool(registrations[0], "tool:write")).resolves.toMatchObject({
+        verdict: "deny",
+      });
+    });
+
+    it("keeps explicit policyPlan permission config ahead of legacy permissions", async () => {
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call", allowlist: ["tool:plan"] } },
+          },
+        ],
+        labels: ["security"],
+      };
+      const permissions = { action: "tool.call", allowlist: ["tool:legacy"] };
+
+      const registrations = buildWorkerMiddleware({ policyPlan, permissions });
+      await expect(invokeTool(registrations[0], "tool:plan")).resolves.toMatchObject({
+        verdict: "allow",
+      });
+      await expect(invokeTool(registrations[0], "tool:legacy")).resolves.toMatchObject({
+        verdict: "deny",
+      });
+    });
+
+    it("fails closed for malformed explicit policyPlan permission config", async () => {
+      const permissions = { action: "tool.call", allowlist: ["tool:legacy"] };
+
+      for (const permission of [
+        { action: "tool.call", allowlist: "tool:plan" },
+        undefined,
+        null,
+      ] as const) {
+        const policyPlan: Policy.PolicyPlan = {
+          policies: [
+            {
+              id: "builtin:tool-permission",
+              required: true,
+              config: { permission },
+            },
+          ],
+          labels: ["security"],
+        };
+
+        const registrations = buildWorkerMiddleware({ policyPlan, permissions });
+        await expect(invokeTool(registrations[0], "tool:legacy")).resolves.toMatchObject({
+          verdict: "deny",
+        });
+      }
     });
   });
 });

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -4,16 +4,18 @@ import {
   defaultRegistry,
 } from "@openomni/agent";
 import type { PolicyRegistration } from "@openomni/agent";
-import type { Policy } from "@openomni/protocol";
+import { Policy } from "@openomni/protocol";
 
 export interface WorkerMiddlewareConfig {
   permissions?: Policy.Permission;
   policyPlan?: Policy.PolicyPlan;
 }
 
+const FAIL_CLOSED_TOOL_PERMISSION: Policy.Permission = { action: "tool.call", denylist: ["*"] };
+
 export function buildWorkerMiddleware(config: WorkerMiddlewareConfig): PolicyRegistration[] {
   if (config.policyPlan) {
-    return resolvePoliciesFromPlan(config.policyPlan);
+    return resolvePoliciesFromPlan(hydrateLegacyPermissions(config.policyPlan, config.permissions));
   }
 
   return buildLegacyMiddleware(config.permissions);
@@ -31,4 +33,42 @@ function buildLegacyMiddleware(permissions?: Policy.Permission): PolicyRegistrat
 function resolvePoliciesFromPlan(plan: Policy.PolicyPlan): PolicyRegistration[] {
   const registry = defaultRegistry();
   return registry.resolve(plan, {});
+}
+
+function hydrateLegacyPermissions(
+  plan: Policy.PolicyPlan,
+  permissions: Policy.Permission | undefined,
+): Policy.PolicyPlan {
+  const fallbackPermission = permissions ?? { action: "tool.call" };
+  let changed = false;
+  const policies = plan.policies.map((policy) => {
+    if (policy.id !== "builtin:tool-permission") return policy;
+    const config = policy.config ?? {};
+    // Keep legacy permissions effective for policy plans that select the
+    // builtin guard without owning its config yet.
+    // A present-but-invalid permission is treated as explicit and fails closed.
+    if (!("permission" in config)) {
+      changed = true;
+      return {
+        ...policy,
+        config: {
+          ...config,
+          permission: fallbackPermission,
+        },
+      };
+    }
+
+    if (Policy.Permission.safeParse(config.permission).success) return policy;
+
+    changed = true;
+    return {
+      ...policy,
+      config: {
+        ...config,
+        permission: FAIL_CLOSED_TOOL_PERMISSION,
+      },
+    };
+  });
+
+  return changed ? { ...plan, policies } : plan;
 }

--- a/packages/openomni/src/execution-runtime/tool/agent/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/index.ts
@@ -1,3 +1,6 @@
 export { AgentToolProvider } from "./provider.js";
 export { createSubagentTool } from "./tools/subagent.js";
-export { createWorkerSubagentRuntime } from "./tools/subagent-runtime.js";
+export {
+  buildWorkerChildRuntimeConfig,
+  createWorkerSubagentRuntime,
+} from "./tools/subagent-runtime.js";

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { PolicyEngine, type PolicyRegistration } from "@openomni/agent";
 import { Subagent, type ToolSelection, type WorkerBootstrap } from "@openomni/protocol";
 import { Session, Storage } from "@openomni/session";
 import { SubagentRuntime } from "../../../../subagent/runtime.js";
@@ -21,7 +22,30 @@ function makeTool(name: string): NativeTool {
   };
 }
 
-function makeRuntime(selection: ToolSelection.Selection) {
+async function evaluateTool(middleware: PolicyRegistration[] | undefined, toolName: string) {
+  const engine = PolicyEngine.create({ audit: false });
+  for (const registration of middleware ?? []) {
+    engine.register(registration);
+  }
+  return engine.dispatch("invoke.prepare", {
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    toolName,
+  });
+}
+
+function makeRuntime(
+  selection: ToolSelection.Selection,
+  options: {
+    child?: Partial<WorkerBootstrap.RuntimeAgentDefinition>;
+    parentPermissions?: WorkerBootstrap.RuntimeAgentDefinition["permissions"];
+    parentPolicyPlan?: WorkerBootstrap.RuntimeAgentDefinition["policyPlan"];
+  } = {},
+) {
   const readTool = makeTool("read");
   const bashTool = makeTool("bash");
   const subagentTool = makeTool("subagent");
@@ -37,6 +61,7 @@ function makeRuntime(selection: ToolSelection.Selection) {
         name: "child",
         description: "child",
         tools: selection,
+        ...options.child,
       },
     ],
   ]);
@@ -49,6 +74,8 @@ function makeRuntime(selection: ToolSelection.Selection) {
     parentSessionId: "parent-session",
     catalogRef: { catalog },
     agentDefinitionsRef: { definitions },
+    parentPermissions: options.parentPermissions,
+    parentPolicyPlan: options.parentPolicyPlan,
     resolveAuth: (provider) =>
       provider === "anthropic"
         ? { type: "proxy", baseURL: "http://localhost:8317/v1", apiKey: "proxy" }
@@ -113,6 +140,246 @@ describe("createWorkerSubagentRuntime", () => {
       apiKey: "proxy",
     });
     expect(spawnSpy.mock.calls[0]?.[0].allowAuthFallback).toBe(false);
+  });
+
+  test("spawn prefers bootstrap child system prompt over registry call config", async () => {
+    const runtime = makeRuntime({ all: true }, { child: { systemPrompt: "bootstrap prompt" } });
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "test", id: "model" },
+      systemPrompt: "registry prompt",
+    });
+
+    expect(spawnSpy.mock.calls[0]?.[0].systemPrompt).toBe("bootstrap prompt");
+  });
+
+  test("spawn applies child policy plans when legacy permissions are absent", async () => {
+    const runtime = makeRuntime(
+      { all: true },
+      {
+        child: {
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["read"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+      },
+    );
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "test", id: "model" },
+    });
+
+    expect(spawnSpy.mock.calls[0]?.[0].middleware).toBeUndefined();
+    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
+    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
+      verdict: "allow",
+    });
+    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+  });
+
+  test("spawn keeps parent permissions constraining child policy plans", async () => {
+    const runtime = makeRuntime(
+      { all: true },
+      {
+        parentPermissions: { action: "tool.call", allowlist: ["read"] },
+        child: {
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["bash"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+      },
+    );
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "test", id: "model" },
+    });
+
+    expect(spawnSpy.mock.calls[0]?.[0].middleware).toBeUndefined();
+    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
+    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+  });
+
+  test("spawn keeps parent policy plans constraining child policy plans", async () => {
+    const runtime = makeRuntime(
+      { all: true },
+      {
+        parentPolicyPlan: {
+          policies: [
+            {
+              id: "builtin:tool-permission",
+              required: true,
+              config: { permission: { action: "tool.call", allowlist: ["read"] } },
+            },
+          ],
+          labels: ["security"],
+        },
+        child: {
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["bash"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+      },
+    );
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "test", id: "model" },
+    });
+
+    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
+    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+  });
+
+  test("spawn keeps parent policy plans constraining legacy child agents", async () => {
+    const runtime = makeRuntime(
+      { all: true },
+      {
+        parentPolicyPlan: {
+          policies: [
+            {
+              id: "builtin:tool-permission",
+              required: true,
+              config: { permission: { action: "tool.call", allowlist: ["read"] } },
+            },
+          ],
+          labels: ["security"],
+        },
+      },
+    );
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "test", id: "model" },
+    });
+
+    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
+    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
+      verdict: "allow",
+    });
+    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+  });
+
+  test("spawn lets parent policy plans own legacy parent permission hydration", async () => {
+    const runtime = makeRuntime(
+      { all: true },
+      {
+        parentPermissions: { action: "tool.call", allowlist: ["read"] },
+        parentPolicyPlan: {
+          policies: [
+            {
+              id: "builtin:tool-permission",
+              required: true,
+              config: { permission: { action: "tool.call", allowlist: ["bash"] } },
+            },
+          ],
+          labels: ["security"],
+        },
+      },
+    );
+    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
+      sessionId: "child-session",
+      runId: "child-run",
+      output: "done",
+      finishReason: "stop",
+    });
+
+    await runtime.spawn({
+      agentName: "child",
+      title: "child task",
+      prompt: "run",
+      model: { provider: "test", id: "model" },
+    });
+
+    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
+    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
+      verdict: "deny",
+    });
+    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+      verdict: "allow",
+    });
   });
 
   test("send resolves tools from the child session metadata and depth", async () => {

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -1,9 +1,10 @@
-import { ChatAgent } from "@openomni/agent";
+import { ChatAgent, createToolPermissionPolicy } from "@openomni/agent";
 import type { SubagentToolOptions, ChatAgentConfig } from "@openomni/agent";
 import { Subagent } from "@openomni/protocol";
 import type { Policy, WorkerBootstrap } from "@openomni/protocol";
 import { Session } from "@openomni/session";
 import { SubagentRuntime } from "../../../../subagent/runtime.js";
+import { buildWorkerMiddleware } from "../../../middleware.js";
 import { resolveToolSelection } from "../../catalog.js";
 import type { CatalogEntry } from "../../catalog.js";
 
@@ -83,16 +84,27 @@ function intersectAllowPatterns(
   return child.filter((pattern) => parentSet.has(pattern));
 }
 
-type WorkerRuntimeConfig = {
+export type WorkerRuntimeConfig = {
   // Lazily resolved after createExecutionToolContext — filled before any tool call.
   toolsRef: { tools?: ChatAgentConfig["tools"]; toolExecutor?: ChatAgentConfig["toolExecutor"] };
   parentSessionId: string;
   parentPermissions?: Policy.Permission;
+  parentPolicyPlan?: Policy.PolicyPlan;
   // Lazily resolved alongside toolsRef — used to compute depth-filtered child tool sets.
   catalogRef?: { catalog?: CatalogEntry[] };
   agentDefinitionsRef?: { definitions?: Map<string, RuntimeAgentDefinition> };
   resolveAuth?: (provider: string) => ChatAgentConfig["auth"];
   allowAuthFallback?: ChatAgentConfig["allowAuthFallback"];
+};
+
+export type WorkerChildRuntimeConfig = {
+  childDefinition?: RuntimeAgentDefinition;
+  tools: ChatAgentConfig["tools"];
+  toolExecutor: ChatAgentConfig["toolExecutor"];
+  systemPrompt?: string;
+  permissions?: Policy.Permission;
+  middleware: ChatAgentConfig["middleware"];
+  childMiddleware: ChatAgentConfig["middleware"];
 };
 
 function resolveChildDefinition(
@@ -134,12 +146,83 @@ function resolveChildTools(
   return filtered.map((entry) => entry.tool.spec);
 }
 
+function buildChildRuntimeMiddleware(
+  childDefinition: RuntimeAgentDefinition | undefined,
+  childPermissions: Policy.Permission | undefined,
+  parentPolicyPlan: Policy.PolicyPlan | undefined,
+  parentPermissions: Policy.Permission | undefined,
+): ChatAgentConfig["middleware"] {
+  const middleware: ChatAgentConfig["middleware"] = [];
+  if (parentPolicyPlan) {
+    // Ancestor policy plans are runtime constraints for descendants, not
+    // delegation-admission guards for the spawn/send operation itself.
+    middleware.push(
+      ...buildWorkerMiddleware({
+        policyPlan: parentPolicyPlan,
+        // Used only when the parent plan selected the builtin guard without
+        // owning config yet; explicit parent plan config still wins.
+        permissions: parentPermissions,
+      }),
+    );
+  } else if (parentPermissions && childDefinition?.policyPlan) {
+    // Parent legacy permissions remain an ancestor runtime guard even when the
+    // child plan owns the child-scoped permission config.
+    middleware.push(createToolPermissionPolicy({ permission: parentPermissions }));
+  }
+  if (childDefinition?.policyPlan) {
+    middleware.push(
+      ...buildWorkerMiddleware({
+        policyPlan: childDefinition.policyPlan,
+        permissions: childPermissions,
+      }),
+    );
+  }
+  return middleware.length > 0 ? middleware : undefined;
+}
+
+export function buildWorkerChildRuntimeConfig(
+  cfg: WorkerRuntimeConfig,
+  input: {
+    agentName?: string;
+    childDefinition?: RuntimeAgentDefinition;
+    depth: number;
+    middleware?: ChatAgentConfig["middleware"];
+  },
+): WorkerChildRuntimeConfig {
+  const childDefinition = input.childDefinition ?? resolveChildDefinition(cfg, input.agentName);
+  const childPermissions = childDefinition?.permissions;
+  const permissions = childDefinition?.policyPlan
+    ? undefined
+    : cfg.parentPolicyPlan
+      ? // Parent legacy permissions are only a hydration fallback for parent
+        // policy plans; do not stack them as a separate child runtime guard.
+        // Child legacy permissions remain child-owned runtime config.
+        childPermissions
+      : intersectPermissions(cfg.parentPermissions, childPermissions);
+  return {
+    ...(childDefinition ? { childDefinition } : {}),
+    tools: resolveChildTools(cfg, childDefinition, input.depth),
+    toolExecutor: cfg.toolsRef.toolExecutor,
+    systemPrompt: childDefinition?.systemPrompt,
+    permissions,
+    middleware: input.middleware,
+    childMiddleware: buildChildRuntimeMiddleware(
+      childDefinition,
+      childPermissions,
+      cfg.parentPolicyPlan,
+      cfg.parentPermissions,
+    ),
+  };
+}
+
 export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentRuntimeInterface {
   return {
     async spawn(config) {
-      const childDefinition = resolveChildDefinition(cfg, config.agentName);
-      const permissions = intersectPermissions(cfg.parentPermissions, childDefinition?.permissions);
-      const childTools = resolveChildTools(cfg, childDefinition, 1);
+      const childRuntime = buildWorkerChildRuntimeConfig(cfg, {
+        agentName: config.agentName,
+        depth: 1,
+        middleware: config.middleware,
+      });
 
       const result = await SubagentRuntime.spawn({
         agentName: config.agentName,
@@ -148,12 +231,15 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         model: config.model,
         auth: cfg.resolveAuth?.(config.model.provider),
         allowAuthFallback: cfg.allowAuthFallback,
-        systemPrompt: config.systemPrompt,
-        tools: childTools,
-        toolExecutor: cfg.toolsRef.toolExecutor,
+        // Worker bootstrap definitions are the source of truth; config is only
+        // a compatibility fallback for runtimes without bootstrap context.
+        systemPrompt: childRuntime.systemPrompt ?? config.systemPrompt,
+        tools: childRuntime.tools,
+        toolExecutor: childRuntime.toolExecutor,
         parentSessionId: cfg.parentSessionId,
-        permissions,
-        middleware: config.middleware,
+        permissions: childRuntime.permissions,
+        middleware: childRuntime.middleware,
+        childMiddleware: childRuntime.childMiddleware,
         signal: config.signal,
       });
       return { sessionId: result.sessionId, runId: result.runId, output: result.output };
@@ -163,19 +249,26 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         cfg,
         resolveSessionAgentName(config.sessionId),
       );
-      const permissions = intersectPermissions(cfg.parentPermissions, childDefinition?.permissions);
       const depth = Session.get(config.sessionId)?.spawnDepth ?? 1;
+      const childRuntime = buildWorkerChildRuntimeConfig(cfg, {
+        childDefinition,
+        depth,
+        middleware: config.middleware,
+      });
       const result = await SubagentRuntime.send({
         sessionId: config.sessionId,
         prompt: config.prompt,
         model: config.model,
         auth: cfg.resolveAuth?.(config.model.provider),
         allowAuthFallback: cfg.allowAuthFallback,
-        systemPrompt: config.systemPrompt,
-        tools: resolveChildTools(cfg, childDefinition, depth),
-        toolExecutor: cfg.toolsRef.toolExecutor,
-        permissions,
-        middleware: config.middleware,
+        // Worker bootstrap definitions are the source of truth; config is only
+        // a compatibility fallback for runtimes without bootstrap context.
+        systemPrompt: childRuntime.systemPrompt ?? config.systemPrompt,
+        tools: childRuntime.tools,
+        toolExecutor: childRuntime.toolExecutor,
+        permissions: childRuntime.permissions,
+        middleware: childRuntime.middleware,
+        childMiddleware: childRuntime.childMiddleware,
         signal: config.signal,
       });
       return { sessionId: result.sessionId, runId: result.runId, output: result.output };

--- a/packages/openomni/src/execution-runtime/tool/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/index.ts
@@ -1,4 +1,8 @@
-export { AgentToolProvider, createWorkerSubagentRuntime } from "./agent/index.js";
+export {
+  AgentToolProvider,
+  buildWorkerChildRuntimeConfig,
+  createWorkerSubagentRuntime,
+} from "./agent/index.js";
 export { buildToolCatalog, resolveCategory, resolveToolSelection } from "./catalog.js";
 export { Tool, defineTool, resolveMeta } from "./define.js";
 export { createToolExecutor } from "./executor.js";

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -94,6 +94,7 @@ export {
   WorkspaceLock,
   buildToolCatalog,
   buildWorkerMiddleware,
+  buildWorkerChildRuntimeConfig,
   createToolExecutor,
   createWorkerSubagentRuntime,
   defineTool,

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -260,7 +260,7 @@ export class ResidentRuntime {
       systemPrompt: ctx.event.agent.systemPrompt,
       budget: ctx.event.agent.budget,
       tools: ctx.event.agent.tools,
-      permissions: ctx.event.agent.permissions,
+      ...(ctx.event.agent.policyPlan ? {} : { permissions: ctx.event.agent.permissions }),
       toolExecutor: toolExecutor as
         | ((call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>)
         | undefined,

--- a/packages/openomni/src/subagent/background-manager.ts
+++ b/packages/openomni/src/subagent/background-manager.ts
@@ -19,6 +19,12 @@ type LaunchInput = {
   model: Model.Ref;
   parentSessionId: string;
   depth?: number;
+  permissions?: Policy.Permission;
+  systemPrompt?: RuntimeConfig["systemPrompt"];
+  tools?: RuntimeConfig["tools"];
+  toolExecutor?: RuntimeConfig["toolExecutor"];
+  middleware?: RuntimeConfig["middleware"];
+  childMiddleware?: RuntimeConfig["childMiddleware"];
 };
 
 type Config = {
@@ -175,6 +181,12 @@ export const BackgroundManager = {
             model: input.model,
             auth: resolveAuth?.(input.model.provider),
             allowAuthFallback,
+            permissions: input.permissions,
+            systemPrompt: input.systemPrompt,
+            tools: input.tools,
+            toolExecutor: input.toolExecutor,
+            middleware: input.middleware,
+            childMiddleware: input.childMiddleware,
             signal: controller.signal,
           }),
         )

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -178,6 +178,16 @@ function applyPreDelegationDecision(
   applyDelegationConstraints(config, decision);
 }
 
+function buildChildRunMiddleware(config: RuntimeConfig & { permissions?: Policy.Permission }) {
+  // Used by spawn/send/resume for the child run itself. Admission still reads
+  // config.middleware before this helper, so childMiddleware never participates
+  // in the parent-scoped delegation decision.
+  return SubagentSpawnPolicyMiddleware.childMiddleware(
+    config.childMiddleware ?? config.middleware,
+    config.permissions !== undefined || config.childMiddleware !== undefined,
+  );
+}
+
 export namespace SubagentRuntime {
   export interface SpawnConfig extends RuntimeConfig {
     parentSessionId?: string;
@@ -275,10 +285,7 @@ export namespace SubagentRuntime {
       );
       await WorkerRun.updateStatus(session.id, runId, "starting");
       await WorkerRun.updateStatus(session.id, runId, "running");
-      const middleware = SubagentSpawnPolicyMiddleware.childMiddleware(
-        config.middleware,
-        config.permissions !== undefined,
-      );
+      const middleware = buildChildRunMiddleware(config);
       const runConfig = { ...config, middleware };
       const result = await executeRun(session.id, runId, config.model, timers, () =>
         runWithTranscript(session.id, runConfig, signal, config.permissions),
@@ -312,10 +319,7 @@ export namespace SubagentRuntime {
     await WorkerRun.updateStatus(session.id, runId, "starting");
     await WorkerRun.updateStatus(session.id, runId, "running");
 
-    const middleware = SubagentSpawnPolicyMiddleware.childMiddleware(
-      config.middleware,
-      config.permissions !== undefined,
-    );
+    const middleware = buildChildRunMiddleware(config);
     const runConfig = { ...config, middleware };
     const backgroundRun = sendToMailbox(session.id, () =>
       executeRun(session.id, runId, config.model, timers, () =>
@@ -368,10 +372,7 @@ export namespace SubagentRuntime {
       await WorkerRun.updateStatus(session.id, runId, "starting");
       await WorkerRun.updateStatus(session.id, runId, "running");
 
-      const middleware = SubagentSpawnPolicyMiddleware.childMiddleware(
-        config.middleware,
-        config.permissions !== undefined,
-      );
+      const middleware = buildChildRunMiddleware(config);
       const runConfig = { ...config, middleware };
       const messages = await maybeCompactSendTranscript(
         session.id,
@@ -416,7 +417,7 @@ export namespace SubagentRuntime {
       await WorkerRun.updateStatus(config.sessionId, runId, "running");
       const runConfig = {
         ...config,
-        middleware: SubagentSpawnPolicyMiddleware.childMiddleware(config.middleware, false),
+        middleware: buildChildRunMiddleware(config),
       };
       const result = await executeRun(config.sessionId, runId, config.model, undefined, () =>
         runWithTranscript(config.sessionId, runConfig, signal),

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -21,6 +21,7 @@ export type RuntimeConfig = {
   toolExecutor?: ChatAgentConfig["toolExecutor"];
   budget?: ChatAgentConfig["budget"];
   middleware?: PolicyRegistration[];
+  childMiddleware?: PolicyRegistration[];
 };
 
 export type SendCompactionConfig = {

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -115,6 +115,10 @@ describe("IngressHandlers", () => {
   it("buildExecutionRequest preserves tool execution config", () => {
     const toolConfig = { workspaceRoot: "/workspace/openomni" };
     const permissions = { action: "tool.call", denylist: ["bash"] };
+    const policyPlan = {
+      policies: [{ id: "builtin:tool-permission", required: true }],
+      labels: ["direct"],
+    };
     const event: Ingress.InboundEvent = {
       id: "event-request-1",
       surface: "tui",
@@ -125,6 +129,7 @@ describe("IngressHandlers", () => {
         tools: [{ name: "bash", inputSchema: { type: "object" } }],
         toolConfig,
         permissions,
+        policyPlan,
       },
     };
 
@@ -137,6 +142,7 @@ describe("IngressHandlers", () => {
     expect(request.tools).toEqual(event.agent.tools);
     expect(request.toolConfig).toEqual(toolConfig);
     expect(request.permissions).toEqual(permissions);
+    expect(request.policyPlan).toEqual(policyPlan);
   });
 
   it("handleDirect dispatches via coordinator and stores output", async () => {

--- a/packages/openomni/test/resident/runtime.test.ts
+++ b/packages/openomni/test/resident/runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { PolicyEngine, type ChatAgentConfig } from "@openomni/agent";
 import { IngressEvent } from "@openomni/protocol";
 import { Bus, Session, Storage } from "@openomni/session";
 import { ResidentRuntime } from "../../src/resident/runtime";
@@ -12,6 +13,22 @@ function makeEvent() {
     meta: { target: { kind: "resident" as const } },
     agent: { model: { provider: "test", id: "fixture" } },
   };
+}
+
+async function evaluateTool(middleware: ChatAgentConfig["middleware"], toolName: string) {
+  const engine = PolicyEngine.create({ audit: false });
+  for (const registration of middleware ?? []) {
+    engine.register(registration);
+  }
+  return engine.dispatch("invoke.prepare", {
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    toolName,
+  });
 }
 
 describe("ResidentRuntime", () => {
@@ -59,6 +76,50 @@ describe("ResidentRuntime", () => {
 
     expect(manager.getLifecycle(session.id)).toBe("sleeping");
     expect(manager.stats().activations).toBe(0);
+  });
+
+  test("lets policyPlan own resident tool permissions", async () => {
+    let capturedConfig: ChatAgentConfig | undefined;
+    const manager = ResidentRuntime.create({
+      runAgent: async (config) => {
+        capturedConfig = config;
+        return { text: "ok", finishReason: "stop" };
+      },
+    });
+
+    const session = Session.create({
+      title: "resident-policy-plan-test",
+      model: { providerID: "test", modelID: "fixture" },
+    });
+
+    await manager.run({
+      sessionId: session.id,
+      event: {
+        ...makeEvent(),
+        agent: {
+          model: { provider: "test", id: "fixture" },
+          permissions: { action: "tool.call", allowlist: ["tool:legacy"] },
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["tool:plan"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+      },
+    });
+
+    expect(capturedConfig?.permissions).toBeUndefined();
+    await expect(evaluateTool(capturedConfig?.middleware, "tool:plan")).resolves.toMatchObject({
+      verdict: "allow",
+    });
+    await expect(evaluateTool(capturedConfig?.middleware, "tool:legacy")).resolves.toMatchObject({
+      verdict: "deny",
+    });
   });
 });
 

--- a/packages/openomni/test/subagent/runtime.test.ts
+++ b/packages/openomni/test/subagent/runtime.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import {
   ChatAgent,
+  createToolPermissionPolicy,
   type AgentResult,
   type ChatAgentInput,
   type PolicyRegistration,
@@ -397,6 +398,32 @@ describe("SubagentRuntime", () => {
       });
 
       expect(result.output).toBe("allowed output");
+    });
+
+    it("does not evaluate child runtime middleware during spawn admission", async () => {
+      queueResult("child runtime output");
+
+      const allowAdmissionPolicy: PolicyRegistration = {
+        name: "test:allow-admission",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: () => PolicyDecision.allow({ policyId: "test:allow-admission" }),
+      };
+
+      const result = await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "child runtime policy",
+        prompt: "do work",
+        model,
+        middleware: [allowAdmissionPolicy],
+        childMiddleware: [
+          createToolPermissionPolicy({
+            permission: { action: "tool.call", allowlist: ["read"] },
+          }),
+        ],
+      });
+
+      expect(result.output).toBe("child runtime output");
     });
 
     it("spawn applies transform constraints from invoke.prepare verdict", async () => {

--- a/packages/protocol/src/agent/index.ts
+++ b/packages/protocol/src/agent/index.ts
@@ -60,6 +60,7 @@ export namespace AgentProfile {
     tools: z.string().array().default([]),
     model: ModelRef.optional(),
     permissions: Policy.Permission.optional(),
+    policyPlan: Policy.PolicyPlan.optional(),
     variant: z.string().optional(),
     temperature: z.number().min(0).max(2).optional(),
     budget: AgentBudget.optional(),

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -53,6 +53,7 @@ const methods = {
       // IronClaw capability injection — workers never read env vars for API keys
       credentials: z.record(z.string()).optional(),
       permissions: Policy.Permission.optional(),
+      policyPlan: Policy.PolicyPlan.optional(),
       softTimeoutMs: z.number().optional(),
       hardTimeoutMs: z.number().optional(),
     }),

--- a/packages/protocol/src/worker-bootstrap/index.ts
+++ b/packages/protocol/src/worker-bootstrap/index.ts
@@ -13,6 +13,7 @@ export namespace WorkerBootstrap {
     systemPrompt: z.string().optional(),
     tools: ToolSelection.Selection,
     permissions: Policy.Permission.optional(),
+    policyPlan: Policy.PolicyPlan.optional(),
     budget: AgentProfile.AgentBudget.optional(),
   });
   export type RuntimeAgentDefinition = z.infer<typeof RuntimeAgentDefinition>;

--- a/packages/protocol/src/worker-bootstrap/worker-bootstrap.test.ts
+++ b/packages/protocol/src/worker-bootstrap/worker-bootstrap.test.ts
@@ -9,11 +9,16 @@ describe("WorkerBootstrap", () => {
       tools: { allow: ["tool1", "tool2"] },
       model: { provider: "anthropic", id: "claude-3-sonnet" },
       systemPrompt: "You are helpful",
+      policyPlan: {
+        policies: [{ id: "builtin:tool-permission", required: true }],
+        labels: ["worker"],
+      },
     };
 
     const parsed = WorkerBootstrap.RuntimeAgentDefinition.parse(agent);
     expect(parsed.name).toBe("test-agent");
     expect(parsed.tools).toEqual({ allow: ["tool1", "tool2"] });
+    expect(parsed.policyPlan?.labels).toEqual(["worker"]);
   });
 
   test("RuntimeToolCatalogEntry round-trip parse", () => {

--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -21,6 +21,10 @@ describe("AgentProfile.Definition", () => {
       tools: ["read_file", "write_file"],
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       permissions: { action: "tool.call", allowlist: ["read_file"] },
+      policyPlan: {
+        policies: [{ id: "builtin:tool-permission", required: true }],
+        labels: ["runtime"],
+      },
       variant: "high",
       temperature: 0.7,
       budget: { maxTurns: 10, warningThreshold: 0.75, reassuranceThreshold: 0.5 },
@@ -29,6 +33,8 @@ describe("AgentProfile.Definition", () => {
     expect(result.model?.id).toBe("claude-3-haiku-20240307");
     expect(result.permissions?.action).toBe("tool.call");
     expect(result.permissions?.allowlist).toEqual(["read_file"]);
+    expect(result.policyPlan?.policies[0]?.id).toBe("builtin:tool-permission");
+    expect(result.policyPlan?.labels).toEqual(["runtime"]);
     expect(result.variant).toBe("high");
     expect(result.temperature).toBe(0.7);
     expect(result.budget?.maxTurns).toBe(10);

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -160,8 +160,29 @@ describe("Ipc.Methods param schemas", () => {
             },
           ],
         },
+        policyPlan: {
+          policies: [{ id: "builtin:tool-permission", required: true }],
+          labels: ["ipc"],
+        },
       }).success,
     ).toBe(true);
+  });
+
+  test("coordinator.spawn_run preserves policy plans", () => {
+    const parsed = Ipc.Methods["coordinator.spawn_run"].params.parse({
+      authToken: "token",
+      runId: "run-1",
+      sessionId: "sess-1",
+      prompt: "do work",
+      model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
+      policyPlan: {
+        policies: [{ id: "builtin:tool-permission", required: true }],
+        labels: ["ipc"],
+      },
+    });
+
+    expect(parsed.policyPlan?.labels).toEqual(["ipc"]);
+    expect(parsed.policyPlan?.policies[0]?.id).toBe("builtin:tool-permission");
   });
 
   test("coordinator.spawn_run rejects permission payloads without canonical action", () => {


### PR DESCRIPTION
## Summary

Propagates per-agent `policyPlan` through protocol contracts, server bootstrap/registry, ingress execution requests, resident runs, and worker subagent/background runtimes. This lets explicit policy plans own tool-permission config while legacy `permissions` remain a backward-compatible hydration fallback.

Fixes #
Relates to #

## Changes

- Add optional `policyPlan` to protocol agent, worker-bootstrap, and IPC spawn contracts.
- Carry policy plans through server bootstrap, ingress bridge, worker runner, resident runtime, and child runtime wiring.
- Split child runtime middleware from parent-scoped delegation admission middleware for foreground, send, resume, and background launches.
- Preserve legacy permissions only as hydration fallback when a policy plan selects the builtin tool-permission guard without config; malformed explicit config fails closed.
- Add regression coverage for parent policy plan precedence, legacy-permission hydration, background parity, resident policy ownership, and bootstrap child system prompt precedence.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [x] `protocol`
- [ ] `session`
- [ ] `llm`
- [x] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Verification

- [x] `git diff --check origin/main`
- [x] `git diff --name-only origin/main | xargs bunx biome check`
- [x] `bun test packages/protocol/test/ipc/schema.test.ts packages/openomni/src/execution-runtime/middleware.test.ts packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts packages/openomni/test/subagent/runtime.test.ts packages/openomni/test/resident/runtime.test.ts apps/server/test/execution/worker-runner.test.ts apps/server/test/ingress-bridge.test.ts packages/protocol/test/agent.test.ts packages/protocol/src/worker-bootstrap/worker-bootstrap.test.ts apps/server/test/agents/runtime-definition.test.ts apps/server/test/execution/worker-bootstrap-handler.test.ts packages/openomni/test/ingress/handlers.test.ts`
- [x] `bun test packages/openomni/test/subagent/abort-registry.test.ts`
- [x] `bun run check-types`
- [x] `bun run build`
- [x] `bun run script/check-deps.ts`

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent definitions can include optional policy plans preserved across spawn, bootstrap, ingress, and runtime flows; parent policy plans constrain child/subagent behavior and middleware.
  * Middleware propagation applied to both foreground and background subagents; background launches accept scoped runtime fields (permissions, system prompt, tools, middleware).

* **Public API**
  * Exposed helper to build per-child worker runtime configuration for subagent launches; new runtime types re-exported.

* **Refactor**
  * Child-runtime computation centralized to derive effective tools, permissions, and middleware.

* **Tests**
  * Expanded coverage for policyPlan parsing, precedence, legacy-permission hydration, middleware propagation, and subagent/worker interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->