### PR TITLE
refactor(coordinator): drop unused runtime dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,9 +51,6 @@
       "name": "@openomni/coordinator",
       "version": "0.0.1",
       "dependencies": {
-        "@openomni/agent": "workspace:*",
-        "@openomni/llm": "workspace:*",
-        "@openomni/openomni": "workspace:*",
         "@openomni/protocol": "workspace:*",
         "@openomni/session": "workspace:*",
       },
@@ -588,6 +585,8 @@
 
     "@openomni/agent/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@openomni/coordinator/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@openomni/llm/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@openomni/openomni/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -599,6 +598,8 @@
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "@openomni/agent/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@openomni/coordinator/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@openomni/llm/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/coordinator/AGENTS.md
+++ b/packages/coordinator/AGENTS.md
@@ -17,7 +17,7 @@ src/
 
 ## DEPENDENCIES
 
-Depends on `@openomni/protocol`, `@openomni/session`, `@openomni/agent`, and `@openomni/openomni` because the coordinator reconstructs real execution in worker processes.
+Depends on `@openomni/protocol` and `@openomni/session`. Runtime execution wiring lives in `apps/server/src/execution/worker-entry.ts`, so the coordinator receives a worker script path and stays independent of `@openomni/agent`, `@openomni/llm`, and `@openomni/openomni`.
 
 ## MODULES
 

--- a/packages/coordinator/package.json
+++ b/packages/coordinator/package.json
@@ -10,9 +10,6 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@openomni/agent": "workspace:*",
-    "@openomni/llm": "workspace:*",
-    "@openomni/openomni": "workspace:*",
     "@openomni/protocol": "workspace:*",
     "@openomni/session": "workspace:*"
   },


### PR DESCRIPTION
## Summary
- remove unused @openomni/agent, @openomni/llm, and @openomni/openomni dependencies from @openomni/coordinator
- update bun.lock to match the coordinator manifest
- correct packages/coordinator/AGENTS.md so dependency ownership matches current server-owned worker runtime wiring

## Validation
- exact coordinator src/test import scan for removed deps: zero matches
- bun install --frozen-lockfile
- bun test packages/coordinator/test packages/coordinator/src: 97 pass, 0 fail
- bun run --cwd packages/coordinator check-types
- bun run check-types
- bun run lint:guards
- bun run build
- bun run lint
- git diff --check
- LSP diagnostics on packages/coordinator/src/index.ts and packages/coordinator/src/worker-manager/manager.ts
- codex-ultrawork-reviewer PASS

## Notes
- Runtime dependencies remain in apps/server worker-entry/worker-runner/bootstrap. Coordinator receives a workerScript path and only depends on protocol/session contracts.
- JSON LSP was unavailable locally; package.json was covered by frozen lockfile and Biome lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused runtime dependencies from `@openomni/coordinator` to shrink the install footprint and keep runtime wiring in the server. Coordinator now only depends on `@openomni/protocol` and `@openomni/session`; removed `@openomni/agent`, `@openomni/llm`, and `@openomni/openomni`.

- **Refactors**
  - Cleaned `packages/coordinator/package.json` to drop unused deps.
  - Updated `bun.lock` to match the manifest.
  - Clarified `AGENTS.md` to note server-owned worker bootstrap and coordinator independence.

<sup>Written for commit 594401cea1f11c06db2427a2adc71f85d223a3bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

