### PR TITLE
refactor(session): reuse app connector guard

### DIFF
--- a/packages/session/src/app-connector/index.ts
+++ b/packages/session/src/app-connector/index.ts
@@ -1,5 +1,6 @@
 import { AppConnector } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
+import { requireSubAdapter } from "../storage/timestamped-store";
 import { assertConsentMatchesRequirements } from "./consent-validation";
 
 type InstallationInput = Omit<AppConnector.Installation, "createdAt" | "updatedAt"> &
@@ -10,11 +11,10 @@ type SmokeVerifiedInput = Pick<AppConnector.Installation, "detectedVersion">;
 type SmokeVerificationFailedInput = Partial<Pick<AppConnector.Installation, "detectedVersion">>;
 
 function requireAdapter(): NonNullable<Storage.Adapter["appConnectorInstallation"]> {
-  const adapter = Storage.get().appConnectorInstallation;
-  if (!adapter) {
-    throw new Error("Storage adapter does not implement app connector installations");
-  }
-  return adapter;
+  return requireSubAdapter(
+    Storage.get().appConnectorInstallation,
+    "Storage adapter does not implement app connector installations",
+  );
 }
 
 function withTimestamps(

--- a/packages/session/test/app-connector/lifecycle.test.ts
+++ b/packages/session/test/app-connector/lifecycle.test.ts
@@ -121,6 +121,36 @@ describe("AppConnectorInstallationStore lifecycle", () => {
     expect(AppConnectorInstallationStore.get(consented.id)).toEqual(disabled);
   });
 
+  test("rejects storage adapters without app connector installation support", () => {
+    // Given
+    const adapterWithoutAppConnector = {
+      session: {
+        get: () => undefined,
+        set: () => undefined,
+        list: () => [],
+        remove: () => false,
+      },
+      message: {
+        get: () => undefined,
+        set: () => undefined,
+        list: () => [],
+        remove: () => false,
+      },
+      part: {
+        get: () => undefined,
+        set: () => undefined,
+        list: () => [],
+        remove: () => false,
+      },
+    } satisfies Storage.Adapter;
+    Storage.configure(adapterWithoutAppConnector);
+
+    // When / Then
+    expect(() => AppConnectorInstallationStore.list()).toThrow(
+      "Storage adapter does not implement app connector installations",
+    );
+  });
+
   test("marks a consented installation enabled when smoke verification succeeds", async () => {
     // Given
     const consented = consentInstallation("install-1");


### PR DESCRIPTION
## Summary
- reuse the shared requireSubAdapter helper for AppConnectorInstallationStore's storage adapter guard
- add a regression test for the missing appConnectorInstallation adapter error message

## Verification
- bun test packages/session/test/app-connector/lifecycle.test.ts packages/session/test/app-connector/persistence.test.ts
- bun run check-types
- bun run lint:guards
- bun run build
- bun run lint
- LSP diagnostics: packages/session/src/app-connector/index.ts, packages/session/test/app-connector/lifecycle.test.ts
- banned-pattern scan on changed files
- git diff --check

Internal ultrawork reviewer: PASS after r3 evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the AppConnector installation adapter guard by reusing the shared `requireSubAdapter`, removing duplicate logic and unifying the error message. Added a regression test that asserts we throw "Storage adapter does not implement app connector installations" when adapters lack support.

<sup>Written for commit 11d32bbbfcf827b3be1296b2cd7a142144eaef87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

