### PR TITLE
refactor(openomni): remove unused session lock wrapper

### DIFF
--- a/packages/openomni/src/subagent/AGENTS.md
+++ b/packages/openomni/src/subagent/AGENTS.md
@@ -14,15 +14,14 @@ Session-backed subagent execution runtime for the openomni orchestration layer.
 | `message-builder.ts` | Message construction and serialization for subagent communication | no |
 | `run-lifecycle.ts` | Abort, timeout, and finalize functions for `WorkerRun` lifecycle | no |
 | `transcript.ts` | Compaction bridge and `runWithTranscript` (imports from `@openomni/agent` barrel, no relative cross-package imports) | no |
-| `session-lock.ts` | `withSessionLock` wrapper — prevents concurrent writes to the same session | no |
 | `session-mailbox.ts` | Mailbox abstraction for queued message delivery to a session | no |
 | `abort-registry.ts` | Global registry mapping run IDs to abort controllers | no |
 
 ## Module Split Rationale
 
-`runtime.ts` was refactored from ~1094 LOC into focused modules. The split follows single-responsibility: each internal module owns one concern (types, message construction, lifecycle, transcript, locking). Only the four public classes are re-exported from `index.ts`; the rest are internal implementation details.
+`runtime.ts` was refactored from ~1094 LOC into focused modules. The split follows single-responsibility: each internal module owns one concern (types, message construction, lifecycle, transcript, mailbox delivery). Only the four public classes are re-exported from `index.ts`; the rest are internal implementation details.
 
-Internal modules (`shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-lock.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
+Internal modules (`shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
 
 ## Dependencies
 

--- a/packages/openomni/src/subagent/session-lock.ts
+++ b/packages/openomni/src/subagent/session-lock.ts
@@ -1,5 +1,0 @@
-import { sendToMailbox } from "./session-mailbox.js";
-
-export function withSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
-  return sendToMailbox(sessionId, fn);
-}


### PR DESCRIPTION
## Summary
- remove the unused subagent `session-lock.ts` wrapper around `sendToMailbox`
- update subagent AGENTS docs so internal module inventory matches source

## Verification
- `bun test packages/openomni/test/subagent/session-mailbox.test.ts packages/openomni/test/subagent/runtime.test.ts packages/openomni/test/subagent/spawn-background.test.ts` (34 pass)
- `bun run check-types`
- `bun run lint:guards`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean for `runtime.ts` and `session-mailbox.ts`
- ultrawork reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused subagent `session-lock.ts` wrapper around `sendToMailbox` to reduce dead code. Updated `AGENTS.md` to drop the module and clarify the split (now references mailbox delivery); no runtime or API changes.

<sup>Written for commit b5119487371313b670da7a9210dfcc800434839b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the session-scoped locking helper function
* **Documentation**
  * Updated internal module documentation to reflect current implementation structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->