### PR TITLE
Remove communication dispatch legacies

### DIFF
--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -45,14 +45,11 @@ function buildAgentDefFromEntries(
   deps: BridgeDeps,
   selectedEntries: ReturnType<typeof selectToolEntries>,
 ): Ingress.AgentDef {
-  const modelFacingEntries = selectedEntries.filter(
-    (entry) => entry.tool.spec.name !== "inbound_message",
-  );
-  const specs = modelFacingEntries.map((entry) => ({
+  const specs = selectedEntries.map((entry) => ({
     ...entry.tool.spec,
     name: sanitizeToolName(entry.tool.spec.name),
   }));
-  const nativeTools = modelFacingEntries.map((entry) => entry.tool);
+  const nativeTools = selectedEntries.map((entry) => entry.tool);
 
   return {
     model: definition.model,
@@ -76,18 +73,9 @@ function buildAgentDefFromEntries(
   };
 }
 
-function fallbackDefinition(agentName: string, deps: BridgeDeps): AgentDefinition {
-  return {
-    name: agentName,
-    description: `Fallback agent definition for ${agentName}`,
-    model: deps.defaultModel ?? { provider: "anthropic", id: "claude-3-5-sonnet-20241022" },
-    systemPrompt: "",
-    tools: { categories: ["filesystem", "execution", "delegation", "mcp", "custom"] },
-  };
-}
-
 export function buildAgentDef(agentName: string, deps: BridgeDeps): Ingress.AgentDef {
-  const definition = getAgentDefinition(agentName) ?? fallbackDefinition(agentName, deps);
+  const definition = getAgentDefinition(agentName);
+  if (!definition) throw new Error(`Unknown agent definition: ${agentName}`);
   return buildAgentDefFromEntries(definition, deps, selectToolEntries(definition, deps));
 }
 
@@ -112,8 +100,7 @@ function rawCorrelationToken(raw: unknown): string | undefined {
 function findPendingAskForMessage(message: Adapter.InboundMessage) {
   const token = rawCorrelationToken(message.raw);
   const descriptor = SurfaceKey.parse(message.surfaceKey);
-  const legacyChannelId = message.surfaceKey.split(":")[2];
-  const channelId = descriptor.id ?? legacyChannelId;
+  const channelId = descriptor.id;
   const scoped = {
     endpointId: descriptor.namespace || descriptor.surface,
     ...(channelId ? { channelId } : {}),

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -272,7 +272,6 @@ describe("WorkerRunner", () => {
                 (dispatchTool?.inputSchema as { properties?: Record<string, unknown> }).properties
                   ?.target,
               ).not.toHaveProperty("properties.sessionId");
-              expect(toolNames).not.toContain("inbound_message");
               expect(toolNames).not.toContain("check_inbox");
               expect(toolNames).not.toContain("ask_main");
               expect(options.systemPrompt).toContain(
@@ -281,7 +280,6 @@ describe("WorkerRunner", () => {
               expect(options.systemPrompt).toContain(
                 "responses from other agents arrive automatically, no polling needed",
               );
-              expect(options.systemPrompt).not.toContain("inbound_message");
               expect(options.systemPrompt).not.toContain("use ask_main");
               return successfulResult;
             },

--- a/apps/server/test/ingress-bridge.test.ts
+++ b/apps/server/test/ingress-bridge.test.ts
@@ -46,7 +46,7 @@ function makeProvider(tools: NativeTool[]): ToolProvider {
 function makeMessage(): Adapter.InboundMessage {
   return {
     id: "message-1",
-    surfaceKey: "discord:guild:dev",
+    surfaceKey: "discord:guild:channel:dev",
     text: "hello",
     sender: { id: "user-1", name: "User" },
   };
@@ -68,11 +68,7 @@ function makeWorkerHintedOwnerMessage(): Adapter.InboundMessage {
 
 const deps = {
   systemProvider: makeProvider([makeTool("read"), makeTool("bash")]),
-  agentProvider: makeProvider([
-    makeTool("subagent"),
-    makeTool("dispatch"),
-    makeTool("inbound_message"),
-  ]),
+  agentProvider: makeProvider([makeTool("subagent"), makeTool("dispatch")]),
   mcpProvider: makeProvider([makeTool("mcp_search")]),
   customProvider: makeProvider([makeTool("weather_lookup")]),
   defaultModel: { provider: "anthropic", id: "claude-3-haiku-20240307" },
@@ -89,7 +85,7 @@ describe("ingress bridge tool surfaces", () => {
     Storage.reset();
   });
 
-  it("uses Resident identity and tool selection with dispatch and without inbound_message", () => {
+  it("uses Resident identity and dispatch tool selection", () => {
     const event = buildInboundEvent(makeMessage(), "dev", deps);
 
     expect(event.target).toEqual({ kind: "resident" });

--- a/packages/openomni/src/dispatch/handlers/schedule.ts
+++ b/packages/openomni/src/dispatch/handlers/schedule.ts
@@ -12,22 +12,9 @@ function requireScheduler(scheduler: DispatchSchedulerOwner | undefined): Dispat
   return scheduler;
 }
 
-function compatibilitySchedule(
-  context: { compatibility?: Record<string, unknown> } | undefined,
-): string | undefined {
-  const schedule = context?.compatibility?.schedule;
-  return typeof schedule === "string" ? schedule : undefined;
-}
-
-function scheduleFromPayload(
-  command: Dispatch.Command,
-  context: { compatibility?: Record<string, unknown> } | undefined,
-): string | undefined {
+function scheduleFromPayload(command: Dispatch.Command): string | undefined {
   const payload = asRecord(command.payload);
-  return (
-    (typeof payload?.schedule === "string" ? payload.schedule : undefined) ??
-    compatibilitySchedule(context)
-  );
+  return typeof payload?.schedule === "string" ? payload.schedule : undefined;
 }
 
 function payloadText(command: Dispatch.Command): string {
@@ -56,9 +43,9 @@ export function createScheduleDispatchHandlers(
   options: ScheduleDispatchHandlerOptions = {},
 ): Record<"schedule.create" | "schedule.cancel", DispatchHandler> {
   return {
-    "schedule.create"(command, context) {
+    "schedule.create"(command) {
       const scheduler = requireScheduler(options.scheduler);
-      const schedule = scheduleFromPayload(command, context);
+      const schedule = scheduleFromPayload(command);
       if (!schedule) throw new Error("schedule.create requires payload.schedule");
       const payload = asRecord(command.payload);
       const agentName =

--- a/packages/openomni/src/dispatch/registry.ts
+++ b/packages/openomni/src/dispatch/registry.ts
@@ -9,7 +9,6 @@ export interface DispatchHandlerContext {
   readonly agentName?: string;
   readonly workspaceRoot?: string;
   readonly sourceTool?: string;
-  readonly compatibility?: Record<string, unknown>;
 }
 
 export interface DispatchHandlerResult {

--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -28,7 +28,6 @@ export interface DispatchSubmitOptions extends DispatchRuntimeContext, DispatchH
   readonly includeDefaultPolicies?: boolean;
   readonly onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
   readonly sourceTool?: string;
-  readonly compatibility?: Record<string, unknown>;
 }
 
 export interface DispatchRuntimeOptions {
@@ -226,7 +225,6 @@ export class DispatchRuntime {
         ...(options.agentName ? { agentName: options.agentName } : {}),
         ...(options.workspaceRoot ? { workspaceRoot: options.workspaceRoot } : {}),
         ...(options.sourceTool ? { sourceTool: options.sourceTool } : {}),
-        ...(options.compatibility ? { compatibility: options.compatibility } : {}),
       });
       const output = normalizeHandlerOutput(raw);
       Bus.publish(DispatchProtocol.Events.Completed, {


### PR DESCRIPTION
## Summary

- Remove legacy inbound tool filtering and test fixture references from ingress bridge coverage.
- Remove Dispatch compatibility context plumbing and schedule fallback handling.
- Fail fast on unknown ingress agent definitions.
- Require normalized surface keys for PendingAsk matching.

## Behavior changes

- `schedule.create` now reads schedules only from `payload.schedule`.
- Unknown agent names now throw instead of silently using an empty fallback definition.
- PendingAsk reply matching uses normalized `SurfaceKey` parsing only.

## Tests

- `bun run lint`
- `bun run check-types`
- `bun run build`
- Targeted dispatch/communication tests:
  - `packages/protocol/test/communication/schema.test.ts`
  - `packages/protocol/test/dispatch/schema.test.ts`
  - `packages/session/test/pending-ask/store.test.ts`
  - `packages/session/test/worker-grant/store.test.ts`
  - `packages/openomni/test/dispatch/runtime.test.ts`
  - `packages/openomni/test/dispatch/handlers.test.ts`
  - `packages/openomni/test/execution-runtime/dispatch-tool.test.ts`
  - `apps/server/test/ingress-bridge.test.ts`
  - `apps/server/test/execution/worker-runner.test.ts`
  - `packages/openomni/test/ingress/cron-adapter.test.ts`
  - `packages/openomni/test/ingress/engine-internal.test.ts`
