### PR TITLE
refactor(agent): remove duplicate retry aliases

### DIFF
--- a/packages/agent/src/core/execution/stream-engine.ts
+++ b/packages/agent/src/core/execution/stream-engine.ts
@@ -21,7 +21,7 @@ export async function* streamAgent(
   config: ChatAgentConfig,
   sink?: Sink,
 ): AsyncGenerator<AgentEvent> {
-  const retryPolicy = Retry.DEFAULT_AGENT_RETRY_POLICY;
+  const retryPolicy = Retry.DEFAULT_RETRY_POLICY;
   let attempt = 1;
   let lastError = "";
 

--- a/packages/agent/src/core/execution/stream-flow.ts
+++ b/packages/agent/src/core/execution/stream-flow.ts
@@ -175,7 +175,7 @@ export async function* handleError(
   agentBase: StreamAgentBase,
   error: unknown,
   attempt: number,
-  retryPolicy: Parameters<typeof Retry.shouldAgentRetry>[0],
+  retryPolicy: Parameters<typeof Retry.shouldRetry>[0],
 ): AsyncGenerator<AgentEvent, ErrorDecision> {
   const normalizedError = error instanceof Error ? error : new Error(String(error));
   const onErrorDecision = await engine.dispatch(
@@ -195,7 +195,7 @@ export async function* handleError(
   }
 
   const lastError = normalizedError.message;
-  const retryReason = Retry.classifyAgentRetryReason(lastError);
+  const retryReason = Retry.classifyRetryReason(lastError);
   const retryEffect = effectOf(onErrorDecision, "run.retry_after");
   const effectiveRetryPolicy =
     retryEffect?.maxRetries === undefined
@@ -205,15 +205,15 @@ export async function* handleError(
           maxAttempts: Math.min(retryPolicy.maxAttempts, retryEffect.maxRetries),
         };
 
-  if (Retry.shouldAgentRetry(effectiveRetryPolicy, retryReason, attempt)) {
-    const backoffMs = retryEffect?.delayMs ?? Retry.calculateAgentBackoffMs(retryPolicy, attempt);
+  if (Retry.shouldRetry(effectiveRetryPolicy, retryReason, attempt)) {
+    const backoffMs = retryEffect?.delayMs ?? Retry.calculateBackoffMs(retryPolicy, attempt);
     emitErrorRetry(state, config, agentBase, {
       attempt,
       maxAttempts: effectiveRetryPolicy.maxAttempts,
       error: lastError,
     });
     yield createStreamErrorEvent(normalizedError, true);
-    await Retry.agentSleep(backoffMs, config.signal);
+    await Retry.sleep(backoffMs, config.signal);
     return { action: "retry", kind: "error", error: normalizedError, errorMessage: lastError };
   }
 

--- a/packages/agent/src/core/retry.ts
+++ b/packages/agent/src/core/retry.ts
@@ -10,17 +10,11 @@ export const DEFAULT_RETRY_POLICY: Run.RetryPolicy = {
   retryOn: ["timeout", "tool_error", "transient_error"],
 };
 
-export type AgentRetryReason = RetryReason;
-
-export const DEFAULT_AGENT_RETRY_POLICY = DEFAULT_RETRY_POLICY;
-
 export function calculateBackoffMs(policy: Run.RetryPolicy, attempt: number): number {
   const rawDelay =
     policy.backoffMs.initial * policy.backoffMs.multiplier ** Math.max(0, attempt - 1);
   return Math.min(rawDelay, policy.backoffMs.max);
 }
-
-export const calculateAgentBackoffMs = calculateBackoffMs;
 
 export function classifyRetryReason(errorMessage: string): RetryReason {
   const normalized = errorMessage.toLowerCase();
@@ -67,8 +61,6 @@ export function classifyRetryReason(errorMessage: string): RetryReason {
   });
   return "transient_error";
 }
-
-export const classifyAgentRetryReason = classifyRetryReason;
 
 export function shouldRetry(
   policy: Run.RetryPolicy,
@@ -140,8 +132,6 @@ export function shouldRetry(
   return willRetry;
 }
 
-export const shouldAgentRetry = shouldRetry;
-
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) {
     return Promise.reject(new Error("aborted"));
@@ -165,5 +155,3 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
-
-export const agentSleep = sleep;


### PR DESCRIPTION
## Summary
- remove duplicate `*Agent*` retry aliases from `packages/agent/src/core/retry.ts`
- update agent stream retry flow to call canonical retry helpers directly

## Verification
- `bun test packages/agent/test/core/retry.test.ts packages/agent/test/core/execution/stream-dispatch.test.ts` (46 pass)
- `bun run --cwd packages/agent check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- LSP diagnostics clean for changed TS files
- ultrawork reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate agent retry aliases from `packages/agent/src/core/retry.ts` and updated stream flow/engine to use canonical helpers (`DEFAULT_RETRY_POLICY`, `shouldRetry`, `classifyRetryReason`, `calculateBackoffMs`, `sleep`). No behavior changes; this simplifies the retry API.

<sup>Written for commit 588e2dede09db3f27a61dc499758c4322e386ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

