### PR TITLE
refactor(openomni): trim dispatch barrel surface

### DIFF
--- a/packages/openomni/src/dispatch/index.ts
+++ b/packages/openomni/src/dispatch/index.ts
@@ -29,19 +29,8 @@ export {
   createDeviceDispatchHandlers,
   type DeviceDispatchHandlerOptions,
 } from "./handlers/device.js";
-export {
-  createResidentDispatchHandlers,
-  type ResidentDispatchHandlerOptions,
-} from "./handlers/resident.js";
-export {
-  createScheduleDispatchHandlers,
-  type ScheduleDispatchHandlerOptions,
-} from "./handlers/schedule.js";
+export { createResidentDispatchHandlers } from "./handlers/resident.js";
 export {
   createOutboundDispatchHandlers,
   type OutboundDispatchHandlerOptions,
 } from "./handlers/outbound.js";
-export {
-  createWorkerDispatchHandlers,
-  type WorkerDispatchHandlerOptions,
-} from "./handlers/worker.js";


### PR DESCRIPTION
## Summary
- Trim the `packages/openomni/src/dispatch` domain barrel so it no longer re-exports internal schedule/worker handler factories.
- Remove unused `ResidentDispatchHandlerOptions`, `ScheduleDispatchHandlerOptions`, and `WorkerDispatchHandlerOptions` type re-exports from that barrel.
- Preserve the handler implementations and direct internal setup imports; the package root public API is unchanged.

## Why
Knip reported these dispatch barrel exports as unused public surface. The active runtime registration path imports schedule and worker handlers directly from their leaf modules, and `packages/openomni/src/index.ts` never exposed those removed symbols through the package root.

## Validation
- `bun test packages/openomni/test/dispatch packages/openomni/test/execution-runtime/cron-job-runner.test.ts` — 106 pass / 0 fail
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- LSP diagnostics clean on `packages/openomni/src/dispatch/index.ts`
- `bunx knip --include exports,types --reporter compact` no longer reports the removed dispatch barrel exports
- `codex-ultrawork-reviewer` PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the `packages/openomni/src/dispatch` barrel by dropping unused re-exports: schedule/worker handler factories and the `ResidentDispatchHandlerOptions`, `ScheduleDispatchHandlerOptions`, `WorkerDispatchHandlerOptions` types. No runtime or public API changes; handlers continue to be imported from their leaf modules.

<sup>Written for commit 7e9a49f51e1f8863ed1f33d25089445779b81ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

