### PR TITLE
[codex] refactor(agent): remove unused execution helpers

### DIFF
--- a/packages/agent/src/core/execution/shared.ts
+++ b/packages/agent/src/core/execution/shared.ts
@@ -26,27 +26,6 @@ export async function resolveProviderModel(model: {
   throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
 }
 
-export function getLastUserMessageText(messages: Message.WithParts[]): string | null {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i];
-    if (message?.info.role === "user") {
-      return message.parts
-        .filter((part): part is Message.TextPart => part.type === "text")
-        .map((part) => part.text)
-        .join("");
-    }
-  }
-  return null;
-}
-
-export function prependContextMessage(
-  messages: Message.WithParts[],
-  contextText: string,
-  source: string,
-): Message.WithParts[] {
-  return [createUserMessage(contextText, source), ...messages];
-}
-
 export function toMessagesWithParts(
   messages: ChatAgentInput["messages"],
   source: string,


### PR DESCRIPTION
## Summary

- Remove two unused exported helpers from agent execution shared internals.
- Keep the active shared helpers used by stream-engine, stream-state, tool-executor, and tool-guard.

## Why

Knip reported `getLastUserMessageText` and `prependContextMessage` as unused exports. Repo-wide search and reviewer validation confirmed they are not part of the root `@openomni/agent` API and are not used by the ChatAgent stream path.

## Verification

- bun test packages/agent/test
- bun run --cwd packages/agent check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics: no diagnostics for packages/agent/src/core/execution/shared.ts
- codex-ultrawork-reviewer: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `getLastUserMessageText` and `prependContextMessage` from `packages/agent/src/core/execution/shared.ts` to eliminate unused exports and simplify internals. No changes to the `@openomni/agent` public API or ChatAgent stream path.

<sup>Written for commit 3d8939316ac448b2bdb746c50e4f6f8981a3fdc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

