### PR TITLE
[codex] refactor(coordinator): keep ipc encoder internal

### DIFF
--- a/packages/coordinator/src/ipc/codec.ts
+++ b/packages/coordinator/src/ipc/codec.ts
@@ -16,7 +16,3 @@ export function decodeMessage(raw: unknown): IpcMessage {
 
   throw new IpcProtocolError(`Unknown message type: ${JSON.stringify(raw)}`);
 }
-
-export function encodeMessage(msg: IpcMessage): string {
-  return JSON.stringify(msg);
-}

--- a/packages/coordinator/src/ipc/index.ts
+++ b/packages/coordinator/src/ipc/index.ts
@@ -1,5 +1,5 @@
 export { connectIpcClient, type IpcClient, type ConnectIpcClientOptions } from "./client";
-export { decodeMessage, encodeMessage, type IpcMessage } from "./codec";
+export { decodeMessage, type IpcMessage } from "./codec";
 export { IpcConnectionError, IpcProtocolError, IpcTimeoutError } from "./errors";
 export { encode, LineDecoder } from "./framing";
 export { createIpcServer, type IpcServer, type RequestHandler } from "./server";


### PR DESCRIPTION
## Summary
- Remove unused `encodeMessage` from the coordinator IPC codec.
- Stop re-exporting that unused helper from the IPC barrel.
- Keep `decodeMessage`, `IpcMessage`, and `framing.encode` intact for active IPC parsing/framing paths.

## Verification
- `bun test packages/coordinator/src/ipc packages/coordinator/test/execution packages/coordinator/test/worker-manager` - 41 pass / 0 fail
- `bun run --cwd packages/coordinator check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- LSP diagnostics clean on `packages/coordinator/src/ipc/codec.ts` and `packages/coordinator/src/ipc/index.ts`
- codex-ultrawork-reviewer PASS after LSP evidence recapture


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the IPC encoder internal by removing the unused `encodeMessage` and its barrel export. This tightens the public API with no behavior changes; consumers continue to use `decodeMessage`, `IpcMessage`, and `framing.encode`.

<sup>Written for commit b5e431a6065a278fd44052f1560a985e9eb04cdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when decoding invalid messages to include details about the unknown message type.

* **Refactor**
  * Removed an internal message encoding helper from the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->