### PR TITLE
docs(coordinator): refresh stale AGENTS.md to current module reality

### DIFF
--- a/packages/coordinator/AGENTS.md
+++ b/packages/coordinator/AGENTS.md
@@ -1,17 +1,18 @@
 # packages/coordinator
 
-Multiprocess execution coordinator runtime. This package owns worker pool lifecycle, IPC transport, recovery, credentials/policy helpers, and the worker entrypoint used by server-side dispatch.
+Multiprocess execution coordinator runtime. This package owns on-demand worker lifecycle, IPC transport, recovery, credentials/policy helpers, and the worker supervision used by server-side dispatch. Per [ADR-008](../../docs/design-decisions/008-lightweight-main-persona-on-demand-workers.md) (accepted): workers spawn on demand and idle-shutdown; there is no fixed pool.
 
 ## STRUCTURE
 
 ```
 src/
 ├── index.ts              # Package barrel
-├── credentials/          # Worker credential filtering and injection
+├── credentials/          # Worker credential filtering and injection (internal; not in barrel)
 ├── ipc/                  # Unix socket transport + framing + protocol errors
 ├── recovery/             # Interrupted worker run recovery
-├── tool-permission/      # Non-interactive permission policy + audit log
-└── worker-pool/          # Worker routing, supervision, and worker entrypoint
+├── tool-permission/      # Non-interactive permission policy + audit log (internal; not in barrel)
+├── worker-manager/       # ⭐ LIVE: OnDemandWorkerManager — spawn on demand, slots, idle shutdown
+└── worker-pool/          # LEGACY facade (pool.ts wraps createWorkerManager) + supervisor + session routing
 ```
 
 ## DEPENDENCIES
@@ -22,14 +23,37 @@ Depends on `@openomni/protocol`, `@openomni/session`, `@openomni/agent`, and `@o
 
 | Module | Purpose |
 |--------|---------|
-| `credentials/store.ts` | Loads stored credentials and filters them by provider prefix |
-| `credentials/injector.ts` | Injects provider-scoped credentials into workers |
-| `ipc/*` | Request/response framing, client/server transport, and protocol errors |
-| `recovery/index.ts` | Marks interrupted worker runs failed after restart |
-| `tool-permission/*` | Policy load + audit logging for non-interactive tool decisions |
-| `worker-pool/pool.ts` | Public worker-pool factory |
-| `worker-pool/supervisor.ts` | Worker lifecycle and restart management |
+| `worker-manager/manager.ts` | **Primary API.** `createWorkerManager()` / `OnDemandWorkerManager`: slot-based dispatch, session affinity, spawn on demand up to `maxActiveWorkers` (default 10), waiter queue when saturated, idle shutdown (`idleShutdownMs`, default 600s), generation-tracked restarts |
+| `worker-pool/pool.ts` | Legacy facade — `createWorkerPool()` delegates to `createWorkerManager()` (`size` → `maxActiveWorkers` alias). Kept for compatibility; pending removal (see implementation-status) |
+| `worker-pool/supervisor.ts` | Per-worker process lifecycle: spawn, bootstrap handshake, restart generations, stop |
 | `worker-pool/session-routing.ts` | Session-tree affinity routing |
+| `ipc/*` | Request/response framing, bidirectional client/server transport, protocol errors |
+| `recovery/index.ts` | `recoverInterruptedRuns()` — marks interrupted worker runs failed after restart |
+| `credentials/store.ts` / `credentials/injector.ts` | Loads stored credentials, filters by provider prefix, injects provider-scoped credentials into workers |
+| `tool-permission/*` | Policy load + audit logging for non-interactive tool decisions |
+
+## WORKER LIFECYCLE (worker-manager)
+
+```
+dispatch(runId)
+  → reject if stopping / duplicate runId
+  → acquireSlot(): free slot | new worker (≤ maxActiveWorkers) | wait in queue
+  → slot.load++, clear idle timer
+  → ensureSupervisor() (created on demand; generation check across restarts)
+  → dispatch to supervisor → result
+  → slot.load--; if 0: release one waiter, scheduleIdleShutdown()
+       idleShutdownMs elapsed with load 0 → kill worker, forget slot
+```
+
+## CONSUMER
+
+`apps/server/src/execution/coordinator.ts` is the live consumer: `createExecutionCoordinator()` wraps `createWorkerManager()` (config mapping: `maxWorkers` → `maxActiveWorkers`, `workerIdleTimeoutMs` → `idleShutdownMs`; callbacks `onToolCall`, `onInboundWait`, `onWorkerSnapshot`) and owns dispatch, cancellation, message delivery, stats, and recovery wiring.
+
+Barrel exports (`src/index.ts`): `createWorkerManager` / `OnDemandWorkerManager` (live), `createWorkerPool` (legacy), `createIpcServer`, `recoverInterruptedRuns`, plus types. `credentials/` and `tool-permission/` are internal — not exported from the barrel.
+
+## TESTS
+
+13 files: 3 inline (`src/ipc/framing.test.ts`, `src/ipc/ipc-bidirectional.test.ts`, `src/worker-pool/supervisor.test.ts`) + 10 under `test/` split by module (`worker-manager/`, `worker-pool/` incl. crash/affinity/dispatch/contract-alias, `credentials/`, `recovery/`, `tool-permission/`, `harness/smoke`).
 
 ## ANTI-PATTERNS
 
@@ -37,3 +61,4 @@ Depends on `@openomni/protocol`, `@openomni/session`, `@openomni/agent`, and `@o
 - Do NOT add empty catch blocks; coordinator needs explicit degradation behavior.
 - Do NOT add generic catch-all files like `utils.ts` or `helpers.ts`.
 - Do NOT put session-backed orchestration policy here; coordinator executes and recovers worker processes, while `@openomni/openomni` owns orchestration semantics.
+- Do NOT build new features on `worker-pool/pool.ts` — it is a compatibility facade; target `worker-manager` directly.


### PR DESCRIPTION
Refreshes the stale coordinator AGENTS.md (83 commits, check-deps threshold 50) to match worker-manager reality. Docs only.

Refs #189, #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh `packages/coordinator/AGENTS.md` to match the on‑demand worker model (ADR‑008), documenting `worker-manager` as the live API and marking `worker-pool/pool.ts` as legacy. Clarifies lifecycle, server consumer mapping, barrel exports, tests, and adds an anti‑pattern to avoid the legacy pool; connects to #189 and #216.

<sup>Written for commit b67534ebb860f940e31b211d527e4acfec77d236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coordinator package documentation to clarify worker lifecycle management, including dispatch behavior, session affinity, and idle shutdown mechanisms.
  * Clarified configuration parameter naming conventions for worker management and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->