### PR TITLE
refactor(openomni): keep bash classifiers internal

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/builtins/bash.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/bash.ts
@@ -6,8 +6,6 @@ import type { NativeTool, ToolExecutionContext } from "../types.js";
 import { BASH_PROMPT } from "./bash-prompt.js";
 import { isDestructiveCommand, isReadOnlyCommand, readCommandFromMeta } from "./bash-classify.js";
 
-export { isReadOnlyCommand, isDestructiveCommand };
-
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 600_000;
 


### PR DESCRIPTION
## Summary
- remove the redundant bash classifier re-export from `bash.ts`
- keep classifier definitions and canonical exports in `bash-classify.ts`
- preserve `bashTool` runtime behavior by continuing to import the classifiers internally

## Verification
- LSP diagnostics: `packages/openomni/src/execution-runtime/tool/builtins/bash.ts` clean
- `bun test packages/openomni/src/execution-runtime/tool/builtins/bash.test.ts packages/openomni/src/execution-runtime/workspace-lock.test.ts` (20 pass / 0 fail)
- `bun run --cwd packages/openomni check-types`
- `bunx knip --include exports,types --reporter compact` (target exports removed; remaining exit 1 is existing unrelated unused surface)
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- ultrawork reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Kept bash command classifiers internal by removing the redundant re-export of `isReadOnlyCommand` and `isDestructiveCommand` from `bash.ts`, making `bash-classify.ts` the only export point. No runtime changes; `bashTool` continues importing classifiers internally.

<sup>Written for commit 20ece616bb3bde5989bf621890a9fe1fc6237318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

