### PR TITLE
refactor(openomni): keep skill shared internals private

### DIFF
--- a/packages/openomni/src/skill/shared.ts
+++ b/packages/openomni/src/skill/shared.ts
@@ -3,9 +3,9 @@ import { join } from "node:path";
 import type { Skill } from "@openomni/protocol";
 
 export const SKILL_FILE_NAME = "SKILL.md";
-export const REGISTRY_FILE_NAME = "installed_skills.json";
+const REGISTRY_FILE_NAME = "installed_skills.json";
 
-export interface ErrorWithCode {
+interface ErrorWithCode {
   readonly code?: unknown;
 }
 
@@ -39,7 +39,7 @@ export function resolveGlobalSkillsRoot(options: SkillLoaderOptions): string {
   return options.globalSkillsRoot ?? join(resolveHomeRoot(options.homeRoot), ".openomni", "skills");
 }
 
-export function resolveHomeRoot(homeRoot: string | undefined): string {
+function resolveHomeRoot(homeRoot: string | undefined): string {
   return homeRoot ?? homedir();
 }
 


### PR DESCRIPTION
## Summary
- remove exported status from skill shared internals that are only used within `shared.ts`
- keep the documented public skill API unchanged through `src/skill/index.ts`

## Verification
- `bun test packages/openomni/test/skill`
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- `bunx knip --include exports,types --reporter compact` (targeted `skill/shared.ts` entries removed; remaining findings pre-existing/unrelated)
- LSP diagnostics clean on `packages/openomni/src/skill/shared.ts`

## Review
- `codex-ultrawork-reviewer`: PASS
- Claude Fable oracle attempted, but `claude-fable-5` was unavailable with model 404, so it is not counted as approval evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped internal helpers in `packages/openomni/src/skill/shared.ts` to reduce the public surface. The public skill API via `src/skill/index.ts` is unchanged; no breaking changes.

- **Refactors**
  - Made `REGISTRY_FILE_NAME` a module-private const.
  - Made `ErrorWithCode` and `resolveHomeRoot` non-exported.
  - Kept `SKILL_FILE_NAME` and `resolveGlobalSkillsRoot` as exports.

<sup>Written for commit 2ff41aca924b2198fdd4b7c3d28c032ec40e9fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

