### PR TITLE
[codex] refactor(agent): trim builtin policy surface

### DIFF
--- a/packages/agent/src/core/policy/builtin/budget.ts
+++ b/packages/agent/src/core/policy/builtin/budget.ts
@@ -1,6 +1,6 @@
 import { PolicyDecision } from "@openomni/protocol";
 import { checkBudget, describeBudgetRemaining, effectiveBudgetThresholds } from "../../budget";
-import type { PolicyFactory, PolicyRegistration } from "../types";
+import type { PolicyRegistration } from "../types";
 
 export function createBudgetReassurancePolicy(): PolicyRegistration {
   let issued = false;
@@ -37,11 +37,6 @@ export function createBudgetReassurancePolicy(): PolicyRegistration {
   };
 }
 
-export const budgetReassuranceFactory: PolicyFactory = {
-  id: "policy:budget-reassurance",
-  create: () => createBudgetReassurancePolicy(),
-};
-
 export function createBudgetWarningPolicy(): PolicyRegistration {
   let issued = false;
   return {
@@ -76,8 +71,3 @@ export function createBudgetWarningPolicy(): PolicyRegistration {
     },
   };
 }
-
-export const budgetWarningFactory: PolicyFactory = {
-  id: "policy:budget-warning",
-  create: () => createBudgetWarningPolicy(),
-};

--- a/packages/agent/src/core/policy/builtin/compaction.ts
+++ b/packages/agent/src/core/policy/builtin/compaction.ts
@@ -1,9 +1,8 @@
 import { PolicyDecision } from "@openomni/protocol";
-import { InMemoryCompactor } from "../../execution/compaction";
-import type { PolicyFactory, PolicyRegistration } from "../types";
-import type { ChatAgentConfig } from "../../types";
+import { InMemoryCompactor, type CompactionOptions } from "../../execution/compaction";
+import type { PolicyRegistration } from "../types";
 
-type CompactionConfig = NonNullable<ChatAgentConfig["compaction"]>;
+type CompactionConfig = CompactionOptions;
 
 export function createCompactionPolicy(config: CompactionConfig): PolicyRegistration {
   return {
@@ -43,8 +42,3 @@ export function createCompactionPolicy(config: CompactionConfig): PolicyRegistra
     },
   };
 }
-
-export const compactionFactory: PolicyFactory = {
-  id: "policy:compaction",
-  create: (config) => createCompactionPolicy(config as CompactionConfig),
-};

--- a/packages/agent/src/core/policy/builtin/idle-nudge.ts
+++ b/packages/agent/src/core/policy/builtin/idle-nudge.ts
@@ -1,5 +1,5 @@
 import { PolicyDecision } from "@openomni/protocol";
-import type { PolicyFactory, PolicyRegistration } from "../types";
+import type { PolicyRegistration } from "../types";
 
 export interface IdleNudgeConfig {
   idleThresholdMs?: number;
@@ -61,8 +61,3 @@ export function createIdleNudgePolicy(config: IdleNudgeConfig = {}): PolicyRegis
     },
   };
 }
-
-export const idleNudgeFactory: PolicyFactory = {
-  id: "policy:idle-nudge",
-  create: (config) => createIdleNudgePolicy(config as IdleNudgeConfig),
-};

--- a/packages/agent/src/core/policy/builtin/index.ts
+++ b/packages/agent/src/core/policy/builtin/index.ts
@@ -1,31 +1,7 @@
 export {
   createBudgetReassurancePolicy,
   createBudgetWarningPolicy,
-  budgetReassuranceFactory,
-  budgetWarningFactory,
 } from "./budget";
-export { createCompactionPolicy, compactionFactory } from "./compaction";
-export { createIdleNudgePolicy, idleNudgeFactory } from "./idle-nudge";
-export type { IdleNudgeConfig } from "./idle-nudge";
-export { createToolPermissionPolicy, toolPermissionFactory } from "./tool-guard";
-export type { ToolPermissionPolicyConfig } from "./tool-guard";
-
-import type { PolicyFactory, PolicyRegistry } from "../types";
-import { budgetReassuranceFactory, budgetWarningFactory } from "./budget";
-import { compactionFactory } from "./compaction";
-import { idleNudgeFactory } from "./idle-nudge";
-import { toolPermissionFactory } from "./tool-guard";
-
-export const builtinFactories: readonly PolicyFactory[] = [
-  budgetReassuranceFactory,
-  budgetWarningFactory,
-  compactionFactory,
-  idleNudgeFactory,
-  toolPermissionFactory,
-];
-
-export function registerBuiltins(registry: PolicyRegistry): void {
-  for (const factory of builtinFactories) {
-    registry.register(factory.id, (config, runtime) => factory.create(config, runtime));
-  }
-}
+export { createCompactionPolicy } from "./compaction";
+export { createIdleNudgePolicy } from "./idle-nudge";
+export { createToolPermissionPolicy } from "./tool-guard";

--- a/packages/agent/src/core/policy/builtin/tool-guard.ts
+++ b/packages/agent/src/core/policy/builtin/tool-guard.ts
@@ -1,7 +1,7 @@
 import { Operational, Policy, PolicyDecision } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import type { AgentEventEmitter } from "../../types";
-import type { PolicyFactory, PolicyRegistration } from "../types";
+import type { PolicyRegistration } from "../types";
 import { summarizeInput } from "../../execution/shared";
 
 const TOOL_CALL_ACTION = "tool.call";
@@ -74,8 +74,3 @@ export function createToolPermissionPolicy(config: ToolPermissionPolicyConfig): 
     },
   };
 }
-
-export const toolPermissionFactory: PolicyFactory = {
-  id: "policy:tool-permission",
-  create: (config) => createToolPermissionPolicy(config as ToolPermissionPolicyConfig),
-};


### PR DESCRIPTION
## Summary
- Remove unused builtin policy factory/registration surface from `@openomni/agent` internals.
- Keep the runtime-facing `create*Policy` functions exported and preserve `PolicyRegistry.defaultRegistry()` direct registration.
- Replace the deprecated `ChatAgentConfig["compaction"]` type reference with `CompactionOptions` in the compaction policy.

## Verification
- `bun test packages/agent/test/core/policy packages/agent/test/core/tool-permission-integration.test.ts` - 173 pass / 10 skip / 0 fail
- `bun run --cwd packages/agent check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- LSP diagnostics clean on all changed files
- codex-ultrawork-reviewer PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused built-in policy factories and registry helpers in `@openomni/agent` to reduce surface area. Kept `create*Policy` exports and direct `PolicyRegistry` registration; updated compaction types to `CompactionOptions`.

- **Refactors**
  - Removed `*Factory` exports and `registerBuiltins`/`builtinFactories` from built-ins index.
  - Deleted factory objects from `budget`, `compaction`, `idle-nudge`, and `tool-guard`.
  - Replaced `ChatAgentConfig["compaction"]` with `CompactionOptions` in the compaction policy.

- **Migration**
  - If you used any `*Factory` or `registerBuiltins`, switch to `create*Policy(...)` and register the returned policy directly with your `PolicyRegistry`.

<sup>Written for commit 1503c531f94301b77ce19d2d9213000a0ec821d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

