### PR TITLE
refactor(session): reuse worker run state guard

### DIFF
--- a/packages/session/src/worker-run/state-store.ts
+++ b/packages/session/src/worker-run/state-store.ts
@@ -1,6 +1,7 @@
 import { Subagent, type WorkItem } from "@openomni/protocol";
 import { z } from "zod";
 import { Storage } from "../storage/storage";
+import { requireSubAdapter } from "../storage/timestamped-store";
 
 const transitions: Record<Subagent.WorkerRunStatus, readonly Subagent.WorkerRunStatus[]> = {
   queued: ["starting"],
@@ -21,11 +22,10 @@ function isValidTransition(
 }
 
 function requireAdapter(): WorkerRunStateStore.Adapter {
-  const adapter = Storage.get().workerRunState;
-  if (!adapter) {
-    throw new Error("Storage adapter does not implement workerRunState");
-  }
-  return adapter;
+  return requireSubAdapter(
+    Storage.get().workerRunState,
+    "Storage adapter does not implement workerRunState",
+  );
 }
 
 export namespace WorkerRunStateStore {
@@ -79,10 +79,11 @@ export namespace WorkerRunStateStore {
   }
 
   export function create(sessionId: string, record: CreateRecord): void {
-    if (requireAdapter().get(sessionId, record.runId)) {
+    const adapter = requireAdapter();
+    if (adapter.get(sessionId, record.runId)) {
       throw new Error(`Worker run ${record.runId} already exists in session ${sessionId}`);
     }
-    requireAdapter().create(sessionId, record);
+    adapter.create(sessionId, record);
   }
 
   export function updateStatus(


### PR DESCRIPTION
## Summary
- Reuse `requireSubAdapter` for `WorkerRunStateStore`'s worker-run-state adapter guard.
- Avoid a duplicate `requireAdapter()` lookup inside `WorkerRunStateStore.create()`.

## Safety / Scope
- Touches only `packages/session/src/worker-run/state-store.ts`.
- Same `Storage.get().workerRunState` adapter field and missing-adapter error string.
- Duplicate run check still happens before create and keeps the same duplicate error.
- No status transition, Zod, lifecycle event, WorkerRun, recovery, adapter, or public export behavior changed.

## Verification
- `bun test packages/session/test/worker-run/state-store.test.ts packages/session/test/worker-run/worker-run.test.ts packages/session/test/worker-run/contract-alias.test.ts` -> 21 pass
- `bun test packages/coordinator/test/recovery/crash.test.ts packages/openomni/test/subagent/wait.test.ts packages/openomni/test/subagent/cancel-timeout.test.ts` -> 20 pass
- `bun run check-types` -> pass
- `bun run lint:guards` -> pass
- `bun run build` -> pass
- `bun run lint` -> pass
- LSP diagnostics on changed file -> no diagnostics
- banned-pattern scan -> no matches
- `git diff --check` -> pass
- pre-push type-check -> pass

## Review Notes
- Internal ultrawork reviewer: PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `WorkerRunStateStore` to reuse `requireSubAdapter` for the worker-run-state adapter guard and avoid duplicate adapter lookups in `create()`. Behavior, error messages, and duplicate-run checks remain the same.

<sup>Written for commit 1ad9b59475999e7dec53e3f04ab526677696d343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

