### PR TITLE
refactor(session): share pending sqlite query helpers

### DIFF
--- a/packages/session/src/storage/sqlite-json-data.ts
+++ b/packages/session/src/storage/sqlite-json-data.ts
@@ -1,0 +1,56 @@
+import type { Database } from "bun:sqlite";
+
+export type SqliteJsonDataTable = "pending_ask" | "pending_interaction";
+
+export type SqliteStringEqualityColumn =
+  | "endpoint_id"
+  | "channel_id"
+  | "external_message_id"
+  | "reply_to_message_id"
+  | "thread_id"
+  | "token_hash"
+  | "external_conversation_id";
+
+export type SqliteJsonDataRow = {
+  readonly data: string;
+};
+
+export function parseSqliteJsonDataRow<T>(row: SqliteJsonDataRow | null): T | undefined {
+  if (!row) return undefined;
+  return JSON.parse(row.data) as T;
+}
+
+export function parseSqliteJsonDataRows<T>(rows: readonly SqliteJsonDataRow[]): T[] {
+  return rows.map((row) => JSON.parse(row.data) as T);
+}
+
+export function listSqliteJsonDataByStatus<T>(
+  db: Database,
+  table: SqliteJsonDataTable,
+  status: readonly string[] | undefined,
+): T[] {
+  const rows =
+    status && status.length > 0
+      ? (db
+          .query(
+            `SELECT data FROM ${table}
+             WHERE status IN (${status.map(() => "?").join(", ")})
+             ORDER BY time_created ASC`,
+          )
+          .all(...status) as SqliteJsonDataRow[])
+      : (db
+          .query(`SELECT data FROM ${table} ORDER BY time_created ASC`)
+          .all() as SqliteJsonDataRow[]);
+  return parseSqliteJsonDataRows<T>(rows);
+}
+
+export function addOptionalStringEqualityCondition(
+  conditions: string[],
+  params: string[],
+  column: SqliteStringEqualityColumn,
+  value: string | undefined,
+): void {
+  if (!value) return;
+  conditions.push(`${column} = ?`);
+  params.push(value);
+}

--- a/packages/session/src/storage/sqlite-pending-ask-adapter.ts
+++ b/packages/session/src/storage/sqlite-pending-ask-adapter.ts
@@ -1,20 +1,12 @@
 import type { Communication, Storage as ProtocolStorage } from "@openomni/protocol";
 import type { Database } from "bun:sqlite";
-
-type PendingAskRow = {
-  id: string;
-  data: string;
-  status: Communication.PendingAsk.Status;
-  origin_session_id: string;
-  endpoint_id: string | null;
-  channel_id: string | null;
-  external_message_id: string | null;
-  reply_to_message_id: string | null;
-  thread_id: string | null;
-  token_hash: string | null;
-  external_conversation_id: string | null;
-  time_created: number;
-};
+import {
+  addOptionalStringEqualityCondition,
+  listSqliteJsonDataByStatus,
+  parseSqliteJsonDataRow,
+  parseSqliteJsonDataRows,
+  type SqliteJsonDataRow,
+} from "./sqlite-json-data";
 
 export function createSqlitePendingAskAdapter(db: Database): ProtocolStorage.PendingAskSubAdapter {
   return {
@@ -22,36 +14,39 @@ export function createSqlitePendingAskAdapter(db: Database): ProtocolStorage.Pen
       insertOrReplace(db, record, false);
     },
     get(id) {
-      const row = db.query("SELECT data FROM pending_ask WHERE id = ?").get(id) as {
-        data: string;
-      } | null;
-      return row ? (JSON.parse(row.data) as Communication.PendingAsk.Record) : undefined;
+      const row = db
+        .query("SELECT data FROM pending_ask WHERE id = ?")
+        .get(id) as SqliteJsonDataRow | null;
+      return parseSqliteJsonDataRow<Communication.PendingAsk.Record>(row);
     },
     list(status) {
-      const rows =
-        status && status.length > 0
-          ? (db
-              .query(
-                `SELECT data FROM pending_ask
-                 WHERE status IN (${status.map(() => "?").join(", ")})
-                 ORDER BY time_created ASC`,
-              )
-              .all(...status) as Array<{ data: string }>)
-          : (db.query("SELECT data FROM pending_ask ORDER BY time_created ASC").all() as Array<{
-              data: string;
-            }>);
-      return rows.map((row) => JSON.parse(row.data) as Communication.PendingAsk.Record);
+      return listSqliteJsonDataByStatus<Communication.PendingAsk.Record>(db, "pending_ask", status);
     },
     findByCorrelation(query) {
       const conditions: string[] = [];
       const params: string[] = [];
-      add(conditions, params, "endpoint_id", query.endpointId);
-      add(conditions, params, "channel_id", query.channelId);
-      add(conditions, params, "external_message_id", query.externalMessageId);
-      add(conditions, params, "reply_to_message_id", query.replyToMessageId);
-      add(conditions, params, "thread_id", query.threadId);
-      add(conditions, params, "token_hash", query.tokenHash);
-      add(conditions, params, "external_conversation_id", query.externalConversationId);
+      addOptionalStringEqualityCondition(conditions, params, "endpoint_id", query.endpointId);
+      addOptionalStringEqualityCondition(conditions, params, "channel_id", query.channelId);
+      addOptionalStringEqualityCondition(
+        conditions,
+        params,
+        "external_message_id",
+        query.externalMessageId,
+      );
+      addOptionalStringEqualityCondition(
+        conditions,
+        params,
+        "reply_to_message_id",
+        query.replyToMessageId,
+      );
+      addOptionalStringEqualityCondition(conditions, params, "thread_id", query.threadId);
+      addOptionalStringEqualityCondition(conditions, params, "token_hash", query.tokenHash);
+      addOptionalStringEqualityCondition(
+        conditions,
+        params,
+        "external_conversation_id",
+        query.externalConversationId,
+      );
       if (conditions.length === 0) return [];
       const rows = db
         .query(
@@ -59,8 +54,8 @@ export function createSqlitePendingAskAdapter(db: Database): ProtocolStorage.Pen
            WHERE status IN ('open', 'ambiguous') AND ${conditions.join(" AND ")}
            ORDER BY time_created ASC`,
         )
-        .all(...params) as Array<{ data: string }>;
-      return rows.map((row) => JSON.parse(row.data) as Communication.PendingAsk.Record);
+        .all(...params) as SqliteJsonDataRow[];
+      return parseSqliteJsonDataRows<Communication.PendingAsk.Record>(rows);
     },
     set(record) {
       insertOrReplace(db, record, true);
@@ -113,10 +108,4 @@ function insertOrReplace(
     record.createdAt,
     record.updatedAt,
   );
-}
-
-function add(conditions: string[], params: string[], column: keyof PendingAskRow, value?: string) {
-  if (!value) return;
-  conditions.push(`${column} = ?`);
-  params.push(value);
 }

--- a/packages/session/src/storage/sqlite-pending-interaction-adapter.ts
+++ b/packages/session/src/storage/sqlite-pending-interaction-adapter.ts
@@ -1,18 +1,12 @@
 import type { Communication, Storage as ProtocolStorage } from "@openomni/protocol";
 import type { Database } from "bun:sqlite";
-
-type PendingInteractionRow = {
-  id: string;
-  data: string;
-  status: Communication.PendingInteraction.Status;
-  endpoint_id: string;
-  channel_id: string;
-  reply_to_message_id: string | null;
-  thread_id: string | null;
-  token_hash: string | null;
-  external_conversation_id: string | null;
-  time_created: number;
-};
+import {
+  addOptionalStringEqualityCondition,
+  listSqliteJsonDataByStatus,
+  parseSqliteJsonDataRow,
+  parseSqliteJsonDataRows,
+  type SqliteJsonDataRow,
+} from "./sqlite-json-data";
 
 export function createSqlitePendingInteractionAdapter(
   db: Database,
@@ -22,41 +16,43 @@ export function createSqlitePendingInteractionAdapter(
       insertOrReplace(db, record, false);
     },
     get(id) {
-      const row = db.query("SELECT data FROM pending_interaction WHERE id = ?").get(id) as {
-        data: string;
-      } | null;
-      return row ? (JSON.parse(row.data) as Communication.PendingInteraction.Record) : undefined;
+      const row = db
+        .query("SELECT data FROM pending_interaction WHERE id = ?")
+        .get(id) as SqliteJsonDataRow | null;
+      return parseSqliteJsonDataRow<Communication.PendingInteraction.Record>(row);
     },
     list(status) {
-      const rows =
-        status && status.length > 0
-          ? (db
-              .query(
-                `SELECT data FROM pending_interaction
-                 WHERE status IN (${status.map(() => "?").join(", ")})
-                 ORDER BY time_created ASC`,
-              )
-              .all(...status) as Array<{ data: string }>)
-          : (db
-              .query("SELECT data FROM pending_interaction ORDER BY time_created ASC")
-              .all() as Array<{ data: string }>);
-      return rows.map((row) => JSON.parse(row.data) as Communication.PendingInteraction.Record);
+      return listSqliteJsonDataByStatus<Communication.PendingInteraction.Record>(
+        db,
+        "pending_interaction",
+        status,
+      );
     },
     findByCorrelation(query) {
       const conditions = ["endpoint_id = ?", "channel_id = ?"];
       const params = [query.endpointId, query.channelId];
-      add(conditions, params, "reply_to_message_id", query.replyToMessageId);
-      add(conditions, params, "thread_id", query.threadId);
-      add(conditions, params, "token_hash", query.tokenHash);
-      add(conditions, params, "external_conversation_id", query.externalConversationId);
+      addOptionalStringEqualityCondition(
+        conditions,
+        params,
+        "reply_to_message_id",
+        query.replyToMessageId,
+      );
+      addOptionalStringEqualityCondition(conditions, params, "thread_id", query.threadId);
+      addOptionalStringEqualityCondition(conditions, params, "token_hash", query.tokenHash);
+      addOptionalStringEqualityCondition(
+        conditions,
+        params,
+        "external_conversation_id",
+        query.externalConversationId,
+      );
       const rows = db
         .query(
           `SELECT data FROM pending_interaction
            WHERE status IN ('open', 'resolved', 'follow_up') AND ${conditions.join(" AND ")}
            ORDER BY time_created ASC`,
         )
-        .all(...params) as Array<{ data: string }>;
-      return rows.map((row) => JSON.parse(row.data) as Communication.PendingInteraction.Record);
+        .all(...params) as SqliteJsonDataRow[];
+      return parseSqliteJsonDataRows<Communication.PendingInteraction.Record>(rows);
     },
     set(record) {
       insertOrReplace(db, record, true);
@@ -117,15 +113,4 @@ function insertOrReplace(
 function followUpUntil(record: Communication.PendingInteraction.Record): number | null {
   if (!record.resolvedAt) return null;
   return record.resolvedAt + record.followUpWindow;
-}
-
-function add(
-  conditions: string[],
-  params: string[],
-  column: keyof PendingInteractionRow,
-  value?: string,
-) {
-  if (!value) return;
-  conditions.push(`${column} = ?`);
-  params.push(value);
 }


### PR DESCRIPTION
## Summary
- Extract package-internal SQLite JSON data query helpers for pending ask/interaction stores.
- Remove duplicated `{ data }` row parsing, list-by-status SQL, and optional string equality condition builders.
- Preserve existing raw `JSON.parse(...) as T` read semantics; no protocol strict parsing added.

## Safety / Scope
- Touches only `packages/session/src/storage/sqlite-json-data.ts`, `sqlite-pending-ask-adapter.ts`, and `sqlite-pending-interaction-adapter.ts`.
- Table identifiers are constrained to `pending_ask | pending_interaction`.
- Condition columns are constrained to a fixed internal union.
- Helper is package-internal and not exported from public barrels.
- Insert/upsert SQL, nullable write handling, status filters, correlation scoping, and ordering are unchanged.

## Verification
- `bun test packages/session/test/pending-ask/store.test.ts packages/session/test/pending-interaction/store.test.ts` -> 11 pass
- `bun test packages/openomni/test/dispatch/runtime.test.ts apps/server/test/ingress-bridge.test.ts` -> 40 pass
- `bun run check-types` -> pass
- `bun run lint:guards` -> pass
- `bun run build` -> pass
- `bun run lint` -> pass
- LSP diagnostics on all changed files -> no diagnostics
- banned-pattern scan for `any`, `as unknown`, non-null assertions, default export -> no matches
- `git diff --check` -> pass
- pre-push type-check -> pass

## Review Notes
- First internal ultrawork review blocked a draft because it used strict protocol Zod parsing on read.
- R2 reverted that behavior change and preserved the existing raw JSON cast semantics.
- Second internal ultrawork review: PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shared internal SQLite JSON query helpers for pending ask and interaction adapters to remove duplication while keeping behavior the same. No changes to SQL filters, ordering, or JSON parsing.

- **Refactors**
  - Added `sqlite-json-data.ts` with `parseSqliteJsonDataRow`, `parseSqliteJsonDataRows`, `listSqliteJsonDataByStatus`, and `addOptionalStringEqualityCondition`.
  - Updated adapters to use these helpers; removed duplicated row parsing and condition builders.
  - Helper is internal; columns and tables limited to known keys and `pending_ask`/`pending_interaction`.

<sup>Written for commit d0e95313b3f9edb3658e6c556f0193a9eff503c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

