### PR TITLE
feat(protocol): add app connector schema

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -23,7 +23,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | `PendingInteraction` (successor; correlation routing, follow-up window) | 📋 | — | Not a pure rename of PendingAsk (status enum, `allowedActions`, `workerRunId` coupling all change). No PI-match session override exists in dispatch |
 | `executorKind` on WorkerRun (`external_api` / `a2a` / `human_channel`) | 📋 | — | Internal ChatAgent execution only today |
 | `local_cli_agent` executor (CLI agents as installed apps) | 📋 | — | ADR-010 §3 — connector philosophy: observe the boundary, don't manage the inside |
-| `AppConnector` schema (declarative connector definition = public ABI) | 📋 | `packages/protocol/src/app-connector/` (planned) | ADR-010 §3 — detect/spawn/observe/bridge/evidence/requires/profile; third parties integrate by writing one file (T1) |
+| `AppConnector` schema (declarative connector definition = public ABI) | ✅ | `packages/protocol/src/app-connector/` | ADR-010 §3 schema shipped: detect/spawn/logs/question bridge/evidence/requires/profile; install lifecycle and runtime wiring remain pending below |
 | Install lifecycle (discover → register → consent → wire → smoke-verify; version-drift re-verification) | 📋 | — | ADR-010 §3 — consent sets the app's permission ceiling; "installed" is itself evidence-gated; drift rides the ADR-012 incident pipeline |
 | App question bridge (permission/clarification prompt → `resident.ask`, suspend/resume) | 📋 | — | ADR-010 §3 |
 | Native app log ingestion (raw → artifact, key events → journal; liveness for stall detection) | 📋 | — | ADR-010 §3 — also the evidence + RCA + cost source for app work |

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -27,6 +27,7 @@ src/
 ├── ipc/                  # IPC request/response schemas and worker transport contracts
 ├── storage/              # Storage.WorkItemSubAdapter interface
 ├── work-item/            # WorkItem.Info, Blocker, Evidence, VerificationGate, Status, deriveStatus(), generateHash(), WorkItem.Events.*
+├── app-connector/        # Declarative installed-app connector ABI
 ├── tool-selection/       # ToolSelection schema for choosing tool categories and overrides
 ├── trace/                # TraceContext schema shared by observability helpers
 ├── worker-bootstrap/     # Worker bootstrap payload contracts
@@ -45,6 +46,7 @@ src/
 - **Storage sub-adapters**: `Storage.WorkItemSubAdapter` in `storage/index.ts` — pure interface contract with no runtime logic. Implementation lives in `@openomni/session`.
 - **WorkItem namespace**: `work-item/index.ts` defines `WorkItem.Info` (universal work state schema with derived status, blockers, evidence, verification gates), `WorkItem.Events.*` (Created, Updated, StatusChanged, Completed, Failed, Removed via `BusEvent.define()`), `deriveStatus()` (pure status derivation from timestamps/blockers), and `generateHash()` (base36 12-char collision-safe IDs).
 - **Execution/IPC contracts**: `execution/`, `ipc/`, and `worker-bootstrap/` describe worker requests, responses, and bootstrap payloads only. Runtime worker lifecycle lives in `@openomni/coordinator`.
+- **AppConnector namespace**: `app-connector/index.ts` defines installed-app connector schema contracts. Runtime install, consent, and process execution live above protocol.
 - **Trace contract**: `trace/index.ts` defines the shared shape; helper creation lives in `@openomni/session`.
 
 ## FUTURE PRODUCT MODEL CONTRACTS

--- a/packages/protocol/src/app-connector/index.ts
+++ b/packages/protocol/src/app-connector/index.ts
@@ -42,25 +42,59 @@ export namespace AppConnector {
     .strict();
   export type Spawn = z.infer<typeof Spawn>;
 
-  export const Logs = z
-    .object({
-      kind: z.enum(["jsonl", "stream_json", "text"]),
-      path: nonEmptyString,
-      eventTimeField: nonEmptyString.optional(),
-      messageField: nonEmptyString.optional(),
-    })
-    .strict();
+  const structuredLogsFields = {
+    path: nonEmptyString,
+    eventTimeField: nonEmptyString,
+    messageField: nonEmptyString,
+  };
+
+  export const Logs = z.discriminatedUnion("kind", [
+    z
+      .object({
+        kind: z.literal("jsonl"),
+        ...structuredLogsFields,
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("stream_json"),
+        ...structuredLogsFields,
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("text"),
+        path: nonEmptyString,
+      })
+      .strict(),
+  ]);
   export type Logs = z.infer<typeof Logs>;
 
-  export const QuestionBridge = z
-    .object({
-      kind: z.enum(["hook", "stdio", "none"]),
-      command: nonEmptyString.optional(),
-      args: commandArgs.optional(),
-      promptField: nonEmptyString.optional(),
-      responseMode: z.enum(["stdout", "file", "webhook"]).optional(),
-    })
-    .strict();
+  const bridgeResponseMode = z.enum(["stdout", "file", "webhook"]);
+
+  export const QuestionBridge = z.discriminatedUnion("kind", [
+    z
+      .object({
+        kind: z.literal("hook"),
+        command: nonEmptyString,
+        args: commandArgs.optional(),
+        promptField: nonEmptyString.optional(),
+        responseMode: bridgeResponseMode.optional(),
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("stdio"),
+        promptField: nonEmptyString.optional(),
+        responseMode: bridgeResponseMode.optional(),
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("none"),
+      })
+      .strict(),
+  ]);
   export type QuestionBridge = z.infer<typeof QuestionBridge>;
 
   export const CompletionReport = z

--- a/packages/protocol/src/app-connector/index.ts
+++ b/packages/protocol/src/app-connector/index.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import { Policy } from "../policy/index.js";
+
+export namespace AppConnector {
+  const nonEmptyString = z.string().min(1);
+  const commandArgs = z.array(nonEmptyString);
+  const positiveInteger = z.number().int().positive();
+
+  export const EvidenceEmitter = z.enum([
+    "exit_code",
+    "diff",
+    "test_result",
+    "tool_call",
+    "token_usage",
+    "artifact",
+    "log_event",
+  ]);
+  export type EvidenceEmitter = z.infer<typeof EvidenceEmitter>;
+
+  export const InitialAutonomy = z.enum(["approval_required", "supervised", "autonomous"]);
+  export type InitialAutonomy = z.infer<typeof InitialAutonomy>;
+
+  export const Detect = z
+    .object({
+      command: nonEmptyString,
+      args: commandArgs.optional(),
+      versionPattern: nonEmptyString.optional(),
+      testedVersions: nonEmptyString,
+    })
+    .strict();
+  export type Detect = z.infer<typeof Detect>;
+
+  export const Spawn = z
+    .object({
+      command: nonEmptyString,
+      args: commandArgs.optional(),
+      promptArgument: nonEmptyString.optional(),
+      cwd: nonEmptyString.optional(),
+      env: z.record(nonEmptyString, nonEmptyString).optional(),
+      timeoutMs: positiveInteger.optional(),
+    })
+    .strict();
+  export type Spawn = z.infer<typeof Spawn>;
+
+  export const Logs = z
+    .object({
+      kind: z.enum(["jsonl", "stream_json", "text"]),
+      path: nonEmptyString,
+      eventTimeField: nonEmptyString.optional(),
+      messageField: nonEmptyString.optional(),
+    })
+    .strict();
+  export type Logs = z.infer<typeof Logs>;
+
+  export const QuestionBridge = z
+    .object({
+      kind: z.enum(["hook", "stdio", "none"]),
+      command: nonEmptyString.optional(),
+      args: commandArgs.optional(),
+      promptField: nonEmptyString.optional(),
+      responseMode: z.enum(["stdout", "file", "webhook"]).optional(),
+    })
+    .strict();
+  export type QuestionBridge = z.infer<typeof QuestionBridge>;
+
+  export const CompletionReport = z
+    .object({
+      finalMessage: z.enum(["stdout", "stderr", "log", "artifact"]),
+      artifactGlobs: z.array(nonEmptyString).optional(),
+    })
+    .strict();
+  export type CompletionReport = z.infer<typeof CompletionReport>;
+
+  export const Evidence = z
+    .object({
+      emits: z.array(EvidenceEmitter).min(1),
+      completionReport: CompletionReport.optional(),
+    })
+    .strict();
+  export type Evidence = z.infer<typeof Evidence>;
+
+  export const Requires = z
+    .object({
+      credentials: z.array(nonEmptyString).optional(),
+      capabilities: z.array(nonEmptyString).optional(),
+      permissions: z.array(Policy.Permission).optional(),
+    })
+    .strict();
+  export type Requires = z.infer<typeof Requires>;
+
+  export const Profile = z
+    .object({
+      executorKind: z.literal("local_cli_agent"),
+      taskTypes: z.array(nonEmptyString).min(1),
+      defaultTimeoutMs: positiveInteger.optional(),
+      defaultMaxAttempts: positiveInteger.optional(),
+      initialAutonomy: InitialAutonomy.optional(),
+    })
+    .strict();
+  export type Profile = z.infer<typeof Profile>;
+
+  export const Definition = z
+    .object({
+      id: nonEmptyString,
+      name: nonEmptyString,
+      version: nonEmptyString,
+      description: nonEmptyString,
+      detect: Detect,
+      spawn: Spawn,
+      logs: Logs.optional(),
+      questionBridge: QuestionBridge.optional(),
+      evidence: Evidence,
+      requires: Requires,
+      profile: Profile,
+    })
+    .strict();
+  export type Definition = z.infer<typeof Definition>;
+}

--- a/packages/protocol/src/extension/index.ts
+++ b/packages/protocol/src/extension/index.ts
@@ -5,6 +5,7 @@ import { Skill } from "../skill/index.js";
 import { McpConfig } from "../mcp/index.js";
 import { Policy } from "../policy/index.js";
 import { BusEvent } from "../bus/index.js";
+import { AppConnector } from "../app-connector/index.js";
 
 export namespace Extension {
   export const LifecycleState = z.enum([
@@ -33,6 +34,7 @@ export namespace Extension {
     mcpServers: z.array(McpConfig.ServerConfig).optional(),
     middlewares: z.array(Policy.Definition).optional(),
     surfaces: z.array(SurfaceBinding).optional(),
+    appConnectors: z.array(AppConnector.Definition).optional(),
   });
   export type Contributes = z.infer<typeof Contributes>;
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -26,3 +26,4 @@ export * from "./trace/index.js";
 export * from "./skill/index.js";
 export * from "./extension/index.js";
 export * from "./dispatch/index.js";
+export * from "./app-connector/index.js";

--- a/packages/protocol/test/app-connector.test.ts
+++ b/packages/protocol/test/app-connector.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+import { AppConnector, Extension } from "../src/index.js";
+
+const it = test;
+
+function validConnector(): Record<string, unknown> {
+  return {
+    id: "app.claude-code",
+    name: "Claude Code",
+    version: "1.0.0",
+    description: "Runs Claude Code as an installed CLI application",
+    detect: {
+      command: "claude",
+      args: ["--version"],
+      versionPattern: "claude-code (?<version>\\d+\\.\\d+\\.\\d+)",
+      testedVersions: ">=1.0.0 <2.0.0",
+    },
+    spawn: {
+      command: "claude",
+      args: ["--print", "{{prompt}}"],
+      promptArgument: "{{prompt}}",
+      cwd: "{{worktree}}",
+      timeoutMs: 600_000,
+    },
+    logs: {
+      kind: "jsonl",
+      path: "~/.claude/projects/{{workspaceHash}}/*.jsonl",
+      eventTimeField: "timestamp",
+      messageField: "message",
+    },
+    questionBridge: {
+      kind: "hook",
+      command: "openomni-claude-permission-hook",
+      promptField: "prompt",
+      responseMode: "stdout",
+    },
+    evidence: {
+      emits: ["exit_code", "diff", "test_result", "tool_call", "token_usage"],
+      completionReport: {
+        finalMessage: "stdout",
+        artifactGlobs: ["*.patch", "test-results/*.json"],
+      },
+    },
+    requires: {
+      credentials: ["ANTHROPIC_API_KEY"],
+      capabilities: ["git", "network", "filesystem.write"],
+      permissions: [{ action: "tool.call", allowlist: ["bash", "edit"] }],
+    },
+    profile: {
+      executorKind: "local_cli_agent",
+      taskTypes: ["code.change", "code.review"],
+      defaultTimeoutMs: 600_000,
+      defaultMaxAttempts: 2,
+      initialAutonomy: "approval_required",
+    },
+  };
+}
+
+describe("AppConnector protocol domain", () => {
+  describe("AppConnector.Definition", () => {
+    it("parses a declarative installed app connector", () => {
+      // Given
+      const connector = validConnector();
+
+      // When
+      const result = AppConnector.Definition.safeParse(connector);
+
+      // Then
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.id).toBe("app.claude-code");
+        expect(result.data.detect.testedVersions).toBe(">=1.0.0 <2.0.0");
+        expect(result.data.spawn.promptArgument).toBe("{{prompt}}");
+        expect(result.data.profile.executorKind).toBe("local_cli_agent");
+      }
+    });
+
+    it("accepts optional connector wires without requiring runtime code", () => {
+      // Given
+      const connector = {
+        id: "app.minimal",
+        name: "Minimal App",
+        version: "0.1.0",
+        description: "Minimal connector",
+        detect: { command: "minimal", testedVersions: "*" },
+        spawn: { command: "minimal", args: ["run"] },
+        evidence: { emits: ["exit_code"] },
+        requires: {},
+        profile: { executorKind: "local_cli_agent", taskTypes: ["read.only"] },
+      };
+
+      // When
+      const result = AppConnector.Definition.safeParse(connector);
+
+      // Then
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.logs).toBe(undefined);
+        expect(result.data.questionBridge).toBe(undefined);
+        expect(result.data.requires.credentials).toBe(undefined);
+        expect(result.data.requires.capabilities).toBe(undefined);
+      }
+    });
+
+    it("rejects connectors missing the required public ABI sections", () => {
+      // Given
+      const connector = {
+        id: "app.incomplete",
+        name: "Incomplete",
+        version: "1.0.0",
+        description: "Missing spawn/evidence/requires/profile",
+        detect: { command: "incomplete", testedVersions: "*" },
+      };
+
+      // When
+      const result = AppConnector.Definition.safeParse(connector);
+
+      // Then
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects unsupported evidence emitters", () => {
+      // Given
+      const connector = validConnector();
+
+      // When
+      const result = AppConnector.Definition.safeParse({
+        ...connector,
+        evidence: { emits: ["screenshot"] },
+      });
+
+      // Then
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid runtime limits", () => {
+      // Given
+      const connector = validConnector();
+
+      // When
+      const result = AppConnector.Definition.safeParse({
+        ...connector,
+        profile: {
+          executorKind: "local_cli_agent",
+          taskTypes: ["code.change"],
+          defaultTimeoutMs: 0,
+          defaultMaxAttempts: 0,
+        },
+      });
+
+      // Then
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects unknown connector keys", () => {
+      // Given
+      const connector = validConnector();
+
+      // When
+      const result = AppConnector.Definition.safeParse({
+        ...connector,
+        runtimeCode: "not allowed in a declarative connector",
+      });
+
+      // Then
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Extension.Manifest", () => {
+    it("parses contributed app connectors", () => {
+      // Given
+      const manifest = {
+        id: "ext-installed-apps",
+        name: "Installed Apps",
+        version: "1.0.0",
+        description: "Contributes local CLI app connectors",
+        contributes: {
+          appConnectors: [validConnector()],
+        },
+      };
+
+      // When
+      const result = Extension.Manifest.safeParse(manifest);
+
+      // Then
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const connectors = result.data.contributes?.appConnectors;
+        expect(connectors?.length).toBe(1);
+        expect(connectors?.[0]?.profile.initialAutonomy).toBe("approval_required");
+      }
+    });
+  });
+});

--- a/packages/protocol/test/app-connector.test.ts
+++ b/packages/protocol/test/app-connector.test.ts
@@ -152,6 +152,66 @@ describe("AppConnector protocol domain", () => {
       expect(result.success).toBe(false);
     });
 
+    it("rejects log kind field mismatches", () => {
+      // Given
+      const connector = validConnector();
+
+      // When
+      const textResult = AppConnector.Definition.safeParse({
+        ...connector,
+        logs: {
+          kind: "text",
+          path: "/tmp/app.log",
+          eventTimeField: "timestamp",
+        },
+      });
+      const jsonlResult = AppConnector.Definition.safeParse({
+        ...connector,
+        logs: {
+          kind: "jsonl",
+          path: "/tmp/app.log",
+          eventTimeField: "timestamp",
+        },
+      });
+
+      // Then
+      expect(textResult.success).toBe(false);
+      expect(jsonlResult.success).toBe(false);
+    });
+
+    it("rejects question bridge kind field mismatches", () => {
+      // Given
+      const connector = validConnector();
+
+      // When
+      const noneResult = AppConnector.Definition.safeParse({
+        ...connector,
+        questionBridge: {
+          kind: "none",
+          command: "should-not-run",
+        },
+      });
+      const stdioResult = AppConnector.Definition.safeParse({
+        ...connector,
+        questionBridge: {
+          kind: "stdio",
+          command: "should-not-run",
+        },
+      });
+      const hookResult = AppConnector.Definition.safeParse({
+        ...connector,
+        questionBridge: {
+          kind: "hook",
+          responseMode: "stdout",
+        },
+      });
+
+      // Then
+      expect(noneResult.success).toBe(false);
+      expect(stdioResult.success).toBe(false);
+      expect(hookResult.success).toBe(false);
+    });
+
     it("rejects unknown connector keys", () => {
       // Given
       const connector = validConnector();


### PR DESCRIPTION
## Summary
- add the protocol-level AppConnector declarative ABI for installed local CLI apps
- expose AppConnector at the protocol root and wire Extension.Manifest contributes.appConnectors
- mark only the implementation-status schema row complete; install lifecycle/runtime wiring remain pending

## Verification
- red-before-green: focused app-connector test initially failed before the AppConnector export existed
- bun --cwd packages/protocol test test/app-connector.test.ts (7 pass / 0 fail)
- bun run --cwd packages/protocol check-types && bun run --cwd packages/protocol build && bun run --cwd packages/protocol test (467 pass / 0 fail)
- bun run check-types (10/10), bun run build (4/4), bun run test (9/9)
- dist import probe for AppConnector + Extension manifest contribution
- biome + LSP diagnostics clean for touched TS files
- git diff --check
- Claude Fable oracle PASS
- independent reviewer PASS after fresh root test rerun
- remove-ai-slops pass completed; docs/AGENTS wording tightened

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a declarative `AppConnector` schema in `packages/protocol` for installed local CLI apps. Exposes it at the protocol root and allows extensions to contribute connectors via `Extension.Manifest.contributes.appConnectors`.

- New Features
  - Added `AppConnector.Definition` with detect, spawn, logs, questionBridge, evidence, requires, profile.
  - Exported from `packages/protocol` root; optional `Extension.Contributes.appConnectors`.
  - Updated tests and docs; marked shipped in implementation status. Install lifecycle and runtime wiring remain pending.

- Bug Fixes
  - Tightened variant schemas for `logs` and `questionBridge` to reject invalid field combinations.

<sup>Written for commit 95ef6701ddebecb82c3c83dc64f760a55f811fe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced app-connector support, enabling developers to define and configure application connectors with detection, process spawning, logging, and evidence tracking capabilities.

* **Documentation**
  * Updated protocol documentation to include the new app-connector namespace and installed-app connector schema contracts.

* **Tests**
  * Added comprehensive test coverage for app-connector validation and manifest integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->