### PR TITLE
docs: update AGENTS.md files for new terminology and stale content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ openomni/
 ├── packages/
 │   ├── protocol/        # Shared Zod schemas and cross-package contracts
 │   ├── session/         # Session CRUD, Bus pub/sub, Storage adapter (in-memory + SQLite), BusPersistence, Artifact, Snapshot, SurfaceKey, WorkerRun, WorkItemStore (universal work state), TraceContext
-│   ├── llm/             # LLM abstraction: providers, auth (API key + OAuth), streaming, retry, token/cost tracking, provider transforms
+│   ├── llm/             # LLM abstraction: providers, auth (API key + proxy), streaming, retry, token/cost tracking, provider transforms
 │   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + multi-agent runtime (messenger, registry, subagent/background tools, MCP) — depends on session for observability (Bus, TraceContext)
 │   │   ├── src/core/           # ChatAgent, budget, retry, policy engine, memory, delegation, telemetry
 │   │   │   ├── execution/      # StreamEngine, ToolExecutor, compaction, parallel-tools

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Target direction: the user and Resident may submit new inbound work; ordinary Wo
 
 | Concept | Meaning | Current hooks |
 | --- | --- | --- |
-| Resident | Always-on user-facing assistant | Ingress target agent + future persona policy |
+| Resident | Always-on user-facing assistant | Ingress target agent + future Resident policy |
 | Worker | Delegated execution actor (internal agent, external AI, human) | `AgentRegistry`, `SubagentRuntime`, `WorkerRun` |
 | System Governor | Low-privilege layer that adjusts Policy/Skill from execution evidence | Policy engine, Bus observers |
 | Self-loop session | Isolated internal work session for complex reasoning | `Session.createChild()`, `WorkerRun` |

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -50,6 +50,8 @@ src/
 │   ├── types.ts          # AgentDefinition + factory types
 │   ├── model-resolution.ts # resolveRuntimeModel() — alias resolution for per-message models
 │   └── dev-agent/        # Default "dev" agent factory + prompt
+├── profile/
+│   └── resident.ts       # createResidentProfile() — file-based profile loader with hot reload
 ├── tool/
 │   ├── custom/           # CustomToolProvider — user-defined tool provider
 │   └── mcp/              # McpToolProvider — MCP-backed tool provider
@@ -134,6 +136,10 @@ Add a new channel by:
 - Each entry is an `AgentDefinition` with `model`, `systemPrompt`, `tools`, optional `budget`, optional `permissions`, and trigger metadata (slash command / channel list).
 - `getAgentDefinition(name)` returns `undefined` when the agent is unknown, in which case `ingress/bridge.ts` falls back to a generic definition plus the configured default model.
 - `apps/server/src/agents/dev-agent/` is the default agent factory + prompt.
+
+## RESIDENT PROFILE
+
+`src/profile/resident.ts` provides `createResidentProfile()` which loads a Resident profile from `~/.openomni/profile/` (or `OPENOMNI_PROFILE_DIR`). It reads `SOUL.md` (persona identity), `MEMORY.md`, `USER.md`, and an optional JSON config. The profile is hot-reloaded on file change via `fs.watch`. The factory produces an `AgentDefinition` used by the bootstrap to register the Resident agent.
 
 ## CONTEXT SYSTEM
 

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/llm
 
-LLM provider abstraction. Handles auth (API key + OAuth), provider SDK wiring, streaming, retry, message conversion, token/cost tracking, and the `run()` entry point. Depends on `@openomni/protocol` and `@openomni/session`.
+LLM provider abstraction. Handles auth (API key + proxy), provider SDK wiring, streaming, retry, message conversion, token/cost tracking, and the `run()` entry point. Depends on `@openomni/protocol` and `@openomni/session`.
 
 ## STRUCTURE
 
@@ -17,7 +17,7 @@ src/
 │   └── retry.ts      # Retry.delay / sleep / isRetryable — exponential backoff + retry-after
 ├── auth/
 │   ├── storage.ts    # Auth namespace: get / set / remove / all (credential storage)
-│   └── registry.ts   # Provider auth registry (OAuth methods + API key paths)
+│   └── registry.ts   # Provider auth registry (API key + proxy paths)
 ├── provider/
 │   ├── index.ts      # Provider + ProviderTransform + ModelsDev namespaces
 │   └── provider.ts   # getSDK() + getLanguage() — maps Provider.Model to @ai-sdk/* instance
@@ -37,7 +37,7 @@ src/
 
 - **`run()` entry point**: Takes `RunInput` (messages, tools, system, model, toolExecutor, toolChoice, maxSteps, providerOptions), drives a Processor loop, and returns `Run.Outcome` via the injected `Sink`.
 - **Provider.Model**: Zod schema with capabilities, cost, limits, status. Built from `models.dev` data via `Provider.fromModelsDevModel()`. `Provider.listModels()` / `listProviders()` / `getProviderInfo()` surface catalog lookups.
-- **Auth.Info** (discriminated union): `{ type: "api", key }` | `{ type: "oauth", access, refresh, expires, accountId? }` | `{ type: "proxy", baseURL, apiKey? }`. Stored via `Auth.set(providerId, info)` and read by `getSDK()` before each call.
+- **Auth.Info** (discriminated union): `{ type: "api", key }` | `{ type: "proxy", baseURL, apiKey? }`. Stored via `Auth.set(providerId, info)` and read by `getSDK()` before each call.
 - **SDK wiring**: `getSDK(model, auth)` resolves to Anthropic / OpenAI / OpenAI-compatible. SDK and `LanguageModel` instances are cached per `providerID:npm:modelID:auth` key. Provider-specific behavior belongs in `provider/`, `auth/`, or `transform/`, not in call sites.
 - **Provider transforms** (`transform/index.ts`): `normalizeMessages()` filters empty blocks, sanitizes tool-call IDs, applies Anthropic ephemeral caching to the last two user/assistant messages. `variants(model)` exposes per-provider thinking / reasoning presets; `resolveVariant(model, variant?)` picks one.
 - **Processor**: Created via `Processor.create({ assistantMessage, sessionID, model, abort, sink, onToolCall, createStream })`. `process()` returns `"stop" | "continue" | "compact"`. Accumulates `TextPart` / `ReasoningPart` / `ToolPart` and publishes through `Sink`.

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -7,6 +7,8 @@ Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@ope
 | Domain | Purpose | Key exports |
 | --- | --- | --- |
 | `src/dag/` | Pure dependency-graph utilities | `DAG` |
+| `src/profile/` | Agent profile middleware (soul/user/memory from `~/.openomni/profiles/`) | `Profile` |
+| `src/resident/` | Resident runtime lifecycle (in-process execution, direct mode) | `ResidentRuntime` |
 | `src/ingress/` | Inbound event resolution and mode dispatch | `IngressEngine`, `IngressEventProjector`, `IngressHandlers`, `IngressSessionResolver`, `SessionBridge`, `CronAdapter`, `resolveTarget`, `targetKey` |
 | `src/runtime/` | Worker middleware and session utilities | *(no public exports; internal wiring only)* |
 | `src/subagent/` | Session-backed subagent execution | `SubagentRuntime`, `SubagentConsultation`, `BackgroundManager` |
@@ -15,12 +17,14 @@ Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@ope
 ## Architecture
 
 - `src/dag/` is structural only — it knows step topology, not runtime state.
+- `src/profile/` loads `SOUL.md`, `USER.md`, and `MEMORY.md` from the file system and injects them as `context.prepare` policy effects before agent execution.
+- `src/resident/` provides `ResidentRuntime` for in-process Resident execution without coordinator dispatch.
 - `src/ingress/` is the entry path for inbound events. It resolves a session through `SurfaceKey`, projects the event into stored messages, then dispatches to the `direct` handler. `ingestInternal()` accepts internal-origin events (e.g., from `CronAdapter`) without going through the external ingest path. `CronAdapter.fire(job)` creates internal events with `surface="cron"`.
 - `src/subagent/` owns the unified subagent runtime. `SubagentRuntime` runs session-locked spawn / send / resume / cancel / wait operations backed by `WorkerRun` records; `BackgroundManager` wraps the runtime for fire-and-forget execution with concurrency / depth limits.
 - `src/execution-runtime/tool/agent/tools/inbound-message.ts` is the `inbound_message` tool — a cross-sandbox IPC syscall that lets worker agents spawn, send, cancel, resume, or schedule messages to resident or worker agents. It replaces the legacy per-action tools. `wait=true` blocks until the target responds; `action=schedule` registers a cron job via `CronJobRegistry`.
 - `src/execution-runtime/injection-queue.ts` (`InjectionQueue`) holds async responses keyed by `runId`. The worker middleware drains the queue at `turn.finish` and injects pending responses into the agent's next turn.
 - `src/execution-runtime/cron-job-registry.ts` (`CronJobRegistry`) is an in-memory registry of scheduled jobs. `CronAdapter` reads from it to fire periodic internal inbound events.
-- Persona workforce direction: `src/ingress/` remains the external/internal inbound seam, `src/subagent/` remains the child persona execution seam, and a future self-loop/writeback layer should live in this package rather than in `agent`.
+- Persona workforce direction: Resident orchestration seams: controlled inbound authority, self-loop session creation, Worker delegation, and distilled writeback.
 
 WHY: each domain stays small and focused so the domain docs can stay source-of-truth instead of repeating.
 
@@ -28,6 +32,8 @@ WHY: each domain stays small and focused so the domain docs can stay source-of-t
 
 ```
 dag/                → no internal deps
+profile/            → @openomni/session + @openomni/agent + @openomni/protocol
+resident/           → @openomni/session + @openomni/agent + @openomni/llm
 runtime/            → @openomni/session + @openomni/agent (worker middleware, no bus transport)
 execution-runtime/  → no orchestration deps (tool system, workspace, middleware)
 ingress/            → no sibling deps
@@ -41,6 +47,8 @@ subagent/           → execution-runtime/ (uses @openomni/agent + @openomni/ses
 Consumers should only use `@openomni/openomni` exports:
 
 - DAG helpers from `src/dag/`
+- Profile middleware from `src/profile/`
+- Resident runtime from `src/resident/`
 - Ingress orchestration from `src/ingress/`
 
 - Subagent runtime + background manager from `src/subagent/`
@@ -53,7 +61,7 @@ If a symbol is not re-exported from `src/index.ts`, treat it as private to its d
 - Add new tools or tool providers in `src/execution-runtime/tool/` following the `ToolProvider` interface.
 - Extend ingress handling in `src/ingress/` when new inbound surfaces or mode dispatch rules arrive.
 - Add subagent capabilities (new timeout policies, abort semantics, recovery hooks) in `src/subagent/` next to `SubagentRuntime` / `BackgroundManager`.
-- Add persona workforce orchestration here when implementing persona runtime contracts: authority checks near ingress, self-loop creation near session-backed orchestration, and distilled writeback near `SessionBridge`.
+- Add Resident/Worker orchestration here when implementing product model contracts: authority checks near ingress, self-loop creation near session-backed orchestration, and distilled writeback near `SessionBridge`.
 
 ## What This Package Is Not
 
@@ -64,6 +72,7 @@ If a symbol is not re-exported from `src/index.ts`, treat it as private to its d
 ## Domain Docs
 
 - `src/dag/AGENTS.md` — dependency-graph helpers
+- `src/profile/AGENTS.md` and `src/resident/AGENTS.md` do not exist yet; these are intentionally small modules.
 - `src/ingress/AGENTS.md` — inbound event handling and mode dispatch
 - `src/subagent/AGENTS.md` — session-backed subagent runtime and background manager
 - `src/execution-runtime/AGENTS.md` — tool system, workspace lock, and worker middleware

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -51,7 +51,7 @@ src/
 
 The product model is documented in `docs/core-model.md`. Future schemas should live here when they become implementation work:
 
-- persona profile and lifecycle contracts;
+- Resident/Worker profile and lifecycle contracts;
 - inbound authority / actor role contracts;
 - self-loop session metadata;
 - distilled writeback records;

--- a/packages/session/AGENTS.md
+++ b/packages/session/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/session
 
-Session lifecycle, message/part storage, event bus, logs, telemetry, trace context, snapshots, artifacts, event log, surface-key routing, and worker-run records. Depends only on `@openomni/protocol`. In the persona workforce model, this package owns the durable substrate for original sessions, self-loop sessions, child persona sessions, and worker-run history.
+Session lifecycle, message/part storage, event bus, logs, telemetry, trace context, snapshots, artifacts, event log, surface-key routing, and worker-run records. Depends only on `@openomni/protocol`. In the workforce model, this package owns the durable substrate for original sessions, self-loop sessions, child Worker sessions, and worker-run history.
 
 ## STRUCTURE
 
@@ -47,7 +47,7 @@ src/
 - **WorkItemStore namespace**: `WorkItemStore.create()`, `.get()`, `.list()`, `.remove()`, `.update()`, `.start()`, `.complete()`, `.fail()`, `.cancel()`, `.addBlocker()`, `.resolveBlocker()`, `.addEvidence()`, `.setVerificationGate()`, `.areDependenciesMet()`, `.retry()`. Publishes `WorkItem.Events.*` (Created, Updated, StatusChanged, Completed, Failed, Removed) on every mutation. Gracefully degrades when `Storage.Adapter.workItem` is absent. Terminal state transitions are validated (e.g. cannot complete a failed item without retry). `parentHash` is create-only immutable.
 - **WorkerRun**: Event-sourced via `Storage.Adapter.eventLog`. `WorkerRun.create()`, `WorkerRun.updateStatus()`, `WorkerRun.listBySession()`. State transitions (e.g. `waiting_input → running`) increment `resumeCount`. Used by `SubagentRuntime` / `BackgroundManager` to persist subagent runs.
 - **TTL / lazy deletion**: `Session.create({ ttlMs })` sets `expiresAt`; `Session.get()` and `.list()` check expiry and auto-delete.
-- **Persona session lineage**: `Session.createChild()` + `parentSessionId` + `spawnDepth` are the current foundation for original → self-loop → child persona trees. Future work should add explicit metadata conventions before adding new storage shapes.
+- **Session lineage**: `Session.createChild()` + `parentSessionId` + `spawnDepth` are the current foundation for original → self-loop → child Worker trees. Future work should add explicit metadata conventions before adding new storage shapes.
 
 ## ANTI-PATTERNS
 

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -253,10 +253,10 @@ async function validateDeepImports(): Promise<string[]> {
   return violations;
 }
 
-// See docs/golden-principles.md for the full list.
+// See docs/golden-principles.local.md for the full list.
 
 // Allowed `as any` locations:
-// - protocol/error: sole exception per golden-principles.md #5
+// - protocol/error: sole exception per golden-principles.local.md #5
 // - remaining entries: pre-existing tech debt (do not extend)
 const ALLOWED_AS_ANY_FILES = new Set([
   "packages/protocol/src/error/index.ts",
@@ -304,14 +304,14 @@ async function validateGoldenPrinciples(): Promise<string[]> {
       // #5: No `as any` (except allowed files)
       if (!ALLOWED_AS_ANY_FILES.has(filePath) && /\bas\s+any\b/.test(line)) {
         violations.push(
-          `VIOLATION: ${filePath}:${lineNum} — \`as any\` detected. See docs/golden-principles.md #5`,
+          `VIOLATION: ${filePath}:${lineNum} — \`as any\` detected. See docs/golden-principles.local.md #5`,
         );
       }
 
       // #5: No @ts-ignore or @ts-expect-error
       if (/@ts-ignore|@ts-expect-error/.test(line)) {
         violations.push(
-          `VIOLATION: ${filePath}:${lineNum} — type suppression directive detected. See docs/golden-principles.md #5`,
+          `VIOLATION: ${filePath}:${lineNum} — type suppression directive detected. See docs/golden-principles.local.md #5`,
         );
       }
 
@@ -328,7 +328,7 @@ async function validateGoldenPrinciples(): Promise<string[]> {
         console.warn(`KNOWN: ${key} — empty catch block (tracked tech debt)`);
       } else {
         violations.push(
-          `VIOLATION: ${filePath}:${catchLine} — empty catch block detected. See docs/golden-principles.md #5`,
+          `VIOLATION: ${filePath}:${catchLine} — empty catch block detected. See docs/golden-principles.local.md #5`,
         );
       }
       emptyCatchMatch = emptyCatchPattern.exec(source);
@@ -342,7 +342,7 @@ async function validateGoldenPrinciples(): Promise<string[]> {
       !KNOWN_CATCHALL_FILES.has(filePath)
     ) {
       violations.push(
-        `VIOLATION: ${filePath} — catch-all filename detected. See docs/golden-principles.md #7`,
+        `VIOLATION: ${filePath} — catch-all filename detected. See docs/golden-principles.local.md #7`,
       );
     }
   }
@@ -357,8 +357,8 @@ const TRACKED_DOCS = [
   "packages/llm/AGENTS.md",
   "packages/agent/AGENTS.md",
   "packages/openomni/AGENTS.md",
-  "docs/golden-principles.md",
-  "docs/quality-score.md",
+  "packages/coordinator/AGENTS.md",
+  "apps/server/AGENTS.md",
 ];
 
 const STALE_THRESHOLD = 50; // commits since last modification


### PR DESCRIPTION
## Summary

Update AGENTS.md files across the project to align with Resident/Worker/System Governor terminology from #186, fix stale content, document new modules, and update check-deps script for the new doc structure.

## Changes

- `packages/session/AGENTS.md` — replace persona workforce terminology with Resident/Worker
- `packages/openomni/AGENTS.md` — add `profile/` and `resident/` modules to module map, architecture, dependency shape, public surface; fix remaining persona references
- `apps/server/AGENTS.md` — add resident profile subsystem documentation
- `packages/llm/AGENTS.md` — remove stale OAuth auth references (only api + proxy remain)
- `packages/protocol/AGENTS.md` — fix remaining persona reference in future contracts section
- Root `AGENTS.md` — fix stale OAuth reference and persona policy reference
- `script/check-deps.ts` — remove deleted docs from TRACKED_DOCS, add coordinator/server AGENTS.md, update golden-principles path references to .local.md

## Type

- [x] `docs` — Documentation only
- [x] `chore` — Build, CI, tooling, dependencies

## Affected Packages

- [x] `protocol`
- [x] `session`
- [x] `llm`
- [x] `openomni`
- [x] `server`

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [ ] Tests added/updated for changes — N/A (docs + script path update only)
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] AGENTS.md updated if public API or architecture changed