### PR TITLE
refactor(session): remove artifact reset no-op

### DIFF
--- a/packages/session/src/artifact/index.ts
+++ b/packages/session/src/artifact/index.ts
@@ -30,8 +30,4 @@ export namespace Artifact {
     if (!row) return [];
     return [JSON.parse(row.meta) as ArtifactSchema.Meta];
   }
-
-  export function _reset(): void {
-    // no-op: callers use Storage.reset() for test isolation
-  }
 }

--- a/packages/session/test/artifact/artifact.test.ts
+++ b/packages/session/test/artifact/artifact.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  Artifact._reset();
   Storage.reset();
 });
 

--- a/packages/session/test/artifact/persistence.test.ts
+++ b/packages/session/test/artifact/persistence.test.ts
@@ -28,6 +28,7 @@ function ensureSession(adapter: SqliteStorageAdapter, id: string): void {
     title: `Session ${id}`,
     model: { providerID: "test", modelID: "test-model" },
     time: { created: Date.now(), updated: Date.now() },
+    spawnDepth: 0,
   });
 }
 
@@ -43,12 +44,10 @@ describe("Artifact persistence (SQLite)", () => {
     adapter = new SqliteStorageAdapter(dbPath);
     Storage.initialize({ dbPath: ":memory:" });
     Storage.configure(adapter);
-    Artifact._reset();
     ensureSession(adapter, "sess-1");
   });
 
   afterEach(() => {
-    Artifact._reset();
     Storage.reset();
     try {
       adapter.close();
@@ -62,7 +61,6 @@ describe("Artifact persistence (SQLite)", () => {
     const meta = makeMeta();
     await Artifact.store("sess-1", meta, "hello world");
     adapter.close();
-    Artifact._reset();
 
     const adapter2 = new SqliteStorageAdapter(dbPath);
     Storage.configure(adapter2);
@@ -79,7 +77,6 @@ describe("Artifact persistence (SQLite)", () => {
     await Artifact.store("sess-1", makeMeta({ id: "art-1" }), "content-1");
     await Artifact.store("sess-1", makeMeta({ id: "art-2" }), "content-2");
     adapter.close();
-    Artifact._reset();
 
     const adapter2 = new SqliteStorageAdapter(dbPath);
     Storage.configure(adapter2);
@@ -95,7 +92,6 @@ describe("Artifact persistence (SQLite)", () => {
     await Artifact.store("sess-1", makeMeta({ version: 1 }), "v1");
     await Artifact.store("sess-1", makeMeta({ version: 2, title: "updated.txt" }), "v2");
     adapter.close();
-    Artifact._reset();
 
     const adapter2 = new SqliteStorageAdapter(dbPath);
     Storage.configure(adapter2);


### PR DESCRIPTION
## Summary
- Remove dead no-op `Artifact._reset()` from the session artifact module.
- Remove test-only calls that were relying on that no-op.
- Add the required `spawnDepth: 0` field to the SQLite artifact test session fixture.

## Verification
- `bun test packages/session/test/artifact/artifact.test.ts packages/session/test/artifact/persistence.test.ts` (12 pass)
- `rg "Artifact\\._reset|export function _reset" packages/session/src packages/session/test` returns no matches
- `bun run check-types`
- `bun run lint:guards`
- `bun run build`
- `bun run lint`
- LSP diagnostics: no diagnostics for all three changed files

## Review Notes
- Ultrawork reviewer pass: PASS.
- `Artifact._reset()` was a no-op; test isolation remains through `Storage.reset()` and adapter recreation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead no-op `Artifact._reset()` and cleaned up tests that referenced it. Added the required `spawnDepth: 0` to the SQLite artifact test session fixture.

<sup>Written for commit 8fdceb816535721aa36f009e5e42d1a52284b12c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

