### PR TITLE
feat(llm,server): proxy model discovery and improved default selection

### DIFF
--- a/apps/server/src/agents/model-resolution.ts
+++ b/apps/server/src/agents/model-resolution.ts
@@ -158,7 +158,7 @@ export async function resolveDefaultProviderModel(): Promise<CatalogModel | unde
     const [providerID, auth] = firstEntry;
     const authType = auth.type === "proxy" ? "proxy" : "api";
     const models = await Provider.listModels(providerID, authType);
-    const preferred = models[0];
+    const preferred = sortModels(models)[0];
     if (!preferred) return undefined;
     return resolveCatalogModel(preferred.id, models) ?? preferred;
   } catch (error) {

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,7 +1,13 @@
 export { Auth } from "./auth";
 export { getAuthProviders, getAuthProvider } from "./auth/registry";
 export type { AuthCallbacks, AuthProvider, AuthMethod } from "./auth/registry";
-export { Provider, ProviderTransform, ModelsDev } from "./provider";
+export {
+  Provider,
+  ProviderTransform,
+  ModelsDev,
+  fetchProxyModels,
+  enrichWithCatalog,
+} from "./provider";
 export {
   NamedError,
   AuthError,

--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 import { Model as ProtocolModel } from "@openomni/protocol";
 import { ProviderError } from "../error";
 import { ModelsDev } from "../model";
+import { Auth } from "../auth/storage";
 import { fromModelsDevProvider, filterModels } from "./provider";
+import { enrichWithCatalog, fetchProxyModels } from "./proxy-models";
 
 export namespace Provider {
   export const Model = z.object({
@@ -169,6 +171,16 @@ export namespace Provider {
       });
     }
     const info = fromModelsDevProvider(provider);
+    if (authType === "proxy") {
+      const auth = await Auth.get(providerID);
+      if (auth?.type === "proxy") {
+        const proxyModelIds = await fetchProxyModels(auth.baseURL);
+        if (proxyModelIds.length > 0) {
+          return enrichWithCatalog(proxyModelIds, info.models, providerID);
+        }
+      }
+    }
+
     const models = Object.values(info.models);
     return filterModels(providerID, authType ?? "api", models);
   }
@@ -194,6 +206,8 @@ export {
   PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES,
   PROVIDER_SDK_CACHE_MAX_ENTRIES,
 } from "./provider";
+
+export { fetchProxyModels, enrichWithCatalog } from "./proxy-models";
 
 export { ModelsDev } from "../model";
 

--- a/packages/llm/src/provider/provider.ts
+++ b/packages/llm/src/provider/provider.ts
@@ -88,11 +88,17 @@ export function getSDK(model: Provider.Model, auth: Auth.Info): ProviderSDK {
     if (!baseURL) {
       throw new Error(`No bundled provider for npm package: ${npm} and no API URL available`);
     }
-    const sdk = createOpenAICompatible({
-      name: providerID,
-      baseURL,
-      apiKey: sdkOptions.apiKey,
-    });
+    const sdk =
+      auth.type === "proxy"
+        ? createOpenAI({
+            baseURL,
+            apiKey: sdkOptions.apiKey,
+          })
+        : createOpenAICompatible({
+            name: providerID,
+            baseURL,
+            apiKey: sdkOptions.apiKey,
+          });
     setCached(SDK_CACHE, cacheKey, sdk, PROVIDER_SDK_CACHE_MAX_ENTRIES);
     return sdk;
   }
@@ -203,8 +209,7 @@ export function filterModels(
   authType: "api" | "proxy",
   models: Provider.Model[],
 ): Provider.Model[] {
-  if (providerID === "openai" && authType === "proxy") {
-    return models.filter((m) => CODEX_ALLOWED_MODELS.has(m.id));
-  }
+  void providerID;
+  void authType;
   return models;
 }

--- a/packages/llm/src/provider/proxy-models.ts
+++ b/packages/llm/src/provider/proxy-models.ts
@@ -1,0 +1,60 @@
+import type { Provider } from "./index";
+
+type CacheEntry = {
+  readonly expiresAt: number;
+  readonly ids: string[];
+};
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const modelCache = new Map<string, CacheEntry>();
+
+function normalizeModelsURL(baseURL: string): string {
+  const trimmed = baseURL.replace(/\/+$/u, "");
+  const root = trimmed.replace(/\/v1$/u, "");
+  return `${root}/v1/models`;
+}
+
+function readModelIds(value: unknown): string[] {
+  if (typeof value !== "object" || value === null || !("data" in value)) return [];
+  const data = value.data;
+  if (!Array.isArray(data)) return [];
+  return data
+    .map((item) => {
+      if (typeof item !== "object" || item === null || !("id" in item)) return undefined;
+      return typeof item.id === "string" ? item.id : undefined;
+    })
+    .filter((id): id is string => Boolean(id));
+}
+
+export async function fetchProxyModels(baseURL: string): Promise<string[]> {
+  const url = normalizeModelsURL(baseURL);
+  const cached = modelCache.get(url);
+  if (cached && cached.expiresAt > Date.now()) return cached.ids;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return [];
+    const ids = readModelIds(await response.json());
+    modelCache.set(url, { ids, expiresAt: Date.now() + CACHE_TTL_MS });
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
+export function enrichWithCatalog(
+  proxyModelIds: string[],
+  catalogModels: Record<string, Provider.Model>,
+  providerID: string,
+): Provider.Model[] {
+  return proxyModelIds.map((id) =>
+    catalogModels[id]
+      ? catalogModels[id]
+      : {
+          id,
+          providerID,
+          name: id,
+          status: "active",
+        },
+  );
+}

--- a/packages/llm/test/provider/integration.test.ts
+++ b/packages/llm/test/provider/integration.test.ts
@@ -106,11 +106,10 @@ describe("Provider Integration", () => {
     expect(openaiModels.length).toBeGreaterThan(0);
   });
 
-  it("should filter OpenAI models by auth type", async () => {
+  it("should return all OpenAI models for both proxy and api auth types", async () => {
     const proxyModels = await Provider.listModels("openai", "proxy");
     expect(Array.isArray(proxyModels)).toBe(true);
-    expect(proxyModels.find((m) => m.id === "gpt-5.1-codex-max")).toBeDefined();
-    expect(proxyModels.find((m) => m.id === "gpt-4o")).toBeUndefined();
+    expect(proxyModels.length).toBeGreaterThan(0);
 
     const apiModels = await Provider.listModels("openai", "api");
     expect(Array.isArray(apiModels)).toBe(true);

--- a/packages/llm/test/provider/registry.test.ts
+++ b/packages/llm/test/provider/registry.test.ts
@@ -78,14 +78,11 @@ describe("Provider Registry", () => {
       expect(models.length).toBeGreaterThan(0);
     });
 
-    it("should return filtered OpenAI models for proxy auth type", async () => {
+    it("should return OpenAI models for proxy auth type without CODEX filter", async () => {
       const models = await Provider.listModels("openai", "proxy");
       expect(models).toBeDefined();
       expect(Array.isArray(models)).toBe(true);
       expect(models.length).toBeGreaterThan(0);
-      expect(models.find((m) => m.id === "gpt-5.1-codex-max")).toBeDefined();
-      const nonCodexModel = models.find((m) => m.id === "gpt-4o");
-      expect(nonCodexModel).toBeUndefined();
     });
 
     it("should return all OpenAI models for API auth type", async () => {


### PR DESCRIPTION
## Summary

Fix model discovery for proxy providers. `Provider.listModels()` now queries the proxy's `/v1/models` endpoint to discover actually-available models instead of relying solely on the static models.dev catalog. Default model selection uses release date instead of arbitrary object key ordering.

Relates to #189

## Changes

- Add `proxy-models.ts` with `fetchProxyModels()` (cached, 5-min TTL) and `enrichWithCatalog()` to merge proxy availability with models.dev metadata
- `Provider.listModels()` proxy branch: query proxy `/v1/models`, return only available models enriched with catalog metadata, fall back to catalog on failure
- Remove CODEX-only filter for `openai` + `proxy` — proxy availability is the filter now
- Non-bundled proxy providers fall back to `@ai-sdk/openai` instead of `@ai-sdk/openai-compatible` to avoid AI SDK 6 spec v1 rejection
- `resolveDefaultProviderModel()` sorts candidates by `release_date` descending before picking default
- Update tests to reflect CODEX filter removal

## Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [ ] `session`
- [x] `llm`
- [ ] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] Yes — describe migration path below

`filterModels()` no longer restricts OpenAI proxy models to CODEX-only list. All proxy-available models are now returned. Existing setups using OpenAI proxy that relied on the CODEX filter will now see all models from the proxy's `/v1/models` response.

Non-bundled providers through proxy now use `@ai-sdk/openai` SDK instead of `@ai-sdk/openai-compatible`. This fixes the AI SDK 6 spec v1 rejection but means proxy endpoints must be OpenAI chat-completions compatible.

## Checklist

- [x] `bun run check-types` passes
- [ ] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxy model discovery now queries the proxy’s `/v1/models` and caches results, and the server picks the default model by newest `release_date` for better defaults and accuracy.

- **New Features**
  - Discover proxy-available models via `/v1/models` with a 5-minute cache; enrich results with `models.dev` metadata and fall back to the catalog on failure.
  - Removed CODEX-only filter for OpenAI proxies; return whatever the proxy exposes.
  - Non-bundled proxy providers now use `@ai-sdk/openai` instead of `@ai-sdk/openai-compatible`.
  - Default model selection sorts by `release_date` descending.

- **Migration**
  - OpenAI proxy users will see all models reported by the proxy, not just CODEX; update any app-side filters if needed.
  - Proxies must be OpenAI chat-completions compatible due to the switch to `@ai-sdk/openai`.

<sup>Written for commit 2c2d473dcb1adab04e30d84f79ab282ab43a43c3. Summary will update on new commits. <a href="https://cubic.dev/pr/INONONO66/openomni/pull/197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proxy-based model discovery with 5-minute caching for improved performance when using proxy authentication.
  * Enhanced model resolution to intelligently select from sorted model options instead of using the first available entry.

* **Bug Fixes**
  * Improved SDK creation logic to properly handle proxy authentication separately from other auth types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->