### PR TITLE
[codex] refactor(llm): use protocol message types in tests

### DIFF
--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -11,9 +11,8 @@ src/
 ├── error.ts          # Re-exports NamedError classes from protocol
 ├── session/
 │   ├── processor.ts  # Processor.create() — drives streaming LLM call + tool turns
-│   ├── message.ts    # Message namespace helpers
+│   ├── index.ts      # Re-exports protocol Message/Tool plus session helpers
 │   ├── convert.ts    # toModelMessages() — Message.WithParts[] → AI SDK messages
-│   ├── tool.ts       # Tool namespace helpers (execution within session context)
 │   └── retry.ts      # Retry.delay / sleep / isRetryable — exponential backoff + retry-after
 ├── auth/
 │   ├── storage.ts    # Auth namespace: get / set / remove / all (credential storage)

--- a/packages/llm/test/session/convert.test.ts
+++ b/packages/llm/test/session/convert.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Message } from "../../src/session/message";
+import type { Message } from "@openomni/protocol";
 import { toModelMessages } from "../../src/session/convert";
 import type { Provider } from "../../src/provider";
 

--- a/packages/llm/test/session/session.test.ts
+++ b/packages/llm/test/session/session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { Session, Storage } from "@openomni/session";
-import type { Message } from "../../src/session/message";
+import type { Message } from "@openomni/protocol";
 
 describe("Session", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Replace stale LLM session test Message imports from the non-existent ../../src/session/message path with the protocol SSOT.
- Correct packages/llm/AGENTS.md session file map so it reflects session/index.ts re-exporting protocol Message/Tool.

## Why

packages/llm/src/session/message.ts and tool.ts do not exist. Message is owned by @openomni/protocol and already used directly by neighboring LLM code/tests.

## Verification

- bun test packages/llm/test/session/convert.test.ts packages/llm/test/session/session.test.ts
- bun test packages/llm/test/session
- bun run --cwd packages/llm check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics: no diagnostics for changed TS test files
- codex-ultrawork-reviewer: PASS after LSP evidence was added


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor tests to use the `Message` type from `@openomni/protocol` and update `AGENTS.md` to reference `session/index.ts` re-exports. This removes stale paths and prevents broken imports.

<sup>Written for commit 6ae32122ccfebda2161877ac9c4d7304a0de2a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured module documentation for improved clarity.

* **Tests**
  * Updated test infrastructure imports for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->