### PR TITLE
refactor(session): share create timestamp defaults

### DIFF
--- a/packages/session/src/pending-ask/index.ts
+++ b/packages/session/src/pending-ask/index.ts
@@ -1,6 +1,7 @@
 import { Communication } from "@openomni/protocol";
 import { Bus } from "../bus";
 import { Storage } from "../storage/storage";
+import { withCreateTimestamps } from "../storage/timestamped-store";
 
 function requireAdapter() {
   const adapter = Storage.get().pendingAsk;
@@ -20,13 +21,12 @@ function eventBase(record: Communication.PendingAsk.Record) {
 }
 
 function nowRecord(input: Communication.PendingAsk.Create): Communication.PendingAsk.Record {
-  const now = Date.now();
-  return Communication.PendingAsk.Record.parse({
-    ...input,
-    status: input.status ?? "open",
-    createdAt: input.createdAt ?? now,
-    updatedAt: input.updatedAt ?? input.createdAt ?? now,
-  });
+  return Communication.PendingAsk.Record.parse(
+    withCreateTimestamps({
+      ...input,
+      status: input.status ?? "open",
+    }),
+  );
 }
 
 function updateStatus(

--- a/packages/session/src/pending-interaction/index.ts
+++ b/packages/session/src/pending-interaction/index.ts
@@ -1,6 +1,7 @@
 import { Communication } from "@openomni/protocol";
 import { Bus } from "../bus";
 import { Storage } from "../storage/storage";
+import { withCreateTimestamps } from "../storage/timestamped-store";
 
 function requireAdapter() {
   const adapter = Storage.get().pendingInteraction;
@@ -23,13 +24,12 @@ function eventBase(record: Communication.PendingInteraction.Record) {
 function nowRecord(
   input: Communication.PendingInteraction.Create,
 ): Communication.PendingInteraction.Record {
-  const now = Date.now();
-  return Communication.PendingInteraction.Record.parse({
-    ...input,
-    status: input.status ?? "open",
-    createdAt: input.createdAt ?? now,
-    updatedAt: input.updatedAt ?? input.createdAt ?? now,
-  });
+  return Communication.PendingInteraction.Record.parse(
+    withCreateTimestamps({
+      ...input,
+      status: input.status ?? "open",
+    }),
+  );
 }
 
 function updateStatus(

--- a/packages/session/src/storage/timestamped-store.ts
+++ b/packages/session/src/storage/timestamped-store.ts
@@ -12,3 +12,13 @@ export function withStoreTimestamps<
     updatedAt: existing === undefined ? (record.updatedAt ?? now) : now,
   };
 }
+
+export function withCreateTimestamps<
+  T extends { readonly createdAt?: number; readonly updatedAt?: number },
+>(record: T, now = Date.now()): T {
+  return {
+    ...record,
+    createdAt: record.createdAt ?? now,
+    updatedAt: record.updatedAt ?? record.createdAt ?? now,
+  };
+}

--- a/packages/session/src/worker-grant/index.ts
+++ b/packages/session/src/worker-grant/index.ts
@@ -1,6 +1,7 @@
 import { Communication } from "@openomni/protocol";
 import { Bus } from "../bus";
 import { Storage } from "../storage/storage";
+import { withCreateTimestamps } from "../storage/timestamped-store";
 
 const riskRank = { low: 1, medium: 2, high: 3 } as const;
 
@@ -21,15 +22,14 @@ function eventBase(record: Communication.WorkerGrant.Record) {
 }
 
 function createRecord(input: Communication.WorkerGrant.Create): Communication.WorkerGrant.Record {
-  const now = Date.now();
-  return Communication.WorkerGrant.Record.parse({
-    ...input,
-    status: input.status ?? "active",
-    version: input.version ?? 1,
-    canCreateExternalTasks: input.canCreateExternalTasks ?? false,
-    createdAt: input.createdAt ?? now,
-    updatedAt: input.updatedAt ?? input.createdAt ?? now,
-  });
+  return Communication.WorkerGrant.Record.parse(
+    withCreateTimestamps({
+      ...input,
+      status: input.status ?? "active",
+      version: input.version ?? 1,
+      canCreateExternalTasks: input.canCreateExternalTasks ?? false,
+    }),
+  );
 }
 
 function matchesList(list: readonly string[] | undefined, value: string | undefined): boolean {


### PR DESCRIPTION
## Summary
- Add internal `withCreateTimestamps` helper for create-time timestamp defaults.
- Reuse it in PendingAskStore, PendingInteractionStore, and WorkerGrantStore.
- Keep store-specific defaults and lifecycle/domain logic local to each store.

## Verification
- `bun test packages/session/test/pending-ask/store.test.ts packages/session/test/pending-interaction/store.test.ts packages/session/test/worker-grant/store.test.ts` (17 pass)
- `bun run check-types`
- `bun run lint:guards`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics: no diagnostics for all four changed source files

## Review Notes
- Ultrawork reviewer pass: PASS.
- Scope limited to four session source files; no protocol, adapter, package barrel, or test edits.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralize create-time timestamp defaults with a shared `withCreateTimestamps` helper and use it in pending ask, pending interaction, and worker grant stores to reduce duplication and keep `createdAt`/`updatedAt` behavior consistent.

- **Refactors**
  - Added `withCreateTimestamps` in `packages/session/src/storage/timestamped-store.ts` to default `createdAt` and `updatedAt`.
  - Replaced inline timestamp code in `packages/session/src/pending-ask`, `packages/session/src/pending-interaction`, and `packages/session/src/worker-grant`.
  - Kept store-specific defaults (e.g., `status`, `version`, `canCreateExternalTasks`) and lifecycle logic local; no behavior changes expected.

<sup>Written for commit da40f65fb645d3ad747351003d3cbc200b22fd3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

