### PR TITLE
refactor(session): share timestamped store mechanics

### DIFF
--- a/packages/session/src/actor/index.ts
+++ b/packages/session/src/actor/index.ts
@@ -1,19 +1,12 @@
 import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
+import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
 function requireAdapter(): NonNullable<Storage.Adapter["actorRegistry"]> {
-  const adapter = Storage.get().actorRegistry;
-  if (!adapter) throw new Error("Storage adapter does not implement actorRegistry");
-  return adapter;
-}
-
-function withTimestamps<T extends Actor.Identity | Actor.Endpoint>(record: T, existing?: T): T {
-  const now = Date.now();
-  return {
-    ...record,
-    createdAt: record.createdAt ?? existing?.createdAt ?? now,
-    updatedAt: existing ? now : (record.updatedAt ?? now),
-  };
+  return requireSubAdapter(
+    Storage.get().actorRegistry,
+    "Storage adapter does not implement actorRegistry",
+  );
 }
 
 export namespace ActorRegistry {
@@ -23,7 +16,9 @@ export namespace ActorRegistry {
 
   export function registerIdentity(input: Identity): Identity {
     const adapter = requireAdapter();
-    const identity = Actor.Identity.parse(withTimestamps(input, adapter.getIdentity(input.id)));
+    const identity = Actor.Identity.parse(
+      withStoreTimestamps(input, adapter.getIdentity(input.id)),
+    );
     adapter.setIdentity(identity);
     return identity;
   }
@@ -42,7 +37,9 @@ export namespace ActorRegistry {
 
   export function registerEndpoint(input: Endpoint): Endpoint {
     const adapter = requireAdapter();
-    const endpoint = Actor.Endpoint.parse(withTimestamps(input, adapter.getEndpoint(input.id)));
+    const endpoint = Actor.Endpoint.parse(
+      withStoreTimestamps(input, adapter.getEndpoint(input.id)),
+    );
     if (!adapter.getIdentity(endpoint.actorId)) {
       throw new Error(`Actor identity not found: ${endpoint.actorId}`);
     }

--- a/packages/session/src/blacklist/index.ts
+++ b/packages/session/src/blacklist/index.ts
@@ -1,5 +1,6 @@
 import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
+import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
 export interface BlacklistMatchInput {
   readonly actorId?: string;
@@ -13,18 +14,7 @@ function adapter(): Storage.Adapter["blacklist"] {
 }
 
 function requireAdapter(): NonNullable<Storage.Adapter["blacklist"]> {
-  const current = adapter();
-  if (!current) throw new Error("Storage adapter does not implement blacklist");
-  return current;
-}
-
-function withTimestamps(entry: Actor.BlacklistEntry, existing?: Actor.BlacklistEntry) {
-  const now = Date.now();
-  return {
-    ...entry,
-    createdAt: entry.createdAt ?? existing?.createdAt ?? now,
-    updatedAt: existing ? now : (entry.updatedAt ?? now),
-  };
+  return requireSubAdapter(adapter(), "Storage adapter does not implement blacklist");
 }
 
 function isActive(entry: Actor.BlacklistEntry, now: number): boolean {
@@ -63,7 +53,7 @@ export namespace BlacklistStore {
 
   export function put(input: Entry): Entry {
     const store = requireAdapter();
-    const entry = Actor.BlacklistEntry.parse(withTimestamps(input, store.get(input.id)));
+    const entry = Actor.BlacklistEntry.parse(withStoreTimestamps(input, store.get(input.id)));
     store.set(entry);
     return entry;
   }

--- a/packages/session/src/channel-grant/index.ts
+++ b/packages/session/src/channel-grant/index.ts
@@ -1,5 +1,6 @@
 import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
+import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
 export interface ChannelGrantMatchInput {
   readonly surface: string;
@@ -17,18 +18,7 @@ function adapter(): Storage.Adapter["channelGrant"] {
 }
 
 function requireAdapter(): NonNullable<Storage.Adapter["channelGrant"]> {
-  const current = adapter();
-  if (!current) throw new Error("Storage adapter does not implement channel grants");
-  return current;
-}
-
-function withTimestamps(grant: Actor.ChannelGrant, existing?: Actor.ChannelGrant) {
-  const now = Date.now();
-  return {
-    ...grant,
-    createdAt: grant.createdAt ?? existing?.createdAt ?? now,
-    updatedAt: existing ? now : (grant.updatedAt ?? now),
-  };
+  return requireSubAdapter(adapter(), "Storage adapter does not implement channel grants");
 }
 
 function defaultTreatment(kind: Actor.ChannelGrantKind): Actor.InboundTreatment {
@@ -53,7 +43,7 @@ export namespace ChannelGrantStore {
 
   export function put(input: Grant): Grant {
     const store = requireAdapter();
-    const grant = Actor.ChannelGrant.parse(withTimestamps(input, store.get(input.id)));
+    const grant = Actor.ChannelGrant.parse(withStoreTimestamps(input, store.get(input.id)));
     store.set(grant);
     return grant;
   }

--- a/packages/session/src/storage/timestamped-store.ts
+++ b/packages/session/src/storage/timestamped-store.ts
@@ -1,0 +1,14 @@
+export function requireSubAdapter<T>(adapter: T | null | undefined, message: string): T {
+  if (!adapter) throw new Error(message);
+  return adapter;
+}
+
+export function withStoreTimestamps<
+  T extends { readonly createdAt?: number; readonly updatedAt?: number },
+>(record: T, existing?: T, now = Date.now()): T {
+  return {
+    ...record,
+    createdAt: record.createdAt ?? existing?.createdAt ?? now,
+    updatedAt: existing === undefined ? (record.updatedAt ?? now) : now,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract shared session-store adapter/timestamp mechanics into an internal helper.
- Replace duplicated timestamp stamping in ActorRegistry, BlacklistStore, and ChannelGrantStore.
- Keep domain rules local: actor endpoint validation, blacklist matching, and channel-grant resolution are unchanged.

## Verification
- `bun test packages/session/test/actor/persistence.test.ts packages/session/test/blacklist/persistence.test.ts packages/session/test/channel-grant/persistence.test.ts` (13 pass)
- Edge replay covers unknown actor endpoint rejection, expired blacklist ignored, and no matching channel grant returns undefined
- `bun -e "...requireSubAdapter(null)..."` smoke confirms explicit adapter errors are preserved for runtime null
- `bun run check-types`
- `bun run lint:guards`
- `bun run build`
- `bun run lint`
- LSP diagnostics: no diagnostics for all four changed source files

## Review Notes
- First ultrawork reviewer pass blocked on a real null-adapter semantic drift.
- Fixed by making `requireSubAdapter` accept `T | null | undefined` and preserve the old `if (!adapter)` behavior.
- Second ultrawork reviewer pass: PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored session stores to share timestamp logic and adapter checks via a new helper, reducing duplication and keeping behavior unchanged.

- **Refactors**
  - Added `packages/session/src/storage/timestamped-store.ts` with `withStoreTimestamps` and `requireSubAdapter`.
  - Updated `packages/session/src/actor/index.ts`, `.../blacklist/index.ts`, and `.../channel-grant/index.ts` to use the helper and removed local timestamp code.
  - Preserved existing rules and errors: endpoint validation, blacklist expiry/matching, channel-grant resolution; `requireSubAdapter` accepts `T | null | undefined` to keep old missing-adapter semantics.

<sup>Written for commit 451948aa68e985ca1b5c6273e0237f98f0b6eb56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal storage utilities to improve code maintainability and consistency across session management modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->