### PR TITLE
fix(agent): fallback to proxy model list when models.dev catalog misses

### DIFF
--- a/packages/agent/src/core/execution/shared.ts
+++ b/packages/agent/src/core/execution/shared.ts
@@ -15,11 +15,15 @@ export async function resolveProviderModel(model: {
   }
 
   const rawModel = providerData.models?.[model.id];
-  if (!rawModel) {
-    throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
+  if (rawModel) {
+    return Provider.fromModelsDevModel(providerData, rawModel as ModelsDev.Model);
   }
 
-  return Provider.fromModelsDevModel(providerData, rawModel as ModelsDev.Model);
+  const proxyModels = await Provider.listModels(model.provider, "proxy").catch(() => []);
+  const match = proxyModels.find((m) => m.id === model.id);
+  if (match) return match;
+
+  throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
 }
 
 export function getLastUserMessageText(messages: Message.WithParts[]): string | null {


### PR DESCRIPTION
## Summary

Fix agent execution failing for proxy-only models (e.g. `gpt-5.5`) that exist in the proxy `/v1/models` endpoint but are absent from the static models.dev catalog. `resolveProviderModel` now falls back to `Provider.listModels(provider, "proxy")` when the catalog lookup misses.

Fixes the remaining half of the model resolution failure after #203 fixed the auth header.

## Changes

- Add fallback to `Provider.listModels(provider, "proxy")` in `resolveProviderModel` when the model is not found in the models.dev static catalog
- Gracefully catch errors from the proxy lookup so catalog-only environments are unaffected

## Type

- [x] `fix` — Bug fix

## Affected Packages

- [x] `agent`

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] `bun run check-types` passes
- [x] `bun run script/check-deps.ts` clean
- [x] Tests added/updated for changes — existing mock covers this path
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [ ] AGENTS.md updated if public API or architecture changed — N/A, internal fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model resolution in `agent` for proxy-only models (e.g. `gpt-5.5`) by falling back to the proxy `/v1/models` list when the models.dev catalog doesn’t include the model. This prevents "Model not found" errors and keeps catalog-only environments unchanged by catching proxy lookup errors.

<sup>Written for commit cd1aafa8290ace8c46ac7bd3d4bd49e79dcf372a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model resolution to support additional model sources, improving system reliability when accessing models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->