### PR TITLE
refactor(openomni,server): isolate subagent admission policy

### DIFF
--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -20,6 +20,18 @@ import { buildWorkerInputMessages, createExecutionToolContext } from "./worker-r
 
 const WORKER_TOOL_CALL_IPC_TIMEOUT_MS = 5 * 60_000;
 
+function buildDelegationAdmissionMiddleware(
+  request: Execution.Request,
+): ReturnType<typeof buildWorkerMiddleware> | undefined {
+  if (!request.policyPlan) return undefined;
+  return buildWorkerMiddleware({
+    permissions: request.permissions,
+    policyPlan: request.policyPlan,
+    includeLifecycle: false,
+    includeIdle: false,
+  }).map((registration) => ({ ...registration, propagate: true }));
+}
+
 function createToolCallAbortError(): Error {
   const error = new Error("Tool call aborted");
   error.name = "AbortError";
@@ -227,7 +239,6 @@ export namespace WorkerRunner {
           allowAuthFallback: false,
           parentSessionId: sessionId,
           parentPermissions: request.permissions,
-          parentPolicyPlan: request.policyPlan,
         };
         const scopedBackgroundManager: ReturnType<typeof BackgroundManager.create> = {
           launch(input: Parameters<typeof backgroundManager.launch>[0]) {
@@ -257,6 +268,7 @@ export namespace WorkerRunner {
 
         const agentProvider = new AgentToolProvider({
           subagentRuntime: createWorkerSubagentRuntime(workerSubagentConfig),
+          middleware: buildDelegationAdmissionMiddleware(request),
           delegationContext: {
             depth: 0,
             maxDepth: 3,

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -315,6 +315,112 @@ describe("WorkerRunner", () => {
     }
   });
 
+  it("applies parent policy plans as delegation admission middleware", async () => {
+    const responses: unknown[] = [];
+    let subagentResult: Tool.Result | undefined;
+    const bootstrap: WorkerBootstrap.Bootstrap = {
+      configEpoch: "epoch-1",
+      toolCatalog: [],
+      agents: [
+        {
+          name: "child",
+          description: "child",
+          model: { provider: "test", id: "child" },
+          tools: { all: true },
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: { permission: { action: "tool.call", allowlist: ["read"] } },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+      ],
+    };
+    AgentRegistry.define({
+      name: "child",
+      description: "child",
+      model: { provider: "test", id: "child" },
+    });
+    const responseReceived = new Promise<void>((resolve) => {
+      const options = createSpawnOptions(
+        {
+          ...createValidRequest(),
+          tools: [{ name: "subagent", inputSchema: {} }],
+          policyPlan: {
+            policies: [
+              {
+                id: "builtin:tool-permission",
+                required: true,
+                config: {
+                  permission: {
+                    action: "tool.call",
+                    inputRules: [
+                      {
+                        toolPattern: "subagent",
+                        field: "childRuntimeMiddlewareNames",
+                        pattern: "builtin:tool-permission",
+                        action: "deny",
+                        reason: "child runtime policy requires admission review",
+                        priority: 1,
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+            labels: ["security"],
+          },
+        },
+        (result) => {
+          responses.push(result);
+          resolve();
+        },
+        {
+          getBootstrap: () => bootstrap,
+          server: {
+            async call() {
+              throw new Error("unexpected server call");
+            },
+            notify() {
+              // lifecycle notification
+            },
+          },
+          createAgent: (options) => ({
+            async run() {
+              if (!options.toolExecutor) throw new Error("tool executor missing");
+              subagentResult = await options.toolExecutor({
+                id: "agent-tool-call",
+                tool: "subagent",
+                input: { agentName: "child", prompt: "delegate" },
+              });
+              return successfulResult;
+            },
+          }),
+        },
+      );
+
+      WorkerRunner.spawnRun(options);
+    });
+
+    try {
+      await responseReceived;
+
+      expect(responses[0]).toMatchObject({ status: "succeeded" });
+      expect(subagentResult).toMatchObject({
+        id: expect.any(String),
+        toolCallId: expect.any(String),
+        isError: true,
+        output: "child runtime policy requires admission review",
+      });
+    } finally {
+      AgentRegistry.clear();
+    }
+  });
+
   it("enriches background subagent launches with child runtime policy config", async () => {
     const responses: unknown[] = [];
     const notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -20,6 +20,7 @@ export interface WorkerMiddlewareConfig {
 }
 
 const FAIL_CLOSED_TOOL_PERMISSION: Policy.Permission = { action: "tool.call", denylist: ["*"] };
+const DEFAULT_TOOL_PERMISSION: Policy.Permission = { action: "tool.call" };
 
 export function buildWorkerMiddleware(config: WorkerMiddlewareConfig): PolicyRegistration[] {
   const policyPlanMiddleware = config.policyPlan
@@ -69,7 +70,7 @@ export function registrationsAbsentFrom(
 function buildLegacyPermissionMiddleware(config: WorkerMiddlewareConfig): PolicyRegistration[] {
   return [
     createToolPermissionPolicy({
-      permission: config.permissions ?? { action: "tool.call" },
+      permission: config.permissions ?? DEFAULT_TOOL_PERMISSION,
       ...(config.eventEmitter !== undefined && { eventEmitter: config.eventEmitter }),
       source: config.source ?? "stream-engine",
     }),
@@ -81,11 +82,32 @@ function resolvePoliciesFromPlan(plan: Policy.PolicyPlan): PolicyRegistration[] 
   return registry.resolve(plan, {});
 }
 
+export function resolvePolicyPlanToolPermission(
+  plan: Policy.PolicyPlan | undefined,
+  fallbackPermission: Policy.Permission | undefined,
+): Policy.Permission | undefined {
+  if (!plan) return fallbackPermission;
+  const toolPermissionPolicy = plan.policies.find(
+    (policy) => policy.id === "builtin:tool-permission",
+  );
+  if (!toolPermissionPolicy) return undefined;
+  return resolveToolPermissionConfig(toolPermissionPolicy.config ?? {}, fallbackPermission);
+}
+
+function resolveToolPermissionConfig(
+  config: Record<string, unknown>,
+  fallbackPermission: Policy.Permission | undefined,
+): Policy.Permission {
+  if (!("permission" in config)) return fallbackPermission ?? DEFAULT_TOOL_PERMISSION;
+  const parsed = Policy.Permission.safeParse(config.permission);
+  return parsed.success ? parsed.data : FAIL_CLOSED_TOOL_PERMISSION;
+}
+
 function hydrateToolPermissionConfig(
   plan: Policy.PolicyPlan,
   workerConfig: WorkerMiddlewareConfig,
 ): Policy.PolicyPlan {
-  const fallbackPermission = workerConfig.permissions ?? { action: "tool.call" };
+  const fallbackPermission = workerConfig.permissions ?? DEFAULT_TOOL_PERMISSION;
   let changed = false;
   const policies = plan.policies.map((policy) => {
     if (policy.id !== "builtin:tool-permission") return policy;
@@ -95,19 +117,15 @@ function hydrateToolPermissionConfig(
     // Keep legacy permissions effective for policy plans that select the
     // builtin guard without owning its config yet.
     // A present-but-invalid permission is treated as explicit and fails closed.
-    if (!("permission" in hydratedConfig)) {
+    if ("permission" in hydratedConfig) {
+      if (Policy.Permission.safeParse(hydratedConfig.permission).success) {
+        return hydratedConfig === config ? policy : { ...policy, config: hydratedConfig };
+      }
       changed = true;
       return {
         ...policy,
-        config: {
-          ...hydratedConfig,
-          permission: fallbackPermission,
-        },
+        config: { ...hydratedConfig, permission: FAIL_CLOSED_TOOL_PERMISSION },
       };
-    }
-
-    if (Policy.Permission.safeParse(hydratedConfig.permission).success) {
-      return hydratedConfig === config ? policy : { ...policy, config: hydratedConfig };
     }
 
     changed = true;
@@ -115,7 +133,7 @@ function hydrateToolPermissionConfig(
       ...policy,
       config: {
         ...hydratedConfig,
-        permission: FAIL_CLOSED_TOOL_PERMISSION,
+        permission: fallbackPermission,
       },
     };
   });

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
@@ -43,7 +43,6 @@ function makeRuntime(
   options: {
     child?: Partial<WorkerBootstrap.RuntimeAgentDefinition>;
     parentPermissions?: WorkerBootstrap.RuntimeAgentDefinition["permissions"];
-    parentPolicyPlan?: WorkerBootstrap.RuntimeAgentDefinition["policyPlan"];
   } = {},
 ) {
   const readTool = makeTool("read");
@@ -75,7 +74,6 @@ function makeRuntime(
     catalogRef: { catalog },
     agentDefinitionsRef: { definitions },
     parentPermissions: options.parentPermissions,
-    parentPolicyPlan: options.parentPolicyPlan,
     resolveAuth: (provider) =>
       provider === "anthropic"
         ? { type: "proxy", baseURL: "http://localhost:8317/v1", apiKey: "proxy" }
@@ -249,20 +247,23 @@ describe("createWorkerSubagentRuntime", () => {
     });
   });
 
-  test("spawn keeps parent policy plans constraining child policy plans", async () => {
+  test("spawn keeps admission middleware separate from child policy plan middleware", async () => {
+    const admissionMiddleware: PolicyRegistration[] = [
+      {
+        name: "parent:admission-only",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: () => ({
+          policyId: "parent:admission-only",
+          verdict: "allow",
+          reasonCodes: [],
+          effects: [],
+        }),
+      },
+    ];
     const runtime = makeRuntime(
       { all: true },
       {
-        parentPolicyPlan: {
-          policies: [
-            {
-              id: "builtin:tool-permission",
-              required: true,
-              config: { permission: { action: "tool.call", allowlist: ["read"] } },
-            },
-          ],
-          labels: ["security"],
-        },
         child: {
           policyPlan: {
             policies: [
@@ -289,95 +290,20 @@ describe("createWorkerSubagentRuntime", () => {
       title: "child task",
       prompt: "run",
       model: { provider: "test", id: "model" },
+      middleware: admissionMiddleware,
     });
 
-    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
-    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
-    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
-      verdict: "deny",
-    });
-    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
-      verdict: "deny",
-    });
-  });
-
-  test("spawn keeps parent policy plans constraining legacy child agents", async () => {
-    const runtime = makeRuntime(
-      { all: true },
-      {
-        parentPolicyPlan: {
-          policies: [
-            {
-              id: "builtin:tool-permission",
-              required: true,
-              config: { permission: { action: "tool.call", allowlist: ["read"] } },
-            },
-          ],
-          labels: ["security"],
-        },
-      },
+    expect(spawnSpy.mock.calls[0]?.[0].middleware).toBe(admissionMiddleware);
+    const childMiddleware = spawnSpy.mock.calls[0]?.[0].childMiddleware as
+      | PolicyRegistration[]
+      | undefined;
+    expect(childMiddleware?.map((registration) => registration.name)).not.toContain(
+      "parent:admission-only",
     );
-    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
-      sessionId: "child-session",
-      runId: "child-run",
-      output: "done",
-      finishReason: "stop",
-    });
-
-    await runtime.spawn({
-      agentName: "child",
-      title: "child task",
-      prompt: "run",
-      model: { provider: "test", id: "model" },
-    });
-
-    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
-    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
-    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
-      verdict: "allow",
-    });
-    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+    await expect(evaluateTool(childMiddleware, "read")).resolves.toMatchObject({
       verdict: "deny",
     });
-  });
-
-  test("spawn lets parent policy plans own legacy parent permission hydration", async () => {
-    const runtime = makeRuntime(
-      { all: true },
-      {
-        parentPermissions: { action: "tool.call", allowlist: ["read"] },
-        parentPolicyPlan: {
-          policies: [
-            {
-              id: "builtin:tool-permission",
-              required: true,
-              config: { permission: { action: "tool.call", allowlist: ["bash"] } },
-            },
-          ],
-          labels: ["security"],
-        },
-      },
-    );
-    spawnSpy = spyOn(SubagentRuntime, "spawn").mockResolvedValue({
-      sessionId: "child-session",
-      runId: "child-run",
-      output: "done",
-      finishReason: "stop",
-    });
-
-    await runtime.spawn({
-      agentName: "child",
-      title: "child task",
-      prompt: "run",
-      model: { provider: "test", id: "model" },
-    });
-
-    const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
-    expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
-    await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
-      verdict: "deny",
-    });
-    await expect(evaluateTool(middleware, "bash")).resolves.toMatchObject({
+    await expect(evaluateTool(childMiddleware, "bash")).resolves.toMatchObject({
       verdict: "allow",
     });
   });

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
@@ -195,6 +195,10 @@ describe("createWorkerSubagentRuntime", () => {
     expect(spawnSpy.mock.calls[0]?.[0].middleware).toBeUndefined();
     const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
     expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    expect(spawnSpy.mock.calls[0]?.[0].admissionPermissions).toEqual({
+      action: "tool.call",
+      allowlist: ["read"],
+    });
     await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
       verdict: "allow",
     });
@@ -239,6 +243,16 @@ describe("createWorkerSubagentRuntime", () => {
     expect(spawnSpy.mock.calls[0]?.[0].middleware).toBeUndefined();
     const middleware = spawnSpy.mock.calls[0]?.[0].childMiddleware;
     expect(spawnSpy.mock.calls[0]?.[0].permissions).toBeUndefined();
+    expect(spawnSpy.mock.calls[0]?.[0].admissionPermissions).toEqual({
+      action: "tool.call",
+      allowlist: [],
+      denylist: [],
+      denyLabels: [],
+      allowLabels: undefined,
+      requireApproval: [],
+      requireApprovalLabels: [],
+      inputRules: [],
+    });
     await expect(evaluateTool(middleware, "read")).resolves.toMatchObject({
       verdict: "deny",
     });

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -1,10 +1,10 @@
 import { ChatAgent, createToolPermissionPolicy } from "@openomni/agent";
 import type { SubagentToolOptions, ChatAgentConfig } from "@openomni/agent";
-import { Subagent } from "@openomni/protocol";
-import type { Policy, WorkerBootstrap } from "@openomni/protocol";
+import { type Policy, Subagent } from "@openomni/protocol";
+import type { WorkerBootstrap } from "@openomni/protocol";
 import { Session } from "@openomni/session";
 import { SubagentRuntime } from "../../../../subagent/runtime.js";
-import { buildWorkerMiddleware } from "../../../middleware.js";
+import { buildWorkerMiddleware, resolvePolicyPlanToolPermission } from "../../../middleware.js";
 import { resolveToolSelection } from "../../catalog.js";
 import type { CatalogEntry } from "../../catalog.js";
 
@@ -102,6 +102,7 @@ export type WorkerChildRuntimeConfig = {
   toolExecutor: ChatAgentConfig["toolExecutor"];
   systemPrompt?: string;
   permissions?: Policy.Permission;
+  admissionPermissions?: Policy.Permission;
   middleware: ChatAgentConfig["middleware"];
   childMiddleware: ChatAgentConfig["middleware"];
 };
@@ -181,15 +182,22 @@ export function buildWorkerChildRuntimeConfig(
 ): WorkerChildRuntimeConfig {
   const childDefinition = input.childDefinition ?? resolveChildDefinition(cfg, input.agentName);
   const childPermissions = childDefinition?.permissions;
-  const permissions = childDefinition?.policyPlan
-    ? undefined
-    : intersectPermissions(cfg.parentPermissions, childPermissions);
+  const childPolicyPlanPermissions = resolvePolicyPlanToolPermission(
+    childDefinition?.policyPlan,
+    childPermissions,
+  );
+  const effectivePermissions = intersectPermissions(
+    cfg.parentPermissions,
+    childDefinition?.policyPlan ? childPolicyPlanPermissions : childPermissions,
+  );
+  const permissions = childDefinition?.policyPlan ? undefined : effectivePermissions;
   return {
     ...(childDefinition ? { childDefinition } : {}),
     tools: resolveChildTools(cfg, childDefinition, input.depth),
     toolExecutor: cfg.toolsRef.toolExecutor,
     systemPrompt: childDefinition?.systemPrompt,
     permissions,
+    admissionPermissions: effectivePermissions,
     middleware: input.middleware,
     childMiddleware: buildChildRuntimeMiddleware(
       childDefinition,
@@ -222,6 +230,7 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         toolExecutor: childRuntime.toolExecutor,
         parentSessionId: cfg.parentSessionId,
         permissions: childRuntime.permissions,
+        admissionPermissions: childRuntime.admissionPermissions,
         middleware: childRuntime.middleware,
         childMiddleware: childRuntime.childMiddleware,
         signal: config.signal,
@@ -251,6 +260,7 @@ export function createWorkerSubagentRuntime(cfg: WorkerRuntimeConfig): SubagentR
         tools: childRuntime.tools,
         toolExecutor: childRuntime.toolExecutor,
         permissions: childRuntime.permissions,
+        admissionPermissions: childRuntime.admissionPermissions,
         middleware: childRuntime.middleware,
         childMiddleware: childRuntime.childMiddleware,
         signal: config.signal,

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -89,7 +89,6 @@ export type WorkerRuntimeConfig = {
   toolsRef: { tools?: ChatAgentConfig["tools"]; toolExecutor?: ChatAgentConfig["toolExecutor"] };
   parentSessionId: string;
   parentPermissions?: Policy.Permission;
-  parentPolicyPlan?: Policy.PolicyPlan;
   // Lazily resolved alongside toolsRef — used to compute depth-filtered child tool sets.
   catalogRef?: { catalog?: CatalogEntry[] };
   agentDefinitionsRef?: { definitions?: Map<string, RuntimeAgentDefinition> };
@@ -149,26 +148,13 @@ function resolveChildTools(
 function buildChildRuntimeMiddleware(
   childDefinition: RuntimeAgentDefinition | undefined,
   childPermissions: Policy.Permission | undefined,
-  parentPolicyPlan: Policy.PolicyPlan | undefined,
   parentPermissions: Policy.Permission | undefined,
 ): ChatAgentConfig["middleware"] {
   const middleware: ChatAgentConfig["middleware"] = [];
-  if (parentPolicyPlan) {
-    // Ancestor policy plans are runtime constraints for descendants, not
-    // delegation-admission guards for the spawn/send operation itself.
-    middleware.push(
-      ...buildWorkerMiddleware({
-        policyPlan: parentPolicyPlan,
-        // Used only when the parent plan selected the builtin guard without
-        // owning config yet; explicit parent plan config still wins.
-        permissions: parentPermissions,
-        includeLifecycle: false,
-        includeIdle: false,
-      }),
-    );
-  } else if (parentPermissions && childDefinition?.policyPlan) {
-    // Parent legacy permissions remain an ancestor runtime guard even when the
-    // child plan owns the child-scoped permission config.
+  if (parentPermissions && childDefinition?.policyPlan) {
+    // Legacy parent permissions remain an ancestor runtime guard even when the
+    // child plan owns the child-scoped permission config. Parent policy plans
+    // stay parent-scoped and are not copied into child runtime middleware.
     middleware.push(createToolPermissionPolicy({ permission: parentPermissions }));
   }
   if (childDefinition?.policyPlan) {
@@ -197,12 +183,7 @@ export function buildWorkerChildRuntimeConfig(
   const childPermissions = childDefinition?.permissions;
   const permissions = childDefinition?.policyPlan
     ? undefined
-    : cfg.parentPolicyPlan
-      ? // Parent legacy permissions are only a hydration fallback for parent
-        // policy plans; do not stack them as a separate child runtime guard.
-        // Child legacy permissions remain child-owned runtime config.
-        childPermissions
-      : intersectPermissions(cfg.parentPermissions, childPermissions);
+    : intersectPermissions(cfg.parentPermissions, childPermissions);
   return {
     ...(childDefinition ? { childDefinition } : {}),
     tools: resolveChildTools(cfg, childDefinition, input.depth),
@@ -213,7 +194,6 @@ export function buildWorkerChildRuntimeConfig(
     childMiddleware: buildChildRuntimeMiddleware(
       childDefinition,
       childPermissions,
-      cfg.parentPolicyPlan,
       cfg.parentPermissions,
     ),
   };

--- a/packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts
@@ -279,12 +279,24 @@ export namespace SubagentSpawnPolicyMiddleware {
     };
   }
 
+  export interface ChildRuntimeMiddlewareInput {
+    readonly middleware?: PolicyRegistration[];
+    readonly hasExplicitRuntimePolicy: boolean;
+  }
+
+  export function buildChildRuntimeMiddleware(
+    input: ChildRuntimeMiddlewareInput,
+  ): PolicyRegistration[] {
+    return childMiddleware(input.middleware, input.hasExplicitRuntimePolicy) ?? [];
+  }
+
   export function childMiddleware(
     middleware: PolicyRegistration[] | undefined,
-    hasExplicitPermissions: boolean,
+    hasExplicitRuntimePolicy: boolean,
   ): PolicyRegistration[] | undefined {
-    if (hasExplicitPermissions) return middleware;
-    return [createDefaultDenylist(), ...(middleware ?? [])];
+    const childMiddleware = middleware === undefined ? undefined : [...middleware];
+    if (hasExplicitRuntimePolicy) return childMiddleware;
+    return [createDefaultDenylist(), ...(childMiddleware ?? [])];
   }
 
   export function registrations(state: PreSpawnState): PolicyRegistration[] {

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -50,6 +50,51 @@ type ResourcePolicyContext = Omit<PolicyContext, "timing"> & {
 
 type PreDelegationOperation = "spawn" | "spawn_background" | "send";
 
+interface ChildRuntimeAdmissionSummary {
+  readonly toolNames?: string[];
+  readonly permissions?: Policy.Permission;
+  readonly childRuntimeMiddlewareNames?: string[];
+  readonly hasExplicitRuntimePolicy: boolean;
+}
+
+function summarizeChildRuntimeAdmission(
+  config: RuntimeConfig & { permissions?: Policy.Permission },
+): ChildRuntimeAdmissionSummary | undefined {
+  const toolNames = config.tools?.map((tool) => tool.name);
+  const childRuntimeMiddlewareNames = config.childMiddleware?.map(
+    (registration) => registration.name,
+  );
+  if (
+    toolNames === undefined &&
+    config.permissions === undefined &&
+    childRuntimeMiddlewareNames === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(toolNames !== undefined && { toolNames }),
+    ...(config.permissions !== undefined && { permissions: config.permissions }),
+    ...(childRuntimeMiddlewareNames !== undefined && { childRuntimeMiddlewareNames }),
+    hasExplicitRuntimePolicy:
+      config.permissions !== undefined || config.childMiddleware !== undefined,
+  };
+}
+
+function childRuntimeAdmissionFields(
+  summary: ChildRuntimeAdmissionSummary | undefined,
+): Record<string, unknown> {
+  if (summary === undefined) return {};
+  return {
+    childRuntime: summary,
+    ...(summary.toolNames !== undefined && { childToolNames: summary.toolNames.join(",") }),
+    ...(summary.childRuntimeMiddlewareNames !== undefined && {
+      childRuntimeMiddlewareNames: summary.childRuntimeMiddlewareNames.join(","),
+    }),
+    childHasExplicitRuntimePolicy: String(summary.hasExplicitRuntimePolicy),
+  };
+}
+
 function createDelegationTrace(parentSessionId: string | undefined) {
   if (parentSessionId === undefined) return undefined;
   return { traceId: crypto.randomUUID(), sessionId: parentSessionId };
@@ -97,6 +142,7 @@ async function dispatchPreDelegation(input: {
   parentSessionId?: string;
   operation: PreDelegationOperation;
   prompt: string;
+  childRuntime?: ChildRuntimeAdmissionSummary;
 }): Promise<Policy.PolicyDecision> {
   if (!input.middleware?.length) {
     return PolicyDecision.allow({
@@ -136,6 +182,7 @@ async function dispatchPreDelegation(input: {
       childAgent: input.childAgent,
       prompt: input.prompt,
       ...(input.parentSessionId !== undefined && { parentSessionId: input.parentSessionId }),
+      ...childRuntimeAdmissionFields(input.childRuntime),
     },
     labels: [
       { value: `actor.child:${input.childAgent}`, source: "system" as const },
@@ -184,21 +231,21 @@ function applyPreDelegationDecision(
 }
 
 function buildChildRunMiddleware(config: RuntimeConfig & { permissions?: Policy.Permission }) {
-  // Used by spawn/send/resume for the child run itself. Admission still reads
-  // config.middleware before this helper, so childMiddleware never participates
-  // in the parent-scoped delegation decision.
-  const inheritedMiddleware = SubagentSpawnPolicyMiddleware.childMiddleware(
-    config.childMiddleware ?? config.middleware,
-    config.permissions !== undefined || config.childMiddleware !== undefined,
-  );
-  const inherited = inheritedMiddleware ?? [];
+  // Used by spawn/send/resume for the child run itself. Delegation admission
+  // reads config.middleware separately when applicable, so parent-scoped
+  // policies are not reused as child runtime policies.
+  const childRuntimeMiddleware = SubagentSpawnPolicyMiddleware.buildChildRuntimeMiddleware({
+    middleware: config.childMiddleware,
+    hasExplicitRuntimePolicy:
+      config.permissions !== undefined || config.childMiddleware !== undefined,
+  });
   return [
-    ...registrationsAbsentFrom(buildAgentLifecycleMiddleware(undefined), inherited),
+    ...registrationsAbsentFrom(buildAgentLifecycleMiddleware(undefined), childRuntimeMiddleware),
     // Subagent run middleware preserves the prior child-run defaults:
     // budget lifecycle + permission constraints only. Send transcript compaction
     // is handled separately before resume; idle nudge is worker-runtime owned.
     ...(config.permissions ? [createToolPermissionPolicy({ permission: config.permissions })] : []),
-    ...inherited,
+    ...childRuntimeMiddleware,
   ];
 }
 
@@ -277,6 +324,7 @@ export namespace SubagentRuntime {
       parentSessionId: config.parentSessionId,
       operation: "spawn",
       prompt: config.prompt,
+      childRuntime: summarizeChildRuntimeAdmission(config),
     });
     applyPreDelegationDecision(config, decision, "invoke.prepare policy aborted spawn");
 
@@ -315,6 +363,7 @@ export namespace SubagentRuntime {
       parentSessionId: config.parentSessionId,
       operation: "spawn_background",
       prompt: config.prompt,
+      childRuntime: summarizeChildRuntimeAdmission(config),
     });
     applyPreDelegationDecision(config, decision, "invoke.prepare policy aborted background spawn");
 
@@ -358,6 +407,7 @@ export namespace SubagentRuntime {
       parentSessionId: childSession?.parentSessionId,
       operation: "send",
       prompt: config.prompt,
+      childRuntime: summarizeChildRuntimeAdmission(config),
     });
     applyPreDelegationDecision(config, sendDecision, "invoke.prepare policy aborted send");
 

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -57,16 +57,21 @@ interface ChildRuntimeAdmissionSummary {
   readonly hasExplicitRuntimePolicy: boolean;
 }
 
+function hasExplicitRuntimePolicy(config: RuntimeConfig & { permissions?: Policy.Permission }) {
+  return config.permissions !== undefined || config.childMiddleware !== undefined;
+}
+
 function summarizeChildRuntimeAdmission(
   config: RuntimeConfig & { permissions?: Policy.Permission },
 ): ChildRuntimeAdmissionSummary | undefined {
   const toolNames = config.tools?.map((tool) => tool.name);
+  const permissions = config.admissionPermissions ?? config.permissions;
   const childRuntimeMiddlewareNames = config.childMiddleware?.map(
     (registration) => registration.name,
   );
   if (
     toolNames === undefined &&
-    config.permissions === undefined &&
+    permissions === undefined &&
     childRuntimeMiddlewareNames === undefined
   ) {
     return undefined;
@@ -74,10 +79,9 @@ function summarizeChildRuntimeAdmission(
 
   return {
     ...(toolNames !== undefined && { toolNames }),
-    ...(config.permissions !== undefined && { permissions: config.permissions }),
+    ...(permissions !== undefined && { permissions }),
     ...(childRuntimeMiddlewareNames !== undefined && { childRuntimeMiddlewareNames }),
-    hasExplicitRuntimePolicy:
-      config.permissions !== undefined || config.childMiddleware !== undefined,
+    hasExplicitRuntimePolicy: hasExplicitRuntimePolicy(config),
   };
 }
 
@@ -230,14 +234,16 @@ function applyPreDelegationDecision(
   applyDelegationConstraints(config, decision);
 }
 
-function buildChildRunMiddleware(config: RuntimeConfig & { permissions?: Policy.Permission }) {
+function buildChildRunMiddleware(
+  config: RuntimeConfig & { permissions?: Policy.Permission },
+  hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config),
+) {
   // Used by spawn/send/resume for the child run itself. Delegation admission
   // reads config.middleware separately when applicable, so parent-scoped
   // policies are not reused as child runtime policies.
   const childRuntimeMiddleware = SubagentSpawnPolicyMiddleware.buildChildRuntimeMiddleware({
     middleware: config.childMiddleware,
-    hasExplicitRuntimePolicy:
-      config.permissions !== undefined || config.childMiddleware !== undefined,
+    hasExplicitRuntimePolicy: hasExplicitChildRuntimePolicy,
   });
   return [
     ...registrationsAbsentFrom(buildAgentLifecycleMiddleware(undefined), childRuntimeMiddleware),
@@ -318,6 +324,7 @@ export namespace SubagentRuntime {
   }
 
   export async function spawn(config: SpawnConfig): Promise<RunResult> {
+    const hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config);
     const decision = await dispatchPreDelegation({
       middleware: config.middleware,
       childAgent: config.agentName,
@@ -347,7 +354,7 @@ export namespace SubagentRuntime {
       );
       await WorkerRun.updateStatus(session.id, runId, "starting");
       await WorkerRun.updateStatus(session.id, runId, "running");
-      const middleware = buildChildRunMiddleware(config);
+      const middleware = buildChildRunMiddleware(config, hasExplicitChildRuntimePolicy);
       const runConfig = { ...config, middleware };
       const result = await executeRun(session.id, runId, config.model, timers, () =>
         runWithTranscript(session.id, runConfig, signal),
@@ -357,6 +364,7 @@ export namespace SubagentRuntime {
   }
 
   export async function spawnBackground(config: SpawnConfig): Promise<SpawnBackgroundResult> {
+    const hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config);
     const decision = await dispatchPreDelegation({
       middleware: config.middleware,
       childAgent: config.agentName,
@@ -382,7 +390,7 @@ export namespace SubagentRuntime {
     await WorkerRun.updateStatus(session.id, runId, "starting");
     await WorkerRun.updateStatus(session.id, runId, "running");
 
-    const middleware = buildChildRunMiddleware(config);
+    const middleware = buildChildRunMiddleware(config, hasExplicitChildRuntimePolicy);
     const runConfig = { ...config, middleware };
     const backgroundRun = sendToMailbox(session.id, () =>
       executeRun(session.id, runId, config.model, timers, () =>
@@ -397,6 +405,7 @@ export namespace SubagentRuntime {
   }
 
   export async function send(config: SendConfig): Promise<RunResult> {
+    const hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config);
     const childMeta = Session.getWorkerMeta(config.sessionId);
     const childAgent =
       typeof childMeta?.agentName === "string" ? childMeta.agentName : config.sessionId;
@@ -436,7 +445,7 @@ export namespace SubagentRuntime {
       await WorkerRun.updateStatus(session.id, runId, "starting");
       await WorkerRun.updateStatus(session.id, runId, "running");
 
-      const middleware = buildChildRunMiddleware(config);
+      const middleware = buildChildRunMiddleware(config, hasExplicitChildRuntimePolicy);
       const runConfig = { ...config, middleware };
       const messages = await maybeCompactSendTranscript(
         session.id,

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -23,6 +23,8 @@ export type RuntimeConfig = {
   middleware?: PolicyRegistration[];
   /** Child-run middleware assembled from explicit child context only. */
   childMiddleware?: PolicyRegistration[];
+  /** Effective child authority exposed to parent-scoped delegation admission only. */
+  admissionPermissions?: ChatAgentConfig["permissions"];
 };
 
 export type SendCompactionConfig = {

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -19,7 +19,9 @@ export type RuntimeConfig = {
   tools?: ChatAgentConfig["tools"];
   toolExecutor?: ChatAgentConfig["toolExecutor"];
   budget?: ChatAgentConfig["budget"];
+  /** Parent-scoped delegation/admission middleware; never reused for child runs. */
   middleware?: PolicyRegistration[];
+  /** Child-run middleware assembled from explicit child context only. */
   childMiddleware?: PolicyRegistration[];
 };
 

--- a/packages/openomni/test/policy/middleware-integration.test.ts
+++ b/packages/openomni/test/policy/middleware-integration.test.ts
@@ -584,7 +584,7 @@ describe("SubagentSpawnPolicyMiddleware integration", () => {
     expect(names).toContain("subagent:wait-timeout");
   });
 
-  test("childMiddleware prepends default denylist when no explicit permissions", () => {
+  test("childMiddleware prepends default denylist when no explicit runtime policy exists", () => {
     const existing: PolicyRegistration[] = [
       {
         name: "custom-policy",
@@ -602,7 +602,7 @@ describe("SubagentSpawnPolicyMiddleware integration", () => {
     expect(result?.[1].name).toBe("custom-policy");
   });
 
-  test("childMiddleware passes through when explicit permissions exist", () => {
+  test("childMiddleware copies explicit child runtime middleware", () => {
     const existing: PolicyRegistration[] = [
       {
         name: "custom-policy",
@@ -615,7 +615,35 @@ describe("SubagentSpawnPolicyMiddleware integration", () => {
 
     const result = SubagentSpawnPolicyMiddleware.childMiddleware(existing, true);
 
-    expect(result).toBe(existing);
+    expect(result).toEqual(existing);
+    expect(result).not.toBe(existing);
+
+    existing.push({
+      name: "late-policy",
+      timing: "invoke.prepare",
+      priority: 1,
+      failPolicy: "fail-open",
+      fn: () => PolicyDecision.allow({ policyId: "late-policy" }),
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  test("buildChildRuntimeMiddleware treats explicit empty child policy as an opt-out", () => {
+    const result = SubagentSpawnPolicyMiddleware.buildChildRuntimeMiddleware({
+      middleware: [],
+      hasExplicitRuntimePolicy: true,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("buildChildRuntimeMiddleware creates default child guard without child policy", () => {
+    const result = SubagentSpawnPolicyMiddleware.buildChildRuntimeMiddleware({
+      hasExplicitRuntimePolicy: false,
+    });
+
+    expect(result.map((registration) => registration.name)).toEqual(["subagent:default-denylist"]);
   });
 
   test("evaluatePreSpawn full pipeline for send on existing session", async () => {

--- a/packages/openomni/test/subagent/runtime.test.ts
+++ b/packages/openomni/test/subagent/runtime.test.ts
@@ -426,6 +426,33 @@ describe("SubagentRuntime", () => {
       expect(result.output).toBe("child runtime output");
     });
 
+    it("does not reuse admission middleware as child runtime middleware", async () => {
+      queueResult("child runtime output");
+
+      const admissionOnlyPolicy: PolicyRegistration = {
+        name: "test:admission-only",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: () => PolicyDecision.allow({ policyId: "test:admission-only" }),
+      };
+
+      await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "admission-only policy",
+        prompt: "do work",
+        model,
+        middleware: [admissionOnlyPolicy],
+      });
+
+      const childRuntimeMiddleware = createSpy.mock.calls[0]?.[0].middleware ?? [];
+      expect(childRuntimeMiddleware.map((registration) => registration.name)).toContain(
+        "subagent:default-denylist",
+      );
+      expect(childRuntimeMiddleware.map((registration) => registration.name)).not.toContain(
+        "test:admission-only",
+      );
+    });
+
     it("spawn applies transform constraints from invoke.prepare verdict", async () => {
       queueResult("transformed output");
 
@@ -497,6 +524,53 @@ describe("SubagentRuntime", () => {
         { value: "actor.child:child-agent", source: "system" },
         { value: `actor.parent:${parentSessionId}`, source: "system" },
       ]);
+    });
+
+    it("invoke.prepare exposes child runtime authority summary for admission policy", async () => {
+      queueResult("admission summary output");
+
+      let capturedToolInput: unknown;
+      const capturePolicy: PolicyRegistration = {
+        name: "test:capture-child-runtime",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: (ctx) => {
+          capturedToolInput = ctx.toolInput;
+          return PolicyDecision.allow({ policyId: "test:capture-child-runtime" });
+        },
+      };
+      const childRuntimePolicy: PolicyRegistration = {
+        name: "child:runtime-policy",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: () => PolicyDecision.allow({ policyId: "child:runtime-policy" }),
+      };
+
+      await SubagentRuntime.spawn({
+        agentName: "child-agent",
+        title: "summarized child task",
+        prompt: "test child authority",
+        model,
+        tools: [{ name: "bash", inputSchema: { type: "object", properties: {} } }],
+        permissions: { action: "tool.call", allowlist: ["bash"] },
+        middleware: [capturePolicy],
+        childMiddleware: [childRuntimePolicy],
+      });
+
+      expect(capturedToolInput).toEqual({
+        operation: "spawn",
+        childAgent: "child-agent",
+        prompt: "test child authority",
+        childRuntime: {
+          toolNames: ["bash"],
+          permissions: { action: "tool.call", allowlist: ["bash"] },
+          childRuntimeMiddlewareNames: ["child:runtime-policy"],
+          hasExplicitRuntimePolicy: true,
+        },
+        childToolNames: "bash",
+        childRuntimeMiddlewareNames: "child:runtime-policy",
+        childHasExplicitRuntimePolicy: "true",
+      });
     });
 
     it("emits durable audit events for parent-scoped delegation policy", async () => {

--- a/packages/openomni/test/subagent/runtime.test.ts
+++ b/packages/openomni/test/subagent/runtime.test.ts
@@ -467,7 +467,11 @@ describe("SubagentRuntime", () => {
             effects: [
               {
                 type: "delegation.set_constraints",
-                constraints: { softTimeoutMs: 5000, hardTimeoutMs: 10000 },
+                constraints: {
+                  softTimeoutMs: 5000,
+                  hardTimeoutMs: 10000,
+                  permissions: { action: "tool.call", allowlist: ["read"] },
+                },
               },
             ],
           }),
@@ -486,6 +490,11 @@ describe("SubagentRuntime", () => {
       expect(result.output).toBe("transformed output");
       expect(config.softTimeoutMs).toBe(5000);
       expect(config.hardTimeoutMs).toBe(10000);
+      expect(config.permissions).toEqual({ action: "tool.call", allowlist: ["read"] });
+      const childRuntimeMiddleware = createSpy.mock.calls[0]?.[0].middleware ?? [];
+      expect(childRuntimeMiddleware.map((registration) => registration.name)).toContain(
+        "subagent:default-denylist",
+      );
     });
 
     it("invoke.prepare receives parent/child agent labels", async () => {


### PR DESCRIPTION
## Summary

Keeps subagent child runtime policy assembly independent from parent delegation policy while preserving legacy permission constraints and worker-path admission checks.

Fixes #
Relates to #

## Changes

- Build child-run middleware only from explicit child runtime context, copying registrations instead of sharing arrays.
- Move parent worker `policyPlan` handling to delegation admission middleware so it can approve/deny spawn/send without being copied into child runtime policy.
- Expose child runtime authority summary fields to delegation admission policy (`childRuntime`, tool names, runtime middleware names, explicit-policy flag).
- Preserve legacy parent/child permission intersection for child runs that do not own a child `policyPlan`.
- Add worker, runtime, and middleware tests for parent admission denial, child runtime isolation, explicit empty child-policy opt-out, and child runtime admission fields.

## Type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [ ] `agent`
- [ ] `llm`
- [x] `openomni`
- [ ] `coordinator`
- [x] `server`

## Verification

- [x] `git diff --check`
- [x] Changed-files Biome check
- [x] `bun run check-types`
- [x] `bun run build`
- [x] `bun run script/check-deps.ts` via push hook (passes with pre-existing stale `packages/llm/AGENTS.md` notice)
- [x] Targeted worker/subagent/policy tests: 86 pass
- [x] `packages/openomni/test/subagent/abort-registry.test.ts`: 19 pass

## Review Evidence

- External review: APPROVE
- Code review lane: APPROVE
- Architecture review lane: CLEAR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates child runtime policy from parent delegation policy. Parent `policyPlan` is admission-only; child runtime middleware comes from explicit child config. Admission now sees effective child permissions, and the default child denylist persists after constraint updates.

- **Refactors**
  - Build child-run middleware only from child context; do not copy parent `policyPlan` or reuse admission middleware.
  - Use parent `policyPlan` only as propagated delegation admission middleware in `server`.
  - Preserve legacy behavior: intersect parent/child permissions when the child has no `policyPlan`, copy child middleware defensively, allow explicit empty child policy (opt-out), and add a default denylist when no explicit child runtime policy exists.
  - Expose child runtime summary to admission: `toolNames`, `childRuntimeMiddlewareNames`, `permissions`, and `hasExplicitRuntimePolicy`.

- **Bug Fixes**
  - Expose effective child permissions to admission when a child `policyPlan` owns enforcement via `admissionPermissions`, and keep the default child denylist after `invoke.prepare` updates constraints.

<sup>Written for commit 441479da764b1787f43d44e73ff0bb1fbec6d297. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved delegation behavior: parent-level constraints are enforced as admission-only checks separate from child runtime policies, ensuring child runs receive isolated policy sets.
  * Child runtime now receives explicit admission metadata at delegation time (tools/permissions/middleware summary).
  * Tool-permission defaults and resolution were hardened to provide safer fallback and fail-closed behavior.
* **Tests**
  * Added/updated tests validating delegation admission, child-runtime isolation, and default-deny behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->