### PR TITLE
[codex] refactor(agent): trim mock llm helper surface

### DIFF
--- a/packages/agent/test/helpers/mock-llm.ts
+++ b/packages/agent/test/helpers/mock-llm.ts
@@ -1,24 +1,17 @@
-import type { Run, Sink, Tool } from "@openomni/protocol";
+import type { Run, Sink } from "@openomni/protocol";
 import type { ChatAgentConfig } from "../../src/core/types";
 
-export type MockLlmInput = {
+type MockLlmInput = {
   readonly messages?: readonly unknown[];
   readonly maxSteps?: number;
-  readonly signal?: AbortSignal;
-  readonly toolExecutor?: (
-    call: Tool.Call,
-    context?: Tool.ExecutionContext,
-  ) => Promise<Tool.Result>;
+  readonly signal?: ChatAgentConfig["signal"];
+  readonly toolExecutor?: ChatAgentConfig["toolExecutor"];
 };
 
 export type MockLlmFn = (input: MockLlmInput, sink: Sink) => Promise<Run.Outcome>;
 
 export function createStopOutcome(): Run.Outcome {
   return { type: "stop" };
-}
-
-export function createAbortedOutcome(): Run.Outcome {
-  return { type: "aborted" };
 }
 
 export function createErrorOutcome(message: string): Run.Outcome {


### PR DESCRIPTION
## Summary
- Delete unused `createAbortedOutcome` from the agent mock LLM test helper.
- Make `MockLlmInput` file-local because only exported `MockLlmFn` uses it.
- Reuse `ChatAgentConfig` indexed types for signal/toolExecutor helper input fields.

## Why
- Knip reported `createAbortedOutcome` and exported type `MockLlmInput` as unused helper exports.
- CodeGraph and `rg` show no callers for `createAbortedOutcome`, and `MockLlmInput` is only used inside `mock-llm.ts`.

## Verification
- `bun test packages/agent/test/agent.test.ts packages/agent/test/core/policy/run-gate.test.ts packages/agent/test/core/streaming.test.ts packages/agent/test/core/run-delegation.test.ts packages/agent/test/core/tool-permission-integration.test.ts` (40 pass)
- `bun test packages/agent/test` (405 pass / 10 skip)
- `bun run --cwd packages/agent check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- LSP diagnostics clean on `packages/agent/test/helpers/mock-llm.ts`
- `codex-ultrawork-reviewer` PASS: 019ec267-bc7c-7803-b2bb-b705b26900e4

## Notes
- Pre-push dep-check reported stale docs only: `AGENTS.md` and `packages/protocol/AGENTS.md`; no dependency violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim the agent mock LLM test helper by removing an unused export and narrowing its public API. Reuse `ChatAgentConfig` indexed types for `signal` and `toolExecutor` to keep types aligned.

- **Refactors**
  - Delete `createAbortedOutcome`; make `MockLlmInput` file-local.
  - Use `ChatAgentConfig["signal"]` and `ChatAgentConfig["toolExecutor"]` instead of explicit types.
  - Remove unused `Tool` import.

<sup>Written for commit 60021161ca2ec994e073da4b801046ff6b856c04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

