### PR TITLE
refactor(session): reuse sub-adapter guard helper

### DIFF
--- a/packages/session/src/pending-ask/index.ts
+++ b/packages/session/src/pending-ask/index.ts
@@ -1,12 +1,13 @@
 import { Communication } from "@openomni/protocol";
 import { Bus } from "../bus";
 import { Storage } from "../storage/storage";
-import { withCreateTimestamps } from "../storage/timestamped-store";
+import { requireSubAdapter, withCreateTimestamps } from "../storage/timestamped-store";
 
 function requireAdapter() {
-  const adapter = Storage.get().pendingAsk;
-  if (!adapter) throw new Error("Storage adapter does not implement pendingAsk");
-  return adapter;
+  return requireSubAdapter(
+    Storage.get().pendingAsk,
+    "Storage adapter does not implement pendingAsk",
+  );
 }
 
 function eventBase(record: Communication.PendingAsk.Record) {

--- a/packages/session/src/pending-interaction/index.ts
+++ b/packages/session/src/pending-interaction/index.ts
@@ -1,12 +1,13 @@
 import { Communication } from "@openomni/protocol";
 import { Bus } from "../bus";
 import { Storage } from "../storage/storage";
-import { withCreateTimestamps } from "../storage/timestamped-store";
+import { requireSubAdapter, withCreateTimestamps } from "../storage/timestamped-store";
 
 function requireAdapter() {
-  const adapter = Storage.get().pendingInteraction;
-  if (!adapter) throw new Error("Storage adapter does not implement pendingInteraction");
-  return adapter;
+  return requireSubAdapter(
+    Storage.get().pendingInteraction,
+    "Storage adapter does not implement pendingInteraction",
+  );
 }
 
 function eventBase(record: Communication.PendingInteraction.Record) {

--- a/packages/session/src/worker-grant/index.ts
+++ b/packages/session/src/worker-grant/index.ts
@@ -1,14 +1,15 @@
 import { Communication } from "@openomni/protocol";
 import { Bus } from "../bus";
 import { Storage } from "../storage/storage";
-import { withCreateTimestamps } from "../storage/timestamped-store";
+import { requireSubAdapter, withCreateTimestamps } from "../storage/timestamped-store";
 
 const riskRank = { low: 1, medium: 2, high: 3 } as const;
 
 function requireAdapter() {
-  const adapter = Storage.get().workerGrant;
-  if (!adapter) throw new Error("Storage adapter does not implement workerGrant");
-  return adapter;
+  return requireSubAdapter(
+    Storage.get().workerGrant,
+    "Storage adapter does not implement workerGrant",
+  );
 }
 
 function eventBase(record: Communication.WorkerGrant.Record) {


### PR DESCRIPTION
## Summary
- Reuse the existing `requireSubAdapter` helper in pending ask, pending interaction, and worker grant stores.
- Remove repeated local `Storage.get().x` null-check/throw/return guard logic.
- Preserve the same adapter fields and error message strings.

## Safety / Scope
- Touches only three session store files.
- No public barrel/export changes.
- No lifecycle, status transition, event, schema, storage adapter, or protocol behavior changes.
- `requireSubAdapter` already rejects `null | undefined` and is used by actor/blacklist/channel-grant stores.

## Verification
- `bun test packages/session/test/pending-ask/store.test.ts packages/session/test/pending-interaction/store.test.ts packages/session/test/worker-grant/store.test.ts` -> 17 pass
- `bun test packages/openomni/test/dispatch/runtime.test.ts packages/openomni/test/dispatch/worker-spawn-security.test.ts apps/server/test/ingress-bridge.test.ts` -> 43 pass
- `bun run check-types` -> pass
- `bun run lint:guards` -> pass
- `bun run build` -> pass
- `bun run lint` -> pass
- LSP diagnostics on changed files -> no diagnostics
- banned-pattern scan -> no matches
- `git diff --check` -> pass
- pre-push type-check -> pass

## Review Notes
- Internal ultrawork reviewer: PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor session stores to use the shared `requireSubAdapter` guard for sub-adapter access. Removes duplicate null checks with no behavior changes and preserves existing error messages.

- **Refactors**
  - Applied to `pending-ask`, `pending-interaction`, and `worker-grant` stores in `packages/session`.
  - No API or lifecycle changes; adapter fields and error strings stay the same.

<sup>Written for commit 1c26805ebbfdd10007464cd3f1951daf62a14b16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

