### PR TITLE
fix(session): count actual events per run in getWorkerRunHistory

### DIFF
--- a/packages/session/src/bus-persistence/query.ts
+++ b/packages/session/src/bus-persistence/query.ts
@@ -38,6 +38,7 @@ interface WorkerRunRow {
   readonly status: string;
   readonly time_created: number;
   readonly time_updated: number;
+  readonly event_count: number;
 }
 
 export namespace BusQuery {
@@ -171,10 +172,13 @@ export namespace BusQuery {
   > {
     const rows = getDatabase()
       .query(
-        `SELECT run_id, status, time_created, time_updated
-         FROM worker_run_state
-         WHERE session_id = ?
-         ORDER BY time_created DESC`,
+        `SELECT wrs.run_id, wrs.status, wrs.time_created, wrs.time_updated,
+                COUNT(be.id) AS event_count
+         FROM worker_run_state wrs
+         LEFT JOIN bus_event be ON be.run_id = wrs.run_id
+         WHERE wrs.session_id = ?
+         GROUP BY wrs.run_id
+         ORDER BY wrs.time_created DESC`,
       )
       .all(sessionId) as WorkerRunRow[];
 
@@ -182,7 +186,7 @@ export namespace BusQuery {
       rows.map((row) => ({
         runId: row.run_id,
         status: row.status,
-        eventCount: 0,
+        eventCount: row.event_count,
         startTime: row.time_created,
         endTime: row.time_updated,
       })),

--- a/packages/session/test/bus-persistence/query.test.ts
+++ b/packages/session/test/bus-persistence/query.test.ts
@@ -316,6 +316,87 @@ describe("BusQuery", () => {
     ]);
   });
 
+  test("getWorkerRunHistory reports actual event count per run", async () => {
+    insertWorkerRun({
+      runId: "run-1",
+      sessionId: "sess-1",
+      status: "completed",
+      timeCreated: 100,
+      timeUpdated: 200,
+    });
+    insertWorkerRun({
+      runId: "run-2",
+      sessionId: "sess-1",
+      status: "running",
+      timeCreated: 300,
+      timeUpdated: 350,
+    });
+    insertWorkerRun({
+      runId: "run-3",
+      sessionId: "sess-2",
+      status: "completed",
+      timeCreated: 400,
+      timeUpdated: 450,
+    });
+
+    insertEvent({
+      sessionId: "sess-1",
+      runId: "run-1",
+      type: "agent.step.started",
+      category: "agent",
+      traceId: "t1",
+      timeCreated: 110,
+    });
+    insertEvent({
+      sessionId: "sess-1",
+      runId: "run-1",
+      type: "agent.tool.invoked",
+      category: "agent",
+      traceId: "t2",
+      timeCreated: 120,
+    });
+    insertEvent({
+      sessionId: "sess-1",
+      runId: "run-1",
+      type: "agent.step.completed",
+      category: "agent",
+      traceId: "t3",
+      timeCreated: 130,
+    });
+    insertEvent({
+      sessionId: "sess-1",
+      runId: "run-2",
+      type: "agent.step.started",
+      category: "agent",
+      traceId: "t4",
+      timeCreated: 310,
+    });
+    // run-3 belongs to sess-2 — must not count toward sess-1 results
+    insertEvent({
+      sessionId: "sess-2",
+      runId: "run-3",
+      type: "agent.step.started",
+      category: "agent",
+      traceId: "t5",
+      timeCreated: 410,
+    });
+    // session-scoped event with no run_id — must not leak into any run count
+    insertEvent({
+      sessionId: "sess-1",
+      type: "custom.note",
+      category: "custom",
+      traceId: "t6",
+      timeCreated: 500,
+    });
+
+    const runs = await BusQuery.getWorkerRunHistory("sess-1");
+
+    expect(runs).toEqual([
+      { runId: "run-2", status: "running", eventCount: 1, startTime: 300, endTime: 350 },
+      { runId: "run-1", status: "completed", eventCount: 3, startTime: 100, endTime: 200 },
+    ]);
+  });
+
   test("query functions return empty results for missing data", async () => {
     await expect(BusQuery.listBySession("sess-1")).resolves.toEqual([]);
     await expect(BusQuery.listByRun("missing-run")).resolves.toEqual([]);


### PR DESCRIPTION
## Summary

`BusQuery.getWorkerRunHistory()` was returning `eventCount: 0` as a hardcoded placeholder — every caller saw a flat zero regardless of how many bus events the run produced. This PR wires it to the real count via a single LEFT JOIN against `bus_event`, unblocking downstream telemetry consumers that need accurate per-run event counts.

Relates to: Track B (Governor) prerequisite

## Changes

- `BusQuery.getWorkerRunHistory`: replace `eventCount: 0` with `LEFT JOIN bus_event ON be.run_id = wrs.run_id` + `COUNT(be.id)` + `GROUP BY wrs.run_id`. Uses the existing `idx_bus_event_run_time` index, so the join is cheap.
- Add regression test that seeds two worker runs (3 events + 1 event) and asserts the reported counts. Includes negative cases for cross-session leakage and events without a `run_id` to lock in the GROUP BY scope.

## Type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, tooling, dependencies
- [ ] `perf` — Performance improvement

## Affected Packages

- [ ] `protocol`
- [x] `session`
- [ ] `llm`
- [ ] `agent`
- [ ] `openomni`
- [ ] `coordinator`
- [ ] `server`

## Breaking Changes

- [x] No breaking changes
- [ ] Yes — describe migration path below

The return shape of `getWorkerRunHistory` is unchanged; only the `eventCount` value transitions from a constant `0` to the real count. Callers that previously ignored the field are unaffected; callers that read it now get accurate data.

## Checklist

- [x] \`bun run check-types\` passes
- [x] \`bun run script/check-deps.ts\` clean
- [x] Tests added/updated for changes
- [x] No \`as any\`, \`@ts-ignore\`, or \`@ts-expect-error\` added
- [x] AGENTS.md updated if public API or architecture changed (N/A — no public API or architecture change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `BusQuery.getWorkerRunHistory()` in `session` to return the real number of events per worker run instead of a hardcoded 0. This makes telemetry accurate without changing the return shape.

- **Bug Fixes**
  - Compute `eventCount` with `LEFT JOIN bus_event` + `COUNT(be.id)` and `GROUP BY wrs.run_id`.
  - Uses existing `idx_bus_event_run_time` index for efficient lookups.
  - Adds tests for two runs (3 and 1 events), cross-session isolation, and excluding events without `run_id`.

<sup>Written for commit 89501738565d9d1cde8b8b53c60d721d60b31f48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worker run history now displays accurate event counts based on actual recorded events rather than default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->