### PR TITLE
feat(openomni): enforce actor blacklist gate

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -15,7 +15,7 @@ Single source of truth for the gap between accepted design and running code. Oth
 | `ActorResolver` / `ActorIdentity` / `ActorEndpoint` / `ActorRegistry` | ✅ | `packages/protocol/src/actor/`, `packages/session/src/actor/`, `packages/openomni/src/ingress/actor-resolver.ts` | Canonical actor identity + endpoint schemas, SQLite-backed registry, and ingress resolution for registered `(channel, workspace, externalId)` endpoints are wired, where `channel` is the platform/surface identifier. Unregistered endpoints are sanitized back to legacy `id`/`role`; ChannelGrant and TrustTier evaluation remain pending below |
 | DispatchRuntime (policy authorize → handler routing) | ✅ | `packages/openomni/src/dispatch/runtime.ts` | Actions: `resident.ask`, `worker.spawn/send/resume/cancel`, `schedule.create/cancel` |
 | WorkerGrant evaluation | ✅ | `packages/openomni/src/dispatch/policy.ts` | The only authority axis currently evaluated |
-| Blacklist | 📋 | — | Checked nowhere |
+| Blacklist | ✅ | `packages/protocol/src/actor/`, `packages/session/src/blacklist/`, `packages/openomni/src/ingress/middleware/ingress-authority.ts`, `packages/openomni/src/dispatch/policy.ts` | Actor/endpoint/channel/pattern blacklist entries are schema-backed, persisted in SQLite, and checked as an absolute deny gate on both inbound ingress and dispatch authorization. PendingInteraction, ChannelGrant, and TrustTier evaluation remain pending below |
 | ChannelGrant (+ inbound treatment ceiling) | 📋 | — | |
 | `TrustTier` enum + evaluation | 📋 | — | Loose string field on `Dispatch.ActorContext`; never evaluated. Ingress authority still string-matches roles |
 | `effectiveAuthority` (5-axis intersection) | 📋 | — | |

--- a/packages/openomni/src/dispatch/policy.ts
+++ b/packages/openomni/src/dispatch/policy.ts
@@ -1,6 +1,6 @@
 import { PolicyDecision, type Dispatch, type Policy } from "@openomni/protocol";
 import type { PolicyRegistration } from "@openomni/agent";
-import { WorkerGrantStore } from "@openomni/session";
+import { BlacklistStore, WorkerGrantStore } from "@openomni/session";
 
 function deny(reason: string): Policy.PolicyDecision {
   return PolicyDecision.deny({
@@ -21,6 +21,26 @@ function allow(reason: string): Policy.PolicyDecision {
   });
 }
 
+function blacklistReason(kind: string, value: string, reason: string | undefined): string {
+  return reason ?? `dispatch.blacklist.${kind}.${value}`;
+}
+
+function blacklistMatchInput(
+  actor: Dispatch.ActorContext | undefined,
+  target: Dispatch.Target | undefined,
+) {
+  return {
+    actorId: actor?.actorId,
+    endpointId: target?.kind === "external_actor" ? (target.id ?? target.name) : undefined,
+    channel: target?.kind === "surface" ? (target.id ?? target.name) : undefined,
+    candidates: [
+      ...(target?.id ? [target.id] : []),
+      ...(target?.name ? [target.name] : []),
+      ...(target?.labels ?? []),
+    ],
+  };
+}
+
 export function createDefaultDispatchPolicy(): PolicyRegistration {
   return {
     name: "dispatch.default-authority",
@@ -36,6 +56,10 @@ export function createDefaultDispatchPolicy(): PolicyRegistration {
       const action = typeof input.action === "string" ? input.action : "";
       const actor = input.actor;
       const target = input.target;
+      const blacklisted = BlacklistStore.match(blacklistMatchInput(actor, target));
+      if (blacklisted) {
+        return deny(blacklistReason(blacklisted.kind, blacklisted.value, blacklisted.reason));
+      }
 
       if (!actor || actor.kind === "unknown") {
         return deny("dispatch.actor.required");

--- a/packages/openomni/src/execution-runtime/cron-job-registry.ts
+++ b/packages/openomni/src/execution-runtime/cron-job-registry.ts
@@ -4,7 +4,7 @@ import { Bus, Storage } from "@openomni/session";
 const jobs = new Map<string, CronJob.Info>();
 
 function adapter() {
-  if (Storage.initializedDbPath === null) return undefined;
+  if (Storage.getInitializedDbPath() === null) return undefined;
   return Storage.get().cronJob;
 }
 

--- a/packages/openomni/src/ingress/middleware/ingress-authority.ts
+++ b/packages/openomni/src/ingress/middleware/ingress-authority.ts
@@ -1,5 +1,6 @@
 import { PolicyEngine, type PolicyRegistration } from "@openomni/agent";
 import { Policy, PolicyDecision, Ingress, type TraceContext } from "@openomni/protocol";
+import { BlacklistStore } from "@openomni/session";
 import type { ZodError } from "zod";
 import type { CoordinatorLike } from "../coordinator-like";
 import { resolveTarget, targetKey } from "../target";
@@ -38,6 +39,10 @@ function abortDecision(policyId: string, reason: string): Policy.PolicyDecision 
     reasonCodes: [reason],
     effects: [{ type: "run.abort", reason }],
   });
+}
+
+function blacklistReason(kind: string, value: string, reason: string | undefined): string {
+  return reason ?? `blacklist.${kind}.${value}`;
 }
 
 function getActor(event: Ingress.InboundEvent): ActorRecord | undefined {
@@ -203,6 +208,32 @@ function evaluateIngressAuthority(event: Ingress.InboundEvent): Policy.PolicyDec
   return { ...decision, factsUsed: resourceLabels };
 }
 
+function createBlacklistCheck(state: PreRunState): PolicyRegistration {
+  return {
+    ...IngressAuthorityMiddleware.BlacklistCheck,
+    failPolicy: "fail-closed",
+    fn: () => {
+      const event = requireParsedEvent(state);
+      const actor = getActor(event);
+      const entry = BlacklistStore.match({
+        actorId: typeof actor?.actorId === "string" ? actor.actorId : undefined,
+        endpointId: typeof actor?.endpointId === "string" ? actor.endpointId : undefined,
+        channel: event.surface,
+        candidates: [
+          event.surface,
+          ...(event.channel ? [event.channel] : []),
+          `${event.surface}:${event.workspace ?? ""}:${event.channel ?? ""}`,
+        ],
+      });
+      if (!entry) return allowDecision("ingress.blacklist", "blacklist.clear");
+      return abortDecision(
+        "ingress.blacklist",
+        blacklistReason(entry.kind, entry.value, entry.reason),
+      );
+    },
+  };
+}
+
 function requireParsedEvent(state: PreRunState): Ingress.InboundEvent {
   if (!state.parsedEvent) {
     throw new Error("ingress event must be schema-validated before authority middleware");
@@ -302,6 +333,13 @@ export namespace IngressAuthorityMiddleware {
     failPolicy: "fail-closed",
   } as const satisfies Policy.Definition;
 
+  export const BlacklistCheck = {
+    name: "ingress:blacklist",
+    timing: "run.start",
+    priority: 5,
+    failPolicy: "fail-closed",
+  } as const satisfies Policy.Definition;
+
   export const AuthorityCheck = {
     name: "ingress:authority",
     timing: "run.start",
@@ -333,6 +371,7 @@ export namespace IngressAuthorityMiddleware {
   export function registrations(state: PreRunState): PolicyRegistration[] {
     return [
       createSchemaValidation(state),
+      createBlacklistCheck(state),
       createCoordinatorPresence(state),
       createAuthorityCheck(state),
       createModeDispatch(state),

--- a/packages/openomni/test/dispatch/runtime.test.ts
+++ b/packages/openomni/test/dispatch/runtime.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { Operational, PolicyDecision, type Dispatch as DispatchProtocol } from "@openomni/protocol";
-import { Bus, Session, Storage, WorkerGrantStore, WorkerRun } from "@openomni/session";
+import {
+  BlacklistStore,
+  Bus,
+  Session,
+  Storage,
+  WorkerGrantStore,
+  WorkerRun,
+} from "@openomni/session";
 import { DispatchRuntime } from "../../src/dispatch/runtime";
 
 const flushBus = () => new Promise((resolve) => queueMicrotask(resolve));
@@ -94,6 +101,36 @@ describe("DispatchRuntime", () => {
     expect(called).toBe(false);
     expect(events).toContain("dispatch.denied");
     expect(events).not.toContain("dispatch.routed");
+  });
+
+  test("default policy blocks blacklisted external targets before routing", async () => {
+    Storage.initialize({ dbPath: ":memory:" });
+    BlacklistStore.put({
+      id: "bl-endpoint",
+      kind: "endpoint",
+      value: "ep_blocked",
+      reason: "blocked endpoint",
+      createdBy: "act_owner",
+    });
+    let called = false;
+    const runtime = new DispatchRuntime();
+    runtime.register("external.ask", () => {
+      called = true;
+      return { output: "sent" };
+    });
+
+    const result = await runtime.submit(
+      {
+        action: "external.ask",
+        target: { kind: "external_actor", id: "ep_blocked" },
+        payload: "hello",
+      },
+      { agentName: "resident", actorKind: "resident", actorId: "act_resident" },
+    );
+
+    expect(result.status).toBe("denied");
+    expect(result.reason).toBe("blocked endpoint");
+    expect(called).toBe(false);
   });
 
   test("default policy denies worker spawning independent work", async () => {

--- a/packages/openomni/test/execution-runtime/cron-job-registry.test.ts
+++ b/packages/openomni/test/execution-runtime/cron-job-registry.test.ts
@@ -53,7 +53,7 @@ describe("CronJobRegistry persistence", () => {
 
     CronJobRegistry.register(job);
 
-    expect(Storage.initializedDbPath).toBeNull();
+    expect(Storage.getInitializedDbPath()).toBeNull();
     expect(CronJobRegistry.list()).toEqual([job]);
     expect(CronJobRegistry.remove(job.id)).toBe(true);
     expect(CronJobRegistry.list()).toEqual([]);

--- a/packages/openomni/test/ingress/blacklist.test.ts
+++ b/packages/openomni/test/ingress/blacklist.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { BlacklistStore } from "@openomni/session";
+import {
+  captureActorPolicy,
+  getIngressEngine,
+  makeEvent,
+  registerOwnerEndpoint,
+  setupIngressActorResolverTest,
+  testState,
+} from "./_actor-resolver-fixture";
+
+setupIngressActorResolverTest();
+
+describe("Ingress blacklist", () => {
+  it("blocks registered blacklisted actors before inbound policies", async () => {
+    registerOwnerEndpoint("guild");
+    BlacklistStore.put({
+      id: "bl-owner",
+      kind: "actor",
+      value: "act_owner",
+      reason: "blocked actor",
+      createdBy: "act_owner",
+    });
+    const engine = getIngressEngine();
+    let inboundPolicyCalled = false;
+    engine.registerIngressPolicy(
+      captureActorPolicy(() => {
+        inboundPolicyCalled = true;
+      }),
+    );
+    testState.responseQueue.push("ok");
+
+    let caughtError: Error | undefined;
+    try {
+      await engine.ingest(makeEvent("user-1"));
+    } catch (err) {
+      if (!(err instanceof Error)) throw err;
+      caughtError = err;
+    }
+
+    expect(caughtError?.message).toContain("blocked actor");
+    expect(inboundPolicyCalled).toBe(false);
+  });
+
+  it("blocks blacklisted channels before resident execution", async () => {
+    BlacklistStore.put({
+      id: "bl-channel",
+      kind: "channel",
+      value: "discord:guild:dev",
+      createdBy: "act_owner",
+    });
+    const engine = getIngressEngine();
+    testState.responseQueue.push("ok");
+
+    let caughtError: Error | undefined;
+    try {
+      await engine.ingest(makeEvent("unknown-user"));
+    } catch (err) {
+      if (!(err instanceof Error)) throw err;
+      caughtError = err;
+    }
+
+    expect(caughtError?.message).toContain("blacklist.channel.discord:guild:dev");
+    expect(testState.llmInputs).toHaveLength(0);
+  });
+});

--- a/packages/openomni/test/policy/middleware-integration.test.ts
+++ b/packages/openomni/test/policy/middleware-integration.test.ts
@@ -318,14 +318,15 @@ describe("IngressAuthorityMiddleware integration", () => {
     }
   });
 
-  test("registrations produce all four middleware steps", () => {
+  test("registrations produce all five middleware steps", () => {
     const state = { input: makeInboundEvent(), coordinator: stubCoordinator };
     const regs = IngressAuthorityMiddleware.registrations(state as never);
 
-    expect(regs).toHaveLength(4);
+    expect(regs).toHaveLength(5);
     const names = regs.map((r) => r.name);
     expect(names).toContain("ingress:coordinator-presence");
     expect(names).toContain("ingress:schema-validation");
+    expect(names).toContain("ingress:blacklist");
     expect(names).toContain("ingress:authority");
     expect(names).toContain("ingress:mode-dispatch");
   });

--- a/packages/protocol/src/actor/index.ts
+++ b/packages/protocol/src/actor/index.ts
@@ -65,4 +65,19 @@ export namespace Actor {
     endpoint: Endpoint,
   });
   export type ResolvedEndpoint = z.infer<typeof ResolvedEndpoint>;
+
+  export const BlacklistKind = z.enum(["actor", "endpoint", "channel", "pattern"]);
+  export type BlacklistKind = z.infer<typeof BlacklistKind>;
+
+  export const BlacklistEntry = z.object({
+    id: z.string().min(1),
+    kind: BlacklistKind,
+    value: z.string().min(1),
+    reason: z.string().min(1).optional(),
+    expiresAt: z.number().optional(),
+    createdBy: z.string().min(1),
+    createdAt: z.number().optional(),
+    updatedAt: z.number().optional(),
+  });
+  export type BlacklistEntry = z.infer<typeof BlacklistEntry>;
 }

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -59,4 +59,11 @@ export namespace Storage {
     listEndpoints(actorId?: string, workspace?: string): Actor.Endpoint[];
     removeEndpoint(id: string): boolean;
   }
+
+  export interface BlacklistSubAdapter {
+    get(id: string): Actor.BlacklistEntry | undefined;
+    set(entry: Actor.BlacklistEntry): void;
+    list(): Actor.BlacklistEntry[];
+    remove(id: string): boolean;
+  }
 }

--- a/packages/protocol/test/blacklist.test.ts
+++ b/packages/protocol/test/blacklist.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { Actor } from "../src/actor/index.js";
+
+describe("Blacklist protocol contracts", () => {
+  test("parses active actor, endpoint, channel, and pattern entries", () => {
+    for (const kind of ["actor", "endpoint", "channel", "pattern"] as const) {
+      const entry = Actor.BlacklistEntry.parse({
+        id: `bl-${kind}`,
+        kind,
+        value: `${kind}:value`,
+        reason: "abuse",
+        createdBy: "act_owner",
+      });
+
+      expect(entry.kind).toBe(kind);
+      expect(entry.createdBy).toBe("act_owner");
+    }
+  });
+
+  test("rejects entries without an audit creator", () => {
+    let failed = false;
+    try {
+      Actor.BlacklistEntry.parse({
+        id: "bl-missing-creator",
+        kind: "actor",
+        value: "act_bad",
+      });
+    } catch {
+      failed = true;
+    }
+
+    expect(failed).toBe(true);
+  });
+});

--- a/packages/session/migration/0007_blacklist/migration.sql
+++ b/packages/session/migration/0007_blacklist/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS blacklist (
+  id TEXT PRIMARY KEY,
+  data TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  value TEXT NOT NULL,
+  expires_at INTEGER,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_blacklist_kind_value ON blacklist(kind, value);
+CREATE INDEX IF NOT EXISTS idx_blacklist_expires ON blacklist(expires_at);

--- a/packages/session/src/blacklist/index.ts
+++ b/packages/session/src/blacklist/index.ts
@@ -1,0 +1,88 @@
+import { Actor } from "@openomni/protocol";
+import { Storage } from "../storage/storage";
+
+export interface BlacklistMatchInput {
+  readonly actorId?: string;
+  readonly endpointId?: string;
+  readonly channel?: string;
+  readonly candidates?: readonly string[];
+}
+
+function adapter(): Storage.Adapter["blacklist"] {
+  return Storage.get().blacklist;
+}
+
+function requireAdapter(): NonNullable<Storage.Adapter["blacklist"]> {
+  const current = adapter();
+  if (!current) throw new Error("Storage adapter does not implement blacklist");
+  return current;
+}
+
+function withTimestamps(entry: Actor.BlacklistEntry, existing?: Actor.BlacklistEntry) {
+  const now = Date.now();
+  return {
+    ...entry,
+    createdAt: entry.createdAt ?? existing?.createdAt ?? now,
+    updatedAt: existing ? now : (entry.updatedAt ?? now),
+  };
+}
+
+function isActive(entry: Actor.BlacklistEntry, now: number): boolean {
+  return entry.expiresAt === undefined || entry.expiresAt > now;
+}
+
+function wildcardMatches(pattern: string, candidate: string): boolean {
+  if (pattern === "*") return true;
+  const parts = pattern.split("*");
+  if (parts.length === 1) return pattern === candidate;
+
+  let offset = 0;
+  for (const [index, part] of parts.entries()) {
+    if (part === "") continue;
+    const found = candidate.indexOf(part, offset);
+    if (found === -1) return false;
+    if (index === 0 && found !== 0) return false;
+    offset = found + part.length;
+  }
+
+  const last = parts[parts.length - 1];
+  return last === "" || candidate.endsWith(last ?? "");
+}
+
+function entryMatches(entry: Actor.BlacklistEntry, input: BlacklistMatchInput): boolean {
+  const candidates = input.candidates ?? [];
+  if (entry.kind === "actor") return entry.value === input.actorId;
+  if (entry.kind === "endpoint") return entry.value === input.endpointId;
+  if (entry.kind === "channel")
+    return entry.value === input.channel || candidates.includes(entry.value);
+  return candidates.some((candidate) => wildcardMatches(entry.value, candidate));
+}
+
+export namespace BlacklistStore {
+  export type Entry = Actor.BlacklistEntry;
+
+  export function put(input: Entry): Entry {
+    const store = requireAdapter();
+    const entry = Actor.BlacklistEntry.parse(withTimestamps(input, store.get(input.id)));
+    store.set(entry);
+    return entry;
+  }
+
+  export function get(id: string): Entry | undefined {
+    return requireAdapter().get(id);
+  }
+
+  export function list(): Entry[] {
+    return requireAdapter().list();
+  }
+
+  export function remove(id: string): boolean {
+    return requireAdapter().remove(id);
+  }
+
+  export function match(input: BlacklistMatchInput, now = Date.now()): Entry | undefined {
+    const store = adapter();
+    if (!store) return undefined;
+    return store.list().find((entry) => isActive(entry, now) && entryMatches(entry, input));
+  }
+}

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -8,6 +8,7 @@ export { Snapshot, InMemorySnapshotProvider } from "./snapshot";
 export { SurfaceKey } from "./surface-key";
 export { Artifact } from "./artifact/index";
 export { ActorRegistry } from "./actor/index.js";
+export { BlacklistStore } from "./blacklist/index.js";
 export * from "./worker-run/index.js";
 export { WorkerRunStateStore } from "./worker-run/state-store.js";
 export { TraceContext } from "./trace/index.js";

--- a/packages/session/src/storage/drizzle/schema.ts
+++ b/packages/session/src/storage/drizzle/schema.ts
@@ -222,3 +222,20 @@ export const actorEndpointTable = sqliteTable(
     uniqueIndex("idx_actor_endpoint_lookup").on(t.channel, t.workspace, t.external_id),
   ],
 );
+
+export const blacklistTable = sqliteTable(
+  "blacklist",
+  {
+    id: text("id").primaryKey(),
+    data: text("data").notNull(),
+    kind: text("kind").notNull(),
+    value: text("value").notNull(),
+    expires_at: integer("expires_at"),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_blacklist_kind_value").on(t.kind, t.value),
+    index("idx_blacklist_expires").on(t.expires_at),
+  ],
+);

--- a/packages/session/src/storage/initialize.ts
+++ b/packages/session/src/storage/initialize.ts
@@ -9,9 +9,10 @@ export interface InitializeOptions {
 
 export function initialize(options?: InitializeOptions): void {
   const dbPath = options?.dbPath ?? process.env.OPENOMNI_DB_PATH ?? ":memory:";
+  const initializedDbPath = Storage.getInitializedDbPath();
 
-  if (Storage.initializedDbPath !== null && Storage.initializedDbPath !== "__configured__") {
-    if (Storage.initializedDbPath === dbPath) return;
+  if (initializedDbPath !== null && initializedDbPath !== "__configured__") {
+    if (initializedDbPath === dbPath) return;
     throw new Error(
       "Storage already initialized with a different dbPath. Call Storage.reset() first.",
     );
@@ -21,7 +22,7 @@ export function initialize(options?: InitializeOptions): void {
     mkdirSync(dirname(dbPath), { recursive: true });
   }
   Storage.configure(new SqliteStorageAdapter(dbPath));
-  Storage.initializedDbPath = dbPath;
+  Storage.setInitializedDbPath(dbPath);
 }
 
 declare module "./storage" {

--- a/packages/session/src/storage/sqlite-blacklist-adapter.ts
+++ b/packages/session/src/storage/sqlite-blacklist-adapter.ts
@@ -1,0 +1,48 @@
+import type { Database } from "bun:sqlite";
+import { Actor, type Storage as ProtocolStorage } from "@openomni/protocol";
+import { z } from "zod";
+
+const DataRow = z.object({ data: z.string() });
+const DataRows = z.array(DataRow);
+
+export function createSqliteBlacklistAdapter(db: Database): ProtocolStorage.BlacklistSubAdapter {
+  return {
+    get(id) {
+      const row = DataRow.nullable().parse(
+        db.query("SELECT data FROM blacklist WHERE id = ?").get(id),
+      );
+      return row ? Actor.BlacklistEntry.parse(JSON.parse(row.data)) : undefined;
+    },
+    set(entry) {
+      const now = Date.now();
+      db.query(
+        `INSERT INTO blacklist (
+           id, data, kind, value, expires_at, time_created, time_updated
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           data = excluded.data,
+           kind = excluded.kind,
+           value = excluded.value,
+           expires_at = excluded.expires_at,
+           time_updated = excluded.time_updated`,
+      ).run(
+        entry.id,
+        JSON.stringify(entry),
+        entry.kind,
+        entry.value,
+        entry.expiresAt ?? null,
+        entry.createdAt ?? now,
+        entry.updatedAt ?? now,
+      );
+    },
+    list() {
+      const rows = DataRows.parse(
+        db.query("SELECT data FROM blacklist ORDER BY time_created ASC, id ASC").all(),
+      );
+      return rows.map((row) => Actor.BlacklistEntry.parse(JSON.parse(row.data)));
+    },
+    remove(id) {
+      return db.query("DELETE FROM blacklist WHERE id = ?").run(id).changes > 0;
+    },
+  };
+}

--- a/packages/session/src/storage/sqlite-schema-lifecycle.ts
+++ b/packages/session/src/storage/sqlite-schema-lifecycle.ts
@@ -11,10 +11,12 @@ const ORDERED_MIGRATIONS: Migration.Definition[] = [
   { name: "0004_cron_job/migration.sql" },
   { name: "0005_worker_run_executor_kind/migration.sql" },
   { name: "0006_actor_registry/migration.sql" },
+  { name: "0007_blacklist/migration.sql" },
 ];
 
 const CLEAR_ORDER = [
   "event_chain",
+  "blacklist",
   "actor_endpoint",
   "actor_identity",
   "cron_job",

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import type { WorkerRunStateStore } from "../worker-run/state-store";
 import { createSqliteActorRegistryAdapter } from "./sqlite-actor-registry-adapter";
+import { createSqliteBlacklistAdapter } from "./sqlite-blacklist-adapter";
 import { createSqliteArtifactAdapter } from "./sqlite-artifact-adapter";
 import { createSqliteBackgroundTaskAdapter } from "./sqlite-background-task-adapter";
 import { createSqliteCronJobAdapter } from "./sqlite-cron-job-adapter";
@@ -30,6 +31,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
   readonly workerGrant: NonNullable<Storage.Adapter["workerGrant"]>;
   readonly cronJob: NonNullable<Storage.Adapter["cronJob"]>;
   readonly actorRegistry: NonNullable<Storage.Adapter["actorRegistry"]>;
+  readonly blacklist: NonNullable<Storage.Adapter["blacklist"]>;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
@@ -52,6 +54,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
     this.workerGrant = createSqliteWorkerGrantAdapter(this.db);
     this.cronJob = createSqliteCronJobAdapter(this.db);
     this.actorRegistry = createSqliteActorRegistryAdapter(this.db);
+    this.blacklist = createSqliteBlacklistAdapter(this.db);
   }
 
   clear(): void {

--- a/packages/session/src/storage/storage.ts
+++ b/packages/session/src/storage/storage.ts
@@ -67,17 +67,26 @@ export namespace Storage {
     workerGrant?: ProtocolStorage.WorkerGrantSubAdapter;
     cronJob?: ProtocolStorage.CronJobSubAdapter;
     actorRegistry?: ProtocolStorage.ActorRegistrySubAdapter;
+    blacklist?: ProtocolStorage.BlacklistSubAdapter;
   }
 }
 
 export namespace Storage {
   let adapter: Adapter | null = null;
-  export let initializedDbPath: string | null = null;
+  let initializedDbPathValue: string | null = null;
   let warnedOnce = false;
 
   export function configure(newAdapter: Adapter): void {
     adapter = newAdapter;
-    initializedDbPath = "__configured__";
+    initializedDbPathValue = "__configured__";
+  }
+
+  export function getInitializedDbPath(): string | null {
+    return initializedDbPathValue;
+  }
+
+  export function setInitializedDbPath(dbPath: string | null): void {
+    initializedDbPathValue = dbPath;
   }
 
   export function get(): Adapter {
@@ -99,7 +108,7 @@ export namespace Storage {
 
   export function reset(): void {
     adapter = null;
-    initializedDbPath = null;
+    initializedDbPathValue = null;
     warnedOnce = false;
   }
 }

--- a/packages/session/test/blacklist/persistence.test.ts
+++ b/packages/session/test/blacklist/persistence.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BlacklistStore, SqliteStorageAdapter, Storage } from "../../src/index.js";
+
+describe("BlacklistStore SQLite persistence", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "blacklist-test-"));
+    dbPath = join(tmpDir, "test.db");
+    Storage.initialize({ dbPath: ":memory:" });
+    Storage.configure(new SqliteStorageAdapter(dbPath));
+  });
+
+  afterEach(async () => {
+    Storage.reset();
+    await rm(tmpDir, { recursive: true });
+  });
+
+  test("persists and matches active blacklist entries across storage re-init", () => {
+    BlacklistStore.put({
+      id: "bl-actor",
+      kind: "actor",
+      value: "act_bad",
+      reason: "abuse",
+      createdBy: "act_owner",
+    });
+
+    Storage.configure(new SqliteStorageAdapter(dbPath));
+
+    const matched = BlacklistStore.match({ actorId: "act_bad" });
+    expect(matched?.id).toBe("bl-actor");
+    expect(matched?.reason).toBe("abuse");
+  });
+
+  test("ignores expired blacklist entries", () => {
+    BlacklistStore.put({
+      id: "bl-expired",
+      kind: "endpoint",
+      value: "ep_old",
+      expiresAt: 1,
+      createdBy: "act_owner",
+    });
+
+    expect(BlacklistStore.match({ endpointId: "ep_old" }, 2)).toBeUndefined();
+  });
+
+  test("matches wildcard pattern entries against candidates", () => {
+    BlacklistStore.put({
+      id: "bl-pattern",
+      kind: "pattern",
+      value: "discord:guild:*",
+      createdBy: "act_owner",
+    });
+
+    expect(BlacklistStore.match({ candidates: ["discord:guild:dev"] })?.id).toBe("bl-pattern");
+    expect(BlacklistStore.match({ candidates: ["discord:other:dev"] })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add schema-backed actor/endpoint/channel/pattern blacklist entries with SQLite persistence
- enforce blacklist as an absolute deny gate in ingress and dispatch authorization
- add protocol/session/openomni coverage and update implementation status SSOT

## Verification
- bun test packages/protocol/test/blacklist.test.ts packages/session/test/blacklist/persistence.test.ts packages/openomni/test/ingress/blacklist.test.ts packages/openomni/test/dispatch/runtime.test.ts packages/openomni/test/execution-runtime/cron-job-registry.test.ts
- bun run lint && bun run build && bun run check-types
- bun run test
- bun test packages/openomni/test/ingress/blacklist.test.ts packages/openomni/test/dispatch/runtime.test.ts -t blacklist
- no-excuse TypeScript rule check on changed core TS files
- independent multi-agent reviewer: APPROVE

## Oracle note
Claude Fable CLI sanity check returned READY, but two read-only review requests hung without output and were killed. Independent ultrawork reviewer approved and said the Claude Fable hang can be recorded as oracle tool failure rather than a merge blocker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a blacklist gate across ingress and dispatch, blocking actors/endpoints/channels/patterns before any policy evaluation or routing. Adds a schema-backed blacklist with SQLite persistence and simple APIs for managing entries.

- **New Features**
  - Added `Actor.BlacklistEntry` schema and `BlacklistStore` APIs (`put/get/list/remove/match`) in `@openomni/session`.
  - Implemented SQLite persistence with migration `0007_blacklist` and an index on `(kind, value)`.
  - Ingress: new `ingress:blacklist` middleware runs at start and aborts with a clear reason on matches.
  - Dispatch: default policy checks blacklist first and denies with reason.
  - Updated docs to mark blacklist as implemented; added tests for protocol, persistence, ingress, and dispatch.
  - Minor storage update: `CronJobRegistry` now uses `Storage.getInitializedDbPath()`.

- **Migration**
  - Database migration runs automatically on `Storage.initialize()`; no manual steps required.
  - If you referenced `Storage.initializedDbPath`, switch to `Storage.getInitializedDbPath()` (and `Storage.setInitializedDbPath()` if needed).

<sup>Written for commit 93dbf610e14ba8289011f0b162914c1c9e1ff9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

