### PR TITLE
feat(openomni): resolve registered actor endpoints

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -12,7 +12,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | --- | --- | --- | --- |
 | Server channel adapters (Discord/Telegram/GitHub/WS) | ✅ | `apps/server/src/channel/` | Raw → `InboundMessage` |
 | IngressEngine (session candidate resolve → project → dispatch) | ✅ | `packages/openomni/src/ingress/engine.ts` | |
-| `ActorResolver` / `ActorIdentity` / `ActorEndpoint` / `ActorRegistry` | ✅ | `packages/protocol/src/actor/`, `packages/session/src/actor/`, `packages/openomni/src/ingress/actor-resolver.ts` | Canonical actor identity + endpoint schemas, SQLite-backed registry, and ingress resolution for registered `(channel, externalId)` endpoints are wired, where `channel` is the platform/surface identifier. Unregistered endpoints are sanitized back to legacy `id`/`role`; ChannelGrant and TrustTier evaluation remain pending below |
+| `ActorResolver` / `ActorIdentity` / `ActorEndpoint` / `ActorRegistry` | ✅ | `packages/protocol/src/actor/`, `packages/session/src/actor/`, `packages/openomni/src/ingress/actor-resolver.ts` | Canonical actor identity + endpoint schemas, SQLite-backed registry, and ingress resolution for registered `(channel, workspace, externalId)` endpoints are wired, where `channel` is the platform/surface identifier. Unregistered endpoints are sanitized back to legacy `id`/`role`; ChannelGrant and TrustTier evaluation remain pending below |
 | DispatchRuntime (policy authorize → handler routing) | ✅ | `packages/openomni/src/dispatch/runtime.ts` | Actions: `resident.ask`, `worker.spawn/send/resume/cancel`, `schedule.create/cancel` |
 | WorkerGrant evaluation | ✅ | `packages/openomni/src/dispatch/policy.ts` | The only authority axis currently evaluated |
 | Blacklist | 📋 | — | Checked nowhere |

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -12,7 +12,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | --- | --- | --- | --- |
 | Server channel adapters (Discord/Telegram/GitHub/WS) | ✅ | `apps/server/src/channel/` | Raw → `InboundMessage` |
 | IngressEngine (session candidate resolve → project → dispatch) | ✅ | `packages/openomni/src/ingress/engine.ts` | |
-| `ActorResolver` / `ActorIdentity` / `ActorEndpoint` / `ActorRegistry` | 📋 | `packages/protocol/src/actor/` (planned) | Zero code. Actor arrives pre-stamped as an untyped `{ role, id, kind }` blob; ingress does **not** resolve identity yet |
+| `ActorResolver` / `ActorIdentity` / `ActorEndpoint` / `ActorRegistry` | ✅ | `packages/protocol/src/actor/`, `packages/session/src/actor/`, `packages/openomni/src/ingress/actor-resolver.ts` | Canonical actor identity + endpoint schemas, SQLite-backed registry, and ingress resolution for registered `(channel, externalId)` endpoints are wired, where `channel` is the platform/surface identifier. Unregistered endpoints are sanitized back to legacy `id`/`role`; ChannelGrant and TrustTier evaluation remain pending below |
 | DispatchRuntime (policy authorize → handler routing) | ✅ | `packages/openomni/src/dispatch/runtime.ts` | Actions: `resident.ask`, `worker.spawn/send/resume/cancel`, `schedule.create/cancel` |
 | WorkerGrant evaluation | ✅ | `packages/openomni/src/dispatch/policy.ts` | The only authority axis currently evaluated |
 | Blacklist | 📋 | — | Checked nowhere |

--- a/packages/openomni/src/ingress/actor-resolver.ts
+++ b/packages/openomni/src/ingress/actor-resolver.ts
@@ -25,11 +25,8 @@ export function resolveIngressActor(event: Ingress.InboundEvent): Ingress.Inboun
     };
   }
 
-  const resolved = ActorRegistry.resolveEndpoint(event.surface, externalId);
-  if (
-    !resolved ||
-    (resolved.endpoint.workspace && resolved.endpoint.workspace !== event.workspace)
-  ) {
+  const resolved = ActorRegistry.resolveEndpoint(event.surface, externalId, event.workspace);
+  if (!resolved) {
     return {
       ...event,
       meta: {
@@ -44,7 +41,8 @@ export function resolveIngressActor(event: Ingress.InboundEvent): Ingress.Inboun
     meta: {
       ...event.meta,
       actor: {
-        ...legacyActorFields(event.meta?.actor),
+        id: resolved.endpoint.externalId,
+        role: "user",
         actorId: resolved.identity.id,
         kind: resolved.identity.kind,
         trustTier: resolved.identity.trustTier,

--- a/packages/openomni/src/ingress/actor-resolver.ts
+++ b/packages/openomni/src/ingress/actor-resolver.ts
@@ -1,0 +1,57 @@
+import type { Ingress } from "@openomni/protocol";
+import { ActorRegistry, Storage } from "@openomni/session";
+
+function legacyActorFields(actor: Ingress.Actor | undefined): Ingress.Actor | undefined {
+  if (!actor) return undefined;
+  const legacyActor: Ingress.Actor = {};
+  if (actor.id) legacyActor.id = actor.id;
+  if (actor.role) legacyActor.role = actor.role;
+  return legacyActor;
+}
+
+function externalActorId(event: Ingress.InboundEvent): string | undefined {
+  return event.userId;
+}
+
+export function resolveIngressActor(event: Ingress.InboundEvent): Ingress.InboundEvent {
+  const externalId = externalActorId(event);
+  if (!externalId || !Storage.get().actorRegistry) {
+    return {
+      ...event,
+      meta: {
+        ...event.meta,
+        actor: legacyActorFields(event.meta?.actor),
+      },
+    };
+  }
+
+  const resolved = ActorRegistry.resolveEndpoint(event.surface, externalId);
+  if (
+    !resolved ||
+    (resolved.endpoint.workspace && resolved.endpoint.workspace !== event.workspace)
+  ) {
+    return {
+      ...event,
+      meta: {
+        ...event.meta,
+        actor: legacyActorFields(event.meta?.actor),
+      },
+    };
+  }
+
+  return {
+    ...event,
+    meta: {
+      ...event.meta,
+      actor: {
+        ...legacyActorFields(event.meta?.actor),
+        actorId: resolved.identity.id,
+        kind: resolved.identity.kind,
+        trustTier: resolved.identity.trustTier,
+        relationship: resolved.identity.relationship,
+        endpointId: resolved.endpoint.id,
+        endpoint: resolved.endpoint,
+      },
+    },
+  };
+}

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -1,5 +1,6 @@
 import { PolicyEngine, type PolicyDecision, type PolicyRegistration } from "@openomni/agent";
 import {
+  Ingress as IngressNamespace,
   type Ingress,
   type Policy,
   IngressEvent,
@@ -81,12 +82,9 @@ export namespace IngressEngine {
     _ingressPolicies.push(reg);
   }
 
-  export async function ingest(event: Ingress.InboundEvent): Promise<Ingress.IngressResult> {
-    if ((event as { mode: string }).mode === "internal") {
-      throw new Error("internal mode not allowed on external ingress path");
-    }
-
-    const resolvedActorEvent = resolveIngressActor(event);
+  export async function ingest(event: unknown): Promise<Ingress.IngressResult> {
+    const externalEvent = IngressNamespace.DirectEventSchema.parse(event);
+    const resolvedActorEvent = resolveIngressActor(externalEvent);
     const trace = TraceContext.create();
     const preRun = await IngressAuthorityMiddleware.runPreRun({
       event: resolvedActorEvent,
@@ -94,10 +92,6 @@ export namespace IngressEngine {
       traceContext: trace,
       onDecision: _middlewareDecisionObserver,
     });
-
-    if ((preRun.event as { mode: string }).mode !== "direct") {
-      throw new Error("internal mode not allowed on external ingress path");
-    }
 
     const inboundEvent = preRun.event as Ingress.ResolvedInboundEvent;
     return ingestResolved(inboundEvent, trace, preRun.coordinator);

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -9,6 +9,7 @@ import {
 import { Bus, Storage, SurfaceKey, TraceContext } from "@openomni/session";
 import type { CoordinatorLike } from "./coordinator-like";
 import type { ResidentRuntime } from "../resident/runtime";
+import { resolveIngressActor } from "./actor-resolver";
 import { IngressEventProjector } from "./event-projector";
 import { IngressHandlers } from "./handlers";
 import { IngressAuthorityMiddleware } from "./middleware/ingress-authority";
@@ -85,9 +86,10 @@ export namespace IngressEngine {
       throw new Error("internal mode not allowed on external ingress path");
     }
 
+    const resolvedActorEvent = resolveIngressActor(event);
     const trace = TraceContext.create();
     const preRun = await IngressAuthorityMiddleware.runPreRun({
-      event,
+      event: resolvedActorEvent,
       coordinator: _coordinator,
       traceContext: trace,
       onDecision: _middlewareDecisionObserver,
@@ -164,6 +166,7 @@ export namespace IngressEngine {
         elapsedMs: 0,
         labels,
         toolInput: {
+          actor: inboundEvent.meta?.actor,
           surface: inboundEvent.surface,
           mode: inboundEvent.mode,
           target: target.kind,

--- a/packages/openomni/src/ingress/middleware/ingress-authority.ts
+++ b/packages/openomni/src/ingress/middleware/ingress-authority.ts
@@ -241,7 +241,7 @@ function createSchemaValidation(state: PreRunState): PolicyRegistration {
     ...IngressAuthorityMiddleware.SchemaValidation,
     failPolicy: "fail-closed",
     fn: () => {
-      const parsed = Ingress.InboundEventSchema.safeParse(state.input);
+      const parsed = Ingress.DirectEventSchema.safeParse(state.input);
       if (!parsed.success) {
         state.schemaError = parsed.error;
         return abortDecision("ingress.schema", "invalid ingress event");

--- a/packages/openomni/test/ingress/_actor-resolver-fixture.ts
+++ b/packages/openomni/test/ingress/_actor-resolver-fixture.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, beforeEach, mock } from "bun:test";
+import type { PolicyContext, PolicyRegistration } from "@openomni/agent";
+import {
+  Ingress as IngressNamespace,
+  PolicyDecision as ProtocolPolicyDecision,
+  type Ingress,
+} from "@openomni/protocol";
+import { ActorRegistry, Storage } from "@openomni/session";
+import {
+  defaultRunFn,
+  mockModelsGet,
+  mockProviderFromModelsDevModel,
+  resetTestState,
+  testState,
+} from "./_llm-mock";
+
+let IngressEngine: typeof import("../../src/ingress/engine").IngressEngine;
+let ResidentRuntime: typeof import("../../src/resident/runtime").ResidentRuntime;
+
+export function setupIngressActorResolverTest(): void {
+  beforeAll(async () => {
+    ({ IngressEngine } = await import("../../src/ingress/engine"));
+    ({ ResidentRuntime } = await import("../../src/resident/runtime"));
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  beforeEach(() => {
+    resetTestState();
+    testState.runFn = defaultRunFn("actor-resolver-test");
+    mockModelsGet.mockClear();
+    mockProviderFromModelsDevModel.mockClear();
+    IngressEngine.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    IngressEngine.setResidentRuntime(
+      ResidentRuntime.create({
+        runAgent: async (_config, input) => {
+          testState.llmInputs.push(input);
+          return { text: testState.responseQueue.shift() ?? "{}", finishReason: "stop" };
+        },
+      }),
+    );
+  });
+}
+
+export function getIngressEngine(): typeof import("../../src/ingress/engine").IngressEngine {
+  return IngressEngine;
+}
+
+export function makeEvent(
+  userId: string,
+  actor: Ingress.Actor = { role: "user", id: userId },
+): Ingress.InboundEvent {
+  return {
+    id: `event-${userId}`,
+    surface: "discord",
+    workspace: "guild",
+    channel: "dev",
+    userId,
+    mode: "direct",
+    payload: "hello",
+    meta: { actor },
+    agent: { model: { provider: "anthropic", id: "claude-3-haiku-20240307" } },
+  };
+}
+
+export function captureActorPolicy(
+  onActor: (actor: Ingress.Actor | undefined) => void,
+): PolicyRegistration {
+  return {
+    name: "test:capture-actor",
+    timing: "inbound.receive",
+    priority: 0,
+    fn: (ctx: PolicyContext) => {
+      onActor(IngressNamespace.ActorSchema.parse(ctx.toolInput?.actor));
+      return ProtocolPolicyDecision.allow({
+        policyId: "test.capture-actor",
+        reasonCodes: ["captured"],
+      });
+    },
+  };
+}
+
+export function registerOwnerEndpoint(workspace?: string): void {
+  ActorRegistry.registerIdentity({
+    id: "act_owner",
+    kind: "human",
+    trustTier: "owner",
+    relationship: "owner",
+  });
+  ActorRegistry.registerEndpoint({
+    id: "ep_discord_user_1",
+    actorId: "act_owner",
+    channel: "discord",
+    externalId: "user-1",
+    workspace,
+  });
+}
+
+export async function flushBusObservers(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+export { testState };

--- a/packages/openomni/test/ingress/_actor-resolver-fixture.ts
+++ b/packages/openomni/test/ingress/_actor-resolver-fixture.ts
@@ -74,7 +74,8 @@ export function captureActorPolicy(
     timing: "inbound.receive",
     priority: 0,
     fn: (ctx: PolicyContext) => {
-      onActor(IngressNamespace.ActorSchema.parse(ctx.toolInput?.actor));
+      const actor = ctx.toolInput?.actor;
+      onActor(actor === undefined ? undefined : IngressNamespace.ActorSchema.parse(actor));
       return ProtocolPolicyDecision.allow({
         policyId: "test.capture-actor",
         reasonCodes: ["captured"],

--- a/packages/openomni/test/ingress/actor-resolver-sanitization.test.ts
+++ b/packages/openomni/test/ingress/actor-resolver-sanitization.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import type { Ingress } from "@openomni/protocol";
+import { Storage } from "@openomni/session";
+import {
+  captureActorPolicy,
+  getIngressEngine,
+  makeEvent,
+  registerOwnerEndpoint,
+  setupIngressActorResolverTest,
+  testState,
+} from "./_actor-resolver-fixture";
+
+setupIngressActorResolverTest();
+
+describe("Ingress actor resolver sanitization", () => {
+  it("keeps only legacy id and role for unregistered endpoint actor metadata", async () => {
+    // Given
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    // When
+    await engine.ingest(
+      makeEvent("unknown-user", {
+        role: "user",
+        id: "unknown-user",
+        kind: "human",
+        sessionId: "sess-spoof",
+        workerId: "worker-spoof",
+        futureTrustField: true,
+      }),
+    );
+
+    // Then
+    expect(capturedActor).toEqual({ role: "user", id: "unknown-user" });
+  });
+
+  it("strips spoofed canonical actor fields from unregistered endpoints", async () => {
+    // Given
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    // When
+    await engine.ingest(
+      makeEvent("unknown-user", {
+        role: "user",
+        id: "unknown-user",
+        actorId: "act_spoofed",
+        kind: "system",
+        type: "system",
+        trustTier: "owner",
+        relationship: "owner",
+        endpointId: "ep_spoofed",
+        trusted: true,
+        isTrustedManager: true,
+      }),
+    );
+
+    // Then
+    expect(capturedActor).toEqual({ role: "user", id: "unknown-user" });
+  });
+
+  it("does not resolve actor identity from legacy actor id when userId is absent", async () => {
+    // Given
+    registerOwnerEndpoint();
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+    const event = makeEvent("user-1", {
+      role: "user",
+      id: "user-1",
+      actorId: "act_spoofed",
+      kind: "system",
+      type: "system",
+      trustTier: "owner",
+      trusted: true,
+      isTrustedManager: true,
+    });
+    const { userId: _userId, ...withoutUserId } = event;
+
+    // When
+    await engine.ingest(withoutUserId);
+
+    // Then
+    expect(capturedActor).toEqual({ role: "user", id: "user-1" });
+  });
+
+  it("does not resolve same external id from a different surface", async () => {
+    // Given
+    registerOwnerEndpoint();
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    // When
+    await engine.ingest({ ...makeEvent("user-1"), surface: "telegram" });
+
+    // Then
+    expect(capturedActor).toEqual({ role: "user", id: "user-1" });
+  });
+
+  it("keeps ingest working with storage adapters that do not implement actorRegistry", async () => {
+    // Given
+    const { actorRegistry: _actorRegistry, ...legacyAdapter } = Storage.get();
+    Storage.configure(legacyAdapter);
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    // When
+    await engine.ingest(
+      makeEvent("user-1", {
+        role: "user",
+        id: "user-1",
+        actorId: "act_spoofed",
+        kind: "system",
+        type: "system",
+        trustTier: "owner",
+        trusted: true,
+        isTrustedManager: true,
+      }),
+    );
+
+    // Then
+    expect(capturedActor).toEqual({ role: "user", id: "user-1" });
+  });
+});

--- a/packages/openomni/test/ingress/actor-resolver-sanitization.test.ts
+++ b/packages/openomni/test/ingress/actor-resolver-sanitization.test.ts
@@ -73,7 +73,7 @@ describe("Ingress actor resolver sanitization", () => {
 
   it("does not resolve actor identity from legacy actor id when userId is absent", async () => {
     // Given
-    registerOwnerEndpoint();
+    registerOwnerEndpoint("guild");
     const engine = getIngressEngine();
     let capturedActor: Ingress.Actor | undefined;
     engine.registerIngressPolicy(
@@ -103,7 +103,7 @@ describe("Ingress actor resolver sanitization", () => {
 
   it("does not resolve same external id from a different surface", async () => {
     // Given
-    registerOwnerEndpoint();
+    registerOwnerEndpoint("guild");
     const engine = getIngressEngine();
     let capturedActor: Ingress.Actor | undefined;
     engine.registerIngressPolicy(

--- a/packages/openomni/test/ingress/actor-resolver.test.ts
+++ b/packages/openomni/test/ingress/actor-resolver.test.ts
@@ -26,7 +26,7 @@ setupIngressActorResolverTest();
 describe("Ingress actor resolver", () => {
   it("adds canonical actor fields for registered endpoints before inbound policies", async () => {
     // Given
-    registerOwnerEndpoint();
+    registerOwnerEndpoint("guild");
     const engine = getIngressEngine();
     let capturedActor: Ingress.Actor | undefined;
     engine.registerIngressPolicy(
@@ -39,8 +39,8 @@ describe("Ingress actor resolver", () => {
     // When
     await engine.ingest(
       makeEvent("user-1", {
-        role: "user",
         id: "user-1",
+        role: "manager",
         type: "system",
         trusted: true,
         isTrustedManager: true,
@@ -64,7 +64,7 @@ describe("Ingress actor resolver", () => {
 
   it("projects the resolved actor after inbound policy evaluation", async () => {
     // Given
-    registerOwnerEndpoint();
+    registerOwnerEndpoint("guild");
     const engine = getIngressEngine();
     let projectedActor: Ingress.Actor | undefined;
     const unobserve = Bus.observe((event, data) => {

--- a/packages/openomni/test/ingress/actor-resolver.test.ts
+++ b/packages/openomni/test/ingress/actor-resolver.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "bun:test";
+import { Ingress as IngressNamespace, Operational, type Ingress } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { z } from "zod";
+import {
+  captureActorPolicy,
+  flushBusObservers,
+  getIngressEngine,
+  makeEvent,
+  registerOwnerEndpoint,
+  setupIngressActorResolverTest,
+  testState,
+} from "./_actor-resolver-fixture";
+
+const AuditPayloadSchema = z.object({
+  audit: z.object({
+    payload: z.object({
+      eventId: z.string(),
+      actor: z.unknown().optional(),
+    }),
+  }),
+});
+
+setupIngressActorResolverTest();
+
+describe("Ingress actor resolver", () => {
+  it("adds canonical actor fields for registered endpoints before inbound policies", async () => {
+    // Given
+    registerOwnerEndpoint();
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    // When
+    await engine.ingest(
+      makeEvent("user-1", {
+        role: "user",
+        id: "user-1",
+        type: "system",
+        trusted: true,
+        isTrustedManager: true,
+      }),
+    );
+
+    // Then
+    expect(capturedActor).toMatchObject({
+      role: "user",
+      id: "user-1",
+      actorId: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+      endpointId: "ep_discord_user_1",
+    });
+    expect(capturedActor).not.toHaveProperty("type");
+    expect(capturedActor).not.toHaveProperty("trusted");
+    expect(capturedActor).not.toHaveProperty("isTrustedManager");
+  });
+
+  it("projects the resolved actor after inbound policy evaluation", async () => {
+    // Given
+    registerOwnerEndpoint();
+    const engine = getIngressEngine();
+    let projectedActor: Ingress.Actor | undefined;
+    const unobserve = Bus.observe((event, data) => {
+      if (event.name !== Operational.Info.name) return;
+      const parsed = Operational.Info.schema.parse(data);
+      const audit = AuditPayloadSchema.safeParse(parsed.context);
+      if (!audit.success) return;
+      if (audit.data.audit.payload.eventId !== "event-user-1") return;
+      if (audit.data.audit.payload.actor === undefined) return;
+      projectedActor = IngressNamespace.ActorSchema.parse(audit.data.audit.payload.actor);
+    });
+    testState.responseQueue.push("ok");
+
+    try {
+      // When
+      await engine.ingest(makeEvent("user-1"));
+      await flushBusObservers();
+    } finally {
+      unobserve();
+    }
+
+    // Then
+    expect(projectedActor).toMatchObject({
+      role: "user",
+      id: "user-1",
+      actorId: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+      endpointId: "ep_discord_user_1",
+    });
+  });
+
+  it("strips canonical actor fields when endpoint workspace does not match", async () => {
+    // Given
+    registerOwnerEndpoint("guild-a");
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+    const event = {
+      ...makeEvent("user-1", {
+        role: "user",
+        id: "user-1",
+        actorId: "act_spoofed",
+        kind: "system",
+        type: "system",
+        trustTier: "owner",
+        trusted: true,
+        isTrustedManager: true,
+      }),
+      workspace: "guild-b",
+    };
+
+    // When
+    await engine.ingest(event);
+
+    // Then
+    expect(capturedActor).toEqual({ role: "user", id: "user-1" });
+  });
+
+  it("resolves actor identity when endpoint workspace matches", async () => {
+    // Given
+    registerOwnerEndpoint("guild");
+    const engine = getIngressEngine();
+    let capturedActor: Ingress.Actor | undefined;
+    engine.registerIngressPolicy(
+      captureActorPolicy((actor) => {
+        capturedActor = actor;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    // When
+    await engine.ingest(makeEvent("user-1"));
+
+    // Then
+    expect(capturedActor).toMatchObject({
+      actorId: "act_owner",
+      endpointId: "ep_discord_user_1",
+      trustTier: "owner",
+      relationship: "owner",
+    });
+  });
+});

--- a/packages/openomni/test/ingress/engine-internal.test.ts
+++ b/packages/openomni/test/ingress/engine-internal.test.ts
@@ -42,11 +42,12 @@ const mockAgentDef: Ingress.AgentDef = {
   model: { provider: "anthropic", id: "claude-3-5-sonnet" },
 };
 
-async function catchError(promise: Promise<unknown>): Promise<unknown> {
+async function catchError(promise: Promise<unknown>): Promise<Error | undefined> {
   try {
     await promise;
     return undefined;
   } catch (error) {
+    if (!(error instanceof Error)) throw error;
     return error;
   }
 }
@@ -64,7 +65,7 @@ describe("ingestInternal", () => {
     const error = await catchError(IngressEngine.ingestInternal(event));
 
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("agent resolver not configured");
+    expect(error?.message).toContain("agent resolver not configured");
   });
 
   it("resolves agent and dispatches via resident runtime", async () => {
@@ -94,13 +95,11 @@ describe("ingest() security", () => {
       mode: "internal",
       agentName: "dev",
       payload: "hack",
-    } as unknown as Ingress.InboundEvent;
+    };
 
     const error = await catchError(IngressEngine.ingest(event));
 
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain(
-      "internal mode not allowed on external ingress path",
-    );
+    expect(error?.message).toContain("invalid_literal");
   });
 });

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { PolicyDecision, PolicyRegistration } from "@openomni/agent";
 import {
-  Ingress as IngressNamespace,
   IngressEvent,
   PolicyDecision as ProtocolPolicyDecision,
   type Ingress,
@@ -64,11 +63,12 @@ function installCoordinator() {
   });
 }
 
-async function catchError(promise: Promise<unknown>): Promise<unknown> {
+async function catchError(promise: Promise<unknown>): Promise<Error | undefined> {
   try {
     await promise;
     return undefined;
   } catch (error) {
+    if (!(error instanceof Error)) throw error;
     return error;
   }
 }
@@ -135,7 +135,7 @@ describe("IngressEngine", () => {
         id: "invalid-1",
         surface: "tui",
         payload: "hello",
-      } as unknown as Ingress.InboundEvent),
+      }),
     );
 
     expect(error).toBeDefined();
@@ -369,8 +369,8 @@ describe("IngressEngine", () => {
     expect(first.sessionId).not.toBe(second.sessionId);
   });
 
-  it("ingest() with unknown mode throws UNKNOWN_INGRESS_MODE error", async () => {
-    const event: Ingress.InboundEvent = {
+  it("ingest() with unknown mode fails external ingress schema validation", async () => {
+    const event = {
       id: "event-unknown-1",
       surface: "tui",
       workspace: "/repo",
@@ -380,31 +380,22 @@ describe("IngressEngine", () => {
       agent: {
         model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       },
-    } as unknown as Ingress.InboundEvent;
-
-    const schema = IngressNamespace.InboundEventSchema as unknown as {
-      safeParse: (input: unknown) => unknown;
     };
-    const originalSafeParse = schema.safeParse;
-    schema.safeParse = () => ({ success: true, data: event });
 
+    let caughtError: Error | undefined;
     try {
-      let caughtError: unknown;
-      try {
-        await IngressEngine.ingest(event);
-      } catch (err) {
-        caughtError = err;
-      }
-
-      expect(caughtError).toBeInstanceOf(Error);
-      expect((caughtError as Error).message).toContain("unknown ingress mode");
-    } finally {
-      schema.safeParse = originalSafeParse;
+      await IngressEngine.ingest(event);
+    } catch (err) {
+      if (!(err instanceof Error)) throw err;
+      caughtError = err;
     }
+
+    expect(caughtError).toBeInstanceOf(Error);
+    expect(caughtError?.message).toContain("invalid_literal");
   });
 
   describe("inbound.receive policy dispatch", () => {
-    function makeEvent(overrides?: Partial<Ingress.InboundEvent>): Ingress.InboundEvent {
+    function makeEvent(overrides?: Partial<Ingress.DirectEvent>): Ingress.DirectEvent {
       return {
         id: "event-policy-1",
         surface: "tui",

--- a/packages/protocol/src/actor/index.ts
+++ b/packages/protocol/src/actor/index.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export namespace Actor {
+  export const Kind = z.enum([
+    "human",
+    "ai_agent",
+    "service",
+    "resident",
+    "internal_worker",
+    "system",
+  ]);
+  export type Kind = z.infer<typeof Kind>;
+
+  export const TrustTier = z.enum([
+    "owner",
+    "co_owner",
+    "manager",
+    "collaborator",
+    "observer",
+    "assigned_worker",
+  ]);
+  export type TrustTier = z.infer<typeof TrustTier>;
+
+  export const Relationship = z.enum([
+    "owner",
+    "co_owner",
+    "collaborator",
+    "observer",
+    "contractor",
+    "external_agent",
+    "worker",
+  ]);
+  export type Relationship = z.infer<typeof Relationship>;
+
+  const Metadata = z.record(z.unknown());
+
+  export const Identity = z.object({
+    id: z.string().min(1),
+    kind: Kind,
+    trustTier: TrustTier,
+    relationship: Relationship,
+    displayName: z.string().min(1).optional(),
+    metadata: Metadata.optional(),
+    createdAt: z.number().optional(),
+    updatedAt: z.number().optional(),
+  });
+  export type Identity = z.infer<typeof Identity>;
+
+  export const Endpoint = z.object({
+    id: z.string().min(1),
+    actorId: z.string().min(1),
+    channel: z.string().min(1),
+    externalId: z.string().min(1),
+    workspace: z.string().min(1).optional(),
+    displayName: z.string().min(1).optional(),
+    metadata: Metadata.optional(),
+    verifiedAt: z.number().optional(),
+    createdAt: z.number().optional(),
+    updatedAt: z.number().optional(),
+  });
+  export type Endpoint = z.infer<typeof Endpoint>;
+
+  export const ResolvedEndpoint = z.object({
+    identity: Identity,
+    endpoint: Endpoint,
+  });
+  export type ResolvedEndpoint = z.infer<typeof ResolvedEndpoint>;
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -9,6 +9,7 @@ export * from "./bus/index.js";
 export * from "./event/index.js";
 export * from "./mcp/index.js";
 export * from "./adapter/index.js";
+export * from "./actor/index.js";
 export * from "./communication/index.js";
 export * from "./ingress/index.js";
 export * from "./policy/index.js";

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { AgentProfile } from "../agent/index.js";
+import { Actor } from "../actor/index.js";
 import { Model } from "../model/index.js";
 import { Policy } from "../policy/index.js";
 import { Tool } from "../tool/index.js";
@@ -7,9 +8,14 @@ import { Tool } from "../tool/index.js";
 const ActorSchemaImpl = z
   .object({
     id: z.string().optional(),
+    actorId: z.string().optional(),
     role: z.string().optional(),
     kind: z.string().optional(),
     type: z.string().optional(),
+    trustTier: Actor.TrustTier.optional(),
+    relationship: Actor.Relationship.optional(),
+    endpointId: z.string().optional(),
+    endpoint: Actor.Endpoint.optional(),
     sessionId: z.string().optional(),
     workerId: z.string().optional(),
     trusted: z.boolean().optional(),

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -156,7 +156,9 @@ export namespace Ingress {
     DirectEventSchema,
     InternalEventSchema,
   ]);
+  export const ExternalInboundEventSchema = DirectEventSchema;
   export type InboundEvent = DirectEvent | InternalEvent;
+  export type ExternalInboundEvent = DirectEvent;
   export type ResolvedInboundEvent = DirectEvent | (InternalEvent & { agent: AgentDef });
 
   export type DirectResult = {

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -1,3 +1,4 @@
+import type { Actor } from "../actor/index.js";
 import type { Communication } from "../communication/index.js";
 import type { CronJob } from "../cron/index.js";
 import type { WorkItem } from "../work-item/index.js";
@@ -41,5 +42,17 @@ export namespace Storage {
     set(job: CronJob.Info): void;
     list(): CronJob.Info[];
     remove(id: string): boolean;
+  }
+
+  export interface ActorRegistrySubAdapter {
+    getIdentity(id: string): Actor.Identity | undefined;
+    setIdentity(identity: Actor.Identity): void;
+    listIdentities(): Actor.Identity[];
+    removeIdentity(id: string): boolean;
+    getEndpoint(id: string): Actor.Endpoint | undefined;
+    setEndpoint(endpoint: Actor.Endpoint): void;
+    findEndpoint(channel: string, externalId: string): Actor.Endpoint | undefined;
+    listEndpoints(actorId?: string): Actor.Endpoint[];
+    removeEndpoint(id: string): boolean;
   }
 }

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -51,8 +51,12 @@ export namespace Storage {
     removeIdentity(id: string): boolean;
     getEndpoint(id: string): Actor.Endpoint | undefined;
     setEndpoint(endpoint: Actor.Endpoint): void;
-    findEndpoint(channel: string, externalId: string): Actor.Endpoint | undefined;
-    listEndpoints(actorId?: string): Actor.Endpoint[];
+    findEndpoint(
+      channel: string,
+      externalId: string,
+      workspace: string | undefined,
+    ): Actor.Endpoint | undefined;
+    listEndpoints(actorId?: string, workspace?: string): Actor.Endpoint[];
     removeEndpoint(id: string): boolean;
   }
 }

--- a/packages/protocol/test/actor.test.ts
+++ b/packages/protocol/test/actor.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { Actor } from "../src/actor/index.js";
+
+describe("Actor protocol contracts", () => {
+  test("parses canonical identity and endpoint records", () => {
+    // Given
+    const identityInput = {
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+      displayName: "Owner",
+    };
+    const endpointInput = {
+      id: "ep_discord_user_1",
+      actorId: "act_owner",
+      channel: "discord",
+      externalId: "user-1",
+    };
+
+    // When
+    const identity = Actor.Identity.parse(identityInput);
+    const endpoint = Actor.Endpoint.parse(endpointInput);
+
+    // Then
+    expect(identity).toEqual(identityInput);
+    expect(endpoint).toEqual(endpointInput);
+  });
+
+  test("rejects invalid actor vocabulary values", () => {
+    // Given
+    const invalidIdentity = {
+      id: "act_bad",
+      kind: "bot",
+      trustTier: "root",
+      relationship: "stranger",
+    };
+
+    // When
+    const result = Actor.Identity.safeParse(invalidIdentity);
+
+    // Then
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/protocol/test/ingress-internal.test.ts
+++ b/packages/protocol/test/ingress-internal.test.ts
@@ -47,6 +47,18 @@ describe("InternalEventSchema", () => {
     expect(direct.mode).toBe("direct");
   });
 
+  test("external inbound schema rejects internal events", () => {
+    expectParseFailure(() =>
+      Ingress.ExternalInboundEventSchema.parse({
+        id: "t3",
+        surface: "cron",
+        mode: "internal",
+        agentName: "dev",
+        payload: "test",
+      }),
+    );
+  });
+
   test("trigger metadata parses correctly", () => {
     const result = Ingress.InternalEventSchema.parse({
       id: "test-3",

--- a/packages/session/migration/0006_actor_registry/migration.sql
+++ b/packages/session/migration/0006_actor_registry/migration.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS actor_identity (
+  id TEXT PRIMARY KEY,
+  data TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  trust_tier TEXT NOT NULL,
+  relationship TEXT NOT NULL,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_actor_identity_trust_tier ON actor_identity(trust_tier);
+
+CREATE TABLE IF NOT EXISTS actor_endpoint (
+  id TEXT PRIMARY KEY,
+  actor_id TEXT NOT NULL REFERENCES actor_identity(id) ON DELETE CASCADE,
+  data TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_actor_endpoint_actor ON actor_endpoint(actor_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_endpoint_lookup ON actor_endpoint(channel, external_id);

--- a/packages/session/migration/0006_actor_registry/migration.sql
+++ b/packages/session/migration/0006_actor_registry/migration.sql
@@ -15,10 +15,11 @@ CREATE TABLE IF NOT EXISTS actor_endpoint (
   actor_id TEXT NOT NULL REFERENCES actor_identity(id) ON DELETE CASCADE,
   data TEXT NOT NULL,
   channel TEXT NOT NULL,
+  workspace TEXT NOT NULL,
   external_id TEXT NOT NULL,
   time_created INTEGER NOT NULL,
   time_updated INTEGER NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_actor_endpoint_actor ON actor_endpoint(actor_id);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_endpoint_lookup ON actor_endpoint(channel, external_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_endpoint_lookup ON actor_endpoint(channel, workspace, external_id);

--- a/packages/session/src/actor/index.ts
+++ b/packages/session/src/actor/index.ts
@@ -1,0 +1,82 @@
+import { Actor } from "@openomni/protocol";
+import { Storage } from "../storage/storage";
+
+function requireAdapter(): NonNullable<Storage.Adapter["actorRegistry"]> {
+  const adapter = Storage.get().actorRegistry;
+  if (!adapter) throw new Error("Storage adapter does not implement actorRegistry");
+  return adapter;
+}
+
+function withTimestamps<T extends Actor.Identity | Actor.Endpoint>(record: T, existing?: T): T {
+  const now = Date.now();
+  return {
+    ...record,
+    createdAt: record.createdAt ?? existing?.createdAt ?? now,
+    updatedAt: existing ? now : (record.updatedAt ?? now),
+  };
+}
+
+export namespace ActorRegistry {
+  export type Identity = Actor.Identity;
+  export type Endpoint = Actor.Endpoint;
+  export type ResolvedEndpoint = Actor.ResolvedEndpoint;
+
+  export function registerIdentity(input: Identity): Identity {
+    const adapter = requireAdapter();
+    const identity = Actor.Identity.parse(withTimestamps(input, adapter.getIdentity(input.id)));
+    adapter.setIdentity(identity);
+    return identity;
+  }
+
+  export function getIdentity(id: string): Identity | undefined {
+    return requireAdapter().getIdentity(id);
+  }
+
+  export function listIdentities(): Identity[] {
+    return requireAdapter().listIdentities();
+  }
+
+  export function removeIdentity(id: string): boolean {
+    return requireAdapter().removeIdentity(id);
+  }
+
+  export function registerEndpoint(input: Endpoint): Endpoint {
+    const adapter = requireAdapter();
+    const endpoint = Actor.Endpoint.parse(withTimestamps(input, adapter.getEndpoint(input.id)));
+    if (!adapter.getIdentity(endpoint.actorId)) {
+      throw new Error(`Actor identity not found: ${endpoint.actorId}`);
+    }
+    const existingForAddress = adapter.findEndpoint(endpoint.channel, endpoint.externalId);
+    if (existingForAddress && existingForAddress.id !== endpoint.id) {
+      throw new Error(
+        `Actor endpoint already registered for ${endpoint.channel}:${endpoint.externalId}`,
+      );
+    }
+    adapter.setEndpoint(endpoint);
+    return endpoint;
+  }
+
+  export function getEndpoint(id: string): Endpoint | undefined {
+    return requireAdapter().getEndpoint(id);
+  }
+
+  export function listEndpoints(actorId?: string): Endpoint[] {
+    return requireAdapter().listEndpoints(actorId);
+  }
+
+  export function resolveEndpoint(
+    channel: string,
+    externalId: string,
+  ): ResolvedEndpoint | undefined {
+    const adapter = requireAdapter();
+    const endpoint = adapter.findEndpoint(channel, externalId);
+    if (!endpoint) return undefined;
+    const identity = adapter.getIdentity(endpoint.actorId);
+    if (!identity) return undefined;
+    return { identity, endpoint };
+  }
+
+  export function removeEndpoint(id: string): boolean {
+    return requireAdapter().removeEndpoint(id);
+  }
+}

--- a/packages/session/src/actor/index.ts
+++ b/packages/session/src/actor/index.ts
@@ -46,10 +46,14 @@ export namespace ActorRegistry {
     if (!adapter.getIdentity(endpoint.actorId)) {
       throw new Error(`Actor identity not found: ${endpoint.actorId}`);
     }
-    const existingForAddress = adapter.findEndpoint(endpoint.channel, endpoint.externalId);
+    const existingForAddress = adapter.findEndpoint(
+      endpoint.channel,
+      endpoint.externalId,
+      endpoint.workspace,
+    );
     if (existingForAddress && existingForAddress.id !== endpoint.id) {
       throw new Error(
-        `Actor endpoint already registered for ${endpoint.channel}:${endpoint.externalId}`,
+        `Actor endpoint already registered for ${endpoint.channel}:${endpoint.workspace ?? ""}:${endpoint.externalId}`,
       );
     }
     adapter.setEndpoint(endpoint);
@@ -60,16 +64,17 @@ export namespace ActorRegistry {
     return requireAdapter().getEndpoint(id);
   }
 
-  export function listEndpoints(actorId?: string): Endpoint[] {
-    return requireAdapter().listEndpoints(actorId);
+  export function listEndpoints(actorId?: string, workspace?: string): Endpoint[] {
+    return requireAdapter().listEndpoints(actorId, workspace);
   }
 
   export function resolveEndpoint(
     channel: string,
     externalId: string,
+    workspace?: string,
   ): ResolvedEndpoint | undefined {
     const adapter = requireAdapter();
-    const endpoint = adapter.findEndpoint(channel, externalId);
+    const endpoint = adapter.findEndpoint(channel, externalId, workspace);
     if (!endpoint) return undefined;
     const identity = adapter.getIdentity(endpoint.actorId);
     if (!identity) return undefined;

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -7,6 +7,7 @@ export { Session } from "./session";
 export { Snapshot, InMemorySnapshotProvider } from "./snapshot";
 export { SurfaceKey } from "./surface-key";
 export { Artifact } from "./artifact/index";
+export { ActorRegistry } from "./actor/index.js";
 export * from "./worker-run/index.js";
 export { WorkerRunStateStore } from "./worker-run/state-store.js";
 export { TraceContext } from "./trace/index.js";

--- a/packages/session/src/storage/drizzle/schema.ts
+++ b/packages/session/src/storage/drizzle/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const sessionTable = sqliteTable("session", {
   id: text("id").primaryKey(),
@@ -188,3 +188,36 @@ export const cronJobTable = sqliteTable("cron_job", {
   time_created: integer("time_created").notNull(),
   time_updated: integer("time_updated").notNull(),
 });
+
+export const actorIdentityTable = sqliteTable(
+  "actor_identity",
+  {
+    id: text("id").primaryKey(),
+    data: text("data").notNull(),
+    kind: text("kind").notNull(),
+    trust_tier: text("trust_tier").notNull(),
+    relationship: text("relationship").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [index("idx_actor_identity_trust_tier").on(t.trust_tier)],
+);
+
+export const actorEndpointTable = sqliteTable(
+  "actor_endpoint",
+  {
+    id: text("id").primaryKey(),
+    actor_id: text("actor_id")
+      .notNull()
+      .references(() => actorIdentityTable.id, { onDelete: "cascade" }),
+    data: text("data").notNull(),
+    channel: text("channel").notNull(),
+    external_id: text("external_id").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_actor_endpoint_actor").on(t.actor_id),
+    uniqueIndex("idx_actor_endpoint_lookup").on(t.channel, t.external_id),
+  ],
+);

--- a/packages/session/src/storage/drizzle/schema.ts
+++ b/packages/session/src/storage/drizzle/schema.ts
@@ -212,12 +212,13 @@ export const actorEndpointTable = sqliteTable(
       .references(() => actorIdentityTable.id, { onDelete: "cascade" }),
     data: text("data").notNull(),
     channel: text("channel").notNull(),
+    workspace: text("workspace").notNull(),
     external_id: text("external_id").notNull(),
     time_created: integer("time_created").notNull(),
     time_updated: integer("time_updated").notNull(),
   },
   (t) => [
     index("idx_actor_endpoint_actor").on(t.actor_id),
-    uniqueIndex("idx_actor_endpoint_lookup").on(t.channel, t.external_id),
+    uniqueIndex("idx_actor_endpoint_lookup").on(t.channel, t.workspace, t.external_id),
   ],
 );

--- a/packages/session/src/storage/sqlite-actor-registry-adapter.ts
+++ b/packages/session/src/storage/sqlite-actor-registry-adapter.ts
@@ -5,6 +5,10 @@ import { z } from "zod";
 const DataRow = z.object({ data: z.string() });
 const DataRows = z.array(DataRow);
 
+function workspaceKey(workspace: string | undefined): string {
+  return workspace ?? "";
+}
+
 export function createSqliteActorRegistryAdapter(
   db: Database,
 ): ProtocolStorage.ActorRegistrySubAdapter {
@@ -56,12 +60,13 @@ export function createSqliteActorRegistryAdapter(
       const now = Date.now();
       db.query(
         `INSERT INTO actor_endpoint (
-           id, actor_id, data, channel, external_id, time_created, time_updated
-         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+           id, actor_id, data, channel, workspace, external_id, time_created, time_updated
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id) DO UPDATE SET
            actor_id = excluded.actor_id,
            data = excluded.data,
            channel = excluded.channel,
+           workspace = excluded.workspace,
            external_id = excluded.external_id,
            time_updated = excluded.time_updated`,
       ).run(
@@ -69,30 +74,51 @@ export function createSqliteActorRegistryAdapter(
         endpoint.actorId,
         JSON.stringify(endpoint),
         endpoint.channel,
+        workspaceKey(endpoint.workspace),
         endpoint.externalId,
         endpoint.createdAt ?? now,
         endpoint.updatedAt ?? now,
       );
     },
-    findEndpoint(channel, externalId) {
+    findEndpoint(channel, externalId, workspace) {
       const row = DataRow.nullable().parse(
         db
-          .query("SELECT data FROM actor_endpoint WHERE channel = ? AND external_id = ?")
-          .get(channel, externalId),
+          .query(
+            `SELECT data FROM actor_endpoint
+             WHERE channel = ? AND workspace = ? AND external_id = ?`,
+          )
+          .get(channel, workspaceKey(workspace), externalId),
       );
       return row ? Actor.Endpoint.parse(JSON.parse(row.data)) : undefined;
     },
-    listEndpoints(actorId) {
+    listEndpoints(actorId, workspace) {
+      const workspaceFilter = workspaceKey(workspace);
       const rows = DataRows.parse(
-        actorId === undefined
+        actorId === undefined && workspace === undefined
           ? db.query("SELECT data FROM actor_endpoint ORDER BY time_created ASC, id ASC").all()
-          : db
-              .query(
-                `SELECT data FROM actor_endpoint
-                 WHERE actor_id = ?
-                 ORDER BY time_created ASC, id ASC`,
-              )
-              .all(actorId),
+          : actorId === undefined
+            ? db
+                .query(
+                  `SELECT data FROM actor_endpoint
+                   WHERE workspace = ?
+                   ORDER BY time_created ASC, id ASC`,
+                )
+                .all(workspaceFilter)
+            : workspace === undefined
+              ? db
+                  .query(
+                    `SELECT data FROM actor_endpoint
+                     WHERE actor_id = ?
+                     ORDER BY time_created ASC, id ASC`,
+                  )
+                  .all(actorId)
+              : db
+                  .query(
+                    `SELECT data FROM actor_endpoint
+                     WHERE actor_id = ? AND workspace = ?
+                     ORDER BY time_created ASC, id ASC`,
+                  )
+                  .all(actorId, workspaceFilter),
       );
       return rows.map((row) => Actor.Endpoint.parse(JSON.parse(row.data)));
     },

--- a/packages/session/src/storage/sqlite-actor-registry-adapter.ts
+++ b/packages/session/src/storage/sqlite-actor-registry-adapter.ts
@@ -1,0 +1,103 @@
+import type { Database } from "bun:sqlite";
+import { Actor, type Storage as ProtocolStorage } from "@openomni/protocol";
+import { z } from "zod";
+
+const DataRow = z.object({ data: z.string() });
+const DataRows = z.array(DataRow);
+
+export function createSqliteActorRegistryAdapter(
+  db: Database,
+): ProtocolStorage.ActorRegistrySubAdapter {
+  return {
+    getIdentity(id) {
+      const row = DataRow.nullable().parse(
+        db.query("SELECT data FROM actor_identity WHERE id = ?").get(id),
+      );
+      return row ? Actor.Identity.parse(JSON.parse(row.data)) : undefined;
+    },
+    setIdentity(identity) {
+      const now = Date.now();
+      db.query(
+        `INSERT INTO actor_identity (
+           id, data, kind, trust_tier, relationship, time_created, time_updated
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           data = excluded.data,
+           kind = excluded.kind,
+           trust_tier = excluded.trust_tier,
+           relationship = excluded.relationship,
+           time_updated = excluded.time_updated`,
+      ).run(
+        identity.id,
+        JSON.stringify(identity),
+        identity.kind,
+        identity.trustTier,
+        identity.relationship,
+        identity.createdAt ?? now,
+        identity.updatedAt ?? now,
+      );
+    },
+    listIdentities() {
+      const rows = DataRows.parse(
+        db.query("SELECT data FROM actor_identity ORDER BY time_created ASC, id ASC").all(),
+      );
+      return rows.map((row) => Actor.Identity.parse(JSON.parse(row.data)));
+    },
+    removeIdentity(id) {
+      return db.query("DELETE FROM actor_identity WHERE id = ?").run(id).changes > 0;
+    },
+    getEndpoint(id) {
+      const row = DataRow.nullable().parse(
+        db.query("SELECT data FROM actor_endpoint WHERE id = ?").get(id),
+      );
+      return row ? Actor.Endpoint.parse(JSON.parse(row.data)) : undefined;
+    },
+    setEndpoint(endpoint) {
+      const now = Date.now();
+      db.query(
+        `INSERT INTO actor_endpoint (
+           id, actor_id, data, channel, external_id, time_created, time_updated
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           actor_id = excluded.actor_id,
+           data = excluded.data,
+           channel = excluded.channel,
+           external_id = excluded.external_id,
+           time_updated = excluded.time_updated`,
+      ).run(
+        endpoint.id,
+        endpoint.actorId,
+        JSON.stringify(endpoint),
+        endpoint.channel,
+        endpoint.externalId,
+        endpoint.createdAt ?? now,
+        endpoint.updatedAt ?? now,
+      );
+    },
+    findEndpoint(channel, externalId) {
+      const row = DataRow.nullable().parse(
+        db
+          .query("SELECT data FROM actor_endpoint WHERE channel = ? AND external_id = ?")
+          .get(channel, externalId),
+      );
+      return row ? Actor.Endpoint.parse(JSON.parse(row.data)) : undefined;
+    },
+    listEndpoints(actorId) {
+      const rows = DataRows.parse(
+        actorId === undefined
+          ? db.query("SELECT data FROM actor_endpoint ORDER BY time_created ASC, id ASC").all()
+          : db
+              .query(
+                `SELECT data FROM actor_endpoint
+                 WHERE actor_id = ?
+                 ORDER BY time_created ASC, id ASC`,
+              )
+              .all(actorId),
+      );
+      return rows.map((row) => Actor.Endpoint.parse(JSON.parse(row.data)));
+    },
+    removeEndpoint(id) {
+      return db.query("DELETE FROM actor_endpoint WHERE id = ?").run(id).changes > 0;
+    },
+  };
+}

--- a/packages/session/src/storage/sqlite-schema-lifecycle.ts
+++ b/packages/session/src/storage/sqlite-schema-lifecycle.ts
@@ -10,10 +10,13 @@ const ORDERED_MIGRATIONS: Migration.Definition[] = [
   { name: "0003_communication_state_constraints/migration.sql" },
   { name: "0004_cron_job/migration.sql" },
   { name: "0005_worker_run_executor_kind/migration.sql" },
+  { name: "0006_actor_registry/migration.sql" },
 ];
 
 const CLEAR_ORDER = [
   "event_chain",
+  "actor_endpoint",
+  "actor_identity",
   "cron_job",
   "worker_grant",
   "pending_ask",

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import type { WorkerRunStateStore } from "../worker-run/state-store";
+import { createSqliteActorRegistryAdapter } from "./sqlite-actor-registry-adapter";
 import { createSqliteArtifactAdapter } from "./sqlite-artifact-adapter";
 import { createSqliteBackgroundTaskAdapter } from "./sqlite-background-task-adapter";
 import { createSqliteCronJobAdapter } from "./sqlite-cron-job-adapter";
@@ -28,6 +29,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
   readonly pendingAsk: NonNullable<Storage.Adapter["pendingAsk"]>;
   readonly workerGrant: NonNullable<Storage.Adapter["workerGrant"]>;
   readonly cronJob: NonNullable<Storage.Adapter["cronJob"]>;
+  readonly actorRegistry: NonNullable<Storage.Adapter["actorRegistry"]>;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
@@ -49,6 +51,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
     this.pendingAsk = createSqlitePendingAskAdapter(this.db);
     this.workerGrant = createSqliteWorkerGrantAdapter(this.db);
     this.cronJob = createSqliteCronJobAdapter(this.db);
+    this.actorRegistry = createSqliteActorRegistryAdapter(this.db);
   }
 
   clear(): void {

--- a/packages/session/src/storage/storage.ts
+++ b/packages/session/src/storage/storage.ts
@@ -66,6 +66,7 @@ export namespace Storage {
     pendingAsk?: ProtocolStorage.PendingAskSubAdapter;
     workerGrant?: ProtocolStorage.WorkerGrantSubAdapter;
     cronJob?: ProtocolStorage.CronJobSubAdapter;
+    actorRegistry?: ProtocolStorage.ActorRegistrySubAdapter;
   }
 }
 

--- a/packages/session/test/actor/persistence.test.ts
+++ b/packages/session/test/actor/persistence.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ActorRegistry, SqliteStorageAdapter, Storage } from "../../src/index.js";
+
+describe("ActorRegistry SQLite persistence", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "actor-registry-test-"));
+    dbPath = join(tmpDir, "test.db");
+    Storage.initialize({ dbPath: ":memory:" });
+    Storage.configure(new SqliteStorageAdapter(dbPath));
+  });
+
+  afterEach(async () => {
+    Storage.reset();
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("resolves registered endpoints across storage re-init", () => {
+    // Given
+    ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+    });
+    ActorRegistry.registerEndpoint({
+      id: "ep_discord_user_1",
+      actorId: "act_owner",
+      channel: "discord",
+      externalId: "user-1",
+    });
+
+    // When
+    Storage.configure(new SqliteStorageAdapter(dbPath));
+    const resolved = ActorRegistry.resolveEndpoint("discord", "user-1");
+
+    // Then
+    expect(resolved?.identity.id).toBe("act_owner");
+    expect(resolved?.identity.trustTier).toBe("owner");
+    expect(resolved?.endpoint.id).toBe("ep_discord_user_1");
+  });
+
+  test("returns undefined for unregistered endpoints", () => {
+    // Given
+    ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+    });
+
+    // When
+    const resolved = ActorRegistry.resolveEndpoint("discord", "unknown-user");
+
+    // Then
+    expect(resolved).toBeUndefined();
+  });
+
+  test("preserves createdAt when re-registering an identity", () => {
+    // Given
+    const createdAt = 100;
+    ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    // When
+    const updated = ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "manager",
+      relationship: "owner",
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    // Then
+    expect(updated.createdAt).toBe(createdAt);
+    expect(updated.updatedAt).toBeGreaterThan(createdAt);
+    expect(ActorRegistry.getIdentity("act_owner")?.trustTier).toBe("manager");
+  });
+
+  test("rejects endpoints for unknown actor identities", () => {
+    // When / Then
+    expect(() =>
+      ActorRegistry.registerEndpoint({
+        id: "ep_missing_actor",
+        actorId: "act_missing",
+        channel: "discord",
+        externalId: "user-1",
+      }),
+    ).toThrow("Actor identity not found: act_missing");
+  });
+
+  test("rejects duplicate endpoint addresses with different endpoint ids", () => {
+    // Given
+    ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+    });
+    ActorRegistry.registerEndpoint({
+      id: "ep_discord_user_1",
+      actorId: "act_owner",
+      channel: "discord",
+      externalId: "user-1",
+    });
+
+    // When / Then
+    expect(() =>
+      ActorRegistry.registerEndpoint({
+        id: "ep_discord_user_1_duplicate",
+        actorId: "act_owner",
+        channel: "discord",
+        externalId: "user-1",
+      }),
+    ).toThrow("Actor endpoint already registered for discord:user-1");
+  });
+
+  test("removing an identity removes its endpoints through SQLite cascade", () => {
+    // Given
+    ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+    });
+    ActorRegistry.registerEndpoint({
+      id: "ep_discord_user_1",
+      actorId: "act_owner",
+      channel: "discord",
+      externalId: "user-1",
+    });
+
+    // When
+    ActorRegistry.removeIdentity("act_owner");
+
+    // Then
+    expect(ActorRegistry.getEndpoint("ep_discord_user_1")).toBeUndefined();
+    expect(ActorRegistry.resolveEndpoint("discord", "user-1")).toBeUndefined();
+  });
+});

--- a/packages/session/test/actor/persistence.test.ts
+++ b/packages/session/test/actor/persistence.test.ts
@@ -33,11 +33,12 @@ describe("ActorRegistry SQLite persistence", () => {
       actorId: "act_owner",
       channel: "discord",
       externalId: "user-1",
+      workspace: "guild",
     });
 
     // When
     Storage.configure(new SqliteStorageAdapter(dbPath));
-    const resolved = ActorRegistry.resolveEndpoint("discord", "user-1");
+    const resolved = ActorRegistry.resolveEndpoint("discord", "user-1", "guild");
 
     // Then
     expect(resolved?.identity.id).toBe("act_owner");
@@ -114,6 +115,7 @@ describe("ActorRegistry SQLite persistence", () => {
       actorId: "act_owner",
       channel: "discord",
       externalId: "user-1",
+      workspace: "guild",
     });
 
     // When / Then
@@ -123,8 +125,50 @@ describe("ActorRegistry SQLite persistence", () => {
         actorId: "act_owner",
         channel: "discord",
         externalId: "user-1",
+        workspace: "guild",
       }),
-    ).toThrow("Actor endpoint already registered for discord:user-1");
+    ).toThrow("Actor endpoint already registered for discord:guild:user-1");
+  });
+
+  test("allows the same endpoint address in different workspaces", () => {
+    // Given
+    ActorRegistry.registerIdentity({
+      id: "act_owner",
+      kind: "human",
+      trustTier: "owner",
+      relationship: "owner",
+    });
+    ActorRegistry.registerIdentity({
+      id: "act_collaborator",
+      kind: "human",
+      trustTier: "collaborator",
+      relationship: "collaborator",
+    });
+    ActorRegistry.registerEndpoint({
+      id: "ep_discord_user_1_guild_a",
+      actorId: "act_owner",
+      channel: "discord",
+      externalId: "user-1",
+      workspace: "guild-a",
+    });
+
+    // When
+    ActorRegistry.registerEndpoint({
+      id: "ep_discord_user_1_guild_b",
+      actorId: "act_collaborator",
+      channel: "discord",
+      externalId: "user-1",
+      workspace: "guild-b",
+    });
+
+    // Then
+    expect(ActorRegistry.resolveEndpoint("discord", "user-1", "guild-a")?.identity.id).toBe(
+      "act_owner",
+    );
+    expect(ActorRegistry.resolveEndpoint("discord", "user-1", "guild-b")?.identity.id).toBe(
+      "act_collaborator",
+    );
+    expect(ActorRegistry.resolveEndpoint("discord", "user-1", "guild-c")).toBeUndefined();
   });
 
   test("removing an identity removes its endpoints through SQLite cascade", () => {
@@ -140,6 +184,7 @@ describe("ActorRegistry SQLite persistence", () => {
       actorId: "act_owner",
       channel: "discord",
       externalId: "user-1",
+      workspace: "guild",
     });
 
     // When
@@ -147,6 +192,6 @@ describe("ActorRegistry SQLite persistence", () => {
 
     // Then
     expect(ActorRegistry.getEndpoint("ep_discord_user_1")).toBeUndefined();
-    expect(ActorRegistry.resolveEndpoint("discord", "user-1")).toBeUndefined();
+    expect(ActorRegistry.resolveEndpoint("discord", "user-1", "guild")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add canonical Actor identity/endpoint schemas and storage adapter contracts
- add SQLite-backed ActorRegistry persistence with migration and Drizzle schema
- resolve registered ingress endpoints into canonical actor metadata before inbound policy, while allowlist-sanitizing unresolved actor metadata back to legacy id/role
- update implementation status for only the ActorResolver / ActorIdentity / ActorEndpoint / ActorRegistry row

## Validation
- `bun test packages/protocol/test/actor.test.ts packages/session/test/actor/persistence.test.ts packages/openomni/test/ingress/actor-resolver.test.ts packages/openomni/test/ingress/actor-resolver-sanitization.test.ts`
- LSP diagnostics on changed TS files: no diagnostics
- no-excuse rules: no violations in 13 files
- `git diff --check`
- `bun run lint`
- `bun run build`
- `bun run check-types`
- `bun run test`
- real SQLite + IngressEngine smoke evidence for registered, unregistered, spoofed, and no-userId paths
- Claude Fable 5 oracle: APPROVE
- ultrawork reviewer: APPROVE

## Notes
- ChannelGrant and TrustTier evaluation remain pending; this only wires canonical identity resolution and registry storage.
- Pre-push dep-check reported stale `packages/llm/AGENTS.md` and `packages/agent/AGENTS.md` warnings, but no violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical actor identity/endpoint registry and resolves ingress actors from registered `(surface/channel, workspace, userId)` before policy; unregistered or mismatched endpoints are sanitized to legacy `{ id, role }`. External ingress now validates with the direct-event schema and projects the resolved actor into `toolInput.actor` and audit context.

- **New Features**
  - Protocol: adds `Actor.Identity`, `Actor.Endpoint`, `Actor.ResolvedEndpoint`; extends `Ingress.Actor` with `actorId`, `trustTier`, `relationship`, `endpointId`, `endpoint`.
  - Session (`@openomni/session`): adds `ActorRegistry` with SQLite adapter, CRUD APIs, and unique `(channel, workspace, externalId)` constraint.
  - OpenOmni: resolves using registry with strict surface + workspace scoping; strips spoofed fields; parses external events with `Ingress.DirectEventSchema`; projects actor into `toolInput.actor` and audit context.

- **Migration**
  - Adds `0006_actor_registry` SQLite migration; applied by `SqliteStorageAdapter`.
  - Adapters without `actorRegistry` continue to work; actor resolution is skipped.

<sup>Written for commit 4a27cbf57aa91970c8e52b9bcc6095cf641bc7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented actor identity and endpoint registry system for managing actor metadata across communication channels
  * Added automatic resolution and enrichment of inbound events with resolved actor identity and endpoint information
  * Enabled persistent storage of actor identities and endpoints in SQLite database

* **Documentation**
  * Updated implementation status to reflect completed actor resolver and registry functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->