### PR TITLE
[codex] refactor(agent): keep tracking sink internal

### DIFF
--- a/packages/agent/src/core/execution/stream-turn.ts
+++ b/packages/agent/src/core/execution/stream-turn.ts
@@ -200,7 +200,7 @@ export async function buildTurn(
   };
 }
 
-export function createTrackingSink(
+function createTrackingSink(
   state: StreamRunState,
   sink: Sink | undefined,
   turnUsage: TokenUsage,


### PR DESCRIPTION
## Summary
- Make `createTrackingSink` file-local in `stream-turn.ts` instead of exporting an internal helper.
- Keep active stream-turn exports `resolveToolChoice`, `assertToolExecutor`, and `buildTurn` unchanged.

## Why
- Knip reported `createTrackingSink` as an unused export.
- CodeGraph and `rg` show it is only called inside `stream-turn.ts`; it is not part of the `@openomni/agent` root API.

## Verification
- `bun test packages/agent/test/core/execution/stream-dispatch.test.ts packages/agent/test/core/execution/tool-selection.test.ts packages/agent/test/core/execution/stream-verdicts.test.ts` (58 pass)
- `bun test packages/agent/test` (405 pass / 10 skip)
- `bun run --cwd packages/agent check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- LSP diagnostics clean on `packages/agent/src/core/execution/stream-turn.ts`
- `codex-ultrawork-reviewer` PASS: 019ec253-cb27-77d0-a9a4-c4dfe50ccd16

## Notes
- Pre-push dep-check reported stale docs only: `AGENTS.md` and `packages/protocol/AGENTS.md`; no dependency violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `createTrackingSink` internal by removing its export from `stream-turn.ts`, keeping the helper private and tightening the `@openomni/agent` public API. No behavior changes; `resolveToolChoice`, `assertToolExecutor`, and `buildTurn` remain exported.

<sup>Written for commit f0a40a60857c128bd7d50ce4fdd5215db7a0ade8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

