### PR TITLE
Wire BusQuery observability endpoint

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -380,7 +380,9 @@ export async function main(): Promise<void> {
     });
   }
 
-  const app = createRouter(githubWebhookHandler);
+  const app = createRouter(githubWebhookHandler, {
+    observabilityToken: config.server.wsToken,
+  });
   const server = Bun.serve({
     port: config.server.port,
     hostname: config.server.host,

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -1,12 +1,23 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
+import { Bus, BusQuery } from "@openomni/session";
 
 type Env = { Variables: { requestId: string } };
 
+type EventSummary = {
+  eventType: string;
+  traceId: string;
+  timeCreated: number;
+};
+
+type RouterOptions = {
+  observabilityToken?: string;
+};
+
 export function createRouter(
   githubWebhookHandler?: (req: Request) => Promise<Response>,
+  options: RouterOptions = {},
 ): Hono<Env> {
   const app = new Hono<Env>();
 
@@ -45,9 +56,57 @@ export function createRouter(
     }),
   );
 
+  if (options.observabilityToken) {
+    app.get("/observability/sessions/:sessionId/events", async (c) => {
+      if (c.req.header("Authorization") !== `Bearer ${options.observabilityToken}`) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sessionId = c.req.param("sessionId");
+      try {
+        const [stats, errors, workerRuns, chainIntegrity] = await Promise.all([
+          BusQuery.getStats(sessionId),
+          BusQuery.listErrors(sessionId),
+          BusQuery.getWorkerRunHistory(sessionId),
+          BusQuery.verifyChainIntegrity(sessionId),
+        ]);
+        return c.json({
+          sessionId,
+          stats,
+          errors: errors.map(toEventSummary),
+          workerRuns,
+          chainIntegrity,
+        });
+      } catch (error) {
+        Bus.publish(Operational.Error, {
+          traceId: c.get("requestId"),
+          time: Date.now(),
+          component: "server",
+          msg: "observability query failed",
+          error: error instanceof Error ? error.message : String(error),
+          context: { sessionId },
+        });
+        return c.json(
+          {
+            error: "Observability query unavailable",
+          },
+          503,
+        );
+      }
+    });
+  }
+
   if (githubWebhookHandler) {
     app.post("/github/webhook", async (c) => githubWebhookHandler(c.req.raw));
   }
 
   return app;
+}
+
+function toEventSummary(event: BusQuery.EventRecord): EventSummary {
+  return {
+    eventType: event.eventType,
+    traceId: event.traceId,
+    timeCreated: event.timeCreated,
+  };
 }

--- a/apps/server/test/server/observability.test.ts
+++ b/apps/server/test/server/observability.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { Operational } from "@openomni/protocol";
+import { Bus, BusPersistence, BusQuery, Session, Storage } from "@openomni/session";
+import { createRouter } from "../../src/server/routes";
+
+function db(): Database {
+  return (Storage.getAdapter() as unknown as { readonly db: Database }).db;
+}
+
+async function flushBusPersistence(): Promise<void> {
+  await BusPersistence.flush();
+}
+
+function insertWorkerRun(input: {
+  readonly runId: string;
+  readonly sessionId: string;
+  readonly status: string;
+  readonly timeCreated: number;
+  readonly timeUpdated: number;
+}): void {
+  db()
+    .query(
+      `INSERT INTO worker_run_state
+       (run_id, session_id, parent_session_id, agent_name, status, title, prompt,
+        resume_count, assigned_step_id, error, time_created, time_updated)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      input.runId,
+      input.sessionId,
+      null,
+      "worker",
+      input.status,
+      `Run ${input.runId}`,
+      "do the work",
+      0,
+      null,
+      null,
+      input.timeCreated,
+      input.timeUpdated,
+    );
+}
+
+describe("observability routes", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    Bus.reset();
+    BusPersistence.start();
+  });
+
+  afterEach(() => {
+    BusPersistence.stop();
+    Bus.reset();
+    Storage.reset();
+  });
+
+  test("session event journal endpoint reads BusQuery aggregates without exposing payload data", async () => {
+    const app = createRouter(undefined, { observabilityToken: "test-token" });
+    const session = Session.create({
+      title: "observability",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+
+    insertWorkerRun({
+      runId: "run-observe",
+      sessionId: session.id,
+      status: "succeeded",
+      timeCreated: 100,
+      timeUpdated: 200,
+    });
+
+    Bus.publish(Operational.Info, {
+      traceId: "trace-info",
+      sessionId: session.id,
+      time: 100,
+      component: "test",
+      msg: "info",
+      context: { secret: "redacted by route" },
+    });
+    Bus.publish(Operational.Error, {
+      traceId: "trace-error",
+      sessionId: session.id,
+      time: 200,
+      component: "test",
+      msg: "error",
+      error: "boom",
+      context: { secret: "redacted by route" },
+    });
+    await flushBusPersistence();
+
+    const res = await app.fetch(
+      new Request(`http://localhost/observability/sessions/${session.id}/events`, {
+        headers: { Authorization: "Bearer test-token" },
+      }),
+    );
+    const body = (await res.json()) as {
+      sessionId: string;
+      stats: { totalEvents: number; byCategory: Record<string, number> };
+      errors: Array<{ eventType: string; traceId: string; timeCreated: number; data?: unknown }>;
+      workerRuns: Array<{
+        runId: string;
+        status: string;
+        eventCount: number;
+        startTime: number;
+        endTime: number;
+      }>;
+      chainIntegrity: { valid: boolean; totalVerified: number };
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.sessionId).toBe(session.id);
+    expect(body.stats.totalEvents).toBe(3);
+    expect(body.stats.byCategory.operational).toBe(2);
+    expect(body.stats.byCategory.session).toBe(1);
+    expect(body.errors).toEqual([
+      {
+        eventType: "operational.error",
+        traceId: "trace-error",
+        timeCreated: 200,
+      },
+    ]);
+    expect(body.workerRuns).toEqual([
+      {
+        runId: "run-observe",
+        status: "succeeded",
+        eventCount: 0,
+        startTime: 100,
+        endTime: 200,
+      },
+    ]);
+    expect(body.chainIntegrity.valid).toBe(true);
+    expect(body.chainIntegrity.totalVerified).toBe(3);
+  });
+
+  test("session event journal endpoint is not registered without an observability token", async () => {
+    const app = createRouter();
+    const res = await app.fetch(
+      new Request("http://localhost/observability/sessions/session-1/events"),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  test("session event journal endpoint rejects missing or wrong bearer tokens before querying storage", async () => {
+    BusPersistence.stop();
+    Storage.reset();
+
+    const app = createRouter(undefined, { observabilityToken: "test-token" });
+
+    const missingToken = await app.fetch(
+      new Request("http://localhost/observability/sessions/session-1/events"),
+    );
+    const wrongToken = await app.fetch(
+      new Request("http://localhost/observability/sessions/session-1/events", {
+        headers: { Authorization: "Bearer wrong-token" },
+      }),
+    );
+
+    expect(missingToken.status).toBe(401);
+    expect(await missingToken.json()).toEqual({ error: "Unauthorized" });
+    expect(wrongToken.status).toBe(401);
+    expect(await wrongToken.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  test("session event journal endpoint does not expose storage errors", async () => {
+    const app = createRouter(undefined, { observabilityToken: "test-token" });
+    const getStats = BusQuery.getStats;
+
+    Object.defineProperty(BusQuery, "getStats", {
+      configurable: true,
+      value: async () => {
+        throw new Error("raw sqlite path /tmp/openomni.db");
+      },
+    });
+
+    try {
+      const res = await app.fetch(
+        new Request("http://localhost/observability/sessions/session-1/events", {
+          headers: { Authorization: "Bearer test-token" },
+        }),
+      );
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: "Observability query unavailable" });
+    } finally {
+      Object.defineProperty(BusQuery, "getStats", {
+        configurable: true,
+        value: getStats,
+      });
+    }
+  });
+});

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -43,7 +43,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | Owner adoption signal (`outcome`: adopted/corrected/redone/ignored) | 📋 | — | ADR-011 — Governor's ground truth; also calibrates Resident evaluation leniency |
 | Task ledger view ("show open tasks" — the OS's `ps`) | 📋 | — | Ledger query via chat command first; web view later |
 | Bus persistence (hash-chained event journal) | ✅ | `packages/session/src/bus-persistence/` | — |
-| `BusQuery` (stats, errors, worker-run history, chain verify) | 🔌 | `packages/session/src/bus-persistence/query.ts` | **Zero production callers.** First consumer: Governor v0 |
+| `BusQuery` (stats, errors, worker-run history, chain verify) | ✅ | `packages/session/src/bus-persistence/query.ts`, `apps/server/src/server/routes.ts` | Wired consumer: token-protected `GET /observability/sessions/:sessionId/events` returns event stats, redacted error metadata, worker-run history, and hash-chain verification. Governor aggregation remains pending below |
 | Token/cost tracking (per call, per message) | ✅ | `packages/llm/src/token/` | Aggregation (per agent/task type, success-rate correlation) absent |
 | System Governor (postmortem engine: incident RCA + slow aggregation loop) | 📋 | — | Zero code. v0 scoped in ADR-012: two lanes (immediate / daily batch), storm collapse, triage (defect vs preference→memory candidate) |
 | Incident fingerprint registry (cause × task type × failure mode; recurrence ladder) | 📋 | — | ADR-012 — match-before-create dedup discipline |


### PR DESCRIPTION
## Summary
- add a token-protected session observability endpoint that calls BusQuery stats, errors, worker-run history, and chain verification
- wire the endpoint from server bootstrap using the existing ws token
- update implementation-status SSOT to mark BusQuery as having a production consumer while leaving Governor aggregation pending

## Verification
- failing-first: new observability route test initially failed with 404 before implementation
- focused: bun test apps/server/test/server/observability.test.ts apps/server/test/server/middleware.test.ts apps/server/test/integration/server-boot.test.ts
- bun run check-types
- bun run build
- bun run test
- direct bun test: 2583 pass / 10 skip / 0 fail
- LSP diagnostics: no diagnostics on changed TS files
- manual QA: authorized endpoint returned BusQuery aggregates; missing/wrong auth returned 401 before storage query
- Codex ultrawork reviewer: PASS
- Claude Fable oracle: PASS (modelUsage included claude-fable-5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a token-protected observability endpoint to inspect session event health. It returns `BusQuery` stats, redacted errors, worker-run history, and chain verification, and is wired with the existing server `wsToken`.

- New Features
  - New GET `'/observability/sessions/:sessionId/events'` route (registered only when a token is provided).
  - Auth via `Authorization: Bearer <config.server.wsToken>`; invalid or missing token returns 401 before any storage query.
  - Aggregates from `@openomni/session` `BusQuery`: stats, error summaries (eventType/traceId/time only), worker-run history, and hash-chain verification.
  - On storage/query failures, returns 503 with a generic error and publishes `Operational.Error`.
  - Docs updated to mark `BusQuery` as having a production consumer (Governor aggregation still pending).

<sup>Written for commit 93e9929281d92f4d3b9ec0b6809128ce162e91aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observability session events endpoint now available, providing event statistics, error metadata, worker-run history, and chain verification data via secure token authentication.

* **Tests**
  * Added comprehensive test suite covering endpoint authorization, response validation, and error handling.

* **Documentation**
  * Updated implementation status documenting the observability feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->