### PR TITLE
docs: adopt connector definitions as the public install ABI (ADR-010 §3)

### DIFF
--- a/docs/design-decisions/010-agent-os-kernel-model.md
+++ b/docs/design-decisions/010-agent-os-kernel-model.md
@@ -70,6 +70,19 @@ The `AgentRegistry` grows an **application manifest** per app: capabilities, cos
 
 **Native log ingestion.** Apps keep their own transcripts (JSONL session logs, stream-json output). The connector tails them and (a) stores the raw log as a WorkItem artifact, (b) projects key events — tool calls, errors, token usage — into the journal as app-internal evidence. This single mechanism gives the §7 gate hard evidence for app claims ("tests ran" = the tool-call record exists), gives §8 RCA its autopsy material for app-executed work (the log is the transcript-equivalent), gives cost tracking real token numbers, and gives **stall detection a liveness signal** (no log activity for N minutes → nudge, or kill and mark interrupted). Raw logs never enter sessions — artifact plus journal projection only.
 
+**Installation — the connector definition is the public ABI.** OpenOmni is not a package manager: binaries are installed by the Owner's existing tooling (brew, bun). Installing an app means installing its **connector** — a printer driver, not a printer. The unit is a *declarative* `AppConnector` definition (Zod-validated data, not code): how to detect the binary and its version (`testedVersions` range), how to spawn headless, where its logs live and how to parse them, how its question bridge is materialized, what evidence it can emit, what credentials and capabilities it **requires**, and its initial routing profile. Because the definition is data conforming to a published schema, a third party can integrate their agent by writing one file and never touching the kernel — this is what passes the [T1 third-party test](../agent-os-definition.md) as an OS rather than as a framework.
+
+Install lifecycle: **discover → register → consent → wire → verify**.
+
+- *discover* — detect installed binaries and versions.
+- *consent* — the app-store moment: "Claude Code requests: git, network, `ANTHROPIC_API_KEY`. Allow?" The Owner's one tap sets the app's permission ceiling; from there autonomy grows only through ledger evidence (new apps start with conservative grants and a zero track record).
+- *wire* — materialize bridge hooks and credential mappings.
+- *verify* — a smoke test: run one trivial task, confirm exit status and log ingestion. "Installed" is itself an evidence-gated claim, not a self-report.
+
+**Version drift is an incident.** CLI agents update frequently and break flags and log formats. A version outside `testedVersions` triggers re-verification: smoke test passes → provisional allow + journal record; fails → app disabled + Owner alert. App upgrades thereby ride the §8 incident pipeline for free.
+
+The same lifecycle generalizes later to other package kinds — channel drivers, device drivers, memory engines (ADR-013 port) — but only executor apps are in scope now; building an app store before having three working connectors would be metaphor cosplay.
+
 ### 4. Evidence ledger with userland daemons
 
 The journal (`BusPersistence`) plus the work ledger (`WorkItemStore`: evidence, verification gates) form the **single feedback substrate**. The kernel only appends; improvement logic lives in userland daemons that read it:

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -23,6 +23,8 @@ Single source of truth for the gap between accepted design and running code. Oth
 | `PendingInteraction` (successor; correlation routing, follow-up window) | 📋 | — | Not a pure rename of PendingAsk (status enum, `allowedActions`, `workerRunId` coupling all change). No PI-match session override exists in dispatch |
 | `executorKind` on WorkerRun (`external_api` / `a2a` / `human_channel`) | 📋 | — | Internal ChatAgent execution only today |
 | `local_cli_agent` executor (CLI agents as installed apps) | 📋 | — | ADR-010 §3 — connector philosophy: observe the boundary, don't manage the inside |
+| `AppConnector` schema (declarative connector definition = public ABI) | 📋 | `packages/protocol/src/app-connector/` (planned) | ADR-010 §3 — detect/spawn/observe/bridge/evidence/requires/profile; third parties integrate by writing one file (T1) |
+| Install lifecycle (discover → register → consent → wire → smoke-verify; version-drift re-verification) | 📋 | — | ADR-010 §3 — consent sets the app's permission ceiling; "installed" is itself evidence-gated; drift rides the ADR-012 incident pipeline |
 | App question bridge (permission/clarification prompt → `resident.ask`, suspend/resume) | 📋 | — | ADR-010 §3 |
 | Native app log ingestion (raw → artifact, key events → journal; liveness for stall detection) | 📋 | — | ADR-010 §3 — also the evidence + RCA + cost source for app work |
 | Outbound external actions (`external.ask`, `a2a.ask`, `api.ask`) | 📋 | — | Dispatch tool exposes generic `dispatch` + `resident.ask` only |


### PR DESCRIPTION
Formalizes the one-click app install design from the 2026-06-11 discussion: declarative `AppConnector` definitions as the public ABI (T1 third-party test), the discover→register→consent→wire→smoke-verify lifecycle (consent sets the permission ceiling; 'installed' is itself evidence-gated), version drift as an ADR-012 incident, and the scope guard against app-store cosplay. Tracking rows added to implementation-status.

Docs only. #216's scope is amended separately to implement this.

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formalizes app installation via declarative `AppConnector` definitions as the public ABI. Documents the install flow (discover → register → consent → wire → verify/smoke), makes "installed" evidence-gated with consent as the permission ceiling, treats version drift outside `testedVersions` as an incident requiring re-verification, and adds `AppConnector` schema and lifecycle tracking rows to implementation status.

<sup>Written for commit dd5cd386bc1557f15b4cf012ef4d148c46fe9068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

