### PR TITLE
[codex] refactor(agent): keep mcp converters internal

### DIFF
--- a/packages/agent/src/runtime/mcp/index.ts
+++ b/packages/agent/src/runtime/mcp/index.ts
@@ -1,3 +1,2 @@
 export { McpClient } from "./client";
-export { convertMcpTool, convertMcpResult } from "./convert";
 export type { McpServerConfig } from "@openomni/protocol";


### PR DESCRIPTION
## Summary
- Remove `convertMcpTool` / `convertMcpResult` from the runtime MCP barrel export.
- Keep `McpClient` and `McpServerConfig` exported from the barrel and root package API.
- Leave converter helpers exported from `runtime/mcp/convert.ts` for their direct production/test imports.

## Why
- Knip reported the converter helpers as unused exports from `packages/agent/src/runtime/mcp/index.ts`.
- CodeGraph and `rg` show the converter helpers are used via direct `./convert` imports, not via the barrel or root package API.

## Verification
- `bun test packages/agent/test/runtime/mcp/convert.test.ts packages/agent/test/runtime/mcp/descriptor.test.ts` (25 pass)
- `bun run --cwd packages/agent check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- LSP diagnostics clean on `packages/agent/src/runtime/mcp/index.ts`
- `codex-ultrawork-reviewer` PASS: 019ec25f-3fb2-7f70-939e-37a0e42c29fc

## Notes
- Pre-push dep-check reported stale docs only: `AGENTS.md` and `packages/protocol/AGENTS.md`; no dependency violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP converter helpers internal by removing `convertMcpTool` and `convertMcpResult` from the `runtime/mcp` barrel export. `McpClient` and `McpServerConfig` stay public, and direct imports from `runtime/mcp/convert.ts` keep working.

<sup>Written for commit f4509987d8e7eef4bd6212219ddfbbf5e47f897e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

