### PR TITLE
feat(protocol,server,openomni): add config-driven model and providerOptions override

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -130,7 +130,7 @@ export async function main(): Promise<void> {
   const hasAnyChannel = Boolean(
     config.telegram.token || config.github.secret || config.discord.token,
   );
-  const model = await resolveModel();
+  const model = await resolveModel(config);
   const residentProfile = model
     ? await createResidentProfile({ model: { provider: model.providerID, id: model.id } })
     : undefined;
@@ -144,6 +144,7 @@ export async function main(): Promise<void> {
         mcpProvider,
         customProvider,
         defaultModel: model ? { provider: model.providerID, id: model.id } : undefined,
+        providerOptions: config.model?.providerOptions,
         workspaceRoot: event.workspace ?? config.workspace?.root ?? process.cwd(),
       }),
   });
@@ -213,6 +214,7 @@ export async function main(): Promise<void> {
             mcpProvider,
             customProvider,
             defaultModel: { provider: model.providerID, id: model.id },
+            providerOptions: config.model?.providerOptions,
             workspaceRoot: config.workspace?.root ?? process.cwd(),
           }),
         });

--- a/apps/server/src/bootstrap/providers.ts
+++ b/apps/server/src/bootstrap/providers.ts
@@ -1,5 +1,9 @@
 import { resolveDefaultProviderModel } from "../agents/model-resolution";
+import type { ServerConfig } from "../config";
 
-export async function resolveModel() {
+export async function resolveModel(config?: ServerConfig) {
+  if (config?.model) {
+    return { providerID: config.model.provider, id: config.model.id, name: config.model.id };
+  }
   return resolveDefaultProviderModel();
 }

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -12,6 +12,11 @@ interface RawConfig {
   workspace?: {
     root?: string;
   };
+  model?: {
+    provider?: string;
+    id?: string;
+    providerOptions?: Record<string, unknown>;
+  };
   mcp?: {
     servers?: unknown;
   };
@@ -41,6 +46,7 @@ interface RawConfig {
 
 export interface ServerConfig {
   workspace?: { root: string };
+  model?: { provider: string; id: string; providerOptions?: Record<string, unknown> };
   mcp: { servers: McpServerConfig[] };
   server: { port: number; host: string; wsToken?: string };
   storage: { dbPath: string };
@@ -82,8 +88,18 @@ function resolve(raw: RawConfig, configPath: string): ServerConfig {
     });
   }
 
+  const model =
+    raw.model?.provider && raw.model?.id
+      ? {
+          provider: raw.model.provider,
+          id: raw.model.id,
+          ...(raw.model.providerOptions ? { providerOptions: raw.model.providerOptions } : {}),
+        }
+      : undefined;
+
   return {
     workspace: workspaceRoot ? { root: workspaceRoot } : undefined,
+    model,
     mcp: {
       servers: parseMcpServerConfigs(raw.mcp?.servers, {
         source: "server-config",

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -390,6 +390,7 @@ export namespace WorkerRunner {
             .join("\n\n"),
           tools: exposedTools,
           toolExecutor,
+          ...(request.providerOptions ? { providerOptions: request.providerOptions } : {}),
           middleware: [
             createContextMiddleware({ workspaceRoot: workspaceRoot ?? process.cwd() }),
             ...buildWorkerMiddleware({

--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -12,6 +12,7 @@ export interface BridgeDeps {
   mcpProvider: ToolListProvider;
   customProvider?: { listTools(): NativeTool[] };
   defaultModel?: { provider: string; id: string };
+  providerOptions?: Record<string, unknown>;
   workspaceRoot: string;
 }
 
@@ -63,6 +64,7 @@ function buildAgentDefFromEntries(
           runtime: { sessionId, runId, agentName, workspaceRoot },
         },
       }),
+    ...(deps.providerOptions ? { providerOptions: deps.providerOptions } : {}),
   };
 }
 

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -226,6 +226,8 @@ export namespace IngressHandlers {
       budget: ctx.event.agent.budget,
       workspaceRoot: ctx.event.agent.toolConfig?.workspaceRoot,
       policyPlan: ctx.event.agent.policyPlan,
+      providerOptions: (ctx.event.agent as { providerOptions?: Record<string, unknown> })
+        .providerOptions,
       traceId: ctx.traceContext?.traceId,
       agentName:
         typeof ctx.event.meta?.agentName === "string" ? ctx.event.meta.agentName : undefined,

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -255,6 +255,9 @@ export class ResidentRuntime {
         })
       : ctx.event.agent.toolExecutor;
 
+    const agentProviderOptions = (ctx.event.agent as { providerOptions?: Record<string, unknown> })
+      .providerOptions;
+
     return {
       model: ctx.event.agent.model,
       systemPrompt: ctx.event.agent.systemPrompt,
@@ -264,6 +267,7 @@ export class ResidentRuntime {
         | ((call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>)
         | undefined,
       ...(ctx.signal ? { signal: ctx.signal } : {}),
+      ...(agentProviderOptions ? { providerOptions: agentProviderOptions } : {}),
       middleware: buildWorkerMiddleware({
         permissions: ctx.event.agent.permissions,
         ...(ctx.event.agent.policyPlan ? { policyPlan: ctx.event.agent.policyPlan } : {}),

--- a/packages/protocol/src/execution/index.ts
+++ b/packages/protocol/src/execution/index.ts
@@ -22,6 +22,7 @@ const requestSchema = z.object({
   workspaceRoot: z.string().optional(),
   middleware: z.array(z.string()).optional(),
   policyPlan: Policy.PolicyPlan.optional(),
+  providerOptions: z.record(z.string(), z.unknown()).optional(),
   traceId: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary

Add support for pinning the LLM model and provider options (e.g. `reasoningEffort`) via `~/.openomni/config.json` instead of relying solely on catalog auto-selection. The full pipeline threads `providerOptions` from config through ingress, execution request, and into both the Resident and Worker `ChatAgent` instances.

## Changes

- **protocol**: Add `providerOptions` field to `Execution.Request` schema
- **server/config**: Parse `model.provider`, `model.id`, and `model.providerOptions` from config.json
- **server/bootstrap**: `resolveModel(config)` prefers explicit config over catalog auto-selection; passes `providerOptions` to ingress bridge deps
- **server/bridge**: `BridgeDeps.providerOptions` spreads onto `AgentDef` (passthrough)
- **server/worker-runner**: Forwards `request.providerOptions` to `ChatAgent.create()`
- **openomni/handlers**: `buildExecutionRequest()` copies `providerOptions` from AgentDef into Execution.Request
- **openomni/resident**: `buildAgentConfig()` reads passthrough `providerOptions` and forwards to `ChatAgentConfig`

## Type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [x] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [ ] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for pinning the LLM model and provider options via ~/.openomni/config.json. The server prefers config over catalog auto-selection and threads providerOptions (e.g., reasoningEffort) end-to-end to both resident and worker agents.

- **New Features**
  - `protocol`: Add `providerOptions` to `Execution.Request` schema.
  - `server`: Parse `model.provider`, `model.id`, and `model.providerOptions`; `resolveModel(config)` prefers config; pass `providerOptions` through the ingress bridge and into the worker runner.
  - `openomni`: Copy `providerOptions` from `AgentDef` into the execution request and forward to resident runtime so `ChatAgent` receives them in both paths.

<sup>Written for commit 3af60a976193f27d690ecead03d0bbe6b623b98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/198?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable model provider options through runtime configuration. Provider settings can now be specified during bootstrap and passed through execution requests and agent initialization, enabling enhanced control over model behavior and performance tuning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/INONONO66/openomni/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->