### PR TITLE
feat(openomni): add dispatch gate for internal agent routing

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -3,10 +3,12 @@ import { dirname } from "node:path";
 import type { Adapter } from "@openomni/protocol";
 import type { WorkerBootstrap } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
-import { initialize, Bus, BusPersistence, WorkerRun } from "@openomni/session";
+import { initialize, Bus, BusPersistence, TraceContext, WorkerRun } from "@openomni/session";
 import {
   AgentToolProvider,
   IngressEngine,
+  IngressEventProjector,
+  IngressHandlers,
   ResidentRuntime,
   SystemToolProvider,
   resolveCategory,
@@ -103,7 +105,11 @@ export async function main(): Promise<void> {
   BusPersistence.start();
 
   const systemProvider = new SystemToolProvider(config.workspace?.root);
-  const agentProvider = new AgentToolProvider();
+  let agentProvider: AgentToolProvider | undefined;
+  const requireAgentProvider = (): AgentToolProvider => {
+    if (!agentProvider) throw new Error("agent tool provider is not configured");
+    return agentProvider;
+  };
   const mcpProvider = new McpToolProvider();
 
   const projectMcpServers = McpConfigLoader.discover(config.workspace?.root ?? process.cwd());
@@ -136,18 +142,6 @@ export async function main(): Promise<void> {
     : undefined;
   if (residentProfile) registerAgent(residentProfile.factory, residentProfile.metadata);
   const customProvider = new CustomToolProvider();
-  IngressEngine.setAgentResolver({
-    resolve: async (agentName, event) =>
-      buildAgentDef(agentName, {
-        systemProvider,
-        agentProvider,
-        mcpProvider,
-        customProvider,
-        defaultModel: model ? { provider: model.providerID, id: model.id } : undefined,
-        providerOptions: config.model?.providerOptions,
-        workspaceRoot: event.workspace ?? config.workspace?.root ?? process.cwd(),
-      }),
-  });
   const toolDispatcher = buildToolDispatcher([mcpProvider]);
   const coordinator = createExecutionCoordinator({
     workerScript,
@@ -185,18 +179,20 @@ export async function main(): Promise<void> {
       }
 
       try {
-        const result = await IngressEngine.ingest({
+        const trace = TraceContext.create({ sessionId: mainSessionId });
+        const residentEvent = {
           id: crypto.randomUUID(),
-          surface: "worker-ask-resident",
+          surface: "dispatch",
           workspace: config.workspace?.root ?? process.cwd(),
-          mode: "direct",
+          mode: "internal" as const,
+          agentName: "resident",
           payload: `Worker ${workerId}${runId ? ` run ${runId}` : ""} asks Resident:\n\n${payload}`,
           runtime: {
             durableSessionId: mainSessionId,
-            lifecycle: "active",
+            lifecycle: "active" as const,
             ...(signal ? { signal } : {}),
           },
-          target: { kind: "resident" },
+          target: { kind: "resident" as const, sessionId: mainSessionId },
           meta: {
             actor: {
               role: "worker",
@@ -205,18 +201,30 @@ export async function main(): Promise<void> {
               sessionId,
               runId,
             },
-            target: { kind: "resident" },
+            target: { kind: "resident" as const, sessionId: mainSessionId },
             agentName: "resident",
           },
           agent: buildResidentAgentDef("resident", {
             systemProvider,
-            agentProvider,
+            agentProvider: requireAgentProvider(),
             mcpProvider,
             customProvider,
             defaultModel: { provider: model.providerID, id: model.id },
             providerOptions: config.model?.providerOptions,
             workspaceRoot: config.workspace?.root ?? process.cwd(),
           }),
+        };
+        IngressEventProjector.project(
+          residentEvent,
+          mainSessionId,
+          { providerID: model.providerID, modelID: model.id },
+          trace,
+        );
+        const result = await IngressHandlers.handleResident({
+          sessionId: mainSessionId,
+          event: residentEvent,
+          residentRuntime,
+          traceContext: trace,
         });
         return { requestId, accepted: true, output: result.result.output };
       } finally {
@@ -230,11 +238,30 @@ export async function main(): Promise<void> {
     workerIdleTimeoutMs: Number(process.env.OPENOMNI_WORKER_IDLE_TIMEOUT_MS ?? 30_000),
   });
   IngressEngine.setCoordinator(coordinator);
+  agentProvider = new AgentToolProvider({
+    dispatchOwners: {
+      coordinator,
+      residentRuntime,
+      ...(model ? { defaultModel: { provider: model.providerID, id: model.id } } : {}),
+    },
+  });
+  IngressEngine.setAgentResolver({
+    resolve: async (agentName, event) =>
+      buildAgentDef(agentName, {
+        systemProvider,
+        agentProvider: requireAgentProvider(),
+        mcpProvider,
+        customProvider,
+        defaultModel: model ? { provider: model.providerID, id: model.id } : undefined,
+        providerOptions: config.model?.providerOptions,
+        workspaceRoot: event.workspace ?? config.workspace?.root ?? process.cwd(),
+      }),
+  });
 
   const routingHandler = model
     ? createRoutingHandler(
         systemProvider,
-        agentProvider,
+        requireAgentProvider(),
         mcpProvider,
         config.workspace?.root ?? process.cwd(),
         { provider: model.providerID, id: model.id },

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -107,10 +107,10 @@ export async function main(): Promise<void> {
   BusPersistence.start();
 
   const systemProvider = new SystemToolProvider(config.workspace?.root);
-  let agentProvider: AgentToolProvider | undefined;
+  const agentProviderRef: { current?: AgentToolProvider } = {};
   const requireAgentProvider = (): AgentToolProvider => {
-    if (!agentProvider) throw new Error("agent tool provider is not configured");
-    return agentProvider;
+    if (!agentProviderRef.current) throw new Error("agent tool provider is not configured");
+    return agentProviderRef.current;
   };
   const mcpProvider = new McpToolProvider();
 
@@ -282,7 +282,7 @@ export async function main(): Promise<void> {
     workerIdleTimeoutMs: Number(process.env.OPENOMNI_WORKER_IDLE_TIMEOUT_MS ?? 30_000),
   });
   IngressEngine.setCoordinator(coordinator);
-  agentProvider = new AgentToolProvider({
+  agentProviderRef.current = new AgentToolProvider({
     dispatchOwners: {
       coordinator,
       residentRuntime,

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -149,8 +149,9 @@ export async function main(): Promise<void> {
     workerScript,
     bootstrap,
     toolDispatcher,
-    askResident: async ({ workerId, sessionId, runId, payload, signal }) => {
+    askResident: async ({ workerId, sessionId, runId, payload, workspaceRoot, signal }) => {
       const requestId = crypto.randomUUID();
+      const resolvedWorkspace = workspaceRoot ?? config.workspace?.root ?? process.cwd();
       if (signal?.aborted) {
         return { requestId, accepted: false, error: "worker.inbound_wait aborted" };
       }
@@ -187,7 +188,7 @@ export async function main(): Promise<void> {
           const residentEvent = {
             id: command.dispatchId,
             surface: "dispatch",
-            workspace: config.workspace?.root ?? process.cwd(),
+            workspace: resolvedWorkspace,
             mode: "internal" as const,
             agentName: "resident",
             payload:
@@ -218,7 +219,7 @@ export async function main(): Promise<void> {
               customProvider,
               defaultModel: { provider: model.providerID, id: model.id },
               providerOptions: config.model?.providerOptions,
-              workspaceRoot: config.workspace?.root ?? process.cwd(),
+              workspaceRoot: resolvedWorkspace,
             }),
           };
           IngressEventProjector.project(
@@ -253,6 +254,7 @@ export async function main(): Promise<void> {
             actorId: `${sessionId}:${runId ?? workerId}`,
             agentName: "worker",
             trustTier: "assigned_worker",
+            workspaceRoot: resolvedWorkspace,
             ...(signal ? { signal } : {}),
           },
         );

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -6,12 +6,14 @@ import { Operational } from "@openomni/protocol";
 import { initialize, Bus, BusPersistence, TraceContext, WorkerRun } from "@openomni/session";
 import {
   AgentToolProvider,
+  DispatchRuntime,
   IngressEngine,
   IngressEventProjector,
   IngressHandlers,
   ResidentRuntime,
   SystemToolProvider,
   resolveCategory,
+  type DispatchHandler,
 } from "@openomni/openomni";
 import { Auth } from "@openomni/llm";
 import { loadConfig } from "../config";
@@ -179,54 +181,96 @@ export async function main(): Promise<void> {
       }
 
       try {
-        const trace = TraceContext.create({ sessionId: mainSessionId });
-        const residentEvent = {
-          id: crypto.randomUUID(),
-          surface: "dispatch",
-          workspace: config.workspace?.root ?? process.cwd(),
-          mode: "internal" as const,
-          agentName: "resident",
-          payload: `Worker ${workerId}${runId ? ` run ${runId}` : ""} asks Resident:\n\n${payload}`,
-          runtime: {
-            durableSessionId: mainSessionId,
-            lifecycle: "active" as const,
-            ...(signal ? { signal } : {}),
-          },
-          target: { kind: "resident" as const, sessionId: mainSessionId },
-          meta: {
-            actor: {
-              role: "worker",
-              trusted: true,
-              workerId,
-              sessionId,
-              runId,
+        const residentPayload = `Worker ${workerId}${runId ? ` run ${runId}` : ""} asks Resident:\n\n${payload}`;
+        const residentHandler: DispatchHandler = async (command, context) => {
+          const trace = TraceContext.create({ sessionId: mainSessionId });
+          const residentEvent = {
+            id: command.dispatchId,
+            surface: "dispatch",
+            workspace: config.workspace?.root ?? process.cwd(),
+            mode: "internal" as const,
+            agentName: "resident",
+            payload:
+              typeof command.payload === "string"
+                ? command.payload
+                : JSON.stringify(command.payload),
+            runtime: {
+              durableSessionId: mainSessionId,
+              lifecycle: "active" as const,
+              ...(context?.signal ? { signal: context.signal } : {}),
             },
             target: { kind: "resident" as const, sessionId: mainSessionId },
-            agentName: "resident",
-          },
-          agent: buildResidentAgentDef("resident", {
-            systemProvider,
-            agentProvider: requireAgentProvider(),
-            mcpProvider,
-            customProvider,
-            defaultModel: { provider: model.providerID, id: model.id },
-            providerOptions: config.model?.providerOptions,
-            workspaceRoot: config.workspace?.root ?? process.cwd(),
-          }),
+            meta: {
+              actor: {
+                role: "worker",
+                trusted: true,
+                workerId,
+                sessionId,
+                runId,
+              },
+              target: { kind: "resident" as const, sessionId: mainSessionId },
+              agentName: "resident",
+            },
+            agent: buildResidentAgentDef("resident", {
+              systemProvider,
+              agentProvider: requireAgentProvider(),
+              mcpProvider,
+              customProvider,
+              defaultModel: { provider: model.providerID, id: model.id },
+              providerOptions: config.model?.providerOptions,
+              workspaceRoot: config.workspace?.root ?? process.cwd(),
+            }),
+          };
+          IngressEventProjector.project(
+            residentEvent,
+            mainSessionId,
+            { providerID: model.providerID, modelID: model.id },
+            trace,
+          );
+          const result = await IngressHandlers.handleResident({
+            sessionId: mainSessionId,
+            event: residentEvent,
+            residentRuntime,
+            traceContext: trace,
+          });
+          return { output: result.result.output };
         };
-        IngressEventProjector.project(
-          residentEvent,
-          mainSessionId,
-          { providerID: model.providerID, modelID: model.id },
-          trace,
+
+        const dispatchRuntime = new DispatchRuntime();
+        dispatchRuntime.register("resident.deliver", residentHandler);
+        const dispatchResult = await dispatchRuntime.submit(
+          {
+            action: "resident.deliver",
+            target: { kind: "resident", sessionId: mainSessionId },
+            payload: residentPayload,
+            wait: true,
+            correlation: requestId,
+          },
+          {
+            sessionId,
+            ...(runId ? { runId } : {}),
+            actorKind: "worker",
+            actorId: `${sessionId}:${runId ?? workerId}`,
+            agentName: "worker",
+            trustTier: "assigned_worker",
+            ...(signal ? { signal } : {}),
+          },
         );
-        const result = await IngressHandlers.handleResident({
-          sessionId: mainSessionId,
-          event: residentEvent,
-          residentRuntime,
-          traceContext: trace,
-        });
-        return { requestId, accepted: true, output: result.result.output };
+        if (dispatchResult.status !== "completed") {
+          return {
+            requestId,
+            accepted: false,
+            error:
+              dispatchResult.error ??
+              dispatchResult.reason ??
+              `worker.inbound_wait dispatch ${dispatchResult.status}`,
+          };
+        }
+        return {
+          requestId,
+          accepted: true,
+          output: typeof dispatchResult.output === "string" ? dispatchResult.output : "",
+        };
       } finally {
         const after = runId ? await WorkerRun.get(sessionId, runId) : undefined;
         if (runId && after?.status === "waiting_input") {

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -184,7 +184,9 @@ export async function main(): Promise<void> {
       try {
         const residentPayload = `Worker ${workerId}${runId ? ` run ${runId}` : ""} asks Resident:\n\n${payload}`;
         const residentHandler: DispatchHandler = async (command, context) => {
-          const trace = TraceContext.create({ sessionId: mainSessionId });
+          const trace = command.traceId
+            ? TraceContext.child({ traceId: command.traceId }, { sessionId: mainSessionId })
+            : TraceContext.create({ sessionId: mainSessionId });
           const residentEvent = {
             id: command.dispatchId,
             surface: "dispatch",

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -84,6 +84,7 @@ function createWorkerDispatchRuntime(options: {
   readonly workerId: string;
   readonly sessionId: string;
   readonly runId: string;
+  readonly workspaceRoot?: string;
 }): DispatchToolRuntime {
   const runtime = new DispatchRuntime();
   const handler: DispatchHandler = async (command, context) => {
@@ -97,8 +98,9 @@ function createWorkerDispatchRuntime(options: {
     const callId = command.dispatchId;
     const payload =
       typeof command.payload === "string" ? command.payload : JSON.stringify(command.payload);
-    const sessionId = command.sessionId ?? context.sessionId ?? options.sessionId;
-    const runId = command.runId ?? context.runId ?? options.runId;
+    const sessionId = context.sessionId ?? options.sessionId;
+    const runId = context.runId ?? options.runId;
+    const workspaceRoot = context.workspaceRoot ?? options.workspaceRoot;
     const cancelInboundWait = () => {
       void options.server
         .call("worker.inbound_wait_cancel", { sessionId, runId, callId }, 5_000)
@@ -116,6 +118,7 @@ function createWorkerDispatchRuntime(options: {
             runId,
             callId,
             payload,
+            ...(workspaceRoot ? { workspaceRoot } : {}),
           },
           WORKER_INBOUND_WAIT_IPC_TIMEOUT_MS,
         ),
@@ -143,6 +146,7 @@ function createWorkerDispatchRuntime(options: {
         ...context,
         sessionId: context.sessionId ?? options.sessionId,
         runId: context.runId ?? options.runId,
+        workspaceRoot: context.workspaceRoot ?? options.workspaceRoot,
         actorKind: context.actorKind ?? "worker",
         actorId: context.actorId ?? `${options.sessionId}:${options.runId}`,
         trustTier: context.trustTier ?? "assigned_worker",
@@ -352,6 +356,7 @@ export namespace WorkerRunner {
             workerId: options.workerId,
             sessionId,
             runId,
+            ...(workspaceRoot ? { workspaceRoot } : {}),
           }),
           middleware: buildDelegationAdmissionMiddleware(request),
           delegationContext: {
@@ -367,7 +372,16 @@ export namespace WorkerRunner {
         const agentTools = agentProvider.listTools();
         const proxyTools = mcpProxyProvider.listTools();
         const availableTools = [...systemTools, ...agentTools, ...proxyTools];
-        const { tools, toolExecutor } = createExecutionToolContext(request, availableTools);
+        const { tools, toolExecutor } = createExecutionToolContext(
+          {
+            ...request,
+            toolConfig: {
+              ...(request.toolConfig ?? {}),
+              ...(workspaceRoot ? { workspaceRoot } : {}),
+            },
+          },
+          availableTools,
+        );
         const exposedTools = tools ?? [];
 
         toolsRef.tools = exposedTools;

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -2,7 +2,9 @@ import { ChatAgent } from "@openomni/agent";
 import type { Auth } from "@openomni/llm";
 import {
   AgentToolProvider,
+  DispatchRuntime,
   type BackgroundManager,
+  type DispatchHandler,
   type InjectionQueue,
   SystemToolProvider,
   ToolProxyProvider,
@@ -11,7 +13,7 @@ import {
   buildWorkerChildRuntimeConfig,
   createWorkerSubagentRuntime,
 } from "@openomni/openomni";
-import { Execution, type Ingress, Subagent, Tool, type WorkerBootstrap } from "@openomni/protocol";
+import { Execution, Subagent, Tool, type WorkerBootstrap } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { createContextMiddleware } from "../context/index";
 import type { WorkerRunState } from "./worker-run-state";
@@ -75,79 +77,66 @@ function abortableIpcCall<T>(
   });
 }
 
-function createWorkerInboundIngress(options: {
+function createWorkerDispatchRuntime(options: {
   readonly server: WorkerRunIpcServer;
   readonly ipcAuthToken: string;
   readonly workerId: string;
   readonly sessionId: string;
   readonly runId: string;
-}): {
-  ingest(
-    event: Ingress.InboundEvent,
-    context?: { readonly signal?: AbortSignal; readonly wait?: boolean },
-  ): Promise<Ingress.IngressResult>;
-} {
-  return {
-    async ingest(event, context) {
-      if (!context?.wait) {
-        throw new Error("worker inbound_message async delivery requires coordinator routing");
-      }
-      if (event.target?.kind !== "resident") {
-        throw new Error("worker inbound_message wait currently supports resident targets only");
-      }
+}): DispatchRuntime {
+  const runtime = new DispatchRuntime();
+  const handler: DispatchHandler = async (command, context) => {
+    if (!context?.wait) {
+      throw new Error("worker inbound_message async delivery requires coordinator routing");
+    }
+    if (command.target.kind !== "resident") {
+      throw new Error("worker inbound_message wait currently supports resident targets only");
+    }
 
-      const callId = crypto.randomUUID();
-      const payload =
-        typeof event.payload === "string" ? event.payload : JSON.stringify(event.payload);
-      const cancelInboundWait = () => {
-        void options.server
-          .call(
-            "worker.inbound_wait_cancel",
-            { sessionId: options.sessionId, runId: options.runId, callId },
-            5_000,
-          )
-          .catch(() => undefined);
-      };
+    const callId = command.dispatchId;
+    const payload =
+      typeof command.payload === "string" ? command.payload : JSON.stringify(command.payload);
+    const sessionId = command.sessionId ?? context.sessionId ?? options.sessionId;
+    const runId = command.runId ?? context.runId ?? options.runId;
+    const cancelInboundWait = () => {
+      void options.server
+        .call("worker.inbound_wait_cancel", { sessionId, runId, callId }, 5_000)
+        .catch(() => undefined);
+    };
 
-      const raw = await abortableIpcCall(
-        () =>
-          options.server.call(
-            "worker.inbound_wait",
-            {
-              authToken: options.ipcAuthToken,
-              workerId: options.workerId,
-              sessionId: options.sessionId,
-              runId: options.runId,
-              callId,
-              payload,
-            },
-            WORKER_INBOUND_WAIT_IPC_TIMEOUT_MS,
-          ),
-        context.signal,
-        cancelInboundWait,
+    const raw = await abortableIpcCall(
+      () =>
+        options.server.call(
+          "worker.inbound_wait",
+          {
+            authToken: options.ipcAuthToken,
+            workerId: options.workerId,
+            sessionId,
+            runId,
+            callId,
+            payload,
+          },
+          WORKER_INBOUND_WAIT_IPC_TIMEOUT_MS,
+        ),
+      context.signal,
+      cancelInboundWait,
+    );
+
+    if (raw === null || typeof raw !== "object") {
+      throw new Error("invalid worker.inbound_wait response");
+    }
+    const result = raw as { accepted?: unknown; output?: unknown; error?: unknown };
+    if (result.accepted !== true) {
+      throw new Error(
+        typeof result.error === "string" ? result.error : "worker.inbound_wait rejected",
       );
+    }
 
-      if (raw === null || typeof raw !== "object") {
-        throw new Error("invalid worker.inbound_wait response");
-      }
-      const result = raw as { accepted?: unknown; output?: unknown; error?: unknown };
-      if (result.accepted !== true) {
-        throw new Error(
-          typeof result.error === "string" ? result.error : "worker.inbound_wait rejected",
-        );
-      }
-
-      return {
-        mode: "direct",
-        target: { kind: "resident" },
-        sessionId: options.sessionId,
-        result: {
-          output: typeof result.output === "string" ? result.output : "",
-          finishReason: "stop",
-        },
-      };
-    },
+    return { output: typeof result.output === "string" ? result.output : "" };
   };
+
+  runtime.register("resident.deliver", handler);
+  return runtime;
 }
 
 export interface WorkerRunIpcServer {
@@ -344,7 +333,7 @@ export namespace WorkerRunner {
 
         const agentProvider = new AgentToolProvider({
           subagentRuntime: createWorkerSubagentRuntime(workerSubagentConfig),
-          ingressEngine: createWorkerInboundIngress({
+          dispatchRuntime: createWorkerDispatchRuntime({
             server,
             ipcAuthToken,
             workerId: options.workerId,

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -5,6 +5,7 @@ import {
   DispatchRuntime,
   type BackgroundManager,
   type DispatchHandler,
+  type DispatchToolRuntime,
   type InjectionQueue,
   SystemToolProvider,
   ToolProxyProvider,
@@ -83,7 +84,7 @@ function createWorkerDispatchRuntime(options: {
   readonly workerId: string;
   readonly sessionId: string;
   readonly runId: string;
-}): DispatchRuntime {
+}): DispatchToolRuntime {
   const runtime = new DispatchRuntime();
   const handler: DispatchHandler = async (command, context) => {
     if (!context?.wait) {
@@ -136,7 +137,19 @@ function createWorkerDispatchRuntime(options: {
   };
 
   runtime.register("resident.deliver", handler);
-  return runtime;
+  return {
+    submit(input, context = {}) {
+      return runtime.submit(input, {
+        ...context,
+        sessionId: context.sessionId ?? options.sessionId,
+        runId: context.runId ?? options.runId,
+        actorKind: context.actorKind ?? "worker",
+        actorId: context.actorId ?? `${options.sessionId}:${options.runId}`,
+        trustTier: context.trustTier ?? "assigned_worker",
+        labels: [...(context.labels ?? []), "worker-runner"],
+      });
+    },
+  };
 }
 
 export interface WorkerRunIpcServer {

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -236,6 +236,7 @@ describe("WorkerRunner", () => {
       const options = createSpawnOptions(
         {
           ...createValidRequest(),
+          workspaceRoot: "/worker/repo",
           tools: [{ name: "inbound_message", inputSchema: {} }],
         },
         (result) => {
@@ -289,6 +290,7 @@ describe("WorkerRunner", () => {
       const options = createSpawnOptions(
         {
           ...createValidRequest(),
+          workspaceRoot: "/worker/repo",
           tools: [{ name: "inbound_message", inputSchema: {} }],
         },
         (result) => {
@@ -345,6 +347,7 @@ describe("WorkerRunner", () => {
           runId: "run-1",
           callId: expect.any(String),
           payload: "Need approval",
+          workspaceRoot: "/worker/repo",
         }),
         timeoutMs: 300_000,
       }),

--- a/packages/coordinator/src/worker-pool/supervisor.ts
+++ b/packages/coordinator/src/worker-pool/supervisor.ts
@@ -37,6 +37,7 @@ export type InboundWaitParams = {
   sessionId: string;
   callId?: string;
   runId?: string;
+  workspaceRoot?: string;
   payload: string;
   signal?: AbortSignal;
 };
@@ -247,6 +248,8 @@ export class WorkerSupervisor {
                   ? params.callId
                   : requestId;
               const payload = typeof params?.payload === "string" ? params.payload : "";
+              const workspaceRoot =
+                typeof params?.workspaceRoot === "string" ? params.workspaceRoot : undefined;
               if (!this.inboundWaitHandler || !sessionId || !payload) {
                 respond({
                   requestId: callId,
@@ -263,6 +266,7 @@ export class WorkerSupervisor {
               const active: ActiveRequest = {
                 ...(runId !== undefined && { runId }),
                 sessionId,
+                ...(workspaceRoot !== undefined && { workspaceRoot }),
                 controller,
                 respond,
                 completed: false,
@@ -274,6 +278,7 @@ export class WorkerSupervisor {
                 sessionId,
                 callId,
                 ...(runId !== undefined && { runId }),
+                ...(workspaceRoot !== undefined && { workspaceRoot }),
                 payload,
                 signal: controller.signal,
               })

--- a/packages/openomni/src/dispatch/actor.ts
+++ b/packages/openomni/src/dispatch/actor.ts
@@ -15,9 +15,9 @@ export interface DispatchRuntimeContext {
 
 function actorKindFromAgent(agentName: string | undefined): Dispatch.ActorKind {
   if (!agentName) return "unknown";
-  const normalized = agentName.toLowerCase();
-  if (normalized === "resident" || normalized.includes("resident")) return "resident";
-  if (normalized === "system" || normalized.includes("scheduler")) return "system";
+  const normalized = agentName.trim().toLowerCase();
+  if (normalized === "resident") return "resident";
+  if (normalized === "system" || normalized === "scheduler") return "system";
   return "worker";
 }
 

--- a/packages/openomni/src/dispatch/actor.ts
+++ b/packages/openomni/src/dispatch/actor.ts
@@ -48,7 +48,8 @@ export function deriveActorContext(context: DispatchRuntimeContext = {}): Dispat
     ...(context.sessionId ? { sessionId: context.sessionId } : {}),
     ...(context.runId ? { runId: context.runId, workerRunId: context.runId } : {}),
     ...(context.workspaceRoot ? { workspaceRoot: context.workspaceRoot } : {}),
-    trustTier: context.trustTier ?? (workerRun ? "assigned_worker" : kind === "unknown" ? "unknown" : kind),
+    trustTier:
+      context.trustTier ?? (workerRun ? "assigned_worker" : kind === "unknown" ? "unknown" : kind),
     labels: [...(context.labels ?? []), `actor.${kind}`],
     ...(kind === "unknown" ? { reason: "missing runtime actor context" } : {}),
   });

--- a/packages/openomni/src/dispatch/actor.ts
+++ b/packages/openomni/src/dispatch/actor.ts
@@ -46,7 +46,8 @@ export function deriveActorContext(context: DispatchRuntimeContext = {}): Dispat
     actorId,
     ...(context.agentName ? { agentName: context.agentName } : {}),
     ...(context.sessionId ? { sessionId: context.sessionId } : {}),
-    ...(context.runId ? { runId: context.runId, workerRunId: context.runId } : {}),
+    ...(context.runId ? { runId: context.runId } : {}),
+    ...(context.runId && kind === "worker" ? { workerRunId: context.runId } : {}),
     ...(context.workspaceRoot ? { workspaceRoot: context.workspaceRoot } : {}),
     trustTier:
       context.trustTier ?? (workerRun ? "assigned_worker" : kind === "unknown" ? "unknown" : kind),

--- a/packages/openomni/src/dispatch/actor.ts
+++ b/packages/openomni/src/dispatch/actor.ts
@@ -1,0 +1,55 @@
+import { Dispatch } from "@openomni/protocol";
+import { WorkerRunStateStore } from "@openomni/session";
+
+export interface DispatchRuntimeContext {
+  readonly sessionId?: string;
+  readonly runId?: string;
+  readonly agentName?: string;
+  readonly workspaceRoot?: string;
+  readonly traceId?: string;
+  readonly actorKind?: Dispatch.ActorKind;
+  readonly actorId?: string;
+  readonly trustTier?: string;
+  readonly labels?: readonly string[];
+}
+
+function actorKindFromAgent(agentName: string | undefined): Dispatch.ActorKind {
+  if (!agentName) return "unknown";
+  const normalized = agentName.toLowerCase();
+  if (normalized === "resident" || normalized.includes("resident")) return "resident";
+  if (normalized === "system" || normalized.includes("scheduler")) return "system";
+  return "worker";
+}
+
+function lookupWorkerRun(sessionId: string | undefined, runId: string | undefined) {
+  if (!sessionId || !runId) return undefined;
+  try {
+    return WorkerRunStateStore.get(sessionId, runId);
+  } catch {
+    return undefined;
+  }
+}
+
+export function deriveActorContext(context: DispatchRuntimeContext = {}): Dispatch.ActorContext {
+  const workerRun = lookupWorkerRun(context.sessionId, context.runId);
+  const kind = context.actorKind ?? (workerRun ? "worker" : actorKindFromAgent(context.agentName));
+  const actorId =
+    context.actorId ??
+    (context.sessionId && context.runId
+      ? `${context.sessionId}:${context.runId}`
+      : context.agentName
+        ? `agent:${context.agentName}`
+        : "unknown");
+
+  return Dispatch.ActorContext.parse({
+    kind,
+    actorId,
+    ...(context.agentName ? { agentName: context.agentName } : {}),
+    ...(context.sessionId ? { sessionId: context.sessionId } : {}),
+    ...(context.runId ? { runId: context.runId, workerRunId: context.runId } : {}),
+    ...(context.workspaceRoot ? { workspaceRoot: context.workspaceRoot } : {}),
+    trustTier: context.trustTier ?? (workerRun ? "assigned_worker" : kind === "unknown" ? "unknown" : kind),
+    labels: [...(context.labels ?? []), `actor.${kind}`],
+    ...(kind === "unknown" ? { reason: "missing runtime actor context" } : {}),
+  });
+}

--- a/packages/openomni/src/dispatch/handlers/resident.ts
+++ b/packages/openomni/src/dispatch/handlers/resident.ts
@@ -1,0 +1,70 @@
+import type { Dispatch, Ingress, Model } from "@openomni/protocol";
+import type { ResidentRuntime } from "../../resident/runtime.js";
+import type { DispatchHandler } from "../registry.js";
+import { DEFAULT_DISPATCH_MODEL } from "../owners.js";
+
+export interface ResidentDispatchHandlerOptions {
+  readonly residentRuntime?: Pick<ResidentRuntime, "run">;
+  readonly defaultModel?: Model.Ref;
+}
+
+function requireResidentRuntime(
+  residentRuntime: Pick<ResidentRuntime, "run"> | undefined,
+): Pick<ResidentRuntime, "run"> {
+  if (!residentRuntime) throw new Error("dispatch resident handler requires residentRuntime owner");
+  return residentRuntime;
+}
+
+function eventFromCommand(
+  command: Dispatch.Command,
+  model: Model.Ref,
+): Ingress.ResolvedInboundEvent {
+  return {
+    id: command.dispatchId,
+    surface: "dispatch",
+    mode: "internal",
+    agentName: command.target.name ?? command.actor.agentName ?? "resident",
+    target: {
+      kind: "resident",
+      ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
+    },
+    payload: command.payload,
+    meta: {
+      actor: {
+        role: command.actor.kind,
+        id: command.actor.actorId,
+        sessionId: command.actor.sessionId,
+        runId: command.actor.runId,
+        agentName: command.actor.agentName,
+      },
+      target: {
+        kind: "resident",
+        ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
+      },
+    },
+    agent: { model },
+  };
+}
+
+export function createResidentDispatchHandlers(
+  options: ResidentDispatchHandlerOptions = {},
+): Record<"resident.deliver", DispatchHandler> {
+  const model = options.defaultModel ?? DEFAULT_DISPATCH_MODEL;
+  return {
+    async "resident.deliver"(command, context) {
+      const residentRuntime = requireResidentRuntime(options.residentRuntime);
+      const sessionId = command.target.sessionId ?? command.sessionId ?? context?.sessionId;
+      if (!sessionId)
+        throw new Error("resident.deliver requires target.sessionId or runtime sessionId");
+      const result = await residentRuntime.run({
+        sessionId,
+        event: eventFromCommand(command, model),
+        traceContext: command.traceId ? { traceId: command.traceId, sessionId } : undefined,
+        signal: context?.signal,
+      });
+      return {
+        output: { output: result.output, finishReason: result.finishReason, runId: result.runId },
+      };
+    },
+  };
+}

--- a/packages/openomni/src/dispatch/handlers/schedule.ts
+++ b/packages/openomni/src/dispatch/handlers/schedule.ts
@@ -1,0 +1,76 @@
+import { CronJob, type Dispatch } from "@openomni/protocol";
+import type { DispatchSchedulerOwner } from "../owners.js";
+import type { DispatchHandler } from "../registry.js";
+import { asRecord, extractText } from "./shared.js";
+
+export interface ScheduleDispatchHandlerOptions {
+  readonly scheduler?: DispatchSchedulerOwner;
+}
+
+function requireScheduler(scheduler: DispatchSchedulerOwner | undefined): DispatchSchedulerOwner {
+  if (!scheduler) throw new Error("dispatch schedule handler requires scheduler owner");
+  return scheduler;
+}
+
+function compatibilitySchedule(
+  context: { compatibility?: Record<string, unknown> } | undefined,
+): string | undefined {
+  const schedule = context?.compatibility?.schedule;
+  return typeof schedule === "string" ? schedule : undefined;
+}
+
+function scheduleFromPayload(
+  command: Dispatch.Command,
+  context: { compatibility?: Record<string, unknown> } | undefined,
+): string | undefined {
+  const payload = asRecord(command.payload);
+  return (
+    (typeof payload?.schedule === "string" ? payload.schedule : undefined) ??
+    compatibilitySchedule(context)
+  );
+}
+
+function payloadText(command: Dispatch.Command): string {
+  const payload = asRecord(command.payload);
+  if (payload && "payload" in payload) return extractText(payload.payload);
+  return extractText(command.payload);
+}
+
+export function createScheduleDispatchHandlers(
+  options: ScheduleDispatchHandlerOptions = {},
+): Record<"schedule.create" | "schedule.cancel", DispatchHandler> {
+  return {
+    "schedule.create"(command, context) {
+      const scheduler = requireScheduler(options.scheduler);
+      const schedule = scheduleFromPayload(command, context);
+      if (!schedule) throw new Error("schedule.create requires payload.schedule");
+      const payload = asRecord(command.payload);
+      const agentName =
+        (typeof payload?.agentName === "string" ? payload.agentName : undefined) ??
+        command.target.name ??
+        command.actor.agentName;
+      if (!agentName) throw new Error("schedule.create requires target.name or payload.agentName");
+
+      const job = CronJob.Info.parse({
+        id: crypto.randomUUID(),
+        agentName,
+        payload: payloadText(command),
+        schedule,
+        target: {
+          kind: command.target.kind === "schedule" ? "resident" : command.target.kind,
+          ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
+        },
+        createdAt: Date.now(),
+      });
+      const jobId = scheduler.register(job);
+      return { output: { scheduled: true, jobId, messageId: jobId } };
+    },
+
+    "schedule.cancel"(command) {
+      const scheduler = requireScheduler(options.scheduler);
+      const jobId = command.target.id ?? command.target.name;
+      if (!jobId) throw new Error("schedule.cancel requires target.id");
+      return { output: { cancelled: scheduler.remove(jobId), jobId } };
+    },
+  };
+}

--- a/packages/openomni/src/dispatch/handlers/schedule.ts
+++ b/packages/openomni/src/dispatch/handlers/schedule.ts
@@ -36,6 +36,22 @@ function payloadText(command: Dispatch.Command): string {
   return extractText(command.payload);
 }
 
+function scheduleTarget(command: Dispatch.Command): CronJob.Target {
+  if (command.target.kind === "worker") {
+    return {
+      kind: "worker",
+      ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
+    };
+  }
+  if (command.target.kind === "resident" || command.target.kind === "schedule") {
+    return {
+      kind: "resident",
+      ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
+    };
+  }
+  throw new Error(`schedule.create cannot target ${command.target.kind}`);
+}
+
 export function createScheduleDispatchHandlers(
   options: ScheduleDispatchHandlerOptions = {},
 ): Record<"schedule.create" | "schedule.cancel", DispatchHandler> {
@@ -56,10 +72,7 @@ export function createScheduleDispatchHandlers(
         agentName,
         payload: payloadText(command),
         schedule,
-        target: {
-          kind: command.target.kind === "schedule" ? "resident" : command.target.kind,
-          ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
-        },
+        target: scheduleTarget(command),
         createdAt: Date.now(),
       });
       const jobId = scheduler.register(job);

--- a/packages/openomni/src/dispatch/handlers/shared.ts
+++ b/packages/openomni/src/dispatch/handlers/shared.ts
@@ -8,7 +8,8 @@ export function extractText(payload: unknown): string {
   ) {
     return (payload as { text: string }).text;
   }
-  return JSON.stringify(payload ?? "") ?? "";
+  if (payload === null || payload === undefined) return "";
+  return JSON.stringify(payload) ?? "";
 }
 
 export function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/openomni/src/dispatch/handlers/shared.ts
+++ b/packages/openomni/src/dispatch/handlers/shared.ts
@@ -1,0 +1,18 @@
+export function extractText(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "text" in payload &&
+    typeof (payload as { text?: unknown }).text === "string"
+  ) {
+    return (payload as { text: string }).text;
+  }
+  return JSON.stringify(payload ?? "") ?? "";
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -1,0 +1,101 @@
+import type { Dispatch, Execution, Model } from "@openomni/protocol";
+import { Session } from "@openomni/session";
+import type { CoordinatorLike } from "../../ingress/coordinator-like.js";
+import type { DispatchHandler } from "../registry.js";
+import { DEFAULT_DISPATCH_MODEL } from "../owners.js";
+import { asRecord, extractText } from "./shared.js";
+
+export interface WorkerDispatchHandlerOptions {
+  readonly coordinator?: CoordinatorLike;
+  readonly defaultModel?: Model.Ref;
+}
+
+function requireCoordinator(coordinator: CoordinatorLike | undefined): CoordinatorLike {
+  if (!coordinator) throw new Error("dispatch worker handler requires coordinator owner");
+  return coordinator;
+}
+
+function targetRunId(command: Dispatch.Command): string | undefined {
+  return command.target.runId ?? command.target.id;
+}
+
+function resolveSessionId(command: Dispatch.Command, model: Model.Ref): string {
+  if (command.target.sessionId) return command.target.sessionId;
+  const session = Session.create({
+    title: `Dispatch worker ${command.action}`,
+    model: { providerID: model.provider, modelID: model.id },
+  });
+  return session.id;
+}
+
+function buildRequest(command: Dispatch.Command, model: Model.Ref): Execution.Request {
+  const payload = asRecord(command.payload);
+  const sessionId = resolveSessionId(command, model);
+  return {
+    runId: crypto.randomUUID(),
+    sessionId,
+    mode: "direct",
+    prompt: extractText(command.payload),
+    model,
+    agentName:
+      (typeof payload?.agentName === "string" ? payload.agentName : undefined) ??
+      command.target.name,
+    workspaceRoot: command.workspaceRoot,
+    traceId: command.traceId,
+  };
+}
+
+export function createWorkerDispatchHandlers(
+  options: WorkerDispatchHandlerOptions = {},
+): Record<"worker.spawn" | "worker.send" | "worker.resume" | "worker.cancel", DispatchHandler> {
+  const model = options.defaultModel ?? DEFAULT_DISPATCH_MODEL;
+  return {
+    async "worker.spawn"(command) {
+      const coordinator = requireCoordinator(options.coordinator);
+      const request = buildRequest(command, model);
+      const result = await coordinator.dispatch(request.sessionId, request);
+      return { output: { sessionId: request.sessionId, runId: request.runId, result } };
+    },
+
+    async "worker.send"(command) {
+      const coordinator = requireCoordinator(options.coordinator);
+      if (!coordinator.deliverMessage) {
+        throw new Error("dispatch worker.send requires coordinator.deliverMessage owner");
+      }
+      const sessionId = command.target.sessionId ?? command.sessionId;
+      if (!sessionId) throw new Error("worker.send requires target.sessionId");
+      const result = await coordinator.deliverMessage(
+        sessionId,
+        extractText(command.payload),
+        targetRunId(command),
+      );
+      return { output: { delivered: true, sessionId, runId: targetRunId(command), result } };
+    },
+
+    async "worker.resume"(command) {
+      const coordinator = requireCoordinator(options.coordinator);
+      if (!coordinator.deliverMessage) {
+        throw new Error("dispatch worker.resume requires coordinator.deliverMessage owner");
+      }
+      const sessionId = command.target.sessionId ?? command.sessionId;
+      if (!sessionId) throw new Error("worker.resume requires target.sessionId");
+      const result = await coordinator.deliverMessage(
+        sessionId,
+        extractText(command.payload),
+        targetRunId(command),
+      );
+      return { output: { resumed: true, sessionId, runId: targetRunId(command), result } };
+    },
+
+    async "worker.cancel"(command) {
+      const coordinator = requireCoordinator(options.coordinator);
+      if (!coordinator.cancelRun) {
+        throw new Error("dispatch worker.cancel requires coordinator.cancelRun owner");
+      }
+      const runId = targetRunId(command);
+      if (!runId) throw new Error("worker.cancel requires target.runId or target.id");
+      const result = await coordinator.cancelRun(runId);
+      return { output: { cancelled: true, runId, result } };
+    },
+  };
+}

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -21,10 +21,15 @@ function targetRunId(command: Dispatch.Command): string | undefined {
 
 function resolveSessionId(command: Dispatch.Command, model: Model.Ref): string {
   if (command.target.sessionId) return command.target.sessionId;
-  const session = Session.create({
-    title: `Dispatch worker ${command.action}`,
-    model: { providerID: model.provider, modelID: model.id },
-  });
+  const title = `Dispatch worker ${command.action}`;
+  const modelInfo = { providerID: model.provider, modelID: model.id };
+  const session = command.target.parentSessionId
+    ? Session.createChild({
+        parentSessionId: command.target.parentSessionId,
+        title,
+        model: modelInfo,
+      })
+    : Session.create({ title, model: modelInfo });
   return session.id;
 }
 

--- a/packages/openomni/src/dispatch/index.ts
+++ b/packages/openomni/src/dispatch/index.ts
@@ -1,0 +1,9 @@
+export { deriveActorContext, type DispatchRuntimeContext } from "./actor.js";
+export { createDefaultDispatchPolicy } from "./policy.js";
+export {
+  DispatchRegistry,
+  type DispatchHandler,
+  type DispatchHandlerContext,
+  type DispatchHandlerResult,
+} from "./registry.js";
+export { DispatchRuntime, type DispatchRuntimeOptions, type DispatchSubmitOptions } from "./runtime.js";

--- a/packages/openomni/src/dispatch/index.ts
+++ b/packages/openomni/src/dispatch/index.ts
@@ -6,4 +6,27 @@ export {
   type DispatchHandlerContext,
   type DispatchHandlerResult,
 } from "./registry.js";
-export { DispatchRuntime, type DispatchRuntimeOptions, type DispatchSubmitOptions } from "./runtime.js";
+export {
+  DispatchRuntime,
+  type DispatchRuntimeOptions,
+  type DispatchSubmitOptions,
+} from "./runtime.js";
+export type { DispatchOwners, DispatchSchedulerOwner } from "./owners.js";
+export {
+  createDefaultDispatchRuntime,
+  registerBuiltInDispatchHandlers,
+  type BuiltInDispatchOptions,
+  type DefaultDispatchRuntimeOptions,
+} from "./setup.js";
+export {
+  createResidentDispatchHandlers,
+  type ResidentDispatchHandlerOptions,
+} from "./handlers/resident.js";
+export {
+  createScheduleDispatchHandlers,
+  type ScheduleDispatchHandlerOptions,
+} from "./handlers/schedule.js";
+export {
+  createWorkerDispatchHandlers,
+  type WorkerDispatchHandlerOptions,
+} from "./handlers/worker.js";

--- a/packages/openomni/src/dispatch/owners.ts
+++ b/packages/openomni/src/dispatch/owners.ts
@@ -1,0 +1,20 @@
+import type { CronJob, Model } from "@openomni/protocol";
+import type { CoordinatorLike } from "../ingress/coordinator-like.js";
+import type { ResidentRuntime } from "../resident/runtime.js";
+
+export interface DispatchSchedulerOwner {
+  register(job: CronJob.Info): string;
+  remove(jobId: string): boolean;
+}
+
+export interface DispatchOwners {
+  readonly coordinator?: CoordinatorLike;
+  readonly residentRuntime?: Pick<ResidentRuntime, "run">;
+  readonly scheduler?: DispatchSchedulerOwner;
+  readonly defaultModel?: Model.Ref;
+}
+
+export const DEFAULT_DISPATCH_MODEL: Model.Ref = {
+  provider: "anthropic",
+  id: "claude-3-5-sonnet-20241022",
+};

--- a/packages/openomni/src/dispatch/policy.ts
+++ b/packages/openomni/src/dispatch/policy.ts
@@ -47,6 +47,10 @@ export function createDefaultDispatchPolicy(): PolicyRegistration {
         return deny("dispatch.worker.spawn.denied");
       }
 
+      if (actor.kind === "worker" && action.startsWith("schedule.")) {
+        return deny("dispatch.worker.schedule.denied");
+      }
+
       if (actor.kind === "worker" && action === "resident.deliver") {
         return allow("dispatch.worker.resident_deliver.allowed");
       }

--- a/packages/openomni/src/dispatch/policy.ts
+++ b/packages/openomni/src/dispatch/policy.ts
@@ -1,12 +1,6 @@
 import { PolicyDecision, type Dispatch, type Policy } from "@openomni/protocol";
 import type { PolicyRegistration } from "@openomni/agent";
 
-const PROTECTED_PREFIXES = ["worker.", "resident.", "schedule."] as const;
-
-function isProtectedAction(action: string): boolean {
-  return PROTECTED_PREFIXES.some((prefix) => action.startsWith(prefix));
-}
-
 function deny(reason: string): Policy.PolicyDecision {
   return PolicyDecision.deny({
     policyId: "dispatch.default-authority",
@@ -38,9 +32,7 @@ export function createDefaultDispatchPolicy(): PolicyRegistration {
       const actor = input.actor;
 
       if (!actor || actor.kind === "unknown") {
-        return isProtectedAction(action)
-          ? deny("dispatch.actor.required")
-          : allow("dispatch.actor.unknown_unprotected");
+        return deny("dispatch.actor.required");
       }
 
       if (actor.kind === "worker" && action === "worker.spawn") {

--- a/packages/openomni/src/dispatch/policy.ts
+++ b/packages/openomni/src/dispatch/policy.ts
@@ -1,0 +1,61 @@
+import { PolicyDecision, type Dispatch, type Policy } from "@openomni/protocol";
+import type { PolicyRegistration } from "@openomni/agent";
+
+const PROTECTED_PREFIXES = ["worker.", "resident.", "schedule."] as const;
+
+function isProtectedAction(action: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => action.startsWith(prefix));
+}
+
+function deny(reason: string): Policy.PolicyDecision {
+  return PolicyDecision.deny({
+    policyId: "dispatch.default-authority",
+    reasonCodes: [reason],
+    effects: [
+      { type: "run.abort", reason },
+      { type: "audit.annotate", annotation: reason, severity: "error" },
+    ],
+  });
+}
+
+function allow(reason: string): Policy.PolicyDecision {
+  return PolicyDecision.allow({
+    policyId: "dispatch.default-authority",
+    reasonCodes: [reason],
+    effects: [{ type: "audit.annotate", annotation: reason, severity: "info" }],
+  });
+}
+
+export function createDefaultDispatchPolicy(): PolicyRegistration {
+  return {
+    name: "dispatch.default-authority",
+    timing: "dispatch.authorize",
+    priority: 0,
+    failPolicy: "fail-closed",
+    fn(ctx) {
+      const input = ctx.toolInput as { actor?: Dispatch.ActorContext; action?: unknown };
+      const action = typeof input.action === "string" ? input.action : "";
+      const actor = input.actor;
+
+      if (!actor || actor.kind === "unknown") {
+        return isProtectedAction(action)
+          ? deny("dispatch.actor.required")
+          : allow("dispatch.actor.unknown_unprotected");
+      }
+
+      if (actor.kind === "worker" && action === "worker.spawn") {
+        return deny("dispatch.worker.spawn.denied");
+      }
+
+      if (actor.kind === "worker" && action === "resident.deliver") {
+        return allow("dispatch.worker.resident_deliver.allowed");
+      }
+
+      if (actor.kind === "system" && action.startsWith("schedule.")) {
+        return allow("dispatch.system.schedule.allowed");
+      }
+
+      return allow("dispatch.default.allowed");
+    },
+  };
+}

--- a/packages/openomni/src/dispatch/registry.ts
+++ b/packages/openomni/src/dispatch/registry.ts
@@ -26,6 +26,9 @@ export class DispatchRegistry {
 
   register(action: string, handler: DispatchHandler): () => void {
     if (!action) throw new Error("dispatch action is required");
+    if (this.handlers.has(action)) {
+      throw new Error(`dispatch action already registered: ${action}`);
+    }
     this.handlers.set(action, handler);
     return () => this.unregister(action);
   }

--- a/packages/openomni/src/dispatch/registry.ts
+++ b/packages/openomni/src/dispatch/registry.ts
@@ -1,0 +1,44 @@
+import type { Dispatch } from "@openomni/protocol";
+
+export interface DispatchHandlerContext {
+  readonly signal?: AbortSignal;
+}
+
+export interface DispatchHandlerResult {
+  readonly output?: unknown;
+}
+
+export type DispatchHandler = (
+  command: Dispatch.Command,
+  context?: DispatchHandlerContext,
+) => Promise<DispatchHandlerResult | unknown> | DispatchHandlerResult | unknown;
+
+export class DispatchRegistry {
+  private readonly handlers = new Map<string, DispatchHandler>();
+
+  register(action: string, handler: DispatchHandler): () => void {
+    if (!action) throw new Error("dispatch action is required");
+    this.handlers.set(action, handler);
+    return () => this.unregister(action);
+  }
+
+  unregister(action: string): boolean {
+    return this.handlers.delete(action);
+  }
+
+  get(action: string): DispatchHandler | undefined {
+    return this.handlers.get(action);
+  }
+
+  has(action: string): boolean {
+    return this.handlers.has(action);
+  }
+
+  clear(): void {
+    this.handlers.clear();
+  }
+
+  list(): string[] {
+    return [...this.handlers.keys()].sort();
+  }
+}

--- a/packages/openomni/src/dispatch/registry.ts
+++ b/packages/openomni/src/dispatch/registry.ts
@@ -2,6 +2,14 @@ import type { Dispatch } from "@openomni/protocol";
 
 export interface DispatchHandlerContext {
   readonly signal?: AbortSignal;
+  readonly wait?: boolean;
+  readonly timeoutMs?: number;
+  readonly sessionId?: string;
+  readonly runId?: string;
+  readonly agentName?: string;
+  readonly workspaceRoot?: string;
+  readonly sourceTool?: string;
+  readonly compatibility?: Record<string, unknown>;
 }
 
 export interface DispatchHandlerResult {

--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -1,0 +1,260 @@
+import { PolicyEngine, type PolicyDecision, type PolicyRegistration } from "@openomni/agent";
+import {
+  Dispatch as DispatchProtocol,
+  PolicyDecision as Decision,
+  type Policy,
+  type RuntimeResource,
+} from "@openomni/protocol";
+import { Bus, TraceContext } from "@openomni/session";
+import { deriveActorContext, type DispatchRuntimeContext } from "./actor.js";
+import { createDefaultDispatchPolicy } from "./policy.js";
+import { DispatchRegistry, type DispatchHandler, type DispatchHandlerContext } from "./registry.js";
+
+const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+type DispatchEventPayload = {
+  readonly dispatchId: string;
+  readonly traceId?: string;
+  readonly sessionId?: string;
+  readonly runId?: string;
+  readonly actor: DispatchProtocol.ActorContext;
+  readonly action: string;
+  readonly target: DispatchProtocol.Target;
+  readonly correlation?: string;
+  readonly time: number;
+};
+
+export interface DispatchSubmitOptions extends DispatchRuntimeContext, DispatchHandlerContext {
+  readonly policies?: readonly PolicyRegistration[];
+  readonly includeDefaultPolicies?: boolean;
+  readonly onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
+}
+
+export interface DispatchRuntimeOptions {
+  readonly registry?: DispatchRegistry;
+  readonly policies?: readonly PolicyRegistration[];
+  readonly includeDefaultPolicies?: boolean;
+  readonly onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
+}
+
+function summarize(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value.slice(0, 200);
+  try {
+    return JSON.stringify(value).slice(0, 200);
+  } catch {
+    return String(value).slice(0, 200);
+  }
+}
+
+function eventBase(command: DispatchProtocol.Command): DispatchEventPayload {
+  return {
+    dispatchId: command.dispatchId,
+    ...(command.traceId ? { traceId: command.traceId } : {}),
+    ...(command.sessionId ? { sessionId: command.sessionId } : {}),
+    ...(command.runId ? { runId: command.runId } : {}),
+    actor: command.actor,
+    action: command.action,
+    target: command.target,
+    ...(command.correlation ? { correlation: command.correlation } : {}),
+    time: Date.now(),
+  };
+}
+
+function resourceDescriptor(action: string): RuntimeResource.Descriptor {
+  return {
+    id: `dispatch:${action}`,
+    kind: "dispatch",
+    labels: ["dispatch", `dispatch.action.${action}`],
+    capabilities: ["route"],
+    effects: ["cross-session"],
+    source: { type: "runtime" },
+  };
+}
+
+function policyTraceContext(command: DispatchProtocol.Command, fallbackTraceId: string) {
+  return {
+    traceId: command.traceId ?? fallbackTraceId,
+    ...(command.sessionId ? { sessionId: command.sessionId } : {}),
+    ...(command.runId ? { runId: command.runId } : {}),
+  };
+}
+
+function collectPolicies(
+  runtimePolicies: readonly PolicyRegistration[],
+  submitPolicies: readonly PolicyRegistration[] | undefined,
+  includeDefaultPolicies: boolean,
+): PolicyRegistration[] {
+  return [
+    ...(includeDefaultPolicies ? [createDefaultDispatchPolicy()] : []),
+    ...runtimePolicies,
+    ...(submitPolicies ?? []),
+  ];
+}
+
+function normalizeHandlerOutput(value: Awaited<ReturnType<DispatchHandler>>): unknown {
+  if (value && typeof value === "object" && "output" in value) {
+    return (value as { output?: unknown }).output;
+  }
+  return value;
+}
+
+export class DispatchRuntime {
+  readonly registry: DispatchRegistry;
+  private readonly policies: readonly PolicyRegistration[];
+  private readonly includeDefaultPolicies: boolean;
+  private readonly onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
+
+  constructor(options: DispatchRuntimeOptions = {}) {
+    this.registry = options.registry ?? new DispatchRegistry();
+    this.policies = options.policies ?? [];
+    this.includeDefaultPolicies = options.includeDefaultPolicies ?? true;
+    this.onPolicyDecision = options.onPolicyDecision;
+  }
+
+  register(action: string, handler: DispatchHandler): () => void {
+    return this.registry.register(action, handler);
+  }
+
+  async submit(input: DispatchProtocol.Input, options: DispatchSubmitOptions = {}): Promise<DispatchProtocol.Result> {
+    const parsed = DispatchProtocol.Input.parse(input);
+    const trace = options.traceId ? { traceId: options.traceId } : TraceContext.create();
+    const actor = deriveActorContext(options);
+    const command = DispatchProtocol.Command.parse({
+      ...parsed,
+      dispatchId: crypto.randomUUID(),
+      actor,
+      traceId: trace.traceId,
+      ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+      ...(options.runId ? { runId: options.runId } : {}),
+      ...(options.workspaceRoot ? { workspaceRoot: options.workspaceRoot } : {}),
+      submittedAt: Date.now(),
+    });
+    const start = Date.now();
+
+    Bus.publish(DispatchProtocol.Events.Submitted, {
+      ...eventBase(command),
+      ...(summarize(command.payload) ? { payloadSummary: summarize(command.payload) } : {}),
+      ...(command.idempotencyKey ? { idempotencyKey: command.idempotencyKey } : {}),
+    });
+
+    const engine = PolicyEngine.create({
+      traceContext: policyTraceContext(command, trace.traceId),
+      onDecision: options.onPolicyDecision ?? this.onPolicyDecision,
+    });
+    for (const reg of collectPolicies(
+      this.policies,
+      options.policies,
+      options.includeDefaultPolicies ?? this.includeDefaultPolicies,
+    )) {
+      engine.register(reg);
+    }
+
+    const decision = await engine.dispatch("dispatch.authorize", {
+      steps: [],
+      usage: emptyUsage,
+      turnCount: 0,
+      isCompletion: false,
+      continuationCount: 0,
+      elapsedMs: 0,
+      labels: [
+        { value: `dispatch.${command.action}`, source: "system" },
+        { value: `actor.${command.actor.kind}`, source: "system" },
+        { value: `target.${command.target.kind}`, source: "system" },
+      ],
+      toolName: "dispatch",
+      toolInput: {
+        actor: command.actor,
+        dispatchId: command.dispatchId,
+        action: command.action,
+        target: command.target,
+        sessionId: command.sessionId,
+        runId: command.runId,
+      },
+      resourceDescriptor: resourceDescriptor(command.action),
+      traceContext: policyTraceContext(command, trace.traceId),
+    });
+
+    if (Decision.isBlocking(decision)) {
+      const reason = Decision.reason(decision, "dispatch.authorize denied");
+      Bus.publish(DispatchProtocol.Events.Denied, {
+        ...eventBase(command),
+        verdict: decision.verdict === "pending" ? "pending" : "deny",
+        reason,
+        policyId: decision.policyId,
+        effects: decision.effects,
+      });
+      return DispatchProtocol.Result.parse({
+        dispatchId: command.dispatchId,
+        status: "denied",
+        reason,
+        error: reason,
+        durationMs: Date.now() - start,
+      });
+    }
+
+    Bus.publish(DispatchProtocol.Events.Authorized, {
+      ...eventBase(command),
+      verdict: "allow",
+      reason: Decision.reason(decision, "dispatch.authorize allowed"),
+      policyId: decision.policyId,
+      effects: decision.effects,
+    });
+
+    const handler = this.registry.get(command.action);
+    if (!handler) {
+      const reason = `No dispatch handler registered for ${command.action}`;
+      Bus.publish(DispatchProtocol.Events.Failed, {
+        ...eventBase(command),
+        durationMs: Date.now() - start,
+        reason,
+      });
+      return DispatchProtocol.Result.parse({
+        dispatchId: command.dispatchId,
+        status: "failed",
+        error: reason,
+        durationMs: Date.now() - start,
+      });
+    }
+
+    Bus.publish(DispatchProtocol.Events.Routed, { ...eventBase(command), handler: command.action });
+
+    try {
+      const raw = await handler(command, { signal: options.signal });
+      const output = normalizeHandlerOutput(raw);
+      Bus.publish(DispatchProtocol.Events.Completed, {
+        ...eventBase(command),
+        handler: command.action,
+        durationMs: Date.now() - start,
+        ...(summarize(output) ? { resultSummary: summarize(output) } : {}),
+      });
+      return DispatchProtocol.Result.parse({
+        dispatchId: command.dispatchId,
+        status: "completed",
+        output,
+        handler: command.action,
+        durationMs: Date.now() - start,
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      Bus.publish(DispatchProtocol.Events.Failed, {
+        ...eventBase(command),
+        handler: command.action,
+        durationMs: Date.now() - start,
+        reason,
+      });
+      return DispatchProtocol.Result.parse({
+        dispatchId: command.dispatchId,
+        status: "failed",
+        error: reason,
+        handler: command.action,
+        durationMs: Date.now() - start,
+      });
+    }
+  }
+}
+
+export const Dispatch = {
+  Runtime: DispatchRuntime,
+  Registry: DispatchRegistry,
+} as const;

--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -215,8 +215,12 @@ export class DispatchRuntime {
     try {
       const raw = await handler(command, {
         signal: options.signal,
-        ...(options.wait !== undefined ? { wait: options.wait } : {}),
-        ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+        ...((options.wait ?? command.wait) !== undefined
+          ? { wait: options.wait ?? command.wait }
+          : {}),
+        ...((options.timeoutMs ?? command.timeoutMs) !== undefined
+          ? { timeoutMs: options.timeoutMs ?? command.timeoutMs }
+          : {}),
         ...(options.sessionId ? { sessionId: options.sessionId } : {}),
         ...(options.runId ? { runId: options.runId } : {}),
         ...(options.agentName ? { agentName: options.agentName } : {}),

--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -28,6 +28,8 @@ export interface DispatchSubmitOptions extends DispatchRuntimeContext, DispatchH
   readonly policies?: readonly PolicyRegistration[];
   readonly includeDefaultPolicies?: boolean;
   readonly onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
+  readonly sourceTool?: string;
+  readonly compatibility?: Record<string, unknown>;
 }
 
 export interface DispatchRuntimeOptions {
@@ -116,7 +118,10 @@ export class DispatchRuntime {
     return this.registry.register(action, handler);
   }
 
-  async submit(input: DispatchProtocol.Input, options: DispatchSubmitOptions = {}): Promise<DispatchProtocol.Result> {
+  async submit(
+    input: DispatchProtocol.Input,
+    options: DispatchSubmitOptions = {},
+  ): Promise<DispatchProtocol.Result> {
     const parsed = DispatchProtocol.Input.parse(input);
     const trace = options.traceId ? { traceId: options.traceId } : TraceContext.create();
     const actor = deriveActorContext(options);
@@ -220,7 +225,17 @@ export class DispatchRuntime {
     Bus.publish(DispatchProtocol.Events.Routed, { ...eventBase(command), handler: command.action });
 
     try {
-      const raw = await handler(command, { signal: options.signal });
+      const raw = await handler(command, {
+        signal: options.signal,
+        ...(options.wait !== undefined ? { wait: options.wait } : {}),
+        ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+        ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+        ...(options.runId ? { runId: options.runId } : {}),
+        ...(options.agentName ? { agentName: options.agentName } : {}),
+        ...(options.workspaceRoot ? { workspaceRoot: options.workspaceRoot } : {}),
+        ...(options.sourceTool ? { sourceTool: options.sourceTool } : {}),
+        ...(options.compatibility ? { compatibility: options.compatibility } : {}),
+      });
       const output = normalizeHandlerOutput(raw);
       Bus.publish(DispatchProtocol.Events.Completed, {
         ...eventBase(command),

--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -38,16 +38,6 @@ export interface DispatchRuntimeOptions {
   readonly onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
 }
 
-function summarize(value: unknown): string | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value === "string") return value.slice(0, 200);
-  try {
-    return JSON.stringify(value).slice(0, 200);
-  } catch {
-    return String(value).slice(0, 200);
-  }
-}
-
 function eventBase(command: DispatchProtocol.Command): DispatchEventPayload {
   return {
     dispatchId: command.dispatchId,
@@ -138,7 +128,6 @@ export class DispatchRuntime {
 
     Bus.publish(DispatchProtocol.Events.Submitted, {
       ...eventBase(command),
-      ...(summarize(command.payload) ? { payloadSummary: summarize(command.payload) } : {}),
       ...(command.idempotencyKey ? { idempotencyKey: command.idempotencyKey } : {}),
     });
 
@@ -240,7 +229,6 @@ export class DispatchRuntime {
         ...eventBase(command),
         handler: command.action,
         durationMs: Date.now() - start,
-        ...(summarize(output) ? { resultSummary: summarize(output) } : {}),
       });
       return DispatchProtocol.Result.parse({
         dispatchId: command.dispatchId,

--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -2,7 +2,6 @@ import { PolicyEngine, type PolicyDecision, type PolicyRegistration } from "@ope
 import {
   Dispatch as DispatchProtocol,
   PolicyDecision as Decision,
-  type Policy,
   type RuntimeResource,
 } from "@openomni/protocol";
 import { Bus, TraceContext } from "@openomni/session";

--- a/packages/openomni/src/dispatch/setup.ts
+++ b/packages/openomni/src/dispatch/setup.ts
@@ -1,5 +1,5 @@
 import { CronJobRegistry } from "../execution-runtime/cron-job-registry.js";
-import { DispatchRegistry } from "./registry.js";
+import type { DispatchRegistry } from "./registry.js";
 import { DispatchRuntime, type DispatchRuntimeOptions } from "./runtime.js";
 import type { DispatchOwners } from "./owners.js";
 import { createResidentDispatchHandlers } from "./handlers/resident.js";

--- a/packages/openomni/src/dispatch/setup.ts
+++ b/packages/openomni/src/dispatch/setup.ts
@@ -1,0 +1,46 @@
+import { CronJobRegistry } from "../execution-runtime/cron-job-registry.js";
+import { DispatchRegistry } from "./registry.js";
+import { DispatchRuntime, type DispatchRuntimeOptions } from "./runtime.js";
+import type { DispatchOwners } from "./owners.js";
+import { createResidentDispatchHandlers } from "./handlers/resident.js";
+import { createScheduleDispatchHandlers } from "./handlers/schedule.js";
+import { createWorkerDispatchHandlers } from "./handlers/worker.js";
+
+export interface BuiltInDispatchOptions {
+  readonly owners?: DispatchOwners;
+}
+
+export function registerBuiltInDispatchHandlers(
+  registry: DispatchRegistry,
+  options: BuiltInDispatchOptions = {},
+): DispatchRegistry {
+  const owners = options.owners ?? {};
+  const scheduler = owners.scheduler ?? CronJobRegistry;
+  const handlers = {
+    ...createResidentDispatchHandlers({
+      residentRuntime: owners.residentRuntime,
+      defaultModel: owners.defaultModel,
+    }),
+    ...createWorkerDispatchHandlers({
+      coordinator: owners.coordinator,
+      defaultModel: owners.defaultModel,
+    }),
+    ...createScheduleDispatchHandlers({ scheduler }),
+  };
+  for (const [action, handler] of Object.entries(handlers)) {
+    registry.register(action, handler);
+  }
+  return registry;
+}
+
+export interface DefaultDispatchRuntimeOptions
+  extends DispatchRuntimeOptions,
+    BuiltInDispatchOptions {}
+
+export function createDefaultDispatchRuntime(
+  options: DefaultDispatchRuntimeOptions = {},
+): DispatchRuntime {
+  const runtime = new DispatchRuntime(options);
+  registerBuiltInDispatchHandlers(runtime.registry, { owners: options.owners });
+  return runtime;
+}

--- a/packages/openomni/src/execution-runtime/AGENTS.md
+++ b/packages/openomni/src/execution-runtime/AGENTS.md
@@ -22,7 +22,7 @@ Tool system, workspace safety, and worker middleware for `@openomni/openomni`. T
 
 ## inbound_message tool
 
-`createInboundMessageTool(ingressEngine)` returns the `inbound_message` tool. It is the single cross-sandbox IPC primitive for worker agents.
+`createInboundMessageTool(dispatchRuntime)` returns the `inbound_message` tool. It is the Dispatch-backed compatibility shim for worker/resident internal messages.
 
 Actions:
 

--- a/packages/openomni/src/execution-runtime/index.ts
+++ b/packages/openomni/src/execution-runtime/index.ts
@@ -10,6 +10,7 @@ export {
   Tool,
   buildToolCatalog,
   buildWorkerChildRuntimeConfig,
+  createDispatchTool,
   createToolExecutor,
   createWorkerSubagentRuntime,
   defineTool,
@@ -29,4 +30,5 @@ export type {
   ToolProvider,
   ToolRiskTier,
   ToolSource,
+  DispatchToolRuntime,
 } from "./tool/index.js";

--- a/packages/openomni/src/execution-runtime/tool/agent/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/index.ts
@@ -1,5 +1,7 @@
 export { AgentToolProvider } from "./provider.js";
 export type { AgentToolProviderOptions } from "./provider.js";
+export { createDispatchTool } from "./tools/dispatch.js";
+export type { DispatchToolRuntime } from "./tools/dispatch.js";
 export { createInboundMessageTool } from "./tools/inbound-message.js";
 export type { InboundMessageIngress } from "./tools/inbound-message.js";
 export { createSubagentTool } from "./tools/subagent.js";

--- a/packages/openomni/src/execution-runtime/tool/agent/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/index.ts
@@ -3,7 +3,6 @@ export type { AgentToolProviderOptions } from "./provider.js";
 export { createDispatchTool } from "./tools/dispatch.js";
 export type { DispatchToolRuntime } from "./tools/dispatch.js";
 export { createInboundMessageTool } from "./tools/inbound-message.js";
-export type { InboundMessageIngress } from "./tools/inbound-message.js";
 export { createSubagentTool } from "./tools/subagent.js";
 export {
   buildWorkerChildRuntimeConfig,

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -11,7 +11,7 @@ import {
 } from "./tools/inbound-message.js";
 import { createSubagentTool } from "./tools/subagent.js";
 
-export type AgentToolProviderOptions = SubagentToolOptions & {
+export type AgentToolProviderOptions = Partial<SubagentToolOptions> & {
   readonly ingressEngine?: InboundMessageIngress;
   readonly dispatchRuntime?: DispatchToolRuntime;
   readonly dispatchOwners?: DispatchOwners;
@@ -86,7 +86,7 @@ export class AgentToolProvider implements ToolProvider {
   private extraTools: NativeTool[] = [];
 
   constructor(options?: AgentToolProviderOptions) {
-    this.subagentOptions = options;
+    this.subagentOptions = options?.subagentRuntime ? (options as SubagentToolOptions) : undefined;
     const dispatchRuntime =
       options?.dispatchRuntime ?? createDefaultDispatchRuntime({ owners: options?.dispatchOwners });
     this.register(createDispatchTool(dispatchRuntime));

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -1,18 +1,12 @@
 import type { SubagentToolOptions } from "@openomni/agent";
 import type { Tool } from "@openomni/protocol";
 import { createDefaultDispatchRuntime, type DispatchOwners } from "../../../dispatch/index.js";
-import { IngressEngine } from "../../../ingress/engine.js";
 import type { NativeTool, ToolCategory, ToolExecutionContext, ToolProvider } from "../types.js";
 import { createDispatchTool, type DispatchToolRuntime } from "./tools/dispatch.js";
-import {
-  createInboundMessageTool,
-  type InboundMessageDispatch,
-  type InboundMessageIngress,
-} from "./tools/inbound-message.js";
+import { createInboundMessageTool, type InboundMessageDispatch } from "./tools/inbound-message.js";
 import { createSubagentTool } from "./tools/subagent.js";
 
 export type AgentToolProviderOptions = Partial<SubagentToolOptions> & {
-  readonly ingressEngine?: InboundMessageIngress;
   readonly dispatchRuntime?: DispatchToolRuntime;
   readonly dispatchOwners?: DispatchOwners;
 };
@@ -91,10 +85,7 @@ export class AgentToolProvider implements ToolProvider {
       options?.dispatchRuntime ?? createDefaultDispatchRuntime({ owners: options?.dispatchOwners });
     this.register(createDispatchTool(dispatchRuntime));
     this.register(
-      createInboundMessageTool({
-        dispatchRuntime: inboundDispatchAdapter(dispatchRuntime),
-        ingressEngine: options?.ingressEngine ?? IngressEngine,
-      }),
+      createInboundMessageTool({ dispatchRuntime: inboundDispatchAdapter(dispatchRuntime) }),
     );
   }
 

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -1,13 +1,82 @@
 import type { SubagentToolOptions } from "@openomni/agent";
 import type { Tool } from "@openomni/protocol";
+import { createDefaultDispatchRuntime, type DispatchOwners } from "../../../dispatch/index.js";
 import { IngressEngine } from "../../../ingress/engine.js";
 import type { NativeTool, ToolCategory, ToolExecutionContext, ToolProvider } from "../types.js";
-import { createInboundMessageTool, type InboundMessageIngress } from "./tools/inbound-message.js";
+import { createDispatchTool, type DispatchToolRuntime } from "./tools/dispatch.js";
+import {
+  createInboundMessageTool,
+  type InboundMessageDispatch,
+  type InboundMessageIngress,
+} from "./tools/inbound-message.js";
 import { createSubagentTool } from "./tools/subagent.js";
 
 export type AgentToolProviderOptions = SubagentToolOptions & {
   readonly ingressEngine?: InboundMessageIngress;
+  readonly dispatchRuntime?: DispatchToolRuntime;
+  readonly dispatchOwners?: DispatchOwners;
 };
+
+function inboundDispatchAdapter(dispatchRuntime: DispatchToolRuntime): InboundMessageDispatch {
+  return {
+    async submit(command, context) {
+      const {
+        agentName: _agentName,
+        parentSessionId: _parentSessionId,
+        ...target
+      } = command.target;
+      const dispatchResult = await dispatchRuntime.submit(
+        {
+          action: command.action,
+          target: command.action === "schedule.create" ? { ...target, kind: "schedule" } : target,
+          payload: command.payload,
+          wait: command.wait,
+          timeoutMs: command.timeoutMs,
+          correlation: command.correlation.messageId,
+        },
+        {
+          ...(context.signal ? { signal: context.signal } : {}),
+          wait: context.wait,
+          timeoutMs: context.timeoutMs,
+          ...(context.sessionId ? { sessionId: context.sessionId } : {}),
+          ...(context.runId ? { runId: context.runId } : {}),
+          ...(context.agentName ? { agentName: context.agentName } : {}),
+          ...(context.workspaceRoot ? { workspaceRoot: context.workspaceRoot } : {}),
+          sourceTool: context.sourceTool,
+          compatibility: context.compatibility,
+        },
+      );
+      const output =
+        typeof dispatchResult.output === "string"
+          ? dispatchResult.output
+          : dispatchResult.output !== undefined
+            ? JSON.stringify(dispatchResult.output)
+            : undefined;
+      const outputRecord =
+        dispatchResult.output &&
+        typeof dispatchResult.output === "object" &&
+        !Array.isArray(dispatchResult.output)
+          ? (dispatchResult.output as Record<string, unknown>)
+          : undefined;
+      const jobId =
+        outputRecord && typeof outputRecord.jobId === "string" ? outputRecord.jobId : undefined;
+      const messageId =
+        outputRecord && typeof outputRecord.messageId === "string"
+          ? outputRecord.messageId
+          : undefined;
+      return {
+        status: dispatchResult.status,
+        dispatchId: dispatchResult.dispatchId,
+        ...(messageId ? { messageId } : {}),
+        ...(jobId ? { jobId } : {}),
+        ...(output ? { output } : {}),
+        ...((dispatchResult.error ?? dispatchResult.reason)
+          ? { error: dispatchResult.error ?? dispatchResult.reason }
+          : {}),
+      };
+    },
+  };
+}
 
 export class AgentToolProvider implements ToolProvider {
   readonly name = "agent";
@@ -18,7 +87,15 @@ export class AgentToolProvider implements ToolProvider {
 
   constructor(options?: AgentToolProviderOptions) {
     this.subagentOptions = options;
-    this.register(createInboundMessageTool(options?.ingressEngine ?? IngressEngine));
+    const dispatchRuntime =
+      options?.dispatchRuntime ?? createDefaultDispatchRuntime({ owners: options?.dispatchOwners });
+    this.register(createDispatchTool(dispatchRuntime));
+    this.register(
+      createInboundMessageTool({
+        dispatchRuntime: inboundDispatchAdapter(dispatchRuntime),
+        ingressEngine: options?.ingressEngine ?? IngressEngine,
+      }),
+    );
   }
 
   register(tool: NativeTool): void {

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -51,7 +51,7 @@ function inboundDispatchAdapter(dispatchRuntime: DispatchToolRuntime): InboundMe
       const dispatchResult = await dispatchRuntime.submit(
         {
           action: command.action,
-          target: command.action === "schedule.create" ? { ...target, kind: "schedule" } : target,
+          target,
           payload: command.payload,
           wait: command.wait,
           timeoutMs: command.timeoutMs,

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -14,11 +14,12 @@ export type AgentToolProviderOptions = Partial<SubagentToolOptions> & {
 function inboundDispatchAdapter(dispatchRuntime: DispatchToolRuntime): InboundMessageDispatch {
   return {
     async submit(command, context) {
-      const {
-        agentName: _agentName,
-        parentSessionId: _parentSessionId,
-        ...target
-      } = command.target;
+      const { agentName, parentSessionId, ...legacyTarget } = command.target;
+      const target = {
+        ...legacyTarget,
+        ...(agentName ? { name: agentName } : {}),
+        ...(parentSessionId ? { parentSessionId } : {}),
+      };
       const dispatchResult = await dispatchRuntime.submit(
         {
           action: command.action,

--- a/packages/openomni/src/execution-runtime/tool/agent/provider.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/provider.ts
@@ -5,11 +5,39 @@ import type { NativeTool, ToolCategory, ToolExecutionContext, ToolProvider } fro
 import { createDispatchTool, type DispatchToolRuntime } from "./tools/dispatch.js";
 import { createInboundMessageTool, type InboundMessageDispatch } from "./tools/inbound-message.js";
 import { createSubagentTool } from "./tools/subagent.js";
+import { createSubagentRuntime } from "./tools/subagent-runtime.js";
 
 export type AgentToolProviderOptions = Partial<SubagentToolOptions> & {
   readonly dispatchRuntime?: DispatchToolRuntime;
   readonly dispatchOwners?: DispatchOwners;
 };
+
+function hasSubagentOptions(options: AgentToolProviderOptions | undefined): boolean {
+  if (!options) return false;
+  return (
+    "context" in options ||
+    "delegationContext" in options ||
+    "middleware" in options ||
+    "defaultModel" in options ||
+    "subagentRuntime" in options ||
+    "backgroundManager" in options
+  );
+}
+
+function resolveSubagentOptions(
+  options: AgentToolProviderOptions | undefined,
+): SubagentToolOptions | undefined {
+  if (!hasSubagentOptions(options)) return undefined;
+  const {
+    dispatchRuntime: _dispatchRuntime,
+    dispatchOwners: _dispatchOwners,
+    ...partial
+  } = options ?? {};
+  return {
+    ...partial,
+    subagentRuntime: options?.subagentRuntime ?? createSubagentRuntime(),
+  };
+}
 
 function inboundDispatchAdapter(dispatchRuntime: DispatchToolRuntime): InboundMessageDispatch {
   return {
@@ -81,7 +109,7 @@ export class AgentToolProvider implements ToolProvider {
   private extraTools: NativeTool[] = [];
 
   constructor(options?: AgentToolProviderOptions) {
-    this.subagentOptions = options?.subagentRuntime ? (options as SubagentToolOptions) : undefined;
+    this.subagentOptions = resolveSubagentOptions(options);
     const dispatchRuntime =
       options?.dispatchRuntime ?? createDefaultDispatchRuntime({ owners: options?.dispatchOwners });
     this.register(createDispatchTool(dispatchRuntime));

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/dispatch.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/dispatch.ts
@@ -1,0 +1,114 @@
+import { Dispatch, type Tool } from "@openomni/protocol";
+import type { DispatchSubmitOptions } from "../../../../dispatch/runtime.js";
+import { defineTool } from "../../define.js";
+import type { NativeTool, ToolExecutionContext } from "../../types.js";
+
+export type DispatchToolRuntime = {
+  submit(input: Dispatch.Input, options?: DispatchSubmitOptions): Promise<Dispatch.Result>;
+};
+
+type RuntimeInput = Dispatch.Input & {
+  readonly sessionId?: string;
+  readonly runId?: string;
+  readonly agentName?: string;
+  readonly workspaceRoot?: string;
+};
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    action: { type: "string" },
+    target: {
+      type: "object",
+      properties: {
+        kind: { enum: ["worker", "resident", "schedule", "session", "surface", "system"] },
+        id: { type: "string" },
+        sessionId: { type: "string" },
+        runId: { type: "string" },
+        name: { type: "string" },
+        labels: { type: "array", items: { type: "string" } },
+      },
+      required: ["kind"],
+      additionalProperties: false,
+    },
+    payload: {},
+    wait: { type: "boolean" },
+    timeoutMs: { type: "number" },
+    correlation: { type: "string" },
+    idempotencyKey: { type: "string" },
+  },
+  required: ["action", "target"],
+  additionalProperties: false,
+};
+
+function stripRuntimeInput(input: RuntimeInput): Dispatch.Input {
+  const {
+    sessionId: _sessionId,
+    runId: _runId,
+    agentName: _agentName,
+    workspaceRoot: _workspaceRoot,
+    ...publicInput
+  } = input;
+  return Dispatch.Input.parse(publicInput);
+}
+
+function result(call: Tool.Call, output: Dispatch.Result, isError?: boolean): Tool.Result {
+  return {
+    id: crypto.randomUUID(),
+    toolCallId: call.id,
+    output: JSON.stringify(output),
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function errorResult(call: Tool.Call, message: string): Tool.Result {
+  return result(
+    call,
+    {
+      dispatchId: crypto.randomUUID(),
+      status: "failed",
+      error: message,
+    },
+    true,
+  );
+}
+
+export function createDispatchTool(dispatchRuntime: DispatchToolRuntime): NativeTool {
+  return defineTool<RuntimeInput>({
+    name: "dispatch",
+    description: "Submit a cross-session OpenOmni action through the Dispatch policy/audit gate.",
+    inputSchema,
+    source: "agent",
+    riskTier: 1,
+    isReadOnly: false,
+    isConcurrencySafe: true,
+    implicitInputs: {
+      sessionId: "sessionId",
+      runId: "runId",
+      agentName: "agentName",
+      workspaceRoot: "workspaceRoot",
+    },
+    async execute(call, context?: ToolExecutionContext) {
+      let input: Dispatch.Input;
+      try {
+        input = stripRuntimeInput(call.input);
+      } catch (error) {
+        return errorResult(call, error instanceof Error ? error.message : String(error));
+      }
+
+      try {
+        const output = await dispatchRuntime.submit(input, {
+          signal: context?.signal,
+          ...(call.input.sessionId ? { sessionId: call.input.sessionId } : {}),
+          ...(call.input.runId ? { runId: call.input.runId } : {}),
+          ...(call.input.agentName ? { agentName: call.input.agentName } : {}),
+          ...(call.input.workspaceRoot ? { workspaceRoot: call.input.workspaceRoot } : {}),
+          sourceTool: "dispatch",
+        });
+        return result(call, output, output.status !== "completed");
+      } catch (error) {
+        return errorResult(call, error instanceof Error ? error.message : String(error));
+      }
+    },
+  });
+}

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/dispatch.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/dispatch.ts
@@ -24,6 +24,7 @@ const inputSchema = {
         kind: { enum: ["worker", "resident", "schedule", "session", "surface", "system"] },
         id: { type: "string" },
         sessionId: { type: "string" },
+        parentSessionId: { type: "string" },
         runId: { type: "string" },
         name: { type: "string" },
         labels: { type: "array", items: { type: "string" } },

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
@@ -1,6 +1,6 @@
 import type { InboundMessage, Tool } from "@openomni/protocol";
-import { InboundMessage as InboundMessageProtocol } from "@openomni/protocol";
-import { WorkerRunStateStore } from "@openomni/session";
+import { InboundMessage as InboundMessageProtocol, Operational } from "@openomni/protocol";
+import { Bus, WorkerRunStateStore } from "@openomni/session";
 import { defineTool } from "../../define.js";
 import type { NativeTool, ToolExecutionContext } from "../../types.js";
 
@@ -49,6 +49,7 @@ type InboundMessageDispatchResult = {
   readonly jobId?: string;
   readonly output?: string;
   readonly error?: string;
+  readonly reason?: string;
   readonly timedOut?: boolean;
   readonly result?: { readonly output?: unknown };
 };
@@ -197,18 +198,46 @@ function dispatchMessageId(result: InboundMessageDispatchResult, fallback: strin
   return result.messageId ?? result.dispatchId ?? fallback;
 }
 
+function dispatchError(result: InboundMessageDispatchResult): string | undefined {
+  return result.error ?? result.reason;
+}
+
+function isDispatchError(result: InboundMessageDispatchResult): boolean {
+  return (
+    result.status === "error" ||
+    result.status === "failed" ||
+    result.status === "denied" ||
+    result.status === "pending"
+  );
+}
+
+function publishAsyncDispatchFailure(
+  result: InboundMessageDispatchResult,
+  messageId: string,
+  input: RuntimeInput,
+): void {
+  Bus.publish(Operational.Warn, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    component: "inbound_message",
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.runId ? { runId: input.runId } : {}),
+    msg: `async inbound_message dispatch ${result.status ?? "failed"}: ${dispatchError(result) ?? messageId}`,
+  });
+}
+
 function resultFromDispatchDelivery(
   call: Tool.Call,
   messageId: string,
   result: InboundMessageDispatchResult,
 ): Tool.Result {
-  if (result.status === "error" || result.status === "failed") {
+  if (isDispatchError(result)) {
     return toolResult(
       call,
       {
         status: "error",
         messageId: dispatchMessageId(result, messageId),
-        ...(result.error ? { error: result.error } : {}),
+        ...(dispatchError(result) ? { error: dispatchError(result) } : {}),
         ...(result.timedOut ? { timedOut: true } : {}),
       },
       true,
@@ -227,13 +256,13 @@ function resultFromDispatchSchedule(
   messageId: string,
   result: InboundMessageDispatchResult,
 ): Tool.Result {
-  if (result.status === "error" || result.status === "failed") {
+  if (isDispatchError(result)) {
     return toolResult(
       call,
       {
         status: "error",
         messageId: dispatchMessageId(result, messageId),
-        ...(result.error ? { error: result.error } : {}),
+        ...(dispatchError(result) ? { error: dispatchError(result) } : {}),
       },
       true,
     );
@@ -387,7 +416,20 @@ export function createInboundMessageTool(router: InboundMessageRouter): NativeTo
       if (!parsed.wait) {
         try {
           const submitted = dispatchRuntime.submit(dispatchCommand, dispatchContext);
-          submitted.catch(() => undefined);
+          submitted
+            .then((result) => {
+              if (isDispatchError(result)) publishAsyncDispatchFailure(result, messageId, input);
+            })
+            .catch((error) => {
+              publishAsyncDispatchFailure(
+                {
+                  status: "failed",
+                  error: error instanceof Error ? error.message : String(error),
+                },
+                messageId,
+                input,
+              );
+            });
         } catch (error) {
           return errorResult(
             call,

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
@@ -15,6 +15,67 @@ type InboundMessageIngress = {
   ): Promise<Ingress.IngressResult>;
 };
 
+type InboundMessageDispatchAction =
+  | "resident.deliver"
+  | "worker.spawn"
+  | "worker.send"
+  | "worker.resume"
+  | "worker.cancel"
+  | "schedule.create";
+
+type InboundMessageDispatchCommand = {
+  readonly action: InboundMessageDispatchAction;
+  readonly target: InboundMessage.Target;
+  readonly payload: string;
+  readonly wait: boolean;
+  readonly timeoutMs: number;
+  readonly correlation: { readonly messageId: string };
+};
+
+type InboundMessageDispatchContext = {
+  readonly signal?: AbortSignal;
+  readonly wait: boolean;
+  readonly timeoutMs: number;
+  readonly sessionId?: string;
+  readonly runId?: string;
+  readonly agentName?: string;
+  readonly workspaceRoot?: string;
+  readonly sourceTool: "inbound_message";
+  readonly compatibility: {
+    readonly messageId: string;
+    readonly legacyAction?: InboundMessage.Input["action"];
+    readonly depth: number;
+    readonly injectToHistory: boolean;
+    readonly schedule?: string;
+  };
+};
+
+type InboundMessageDispatchResult = {
+  readonly status?: string;
+  readonly dispatchId?: string;
+  readonly messageId?: string;
+  readonly jobId?: string;
+  readonly output?: string;
+  readonly error?: string;
+  readonly timedOut?: boolean;
+  readonly result?: { readonly output?: unknown };
+};
+
+type InboundMessageDispatch = {
+  submit(
+    command: InboundMessageDispatchCommand,
+    context: InboundMessageDispatchContext,
+  ): Promise<InboundMessageDispatchResult>;
+};
+
+type InboundMessageRouter =
+  | InboundMessageIngress
+  | InboundMessageDispatch
+  | {
+      readonly ingressEngine?: InboundMessageIngress;
+      readonly dispatchRuntime?: InboundMessageDispatch;
+    };
+
 type RuntimeInput = InboundMessage.Input & {
   readonly sessionId?: string;
   readonly runId?: string;
@@ -81,6 +142,121 @@ function depthError(call: Tool.Call): Tool.Result {
   );
 }
 
+function resolveRouter(router: InboundMessageRouter): {
+  readonly ingressEngine?: InboundMessageIngress;
+  readonly dispatchRuntime?: InboundMessageDispatch;
+} {
+  if ("ingest" in router) return { ingressEngine: router };
+  if ("submit" in router) return { dispatchRuntime: router };
+  return { ingressEngine: router.ingressEngine, dispatchRuntime: router.dispatchRuntime };
+}
+
+function dispatchActionFromInput(parsed: InboundMessage.Input): InboundMessageDispatchAction {
+  if (parsed.action === "schedule") return "schedule.create";
+  if (parsed.target.kind === "resident") return "resident.deliver";
+  if (parsed.action === "cancel") return "worker.cancel";
+  if (parsed.action === "resume") return "worker.resume";
+  if (parsed.action === "send") return "worker.send";
+  return parsed.target.sessionId ? "worker.send" : "worker.spawn";
+}
+
+function dispatchCommandFromInput(
+  parsed: InboundMessage.Input,
+  messageId: string,
+): InboundMessageDispatchCommand {
+  return {
+    action: dispatchActionFromInput(parsed),
+    target: parsed.target,
+    payload: parsed.payload,
+    wait: parsed.wait,
+    timeoutMs: parsed.timeoutMs,
+    correlation: { messageId },
+  };
+}
+
+function dispatchContextFromInput(
+  input: RuntimeInput,
+  parsed: InboundMessage.Input,
+  messageId: string,
+  signal?: AbortSignal,
+): InboundMessageDispatchContext {
+  return {
+    ...(signal ? { signal } : {}),
+    wait: parsed.wait,
+    timeoutMs: parsed.timeoutMs,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.agentName ? { agentName: input.agentName } : {}),
+    ...(input.workspaceRoot ? { workspaceRoot: input.workspaceRoot } : {}),
+    sourceTool: "inbound_message",
+    compatibility: {
+      messageId,
+      ...(parsed.action ? { legacyAction: parsed.action } : {}),
+      depth: parsed.depth + 1,
+      injectToHistory: parsed.injectToHistory,
+      ...(parsed.schedule ? { schedule: parsed.schedule } : {}),
+    },
+  };
+}
+
+function dispatchOutput(result: InboundMessageDispatchResult): string | undefined {
+  if (typeof result.output === "string") return result.output;
+  const output = result.result?.output;
+  if (typeof output === "string") return output;
+  if (output !== undefined) return JSON.stringify(output);
+  return undefined;
+}
+
+function dispatchMessageId(result: InboundMessageDispatchResult, fallback: string): string {
+  return result.messageId ?? result.dispatchId ?? fallback;
+}
+
+function resultFromDispatchDelivery(
+  call: Tool.Call,
+  messageId: string,
+  result: InboundMessageDispatchResult,
+): Tool.Result {
+  if (result.status === "error" || result.status === "failed") {
+    return toolResult(
+      call,
+      {
+        status: "error",
+        messageId: dispatchMessageId(result, messageId),
+        ...(result.error ? { error: result.error } : {}),
+        ...(result.timedOut ? { timedOut: true } : {}),
+      },
+      true,
+    );
+  }
+
+  return toolResult(call, {
+    status: "delivered",
+    messageId: dispatchMessageId(result, messageId),
+    output: dispatchOutput(result) ?? "",
+  });
+}
+
+function resultFromDispatchSchedule(
+  call: Tool.Call,
+  messageId: string,
+  result: InboundMessageDispatchResult,
+): Tool.Result {
+  if (result.status === "error" || result.status === "failed") {
+    return toolResult(
+      call,
+      {
+        status: "error",
+        messageId: dispatchMessageId(result, messageId),
+        ...(result.error ? { error: result.error } : {}),
+      },
+      true,
+    );
+  }
+
+  const jobId = result.jobId ?? result.messageId ?? result.dispatchId ?? messageId;
+  return toolResult(call, { status: "scheduled", messageId: jobId, jobId });
+}
+
 function actorFromInput(input: RuntimeInput): Ingress.ActorMetadata {
   return {
     kind: "agent",
@@ -142,10 +318,9 @@ function withTimeout<T>(
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     let settled = false;
-    let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
     let onAbort: () => void = () => undefined;
     const cleanup = () => {
-      if (timer !== undefined) globalThis.clearTimeout(timer);
+      globalThis.clearTimeout(timer);
       signal?.removeEventListener("abort", onAbort);
     };
     const resolveOnce = (value: T) => {
@@ -167,7 +342,7 @@ function withTimeout<T>(
       return;
     }
 
-    timer = globalThis.setTimeout(() => {
+    const timer = globalThis.setTimeout(() => {
       rejectOnce(new TimeoutError(`inbound_message timed out after ${timeoutMs}ms`, messageId));
     }, timeoutMs);
     signal?.addEventListener("abort", onAbort, { once: true });
@@ -234,7 +409,8 @@ function restoreRunRunning(input: RuntimeInput): void {
   }
 }
 
-export function createInboundMessageTool(ingressEngine: InboundMessageIngress): NativeTool {
+export function createInboundMessageTool(router: InboundMessageRouter): NativeTool {
+  const { ingressEngine, dispatchRuntime } = resolveRouter(router);
   return defineTool<RuntimeInput>({
     name: "inbound_message",
     description: "Submit an internal inbound message to a resident or worker agent.",
@@ -254,7 +430,24 @@ export function createInboundMessageTool(ingressEngine: InboundMessageIngress): 
       const parsed = InboundMessageProtocol.Input.parse(input);
       if (parsed.depth >= MAX_DEPTH) return depthError(call);
 
+      const messageId = crypto.randomUUID();
+      const dispatchCommand = dispatchCommandFromInput(parsed, messageId);
+      const dispatchContext = dispatchContextFromInput(input, parsed, messageId, context?.signal);
+
       if (parsed.action === "schedule") {
+        if (dispatchRuntime) {
+          try {
+            const result = await dispatchRuntime.submit(dispatchCommand, dispatchContext);
+            return resultFromDispatchSchedule(call, messageId, result);
+          } catch (error) {
+            return errorResult(
+              call,
+              error instanceof Error ? error.message : String(error),
+              messageId,
+            );
+          }
+        }
+
         try {
           const jobId = CronJobRegistry.register(scheduleJobFromInput(input, parsed));
           return toolResult(call, { status: "scheduled", messageId: jobId, jobId });
@@ -262,6 +455,63 @@ export function createInboundMessageTool(ingressEngine: InboundMessageIngress): 
           return errorResult(call, error instanceof Error ? error.message : String(error));
         }
       }
+
+      if (dispatchRuntime) {
+        if (!parsed.wait) {
+          try {
+            const submitted = dispatchRuntime.submit(dispatchCommand, dispatchContext);
+            submitted.catch(() => undefined);
+          } catch (error) {
+            return errorResult(
+              call,
+              error instanceof Error ? error.message : String(error),
+              messageId,
+            );
+          }
+          return toolResult(call, { status: "sent", messageId });
+        }
+
+        if (context?.signal?.aborted) {
+          return errorResult(call, "inbound_message aborted", messageId);
+        }
+
+        markRunWaiting(input);
+        try {
+          const dispatchResult = await withTimeout(
+            dispatchRuntime.submit(dispatchCommand, dispatchContext),
+            parsed.timeoutMs,
+            messageId,
+            context?.signal,
+          );
+          return resultFromDispatchDelivery(call, messageId, dispatchResult);
+        } catch (error) {
+          if (error instanceof TimeoutError) {
+            return toolResult(
+              call,
+              {
+                status: "error",
+                messageId: error.messageId,
+                error: error.message,
+                timedOut: true,
+              },
+              true,
+            );
+          }
+          if (error instanceof AbortWaitError) {
+            return errorResult(call, error.message, error.messageId);
+          }
+          return errorResult(
+            call,
+            error instanceof Error ? error.message : String(error),
+            messageId,
+          );
+        } finally {
+          restoreRunRunning(input);
+        }
+      }
+
+      if (!ingressEngine)
+        return errorResult(call, "inbound_message dispatch runtime is not configured", messageId);
 
       const event = eventFromInput(input, parsed);
 
@@ -320,4 +570,4 @@ export function createInboundMessageTool(ingressEngine: InboundMessageIngress): 
   });
 }
 
-export type { InboundMessageIngress };
+export type { InboundMessageDispatch, InboundMessageIngress, InboundMessageRouter };

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
@@ -1,7 +1,6 @@
 import type { InboundMessage, Ingress, Tool } from "@openomni/protocol";
-import { CronJob, InboundMessage as InboundMessageProtocol } from "@openomni/protocol";
+import { InboundMessage as InboundMessageProtocol } from "@openomni/protocol";
 import { WorkerRunStateStore } from "@openomni/session";
-import { CronJobRegistry } from "../../../cron-job-registry.js";
 import { defineTool } from "../../define.js";
 import type { NativeTool, ToolExecutionContext } from "../../types.js";
 
@@ -257,59 +256,6 @@ function resultFromDispatchSchedule(
   return toolResult(call, { status: "scheduled", messageId: jobId, jobId });
 }
 
-function actorFromInput(input: RuntimeInput): Ingress.ActorMetadata {
-  return {
-    kind: "agent",
-    role: input.agentName,
-    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
-    ...(input.agentName ? { agentName: input.agentName } : {}),
-    ...(input.runId ? { runId: input.runId } : {}),
-  };
-}
-
-function eventFromInput(input: RuntimeInput, parsed: InboundMessage.Input): Ingress.InboundEvent {
-  const target = parsed.target as Ingress.Target;
-  return {
-    id: crypto.randomUUID(),
-    surface: "internal",
-    ...(input.workspaceRoot ? { workspace: input.workspaceRoot } : {}),
-    mode: "direct",
-    target,
-    payload: parsed.payload,
-    meta: {
-      actor: actorFromInput(input),
-      target,
-      ...(parsed.action ? { action: parsed.action } : {}),
-      depth: parsed.depth + 1,
-      ...(parsed.injectToHistory ? { injectToHistory: true } : {}),
-      ...(parsed.schedule ? { schedule: parsed.schedule } : {}),
-      ...(parsed.target.agentName ? { agentName: parsed.target.agentName } : {}),
-    },
-    agent: {
-      model: { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
-    },
-  };
-}
-
-function scheduleJobFromInput(input: RuntimeInput, parsed: InboundMessage.Input): CronJob.Info {
-  const agentName = parsed.target.agentName ?? input.agentName;
-  if (!agentName) {
-    throw new Error("target.agentName is required when action is schedule");
-  }
-
-  return CronJob.Info.parse({
-    id: crypto.randomUUID(),
-    agentName,
-    payload: parsed.payload,
-    schedule: parsed.schedule,
-    target: {
-      kind: parsed.target.kind,
-      ...(parsed.target.sessionId ? { sessionId: parsed.target.sessionId } : {}),
-    },
-    createdAt: Date.now(),
-  });
-}
-
 function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -410,7 +356,7 @@ function restoreRunRunning(input: RuntimeInput): void {
 }
 
 export function createInboundMessageTool(router: InboundMessageRouter): NativeTool {
-  const { ingressEngine, dispatchRuntime } = resolveRouter(router);
+  const { dispatchRuntime } = resolveRouter(router);
   return defineTool<RuntimeInput>({
     name: "inbound_message",
     description: "Submit an internal inbound message to a resident or worker agent.",
@@ -434,118 +380,50 @@ export function createInboundMessageTool(router: InboundMessageRouter): NativeTo
       const dispatchCommand = dispatchCommandFromInput(parsed, messageId);
       const dispatchContext = dispatchContextFromInput(input, parsed, messageId, context?.signal);
 
-      if (parsed.action === "schedule") {
-        if (dispatchRuntime) {
-          try {
-            const result = await dispatchRuntime.submit(dispatchCommand, dispatchContext);
-            return resultFromDispatchSchedule(call, messageId, result);
-          } catch (error) {
-            return errorResult(
-              call,
-              error instanceof Error ? error.message : String(error),
-              messageId,
-            );
-          }
-        }
-
-        try {
-          const jobId = CronJobRegistry.register(scheduleJobFromInput(input, parsed));
-          return toolResult(call, { status: "scheduled", messageId: jobId, jobId });
-        } catch (error) {
-          return errorResult(call, error instanceof Error ? error.message : String(error));
-        }
+      if (!dispatchRuntime) {
+        return errorResult(call, "inbound_message dispatch runtime is not configured", messageId);
       }
 
-      if (dispatchRuntime) {
-        if (!parsed.wait) {
-          try {
-            const submitted = dispatchRuntime.submit(dispatchCommand, dispatchContext);
-            submitted.catch(() => undefined);
-          } catch (error) {
-            return errorResult(
-              call,
-              error instanceof Error ? error.message : String(error),
-              messageId,
-            );
-          }
-          return toolResult(call, { status: "sent", messageId });
-        }
-
-        if (context?.signal?.aborted) {
-          return errorResult(call, "inbound_message aborted", messageId);
-        }
-
-        markRunWaiting(input);
+      if (parsed.action === "schedule") {
         try {
-          const dispatchResult = await withTimeout(
-            dispatchRuntime.submit(dispatchCommand, dispatchContext),
-            parsed.timeoutMs,
-            messageId,
-            context?.signal,
-          );
-          return resultFromDispatchDelivery(call, messageId, dispatchResult);
+          const result = await dispatchRuntime.submit(dispatchCommand, dispatchContext);
+          return resultFromDispatchSchedule(call, messageId, result);
         } catch (error) {
-          if (error instanceof TimeoutError) {
-            return toolResult(
-              call,
-              {
-                status: "error",
-                messageId: error.messageId,
-                error: error.message,
-                timedOut: true,
-              },
-              true,
-            );
-          }
-          if (error instanceof AbortWaitError) {
-            return errorResult(call, error.message, error.messageId);
-          }
           return errorResult(
             call,
             error instanceof Error ? error.message : String(error),
             messageId,
           );
-        } finally {
-          restoreRunRunning(input);
         }
       }
-
-      if (!ingressEngine)
-        return errorResult(call, "inbound_message dispatch runtime is not configured", messageId);
-
-      const event = eventFromInput(input, parsed);
 
       if (!parsed.wait) {
         try {
-          const ingest = ingressEngine.ingest(event, { wait: false });
-          ingest.catch(() => undefined);
+          const submitted = dispatchRuntime.submit(dispatchCommand, dispatchContext);
+          submitted.catch(() => undefined);
         } catch (error) {
           return errorResult(
             call,
             error instanceof Error ? error.message : String(error),
-            event.id,
+            messageId,
           );
         }
-        return toolResult(call, { status: "sent", messageId: event.id });
+        return toolResult(call, { status: "sent", messageId });
       }
 
       if (context?.signal?.aborted) {
-        return errorResult(call, "inbound_message aborted", event.id);
+        return errorResult(call, "inbound_message aborted", messageId);
       }
 
       markRunWaiting(input);
       try {
-        const ingressResult = await withTimeout(
-          ingressEngine.ingest(event, { signal: context?.signal, wait: true }),
+        const dispatchResult = await withTimeout(
+          dispatchRuntime.submit(dispatchCommand, dispatchContext),
           parsed.timeoutMs,
-          event.id,
+          messageId,
           context?.signal,
         );
-        return toolResult(call, {
-          status: "delivered",
-          messageId: event.id,
-          output: ingressResult.result.output,
-        });
+        return resultFromDispatchDelivery(call, messageId, dispatchResult);
       } catch (error) {
         if (error instanceof TimeoutError) {
           return toolResult(
@@ -562,7 +440,7 @@ export function createInboundMessageTool(router: InboundMessageRouter): NativeTo
         if (error instanceof AbortWaitError) {
           return errorResult(call, error.message, error.messageId);
         }
-        return errorResult(call, error instanceof Error ? error.message : String(error), event.id);
+        return errorResult(call, error instanceof Error ? error.message : String(error), messageId);
       } finally {
         restoreRunRunning(input);
       }

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts
@@ -1,4 +1,4 @@
-import type { InboundMessage, Ingress, Tool } from "@openomni/protocol";
+import type { InboundMessage, Tool } from "@openomni/protocol";
 import { InboundMessage as InboundMessageProtocol } from "@openomni/protocol";
 import { WorkerRunStateStore } from "@openomni/session";
 import { defineTool } from "../../define.js";
@@ -6,13 +6,6 @@ import type { NativeTool, ToolExecutionContext } from "../../types.js";
 
 const MAX_DEPTH = 10;
 const DEFAULT_TIMEOUT_MS = 30_000;
-
-type InboundMessageIngress = {
-  ingest(
-    event: Ingress.InboundEvent,
-    options?: { readonly signal?: AbortSignal; readonly wait?: boolean },
-  ): Promise<Ingress.IngressResult>;
-};
 
 type InboundMessageDispatchAction =
   | "resident.deliver"
@@ -68,12 +61,8 @@ type InboundMessageDispatch = {
 };
 
 type InboundMessageRouter =
-  | InboundMessageIngress
   | InboundMessageDispatch
-  | {
-      readonly ingressEngine?: InboundMessageIngress;
-      readonly dispatchRuntime?: InboundMessageDispatch;
-    };
+  | { readonly dispatchRuntime?: InboundMessageDispatch };
 
 type RuntimeInput = InboundMessage.Input & {
   readonly sessionId?: string;
@@ -142,12 +131,10 @@ function depthError(call: Tool.Call): Tool.Result {
 }
 
 function resolveRouter(router: InboundMessageRouter): {
-  readonly ingressEngine?: InboundMessageIngress;
   readonly dispatchRuntime?: InboundMessageDispatch;
 } {
-  if ("ingest" in router) return { ingressEngine: router };
   if ("submit" in router) return { dispatchRuntime: router };
-  return { ingressEngine: router.ingressEngine, dispatchRuntime: router.dispatchRuntime };
+  return { dispatchRuntime: router.dispatchRuntime };
 }
 
 function dispatchActionFromInput(parsed: InboundMessage.Input): InboundMessageDispatchAction {
@@ -448,4 +435,4 @@ export function createInboundMessageTool(router: InboundMessageRouter): NativeTo
   });
 }
 
-export type { InboundMessageDispatch, InboundMessageIngress, InboundMessageRouter };
+export type { InboundMessageDispatch, InboundMessageRouter };

--- a/packages/openomni/src/execution-runtime/tool/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/index.ts
@@ -1,8 +1,10 @@
 export {
   AgentToolProvider,
   buildWorkerChildRuntimeConfig,
+  createDispatchTool,
   createWorkerSubagentRuntime,
 } from "./agent/index.js";
+export type { DispatchToolRuntime } from "./agent/index.js";
 export { buildToolCatalog, resolveCategory, resolveToolSelection } from "./catalog.js";
 export { Tool, defineTool, resolveMeta } from "./define.js";
 export { createToolExecutor } from "./executor.js";

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -110,6 +110,7 @@ export {
   buildToolCatalog,
   buildWorkerMiddleware,
   buildWorkerChildRuntimeConfig,
+  createDispatchTool,
   createToolExecutor,
   createWorkerSubagentRuntime,
   defineTool,
@@ -130,20 +131,27 @@ export type {
   ToolRiskTier,
   ToolSource,
   WorkerMiddlewareConfig,
+  DispatchToolRuntime,
 } from "./execution-runtime";
 
 // Dispatch runtime
 export {
   DispatchRuntime,
   DispatchRegistry,
+  createDefaultDispatchRuntime,
   createDefaultDispatchPolicy,
   deriveActorContext,
+  registerBuiltInDispatchHandlers,
 } from "./dispatch";
 export type {
+  BuiltInDispatchOptions,
+  DefaultDispatchRuntimeOptions,
   DispatchHandler,
   DispatchHandlerContext,
   DispatchHandlerResult,
+  DispatchOwners,
   DispatchRuntimeContext,
   DispatchRuntimeOptions,
+  DispatchSchedulerOwner,
   DispatchSubmitOptions,
 } from "./dispatch";

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -131,3 +131,19 @@ export type {
   ToolSource,
   WorkerMiddlewareConfig,
 } from "./execution-runtime";
+
+// Dispatch runtime
+export {
+  DispatchRuntime,
+  DispatchRegistry,
+  createDefaultDispatchPolicy,
+  deriveActorContext,
+} from "./dispatch";
+export type {
+  DispatchHandler,
+  DispatchHandlerContext,
+  DispatchHandlerResult,
+  DispatchRuntimeContext,
+  DispatchRuntimeOptions,
+  DispatchSubmitOptions,
+} from "./dispatch";

--- a/packages/openomni/test/dispatch/actor.test.ts
+++ b/packages/openomni/test/dispatch/actor.test.ts
@@ -13,6 +13,9 @@ describe("deriveActorContext", () => {
   test("derives resident actor from resident agent name", () => {
     const actor = deriveActorContext({ sessionId: "s1", runId: "r1", agentName: "resident" });
     expect(actor.kind).toBe("resident");
+    expect(actor.runId).toBe("r1");
+    expect(actor.workerRunId).toBeUndefined();
+    expect(actor.trustTier).toBe("resident");
   });
 
   test("marks missing runtime context as unknown", () => {

--- a/packages/openomni/test/dispatch/actor.test.ts
+++ b/packages/openomni/test/dispatch/actor.test.ts
@@ -18,6 +18,11 @@ describe("deriveActorContext", () => {
     expect(actor.trustTier).toBe("resident");
   });
 
+  test("does not infer privileged actors from substrings", () => {
+    expect(deriveActorContext({ agentName: "resident-helper" }).kind).toBe("worker");
+    expect(deriveActorContext({ agentName: "task-scheduler-worker" }).kind).toBe("worker");
+  });
+
   test("marks missing runtime context as unknown", () => {
     const actor = deriveActorContext();
     expect(actor.kind).toBe("unknown");

--- a/packages/openomni/test/dispatch/actor.test.ts
+++ b/packages/openomni/test/dispatch/actor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { deriveActorContext } from "../../src/dispatch/actor";
+
+describe("deriveActorContext", () => {
+  test("derives worker actor from runtime session and run context", () => {
+    const actor = deriveActorContext({ sessionId: "s1", runId: "r1", agentName: "coder" });
+    expect(actor.kind).toBe("worker");
+    expect(actor.actorId).toBe("s1:r1");
+    expect(actor.sessionId).toBe("s1");
+    expect(actor.runId).toBe("r1");
+  });
+
+  test("derives resident actor from resident agent name", () => {
+    const actor = deriveActorContext({ sessionId: "s1", runId: "r1", agentName: "resident" });
+    expect(actor.kind).toBe("resident");
+  });
+
+  test("marks missing runtime context as unknown", () => {
+    const actor = deriveActorContext();
+    expect(actor.kind).toBe("unknown");
+    expect(actor.reason).toBe("missing runtime actor context");
+  });
+
+  test("explicit trusted system context can be supplied by runtime", () => {
+    const actor = deriveActorContext({ actorKind: "system", actorId: "system:scheduler" });
+    expect(actor.kind).toBe("system");
+    expect(actor.actorId).toBe("system:scheduler");
+  });
+});

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -137,14 +137,17 @@ describe("built-in dispatch handlers", () => {
   });
 
   test("schedule handlers call scheduler owner", async () => {
-    const registered: string[] = [];
+    const registered: Array<{ summary: string; target: string }> = [];
     const removed: string[] = [];
     const registry = new DispatchRegistry();
     registerBuiltInDispatchHandlers(registry, {
       owners: {
         scheduler: {
           register(job) {
-            registered.push(`${job.agentName}:${job.schedule}:${job.payload}`);
+            registered.push({
+              summary: `${job.agentName}:${job.schedule}:${job.payload}`,
+              target: job.target.kind,
+            });
             return "job-1";
           },
           remove(jobId) {
@@ -166,12 +169,38 @@ describe("built-in dispatch handlers", () => {
       command("schedule.cancel", { kind: "schedule", id: "job-1" }),
     );
 
-    expect(registered).toEqual(["resident:0 9 * * *:report"]);
+    expect(registered).toEqual([{ summary: "resident:0 9 * * *:report", target: "resident" }]);
     expect(removed).toEqual(["job-1"]);
     expect(createResult).toEqual({
       output: { scheduled: true, jobId: "job-1", messageId: "job-1" },
     });
     expect(cancelResult).toEqual({ output: { cancelled: true, jobId: "job-1" } });
+  });
+
+  test("schedule.create rejects non-cron target kinds before registering", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        scheduler: {
+          register() {
+            throw new Error("should not register invalid target");
+          },
+          remove() {
+            return false;
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      registry.get("schedule.create")?.(
+        command(
+          "schedule.create",
+          { kind: "system", name: "scheduler" },
+          { schedule: "0 9 * * *", payload: "report" },
+        ),
+      ),
+    ).toThrow("schedule.create cannot target system");
   });
 
   test("resident.deliver calls resident runtime owner", async () => {

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -55,6 +55,42 @@ describe("built-in dispatch handlers", () => {
     expect(result).toMatchObject({ output: { sessionId: requests[0]?.sessionId } });
   });
 
+  test("worker.spawn preserves parent session lineage when provided", async () => {
+    const parent = Session.create({
+      title: "parent",
+      model: { providerID: "test", modelID: "test" },
+    });
+    let dispatchedSessionId = "";
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(sessionId, request) {
+            dispatchedSessionId = sessionId;
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "succeeded",
+              output: "done",
+            };
+          },
+        },
+      },
+    });
+
+    await registry.get("worker.spawn")?.(
+      command(
+        "worker.spawn",
+        { kind: "worker", name: "coder", parentSessionId: parent.id },
+        "build",
+      ),
+    );
+
+    const child = Session.get(dispatchedSessionId);
+    expect(child?.parentSessionId).toBe(parent.id);
+    expect(child?.spawnDepth).toBe((parent.spawnDepth ?? 0) + 1);
+  });
+
   test("worker send/resume/cancel call coordinator owner methods", async () => {
     const delivered: Array<{ sessionId: string; message: string; runId?: string }> = [];
     const cancelled: string[] = [];

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -3,6 +3,7 @@ import type { Dispatch, Execution, Ingress } from "@openomni/protocol";
 import { Session, Storage } from "@openomni/session";
 import { DispatchRegistry } from "../../src/dispatch/registry";
 import { registerBuiltInDispatchHandlers } from "../../src/dispatch/setup";
+import { extractText } from "../../src/dispatch/handlers/shared";
 
 function command(
   action: string,
@@ -24,6 +25,11 @@ describe("built-in dispatch handlers", () => {
   beforeEach(() => {
     Storage.reset();
     Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  test("extractText returns empty string for nullish payloads", () => {
+    expect(extractText(null)).toBe("");
+    expect(extractText(undefined)).toBe("");
   });
 
   test("worker.spawn is a coordinator dispatch adapter", async () => {

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { Dispatch, Execution, Ingress } from "@openomni/protocol";
+import { Session, Storage } from "@openomni/session";
+import { DispatchRegistry } from "../../src/dispatch/registry";
+import { registerBuiltInDispatchHandlers } from "../../src/dispatch/setup";
+
+function command(
+  action: string,
+  target: Dispatch.Target,
+  payload: unknown = "hello",
+): Dispatch.Command {
+  return {
+    dispatchId: `dispatch-${action}`,
+    action,
+    target,
+    payload,
+    actor: { kind: "resident", actorId: "agent:resident", agentName: "resident" },
+    traceId: "trace-1",
+    submittedAt: Date.now(),
+  };
+}
+
+describe("built-in dispatch handlers", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  test("worker.spawn is a coordinator dispatch adapter", async () => {
+    const requests: Execution.Request[] = [];
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            requests.push(request);
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "succeeded",
+              output: "done",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ mode: "direct", prompt: "build it", agentName: "coder" });
+    expect(Session.get(requests[0]?.sessionId ?? "")).toBeDefined();
+    expect(result).toMatchObject({ output: { sessionId: requests[0]?.sessionId } });
+  });
+
+  test("worker send/resume/cancel call coordinator owner methods", async () => {
+    const delivered: Array<{ sessionId: string; message: string; runId?: string }> = [];
+    const cancelled: string[] = [];
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch() {
+            throw new Error("not used");
+          },
+          async deliverMessage(sessionId, message, runId) {
+            delivered.push({ sessionId, message, runId });
+            return { accepted: true };
+          },
+          async cancelRun(runId) {
+            cancelled.push(runId);
+            return { cancelled: true };
+          },
+        },
+      },
+    });
+
+    await registry.get("worker.send")?.(
+      command("worker.send", { kind: "worker", sessionId: "s1", runId: "r1" }, "next"),
+    );
+    await registry.get("worker.resume")?.(
+      command("worker.resume", { kind: "worker", sessionId: "s1", runId: "r1" }, "resume"),
+    );
+    await registry.get("worker.cancel")?.(
+      command("worker.cancel", { kind: "worker", runId: "r1" }),
+    );
+
+    expect(delivered).toEqual([
+      { sessionId: "s1", message: "next", runId: "r1" },
+      { sessionId: "s1", message: "resume", runId: "r1" },
+    ]);
+    expect(cancelled).toEqual(["r1"]);
+  });
+
+  test("schedule handlers call scheduler owner", async () => {
+    const registered: string[] = [];
+    const removed: string[] = [];
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        scheduler: {
+          register(job) {
+            registered.push(`${job.agentName}:${job.schedule}:${job.payload}`);
+            return "job-1";
+          },
+          remove(jobId) {
+            removed.push(jobId);
+            return true;
+          },
+        },
+      },
+    });
+
+    const createResult = await registry.get("schedule.create")?.(
+      command(
+        "schedule.create",
+        { kind: "schedule", name: "resident" },
+        { schedule: "0 9 * * *", payload: "report" },
+      ),
+    );
+    const cancelResult = await registry.get("schedule.cancel")?.(
+      command("schedule.cancel", { kind: "schedule", id: "job-1" }),
+    );
+
+    expect(registered).toEqual(["resident:0 9 * * *:report"]);
+    expect(removed).toEqual(["job-1"]);
+    expect(createResult).toEqual({
+      output: { scheduled: true, jobId: "job-1", messageId: "job-1" },
+    });
+    expect(cancelResult).toEqual({ output: { cancelled: true, jobId: "job-1" } });
+  });
+
+  test("resident.deliver calls resident runtime owner", async () => {
+    const calls: Ingress.ResolvedInboundEvent[] = [];
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        residentRuntime: {
+          async run(ctx) {
+            calls.push(ctx.event);
+            return {
+              output: "answer",
+              finishReason: "stop",
+              runId: "resident-run",
+              activationId: "activation",
+            };
+          },
+        },
+      },
+    });
+
+    const output = await registry.get("resident.deliver")?.(
+      command("resident.deliver", { kind: "resident", sessionId: "resident-session" }, "question"),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      surface: "dispatch",
+      payload: "question",
+      target: { kind: "resident", sessionId: "resident-session" },
+    });
+    expect(output).toEqual({
+      output: { output: "answer", finishReason: "stop", runId: "resident-run" },
+    });
+  });
+});

--- a/packages/openomni/test/dispatch/runtime.test.ts
+++ b/packages/openomni/test/dispatch/runtime.test.ts
@@ -105,6 +105,24 @@ describe("DispatchRuntime", () => {
     expect(called).toBe(false);
   });
 
+  test("default policy denies worker schedule creation", async () => {
+    let called = false;
+    const runtime = new DispatchRuntime();
+    runtime.register("schedule.create", () => {
+      called = true;
+      return { output: "scheduled" };
+    });
+
+    const result = await runtime.submit(
+      { action: "schedule.create", target: { kind: "schedule", name: "resident" } },
+      { sessionId: "session-1", runId: "run-1", agentName: "worker" },
+    );
+
+    expect(result.status).toBe("denied");
+    expect(result.reason).toBe("dispatch.worker.schedule.denied");
+    expect(called).toBe(false);
+  });
+
   test("fails unknown action without routing", async () => {
     const result = await new DispatchRuntime({ includeDefaultPolicies: false }).submit(
       { action: "custom.missing", target: { kind: "system" } },

--- a/packages/openomni/test/dispatch/runtime.test.ts
+++ b/packages/openomni/test/dispatch/runtime.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-
-const flushBus = () => new Promise((resolve) => queueMicrotask(resolve));
-import { PolicyDecision, type Dispatch as DispatchProtocol } from "../../../protocol/src/index";
+import { PolicyDecision, type Dispatch as DispatchProtocol } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { DispatchRuntime } from "../../src/dispatch/runtime";
+
+const flushBus = () => new Promise((resolve) => queueMicrotask(resolve));
 
 function input(action = "resident.deliver"): DispatchProtocol.Input {
   return { action, target: { kind: "resident" }, payload: "hello" };
@@ -121,6 +121,67 @@ describe("DispatchRuntime", () => {
     expect(result.status).toBe("denied");
     expect(result.reason).toBe("dispatch.worker.schedule.denied");
     expect(called).toBe(false);
+  });
+
+  test("default policy denies unknown actors before custom action routing", async () => {
+    let called = false;
+    const runtime = new DispatchRuntime();
+    runtime.register("custom.echo", () => {
+      called = true;
+      return { output: "echo" };
+    });
+
+    const result = await runtime.submit(
+      { action: "custom.echo", target: { kind: "system" }, payload: "secret text" },
+      {},
+    );
+
+    expect(result.status).toBe("denied");
+    expect(result.reason).toBe("dispatch.actor.required");
+    expect(called).toBe(false);
+  });
+
+  test("rejects duplicate handler registrations", () => {
+    const runtime = new DispatchRuntime();
+    runtime.register("resident.deliver", () => ({ output: "first" }));
+
+    expect(() => runtime.register("resident.deliver", () => ({ output: "second" }))).toThrow(
+      "dispatch action already registered: resident.deliver",
+    );
+  });
+
+  test("audit events stay envelope-only without payload or result summaries", async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    Bus.observe((event, data) => {
+      if (event.name.startsWith("dispatch.")) {
+        payloads.push(data as Record<string, unknown>);
+      }
+    });
+    const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
+    runtime.register("resident.deliver", () => ({ output: "private output" }));
+
+    await runtime.submit(
+      {
+        action: "resident.deliver",
+        target: { kind: "resident" },
+        payload: "private input",
+      },
+      {
+        actorKind: "resident",
+        actorId: "resident:main",
+        policies: [
+          {
+            name: "allow-dispatch",
+            timing: "dispatch.authorize",
+            priority: 0,
+            fn: () => PolicyDecision.allow({ policyId: "allow-dispatch" }),
+          },
+        ],
+      },
+    );
+
+    expect(payloads.some((payload) => "payloadSummary" in payload)).toBe(false);
+    expect(payloads.some((payload) => "resultSummary" in payload)).toBe(false);
   });
 
   test("fails unknown action without routing", async () => {

--- a/packages/openomni/test/dispatch/runtime.test.ts
+++ b/packages/openomni/test/dispatch/runtime.test.ts
@@ -205,6 +205,39 @@ describe("DispatchRuntime", () => {
     expect(result.error).toContain("No dispatch handler registered");
   });
 
+  test("forwards input-level wait and timeout to handler context", async () => {
+    const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
+    let handlerContext: { wait?: boolean; timeoutMs?: number } | undefined;
+    runtime.register("resident.deliver", (_command, context) => {
+      handlerContext = { wait: context?.wait, timeoutMs: context?.timeoutMs };
+      return { output: "ok" };
+    });
+
+    const result = await runtime.submit(
+      {
+        action: "resident.deliver",
+        target: { kind: "resident" },
+        wait: true,
+        timeoutMs: 1234,
+      },
+      {
+        actorKind: "resident",
+        actorId: "resident:main",
+        policies: [
+          {
+            name: "allow-dispatch",
+            timing: "dispatch.authorize",
+            priority: 0,
+            fn: () => PolicyDecision.allow({ policyId: "allow-dispatch" }),
+          },
+        ],
+      },
+    );
+
+    expect(result.status).toBe("completed");
+    expect(handlerContext).toEqual({ wait: true, timeoutMs: 1234 });
+  });
+
   test("core treats handler payload opaquely", async () => {
     const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
     runtime.register("custom.fake", (command) => ({ output: command.payload }));

--- a/packages/openomni/test/dispatch/runtime.test.ts
+++ b/packages/openomni/test/dispatch/runtime.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+
+const flushBus = () => new Promise((resolve) => queueMicrotask(resolve));
+import { PolicyDecision, type Dispatch as DispatchProtocol } from "../../../protocol/src/index";
+import { Bus } from "@openomni/session";
+import { DispatchRuntime } from "../../src/dispatch/runtime";
+
+function input(action = "resident.deliver"): DispatchProtocol.Input {
+  return { action, target: { kind: "resident" }, payload: "hello" };
+}
+
+describe("DispatchRuntime", () => {
+  beforeEach(() => {
+    Bus.reset();
+  });
+
+  test("authorizes before routing and completes a handler", async () => {
+    const events: string[] = [];
+    Bus.observe((event) => events.push(event.name));
+    let called = false;
+    const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
+    runtime.register("resident.deliver", async () => {
+      called = true;
+      return { output: "ok" };
+    });
+
+    const result = await runtime.submit(input(), {
+      sessionId: "session-1",
+      runId: "run-1",
+      agentName: "resident",
+      policies: [
+        {
+          name: "allow-dispatch",
+          timing: "dispatch.authorize",
+          priority: 0,
+          fn: () => PolicyDecision.allow({ policyId: "allow-dispatch" }),
+        },
+      ],
+    });
+
+    await flushBus();
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("ok");
+    expect(called).toBe(true);
+    expect(events.filter((event) => event.startsWith("dispatch."))).toEqual([
+      "dispatch.submitted",
+      "dispatch.authorized",
+      "dispatch.routed",
+      "dispatch.completed",
+    ]);
+  });
+
+  test("deny returns before handler invocation", async () => {
+    const events: string[] = [];
+    Bus.observe((event) => events.push(event.name));
+    let called = false;
+    const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
+    runtime.register("worker.spawn", async () => {
+      called = true;
+      return { output: "should not happen" };
+    });
+
+    const result = await runtime.submit(input("worker.spawn"), {
+      sessionId: "session-1",
+      runId: "run-1",
+      agentName: "worker",
+      policies: [
+        {
+          name: "deny-dispatch",
+          timing: "dispatch.authorize",
+          priority: 0,
+          fn: () =>
+            PolicyDecision.deny({
+              policyId: "deny-dispatch",
+              reasonCodes: ["no"],
+              effects: [{ type: "run.abort", reason: "no" }],
+            }),
+        },
+      ],
+    });
+
+    await flushBus();
+    expect(result.status).toBe("denied");
+    expect(called).toBe(false);
+    expect(events).toContain("dispatch.denied");
+    expect(events).not.toContain("dispatch.routed");
+  });
+
+  test("default policy denies worker spawning independent work", async () => {
+    let called = false;
+    const runtime = new DispatchRuntime();
+    runtime.register("worker.spawn", () => {
+      called = true;
+      return { output: "spawned" };
+    });
+
+    const result = await runtime.submit(input("worker.spawn"), {
+      sessionId: "session-1",
+      runId: "run-1",
+      agentName: "worker",
+    });
+
+    expect(result.status).toBe("denied");
+    expect(result.reason).toBe("dispatch.worker.spawn.denied");
+    expect(called).toBe(false);
+  });
+
+  test("fails unknown action without routing", async () => {
+    const result = await new DispatchRuntime({ includeDefaultPolicies: false }).submit(
+      { action: "custom.missing", target: { kind: "system" } },
+      {
+        actorKind: "system",
+        actorId: "system:test",
+        policies: [
+          {
+            name: "allow-dispatch",
+            timing: "dispatch.authorize",
+            priority: 0,
+            fn: () => PolicyDecision.allow({ policyId: "allow-dispatch" }),
+          },
+        ],
+      },
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("No dispatch handler registered");
+  });
+
+  test("core treats handler payload opaquely", async () => {
+    const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
+    runtime.register("custom.fake", (command) => ({ output: command.payload }));
+
+    const payload = { workerLike: { lifecycle: "not-core-owned" } };
+    const result = await runtime.submit(
+      { action: "custom.fake", target: { kind: "system" }, payload },
+      {
+        actorKind: "system",
+        actorId: "system:test",
+        policies: [
+          {
+            name: "allow-dispatch",
+            timing: "dispatch.authorize",
+            priority: 0,
+            fn: () => PolicyDecision.allow({ policyId: "allow-dispatch" }),
+          },
+        ],
+      },
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.output).toEqual(payload);
+  });
+});

--- a/packages/openomni/test/execution-runtime/dispatch-tool.test.ts
+++ b/packages/openomni/test/execution-runtime/dispatch-tool.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type { Dispatch, Tool } from "@openomni/protocol";
+import { AgentToolProvider } from "../../src/execution-runtime/tool/agent/provider";
+import {
+  createDispatchTool,
+  type DispatchToolRuntime,
+} from "../../src/execution-runtime/tool/agent/tools/dispatch";
+
+function call(input: Record<string, unknown>): Tool.Call {
+  return { id: "call-1", tool: "dispatch", input };
+}
+
+describe("dispatch tool", () => {
+  test("AgentToolProvider exposes dispatch", () => {
+    const provider = new AgentToolProvider();
+    expect(provider.listTools().some((tool) => tool.spec.name === "dispatch")).toBe(true);
+  });
+
+  test("public schema omits runtime actor/context fields", () => {
+    const provider = new AgentToolProvider();
+    const tool = provider.listTools().find((entry) => entry.spec.name === "dispatch");
+    expect(tool).toBeDefined();
+    const properties =
+      (tool?.spec.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+    expect(properties.actor).toBeUndefined();
+    expect(properties.sessionId).toBeUndefined();
+    expect(properties.runId).toBeUndefined();
+    expect(properties.workspaceRoot).toBeUndefined();
+    expect(properties.model).toBeUndefined();
+    expect(properties.provider).toBeUndefined();
+    expect(properties.tools).toBeUndefined();
+    expect(properties.permissions).toBeUndefined();
+  });
+
+  test("executes through runtime with implicit context", async () => {
+    let capturedInput: Dispatch.Input | undefined;
+    let capturedOptions: Parameters<DispatchToolRuntime["submit"]>[1];
+    const tool = createDispatchTool({
+      async submit(input, options) {
+        capturedInput = input;
+        capturedOptions = options;
+        return { dispatchId: "dispatch-1", status: "completed", output: "ok" };
+      },
+    });
+
+    const response = await tool.execute(
+      call({
+        action: "resident.deliver",
+        target: { kind: "resident" },
+        payload: "hello",
+        wait: true,
+        timeoutMs: 123,
+        sessionId: "session-1",
+        runId: "run-1",
+        agentName: "worker",
+        workspaceRoot: "/repo",
+      }),
+    );
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.output)).toEqual({
+      dispatchId: "dispatch-1",
+      status: "completed",
+      output: "ok",
+    });
+    expect(capturedInput).toEqual({
+      action: "resident.deliver",
+      target: { kind: "resident" },
+      payload: "hello",
+      wait: true,
+      timeoutMs: 123,
+    });
+    expect(capturedOptions).toMatchObject({
+      sessionId: "session-1",
+      runId: "run-1",
+      agentName: "worker",
+      workspaceRoot: "/repo",
+      sourceTool: "dispatch",
+    });
+  });
+
+  test("rejects public actor-like fields before runtime submission", async () => {
+    let called = false;
+    const tool = createDispatchTool({
+      async submit() {
+        called = true;
+        return { dispatchId: "dispatch-1", status: "completed" };
+      },
+    });
+
+    const response = await tool.execute(
+      call({
+        action: "resident.deliver",
+        target: { kind: "resident" },
+        payload: "hello",
+        actor: { kind: "system", actorId: "fake" },
+      }),
+    );
+
+    expect(response.isError).toBe(true);
+    expect(response.output).toContain("Unrecognized key");
+    expect(called).toBe(false);
+  });
+});

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -3,7 +3,10 @@ import type { Ingress } from "@openomni/protocol";
 import { Session, Storage, WorkerRunStateStore } from "@openomni/session";
 import { CronJobRegistry } from "../../src/execution-runtime/cron-job-registry";
 import { AgentToolProvider } from "../../src/execution-runtime/tool/agent/provider";
-import { createInboundMessageTool } from "../../src/execution-runtime/tool/agent/tools/inbound-message";
+import {
+  createInboundMessageTool,
+  type InboundMessageDispatch,
+} from "../../src/execution-runtime/tool/agent/tools/inbound-message";
 
 function result(output: string): Ingress.IngressResult {
   return {
@@ -96,6 +99,181 @@ describe("inbound_message tool", () => {
     expect(events).toHaveLength(2);
     expect(events[0]?.meta?.depth).toBe(1);
     expect(events[1]?.meta?.depth).toBe(2);
+  });
+
+  test("maps wait:false worker spawns through dispatch without calling ingress", async () => {
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
+    let ingressCalled = false;
+    const tool = createInboundMessageTool({
+      dispatchRuntime: {
+        submit: async (...args) => {
+          dispatches.push(args);
+          return { status: "completed", output: "accepted" };
+        },
+      },
+      ingressEngine: {
+        ingest: async () => {
+          ingressCalled = true;
+          return result("should not use ingress");
+        },
+      },
+    });
+
+    const response = await tool.execute({
+      id: "call-dispatch-spawn",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "worker" },
+        action: "spawn",
+        payload: "research task",
+        wait: false,
+        depth: 2,
+        injectToHistory: true,
+        sessionId: "caller-session",
+        agentName: "resident",
+        runId: "run-dispatch-spawn",
+      },
+    });
+    await Bun.sleep(0);
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: expect.any(String) });
+    expect(ingressCalled).toBe(false);
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.[0]).toMatchObject({
+      action: "worker.spawn",
+      target: { kind: "worker" },
+      payload: "research task",
+      wait: false,
+      timeoutMs: 30000,
+      correlation: { messageId: expect.any(String) },
+    });
+    expect(dispatches[0]?.[1]).toMatchObject({
+      sourceTool: "inbound_message",
+      sessionId: "caller-session",
+      runId: "run-dispatch-spawn",
+      agentName: "resident",
+      compatibility: {
+        messageId: expect.any(String),
+        legacyAction: "spawn",
+        depth: 3,
+        injectToHistory: true,
+      },
+    });
+  });
+
+  test("maps wait:true resident delivery through dispatch and preserves delivered output", async () => {
+    createWorkerRun("run-dispatch-wait");
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
+    const tool = createInboundMessageTool({
+      submit: async (...args) => {
+        dispatches.push(args);
+        return { status: "completed", dispatchId: "dispatch-1", output: "resident answer" };
+      },
+    });
+
+    const response = await tool.execute({
+      id: "call-dispatch-wait",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "resident" },
+        payload: "what next?",
+        wait: true,
+        timeoutMs: 1_000,
+        sessionId: "caller-session",
+        agentName: "worker",
+        runId: "run-dispatch-wait",
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.output)).toEqual({
+      status: "delivered",
+      messageId: "dispatch-1",
+      output: "resident answer",
+    });
+    expect(dispatches[0]?.[0]).toMatchObject({ action: "resident.deliver", wait: true });
+    expect(dispatches[0]?.[1]).toMatchObject({
+      wait: true,
+      timeoutMs: 1000,
+      compatibility: { depth: 1, injectToHistory: false },
+    });
+    expect(WorkerRunStateStore.get("caller-session", "run-dispatch-wait")).toMatchObject({
+      status: "running",
+      resumeCount: 1,
+    });
+  });
+
+  test("maps schedule action through dispatch and preserves scheduled result shape", async () => {
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
+    const tool = createInboundMessageTool({
+      submit: async (...args) => {
+        dispatches.push(args);
+        return { status: "scheduled", dispatchId: "dispatch-schedule", jobId: "job-1" };
+      },
+    });
+
+    const response = await tool.execute({
+      id: "call-dispatch-schedule",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "resident", agentName: "dev" },
+        action: "schedule",
+        payload: "daily summary",
+        schedule: "0 9 * * *",
+        sessionId: "caller-session",
+        agentName: "resident",
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.output)).toEqual({
+      status: "scheduled",
+      messageId: "job-1",
+      jobId: "job-1",
+    });
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.[0]).toMatchObject({
+      action: "schedule.create",
+      payload: "daily summary",
+    });
+    expect(dispatches[0]?.[1]).toMatchObject({
+      compatibility: {
+        legacyAction: "schedule",
+        schedule: "0 9 * * *",
+        depth: 1,
+        injectToHistory: false,
+      },
+    });
+    expect(CronJobRegistry.list()).toEqual([]);
+  });
+
+  test("times out dispatch-backed wait:true calls with legacy error shape", async () => {
+    const tool = createInboundMessageTool({
+      submit: () => new Promise(() => undefined),
+    });
+
+    const response = await tool.execute({
+      id: "call-dispatch-timeout",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "resident" },
+        payload: "please answer",
+        wait: true,
+        timeoutMs: 1,
+        sessionId: "caller-session",
+        agentName: "worker",
+        runId: "run-dispatch-timeout",
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.output)).toEqual({
+      status: "error",
+      messageId: expect.any(String),
+      error: "inbound_message timed out after 1ms",
+      timedOut: true,
+    });
   });
 
   test("wait:false returns immediately after sending through ingress", async () => {

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -64,12 +64,12 @@ describe("inbound_message tool", () => {
     clearCronJobs();
   });
 
-  test("increments depth across legitimate multi-hop calls", async () => {
-    const events: Ingress.InboundEvent[] = [];
+  test("increments depth across legitimate multi-hop dispatch calls", async () => {
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
     const tool = createInboundMessageTool({
-      ingest: async (event) => {
-        events.push(event);
-        return result("accepted");
+      submit: async (...args) => {
+        dispatches.push(args);
+        return { status: "completed", output: "accepted" };
       },
     });
 
@@ -94,12 +94,13 @@ describe("inbound_message tool", () => {
         depth: 1,
       },
     });
+    await Bun.sleep(0);
 
     expect(first.isError).toBeUndefined();
     expect(second.isError).toBeUndefined();
-    expect(events).toHaveLength(2);
-    expect(events[0]?.meta?.depth).toBe(1);
-    expect(events[1]?.meta?.depth).toBe(2);
+    expect(dispatches).toHaveLength(2);
+    expect(dispatches[0]?.[1].compatibility.depth).toBe(1);
+    expect(dispatches[1]?.[1].compatibility.depth).toBe(2);
   });
 
   test("maps wait:false worker spawns through dispatch without calling ingress", async () => {
@@ -277,12 +278,21 @@ describe("inbound_message tool", () => {
     });
   });
 
-  test("wait:false returns immediately after sending through ingress", async () => {
-    const events: Ingress.InboundEvent[] = [];
+  test("wait:false returns immediately after sending through dispatch", async () => {
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
+    let ingressCalled = false;
     const tool = createInboundMessageTool({
-      ingest: async (event) => {
-        events.push(event);
-        return result("accepted");
+      dispatchRuntime: {
+        submit: async (...args) => {
+          dispatches.push(args);
+          return { status: "completed", output: "accepted" };
+        },
+      },
+      ingressEngine: {
+        ingest: async () => {
+          ingressCalled = true;
+          return result("should not use ingress");
+        },
       },
     });
 
@@ -299,27 +309,34 @@ describe("inbound_message tool", () => {
         runId: "run-1",
       },
     });
+    await Bun.sleep(0);
 
     expect(response.isError).toBeUndefined();
-    expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: events[0]?.id });
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      mode: "direct",
-      payload: "continue",
+    expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: expect.any(String) });
+    expect(ingressCalled).toBe(false);
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.[0]).toMatchObject({
+      action: "worker.send",
       target: { kind: "worker", sessionId: "worker-session" },
-      meta: {
-        action: "send",
-        depth: 1,
-        actor: { role: "resident", sessionId: "caller-session", agentName: "resident" },
-      },
+      payload: "continue",
+    });
+    expect(dispatches[0]?.[1]).toMatchObject({
+      sessionId: "caller-session",
+      agentName: "resident",
+      runId: "run-1",
+      compatibility: { depth: 1, injectToHistory: false },
     });
   });
 
-  test("wait:true returns delivered output from ingress", async () => {
+  test("wait:true returns delivered output from dispatch", async () => {
     createWorkerRun("run-sync");
-    const pendingIngress = deferred<Ingress.IngressResult>();
+    const pendingDispatch = deferred<{
+      status: string;
+      dispatchId: string;
+      output: string;
+    }>();
     const tool = createInboundMessageTool({
-      ingest: () => pendingIngress.promise,
+      submit: () => pendingDispatch.promise,
     });
 
     const responsePromise = tool.execute({
@@ -336,13 +353,13 @@ describe("inbound_message tool", () => {
     });
 
     expect(WorkerRunStateStore.get("caller-session", "run-sync")?.status).toBe("waiting_input");
-    pendingIngress.resolve(result("done"));
+    pendingDispatch.resolve({ status: "completed", dispatchId: "dispatch-sync", output: "done" });
     const response = await responsePromise;
 
     expect(response.isError).toBeUndefined();
     expect(JSON.parse(response.output)).toEqual({
       status: "delivered",
-      messageId: expect.any(String),
+      messageId: "dispatch-sync",
       output: "done",
     });
     expect(WorkerRunStateStore.get("caller-session", "run-sync")).toMatchObject({
@@ -351,12 +368,21 @@ describe("inbound_message tool", () => {
     });
   });
 
-  test("schedule action registers a cron job without calling ingress", async () => {
-    const events: Ingress.InboundEvent[] = [];
+  test("schedule action routes through dispatch without registering locally or calling ingress", async () => {
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
+    let ingressCalled = false;
     const tool = createInboundMessageTool({
-      ingest: async (event) => {
-        events.push(event);
-        return result("should not run");
+      dispatchRuntime: {
+        submit: async (...args) => {
+          dispatches.push(args);
+          return { status: "scheduled", dispatchId: "dispatch-schedule", jobId: "job-1" };
+        },
+      },
+      ingressEngine: {
+        ingest: async () => {
+          ingressCalled = true;
+          return result("should not use ingress");
+        },
       },
     });
 
@@ -371,31 +397,28 @@ describe("inbound_message tool", () => {
       },
     });
 
-    const output = JSON.parse(response.output);
-    const jobs = CronJobRegistry.list();
-
     expect(response.isError).toBeUndefined();
-    expect(output.status).toBe("scheduled");
-    expect(typeof output.messageId).toBe("string");
-    expect(typeof output.jobId).toBe("string");
-    expect(output.jobId).toBe(output.messageId);
-    expect(events).toHaveLength(0);
-    expect(jobs).toHaveLength(1);
-    expect(jobs[0]).toMatchObject({
-      id: output.jobId,
-      agentName: "dev",
-      payload: "daily summary",
-      schedule: "0 9 * * *",
-      target: { kind: "resident" },
+    expect(JSON.parse(response.output)).toEqual({
+      status: "scheduled",
+      messageId: "job-1",
+      jobId: "job-1",
     });
-    expect(CronJobRegistry.remove(output.jobId)).toBe(true);
+    expect(ingressCalled).toBe(false);
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.[0]).toMatchObject({
+      action: "schedule.create",
+      payload: "daily summary",
+    });
+    expect(dispatches[0]?.[1]).toMatchObject({
+      compatibility: { legacyAction: "schedule", schedule: "0 9 * * *" },
+    });
     expect(CronJobRegistry.list()).toEqual([]);
   });
 
-  test("wait:true times out when ingress does not resolve", async () => {
+  test("wait:true times out when dispatch does not resolve", async () => {
     createWorkerRun("run-timeout");
     const tool = createInboundMessageTool({
-      ingest: () => new Promise(() => undefined),
+      submit: () => new Promise(() => undefined),
     });
 
     const response = await tool.execute({
@@ -422,11 +445,11 @@ describe("inbound_message tool", () => {
     expect(WorkerRunStateStore.get("caller-session", "run-timeout")?.status).toBe("running");
   });
 
-  test("wait:true abort signal cancels the wait", async () => {
+  test("wait:true abort signal cancels the dispatch wait", async () => {
     createWorkerRun("run-abort");
     const controller = new AbortController();
     const tool = createInboundMessageTool({
-      ingest: () => new Promise(() => undefined),
+      submit: () => new Promise(() => undefined),
     });
 
     const responsePromise = tool.execute(
@@ -459,33 +482,25 @@ describe("inbound_message tool", () => {
     expect(WorkerRunStateStore.get("caller-session", "run-abort")?.status).toBe("running");
   });
 
-  test("rejects calls at and beyond the depth limit before ingress", async () => {
+  test("rejects calls at and beyond the depth limit before dispatch", async () => {
     const calls: number[] = [];
     const tool = createInboundMessageTool({
-      ingest: async () => {
+      submit: async () => {
         calls.push(Date.now());
-        return result("should not happen");
+        return { status: "completed", output: "should not happen" };
       },
     });
 
     const atLimit = await tool.execute({
       id: "call-depth-10",
       tool: "inbound_message",
-      input: {
-        target: { kind: "worker" },
-        payload: "loop",
-        depth: 10,
-      },
+      input: { target: { kind: "worker" }, payload: "loop", depth: 10 },
     });
 
     const beyondLimit = await tool.execute({
       id: "call-depth",
       tool: "inbound_message",
-      input: {
-        target: { kind: "worker" },
-        payload: "loop",
-        depth: 11,
-      },
+      input: { target: { kind: "worker" }, payload: "loop", depth: 11 },
     });
 
     expect(atLimit.isError).toBe(true);
@@ -495,12 +510,12 @@ describe("inbound_message tool", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("allows depth just under the limit", async () => {
-    const events: Ingress.InboundEvent[] = [];
+  test("allows depth just under the limit through dispatch", async () => {
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
     const tool = createInboundMessageTool({
-      ingest: async (event) => {
-        events.push(event);
-        return result("accepted");
+      submit: async (...args) => {
+        dispatches.push(args);
+        return { status: "completed", output: "accepted" };
       },
     });
 
@@ -513,17 +528,20 @@ describe("inbound_message tool", () => {
         depth: 9,
       },
     });
+    await Bun.sleep(0);
 
     expect(response.isError).toBeUndefined();
-    expect(events).toHaveLength(1);
-    expect(events[0]?.meta?.depth).toBe(10);
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]?.[1].compatibility.depth).toBe(10);
   });
 
-  test("authority-denied ingress errors return error-shaped tool results", async () => {
+  test("authority-denied dispatch errors return error-shaped tool results", async () => {
     const tool = createInboundMessageTool({
-      ingest: async () => {
-        throw new Error("actor is not authorized to create top-level inbound work");
-      },
+      submit: async () => ({
+        status: "failed",
+        dispatchId: "dispatch-denied",
+        error: "actor is not authorized to create top-level inbound work",
+      }),
     });
 
     const response = await tool.execute({
@@ -541,7 +559,7 @@ describe("inbound_message tool", () => {
     expect(response.isError).toBe(true);
     expect(JSON.parse(response.output)).toEqual({
       status: "error",
-      messageId: expect.any(String),
+      messageId: "dispatch-denied",
       error: "actor is not authorized to create top-level inbound work",
     });
   });

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -626,6 +626,50 @@ describe("inbound_message tool", () => {
     expect(provider.listTools().some((tool) => tool.spec.name === "inbound_message")).toBe(true);
   });
 
+  test("AgentToolProvider preserves worker target for scheduled inbound messages", async () => {
+    const registered: Array<{ targetKind: string; sessionId?: string; agentName: string }> = [];
+    const provider = new AgentToolProvider({
+      dispatchOwners: {
+        scheduler: {
+          register(job) {
+            registered.push({
+              targetKind: job.target.kind,
+              ...(job.target.sessionId ? { sessionId: job.target.sessionId } : {}),
+              agentName: job.agentName,
+            });
+            return "job-worker";
+          },
+          remove() {
+            return false;
+          },
+        },
+      },
+    });
+
+    const response = await provider.execute({
+      id: "call-provider-schedule-worker",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "worker", agentName: "coder", sessionId: "worker-session" },
+        action: "schedule",
+        payload: "daily worker check",
+        schedule: "0 9 * * *",
+        sessionId: "caller-session",
+        agentName: "resident",
+      },
+    });
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.output)).toEqual({
+      status: "scheduled",
+      messageId: "job-worker",
+      jobId: "job-worker",
+    });
+    expect(registered).toEqual([
+      { targetKind: "worker", sessionId: "worker-session", agentName: "coder" },
+    ]);
+  });
+
   test("preserves partial subagent options without an explicit runtime", async () => {
     const provider = new AgentToolProvider({
       delegationContext: {

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -360,7 +360,7 @@ describe("inbound_message tool", () => {
 
   test("wait:false emits warning evidence when async dispatch is denied", async () => {
     const warnings: string[] = [];
-    Bus.observe((event, data) => {
+    const unsubscribe = Bus.observe((event, data) => {
       if (event.name === "operational.warn") {
         warnings.push(String((data as { msg?: unknown }).msg));
       }
@@ -380,9 +380,16 @@ describe("inbound_message tool", () => {
     });
     await Bun.sleep(0);
 
-    expect(response.isError).toBeUndefined();
-    expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: expect.any(String) });
-    expect(warnings.at(-1)).toContain("dispatch.worker.spawn.denied");
+    try {
+      expect(response.isError).toBeUndefined();
+      expect(JSON.parse(response.output)).toEqual({
+        status: "sent",
+        messageId: expect.any(String),
+      });
+      expect(warnings.at(-1)).toContain("dispatch.worker.spawn.denied");
+    } finally {
+      unsubscribe();
+    }
   });
 
   test("wait:true returns delivered output from dispatch", async () => {
@@ -617,6 +624,26 @@ describe("inbound_message tool", () => {
     const provider = new AgentToolProvider();
 
     expect(provider.listTools().some((tool) => tool.spec.name === "inbound_message")).toBe(true);
+  });
+
+  test("preserves partial subagent options without an explicit runtime", async () => {
+    const provider = new AgentToolProvider({
+      delegationContext: {
+        depth: 1,
+        maxDepth: 1,
+        visitedAgents: new Set<string>(),
+        parentAbort: new AbortController().signal,
+      },
+    });
+
+    const response = await provider.execute({
+      id: "call-subagent-depth",
+      tool: "subagent",
+      input: { agentName: "helper", prompt: "check" },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(response.output).toContain("max delegation depth (1) exceeded");
   });
 
   test("uses caller context when the executor supplies implicit inputs", async () => {

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -3,6 +3,7 @@ import type { Ingress } from "@openomni/protocol";
 import { Session, Storage, WorkerRunStateStore } from "@openomni/session";
 import { CronJobRegistry } from "../../src/execution-runtime/cron-job-registry";
 import { AgentToolProvider } from "../../src/execution-runtime/tool/agent/provider";
+import type { DispatchToolRuntime } from "../../src/execution-runtime/tool/agent/tools/dispatch";
 import {
   createInboundMessageTool,
   type InboundMessageDispatch,
@@ -102,7 +103,7 @@ describe("inbound_message tool", () => {
   });
 
   test("maps wait:false worker spawns through dispatch without calling ingress", async () => {
-    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
+    const dispatches: Parameters<DispatchToolRuntime["submit"]>[] = [];
     let ingressCalled = false;
     const tool = createInboundMessageTool({
       dispatchRuntime: {
@@ -552,12 +553,12 @@ describe("inbound_message tool", () => {
   });
 
   test("uses caller context when the executor supplies implicit inputs", async () => {
-    const events: Ingress.InboundEvent[] = [];
+    const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
     const provider = new AgentToolProvider({
-      ingressEngine: {
-        ingest: async (event) => {
-          events.push(event);
-          return result("ok");
+      dispatchRuntime: {
+        async submit(...args) {
+          dispatches.push(args);
+          return { dispatchId: "dispatch-provider", status: "completed", output: "ok" };
         },
       },
     });
@@ -575,10 +576,15 @@ describe("inbound_message tool", () => {
     });
 
     expect(response.isError).toBeUndefined();
-    expect(events[0]?.meta?.actor).toMatchObject({
-      role: "resident",
+    expect(dispatches[0]?.[1]).toMatchObject({
       sessionId: "caller-session",
       agentName: "resident",
+      runId: "run-provider",
+    });
+    expect(dispatches[0]?.[0]).toMatchObject({
+      action: "resident.deliver",
+      target: { kind: "resident" },
+      payload: "status",
     });
   });
 });

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { Session, Storage, WorkerRunStateStore } from "@openomni/session";
+import { Bus, Session, Storage, WorkerRunStateStore } from "@openomni/session";
 import { CronJobRegistry } from "../../src/execution-runtime/cron-job-registry";
 import { AgentToolProvider } from "../../src/execution-runtime/tool/agent/provider";
 import type { DispatchToolRuntime } from "../../src/execution-runtime/tool/agent/tools/dispatch";
@@ -188,6 +188,34 @@ describe("inbound_message tool", () => {
     });
   });
 
+  test("wait:true maps dispatch denied results to legacy error shape", async () => {
+    const tool = createInboundMessageTool({
+      submit: async () => ({
+        status: "denied",
+        dispatchId: "dispatch-denied",
+        reason: "dispatch.worker.spawn.denied",
+      }),
+    });
+
+    const response = await tool.execute({
+      id: "call-denied-wait",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "worker" },
+        action: "spawn",
+        payload: "new work",
+        wait: true,
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.output)).toEqual({
+      status: "error",
+      messageId: "dispatch-denied",
+      error: "dispatch.worker.spawn.denied",
+    });
+  });
+
   test("maps schedule action through dispatch and preserves scheduled result shape", async () => {
     const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
     const tool = createInboundMessageTool({
@@ -260,6 +288,34 @@ describe("inbound_message tool", () => {
     });
   });
 
+  test("schedule action maps dispatch denied results to legacy error shape", async () => {
+    const tool = createInboundMessageTool({
+      submit: async () => ({
+        status: "denied",
+        dispatchId: "dispatch-schedule-denied",
+        reason: "dispatch.worker.schedule.denied",
+      }),
+    });
+
+    const response = await tool.execute({
+      id: "call-schedule-denied",
+      tool: "inbound_message",
+      input: {
+        target: { kind: "resident", agentName: "dev" },
+        action: "schedule",
+        payload: "daily summary",
+        schedule: "0 9 * * *",
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.output)).toEqual({
+      status: "error",
+      messageId: "dispatch-schedule-denied",
+      error: "dispatch.worker.schedule.denied",
+    });
+  });
+
   test("wait:false returns immediately after sending through dispatch", async () => {
     const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
     const tool = createInboundMessageTool({
@@ -300,6 +356,33 @@ describe("inbound_message tool", () => {
       runId: "run-1",
       compatibility: { depth: 1, injectToHistory: false },
     });
+  });
+
+  test("wait:false emits warning evidence when async dispatch is denied", async () => {
+    const warnings: string[] = [];
+    Bus.observe((event, data) => {
+      if (event.name === "operational.warn") {
+        warnings.push(String((data as { msg?: unknown }).msg));
+      }
+    });
+    const tool = createInboundMessageTool({
+      submit: async () => ({
+        status: "denied",
+        dispatchId: "dispatch-async-denied",
+        reason: "dispatch.worker.spawn.denied",
+      }),
+    });
+
+    const response = await tool.execute({
+      id: "call-async-denied",
+      tool: "inbound_message",
+      input: { target: { kind: "worker" }, action: "spawn", payload: "new work" },
+    });
+    await Bun.sleep(0);
+
+    expect(response.isError).toBeUndefined();
+    expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: expect.any(String) });
+    expect(warnings.at(-1)).toContain("dispatch.worker.spawn.denied");
   });
 
   test("wait:true returns delivered output from dispatch", async () => {
@@ -551,7 +634,7 @@ describe("inbound_message tool", () => {
       id: "call-provider",
       tool: "inbound_message",
       input: {
-        target: { kind: "resident", agentName: "main" },
+        target: { kind: "resident", agentName: "main", parentSessionId: "parent-session" },
         payload: "status",
         sessionId: "caller-session",
         agentName: "resident",
@@ -567,7 +650,7 @@ describe("inbound_message tool", () => {
     });
     expect(dispatches[0]?.[0]).toMatchObject({
       action: "resident.deliver",
-      target: { kind: "resident" },
+      target: { kind: "resident", name: "main", parentSessionId: "parent-session" },
       payload: "status",
     });
   });

--- a/packages/openomni/test/execution-runtime/inbound-message.test.ts
+++ b/packages/openomni/test/execution-runtime/inbound-message.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { Ingress } from "@openomni/protocol";
 import { Session, Storage, WorkerRunStateStore } from "@openomni/session";
 import { CronJobRegistry } from "../../src/execution-runtime/cron-job-registry";
 import { AgentToolProvider } from "../../src/execution-runtime/tool/agent/provider";
@@ -8,15 +7,6 @@ import {
   createInboundMessageTool,
   type InboundMessageDispatch,
 } from "../../src/execution-runtime/tool/agent/tools/inbound-message";
-
-function result(output: string): Ingress.IngressResult {
-  return {
-    mode: "direct",
-    target: { kind: "worker", sessionId: "worker-session" },
-    sessionId: "worker-session",
-    result: { output, finishReason: "stop" },
-  };
-}
 
 function createWorkerRun(runId: string): void {
   const now = Date.now();
@@ -105,18 +95,11 @@ describe("inbound_message tool", () => {
 
   test("maps wait:false worker spawns through dispatch without calling ingress", async () => {
     const dispatches: Parameters<DispatchToolRuntime["submit"]>[] = [];
-    let ingressCalled = false;
     const tool = createInboundMessageTool({
       dispatchRuntime: {
         submit: async (...args) => {
           dispatches.push(args);
           return { status: "completed", output: "accepted" };
-        },
-      },
-      ingressEngine: {
-        ingest: async () => {
-          ingressCalled = true;
-          return result("should not use ingress");
         },
       },
     });
@@ -140,7 +123,6 @@ describe("inbound_message tool", () => {
 
     expect(response.isError).toBeUndefined();
     expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: expect.any(String) });
-    expect(ingressCalled).toBe(false);
     expect(dispatches).toHaveLength(1);
     expect(dispatches[0]?.[0]).toMatchObject({
       action: "worker.spawn",
@@ -280,18 +262,11 @@ describe("inbound_message tool", () => {
 
   test("wait:false returns immediately after sending through dispatch", async () => {
     const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
-    let ingressCalled = false;
     const tool = createInboundMessageTool({
       dispatchRuntime: {
         submit: async (...args) => {
           dispatches.push(args);
           return { status: "completed", output: "accepted" };
-        },
-      },
-      ingressEngine: {
-        ingest: async () => {
-          ingressCalled = true;
-          return result("should not use ingress");
         },
       },
     });
@@ -313,7 +288,6 @@ describe("inbound_message tool", () => {
 
     expect(response.isError).toBeUndefined();
     expect(JSON.parse(response.output)).toEqual({ status: "sent", messageId: expect.any(String) });
-    expect(ingressCalled).toBe(false);
     expect(dispatches).toHaveLength(1);
     expect(dispatches[0]?.[0]).toMatchObject({
       action: "worker.send",
@@ -370,18 +344,11 @@ describe("inbound_message tool", () => {
 
   test("schedule action routes through dispatch without registering locally or calling ingress", async () => {
     const dispatches: Parameters<InboundMessageDispatch["submit"]>[] = [];
-    let ingressCalled = false;
     const tool = createInboundMessageTool({
       dispatchRuntime: {
         submit: async (...args) => {
           dispatches.push(args);
           return { status: "scheduled", dispatchId: "dispatch-schedule", jobId: "job-1" };
-        },
-      },
-      ingressEngine: {
-        ingest: async () => {
-          ingressCalled = true;
-          return result("should not use ingress");
         },
       },
     });
@@ -403,7 +370,6 @@ describe("inbound_message tool", () => {
       messageId: "job-1",
       jobId: "job-1",
     });
-    expect(ingressCalled).toBe(false);
     expect(dispatches).toHaveLength(1);
     expect(dispatches[0]?.[0]).toMatchObject({
       action: "schedule.create",
@@ -565,7 +531,7 @@ describe("inbound_message tool", () => {
   });
 
   test("AgentToolProvider registers inbound_message for agent callers", () => {
-    const provider = new AgentToolProvider({ ingressEngine: { ingest: async () => result("ok") } });
+    const provider = new AgentToolProvider();
 
     expect(provider.listTools().some((tool) => tool.spec.name === "inbound_message")).toBe(true);
   });

--- a/packages/openomni/test/inbound-message/integration.test.ts
+++ b/packages/openomni/test/inbound-message/integration.test.ts
@@ -2,7 +2,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun
 import { IngressEvent, type Ingress } from "@openomni/protocol";
 import { Bus, Session, Storage } from "@openomni/session";
 import { CronJobRegistry } from "../../src/execution-runtime/cron-job-registry";
-import { createInboundMessageTool } from "../../src/execution-runtime/tool/agent/tools/inbound-message";
+import {
+  createInboundMessageTool,
+  type InboundMessageDispatch,
+} from "../../src/execution-runtime/tool/agent/tools/inbound-message";
 import {
   defaultRunFn,
   mockModelsGet,
@@ -59,9 +62,7 @@ beforeEach(() => {
 });
 
 describe("inbound_message integration flows", () => {
-  it("sends resident worker spawns asynchronously through ingress", async () => {
-    installDispatchOnlyCoordinator();
-    const completed = collectBusEvents(IngressEvent.Completed);
+  it("sends resident worker spawns asynchronously through dispatch", async () => {
     const tool = inboundTool();
 
     const response = await tool.execute({
@@ -79,7 +80,6 @@ describe("inbound_message integration flows", () => {
     });
 
     await waitFor(() => dispatches.length === 1);
-    completed.unsubscribe();
 
     expect(response.isError).toBeUndefined();
     expect(JSON.parse(response.output)).toEqual({
@@ -87,7 +87,6 @@ describe("inbound_message integration flows", () => {
       messageId: expect.any(String),
     });
     expect(dispatches[0]).toMatchObject({ prompt: "research task" });
-    expect(completed.events.at(-1)).toMatchObject({ mode: "direct", target: "worker" });
   });
 
   it("delivers a worker question to the resident and returns the sync answer", async () => {
@@ -116,11 +115,7 @@ describe("inbound_message integration flows", () => {
       messageId: expect.any(String),
       output: "resident answer",
     });
-    expect(received.events.at(-1)).toMatchObject({
-      surface: "internal",
-      mode: "direct",
-      target: "resident",
-    });
+    expect(received.events).toHaveLength(0);
   });
 
   it("sends worker messages to an existing worker session", async () => {
@@ -154,10 +149,8 @@ describe("inbound_message integration flows", () => {
     expect(deliveries).toEqual([
       { sessionId: workerSession.id, prompt: "continue with this context", runId: undefined },
     ]);
-    expect(received.events.at(-1)).toMatchObject({
-      target: `worker-session:${workerSession.id}`,
-    });
-    expect(completed.events.at(-1)).toMatchObject({ target: "worker" });
+    expect(received.events).toHaveLength(0);
+    expect(completed.events).toHaveLength(0);
   });
 
   it("schedules a cron inbound message and fires it into resident execution", async () => {
@@ -247,7 +240,7 @@ describe("inbound_message integration flows", () => {
 
   it("times out wait:true calls when ingress never responds", async () => {
     const tool = createInboundMessageTool({
-      ingest: () => new Promise(() => undefined),
+      submit: () => new Promise(() => undefined),
     });
 
     const response = await tool.execute({
@@ -274,8 +267,6 @@ describe("inbound_message integration flows", () => {
   });
 
   it("handles multiple concurrent inbound messages independently", async () => {
-    installDispatchOnlyCoordinator();
-    const completed = collectBusEvents(IngressEvent.Completed);
     const tool = inboundTool();
 
     const responses = await Promise.all(
@@ -296,8 +287,6 @@ describe("inbound_message integration flows", () => {
         }),
       ),
     );
-    completed.unsubscribe();
-
     expect(responses.map((response) => response.isError)).toEqual([
       undefined,
       undefined,
@@ -313,12 +302,68 @@ describe("inbound_message integration flows", () => {
       "beta",
       "gamma",
     ]);
-    expect(completed.events).toHaveLength(3);
   });
 });
 
 function inboundTool() {
-  return createInboundMessageTool(IngressEngine);
+  return createInboundMessageTool({ submit: dispatchSubmit });
+}
+
+async function dispatchSubmit(
+  command: Parameters<InboundMessageDispatch["submit"]>[0],
+  context: Parameters<InboundMessageDispatch["submit"]>[1],
+): ReturnType<InboundMessageDispatch["submit"]> {
+  const dispatchId = crypto.randomUUID();
+  if (context.agentName === "worker" && command.action === "worker.spawn") {
+    return { status: "failed", dispatchId, error: "worker cannot spawn workers" };
+  }
+
+  if (command.action === "resident.deliver") {
+    return {
+      status: "completed",
+      dispatchId,
+      output: testState.responseQueue.shift() ?? "resident:ok",
+    };
+  }
+
+  if (command.action === "worker.send" || command.action === "worker.resume") {
+    if (!command.target.sessionId) {
+      return { status: "failed", dispatchId, error: "worker target sessionId is required" };
+    }
+    deliveries.push({
+      sessionId: command.target.sessionId,
+      prompt: command.payload,
+      runId: undefined,
+    });
+    return {
+      status: "completed",
+      dispatchId,
+      output: JSON.stringify({ delivered: true, sessionId: command.target.sessionId }),
+    };
+  }
+
+  if (command.action === "schedule.create") {
+    const jobId = CronJobRegistry.register({
+      id: crypto.randomUUID(),
+      agentName: command.target.agentName ?? context.agentName ?? "resident",
+      payload: command.payload,
+      schedule: context.compatibility.schedule ?? "",
+      target: {
+        kind: command.target.kind,
+        ...(command.target.sessionId ? { sessionId: command.target.sessionId } : {}),
+      },
+      createdAt: Date.now(),
+    });
+    return { status: "scheduled", dispatchId, jobId, messageId: jobId };
+  }
+
+  dispatches.push({
+    sessionId: command.target.sessionId ?? context.sessionId ?? crypto.randomUUID(),
+    runId: crypto.randomUUID(),
+    prompt: command.payload,
+    target: command.target as Ingress.Target,
+  });
+  return { status: "completed", dispatchId, output: `worker:${command.payload}` };
 }
 
 function installResidentRuntime(): void {
@@ -351,25 +396,6 @@ function installCoordinator(): void {
     async deliverMessage(sessionId, prompt, runId) {
       deliveries.push({ sessionId, prompt, runId });
       return { accepted: true };
-    },
-  });
-}
-
-function installDispatchOnlyCoordinator(): void {
-  IngressEngine.setCoordinator({
-    async dispatch(sessionId, request) {
-      dispatches.push({
-        sessionId,
-        runId: request.runId,
-        prompt: request.prompt,
-      });
-      return {
-        runId: request.runId,
-        sessionId,
-        status: "succeeded" as const,
-        output: `worker:${request.prompt}`,
-        finishReason: "stop" as const,
-      };
     },
   });
 }

--- a/packages/openomni/test/inbound-message/integration.test.ts
+++ b/packages/openomni/test/inbound-message/integration.test.ts
@@ -55,7 +55,6 @@ beforeEach(() => {
   IngressEngine.reset();
   Storage.initialize({ dbPath: ":memory:" });
   installResidentRuntime();
-  installCoordinator();
   IngressEngine.setAgentResolver({
     resolve: async () => ({ model: { provider: "anthropic", id: "claude-3-5-sonnet" } }),
   });
@@ -375,29 +374,6 @@ function installResidentRuntime(): void {
       },
     }),
   );
-}
-
-function installCoordinator(): void {
-  IngressEngine.setCoordinator({
-    async dispatch(sessionId, request) {
-      dispatches.push({
-        sessionId,
-        runId: request.runId,
-        prompt: request.prompt,
-      });
-      return {
-        runId: request.runId,
-        sessionId,
-        status: "succeeded" as const,
-        output: `worker:${request.prompt}`,
-        finishReason: "stop" as const,
-      };
-    },
-    async deliverMessage(sessionId, prompt, runId) {
-      deliveries.push({ sessionId, prompt, runId });
-      return { accepted: true };
-    },
-  });
 }
 
 function createWorkerSession(title: string): Session.Info {

--- a/packages/protocol/src/dispatch/index.ts
+++ b/packages/protocol/src/dispatch/index.ts
@@ -21,6 +21,7 @@ export namespace Dispatch {
       kind: TargetKind,
       id: z.string().min(1).optional(),
       sessionId: z.string().min(1).optional(),
+      parentSessionId: z.string().min(1).optional(),
       runId: z.string().min(1).optional(),
       name: z.string().min(1).optional(),
       labels: z.array(z.string()).optional(),

--- a/packages/protocol/src/dispatch/index.ts
+++ b/packages/protocol/src/dispatch/index.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { BusEvent } from "../bus/index.js";
+import { Policy } from "../policy/index.js";
+
+export namespace Dispatch {
+  export const ActorKind = z.enum(["worker", "resident", "system", "user", "unknown"]);
+  export type ActorKind = z.infer<typeof ActorKind>;
+
+  export const TargetKind = z.enum([
+    "worker",
+    "resident",
+    "schedule",
+    "session",
+    "surface",
+    "system",
+  ]);
+  export type TargetKind = z.infer<typeof TargetKind>;
+
+  export const Target = z
+    .object({
+      kind: TargetKind,
+      id: z.string().min(1).optional(),
+      sessionId: z.string().min(1).optional(),
+      runId: z.string().min(1).optional(),
+      name: z.string().min(1).optional(),
+      labels: z.array(z.string()).optional(),
+    })
+    .strict();
+  export type Target = z.infer<typeof Target>;
+
+  export const Input = z
+    .object({
+      action: z.string().min(1),
+      target: Target,
+      payload: z.unknown().optional(),
+      wait: z.boolean().optional(),
+      timeoutMs: z.number().int().min(0).optional(),
+      correlation: z.string().min(1).optional(),
+      idempotencyKey: z.string().min(1).optional(),
+    })
+    .strict();
+  export type Input = z.infer<typeof Input>;
+
+  export const ActorContext = z
+    .object({
+      kind: ActorKind,
+      actorId: z.string().min(1),
+      agentName: z.string().min(1).optional(),
+      sessionId: z.string().min(1).optional(),
+      runId: z.string().min(1).optional(),
+      workerRunId: z.string().min(1).optional(),
+      workspaceRoot: z.string().min(1).optional(),
+      permissions: z.array(z.string()).optional(),
+      labels: z.array(z.string()).optional(),
+      trustTier: z.string().min(1).optional(),
+      reason: z.string().min(1).optional(),
+    })
+    .strict();
+  export type ActorContext = z.infer<typeof ActorContext>;
+
+  export const Command = Input.extend({
+    dispatchId: z.string().min(1),
+    actor: ActorContext,
+    traceId: z.string().min(1).optional(),
+    sessionId: z.string().min(1).optional(),
+    runId: z.string().min(1).optional(),
+    workspaceRoot: z.string().min(1).optional(),
+    submittedAt: z.number(),
+  }).strict();
+  export type Command = z.infer<typeof Command>;
+
+  export const Result = z
+    .object({
+      dispatchId: z.string().min(1),
+      status: z.enum(["completed", "denied", "failed"]),
+      output: z.unknown().optional(),
+      error: z.string().optional(),
+      reason: z.string().optional(),
+      handler: z.string().optional(),
+      durationMs: z.number().min(0).optional(),
+    })
+    .strict();
+  export type Result = z.infer<typeof Result>;
+
+  const EventBase = z.object({
+    dispatchId: z.string().min(1),
+    traceId: z.string().min(1).optional(),
+    sessionId: z.string().min(1).optional(),
+    runId: z.string().min(1).optional(),
+    actor: ActorContext,
+    action: z.string().min(1),
+    target: Target,
+    correlation: z.string().min(1).optional(),
+    time: z.number(),
+  });
+
+  export namespace Events {
+    export const Submitted = BusEvent.define(
+      "dispatch.submitted",
+      EventBase.extend({
+        payloadSummary: z.string().optional(),
+        idempotencyKey: z.string().min(1).optional(),
+      }),
+    );
+
+    export const Authorized = BusEvent.define(
+      "dispatch.authorized",
+      EventBase.extend({
+        verdict: z.literal("allow"),
+        reason: z.string().optional(),
+        policyId: z.string().optional(),
+        effects: z.array(Policy.PolicyEffect).optional(),
+      }),
+    );
+
+    export const Denied = BusEvent.define(
+      "dispatch.denied",
+      EventBase.extend({
+        verdict: z.enum(["deny", "pending"]),
+        reason: z.string(),
+        policyId: z.string().optional(),
+        effects: z.array(Policy.PolicyEffect).optional(),
+      }),
+    );
+
+    export const Routed = BusEvent.define(
+      "dispatch.routed",
+      EventBase.extend({
+        handler: z.string().min(1),
+      }),
+    );
+
+    export const Completed = BusEvent.define(
+      "dispatch.completed",
+      EventBase.extend({
+        handler: z.string().min(1),
+        durationMs: z.number().min(0),
+        resultSummary: z.string().optional(),
+      }),
+    );
+
+    export const Failed = BusEvent.define(
+      "dispatch.failed",
+      EventBase.extend({
+        handler: z.string().min(1).optional(),
+        durationMs: z.number().min(0).optional(),
+        reason: z.string(),
+      }),
+    );
+  }
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -26,3 +26,4 @@ export * from "./storage/index.js";
 export * from "./trace/index.js";
 export * from "./skill/index.js";
 export * from "./extension/index.js";
+export * from "./dispatch/index.js";

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -88,6 +88,7 @@ const methods = {
       runId: z.string().optional(),
       callId: z.string().optional(),
       payload: z.string(),
+      workspaceRoot: z.string().optional(),
     }),
     result: z.object({
       requestId: z.string(),

--- a/packages/protocol/src/policy/definition.ts
+++ b/packages/protocol/src/policy/definition.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export namespace PolicyDefinition {
   export const Timing = {
     INBOUND_RECEIVE: "inbound.receive",
+    DISPATCH_AUTHORIZE: "dispatch.authorize",
     RUN_START: "run.start",
     TURN_START: "turn.start",
     CONTEXT_PREPARE: "context.prepare",

--- a/packages/protocol/src/policy/point-contract.ts
+++ b/packages/protocol/src/policy/point-contract.ts
@@ -17,6 +17,7 @@ export namespace PolicyPointContractModule {
 
   const policyPointIds = [
     "session.inbound.pre",
+    "dispatch.action.pre",
     "run.lifecycle.pre",
     "run.turn.pre",
     "prompt.context.pre",
@@ -52,7 +53,7 @@ export namespace PolicyPointContractModule {
   export const PolicyPointId = z
     .string()
     .regex(
-      /^(tool|prompt|delegation|session|credential|connection|run)\.[a-z][a-z0-9-]*\.(pre|post|error)$/,
+      /^(tool|prompt|delegation|session|credential|connection|run|dispatch)\.[a-z][a-z0-9-]*\.(pre|post|error)$/,
     );
   export const PolicyPointContract = z.object({
     id: PolicyPointId,

--- a/packages/protocol/src/policy/point-registry.ts
+++ b/packages/protocol/src/policy/point-registry.ts
@@ -18,6 +18,14 @@ export namespace PolicyPointRegistryModule {
       ["audit.annotate", "run.abort", "delegation.set_constraints"],
       ...preBoundary,
     ),
+    "dispatch.action.pre": contract(
+      "dispatch.action.pre",
+      "pre",
+      ["dispatch"],
+      ["actor", "dispatchId", "action", "target", "sessionId", "runId"],
+      ["audit.annotate", "run.abort"],
+      ...preBoundary,
+    ),
     "run.lifecycle.pre": contract(
       "run.lifecycle.pre",
       "pre",
@@ -210,6 +218,7 @@ export namespace PolicyPointRegistryModule {
 
   export const policyPointMigrationMapping = {
     [Timing.INBOUND_RECEIVE]: ["session.inbound.pre"],
+    [Timing.DISPATCH_AUTHORIZE]: ["dispatch.action.pre"],
     [Timing.RUN_START]: ["run.lifecycle.pre"],
     [Timing.TURN_START]: ["run.turn.pre"],
     [Timing.CONTEXT_PREPARE]: ["prompt.context.pre"],

--- a/packages/protocol/src/policy/resource.ts
+++ b/packages/protocol/src/policy/resource.ts
@@ -12,6 +12,7 @@ export namespace RuntimeResource {
     "credential",
     "session",
     "policy",
+    "dispatch",
   ]);
   export type Kind = z.infer<typeof Kind>;
 

--- a/packages/protocol/test/dispatch/schema.test.ts
+++ b/packages/protocol/test/dispatch/schema.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { Dispatch, Policy, RuntimeResource } from "../../src/index.js";
+
+const actor: Dispatch.ActorContext = {
+  kind: "worker",
+  actorId: "worker-1",
+  agentName: "agent",
+  sessionId: "session-1",
+  runId: "run-1",
+};
+
+const target: Dispatch.Target = {
+  kind: "resident",
+  id: "resident-main",
+  sessionId: "resident-session",
+};
+
+const eventBase = {
+  dispatchId: "dispatch-1",
+  traceId: "trace-1",
+  sessionId: "session-1",
+  runId: "run-1",
+  actor,
+  action: "resident.deliver",
+  target,
+  correlation: "corr-1",
+  time: Date.now(),
+};
+
+describe("Dispatch protocol schemas", () => {
+  test("Input accepts the public dispatch envelope", () => {
+    const parsed = Dispatch.Input.parse({
+      action: "resident.deliver",
+      target,
+      payload: { message: "hello" },
+      wait: true,
+      timeoutMs: 1_000,
+      correlation: "corr-1",
+      idempotencyKey: "idem-1",
+    });
+
+    expect(parsed.action).toBe("resident.deliver");
+    expect(parsed.target.kind).toBe("resident");
+    expect(parsed.wait).toBe(true);
+  });
+
+  test("Input rejects actor and runtime-only fields", () => {
+    for (const field of [
+      "actor",
+      "sessionId",
+      "runId",
+      "workspaceRoot",
+      "model",
+      "provider",
+      "budget",
+      "tools",
+      "permissions",
+    ]) {
+      expect(
+        Dispatch.Input.safeParse({
+          action: "worker.spawn",
+          target: { kind: "worker" },
+          [field]: field === "actor" ? { actorId: "fake" } : "fake",
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  test("ActorContext accepts runtime-derived actor shapes", () => {
+    expect(Dispatch.ActorContext.parse(actor).kind).toBe("worker");
+    expect(Dispatch.ActorContext.parse({ kind: "resident", actorId: "resident-main" }).kind).toBe(
+      "resident",
+    );
+    expect(Dispatch.ActorContext.parse({ kind: "system", actorId: "scheduler" }).kind).toBe(
+      "system",
+    );
+    expect(
+      Dispatch.ActorContext.parse({ kind: "unknown", actorId: "unknown", reason: "missing" }).kind,
+    ).toBe("unknown");
+  });
+
+  test("Command and Result carry canonical runtime metadata", () => {
+    const command = Dispatch.Command.parse({
+      action: "resident.deliver",
+      target,
+      payload: { message: "hello" },
+      dispatchId: "dispatch-1",
+      actor,
+      traceId: "trace-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      workspaceRoot: "/workspace",
+      submittedAt: Date.now(),
+    });
+
+    expect(command.actor.actorId).toBe("worker-1");
+
+    const result = Dispatch.Result.parse({
+      dispatchId: command.dispatchId,
+      status: "completed",
+      output: { delivered: true },
+      handler: "resident.deliver",
+      durationMs: 1,
+    });
+
+    expect(result.status).toBe("completed");
+  });
+
+  test("Events parse dispatch lifecycle payloads", () => {
+    expect(Dispatch.Events.Submitted.schema.parse({ ...eventBase }).dispatchId).toBe("dispatch-1");
+    expect(
+      Dispatch.Events.Authorized.schema.parse({
+        ...eventBase,
+        verdict: "allow",
+        policyId: "dispatch.default",
+        effects: [{ type: "audit.annotate", annotation: "ok" }],
+      }).verdict,
+    ).toBe("allow");
+    expect(
+      Dispatch.Events.Denied.schema.parse({
+        ...eventBase,
+        verdict: "deny",
+        reason: "not authorized",
+        policyId: "dispatch.default",
+      }).reason,
+    ).toBe("not authorized");
+    expect(
+      Dispatch.Events.Routed.schema.parse({ ...eventBase, handler: "resident.deliver" }).handler,
+    ).toBe("resident.deliver");
+    expect(
+      Dispatch.Events.Completed.schema.parse({
+        ...eventBase,
+        handler: "resident.deliver",
+        durationMs: 2,
+      }).durationMs,
+    ).toBe(2);
+    expect(
+      Dispatch.Events.Failed.schema.parse({ ...eventBase, reason: "handler failed" }).reason,
+    ).toBe("handler failed");
+  });
+
+  test("Events use canonical descriptor names", () => {
+    expect(Dispatch.Events.Submitted.name).toBe("dispatch.submitted");
+    expect(Dispatch.Events.Authorized.name).toBe("dispatch.authorized");
+    expect(Dispatch.Events.Denied.name).toBe("dispatch.denied");
+    expect(Dispatch.Events.Routed.name).toBe("dispatch.routed");
+    expect(Dispatch.Events.Completed.name).toBe("dispatch.completed");
+    expect(Dispatch.Events.Failed.name).toBe("dispatch.failed");
+  });
+
+  test("RuntimeResource accepts dispatch descriptors for policy audit", () => {
+    const descriptor = RuntimeResource.Descriptor.parse({
+      id: "dispatch:resident.deliver",
+      kind: "dispatch",
+      labels: ["dispatch.resident"],
+      capabilities: ["resident.deliver"],
+      effects: ["message.deliver"],
+      source: { type: "runtime", runtimeId: "dispatch-runtime" },
+    });
+
+    expect(descriptor.kind).toBe("dispatch");
+  });
+
+  test("Policy timing and point expose the canonical dispatch authority gate", () => {
+    expect(Policy.Timing.DISPATCH_AUTHORIZE).toBe("dispatch.authorize");
+    expect(Policy.PolicyPoint.MigrationMapping[Policy.Timing.DISPATCH_AUTHORIZE]).toEqual([
+      "dispatch.action.pre",
+    ]);
+
+    const point = Policy.PolicyPoint.Registry["dispatch.action.pre"];
+    expect(point.phase).toBe("pre");
+    expect(point.defaultFailPolicy).toBe("fail-closed");
+    expect(point.sideEffectBoundary).toBe(true);
+    expect(point.requiredContext).toEqual([
+      "actor",
+      "dispatchId",
+      "action",
+      "target",
+      "sessionId",
+      "runId",
+    ]);
+    expect(point.allowedEffects).toEqual(["audit.annotate", "run.abort"]);
+    expect(Policy.PolicyPoint.Id.parse("dispatch.action.pre")).toBe("dispatch.action.pre");
+  });
+
+  test("legacy policy mappings still resolve", () => {
+    expect(Policy.PolicyPoint.resolve(Policy.Timing.INBOUND_RECEIVE)).toEqual([
+      "session.inbound.pre",
+    ]);
+    expect(
+      Policy.PolicyPoint.resolve(Policy.Timing.INVOKE_PREPARE, { resourceKind: "tool" }),
+    ).toEqual(["tool.native.pre", "tool.mcp.pre"]);
+    expect(Policy.PolicyPoint.resolve(Policy.Timing.WRITEBACK_COMMIT)).toEqual([
+      "session.writeback.pre",
+    ]);
+  });
+});

--- a/packages/protocol/test/dispatch/schema.test.ts
+++ b/packages/protocol/test/dispatch/schema.test.ts
@@ -13,6 +13,7 @@ const target: Dispatch.Target = {
   kind: "resident",
   id: "resident-main",
   sessionId: "resident-session",
+  parentSessionId: "parent-session",
 };
 
 const eventBase = {
@@ -41,6 +42,7 @@ describe("Dispatch protocol schemas", () => {
 
     expect(parsed.action).toBe("resident.deliver");
     expect(parsed.target.kind).toBe("resident");
+    expect(parsed.target.parentSessionId).toBe("parent-session");
     expect(parsed.wait).toBe(true);
   });
 

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -250,6 +250,7 @@ describe("Ipc.Methods param schemas", () => {
         runId: "run-1",
         callId: "call-1",
         payload: "Need approval",
+        workspaceRoot: "/workspace/openomni",
       }).success,
     ).toBe(true);
   });

--- a/packages/protocol/test/policy.test.ts
+++ b/packages/protocol/test/policy.test.ts
@@ -464,9 +464,10 @@ describe("Policy schemas", () => {
   });
 
   describe("Policy.Timing", () => {
-    it("parses all 14 valid timing values", () => {
+    it("parses all 15 valid timing values", () => {
       const timingValues = [
         Policy.Timing.INBOUND_RECEIVE,
+        Policy.Timing.DISPATCH_AUTHORIZE,
         Policy.Timing.RUN_START,
         Policy.Timing.TURN_START,
         Policy.Timing.CONTEXT_PREPARE,
@@ -484,6 +485,7 @@ describe("Policy schemas", () => {
 
       expect(timingValues).toEqual([
         "inbound.receive",
+        "dispatch.authorize",
         "run.start",
         "turn.start",
         "context.prepare",
@@ -500,9 +502,9 @@ describe("Policy schemas", () => {
       ]);
     });
 
-    it("has all 14 timing values as constants", () => {
+    it("has all 15 timing values as constants", () => {
       const timingKeys = Object.keys(Policy.Timing);
-      expect(timingKeys.length).toBe(14);
+      expect(timingKeys.length).toBe(15);
     });
 
     it("rejects invalid timing value", () => {

--- a/packages/protocol/test/policy/conformance/versioning.test.ts
+++ b/packages/protocol/test/policy/conformance/versioning.test.ts
@@ -168,6 +168,21 @@ describe("PolicyPoint versioning conformance", () => {
     }
   });
 
+  test("locks the dispatch policy point golden fixture", () => {
+    const fixture = goldenPolicyPointFixtures.find(
+      (candidate) => candidate.contract.id === "dispatch.action.pre",
+    );
+
+    expect(fixture !== undefined).toBe(true);
+    if (fixture === undefined) throw new Error("dispatch fixture missing");
+
+    const contract = Policy.PolicyPoint.Contract.parse(fixture.contract);
+    expect(contract.inputSchema).toBe("policy.point.dispatch.action.pre.input.v1");
+    expect(contract.allowedEffects).toEqual(["audit.annotate", "run.abort"]);
+    expect(contract.defaultFailPolicy).toBe("fail-closed");
+    expect(contract.sideEffectBoundary).toBe(true);
+  });
+
   test("requires explicit migration errors for breaking point schema changes", () => {
     const fixture = firstDecisionFixture();
     const replay = safeReplay({

--- a/packages/protocol/test/policy/migration-mapping.test.ts
+++ b/packages/protocol/test/policy/migration-mapping.test.ts
@@ -7,6 +7,7 @@ describe("PolicyPoint migration mapping", () => {
 
     expect(Object.keys(mapping).sort()).toEqual(Object.values(Policy.Timing).sort());
     expect(mapping[Policy.Timing.INBOUND_RECEIVE]).toEqual(["session.inbound.pre"]);
+    expect(mapping[Policy.Timing.DISPATCH_AUTHORIZE]).toEqual(["dispatch.action.pre"]);
     expect(mapping[Policy.Timing.RUN_START]).toEqual(["run.lifecycle.pre"]);
     expect(mapping[Policy.Timing.TURN_START]).toEqual(["run.turn.pre"]);
     expect(mapping[Policy.Timing.CONTEXT_PREPARE]).toEqual(["prompt.context.pre"]);

--- a/packages/protocol/test/policy/point-registry.test.ts
+++ b/packages/protocol/test/policy/point-registry.test.ts
@@ -3,6 +3,7 @@ import { Policy } from "../../src/policy/index.js";
 
 const expectedPointIds = [
   "session.inbound.pre",
+  "dispatch.action.pre",
   "run.lifecycle.pre",
   "run.turn.pre",
   "prompt.context.pre",
@@ -27,6 +28,7 @@ const expectedPointIds = [
 describe("PolicyPoint registry", () => {
   test("accepts only canonical 3-tier point IDs", () => {
     expect(Policy.PolicyPoint.Id.parse("tool.native.pre")).toBe("tool.native.pre");
+    expect(Policy.PolicyPoint.Id.parse("dispatch.action.pre")).toBe("dispatch.action.pre");
     expect(Policy.PolicyPoint.Id.safeParse("tool.native.prepare").success).toBe(false);
     expect(Policy.PolicyPoint.Id.safeParse("tool.pre").success).toBe(false);
     expect(Policy.PolicyPoint.Id.safeParse("unknown.native.pre").success).toBe(false);
@@ -79,11 +81,12 @@ describe("PolicyPoint registry", () => {
     }
   });
 
-  test("maps all 14 legacy timings to registered 3-tier point IDs", () => {
+  test("maps all policy timings to registered 3-tier point IDs", () => {
     const aliases = Policy.PolicyPoint.MigrationMapping;
 
     expect(Object.keys(aliases).sort()).toEqual(Object.values(Policy.Timing).sort());
     expect(aliases[Policy.Timing.INBOUND_RECEIVE]).toEqual(["session.inbound.pre"]);
+    expect(aliases[Policy.Timing.DISPATCH_AUTHORIZE]).toEqual(["dispatch.action.pre"]);
     expect(aliases[Policy.Timing.INVOKE_PREPARE]).toEqual([
       "tool.native.pre",
       "tool.mcp.pre",
@@ -105,6 +108,14 @@ describe("PolicyPoint registry", () => {
   });
 
   test("pre-boundary contracts fail closed and post-boundary contracts fail open", () => {
+    expect(Policy.PolicyPoint.Registry["dispatch.action.pre"].defaultFailPolicy).toBe(
+      "fail-closed",
+    );
+    expect(Policy.PolicyPoint.Registry["dispatch.action.pre"].sideEffectBoundary).toBe(true);
+    expect(Policy.PolicyPoint.Registry["dispatch.action.pre"].allowedEffects).toEqual([
+      "audit.annotate",
+      "run.abort",
+    ]);
     expect(Policy.PolicyPoint.Registry["tool.native.pre"].defaultFailPolicy).toBe("fail-closed");
     expect(Policy.PolicyPoint.Registry["tool.native.pre"].sideEffectBoundary).toBe(true);
     expect(Policy.PolicyPoint.Registry["tool.native.post"].defaultFailPolicy).toBe("fail-open");

--- a/qa/dispatch-verification-matrix.md
+++ b/qa/dispatch-verification-matrix.md
@@ -1,6 +1,6 @@
 # Dispatch / Policy Verification Matrix
 
-Task 5 verification record for team goal `G001-add-protocol-dispatch-schemas-events`.
+Verification record for the dispatch schema and policy-gate implementation.
 
 ## Scope
 

--- a/qa/dispatch-verification-matrix.md
+++ b/qa/dispatch-verification-matrix.md
@@ -1,0 +1,51 @@
+# Dispatch / Policy Verification Matrix
+
+Task 5 verification record for team goal `G001-add-protocol-dispatch-schemas-events`.
+
+## Scope
+
+Verified the dispatch-schema, canonical policy timing, inbound-message compatibility,
+worker IPC, resident routing, and subagent policy-admission surfaces that are most
+likely to be affected by dispatch protocol changes.
+
+## Commands and results
+
+| Check | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Dependency bootstrap | `bun install` | PASS | Installed workspace dependencies after initial `turbo: command not found`; no lockfile changes. |
+| Full typecheck | `bun run check-types` | PASS | Turbo reported 10/10 successful tasks. |
+| Full tests | `bun run test` | PASS | Turbo reported 9/9 successful tasks. Agent conformance suite includes 10 documented skipped known-ungoverned policy paths. |
+| Repo lint | `bun run lint` | PASS | Guard lint and side-effect lint passed. Biome exited 0 with 12 pre-existing warnings in tests/runtime files. |
+| Protocol dispatch/policy targets | `bun test packages/protocol/test/policy.test.ts packages/protocol/test/policy/point-registry.test.ts packages/protocol/test/inbound-message/schema.test.ts packages/protocol/test/agent-execution.test.ts packages/protocol/test/ipc/schema.test.ts` | PASS | 100 pass / 0 fail. Covers canonical policy timings, point registry, inbound-message schemas, execution events, and worker IPC schema preservation. |
+| Runtime ingress/delegation targets | `bun test packages/openomni/test/subagent/subagent-spawn-policy.test.ts packages/openomni/test/subagent/descriptor.test.ts packages/openomni/test/resident/runtime.test.ts apps/server/test/ingress-bridge.test.ts apps/server/test/agent-routing.test.ts` | PASS | 31 pass / 0 fail. Covers resident routing, ingress bridge tool surfaces, policy-plan propagation, and subagent worker descriptors. |
+
+## Integration findings
+
+- `packages/protocol/src/policy/definition.ts`, `policy/point-contract.ts`, and
+  `policy/point-registry.ts` are coupled and should be changed together whenever
+  canonical policy timing or point IDs change.
+- `packages/protocol/src/inbound-message/index.ts`, `src/execution/index.ts`,
+  and `src/ipc/index.ts` are the schema choke points for dispatch compatibility.
+- Runtime adapters most exposed to dispatch changes are:
+  - `packages/openomni/src/ingress/handlers.ts`
+  - `packages/openomni/src/ingress/middleware/ingress-authority.ts`
+  - `packages/openomni/src/execution-runtime/tool/agent/tools/inbound-message.ts`
+  - `apps/server/src/ingress/bridge.ts`
+  - `apps/server/src/execution/worker-runner.ts`
+- The full agent policy no-bypass conformance suite still documents skipped
+  known-ungoverned paths. These are existing roadmap gaps, not failures from the
+  current verification pass.
+
+## Fix decisions
+
+No integration fix was applied in this lane. The only initial failure was missing
+workspace dependencies in this worktree (`turbo: command not found`), resolved by
+`bun install`. Subsequent typecheck, test, lint, and focused dispatch/runtime
+checks passed.
+
+## Subagent findings integrated
+
+- Test probe confirmed the most relevant broad commands and highlighted missing
+  direct model-resolution regressions outside this dispatch-lane scope.
+- Change-slice probe identified the coupled protocol policy files, runtime
+  adapter hazards, and the exact focused commands used above.


### PR DESCRIPTION
## Summary

Add a thin Dispatch gate for internal agent routing. Dispatch owns the envelope-level policy decision and bus audit trail, while action-specific behavior stays in handlers/adapters.

Fixes #206

## Changes

- Add Dispatch protocol schemas, lifecycle events, and the `dispatch.authorize` policy point
- Add OpenOmni Dispatch runtime, actor derivation, registry, default policy, and built-in handler adapters
- Add the model-visible `dispatch` tool
- Convert `inbound_message` into a Dispatch-backed compatibility shim without a legacy ingress fallback in the tool path
- Route worker-to-Resident wait flows through Dispatch with worker actor context
- Add regression coverage for policy denial, bus lifecycle events, actor derivation, parent-session preservation, inbound compatibility, and thin-core behavior
- Add a dispatch verification matrix under `qa/`

## Type

- [x] `feat` — New feature or capability
- [x] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only

## Affected Packages

- [x] `protocol`
- [ ] `session`
- [ ] `llm`
- [ ] `agent`
- [x] `openomni`
- [ ] `coordinator`
- [x] `server`

## Breaking Changes

- [x] No breaking changes

## Verification

- [x] `bun run build` passes
- [x] `bun run check-types` passes
- [x] `bun test` passes — 2540 pass / 10 skip / 0 fail
- [x] Targeted dispatch/inbound/worker-runner tests pass
- [x] Scoped Biome checks pass for changed package/app files
- [x] `bun run script/check-deps.ts` reports no violations (stale doc warning for `packages/coordinator/AGENTS.md`, unrelated to this change)

## Checklist

- [x] Tests added/updated for changes
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error` added
- [x] Architecture notes updated for the execution-runtime tool path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Dispatch gate for internal agent routing with envelope-level policy and bus audit events, replacing direct ingress in `inbound_message` and exposing a model-visible `dispatch` tool. Addresses issue #206 by centralizing worker/resident routing and authorization behind Dispatch.

- **New Features**
  - Dispatch protocol schemas and lifecycle events; policy timing `dispatch.authorize` (`dispatch.action.pre`).
  - `DispatchRuntime` with actor derivation (incl. `workspaceRoot`), registry, default policy, and built-in handlers for worker, resident, and schedule.
  - New `dispatch` tool and a Dispatch-backed `inbound_message` shim mapping to `resident.deliver`, `worker.spawn`, and `worker.send`.
  - Server bootstrap and worker runner initialize Dispatch, add ingress event projector/handlers, and route IPC/resident waits through Dispatch; `workspaceRoot` is propagated via IPC and runtime context.
  - `AgentToolProvider` wires a default Dispatch runtime and exposes `dispatch`; public tool schema omits runtime-only fields.

- **Bug Fixes**
  - Preserve worker dispatch actor context and `workspaceRoot` across server, runner, and IPC.
  - Preserve scheduled worker targets in the schedule handler.
  - Harden denial handling and audit effects at the dispatch gate.
  - Remove the legacy ingress fallback from the tool path.

<sup>Written for commit e07970886669f9515f6fd5a8035492b2dd78f94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced dispatch system for executing cross-session actions through authorization policies
  * Added task scheduling with create and cancel operations
  * Implemented structured event lifecycle tracking for dispatched operations

* **Improvements**
  * Enhanced internal communication routing with better event visibility (submitted, authorized, routed, completed states)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->