### PR TITLE
refactor(openomni): trim system tool barrel surface

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/system/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/system/index.ts
@@ -1,7 +1,1 @@
 export { SystemToolProvider } from "./provider.js";
-export { bashTool } from "../builtins/bash.js";
-export { createEditTool } from "../builtins/edit.js";
-export { createGlobTool } from "../builtins/glob.js";
-export { createGrepTool } from "../builtins/grep.js";
-export { createReadTool } from "../builtins/read.js";
-export { createWriteTool } from "../builtins/write.js";


### PR DESCRIPTION
## Summary
- remove unused built-in tool factory re-exports from `tool/system/index.ts`
- keep `SystemToolProvider` as the system-tool public surface
- preserve runtime behavior because `SystemToolProvider` imports built-ins directly from their leaf modules

## Verification
- LSP diagnostics: `packages/openomni/src/execution-runtime/tool/system/index.ts` clean
- `bun test packages/openomni/src/execution-runtime/tool/system/provider.test.ts packages/openomni/src/execution-runtime/tool/builtins/bash.test.ts packages/openomni/src/execution-runtime/tool/builtins/edit.test.ts packages/openomni/src/execution-runtime/workspace-lock.test.ts apps/server/test/execution/worker-runtime.test.ts apps/server/test/execution/worker-full-stack.test.ts` (43 pass / 0 fail)
- `bun run --cwd packages/openomni check-types`
- `bunx knip --include exports,types --reporter compact` (target exports removed; remaining exit 1 is existing unrelated unused surface)
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- ultrawork reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the system tool barrel by removing unused built‑in tool re-exports from `tool/system/index.ts`, keeping `SystemToolProvider` as the public surface. Runtime behavior is unchanged.

- **Migration**
  - If you imported built-in tools from `tool/system`, import from their leaf modules instead (e.g., `../builtins/bash.js`, `../builtins/edit.js`, etc.).

<sup>Written for commit 09c2e4f793c52d1024c770cbb40204609d09ae76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

