### PR TITLE
refactor(openomni): use croner for cron schedules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "@openomni/llm": "workspace:*",
         "@openomni/protocol": "workspace:*",
         "@openomni/session": "workspace:*",
+        "croner": "^10.0.1",
         "zod": "^3.22.4",
       },
       "devDependencies": {
@@ -273,6 +274,8 @@
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
+
+    "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -580,17 +583,25 @@
 
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
 
-    "@openomni/llm/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@openomni/agent/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@openomni/session/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@openomni/llm/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@openomni/openomni/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@openomni/session/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "cosmiconfig/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "@openomni/llm/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@openomni/agent/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "@openomni/session/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@openomni/llm/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@openomni/openomni/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@openomni/session/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cosmiconfig/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
   }

--- a/packages/openomni/package.json
+++ b/packages/openomni/package.json
@@ -15,8 +15,9 @@
   "dependencies": {
     "@openomni/agent": "workspace:*",
     "@openomni/llm": "workspace:*",
-    "@openomni/session": "workspace:*",
     "@openomni/protocol": "workspace:*",
+    "@openomni/session": "workspace:*",
+    "croner": "^10.0.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/openomni/src/execution-runtime/cron-job-runner.ts
+++ b/packages/openomni/src/execution-runtime/cron-job-runner.ts
@@ -1,16 +1,11 @@
 import { CronJob, Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
+import { Cron } from "croner";
 import { CronJobRegistry } from "./cron-job-registry.js";
 
 const DEFAULT_INTERVAL_MS = 30_000;
-const MAX_SEARCH_MINUTES = 5 * 366 * 24 * 60;
 
 type FireJob = (job: CronJob.Info) => Promise<void>;
-
-interface FieldSpec {
-  readonly max: number;
-  readonly values: ReadonlySet<number>;
-}
 
 function parseInteger(value: string, field: string): number {
   if (!/^\d+$/.test(value)) throw new Error(`Invalid cron ${field} value: ${value}`);
@@ -51,7 +46,7 @@ function addRange(
   for (let value = start; value <= end; value += resolvedStep) values.add(value);
 }
 
-function parseField(source: string, field: string, min: number, max: number): FieldSpec {
+function normalizeField(source: string, field: string, min: number, max: number): string {
   const values = new Set<number>();
   for (const part of source.split(",")) {
     if (!part) throw new Error(`Invalid cron ${field} field: ${source}`);
@@ -61,51 +56,30 @@ function parseField(source: string, field: string, min: number, max: number): Fi
     if (!range) throw new Error(`Invalid cron ${field} field: ${source}`);
     addRange(values, field, min, max, range, stepRaw ? parseInteger(stepRaw, field) : undefined);
   }
-  return { max, values };
+  return [...values].sort((left, right) => left - right).join(",");
 }
 
-function matches(spec: FieldSpec, value: number): boolean {
-  const normalized = spec.max === 7 && value === 0 ? 7 : value;
-  return spec.values.has(value) || spec.values.has(normalized);
-}
-
-type ScheduleSpec = readonly [FieldSpec, FieldSpec, FieldSpec, FieldSpec, FieldSpec];
-
-function parseSchedule(schedule: string): ScheduleSpec {
+function normalizeSchedule(schedule: string): string {
   const fields = schedule.trim().split(/\s+/);
   if (fields.length !== 5) throw new Error(`Unsupported cron schedule: ${schedule}`);
   return [
-    parseField(fields[0] ?? "", "minute", 0, 59),
-    parseField(fields[1] ?? "", "hour", 0, 23),
-    parseField(fields[2] ?? "", "day-of-month", 1, 31),
-    parseField(fields[3] ?? "", "month", 1, 12),
-    parseField(fields[4] ?? "", "day-of-week", 0, 7),
-  ];
-}
-
-function minuteAfter(timeMs: number): number {
-  const date = new Date(timeMs);
-  date.setUTCSeconds(0, 0);
-  return date.getTime() <= timeMs ? date.getTime() + 60_000 : date.getTime();
+    normalizeField(fields[0] ?? "", "minute", 0, 59),
+    normalizeField(fields[1] ?? "", "hour", 0, 23),
+    normalizeField(fields[2] ?? "", "day-of-month", 1, 31),
+    normalizeField(fields[3] ?? "", "month", 1, 12),
+    normalizeField(fields[4] ?? "", "day-of-week", 0, 7),
+  ].join(" ");
 }
 
 function computeNextFireAt(schedule: string, afterMs: number): number {
-  const [minute, hour, dayOfMonth, month, dayOfWeek] = parseSchedule(schedule);
-  let candidate = minuteAfter(afterMs);
-  for (let index = 0; index < MAX_SEARCH_MINUTES; index += 1) {
-    const date = new Date(candidate);
-    if (
-      matches(minute, date.getUTCMinutes()) &&
-      matches(hour, date.getUTCHours()) &&
-      matches(dayOfMonth, date.getUTCDate()) &&
-      matches(month, date.getUTCMonth() + 1) &&
-      matches(dayOfWeek, date.getUTCDay())
-    ) {
-      return candidate;
-    }
-    candidate += 60_000;
-  }
-  throw new Error(`Unable to find next cron fire time for schedule: ${schedule}`);
+  const nextRun = new Cron(normalizeSchedule(schedule), {
+    paused: true,
+    timezone: "UTC",
+    domAndDow: true,
+    mode: "5-part",
+  }).nextRun(new Date(afterMs));
+  if (!nextRun) throw new Error(`Unable to find next cron fire time for schedule: ${schedule}`);
+  return nextRun.getTime();
 }
 
 function dueAt(job: CronJob.Info): number {

--- a/packages/openomni/test/execution-runtime/cron-job-runner.test.ts
+++ b/packages/openomni/test/execution-runtime/cron-job-runner.test.ts
@@ -121,6 +121,34 @@ describe("CronJobRunner", () => {
     ]);
   });
 
+  test("computes next fire times in UTC", async () => {
+    const job = {
+      ...dueJob("job-utc-noon"),
+      schedule: "0 12 * * *",
+      createdAt: Date.UTC(2026, 0, 1, 0, 0),
+      nextFireAt: undefined,
+    };
+    CronJobRegistry.register(job);
+
+    await CronJobRunner.tick({ nowMs: () => Date.UTC(2026, 0, 1, 1, 0) });
+
+    expect(CronJobRegistry.get(job.id)?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 12, 0));
+  });
+
+  test("requires day-of-month and day-of-week to both match", async () => {
+    const job = {
+      ...dueJob("job-friday-13"),
+      schedule: "0 0 13 * 5",
+      createdAt: Date.UTC(2026, 0, 1, 0, 0),
+      nextFireAt: undefined,
+    };
+    CronJobRegistry.register(job);
+
+    await CronJobRunner.tick({ nowMs: () => Date.UTC(2026, 0, 2, 0, 0) });
+
+    expect(CronJobRegistry.get(job.id)?.nextFireAt).toBe(Date.UTC(2026, 1, 13, 0, 0));
+  });
+
   test("start runs a boot tick and can be stopped", async () => {
     CronJobRegistry.register(dueJob("job-boot"));
     const fired: string[] = [];
@@ -155,6 +183,72 @@ describe("CronJobRunner", () => {
     });
 
     expect(fired).toEqual(["job-good"]);
+  });
+
+  test("rejects second-precision schedules", async () => {
+    CronJobRegistry.register({
+      ...dueJob("job-six-field"),
+      schedule: "*/5 * * * * *",
+      nextFireAt: undefined,
+    });
+    CronJobRegistry.register(dueJob("job-good"));
+
+    const fired: string[] = [];
+    await CronJobRunner.tick({
+      nowMs: () => 1_710_000_060_000,
+      fire: async (job) => {
+        fired.push(job.id);
+      },
+    });
+
+    expect(fired).toEqual(["job-good"]);
+    expect(CronJobRegistry.get("job-six-field")?.nextFireAt).toBeUndefined();
+  });
+
+  test("rejects croner extension syntax that the legacy parser did not support", async () => {
+    const invalidSchedules = [
+      "@daily",
+      "0 0 * JAN *",
+      "0 0 * * MON",
+      "0 0 ? * *",
+      "0 0 L * *",
+      "0 0 * * 1#2",
+    ];
+    for (const [index, schedule] of invalidSchedules.entries()) {
+      CronJobRegistry.register({
+        ...dueJob(`job-extension-${index}`),
+        schedule,
+        nextFireAt: undefined,
+      });
+    }
+    CronJobRegistry.register(dueJob("job-good"));
+
+    const fired: string[] = [];
+    await CronJobRunner.tick({
+      nowMs: () => 1_710_000_060_000,
+      fire: async (job) => {
+        fired.push(job.id);
+      },
+    });
+
+    expect(fired).toEqual(["job-good"]);
+    for (const [index] of invalidSchedules.entries()) {
+      expect(CronJobRegistry.get(`job-extension-${index}`)?.nextFireAt).toBeUndefined();
+    }
+  });
+
+  test("preserves legacy step values that exceed the field size", async () => {
+    const job = {
+      ...dueJob("job-large-step"),
+      schedule: "*/100 * * * *",
+      createdAt: Date.UTC(2026, 0, 1, 12, 1),
+      nextFireAt: undefined,
+    };
+    CronJobRegistry.register(job);
+
+    await CronJobRunner.tick({ nowMs: () => Date.UTC(2026, 0, 1, 12, 2) });
+
+    expect(CronJobRegistry.get(job.id)?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 13, 0));
   });
 
   test("does not reinsert jobs cancelled while firing", async () => {


### PR DESCRIPTION
## Summary
- replace the cron runner's hand-rolled minute search with `croner`
- keep the legacy numeric five-field schedule language by normalizing schedules before Croner sees them
- add regression coverage for UTC, DOM+DOW AND semantics, rejected Croner extension syntax, rejected six-field schedules, and legacy oversized steps such as `*/100`

## Verification
- `bunx biome check packages/openomni/src/execution-runtime/cron-job-runner.ts packages/openomni/test/execution-runtime/cron-job-runner.test.ts --write`
- LSP diagnostics clean on changed TS/test files
- `bunx turbo run test --filter=@openomni/openomni` (812 pass / 0 fail)
- `bun run check-types`
- `bun run build`
- `bun run test`
- `git diff --check`
- read-only subagent verification: PASS, including `bun --cwd packages/openomni test test/execution-runtime/cron-job-runner.test.ts` (13 pass / 0 fail) and old-vs-new representative schedule probes
- Claude Fable oracle: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch cron schedule evaluation to `croner` for reliable next-run computation and simpler code. Preserves our legacy 5-field UTC behavior (DOM and DOW must both match) and adds regression tests.

- **Refactors**
  - Replace manual cron search with `croner` (UTC timezone, 5-part mode, DOM+DOW AND).
  - Normalize legacy numeric fields; preserve oversized steps like `*/100`.
  - Reject 6-field (seconds) schedules and unsupported `croner` extensions.

- **Dependencies**
  - Add `croner@^10.0.1` to `@openomni/openomni`.

<sup>Written for commit bd8d707a0659d437953a3043d93559daa42ebfbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

