### PR TITLE
refactor(openomni): trim agent tool barrel surface

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/agent/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/index.ts
@@ -1,8 +1,6 @@
 export { AgentToolProvider } from "./provider.js";
-export type { AgentToolProviderOptions } from "./provider.js";
-export { createDispatchTool, createWorkerResidentAskDispatchTool } from "./tools/dispatch.js";
+export { createDispatchTool } from "./tools/dispatch.js";
 export type { DispatchToolRuntime } from "./tools/dispatch.js";
-export { createSubagentTool } from "./tools/subagent.js";
 export {
   buildWorkerChildRuntimeConfig,
   createWorkerSubagentRuntime,


### PR DESCRIPTION
## Summary
- Trim the `execution-runtime/tool/agent` barrel so it no longer re-exports internal helper symbols.
- Remove unused barrel exports for `AgentToolProviderOptions`, `createWorkerResidentAskDispatchTool`, and `createSubagentTool`.
- Preserve provider behavior and parent/root public API; the provider still imports leaf helpers directly.

## Why
Knip reported these barrel exports as unused surface. The symbols are still valid leaf-module internals, but they do not need to be exposed through `tool/agent/index.ts` or the package-root API.

## Validation
- `bun test packages/openomni/src/execution-runtime/tool/agent/provider.test.ts packages/openomni/test/execution-runtime/dispatch-tool.test.ts` — 16 pass / 0 fail
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on `packages/openomni/src/execution-runtime/tool/agent/index.ts`
- `bunx knip --include exports,types --reporter compact` no longer reports the removed agent-tool barrel exports
- `codex-ultrawork-reviewer` PASS after evidence recapture


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the `execution-runtime/tool/agent` barrel to stop re-exporting internal helpers and unused types. Public API and provider behavior remain unchanged.

- **Refactors**
  - Removed barrel exports for `AgentToolProviderOptions`, `createWorkerResidentAskDispatchTool`, and `createSubagentTool`.
  - Kept `createDispatchTool` and `DispatchToolRuntime`; provider imports leaf helpers directly.

<sup>Written for commit 70091ae69c18d381534fca7e9b20db4b52e29eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

