### PR TITLE
[codex] refactor(llm): keep convert helpers internal

### DIFF
--- a/packages/llm/src/session/convert.ts
+++ b/packages/llm/src/session/convert.ts
@@ -42,19 +42,15 @@ type ToolMessage = {
 
 export type SDKMessage = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
 
-export function buildSystemBlock(content: string): SystemMessage {
-  return { role: "system", content };
-}
-
-export function buildUserBlock(content: string): UserMessage {
+function buildUserBlock(content: string): UserMessage {
   return { role: "user", content };
 }
 
-export function buildAssistantTextBlock(content: string): AssistantTextBlock {
+function buildAssistantTextBlock(content: string): AssistantTextBlock {
   return { type: "text", text: content };
 }
 
-export function buildToolCallBlock(call: {
+function buildToolCallBlock(call: {
   id: string;
   tool: string;
   input: Record<string, unknown>;
@@ -67,11 +63,11 @@ export function buildToolCallBlock(call: {
   };
 }
 
-export function buildAssistantBlock(content: AssistantMessage["content"]): AssistantMessage {
+function buildAssistantBlock(content: AssistantMessage["content"]): AssistantMessage {
   return { role: "assistant", content };
 }
 
-export function buildToolResultBlock(result: {
+function buildToolResultBlock(result: {
   id: string;
   tool: string;
   output: string;
@@ -84,7 +80,7 @@ export function buildToolResultBlock(result: {
   };
 }
 
-export function buildToolBlock(content: ToolResultBlock[]): ToolMessage {
+function buildToolBlock(content: ToolResultBlock[]): ToolMessage {
   return { role: "tool", content };
 }
 


### PR DESCRIPTION
## Summary

- Keep LLM convert builder helpers file-local instead of exporting unused deep-import surface.
- Remove dead buildSystemBlock, which became visible as unused once export masking was removed.

## Why

Knip reported the builder helpers as unused exports. Repo-wide references and CodeGraph show they are implementation details of toModelMessages, while SDKMessage and toModelMessages remain the intended exported contract.

## Verification

- bun test packages/llm/test/session/convert.test.ts
- bun test packages/llm/test/session
- bun run --cwd packages/llm check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics: no diagnostics for packages/llm/src/session/convert.ts
- codex-ultrawork-reviewer: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the LLM convert builder helpers file-local and remove the unused buildSystemBlock export. This reduces the public API, prevents deep imports, and keeps `SDKMessage` and `toModelMessages` as the intended contract.

<sup>Written for commit 8c128c5f21f03ab74e50b5161f07dc78d3a3b45e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

