### PR TITLE
refactor(openomni): trim ingress barrel aliases

### DIFF
--- a/packages/openomni/src/ingress/index.ts
+++ b/packages/openomni/src/ingress/index.ts
@@ -1,10 +1,4 @@
-export {
-  IngressEngine,
-  ingestInternal,
-  setAgentResolver,
-  clearAgentResolver,
-  type AgentResolver,
-} from "./engine.js";
+export { IngressEngine } from "./engine.js";
 export { IngressSessionResolver } from "./session-resolver.js";
 export { IngressEventProjector } from "./event-projector.js";
 export { SessionBridge } from "./session-bridge.js";


### PR DESCRIPTION
## Summary
- remove unused bare ingress alias re-exports from `src/ingress/index.ts`
- keep `IngressEngine` as the canonical ingress public surface
- preserve runtime behavior because `IngressEngine.ingestInternal`, `IngressEngine.setAgentResolver`, and `IngressEngine.clearAgentResolver` remain on the namespace in `engine.ts`

## Verification
- LSP diagnostics: `packages/openomni/src/ingress/index.ts` clean
- `bun test packages/openomni/test/ingress/target.test.ts packages/openomni/test/ingress/cron-adapter.test.ts packages/openomni/test/ingress/engine-internal.test.ts apps/server/test/execution/worker-full-stack.test.ts apps/server/test/execution/e2e.test.ts apps/server/test/handler/conversation.test.ts` (32 pass / 0 fail)
- `bun test packages/openomni/test/execution-runtime/cron-job-runner.test.ts` (13 pass / 0 fail)
- note: one broader combined targeted command failed from Storage already initialized with a different dbPath when cron-job-runner shared a Bun process with prior storage-initializing suites; isolated reruns above passed
- `bun run --cwd packages/openomni check-types`
- `bunx knip --include exports,types --reporter compact` (target exports removed; remaining exit 1 is existing unrelated unused surface)
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- ultrawork reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed unused alias re-exports in `packages/openomni` ingress barrel so `IngressEngine` is the single public entry point. No runtime behavior change.

- **Refactors**
  - Removed `ingestInternal`, `setAgentResolver`, `clearAgentResolver`, and `AgentResolver` re-exports from `src/ingress/index.ts`; kept `IngressEngine`.
  - Internal methods remain on `IngressEngine` in `engine.ts` (`IngressEngine.ingestInternal`, `IngressEngine.setAgentResolver`, `IngressEngine.clearAgentResolver`).

<sup>Written for commit e2e50637f8deae88a07cabacf0573387b04b7b01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated public API exports from the ingress module, reducing the number of directly accessible utilities and consolidating the public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->