### PR TITLE
feat(openomni): create work items for worker spawns

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -35,7 +35,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | Component | Status | Code | Missing consumer |
 | --- | --- | --- | --- |
 | WorkItem schemas (`Info`, `Blocker`, `Evidence`, `VerificationGate`, `deriveStatus`) | ✅ | `packages/protocol/src/work-item/` | — |
-| `WorkItemStore` (full CRUD + lifecycle + evidence + gates) | 🔌 | `packages/session/src/work-item/` | **Zero production callers.** ADR-011 designates it the task ledger — created on `worker.spawn`, completed via report gate |
+| `WorkItemStore` (full CRUD + lifecycle + evidence + gates) | ✅ | `packages/session/src/work-item/`, `packages/openomni/src/dispatch/handlers/worker.ts` | Wired consumer: `worker.spawn` creates/starts a ledger item, returns `workItemHash`, and reflects failed/interrupted/cancelled coordinator results. Completion-report gate remains pending below |
 | WorkItem schema deltas (`originSessionId`/`workSessionId` split, `workerRunId`+`executorKind`, `completionReport`, `maxAttempts`, `outcome`) | 📋 | `packages/protocol/src/work-item/` | ADR-011 |
 | Completion-report evidence gate (claims → evidence refs; unevidenced = not done) | 📋 | — | ADR-011 — deterministic, runs before any LLM evaluation. Worker completion claims are accepted without any check today |
 | Read-back verification helpers (re-fetch URL, re-query API, citation-in-source matching) | 📋 | — | ADR-011 |

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -81,6 +81,17 @@ async function reflectCoordinatorResult(
   }
 }
 
+async function markWorkItemFailedAfterDispatchThrow(
+  workItemHash: string,
+  err: unknown,
+): Promise<void> {
+  try {
+    await WorkItemStore.fail(workItemHash, err instanceof Error ? err.message : String(err));
+  } catch {
+    return;
+  }
+}
+
 export function createWorkerDispatchHandlers(
   options: WorkerDispatchHandlerOptions = {},
 ): Record<"worker.spawn" | "worker.send" | "worker.resume" | "worker.cancel", DispatchHandler> {
@@ -94,7 +105,7 @@ export function createWorkerDispatchHandlers(
       try {
         result = await coordinator.dispatch(request.sessionId, request);
       } catch (err) {
-        await WorkItemStore.fail(workItemHash, err instanceof Error ? err.message : String(err));
+        await markWorkItemFailedAfterDispatchThrow(workItemHash, err);
         throw err;
       }
       await reflectCoordinatorResult(workItemHash, result);

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -73,20 +73,19 @@ async function reflectCoordinatorResult(
   result: Execution.Result,
 ): Promise<void> {
   if (result.status === "cancelled") {
-    await WorkItemStore.cancel(workItemHash);
+    await ignoreWorkItemReflectionFailure(() => WorkItemStore.cancel(workItemHash));
     return;
   }
   if (result.status === "failed" || result.status === "interrupted") {
-    await WorkItemStore.fail(workItemHash, result.error ?? result.status);
+    await ignoreWorkItemReflectionFailure(() =>
+      WorkItemStore.fail(workItemHash, result.error ?? result.status),
+    );
   }
 }
 
-async function markWorkItemFailedAfterDispatchThrow(
-  workItemHash: string,
-  err: unknown,
-): Promise<void> {
+async function ignoreWorkItemReflectionFailure(reflect: () => Promise<unknown>): Promise<void> {
   try {
-    await WorkItemStore.fail(workItemHash, err instanceof Error ? err.message : String(err));
+    await reflect();
   } catch {
     return;
   }
@@ -105,7 +104,9 @@ export function createWorkerDispatchHandlers(
       try {
         result = await coordinator.dispatch(request.sessionId, request);
       } catch (err) {
-        await markWorkItemFailedAfterDispatchThrow(workItemHash, err);
+        await ignoreWorkItemReflectionFailure(() =>
+          WorkItemStore.fail(workItemHash, err instanceof Error ? err.message : String(err)),
+        );
         throw err;
       }
       await reflectCoordinatorResult(workItemHash, result);

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, Execution, Model } from "@openomni/protocol";
-import { Session } from "@openomni/session";
+import { Session, WorkItemStore } from "@openomni/session";
 import type { CoordinatorLike } from "../../ingress/coordinator-like.js";
 import type { DispatchHandler } from "../registry.js";
 import { DEFAULT_DISPATCH_MODEL } from "../owners.js";
@@ -50,6 +50,37 @@ function buildRequest(command: Dispatch.Command, model: Model.Ref): Execution.Re
   };
 }
 
+async function createWorkItem(
+  command: Dispatch.Command,
+  request: Execution.Request,
+): Promise<string> {
+  const workItem = await WorkItemStore.create({
+    name: `Dispatch worker ${request.agentName ?? "worker"}`,
+    sourceMessageId: command.dispatchId,
+    sourceChannel: "dispatch",
+    intent: command.action,
+    goal: request.prompt,
+    assigneeId: request.agentName,
+    sessionId: request.sessionId,
+    context: command.sessionId ? `originSessionId=${command.sessionId}` : undefined,
+  });
+  await WorkItemStore.start(workItem.hash);
+  return workItem.hash;
+}
+
+async function reflectCoordinatorResult(
+  workItemHash: string,
+  result: Execution.Result,
+): Promise<void> {
+  if (result.status === "cancelled") {
+    await WorkItemStore.cancel(workItemHash);
+    return;
+  }
+  if (result.status === "failed" || result.status === "interrupted") {
+    await WorkItemStore.fail(workItemHash, result.error ?? result.status);
+  }
+}
+
 export function createWorkerDispatchHandlers(
   options: WorkerDispatchHandlerOptions = {},
 ): Record<"worker.spawn" | "worker.send" | "worker.resume" | "worker.cancel", DispatchHandler> {
@@ -58,8 +89,18 @@ export function createWorkerDispatchHandlers(
     async "worker.spawn"(command) {
       const coordinator = requireCoordinator(options.coordinator);
       const request = buildRequest(command, model);
-      const result = await coordinator.dispatch(request.sessionId, request);
-      return { output: { sessionId: request.sessionId, runId: request.runId, result } };
+      const workItemHash = await createWorkItem(command, request);
+      let result: Execution.Result;
+      try {
+        result = await coordinator.dispatch(request.sessionId, request);
+      } catch (err) {
+        await WorkItemStore.fail(workItemHash, err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+      await reflectCoordinatorResult(workItemHash, result);
+      return {
+        output: { sessionId: request.sessionId, runId: request.runId, workItemHash, result },
+      };
     },
 
     async "worker.send"(command) {

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -32,6 +32,18 @@ function createSessionFixture(id: string): void {
   });
 }
 
+async function expectRejectsWithMessage(operation: () => unknown, message: string): Promise<void> {
+  try {
+    await operation();
+  } catch (err) {
+    expect(err).toBeInstanceOf(Error);
+    if (!(err instanceof Error)) return;
+    expect(err.message).toContain(message);
+    return;
+  }
+  throw new Error(`Expected operation to reject with ${message}`);
+}
+
 describe("built-in dispatch handlers", () => {
   beforeEach(() => {
     Storage.reset();
@@ -97,16 +109,44 @@ describe("built-in dispatch handlers", () => {
       },
     });
 
-    await expect(
-      registry.get("worker.spawn")?.(
-        command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
-      ),
-    ).rejects.toThrow("coordinator unavailable");
+    await expectRejectsWithMessage(
+      () =>
+        registry.get("worker.spawn")?.(
+          command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+        ),
+      "coordinator unavailable",
+    );
 
     const workItems = WorkItemStore.list();
     expect(workItems).toHaveLength(1);
     expect(workItems[0]?.failureReason).toBe("coordinator unavailable");
     expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("failed");
+  });
+
+  test("worker.spawn preserves the coordinator error when recording dispatch failure throws", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch() {
+            const workItemAdapter = Storage.getAdapter().workItem;
+            if (!workItemAdapter) throw new Error("missing work item adapter");
+            workItemAdapter.set = () => {
+              throw new Error("work item write failed");
+            };
+            throw new Error("coordinator unavailable");
+          },
+        },
+      },
+    });
+
+    await expectRejectsWithMessage(
+      () =>
+        registry.get("worker.spawn")?.(
+          command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+        ),
+      "coordinator unavailable",
+    );
   });
 
   test("worker.spawn marks the work item failed when coordinator returns failed", async () => {
@@ -392,10 +432,12 @@ describe("built-in dispatch handlers", () => {
       },
     });
 
-    await expect(
-      registry.get("resident.ask")?.(
-        command("resident.ask", { kind: "worker", sessionId: "worker-session" }, "question"),
-      ),
-    ).rejects.toThrow("resident.ask requires resident target");
+    await expectRejectsWithMessage(
+      () =>
+        registry.get("resident.ask")?.(
+          command("resident.ask", { kind: "worker", sessionId: "worker-session" }, "question"),
+        ),
+      "resident.ask requires resident target",
+    );
   });
 });

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -238,6 +238,105 @@ describe("built-in dispatch handlers", () => {
     });
   });
 
+  test("worker.spawn preserves failed result when recording the failure throws", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            const workItemAdapter = Storage.getAdapter().workItem;
+            if (!workItemAdapter) throw new Error("missing work item adapter");
+            workItemAdapter.set = () => {
+              throw new Error("work item write failed");
+            };
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "failed",
+              error: "worker failed",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(result).toMatchObject({
+      output: { workItemHash: workItems[0]?.hash, result: { status: "failed" } },
+    });
+  });
+
+  test("worker.spawn preserves interrupted result when recording the failure throws", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            const workItemAdapter = Storage.getAdapter().workItem;
+            if (!workItemAdapter) throw new Error("missing work item adapter");
+            workItemAdapter.set = () => {
+              throw new Error("work item write failed");
+            };
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "interrupted",
+              error: "worker interrupted",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(result).toMatchObject({
+      output: { workItemHash: workItems[0]?.hash, result: { status: "interrupted" } },
+    });
+  });
+
+  test("worker.spawn preserves cancelled result when recording cancellation throws", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            const workItemAdapter = Storage.getAdapter().workItem;
+            if (!workItemAdapter) throw new Error("missing work item adapter");
+            workItemAdapter.set = () => {
+              throw new Error("work item write failed");
+            };
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "cancelled",
+              output: "cancelled by owner",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(result).toMatchObject({
+      output: { workItemHash: workItems[0]?.hash, result: { status: "cancelled" } },
+    });
+  });
+
   test("worker.spawn preserves parent session lineage when provided", async () => {
     const parent = Session.create({
       title: "parent",

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import type { Dispatch, Execution, Ingress } from "@openomni/protocol";
-import { PendingAskStore, Session, Storage } from "@openomni/session";
+import { WorkItem, type Dispatch, type Execution, type Ingress } from "@openomni/protocol";
+import { PendingAskStore, Session, Storage, WorkItemStore } from "@openomni/session";
 import { DispatchRegistry } from "../../src/dispatch/registry";
 import { registerBuiltInDispatchHandlers } from "../../src/dispatch/setup";
 import { extractText } from "../../src/dispatch/handlers/shared";
@@ -69,7 +69,133 @@ describe("built-in dispatch handlers", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({ mode: "direct", prompt: "build it", agentName: "coder" });
     expect(Session.get(requests[0]?.sessionId ?? "")).toBeDefined();
-    expect(result).toMatchObject({ output: { sessionId: requests[0]?.sessionId } });
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(workItems[0]).toMatchObject({
+      sourceMessageId: "dispatch-worker.spawn",
+      sourceChannel: "dispatch",
+      intent: "worker.spawn",
+      goal: "build it",
+      assigneeId: "coder",
+      sessionId: requests[0]?.sessionId,
+    });
+    expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("running");
+    expect(result).toMatchObject({
+      output: { sessionId: requests[0]?.sessionId, workItemHash: workItems[0]?.hash },
+    });
+  });
+
+  test("worker.spawn marks the work item failed when coordinator dispatch throws", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch() {
+            throw new Error("coordinator unavailable");
+          },
+        },
+      },
+    });
+
+    await expect(
+      registry.get("worker.spawn")?.(
+        command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+      ),
+    ).rejects.toThrow("coordinator unavailable");
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(workItems[0]?.failureReason).toBe("coordinator unavailable");
+    expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("failed");
+  });
+
+  test("worker.spawn marks the work item failed when coordinator returns failed", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "failed",
+              error: "worker failed",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(workItems[0]?.failureReason).toBe("worker failed");
+    expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("failed");
+    expect(result).toMatchObject({
+      output: { workItemHash: workItems[0]?.hash, result: { status: "failed" } },
+    });
+  });
+
+  test("worker.spawn marks the work item failed when coordinator interrupts dispatch", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "interrupted",
+              error: "worker interrupted",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(workItems[0]?.failureReason).toBe("worker interrupted");
+    expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("failed");
+    expect(result).toMatchObject({
+      output: { workItemHash: workItems[0]?.hash, result: { status: "interrupted" } },
+    });
+  });
+
+  test("worker.spawn marks the work item cancelled when coordinator cancels dispatch", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch(_sessionId, request) {
+            return {
+              runId: request.runId,
+              sessionId: request.sessionId,
+              status: "cancelled",
+              output: "cancelled by owner",
+            };
+          },
+        },
+      },
+    });
+
+    const result = await registry.get("worker.spawn")?.(
+      command("worker.spawn", { kind: "worker", name: "coder" }, "build it"),
+    );
+
+    const workItems = WorkItemStore.list();
+    expect(workItems).toHaveLength(1);
+    expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("cancelled");
+    expect(result).toMatchObject({
+      output: { workItemHash: workItems[0]?.hash, result: { status: "cancelled" } },
+    });
   });
 
   test("worker.spawn preserves parent session lineage when provided", async () => {


### PR DESCRIPTION
## Summary
- Make `worker.spawn` create and start a WorkItem ledger entry before dispatching to the coordinator.
- Return `workItemHash` from the dispatch output so callers can correlate spawned worker runs with durable work state.
- Reflect failed, interrupted, cancelled, and thrown coordinator outcomes into the WorkItem lifecycle.
- Update `docs/implementation-status.md` to mark the first WorkItemStore production consumer as wired while leaving completion-report gates pending.

## Validation
- `bunx biome check --write packages/openomni/src/dispatch/handlers/worker.ts packages/openomni/test/dispatch/handlers.test.ts docs/implementation-status.md`
- `bun test packages/openomni/test/dispatch/handlers.test.ts` (12 pass, 0 fail)
- `bun run script/check-deps.ts`
- `git diff --check`
- LSP diagnostics: no errors for changed TS files
- `bun run check-types`
- `bun run build && bun test && bun run test`
- Manual runtime QA: `worker.spawn` persisted a running WorkItem and returned the matching `workItemHash`
- OMO verifier: PASS after failed/interrupted/cancelled coverage was added
- Claude Fable 5 oracle: PASS after additional result-status coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`worker.spawn` now creates and starts a WorkItem, returns `workItemHash`, mirrors coordinator outcomes into the ledger, and preserves both dispatch errors and terminal results even if ledger writes fail.

- **New Features**
  - Integrated `WorkItemStore` with `worker.spawn`; starts a ledger item and returns `workItemHash`.
  - Reflects coordinator outcomes into the WorkItem (failed/interrupted → failed; cancelled → cancelled); captures source, intent, assignee, goal, and lineage. Docs marked wired; tests cover success, throws, and all terminal states.

- **Bug Fixes**
  - Preserve the original coordinator dispatch error even when `WorkItemStore` writes fail.
  - Preserve terminal results (failed/interrupted/cancelled) when reflecting into the ledger throws.

<sup>Written for commit 4f063458a0285fd6c57f449ed7775f5d05873af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work items are now properly created and tracked when workers are spawned with automatic status management reflecting execution outcomes, including proper handling of failures, interruptions, and cancellations.

* **Tests**
  * Significantly expanded test coverage for work item creation, metadata validation, status transitions, error handling, coordinator failures, and dispatch exception scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->