### PR TITLE
refactor(server): split MCP provider internals

### DIFF
--- a/apps/server/src/tool/mcp/provider-audit.ts
+++ b/apps/server/src/tool/mcp/provider-audit.ts
@@ -1,0 +1,141 @@
+import type { McpServerConfig, Tool } from "@openomni/protocol";
+import { PolicyEvent } from "@openomni/protocol";
+import { Bus, Storage } from "@openomni/session";
+import type { McpLifecycleAuditContext, ResolvedLifecycleAudit } from "./provider-types";
+
+/** @internal Package-local helper for McpToolProvider only. */
+export const MCP_TOOL_ACTION = "mcp.tool.call";
+
+/** @internal Package-local helper for McpToolProvider only. */
+export type McpLifecycleAction =
+  | "mcp.server.connect"
+  | "mcp.server.disconnect"
+  | "mcp.server.disconnect_all";
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function resolveLifecycleAudit(
+  context: McpLifecycleAuditContext | undefined,
+): ResolvedLifecycleAudit | undefined {
+  const sessionId = context?.audit?.sessionId;
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    const fallbackSession = latestSession();
+    if (!fallbackSession) return undefined;
+    return {
+      sessionId: fallbackSession.id,
+      ...(context?.actor !== undefined && { actor: context.actor }),
+    };
+  }
+  return {
+    sessionId,
+    ...(context?.actor !== undefined && { actor: context.actor }),
+  };
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function publishLifecycleRequested(input: {
+  readonly audit: ResolvedLifecycleAudit;
+  readonly actionId: string;
+  readonly action: McpLifecycleAction;
+  readonly resource: string;
+  readonly context?: Record<string, unknown>;
+}): void {
+  Bus.publish(PolicyEvent.ActionRequested, {
+    ...lifecycleBase(input.audit),
+    actionId: input.actionId,
+    actor: buildActor(input.audit.sessionId, input.audit.actor),
+    action: input.action,
+    resource: input.resource,
+    ...(input.context !== undefined ? { context: input.context } : {}),
+  });
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function publishLifecycleApproved(input: {
+  readonly audit: ResolvedLifecycleAudit;
+  readonly actionId: string;
+  readonly action: McpLifecycleAction;
+  readonly resource: string;
+  readonly reason: string;
+}): void {
+  Bus.publish(PolicyEvent.ActionApproved, {
+    ...lifecycleBase(input.audit),
+    actionId: input.actionId,
+    actor: buildActor(input.audit.sessionId, input.audit.actor),
+    action: input.action,
+    resource: input.resource,
+    verdict: "allow" as const,
+    reason: input.reason,
+  });
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function publishLifecycleBlocked(input: {
+  readonly audit: ResolvedLifecycleAudit;
+  readonly actionId: string;
+  readonly action: McpLifecycleAction;
+  readonly resource: string;
+  readonly reason: string;
+}): void {
+  Bus.publish(PolicyEvent.ActionBlocked, {
+    ...lifecycleBase(input.audit),
+    actionId: input.actionId,
+    actor: buildActor(input.audit.sessionId, input.audit.actor),
+    action: input.action,
+    resource: input.resource,
+    verdict: "deny" as const,
+    reason: input.reason,
+  });
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function summarizeServerConfig(config: McpServerConfig): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    serverName: config.name,
+    transport: config.transport,
+    ...(config.timeout !== undefined && { timeout: config.timeout }),
+    ...(config.retries !== undefined && { retries: config.retries }),
+    ...(config.headers !== undefined && { headerNames: Object.keys(config.headers).sort() }),
+  };
+
+  if (config.transport === "stdio") {
+    return {
+      ...summary,
+      command: config.command,
+      ...(config.args !== undefined && { argsCount: config.args.length }),
+    };
+  }
+
+  return { ...summary, url: config.url };
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function readSessionId(call: Tool.Call): string | undefined {
+  const sessionId = call.input.sessionId;
+  return typeof sessionId === "string" && sessionId.length > 0 ? sessionId : undefined;
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function buildActor(
+  sessionId: string | undefined,
+  actor: Record<string, unknown> | undefined = undefined,
+): Record<string, unknown> {
+  return {
+    ...(actor ?? {}),
+    kind: "mcp_provider",
+    ...(sessionId !== undefined && { sessionId }),
+  };
+}
+
+function latestSession(): { readonly id: string } | undefined {
+  return Storage.get()
+    .session.list()
+    .sort((left, right) => right.time.updated - left.time.updated)[0];
+}
+
+function lifecycleBase(audit: ResolvedLifecycleAudit) {
+  return {
+    traceId: crypto.randomUUID(),
+    sessionId: audit.sessionId,
+    time: Date.now(),
+  };
+}

--- a/apps/server/src/tool/mcp/provider-metadata.ts
+++ b/apps/server/src/tool/mcp/provider-metadata.ts
@@ -1,0 +1,37 @@
+import type { RuntimeResource, Tool } from "@openomni/protocol";
+
+function uniqueLabels(labels: readonly string[]): string[] {
+  return [...new Set(labels)];
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function mcpToolMetadata(
+  serverName: string,
+  spec: Tool.Spec,
+): { readonly labels: string[]; readonly descriptor: RuntimeResource.Descriptor } {
+  const labels = uniqueLabels([
+    ...(spec.labels ?? []),
+    `tool:${spec.name}`,
+    "source.mcp",
+    `mcp.${serverName}`,
+  ]);
+
+  return {
+    labels,
+    descriptor: {
+      id: `tool:mcp:${serverName}:${spec.name}`,
+      kind: "tool",
+      source: { type: "mcp", serverId: serverName, remoteName: spec.name },
+      labels,
+      capabilities: [],
+      effects: [],
+    },
+  };
+}
+
+/** @internal Package-local helper for McpToolProvider only. */
+export function createResultSummary(output: unknown): string {
+  const outputStr = typeof output === "string" ? output : JSON.stringify(output);
+  const length = outputStr.length;
+  return `success:text:${length}b`;
+}

--- a/apps/server/src/tool/mcp/provider-types.ts
+++ b/apps/server/src/tool/mcp/provider-types.ts
@@ -1,0 +1,32 @@
+import type { McpServerConfig, Tool } from "@openomni/protocol";
+import type { ToolExecutionContext } from "@openomni/openomni";
+
+/** @internal Package-local injected client seam for McpToolProvider tests/options. */
+export interface McpClientLike {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  listTools(): Promise<Tool.Spec[]>;
+  callTool(
+    toolName: string,
+    input: Record<string, unknown>,
+    callId?: string,
+    context?: ToolExecutionContext,
+  ): Promise<Tool.Result>;
+}
+
+export interface McpToolProviderOptions {
+  readonly createClient?: (config: McpServerConfig) => McpClientLike;
+}
+
+export interface McpLifecycleAuditContext {
+  readonly audit?: {
+    readonly sessionId?: string;
+  };
+  readonly actor?: Record<string, unknown>;
+}
+
+/** @internal Package-local helper for McpToolProvider lifecycle audit. */
+export type ResolvedLifecycleAudit = {
+  readonly sessionId: string;
+  readonly actor?: Record<string, unknown>;
+};

--- a/apps/server/src/tool/mcp/provider.ts
+++ b/apps/server/src/tool/mcp/provider.ts
@@ -1,8 +1,8 @@
 import { McpClient } from "@openomni/agent";
-import type { McpServerConfig, RuntimeResource, Tool } from "@openomni/protocol";
+import type { McpServerConfig, Tool } from "@openomni/protocol";
 import { Mcp, PolicyDecision, PolicyEvent, ToolExecution } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
-import { Bus, Storage } from "@openomni/session";
+import { Bus } from "@openomni/session";
 import type {
   NativeTool,
   ToolCategory,
@@ -10,63 +10,29 @@ import type {
   ToolProvider,
 } from "@openomni/openomni";
 import { McpPrefixGuardMiddleware } from "./mcp-prefix-guard";
+import {
+  MCP_TOOL_ACTION,
+  buildActor,
+  publishLifecycleApproved,
+  publishLifecycleBlocked,
+  publishLifecycleRequested,
+  readSessionId,
+  resolveLifecycleAudit,
+  summarizeServerConfig,
+} from "./provider-audit";
+import { createResultSummary, mcpToolMetadata } from "./provider-metadata";
+import type {
+  McpClientLike,
+  McpLifecycleAuditContext,
+  McpToolProviderOptions,
+} from "./provider-types";
 
-const MCP_TOOL_ACTION = "mcp.tool.call";
+export type { McpLifecycleAuditContext, McpToolProviderOptions } from "./provider-types";
+
 function createAbortError(): Error {
   const error = new Error("MCP tool execution aborted");
   error.name = "AbortError";
   return error;
-}
-
-interface McpClientLike {
-  connect(): Promise<void>;
-  disconnect(): Promise<void>;
-  listTools(): Promise<Tool.Spec[]>;
-  callTool(
-    toolName: string,
-    input: Record<string, unknown>,
-    callId?: string,
-    context?: ToolExecutionContext,
-  ): Promise<Tool.Result>;
-}
-
-function uniqueLabels(labels: readonly string[]): string[] {
-  return [...new Set(labels)];
-}
-
-function mcpToolMetadata(
-  serverName: string,
-  spec: Tool.Spec,
-): { readonly labels: string[]; readonly descriptor: RuntimeResource.Descriptor } {
-  const labels = uniqueLabels([
-    ...(spec.labels ?? []),
-    `tool:${spec.name}`,
-    "source.mcp",
-    `mcp.${serverName}`,
-  ]);
-
-  return {
-    labels,
-    descriptor: {
-      id: `tool:mcp:${serverName}:${spec.name}`,
-      kind: "tool",
-      source: { type: "mcp", serverId: serverName, remoteName: spec.name },
-      labels,
-      capabilities: [],
-      effects: [],
-    },
-  };
-}
-
-export interface McpToolProviderOptions {
-  readonly createClient?: (config: McpServerConfig) => McpClientLike;
-}
-
-export interface McpLifecycleAuditContext {
-  readonly audit?: {
-    readonly sessionId?: string;
-  };
-  readonly actor?: Record<string, unknown>;
 }
 
 export class McpToolProvider implements ToolProvider {
@@ -84,10 +50,9 @@ export class McpToolProvider implements ToolProvider {
     const actionId = crypto.randomUUID();
 
     if (audit) {
-      Bus.publish(PolicyEvent.ActionRequested, {
-        ...lifecycleBase(audit),
+      publishLifecycleRequested({
+        audit,
         actionId,
-        actor: buildActor(audit.sessionId, audit.actor),
         action: "mcp.server.connect",
         resource: config.name,
         context: summarizeServerConfig(config),
@@ -102,25 +67,21 @@ export class McpToolProvider implements ToolProvider {
       this.cachedTools = null;
 
       if (audit) {
-        Bus.publish(PolicyEvent.ActionApproved, {
-          ...lifecycleBase(audit),
+        publishLifecycleApproved({
+          audit,
           actionId,
-          actor: buildActor(audit.sessionId, audit.actor),
           action: "mcp.server.connect",
           resource: config.name,
-          verdict: "allow" as const,
           reason: "MCP server connected",
         });
       }
     } catch (err) {
       if (audit) {
-        Bus.publish(PolicyEvent.ActionBlocked, {
-          ...lifecycleBase(audit),
+        publishLifecycleBlocked({
+          audit,
           actionId,
-          actor: buildActor(audit.sessionId, audit.actor),
           action: "mcp.server.connect",
           resource: config.name,
-          verdict: "deny" as const,
           reason: err instanceof Error ? err.message : String(err),
         });
       }
@@ -144,10 +105,9 @@ export class McpToolProvider implements ToolProvider {
     const actionId = crypto.randomUUID();
 
     if (audit) {
-      Bus.publish(PolicyEvent.ActionRequested, {
-        ...lifecycleBase(audit),
+      publishLifecycleRequested({
+        audit,
         actionId,
-        actor: buildActor(audit.sessionId, audit.actor),
         action: "mcp.server.disconnect",
         resource: name,
         context: { serverName: name },
@@ -160,13 +120,11 @@ export class McpToolProvider implements ToolProvider {
     this.cachedTools = null;
 
     if (audit) {
-      Bus.publish(PolicyEvent.ActionApproved, {
-        ...lifecycleBase(audit),
+      publishLifecycleApproved({
+        audit,
         actionId,
-        actor: buildActor(audit.sessionId, audit.actor),
         action: "mcp.server.disconnect",
         resource: name,
-        verdict: "allow" as const,
         reason: "MCP server disconnected",
       });
     }
@@ -178,10 +136,9 @@ export class McpToolProvider implements ToolProvider {
     const actionId = crypto.randomUUID();
 
     if (audit) {
-      Bus.publish(PolicyEvent.ActionRequested, {
-        ...lifecycleBase(audit),
+      publishLifecycleRequested({
+        audit,
         actionId,
-        actor: buildActor(audit.sessionId, audit.actor),
         action: "mcp.server.disconnect_all",
         resource: "mcp.servers",
         context: { serverNames },
@@ -197,13 +154,11 @@ export class McpToolProvider implements ToolProvider {
     this.cachedTools = null;
 
     if (audit) {
-      Bus.publish(PolicyEvent.ActionApproved, {
-        ...lifecycleBase(audit),
+      publishLifecycleApproved({
+        audit,
         actionId,
-        actor: buildActor(audit.sessionId, audit.actor),
         action: "mcp.server.disconnect_all",
         resource: "mcp.servers",
-        verdict: "allow" as const,
         reason: "MCP servers disconnected",
       });
     }
@@ -336,83 +291,4 @@ export class McpToolProvider implements ToolProvider {
   get serverCount(): number {
     return this.connected.size;
   }
-}
-
-type ResolvedLifecycleAudit = {
-  readonly sessionId: string;
-  readonly actor?: Record<string, unknown>;
-};
-
-function resolveLifecycleAudit(
-  context: McpLifecycleAuditContext | undefined,
-): ResolvedLifecycleAudit | undefined {
-  const sessionId = context?.audit?.sessionId;
-  if (typeof sessionId !== "string" || sessionId.length === 0) {
-    const fallbackSession = latestSession();
-    if (!fallbackSession) return undefined;
-    return {
-      sessionId: fallbackSession.id,
-      ...(context?.actor !== undefined && { actor: context.actor }),
-    };
-  }
-  return {
-    sessionId,
-    ...(context?.actor !== undefined && { actor: context.actor }),
-  };
-}
-
-function latestSession(): { readonly id: string } | undefined {
-  return Storage.get()
-    .session.list()
-    .sort((left, right) => right.time.updated - left.time.updated)[0];
-}
-
-function summarizeServerConfig(config: McpServerConfig): Record<string, unknown> {
-  const summary: Record<string, unknown> = {
-    serverName: config.name,
-    transport: config.transport,
-    ...(config.timeout !== undefined && { timeout: config.timeout }),
-    ...(config.retries !== undefined && { retries: config.retries }),
-    ...(config.headers !== undefined && { headerNames: Object.keys(config.headers).sort() }),
-  };
-
-  if (config.transport === "stdio") {
-    return {
-      ...summary,
-      command: config.command,
-      ...(config.args !== undefined && { argsCount: config.args.length }),
-    };
-  }
-
-  return { ...summary, url: config.url };
-}
-
-function lifecycleBase(audit: ResolvedLifecycleAudit) {
-  return {
-    traceId: crypto.randomUUID(),
-    sessionId: audit.sessionId,
-    time: Date.now(),
-  };
-}
-
-function readSessionId(call: Tool.Call): string | undefined {
-  const sessionId = call.input.sessionId;
-  return typeof sessionId === "string" && sessionId.length > 0 ? sessionId : undefined;
-}
-
-function buildActor(
-  sessionId: string | undefined,
-  actor: Record<string, unknown> | undefined = undefined,
-): Record<string, unknown> {
-  return {
-    ...(actor ?? {}),
-    kind: "mcp_provider",
-    ...(sessionId !== undefined && { sessionId }),
-  };
-}
-
-function createResultSummary(output: unknown): string {
-  const outputStr = typeof output === "string" ? output : JSON.stringify(output);
-  const length = outputStr.length;
-  return `success:text:${length}b`;
 }


### PR DESCRIPTION
## Summary
- Split `McpToolProvider` internals into package-local audit, metadata, and type helper modules.
- Kept `McpToolProvider` as the public class/facade and preserved prior public type exports.
- Marked helper exports as `@internal` to avoid creating a second supported MCP provider API surface.

Closes #191

## Verification
- `bun x biome check apps/server/src/tool/mcp apps/server/test/tool/mcp/provider.test.ts`
- `bun test apps/server/test/tool/mcp/provider.test.ts`
- `bun run check-types`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bun run build --filter=@openomni/server`
- pre-push hook: dep-check (stale `packages/coordinator/AGENTS.md` warning only) + type-check passed

## Review
- Code-review lane: APPROVE.
- Architecture lane: CLEAR after marking helper modules internal and removing accidental `McpClientLike` facade re-export.

## Notes
- No force-push used.
- Behavior-preserving refactor only; no MCP lifecycle semantics changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the MCP tool provider by moving lifecycle audit, metadata, and type helpers into package-local modules while keeping `McpToolProvider` as the public facade. No behavior changes; this reduces internal coupling and clarifies API boundaries. Closes #191.

- **Refactors**
  - Added `provider-audit.ts`, `provider-metadata.ts`, and `provider-types.ts`; marked helper exports as `@internal`.
  - Preserved `McpToolProvider` API and existing public type exports; moved `McpClientLike` and `McpToolProviderOptions` to `provider-types.ts`.
  - Removed the accidental facade re-export of `McpClientLike`; centralized lifecycle audit publishing and metadata helpers.

<sup>Written for commit 3e1dfeceaffaba487362f8b557954c5e02cf9cce. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced MCP server lifecycle management with improved audit tracking for connections and disconnections
  * Better metadata generation for MCP tools with improved configuration handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->