### PR TITLE
refactor(agent,openomni): make policy middleware caller-owned

### DIFF
--- a/docs/design-decisions/004-stateless-chat-agent.md
+++ b/docs/design-decisions/004-stateless-chat-agent.md
@@ -26,5 +26,5 @@ Split responsibilities across two packages:
 
 - `SubagentRuntime` creates fresh `ChatAgent` instances per run while persisting the transcript into `@openomni/session` — `ChatAgent` itself stays stateless.
 - `openomni` depends on `agent`, but `agent` knows nothing about `openomni` or about session storage.
-- Extension points are standardized on the policy engine (`PolicyEngine`). All agent behavior extensions use `policies: [...]`.
+- Extension points are standardized on the policy engine (`PolicyEngine`). `ChatAgent` mounts caller-supplied `middleware: [...]`; orchestration/runtime builders own default policy assembly.
 - `ChatAgent.stream()` is implemented as an `AsyncGenerator<AgentEvent>` via `streamAgent()`; `run()` is a thin wrapper that drains `stream()`.

--- a/docs/golden-principles.md
+++ b/docs/golden-principles.md
@@ -126,7 +126,7 @@ This allows `Todo` to work as both a namespace (`Todo.Schema`, `Todo.Item`) and 
 - Register policies via `PolicyRegistration { name, timing, priority, fn }`. Lower `priority` runs first within a timing.
 - `Policy.evaluate()` is the single call site for permission checks. Do not duplicate permission logic inside individual tools or callers.
 - `Policy.Permission` (from `@openomni/protocol`) is the cross-package contract for tool access rules. Upper packages must not define parallel permission schemas.
-- Built-in policies (`tool-permission`, `budget-*`, `memory`, `compaction`, `post-tool`, `post-turn`, `idle-nudge`) are registered automatically by `PolicyEngine.create()`. Custom policies append to this list via `policies: [...]` in `ChatAgentConfig`.
+- `ChatAgent` registers only caller-supplied `middleware`; runtime builders own default policy assembly (`tool-permission`, `budget-*`, `compaction`, `idle-nudge`) and custom policies append through `middleware: [...]`.
 
 ## 10. Documentation Freshness
 

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -85,10 +85,10 @@ Also exported from `@openomni/agent`:
 | `budget?`        | `AgentBudget`                            | Max turns / tool calls / wall time / tool runtime (use `-1` for unlimited)  |
 | `toolExecutor?`  | `(call) => Promise<Tool.Result>`         | Custom tool executor; wrapped by `createToolExecutor`                       |
 | `signal?`        | `AbortSignal`                            | External cancellation                                                       |
-| `permissions?`   | `Policy.Permission`                      | Evaluated by the built-in `tool-permission` policy                          |
-| `compaction?`    | `{ contextWindowTokens, ... }`           | Trigger message compaction via `InMemoryCompactor`                          |
+| `permissions?`   | `Policy.Permission`                      | Deprecated; ignored by ChatAgent core. Runtime builders must pass `createToolPermissionPolicy()` via `middleware` |
+| `compaction?`    | `{ contextWindowTokens, ... }`           | Deprecated; ignored by ChatAgent core. Runtime builders must pass `createCompactionPolicy()` via `middleware` |
 | `memory?`        | `Memory`                                 | Memory interface retrieved by the `memory` policy                           |
-| `policies?`      | `PolicyRegistration[]`                   | **Preferred extension mechanism**                                           |
+| `middleware?`    | `PolicyRegistration[]`                   | Caller-owned policy registrations                                           |
 | `eventEmitter?`  | `AgentEventEmitter`                      | Optional event emitter for external observers                               |
 | `providerOptions?` | `Record<string, unknown>`              | Forwarded to the underlying provider SDK                                    |
 
@@ -106,6 +106,7 @@ run.start → turn.start → context.prepare → resources.prepare
 - **Registration**: `PolicyRegistration { name, timing, priority, scope?, failPolicy?, fn, propagate? }`. Lower `priority` runs first; `scope.agentType` optionally filters by agent kind; `failPolicy` is `fail-open` (default) or `fail-closed`.
 - **Decision** (`Policy.PolicyDecision`): `allow | deny | pending`, with effects such as `prompt.inject_message`, `prompt.replace`, `tool.rewrite_input`, `run.replace_messages`, and `writeback.rewrite`.
 - **System prompt effects**: `dispatch("context.prepare", ...)` returns canonical prompt effects; composition happens through effect merging rather than legacy verdict transforms.
+- **Ownership**: `ChatAgent` registers only caller-supplied `middleware`; runtime builders own default policy assembly (budget, tool permission, compaction, idle nudge).
 - **Builtins** (priority in parentheses):
   - `tool-permission` (0, fail-closed) — enforces `Policy.Permission` and `InputRule`; returns deny with `tool.skip_invocation` / `run.abort` / `tool.require_approval`
   - `budget-reassurance` (10) — injects a reassurance system message around 60% budget
@@ -121,7 +122,7 @@ run.start → turn.start → context.prepare → resources.prepare
 ```
 streamAgent(input, config, sink) [AsyncGenerator<AgentEvent>]
   ├─ retry loop (maxAttempts)
-  │   ├─ build PolicyEngine (builtins + config.policies)
+  │   ├─ build PolicyEngine (config.middleware only)
   │   ├─ dispatch(run.start)                    → allow (with effects) / deny
   │   └─ turn loop (while budget ok)
   │       ├─ checkBudget → if exceeded, dispatch(run.finish) + yield complete
@@ -154,7 +155,7 @@ streamAgent(input, config, sink) [AsyncGenerator<AgentEvent>]
 
 - **Stateless core**: Every `ChatAgent.run()` is independent — no session mutation, no storage. State (budget, memory, delegation) lives on a per-call context.
 - **Sink-driven**: Callers pass a `Sink` (from `@openomni/protocol`) to receive streaming output. The agent never creates sessions on its own.
-- **Policy > ad-hoc hooks**: New extensions MUST use `policies: [...]`. `PolicyEngine.create()` is the single extension surface.
+- **Policy > ad-hoc hooks**: New extensions MUST use `middleware: [...]`. `PolicyEngine.create()` is the single extension surface.
 - **Budget check before each turn**: `checkBudget()` runs before `llmRun()`, not after, so budget enforcement blocks the next turn cleanly.
 - **Delegation safety**: `DelegationContext` with `visitedAgents: Set<string>` and `maxDepth` prevents circular / runaway delegation.
 - **Message format**: `ChatAgentInput.messages` is a simple `{ role: "user" | "assistant"; content: string }[]`. Richer `Message.WithParts[]` is used internally only.
@@ -162,5 +163,5 @@ streamAgent(input, config, sink) [AsyncGenerator<AgentEvent>]
 ## ANTI-PATTERNS
 
 - Agent depends on `@openomni/session` for observability only (Log, Bus, Telemetry, TraceContext). Do NOT use session for state management — orchestration that needs session state lives in `@openomni/openomni`.
-- Do NOT extend behavior outside `policies: [...]`. `PolicyEngine` is the single extension surface.
+- Do NOT extend behavior outside `middleware: [...]`. `PolicyEngine` is the single extension surface.
 - Do NOT bypass `Policy.evaluate()` by returning placeholder tool results in user code; use a `invoke.prepare` policy so behavior is uniform.

--- a/packages/agent/src/core/execution/stream-helpers.ts
+++ b/packages/agent/src/core/execution/stream-helpers.ts
@@ -16,12 +16,6 @@ import type { BudgetState } from "../budget";
 import { createAssistantMessage, createUserMessage } from "../message-factory";
 import { PolicyEngine } from "../policy";
 import type { DispatchContext, PolicyEngineInstance } from "../policy";
-import {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
-  createCompactionPolicy,
-  createToolPermissionPolicy,
-} from "../policy/builtin";
 import { buildSystemPrompt } from "../prompt-builder";
 import * as Retry from "../retry";
 import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
@@ -116,6 +110,7 @@ export function buildPolicyEngine(
   config: ChatAgentConfig,
   agentBase: StreamAgentBase,
 ): PolicyEngineInstance {
+  publishIgnoredPolicyConfigWarnings(config, agentBase);
   const engine = PolicyEngine.create({
     traceContext: {
       traceId: agentBase.traceId,
@@ -123,24 +118,56 @@ export function buildPolicyEngine(
       ...(agentBase.runId !== undefined && { runId: agentBase.runId }),
     },
   });
-  engine.register(createBudgetReassurancePolicy());
-  engine.register(createBudgetWarningPolicy());
-  if (config.permissions) {
-    engine.register(
-      createToolPermissionPolicy({
-        permission: config.permissions,
-        eventEmitter: config.eventEmitter,
-        source: "stream-engine",
-      }),
-    );
-  }
-  if (config.compaction) {
-    engine.register(createCompactionPolicy(config.compaction));
-  }
   for (const reg of config.middleware ?? []) {
     engine.register(reg);
   }
   return engine;
+}
+
+function publishIgnoredPolicyConfigWarnings(
+  config: ChatAgentConfig,
+  agentBase: StreamAgentBase,
+): void {
+  publishIgnoredPolicyConfigWarning(config, agentBase, {
+    field: "permissions",
+    replacement: "createToolPermissionPolicy()",
+    middlewareName: "builtin:tool-permission",
+  });
+  publishIgnoredPolicyConfigWarning(config, agentBase, {
+    field: "compaction",
+    replacement: "createCompactionPolicy()",
+    middlewareName: "builtin:compaction",
+  });
+}
+
+function publishIgnoredPolicyConfigWarning(
+  config: ChatAgentConfig,
+  agentBase: StreamAgentBase,
+  options: {
+    readonly field: "permissions" | "compaction";
+    readonly replacement: string;
+    readonly middlewareName: string;
+  },
+): void {
+  if (config[options.field] === undefined) return;
+  const replacementMiddlewarePresent = config.middleware?.some(
+    (registration) => registration.name === options.middlewareName,
+  );
+
+  Bus.publish(Operational.Warn, {
+    traceId: agentBase.traceId,
+    ...(agentBase.sessionId !== "" && { sessionId: agentBase.sessionId }),
+    ...(agentBase.runId !== undefined && { runId: agentBase.runId }),
+    time: Date.now(),
+    component: "agent.policy",
+    msg: `ChatAgentConfig.${options.field} is deprecated and ignored`,
+    context: {
+      field: options.field,
+      replacement: options.replacement,
+      middlewareName: options.middlewareName,
+      replacementMiddlewarePresent: replacementMiddlewarePresent ?? false,
+    },
+  });
 }
 
 export function resolveToolChoice(

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -19,7 +19,15 @@ export interface ChatAgentConfig {
   onStepFinish?: (step: AgentStep) => void | Promise<void>;
   toolExecutor?: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
   signal?: AbortSignal;
+  /**
+   * @deprecated Runtime builders should pass createToolPermissionPolicy() via middleware.
+   * ChatAgent no longer auto-registers this field.
+   */
   permissions?: Policy.Permission;
+  /**
+   * @deprecated Runtime builders should pass createCompactionPolicy() via middleware.
+   * ChatAgent no longer auto-registers this field.
+   */
   compaction?: {
     contextWindowTokens: number;
     thresholdRatio?: number;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -45,6 +45,7 @@ export {
   createBudgetReassurancePolicy,
   createBudgetWarningPolicy,
 } from "./core/policy/builtin/budget";
+export { createCompactionPolicy } from "./core/policy/builtin/compaction";
 export { createIdleNudgePolicy } from "./core/policy/builtin/idle-nudge";
 export { createToolPermissionPolicy } from "./core/policy/builtin/tool-guard";
 export { InMemoryCompactor } from "./core/execution/compaction";

--- a/packages/agent/test/core/execution/stream-helpers-dispatch.test.ts
+++ b/packages/agent/test/core/execution/stream-helpers-dispatch.test.ts
@@ -3,7 +3,7 @@ import { Bus } from "@openomni/session";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
 import type { ChatAgentConfig, ChatAgentInput, AgentEvent } from "../../../src/core/types";
-import type { TraceContext } from "@openomni/protocol";
+import { Operational, type TraceContext } from "@openomni/protocol";
 import {
   abortRun,
   allow,
@@ -136,7 +136,8 @@ describe("dispatchPreRun (run.start)", () => {
 
     expect(result).toBeNull();
     expect(state.messages.length).toBe(messagesBefore + 1);
-    const lastMsg = state.messages.at(-1)!;
+    const lastMsg = state.messages.at(-1);
+    if (!lastMsg) throw new Error("expected injected message");
     expect(lastMsg.info.role).toBe("user");
     const text = lastMsg.parts
       .filter(
@@ -1015,16 +1016,118 @@ describe("completion.prepare dispatch", () => {
   });
 });
 
-describe("buildPolicyEngine registers builtins", () => {
-  it("creates engine with builtins from config", () => {
+describe("buildPolicyEngine policy ownership", () => {
+  it("registers only caller-supplied middleware", async () => {
+    Bus.reset();
     const config = makeConfig({
-      budget: { maxTurns: 10 },
+      permissions: { action: "tool.call", denylist: ["bash"] },
       compaction: { contextWindowTokens: 1000 },
     });
 
     const engine = buildPolicyEngine(config, makeAgentBase());
-    expect(engine).toBeDefined();
-    expect(typeof engine.dispatch).toBe("function");
-    expect(typeof engine.register).toBe("function");
+    await expect(
+      engine.dispatch("invoke.prepare", {
+        steps: [],
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        turnCount: 0,
+        isCompletion: false,
+        continuationCount: 0,
+        elapsedMs: 0,
+        toolName: "bash",
+      }),
+    ).resolves.toMatchObject({ verdict: "allow" });
+  });
+
+  it("does not auto-register compaction from deprecated config", async () => {
+    Bus.reset();
+    const config = makeConfig({
+      compaction: { contextWindowTokens: 1, thresholdRatio: 0 },
+    });
+    const engine = buildPolicyEngine(config, makeAgentBase());
+    const state = makeState();
+    const originalMessages = state.messages;
+
+    await handleCompact(state, engine, config, makeAgentBase());
+
+    expect(state.messages).toBe(originalMessages);
+    expect(state.compactionCount).toBe(0);
+  });
+
+  it("publishes warnings for deprecated policy config fields that are ignored", async () => {
+    Bus.reset();
+    const warnings: Array<{ msg?: string; context?: Record<string, unknown> }> = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+
+    buildPolicyEngine(
+      makeConfig({
+        permissions: { action: "tool.call" },
+        compaction: { contextWindowTokens: 1 },
+      }),
+      { traceId: "trace-warning", sessionId: "sess-1" },
+    );
+    await Promise.resolve();
+    unsubscribe();
+
+    expect(warnings.map((warning) => warning.context?.field)).toEqual([
+      "permissions",
+      "compaction",
+    ]);
+    expect(warnings.every((warning) => warning.msg?.includes("deprecated and ignored"))).toBe(true);
+  });
+
+  it("warns for deprecated permissions even when replacement middleware is present", async () => {
+    Bus.reset();
+    const warnings: Array<{ context?: Record<string, unknown> }> = [];
+    const unsubscribe = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
+
+    buildPolicyEngine(
+      makeConfig({
+        permissions: { action: "tool.call", denylist: ["bash"] },
+        middleware: [
+          {
+            name: "builtin:tool-permission",
+            timing: "invoke.prepare",
+            priority: 0,
+            fn: () => allow(),
+          },
+        ],
+      }),
+      { traceId: "trace-replacement-warning", sessionId: "sess-1" },
+    );
+    await Promise.resolve();
+    unsubscribe();
+
+    expect(warnings.map((warning) => warning.context)).toContainEqual(
+      expect.objectContaining({
+        field: "permissions",
+        replacementMiddlewarePresent: true,
+      }),
+    );
+  });
+
+  it("honors explicit middleware supplied by the runtime builder", async () => {
+    const config = makeConfig({
+      middleware: [
+        {
+          name: "test:deny-bash",
+          timing: "invoke.prepare",
+          priority: 0,
+          fn: () => abortRun("test.deny", "blocked"),
+        },
+      ],
+    });
+
+    const engine = buildPolicyEngine(config, makeAgentBase());
+    await expect(
+      engine.dispatch("invoke.prepare", {
+        steps: [],
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        turnCount: 0,
+        isCompletion: false,
+        continuationCount: 0,
+        elapsedMs: 0,
+        toolName: "bash",
+      }),
+    ).resolves.toMatchObject({ verdict: "deny" });
   });
 });

--- a/packages/agent/test/core/tool-permission-integration.test.ts
+++ b/packages/agent/test/core/tool-permission-integration.test.ts
@@ -20,9 +20,11 @@ const mockLlm = createMockLlmConfig({
 });
 
 let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+let createToolPermissionPolicy: typeof import("../../src/core/policy/builtin/tool-guard").createToolPermissionPolicy;
 
 beforeAll(async () => {
   ({ ChatAgent } = await import("../../src/core/chat-agent"));
+  ({ createToolPermissionPolicy } = await import("../../src/core/policy/builtin/tool-guard"));
 });
 
 function createAssistantMessage(text: string) {
@@ -113,18 +115,22 @@ describe("tool permission integration via toolExecutor", () => {
         },
       ],
       toolExecutor: executor,
-      permissions: {
-        action: "tool.call",
-        inputRules: [
-          {
-            toolPattern: "bash",
-            field: "command",
-            pattern: "rm\\s+-rf",
-            action: "deny",
-            priority: 10,
+      middleware: [
+        createToolPermissionPolicy({
+          permission: {
+            action: "tool.call",
+            inputRules: [
+              {
+                toolPattern: "bash",
+                field: "command",
+                pattern: "rm\\s+-rf",
+                action: "deny",
+                priority: 10,
+              },
+            ],
           },
-        ],
-      },
+        }),
+      ],
     });
 
     await agent.run(
@@ -175,10 +181,14 @@ describe("tool permission integration via toolExecutor", () => {
         },
       ],
       toolExecutor: executor,
-      permissions: {
-        action: "tool.call",
-        requireApproval: ["bash"],
-      },
+      middleware: [
+        createToolPermissionPolicy({
+          permission: {
+            action: "tool.call",
+            requireApproval: ["bash"],
+          },
+        }),
+      ],
     });
 
     await agent.run(
@@ -229,10 +239,14 @@ describe("tool permission integration via toolExecutor", () => {
         },
       ],
       toolExecutor: executor,
-      permissions: {
-        action: "tool.call",
-        allowlist: ["bash"],
-      },
+      middleware: [
+        createToolPermissionPolicy({
+          permission: {
+            action: "tool.call",
+            allowlist: ["bash"],
+          },
+        }),
+      ],
     });
 
     await agent.run(
@@ -289,7 +303,7 @@ describe("tool permission integration via toolExecutor", () => {
       llm: mockLlm,
       tools: [writeTool],
       toolExecutor: executor,
-      permissions: labelPermission,
+      middleware: [createToolPermissionPolicy({ permission: labelPermission })],
     });
 
     await agent.run(
@@ -346,7 +360,7 @@ describe("tool permission integration via toolExecutor", () => {
       llm: mockLlm,
       tools: [grepTool],
       toolExecutor: executor,
-      permissions: permission,
+      middleware: [createToolPermissionPolicy({ permission })],
     });
 
     await agent.run(
@@ -433,18 +447,22 @@ describe("tool permission integration via toolExecutor", () => {
         },
       ],
       toolExecutor: executor,
-      permissions: {
-        action: "tool.call",
-        inputRules: [
-          {
-            toolPattern: "bash",
-            field: "command",
-            pattern: "rm\\s+-rf",
-            action: "deny",
-            priority: 10,
+      middleware: [
+        createToolPermissionPolicy({
+          permission: {
+            action: "tool.call",
+            inputRules: [
+              {
+                toolPattern: "bash",
+                field: "command",
+                pattern: "rm\\s+-rf",
+                action: "deny",
+                priority: 10,
+              },
+            ],
           },
-        ],
-      },
+        }),
+      ],
     });
 
     const events = [] as Array<{ type: string; result?: Tool.Result }>;

--- a/packages/openomni/src/execution-runtime/middleware.test.ts
+++ b/packages/openomni/src/execution-runtime/middleware.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "bun:test";
 import type { Policy } from "@openomni/protocol";
 import { buildWorkerMiddleware } from "./middleware";
 
+function findRegistration(registrations: ReturnType<typeof buildWorkerMiddleware>, name: string) {
+  return registrations.find((registration) => registration.name === name);
+}
+
 function invokeTool(
   registration: ReturnType<typeof buildWorkerMiddleware>[number] | undefined,
   toolName: string,
@@ -23,14 +27,16 @@ describe("buildWorkerMiddleware", () => {
     it("returns worker-owned registrations", () => {
       const registrations = buildWorkerMiddleware({});
       expect(registrations.map((r) => r.name)).toEqual([
+        "builtin:budget-reassurance",
+        "builtin:budget-warning",
         "builtin:tool-permission",
         "builtin:idle-nudge",
       ]);
     });
 
-    it("first registration is tool permission with fail-closed policy", () => {
+    it("tool permission registration is fail-closed", () => {
       const registrations = buildWorkerMiddleware({});
-      const toolPermission = registrations[0];
+      const toolPermission = findRegistration(registrations, "builtin:tool-permission");
       if (toolPermission == null) {
         throw new Error("expected tool permission registration");
       }
@@ -47,7 +53,35 @@ describe("buildWorkerMiddleware", () => {
     it("passes permissions to tool permission middleware", () => {
       const permissions = { action: "tool.call", allowlist: ["tool:read"] };
       const registrations = buildWorkerMiddleware({ permissions });
-      expect(registrations[0]?.name).toBe("builtin:tool-permission");
+      expect(findRegistration(registrations, "builtin:tool-permission")?.name).toBe(
+        "builtin:tool-permission",
+      );
+    });
+
+    it("forwards event emitter metadata to legacy tool permission middleware", async () => {
+      const events: Array<{ name: string; data: Record<string, unknown> }> = [];
+      const registrations = buildWorkerMiddleware({
+        permissions: { action: "tool.call", allowlist: ["tool:read"] },
+        eventEmitter: {
+          emit: (name, data) => events.push({ name, data }),
+        },
+        source: "worker-runtime",
+      });
+      const toolPermission = findRegistration(registrations, "builtin:tool-permission");
+
+      await expect(invokeTool(toolPermission, "tool:read")).resolves.toMatchObject({
+        verdict: "allow",
+      });
+
+      expect(events).toEqual([
+        {
+          name: "tool.execution.started",
+          data: expect.objectContaining({
+            sessionId: "worker-runtime",
+            toolName: "tool:read",
+          }),
+        },
+      ]);
     });
   });
 
@@ -85,8 +119,64 @@ describe("buildWorkerMiddleware", () => {
 
       const registrations = buildWorkerMiddleware({ policyPlan });
       expect(registrations.map((r) => r.name)).toEqual([
+        "builtin:budget-reassurance",
+        "builtin:budget-warning",
         "builtin:tool-permission",
         "builtin:idle-nudge",
+      ]);
+    });
+
+    it("does not duplicate lifecycle defaults that a policyPlan already owns", () => {
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          { id: "builtin:budget-reassurance", required: true, config: {} },
+          { id: "builtin:budget-warning", required: true, config: {} },
+          {
+            id: "builtin:compaction",
+            required: true,
+            config: { contextWindowTokens: 1000 },
+          },
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call" } },
+          },
+        ],
+        labels: ["security"],
+      };
+
+      const registrations = buildWorkerMiddleware({
+        policyPlan,
+        compaction: { contextWindowTokens: 2000 },
+      });
+      expect(registrations.map((registration) => registration.name)).toEqual([
+        "builtin:budget-reassurance",
+        "builtin:budget-warning",
+        "builtin:compaction",
+        "builtin:tool-permission",
+        "builtin:idle-nudge",
+      ]);
+    });
+
+    it("can resolve only policy-owned middleware for nested child policy plans", () => {
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call" } },
+          },
+        ],
+        labels: ["security"],
+      };
+
+      const registrations = buildWorkerMiddleware({
+        policyPlan,
+        includeLifecycle: false,
+        includeIdle: false,
+      });
+      expect(registrations.map((registration) => registration.name)).toEqual([
+        "builtin:tool-permission",
       ]);
     });
 
@@ -103,11 +193,17 @@ describe("buildWorkerMiddleware", () => {
       const permissions = { action: "tool.call", allowlist: ["tool:read"] };
 
       const registrations = buildWorkerMiddleware({ policyPlan, permissions });
-      expect(registrations.map((r) => r.name)).toEqual(["builtin:tool-permission"]);
-      await expect(invokeTool(registrations[0], "tool:read")).resolves.toMatchObject({
+      expect(registrations.map((r) => r.name)).toEqual([
+        "builtin:budget-reassurance",
+        "builtin:budget-warning",
+        "builtin:tool-permission",
+        "builtin:idle-nudge",
+      ]);
+      const toolPermission = findRegistration(registrations, "builtin:tool-permission");
+      await expect(invokeTool(toolPermission, "tool:read")).resolves.toMatchObject({
         verdict: "allow",
       });
-      await expect(invokeTool(registrations[0], "tool:write")).resolves.toMatchObject({
+      await expect(invokeTool(toolPermission, "tool:write")).resolves.toMatchObject({
         verdict: "deny",
       });
     });
@@ -126,12 +222,50 @@ describe("buildWorkerMiddleware", () => {
       const permissions = { action: "tool.call", allowlist: ["tool:legacy"] };
 
       const registrations = buildWorkerMiddleware({ policyPlan, permissions });
-      await expect(invokeTool(registrations[0], "tool:plan")).resolves.toMatchObject({
+      const toolPermission = findRegistration(registrations, "builtin:tool-permission");
+      await expect(invokeTool(toolPermission, "tool:plan")).resolves.toMatchObject({
         verdict: "allow",
       });
-      await expect(invokeTool(registrations[0], "tool:legacy")).resolves.toMatchObject({
+      await expect(invokeTool(toolPermission, "tool:legacy")).resolves.toMatchObject({
         verdict: "deny",
       });
+    });
+
+    it("hydrates event emitter metadata into policyPlan tool permission middleware", async () => {
+      const events: Array<{ name: string; data: Record<string, unknown> }> = [];
+      const policyPlan: Policy.PolicyPlan = {
+        policies: [
+          {
+            id: "builtin:tool-permission",
+            required: true,
+            config: { permission: { action: "tool.call", allowlist: ["tool:read"] } },
+          },
+        ],
+        labels: ["security"],
+      };
+
+      const registrations = buildWorkerMiddleware({
+        policyPlan,
+        eventEmitter: {
+          emit: (name, data) => events.push({ name, data }),
+        },
+        source: "policy-plan-runtime",
+      });
+      const toolPermission = findRegistration(registrations, "builtin:tool-permission");
+
+      await expect(invokeTool(toolPermission, "tool:read")).resolves.toMatchObject({
+        verdict: "allow",
+      });
+
+      expect(events).toEqual([
+        {
+          name: "tool.execution.started",
+          data: expect.objectContaining({
+            sessionId: "policy-plan-runtime",
+            toolName: "tool:read",
+          }),
+        },
+      ]);
     });
 
     it("fails closed for malformed explicit policyPlan permission config", async () => {
@@ -154,7 +288,8 @@ describe("buildWorkerMiddleware", () => {
         };
 
         const registrations = buildWorkerMiddleware({ policyPlan, permissions });
-        await expect(invokeTool(registrations[0], "tool:legacy")).resolves.toMatchObject({
+        const toolPermission = findRegistration(registrations, "builtin:tool-permission");
+        await expect(invokeTool(toolPermission, "tool:legacy")).resolves.toMatchObject({
           verdict: "deny",
         });
       }

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -1,32 +1,78 @@
 import {
+  createBudgetReassurancePolicy,
+  createBudgetWarningPolicy,
+  createCompactionPolicy,
   createIdleNudgePolicy,
   createToolPermissionPolicy,
   defaultRegistry,
 } from "@openomni/agent";
-import type { PolicyRegistration } from "@openomni/agent";
+import type { ChatAgentConfig, PolicyRegistration } from "@openomni/agent";
 import { Policy } from "@openomni/protocol";
 
 export interface WorkerMiddlewareConfig {
   permissions?: Policy.Permission;
   policyPlan?: Policy.PolicyPlan;
+  compaction?: ChatAgentConfig["compaction"];
+  eventEmitter?: ChatAgentConfig["eventEmitter"];
+  source?: string;
+  includeLifecycle?: boolean;
+  includeIdle?: boolean;
 }
 
 const FAIL_CLOSED_TOOL_PERMISSION: Policy.Permission = { action: "tool.call", denylist: ["*"] };
 
 export function buildWorkerMiddleware(config: WorkerMiddlewareConfig): PolicyRegistration[] {
-  if (config.policyPlan) {
-    return resolvePoliciesFromPlan(hydrateLegacyPermissions(config.policyPlan, config.permissions));
-  }
+  const policyPlanMiddleware = config.policyPlan
+    ? resolvePoliciesFromPlan(hydrateToolPermissionConfig(config.policyPlan, config))
+    : undefined;
+  const lifecycleMiddleware =
+    config.includeLifecycle === false
+      ? []
+      : registrationsAbsentFrom(
+          buildAgentLifecycleMiddleware(config.compaction),
+          policyPlanMiddleware ?? [],
+        );
 
-  return buildLegacyMiddleware(config.permissions);
+  return [
+    ...lifecycleMiddleware,
+    ...(policyPlanMiddleware ?? buildLegacyPermissionMiddleware(config)),
+    ...(shouldAppendIdleNudge(config, policyPlanMiddleware) ? [createIdleNudgePolicy()] : []),
+  ];
 }
 
-function buildLegacyMiddleware(permissions?: Policy.Permission): PolicyRegistration[] {
+function shouldAppendIdleNudge(
+  config: WorkerMiddlewareConfig,
+  policyPlanMiddleware: PolicyRegistration[] | undefined,
+): boolean {
+  if (config.includeIdle === false) return false;
+  return !policyPlanMiddleware?.some((registration) => registration.name === "builtin:idle-nudge");
+}
+
+export function buildAgentLifecycleMiddleware(
+  compaction: ChatAgentConfig["compaction"],
+): PolicyRegistration[] {
+  return [
+    createBudgetReassurancePolicy(),
+    createBudgetWarningPolicy(),
+    ...(compaction ? [createCompactionPolicy(compaction)] : []),
+  ];
+}
+
+export function registrationsAbsentFrom(
+  registrations: PolicyRegistration[],
+  existing: PolicyRegistration[],
+): PolicyRegistration[] {
+  const existingNames = new Set(existing.map((registration) => registration.name));
+  return registrations.filter((registration) => !existingNames.has(registration.name));
+}
+
+function buildLegacyPermissionMiddleware(config: WorkerMiddlewareConfig): PolicyRegistration[] {
   return [
     createToolPermissionPolicy({
-      permission: permissions ?? { action: "tool.call" },
+      permission: config.permissions ?? { action: "tool.call" },
+      ...(config.eventEmitter !== undefined && { eventEmitter: config.eventEmitter }),
+      source: config.source ?? "stream-engine",
     }),
-    createIdleNudgePolicy(),
   ];
 }
 
@@ -35,40 +81,58 @@ function resolvePoliciesFromPlan(plan: Policy.PolicyPlan): PolicyRegistration[] 
   return registry.resolve(plan, {});
 }
 
-function hydrateLegacyPermissions(
+function hydrateToolPermissionConfig(
   plan: Policy.PolicyPlan,
-  permissions: Policy.Permission | undefined,
+  workerConfig: WorkerMiddlewareConfig,
 ): Policy.PolicyPlan {
-  const fallbackPermission = permissions ?? { action: "tool.call" };
+  const fallbackPermission = workerConfig.permissions ?? { action: "tool.call" };
   let changed = false;
   const policies = plan.policies.map((policy) => {
     if (policy.id !== "builtin:tool-permission") return policy;
     const config = policy.config ?? {};
+    const hydratedConfig = hydrateToolPermissionObservability(config, workerConfig);
+    if (hydratedConfig !== config) changed = true;
     // Keep legacy permissions effective for policy plans that select the
     // builtin guard without owning its config yet.
     // A present-but-invalid permission is treated as explicit and fails closed.
-    if (!("permission" in config)) {
+    if (!("permission" in hydratedConfig)) {
       changed = true;
       return {
         ...policy,
         config: {
-          ...config,
+          ...hydratedConfig,
           permission: fallbackPermission,
         },
       };
     }
 
-    if (Policy.Permission.safeParse(config.permission).success) return policy;
+    if (Policy.Permission.safeParse(hydratedConfig.permission).success) {
+      return hydratedConfig === config ? policy : { ...policy, config: hydratedConfig };
+    }
 
     changed = true;
     return {
       ...policy,
       config: {
-        ...config,
+        ...hydratedConfig,
         permission: FAIL_CLOSED_TOOL_PERMISSION,
       },
     };
   });
 
   return changed ? { ...plan, policies } : plan;
+}
+
+function hydrateToolPermissionObservability(
+  config: Record<string, unknown>,
+  workerConfig: WorkerMiddlewareConfig,
+): Record<string, unknown> {
+  const additions: Record<string, unknown> = {};
+  if (workerConfig.eventEmitter !== undefined && !("eventEmitter" in config)) {
+    additions.eventEmitter = workerConfig.eventEmitter;
+  }
+  if (!("source" in config)) {
+    additions.source = workerConfig.source ?? "stream-engine";
+  }
+  return Object.keys(additions).length === 0 ? config : { ...config, ...additions };
 }

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -162,6 +162,8 @@ function buildChildRuntimeMiddleware(
         // Used only when the parent plan selected the builtin guard without
         // owning config yet; explicit parent plan config still wins.
         permissions: parentPermissions,
+        includeLifecycle: false,
+        includeIdle: false,
       }),
     );
   } else if (parentPermissions && childDefinition?.policyPlan) {
@@ -174,6 +176,8 @@ function buildChildRuntimeMiddleware(
       ...buildWorkerMiddleware({
         policyPlan: childDefinition.policyPlan,
         permissions: childPermissions,
+        includeLifecycle: false,
+        includeIdle: false,
       }),
     );
   }

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -260,7 +260,6 @@ export class ResidentRuntime {
       systemPrompt: ctx.event.agent.systemPrompt,
       budget: ctx.event.agent.budget,
       tools: ctx.event.agent.tools,
-      ...(ctx.event.agent.policyPlan ? {} : { permissions: ctx.event.agent.permissions }),
       toolExecutor: toolExecutor as
         | ((call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>)
         | undefined,

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -1,5 +1,6 @@
 import {
   PolicyEngine,
+  createToolPermissionPolicy,
   type ChatAgent,
   type PolicyContext,
   type PolicyRegistration,
@@ -12,6 +13,10 @@ import {
   type RuntimeResource,
 } from "@openomni/protocol";
 import { Bus, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
+import {
+  buildAgentLifecycleMiddleware,
+  registrationsAbsentFrom,
+} from "../execution-runtime/middleware.js";
 import { get as getAbortEntry, register as registerAbortController } from "./abort-registry";
 import { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-policy.js";
 import {
@@ -182,10 +187,19 @@ function buildChildRunMiddleware(config: RuntimeConfig & { permissions?: Policy.
   // Used by spawn/send/resume for the child run itself. Admission still reads
   // config.middleware before this helper, so childMiddleware never participates
   // in the parent-scoped delegation decision.
-  return SubagentSpawnPolicyMiddleware.childMiddleware(
+  const inheritedMiddleware = SubagentSpawnPolicyMiddleware.childMiddleware(
     config.childMiddleware ?? config.middleware,
     config.permissions !== undefined || config.childMiddleware !== undefined,
   );
+  const inherited = inheritedMiddleware ?? [];
+  return [
+    ...registrationsAbsentFrom(buildAgentLifecycleMiddleware(undefined), inherited),
+    // Subagent run middleware preserves the prior child-run defaults:
+    // budget lifecycle + permission constraints only. Send transcript compaction
+    // is handled separately before resume; idle nudge is worker-runtime owned.
+    ...(config.permissions ? [createToolPermissionPolicy({ permission: config.permissions })] : []),
+    ...inherited,
+  ];
 }
 
 export namespace SubagentRuntime {
@@ -288,7 +302,7 @@ export namespace SubagentRuntime {
       const middleware = buildChildRunMiddleware(config);
       const runConfig = { ...config, middleware };
       const result = await executeRun(session.id, runId, config.model, timers, () =>
-        runWithTranscript(session.id, runConfig, signal, config.permissions),
+        runWithTranscript(session.id, runConfig, signal),
       );
       return result;
     });
@@ -323,7 +337,7 @@ export namespace SubagentRuntime {
     const runConfig = { ...config, middleware };
     const backgroundRun = sendToMailbox(session.id, () =>
       executeRun(session.id, runId, config.model, timers, () =>
-        runWithTranscript(session.id, runConfig, signal, config.permissions),
+        runWithTranscript(session.id, runConfig, signal),
       ),
     );
     backgroundRun.catch(() => {
@@ -380,7 +394,7 @@ export namespace SubagentRuntime {
         config.compaction,
       );
       return executeRun(session.id, runId, config.model, timers, () =>
-        runWithTranscript(session.id, runConfig, signal, config.permissions, messages),
+        runWithTranscript(session.id, runConfig, signal, messages),
       );
     });
   }

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -4,7 +4,6 @@ import {
   type ChatAgentConfig,
   type PolicyRegistration,
 } from "@openomni/agent";
-import type { Policy } from "@openomni/protocol";
 import type { RuntimeModel, RuntimeMessage } from "./shared";
 import {
   buildRuntimeMessages,
@@ -79,7 +78,6 @@ export async function runWithTranscript(
   sessionId: string,
   config: RuntimeConfig,
   signal?: AbortSignal,
-  permissions?: Policy.Permission,
   messages = buildChildMessagesInternal(sessionId),
 ): Promise<Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>> {
   const agent = ChatAgent.create({
@@ -91,7 +89,6 @@ export async function runWithTranscript(
     budget: config.budget,
     toolExecutor: config.toolExecutor,
     signal,
-    permissions,
     middleware: config.middleware,
   });
 


### PR DESCRIPTION
## Summary

Moves builtin policy assembly out of `ChatAgent` core and into runtime builders so policy middleware is caller-owned while preserving worker, resident, and subagent behavior.

Fixes #
Relates to #

## Changes

- Stop `buildPolicyEngine` from auto-registering budget, tool-permission, and compaction policies; it now registers caller-supplied middleware only.
- Mark legacy `ChatAgentConfig.permissions` / `compaction` fields deprecated and warn when they are still supplied.
- Assemble worker defaults explicitly in `buildWorkerMiddleware`, including lifecycle policies, permission/policy-plan resolution, idle-nudge, event metadata hydration, and lifecycle dedupe.
- Route resident and subagent runtimes through explicit middleware instead of passing legacy policy fields into `ChatAgent`.
- Update docs and tests for caller-owned policy middleware and runtime-owned defaults.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [x] `agent`
- [ ] `llm`
- [x] `openomni`
- [ ] `coordinator`
- [x] `server`

## Verification

- [x] `git diff --check`
- [x] Changed-files Biome check
- [x] `bun run check-types`
- [x] `bun run build`
- [x] `bun run script/check-deps.ts` (passes with pre-existing stale `packages/llm/AGENTS.md` notice)
- [x] Targeted policy/runtime tests: 89 pass
- [x] Broader agent/openomni/server policy ownership tests: 519 pass, 10 skip

## Review Evidence

- External review: APPROVE
- Code review lane: APPROVE
- Architecture review lane: CLEAR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes policy middleware caller-owned. Moves built-in policy assembly out of `ChatAgent` and into `openomni` runtime builders while preserving worker, resident, and subagent behavior.

- **Refactors**
  - `ChatAgent` now registers only caller `middleware`; stops auto-adding budget, tool-permission, and compaction policies. Logs deprecation warnings when `permissions` or `compaction` are set.
  - `openomni` adds runtime-owned assembly via `buildWorkerMiddleware` and `buildAgentLifecycleMiddleware`:
    - Assembles budget reassurance/warning, tool-permission (fail-closed), optional compaction, and idle-nudge.
    - Honors `Policy.PolicyPlan`, avoids duplicates, and supports `includeLifecycle`/`includeIdle`.
    - Hydrates `eventEmitter` and `source` into tool-permission config for observability.
  - Resident and subagent runtimes route through explicit middleware. Child runs inherit lifecycle defaults and permission guard without legacy fields.
  - Docs/tests updated to `middleware` terminology; `@openomni/agent` now exports `createCompactionPolicy`.

- **Migration**
  - If you construct `ChatAgent` directly, replace deprecated `permissions`/`compaction` with `middleware: [createToolPermissionPolicy(...), createCompactionPolicy(...)]`. The fields are ignored and emit warnings.
  - Using `openomni` builders requires no changes for defaults. If you own a custom `PolicyPlan`, include any required built-ins (`builtin:tool-permission`, `builtin:budget-*`, `builtin:compaction`, `builtin:idle-nudge`) explicitly.

<sup>Written for commit eefe76bc42706ef6c63e5ae32ddd0548c2c292fe. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural decision records and guidelines to reflect middleware-first policy configuration approach.
  * Clarified that runtime builders now assemble default policies (tool permission, budget, compaction, idle nudge) via middleware.

* **Deprecations**
  * Marked `permissions` and `compaction` configuration fields as deprecated; runtime builders should supply these via middleware instead.

* **API Changes**
  * Exported `createCompactionPolicy` factory for runtime builder integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->