### PR TITLE
fix(coordinator): route worker affinity through SessionRouting

### DIFF
--- a/docs/design-decisions/008-lightweight-main-persona-on-demand-workers.md
+++ b/docs/design-decisions/008-lightweight-main-persona-on-demand-workers.md
@@ -216,7 +216,7 @@ Each worker can have different tool sets, system prompts, and workspace contexts
 ### Rewritten / Current
 - legacy fixed worker-pool facade → `packages/coordinator/src/worker-manager/manager.ts`
 - `packages/coordinator/src/worker-pool/supervisor.ts` remains the shared worker process handle used by `worker-manager`
-- `packages/coordinator/src/worker-pool/session-routing.ts` is retained as a dormant/test-covered session-tree affinity helper; live `worker-manager` routing currently uses its own `sessionAffinity` map
+- `packages/coordinator/src/worker-pool/session-routing.ts` provides the session-to-worker affinity helper used by `worker-manager`
 
 ### Add
 - `packages/openomni/src/resident/runtime.ts` — ResidentRuntime

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -76,7 +76,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | Subagent as bound extension (context-inheriting, ticketless, gate-exempt) | ✅ | `packages/openomni/src/subagent/` | `SubagentRuntime` + `BackgroundManager` — NOT a worker tier; workers are always isolated processes (ADR-010 §6) |
 | Extension-vs-independence routing (subagent vs worker choice in Resident flow) | 📋 | — | ADR-010 §6 — "needs my context, or its own footing?"; domain expertise = independence signal |
 | Worker supervisor internals | ✅ | `packages/coordinator/src/worker-pool/supervisor.ts` | Shared process supervisor used by `worker-manager`; legacy `createWorkerPool` facade removed |
-| SessionRouting helper | 🔌 | `packages/coordinator/src/worker-pool/session-routing.ts` | Dormant/test-covered session-tree affinity helper; not used by `worker-manager`, whose live routing uses its own `sessionAffinity` map |
+| SessionRouting helper | ✅ | `packages/coordinator/src/worker-pool/session-routing.ts`, `packages/coordinator/src/worker-manager/manager.ts` | `worker-manager` uses a `SessionRouter` instance for live session-to-slot affinity; singleton `SessionRouting.route/complete` remains test-covered for fixed worker-index routing |
 | Crash recovery (mark interrupted at boot) | ✅ | `packages/coordinator/src/recovery/` | |
 | Injection queue (async delivery at turn.finish) | ✅ | `packages/openomni/src/execution-runtime/injection-queue.ts` | |
 | Cron job registry persistence | ✅ | `packages/openomni/src/execution-runtime/cron-job-registry.ts`, `packages/session/src/storage/sqlite-cron-job-adapter.ts` | `schedule.create` jobs persist in SQLite and survive `Storage` reinitialize; `schedule.cancel` removes persisted jobs |

--- a/packages/coordinator/AGENTS.md
+++ b/packages/coordinator/AGENTS.md
@@ -12,7 +12,7 @@ src/
 ├── recovery/             # Interrupted worker run recovery
 ├── tool-permission/      # Non-interactive permission policy + audit log (internal; not in barrel)
 ├── worker-manager/       # ⭐ LIVE: OnDemandWorkerManager — spawn on demand, slots, idle shutdown
-└── worker-pool/          # Worker supervisor internals plus dormant SessionRouting helper
+└── worker-pool/          # Worker supervisor internals plus SessionRouting helper
 ```
 
 ## DEPENDENCIES
@@ -25,7 +25,7 @@ Depends on `@openomni/protocol`, `@openomni/session`, `@openomni/agent`, and `@o
 |--------|---------|
 | `worker-manager/manager.ts` | **Primary API.** `createWorkerManager()` / `OnDemandWorkerManager`: slot-based dispatch, session affinity, spawn on demand up to `maxActiveWorkers` (default 10), waiter queue when saturated, idle shutdown (`idleShutdownMs`, default 600s), generation-tracked restarts |
 | `worker-pool/supervisor.ts` | Per-worker process lifecycle: spawn, bootstrap handshake, restart generations, stop |
-| `worker-pool/session-routing.ts` | Dormant/test-covered session-tree affinity helper; `worker-manager` currently uses its own `sessionAffinity` map |
+| `worker-pool/session-routing.ts` | Session affinity helper used by `worker-manager`; fixed worker-index `route/complete` behavior remains test-covered |
 | `ipc/*` | Request/response framing, bidirectional client/server transport, protocol errors |
 | `recovery/index.ts` | `recoverInterruptedRuns()` — marks interrupted worker runs failed after restart |
 | `credentials/store.ts` / `credentials/injector.ts` | Loads stored credentials, filters by provider prefix, injects provider-scoped credentials into workers |
@@ -52,7 +52,7 @@ Barrel exports (`src/index.ts`): `createWorkerManager` / `OnDemandWorkerManager`
 
 ## TESTS
 
-Tests are split by module: inline IPC/supervisor tests live beside source, while `test/` covers `worker-manager/` dispatch/crash behavior, `worker-pool/` supervisor contracts, dormant SessionRouting behavior, barrel contracts, credentials, recovery, tool-permission, and harness smoke coverage.
+Tests are split by module: inline IPC/supervisor tests live beside source, while `test/` covers `worker-manager/` dispatch/crash behavior, `worker-pool/` supervisor contracts, SessionRouting behavior, barrel contracts, credentials, recovery, tool-permission, and harness smoke coverage.
 
 ## ANTI-PATTERNS
 

--- a/packages/coordinator/src/worker-manager/manager.ts
+++ b/packages/coordinator/src/worker-manager/manager.ts
@@ -3,6 +3,7 @@ import net from "node:net";
 import path from "node:path";
 import { Operational, type WorkerBootstrap } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
+import { createSessionRouting, type SessionRouter } from "../worker-pool/session-routing";
 import {
   WorkerSupervisor,
   type InboundWaitParams,
@@ -82,7 +83,7 @@ export class OnDemandWorkerManager implements WorkerManager {
   private readonly slotWaitTimeoutMs: number;
   private readonly maxQueuedDispatches: number;
   private readonly slots = new Map<number, WorkerSlot>();
-  private readonly sessionAffinity = new Map<string, number>();
+  private readonly sessionRouting: SessionRouter = createSessionRouting();
   private readonly activeRuns = new Map<string, ActiveRun>();
   private readonly waiters: SlotWaiter[] = [];
   private nextWorkerId = 0;
@@ -245,7 +246,7 @@ export class OnDemandWorkerManager implements WorkerManager {
       }),
     );
     this.slots.clear();
-    this.sessionAffinity.clear();
+    this.sessionRouting.clear();
     this.activeRuns.clear();
     for (const waiter of this.waiters.splice(0)) {
       waiter.reject(new Error("worker manager is shutting down"));
@@ -272,7 +273,7 @@ export class OnDemandWorkerManager implements WorkerManager {
   }
 
   private async tryAcquireSlot(sessionId: string): Promise<WorkerSlot | undefined> {
-    const affinityId = this.sessionAffinity.get(sessionId);
+    const affinityId = this.sessionRouting.get(sessionId);
     const affinitySlot = affinityId === undefined ? undefined : this.slots.get(affinityId);
     if (affinitySlot !== undefined && affinitySlot.ownerSessionId === sessionId) {
       if (affinitySlot.load > 0 || affinitySlot.reserved) return undefined;
@@ -282,7 +283,7 @@ export class OnDemandWorkerManager implements WorkerManager {
 
     if (this.slots.size < this.maxActiveWorkers) {
       const slot = this.createSlot(sessionId);
-      this.sessionAffinity.set(sessionId, slot.id);
+      this.sessionRouting.assign(sessionId, slot.id);
       return slot;
     }
 
@@ -328,14 +329,12 @@ export class OnDemandWorkerManager implements WorkerManager {
   private async reassignSlot(slot: WorkerSlot, sessionId: string): Promise<WorkerSlot> {
     slot.reserved = true;
     this.clearIdleTimer(slot);
-    for (const [existingSessionId, slotId] of this.sessionAffinity.entries()) {
-      if (slotId === slot.id) this.sessionAffinity.delete(existingSessionId);
-    }
+    this.sessionRouting.forgetWorker(slot.id);
     const supervisor = slot.supervisor;
     slot.supervisor = null;
     await supervisor?.stop();
     slot.ownerSessionId = sessionId;
-    this.sessionAffinity.set(sessionId, slot.id);
+    this.sessionRouting.assign(sessionId, slot.id);
     return slot;
   }
 
@@ -416,9 +415,7 @@ export class OnDemandWorkerManager implements WorkerManager {
   private forgetSlot(slot: WorkerSlot): void {
     this.clearIdleTimer(slot);
     this.slots.delete(slot.id);
-    for (const [sessionId, slotId] of this.sessionAffinity.entries()) {
-      if (slotId === slot.id) this.sessionAffinity.delete(sessionId);
-    }
+    this.sessionRouting.forgetWorker(slot.id);
   }
 
   private clearIdleTimer(slot: WorkerSlot): void {

--- a/packages/coordinator/src/worker-pool/index.ts
+++ b/packages/coordinator/src/worker-pool/index.ts
@@ -1,4 +1,4 @@
-export { SessionRouting } from "./session-routing";
+export { createSessionRouting, SessionRouting, type SessionRouter } from "./session-routing";
 export {
   WorkerSupervisor,
   type ToolCallCancelParams,

--- a/packages/coordinator/src/worker-pool/session-routing.ts
+++ b/packages/coordinator/src/worker-pool/session-routing.ts
@@ -3,48 +3,88 @@ type SessionAffinity = {
   refCount: number;
 };
 
-// rootSessionId → worker affinity; persists until all sessions in that tree complete
-const affinityMap = new Map<string, SessionAffinity>();
-// worker index → number of active session trees assigned
-const workerLoad = new Map<number, number>();
+export type SessionRouter = {
+  route(rootSessionId: string, workerCount: number): number;
+  complete(rootSessionId: string): void;
+  get(rootSessionId: string): number | undefined;
+  assign(rootSessionId: string, workerIndex: number): void;
+  forgetWorker(workerIndex: number): void;
+  clear(): void;
+};
 
-export const SessionRouting = {
-  route(rootSessionId: string, workerCount: number): number {
-    const existing = affinityMap.get(rootSessionId);
-    if (existing !== undefined) {
-      existing.refCount += 1;
-      return existing.workerIndex;
-    }
+export function createSessionRouting(): SessionRouter {
+  const affinityMap = new Map<string, SessionAffinity>();
+  const workerLoad = new Map<number, number>();
 
-    let minLoad = Infinity;
-    let chosen = 0;
-    for (let i = 0; i < workerCount; i++) {
-      const load = workerLoad.get(i) ?? 0;
-      if (load < minLoad) {
-        minLoad = load;
-        chosen = i;
-      }
-    }
-
-    affinityMap.set(rootSessionId, { workerIndex: chosen, refCount: 1 });
-    workerLoad.set(chosen, (workerLoad.get(chosen) ?? 0) + 1);
-    return chosen;
-  },
-
-  complete(rootSessionId: string): void {
-    const affinity = affinityMap.get(rootSessionId);
-    if (affinity === undefined) return;
-
-    affinity.refCount -= 1;
-    if (affinity.refCount > 0) return;
-
-    const current = workerLoad.get(affinity.workerIndex) ?? 0;
+  function decrementWorkerLoad(workerIndex: number): void {
+    const current = workerLoad.get(workerIndex) ?? 0;
     const next = current - 1;
     if (next <= 0) {
-      workerLoad.delete(affinity.workerIndex);
-    } else {
-      workerLoad.set(affinity.workerIndex, next);
+      workerLoad.delete(workerIndex);
+      return;
     }
-    affinityMap.delete(rootSessionId);
-  },
-};
+    workerLoad.set(workerIndex, next);
+  }
+
+  return {
+    route(rootSessionId: string, workerCount: number): number {
+      const existing = affinityMap.get(rootSessionId);
+      if (existing !== undefined) {
+        existing.refCount += 1;
+        return existing.workerIndex;
+      }
+
+      let minLoad = Infinity;
+      let chosen = 0;
+      for (let i = 0; i < workerCount; i++) {
+        const load = workerLoad.get(i) ?? 0;
+        if (load < minLoad) {
+          minLoad = load;
+          chosen = i;
+        }
+      }
+
+      affinityMap.set(rootSessionId, { workerIndex: chosen, refCount: 1 });
+      workerLoad.set(chosen, (workerLoad.get(chosen) ?? 0) + 1);
+      return chosen;
+    },
+
+    complete(rootSessionId: string): void {
+      const affinity = affinityMap.get(rootSessionId);
+      if (affinity === undefined) return;
+
+      affinity.refCount -= 1;
+      if (affinity.refCount > 0) return;
+
+      decrementWorkerLoad(affinity.workerIndex);
+      affinityMap.delete(rootSessionId);
+    },
+
+    get(rootSessionId: string): number | undefined {
+      return affinityMap.get(rootSessionId)?.workerIndex;
+    },
+
+    assign(rootSessionId: string, workerIndex: number): void {
+      const existing = affinityMap.get(rootSessionId);
+      if (existing?.workerIndex === workerIndex) return;
+      if (existing !== undefined) decrementWorkerLoad(existing.workerIndex);
+
+      affinityMap.set(rootSessionId, { workerIndex, refCount: existing?.refCount ?? 1 });
+      workerLoad.set(workerIndex, (workerLoad.get(workerIndex) ?? 0) + 1);
+    },
+
+    forgetWorker(workerIndex: number): void {
+      for (const [rootSessionId, affinity] of affinityMap.entries()) {
+        if (affinity.workerIndex === workerIndex) affinityMap.delete(rootSessionId);
+      }
+      workerLoad.delete(workerIndex);
+    },
+
+    clear(): void {
+      affinityMap.clear();
+      workerLoad.clear();
+    },
+  };
+}
+
+export const SessionRouting = createSessionRouting();

--- a/packages/coordinator/test/worker-pool/affinity.test.ts
+++ b/packages/coordinator/test/worker-pool/affinity.test.ts
@@ -1,7 +1,11 @@
-import { describe, test, expect } from "bun:test";
-import { SessionRouting } from "../../src/worker-pool";
+import { afterEach, describe, test, expect } from "bun:test";
+import { SessionRouting } from "../../src/worker-pool/session-routing";
 
 describe("session routing affinity", () => {
+  afterEach(() => {
+    SessionRouting.clear();
+  });
+
   test("same sessionId always routes to same worker", () => {
     const workerCount = 4;
     const id = "stable-session-xyz";

--- a/packages/coordinator/test/worker-pool/session-routing.test.ts
+++ b/packages/coordinator/test/worker-pool/session-routing.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import { SessionRouting } from "../../src/worker-pool";
+import { createSessionRouting, SessionRouting } from "../../src/worker-pool/session-routing";
 
 describe("SessionRouting", () => {
+  afterEach(() => {
+    SessionRouting.clear();
+  });
+
   test("same session always routes to same worker", () => {
     const id = "ses_same_affinity";
     const first = SessionRouting.route(id, 4);
@@ -86,5 +90,48 @@ describe("SessionRouting", () => {
     for (const blocker of blockers) {
       SessionRouting.complete(blocker);
     }
+  });
+
+  test("createSessionRouting() returns isolated affinity state for production consumers", () => {
+    const first = createSessionRouting();
+    const second = createSessionRouting();
+
+    first.assign("session-a", 7);
+    expect(first.get("session-a")).toBe(7);
+    expect(second.get("session-a")).toBeUndefined();
+
+    first.assign("session-b", 7);
+    first.forgetWorker(7);
+
+    expect(first.get("session-a")).toBeUndefined();
+    expect(first.get("session-b")).toBeUndefined();
+  });
+
+  test("assign() preserves outstanding route references when moving affinity", () => {
+    const routing = createSessionRouting();
+
+    const first = routing.route("session-move", 2);
+    routing.route("session-move", 2);
+    const next = first === 0 ? 1 : 0;
+
+    routing.assign("session-move", next);
+    expect(routing.get("session-move")).toBe(next);
+
+    routing.complete("session-move");
+    expect(routing.get("session-move")).toBe(next);
+
+    routing.complete("session-move");
+    expect(routing.get("session-move")).toBeUndefined();
+  });
+
+  test("assign() is idempotent for the same session and worker", () => {
+    const routing = createSessionRouting();
+
+    routing.assign("session-stable", 1);
+    routing.assign("session-stable", 1);
+    expect(routing.get("session-stable")).toBe(1);
+
+    routing.complete("session-stable");
+    expect(routing.get("session-stable")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- make SessionRouting instance-based while preserving the existing singleton route/complete API
- wire OnDemandWorkerManager session affinity through SessionRouter instead of a private sessionAffinity map
- update SSOT/coordinator docs and ADR-008 current-state notes

## Verification
- bun test packages/coordinator/test/worker-pool/session-routing.test.ts packages/coordinator/test/worker-pool/affinity.test.ts packages/coordinator/test/worker-manager/manager.test.ts
- bun run check-types
- bun run build
- bun run test
- bun test
- manual WorkerManager dispatch QA: same session reused worker 0; different session used worker 1 under cap
- Codex Verifier PASS
- Claude Fable oracle PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route session-to-worker affinity through a new instance-based `SessionRouter`, removing the manager’s private map and keeping the singleton `SessionRouting.route/complete` for compatibility and tests.

- **Refactors**
  - Introduced `createSessionRouting()` and `SessionRouter` (`get`, `assign`, `forgetWorker`, `clear`) in `packages/coordinator/src/worker-pool/session-routing.ts`; retained singleton `SessionRouting`.
  - Wired `OnDemandWorkerManager` to use a `SessionRouter` instead of an internal `sessionAffinity` map; `reassignSlot` and `forgetSlot` now call `forgetWorker`.
  - Exported `createSessionRouting`, `SessionRouting`, and `SessionRouter` from `worker-pool/index.ts`.
  - Updated tests to clear singleton state between runs and added coverage for isolated routers and `assign()` semantics.
  - Updated docs to mark `SessionRouting` as the live affinity helper used by `worker-manager`.

<sup>Written for commit 8e13929d564c3158c91b1b678b97b1ce5009d976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

