### PR TITLE
refactor(openomni): drop unused llm dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@openomni/agent": "workspace:*",
-        "@openomni/llm": "workspace:*",
         "@openomni/protocol": "workspace:*",
         "@openomni/session": "workspace:*",
         "croner": "^10.0.1",

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/openomni
 
-Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@openomni/session`, and `@openomni/llm` to add DAG utilities, inbound event handling, and a session-backed subagent runtime. This package is the future home for Resident orchestration seams: controlled inbound authority, self-loop session creation, Worker delegation, and distilled writeback.
+Orchestration layer for `@openomni/openomni`. Builds on `@openomni/agent`, `@openomni/session`, and `@openomni/protocol` to add DAG utilities, inbound event handling, and a session-backed subagent runtime. This package is the future home for Resident orchestration seams: controlled inbound authority, self-loop session creation, Worker delegation, and distilled writeback.
 
 ## Module Map
 
@@ -39,7 +39,7 @@ agents/             → @openomni/protocol (Model.Ref only)
 app-connector/      → @openomni/protocol (AppConnector.Definition only)
 dag/                → no internal deps
 profile/            → @openomni/session + @openomni/agent + @openomni/protocol
-resident/           → @openomni/session + @openomni/agent + @openomni/llm
+resident/           → @openomni/session + @openomni/agent + @openomni/protocol
 runtime/            → @openomni/session + @openomni/agent (worker middleware, no bus transport)
 execution-runtime/  → no orchestration deps (tool system, workspace, middleware)
 ingress/            → no sibling deps

--- a/packages/openomni/package.json
+++ b/packages/openomni/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@openomni/agent": "workspace:*",
-    "@openomni/llm": "workspace:*",
     "@openomni/protocol": "workspace:*",
     "@openomni/session": "workspace:*",
     "croner": "^10.0.1",


### PR DESCRIPTION
## Summary
- remove unused direct @openomni/llm dependency from @openomni/openomni
- update bun.lock openomni stanza
- correct packages/openomni/AGENTS.md dependency shape to agent/session/protocol

## Validation
- direct openomni src/test import scan for @openomni/llm: zero matches
- remaining @openomni/llm reference is only a Bun mock target in test/ingress/_llm-mock.ts
- bun install --frozen-lockfile
- bun test packages/openomni/test packages/openomni/src: 759 pass, 0 fail
- bun run --cwd packages/openomni check-types
- bun run check-types
- bun run lint:guards
- bun run build
- bun run lint
- git diff --check
- LSP diagnostics on packages/openomni/src/index.ts, resident/runtime.ts, and resident prompt shared.ts
- codex-ultrawork-reviewer PASS

## Notes
- @openomni/agent still owns its @openomni/llm dependency. openomni model types flow through protocol and agent APIs; no public openomni export directly exposes @openomni/llm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped unused `@openomni/llm` from `@openomni/openomni` to simplify dependencies and match the current API surface. Updated `AGENTS.md` to reference `@openomni/protocol` instead; lockfile cleaned up.

<sup>Written for commit 24c2a7717d3cb141d59db782d5fb340d8c1d0a8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

