### PR TITLE
docs(openomni): align cron runner package docs

### DIFF
--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -13,7 +13,7 @@ Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@ope
 | `src/ingress/` | Inbound event resolution and mode dispatch | `IngressEngine`, `IngressEventProjector`, `IngressHandlers`, `IngressSessionResolver`, `SessionBridge`, `CronAdapter`, `resolveTarget`, `targetKey` |
 | `src/runtime/` | Worker middleware and session utilities | *(no public exports; internal wiring only)* |
 | `src/subagent/` | Session-backed subagent execution | `SubagentRuntime`, `SubagentConsultation`, `BackgroundManager` |
-| `src/execution-runtime/` | Tool system, workspace, and worker middleware | `buildWorkerMiddleware`, `WorkspaceLock`, `AgentToolProvider`, `SystemToolProvider`, `ToolProxyProvider`, `Tool`, `buildToolCatalog`, `createToolExecutor`, `createWorkerSubagentRuntime`, `defineTool`, `InjectionQueue`, `CronJobRegistry` |
+| `src/execution-runtime/` | Tool system, workspace, worker middleware, and scheduled job runtime | `buildWorkerMiddleware`, `WorkspaceLock`, `AgentToolProvider`, `SystemToolProvider`, `ToolProxyProvider`, `Tool`, `buildToolCatalog`, `createToolExecutor`, `createWorkerSubagentRuntime`, `defineTool`, `InjectionQueue`, `CronJobRegistry`, `CronJobRunner` |
 
 ## Architecture
 
@@ -56,7 +56,7 @@ Consumers should only use `@openomni/openomni` exports:
 - Ingress orchestration from `src/ingress/`
 
 - Subagent runtime + background manager from `src/subagent/`
-- Tool system, workspace lock, and worker middleware from `src/execution-runtime/`
+- Tool system, workspace lock, worker middleware, and cron runtime from `src/execution-runtime/`
 
 If a symbol is not re-exported from `src/index.ts`, treat it as private to its domain.
 


### PR DESCRIPTION
## Summary

- Align `packages/openomni/AGENTS.md` with the exported `CronJobRunner` public surface.
- Address the CodeRabbit nitpick from PR #230 after that PR had already merged.

## Validation

- `bunx biome check packages/openomni/AGENTS.md`
- `bun run script/check-deps.ts`
- pre-push `dep-check`
- pre-push `type-check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `packages/openomni/AGENTS.md` to include the `CronJobRunner` export and clarify that `src/execution-runtime/` provides the scheduled job (cron) runtime. Keeps `@openomni/openomni` docs aligned with the current public surface.

<sup>Written for commit d161cc9baf89f65abfbfc737b3bf0ae42d7ab2b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

