### PR TITLE
refactor(openomni): remove dispatch namespace alias

### DIFF
--- a/packages/openomni/src/dispatch/runtime.ts
+++ b/packages/openomni/src/dispatch/runtime.ts
@@ -265,8 +265,3 @@ export class DispatchRuntime {
     }
   }
 }
-
-export const Dispatch = {
-  Runtime: DispatchRuntime,
-  Registry: DispatchRegistry,
-} as const;

--- a/packages/openomni/src/execution-runtime/AGENTS.md
+++ b/packages/openomni/src/execution-runtime/AGENTS.md
@@ -44,7 +44,7 @@ Key parameters:
 - `wait`: if `true`, blocks until the target responds (up to `timeoutMs`).
 - Actor identity is runtime-derived from implicit inputs (`sessionId`, `runId`, `agentName`) — not model-specified.
 
-Plugin actions (e.g., `surface.send.*`, `external.invoke.*`) can be registered via `Dispatch.Registry.register()`.
+Plugin actions (e.g., `surface.send.*`, `external.invoke.*`) can be registered via `DispatchRegistry.register()`.
 
 Do not reintroduce the removed legacy model-facing inbound tool or compatibility alias.
 


### PR DESCRIPTION
## Summary
- Remove the unused `Dispatch` namespace-style alias from `dispatch/runtime.ts`.
- Keep the canonical `DispatchRuntime` and `DispatchRegistry` exports intact through the dispatch barrel and package root.
- Update the execution-runtime notes to reference `DispatchRegistry.register()` directly.

## Why
Knip reported `packages/openomni/src/dispatch/runtime.ts: Dispatch` as unused public surface. The alias duplicated the canonical class exports and had no source/test callers.

## Validation
- `bun test packages/openomni/test/dispatch/runtime.test.ts packages/openomni/test/dispatch/worker-spawn-security.test.ts packages/openomni/test/dispatch/worker-spawn-executor-kind.test.ts packages/openomni/test/execution-runtime/cron-job-runner.test.ts` — 56 pass / 0 fail
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on `packages/openomni/src/dispatch/runtime.ts`
- `bunx knip --include exports,types --reporter compact` no longer reports `packages/openomni/src/dispatch/runtime.ts: Dispatch`
- `codex-ultrawork-reviewer` PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `Dispatch` namespace alias to simplify the public API. Canonical exports `DispatchRuntime` and `DispatchRegistry` are unchanged; docs now reference `DispatchRegistry.register()`.

- **Migration**
  - If you used `Dispatch.Registry.register()`, switch to `DispatchRegistry.register()` (no other changes).

<sup>Written for commit 49c4548600b0e9fdead669b73724ebcb7d155ce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

