### PR TITLE
fix(session): validate sqlite reads and snapshot observability

### DIFF
--- a/packages/session/src/bus-persistence/index.ts
+++ b/packages/session/src/bus-persistence/index.ts
@@ -173,18 +173,23 @@ function defaultResolveSessionId(
   const root = toRecord(payload);
   if (!root) return undefined;
 
-  const direct = stringFromRecord(root, "sessionId") ?? stringFromRecord(root, "id");
+  const direct = sessionIdFromRecord(root) ?? stringFromRecord(root, "id");
   if (direct !== undefined) return direct;
 
   const nestedPayload = toRecord(root.payload);
   const nested = nestedPayload
-    ? (stringFromRecord(nestedPayload, "sessionId") ??
-      stringFromRecord(nestedPayload, "parentSessionId"))
+    ? (sessionIdFromRecord(nestedPayload) ?? stringFromRecord(nestedPayload, "parentSessionId"))
     : undefined;
   if (nested !== undefined) return nested;
 
   const info = toRecord(root.info);
-  return info ? stringFromRecord(info, "id") : undefined;
+  return info ? (sessionIdFromRecord(info) ?? stringFromRecord(info, "id")) : undefined;
+}
+
+function sessionIdFromRecord(record: Record<string, unknown> | undefined): string | undefined {
+  // Bus payloads historically use both spellings: newer event envelopes prefer
+  // sessionId, while message/snapshot payloads use sessionID.
+  return stringFromRecord(record, "sessionId") ?? stringFromRecord(record, "sessionID");
 }
 
 function parsePayload(event: Bus.PublishedDescriptor, payload: unknown): unknown {

--- a/packages/session/src/storage/sqlite-session-adapter.ts
+++ b/packages/session/src/storage/sqlite-session-adapter.ts
@@ -16,10 +16,6 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
     },
 
     set: (id: string, info: SessionInfo): void => {
-      const normalized = SessionInfo.parse(info);
-      const data = JSON.stringify(normalized);
-      rememberParsedSessionInfo(parseCache, data, data);
-
       db.query(
         `INSERT INTO session (id, data, time_created, time_updated)
          VALUES (?, ?, ?, ?)
@@ -27,7 +23,7 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
            data = excluded.data,
            time_created = excluded.time_created,
            time_updated = excluded.time_updated`,
-      ).run(id, data, normalized.time.created, normalized.time.updated);
+      ).run(id, JSON.stringify(info), info.time.created, info.time.updated);
     },
 
     list: (): SessionInfo[] => {

--- a/packages/session/src/storage/sqlite-session-adapter.ts
+++ b/packages/session/src/storage/sqlite-session-adapter.ts
@@ -2,16 +2,24 @@ import type { Database } from "bun:sqlite";
 import { SessionInfo } from "../session/info";
 import type { Storage } from "./storage";
 
+const maxSessionParseCacheEntries = 4096;
+
 export function createSqliteSessionAdapter(db: Database): Storage.Adapter["session"] {
+  const parseCache = new Map<string, string>();
+
   return {
     get: (id: string): SessionInfo | undefined => {
       const row = db.query("SELECT data FROM session WHERE id = ?").get(id) as {
         data: string;
       } | null;
-      return row ? parseSessionInfo(row.data) : undefined;
+      return row ? parseSessionInfo(row.data, parseCache) : undefined;
     },
 
     set: (id: string, info: SessionInfo): void => {
+      const normalized = SessionInfo.parse(info);
+      const data = JSON.stringify(normalized);
+      rememberParsedSessionInfo(parseCache, data, data);
+
       db.query(
         `INSERT INTO session (id, data, time_created, time_updated)
          VALUES (?, ?, ?, ?)
@@ -19,12 +27,12 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
            data = excluded.data,
            time_created = excluded.time_created,
            time_updated = excluded.time_updated`,
-      ).run(id, JSON.stringify(info), info.time.created, info.time.updated);
+      ).run(id, data, normalized.time.created, normalized.time.updated);
     },
 
     list: (): SessionInfo[] => {
       const rows = db.query("SELECT data FROM session").all() as Array<{ data: string }>;
-      return rows.map((r) => parseSessionInfo(r.data));
+      return rows.map((r) => parseSessionInfo(r.data, parseCache));
     },
 
     remove: (id: string): boolean => {
@@ -34,8 +42,31 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
   };
 }
 
-function parseSessionInfo(data: string): SessionInfo {
+function parseSessionInfo(data: string, cache: Map<string, string>): SessionInfo {
+  const cached = cache.get(data);
+  if (cached !== undefined) {
+    return JSON.parse(cached) as SessionInfo;
+  }
+
   // The session table stores JSON snapshots; validate reads at the adapter boundary so
   // schema defaults, such as spawnDepth for pre-worker-run rows, are applied consistently.
-  return SessionInfo.parse(JSON.parse(data));
+  // Cache the normalized JSON by the exact stored payload to avoid paying Zod cost on hot
+  // get/list paths while still returning fresh objects like a plain JSON.parse read.
+  const parsed = SessionInfo.parse(JSON.parse(data));
+  rememberParsedSessionInfo(cache, data, JSON.stringify(parsed));
+  return parsed;
+}
+
+function rememberParsedSessionInfo(
+  cache: Map<string, string>,
+  data: string,
+  normalized: string,
+): void {
+  if (cache.size >= maxSessionParseCacheEntries) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+  cache.set(data, normalized);
 }

--- a/packages/session/src/storage/sqlite-session-adapter.ts
+++ b/packages/session/src/storage/sqlite-session-adapter.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import type { SessionInfo } from "../session/info";
+import { SessionInfo } from "../session/info";
 import type { Storage } from "./storage";
 
 export function createSqliteSessionAdapter(db: Database): Storage.Adapter["session"] {
@@ -8,7 +8,7 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
       const row = db.query("SELECT data FROM session WHERE id = ?").get(id) as {
         data: string;
       } | null;
-      return row ? (JSON.parse(row.data) as SessionInfo) : undefined;
+      return row ? parseSessionInfo(row.data) : undefined;
     },
 
     set: (id: string, info: SessionInfo): void => {
@@ -24,7 +24,7 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
 
     list: (): SessionInfo[] => {
       const rows = db.query("SELECT data FROM session").all() as Array<{ data: string }>;
-      return rows.map((r) => JSON.parse(r.data) as SessionInfo);
+      return rows.map((r) => parseSessionInfo(r.data));
     },
 
     remove: (id: string): boolean => {
@@ -32,4 +32,10 @@ export function createSqliteSessionAdapter(db: Database): Storage.Adapter["sessi
       return result.changes > 0;
     },
   };
+}
+
+function parseSessionInfo(data: string): SessionInfo {
+  // The session table stores JSON snapshots; validate reads at the adapter boundary so
+  // schema defaults, such as spawnDepth for pre-worker-run rows, are applied consistently.
+  return SessionInfo.parse(JSON.parse(data));
 }

--- a/packages/session/test/bus-persistence/bus-persistence.test.ts
+++ b/packages/session/test/bus-persistence/bus-persistence.test.ts
@@ -3,7 +3,9 @@ import type { Database } from "bun:sqlite";
 import { z } from "zod";
 import { Bus, BusEvent } from "../../src/bus/index.js";
 import { BusPersistence } from "../../src/bus-persistence/index.js";
+import { BusQuery } from "../../src/bus-persistence/query.js";
 import { Session } from "../../src/session/index.js";
+import { Snapshot } from "../../src/snapshot/index.js";
 import { Storage } from "../../src/storage/storage.js";
 import "../../src/storage/initialize.js";
 
@@ -59,6 +61,7 @@ describe("BusPersistence", () => {
   afterEach(() => {
     BusPersistence.stop();
     Bus.reset();
+    Snapshot.reset();
     Storage.reset();
   });
 
@@ -144,6 +147,35 @@ describe("BusPersistence", () => {
     expect(persisted).toHaveLength(5);
     expect(persisted.map((row) => JSON.parse(row.data).index)).toEqual([0, 1, 2, 3, 4]);
     expect(persisted.map((row) => row.id)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("resolves snapshot events that use sessionID for session-scoped queries", async () => {
+    const session = createSession();
+
+    BusPersistence.start();
+    const snapshotID = Snapshot.track(session.id);
+    Snapshot.restore(session.id, snapshotID);
+    const persisted = await waitForRows(2);
+
+    expect(persisted.map((row) => row.event_type)).toEqual([
+      "snapshot.tracked",
+      "snapshot.restored",
+    ]);
+    for (const row of persisted) {
+      expect(row.session_id).toBe(session.id);
+      expect(JSON.parse(row.data)).toEqual({ sessionID: session.id, snapshotID });
+    }
+    expect(persisted[0]).toMatchObject({
+      session_id: session.id,
+      event_type: "snapshot.tracked",
+      category: "snapshot",
+    });
+
+    const sessionEvents = await BusQuery.listBySession(session.id);
+    expect(sessionEvents.map((event) => event.eventType).sort()).toEqual([
+      "snapshot.restored",
+      "snapshot.tracked",
+    ]);
   });
 
   test("observer errors do not crash publishers", async () => {

--- a/packages/session/test/storage/sqlite-storage.test.ts
+++ b/packages/session/test/storage/sqlite-storage.test.ts
@@ -287,6 +287,26 @@ describe("SqliteStorageAdapter", () => {
       expect(adapter.session.get("s1")).toEqual(session);
     });
 
+    test("get and list apply SessionInfo schema defaults to legacy rows", () => {
+      const legacySession = {
+        id: "legacy",
+        title: "Legacy Session",
+        model: { providerID: "test", modelID: "test-model" },
+        time: { created: 100, updated: 100 },
+      };
+
+      storageDb(adapter)
+        .query(
+          `INSERT INTO session (id, data, time_created, time_updated)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run("legacy", JSON.stringify(legacySession), 100, 100);
+
+      const expected = { ...legacySession, spawnDepth: 0 };
+      expect(adapter.session.get("legacy")).toEqual(expected);
+      expect(adapter.session.list()).toEqual([expected]);
+    });
+
     test("set: upsert overwrites existing session", () => {
       const session = makeSession("s1");
       adapter.session.set("s1", session);

--- a/packages/session/test/storage/sqlite-storage.test.ts
+++ b/packages/session/test/storage/sqlite-storage.test.ts
@@ -307,6 +307,23 @@ describe("SqliteStorageAdapter", () => {
       expect(adapter.session.list()).toEqual([expected]);
     });
 
+    test("get rejects malformed legacy rows while applying SessionInfo defaults", () => {
+      const malformedLegacySession = {
+        title: "Malformed Legacy Session",
+        model: { providerID: "test", modelID: "test-model" },
+        time: { created: 100, updated: 100 },
+      };
+
+      storageDb(adapter)
+        .query(
+          `INSERT INTO session (id, data, time_created, time_updated)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run("malformed-legacy", JSON.stringify(malformedLegacySession), 100, 100);
+
+      expect(() => adapter.session.get("malformed-legacy")).toThrow();
+    });
+
     test("set: upsert overwrites existing session", () => {
       const session = makeSession("s1");
       adapter.session.set("s1", session);


### PR DESCRIPTION
## Summary
- validate SQLite session reads through `SessionInfo.parse` so legacy rows receive schema defaults like `spawnDepth: 0`
- teach BusPersistence to resolve both `sessionId` and existing session-package `sessionID` payload spellings
- add regressions for legacy SQLite session rows and snapshot tracked/restored events being queryable by session

## Verification
- `bun test packages/session/test/storage/sqlite-storage.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts packages/session/test/bus-persistence/query.test.ts packages/session/test/snapshot/snapshot.test.ts`
- `bun x biome check packages/session/src/storage/sqlite-session-adapter.ts packages/session/src/bus-persistence/index.ts packages/session/test/storage/sqlite-storage.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts`
- `bun run check-types`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bun run build --filter=@openomni/session`
- pre-push `turbo run check-types`

## Review
- ai-slop-cleaner scoped pass: no fallback-like findings; bounded duplicate cleanup extracted `sessionIdFromRecord`; regression tests locked before/after cleanup
- code-review lane: APPROVE
- architecture lane: CLEAR after documenting compatibility rationale and covering both snapshot events

Closes #193

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate SQLite session reads and fix session-scoped snapshot observability. Cache validated rows on read to cut overhead while keeping write compatibility.

- **Bug Fixes**
  - SQLite adapter validates reads with `SessionInfo.parse`, applying defaults (e.g., `spawnDepth: 0`) to legacy rows and rejecting malformed ones.
  - `BusPersistence` resolves both `sessionId` and `sessionID` across root, nested `payload`, and `info`, so `snapshot.tracked`/`snapshot.restored` are correctly listed by session.
  - Preserve write compatibility by storing session JSON as provided; normalization happens only on read.

- **Performance**
  - Cache normalized `SessionInfo` JSON by stored payload to avoid repeated parse/validation on `get`/`list`.

<sup>Written for commit fdd19cc359762e1806597ae4dfd6cafdab62aa67. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session ID resolution to handle legacy identifier spellings consistently.

* **Improvements**
  * Normalize and validate stored session data when reading to prevent malformed records.
  * Add bounded caching to reduce repeated session-parse work for frequently accessed sessions.

* **Tests**
  * Added tests for session persistence, legacy session handling, malformed-session errors, and snapshot-related bus events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->