### PR TITLE
refactor(openomni): keep background store internal

### DIFF
--- a/packages/openomni/src/subagent/AGENTS.md
+++ b/packages/openomni/src/subagent/AGENTS.md
@@ -9,7 +9,7 @@ Session-backed subagent execution runtime for the openomni orchestration layer.
 | `runtime.ts` | `SubagentRuntime` — orchestration shell for spawn / send / resume / cancel / wait backed by `WorkerRun` records | yes |
 | `consultation.ts` | `SubagentConsultation` — one-shot synchronous subagent calls (request/response pattern) | yes |
 | `background-manager.ts` | `BackgroundManager` — fire-and-forget wrapper with concurrency and depth limits | yes |
-| `background-store.ts` | `BackgroundStore` — in-memory registry of active background runs | yes |
+| `background-store.ts` | `BackgroundStore` — in-memory registry of active background runs | no |
 | `shared.ts` | `RuntimeModel`, `RuntimeMessage` types and message factory helpers (parameterized agent field) | no |
 | `message-builder.ts` | Message construction and serialization for subagent communication | no |
 | `run-lifecycle.ts` | Abort, timeout, and finalize functions for `WorkerRun` lifecycle | no |
@@ -19,9 +19,9 @@ Session-backed subagent execution runtime for the openomni orchestration layer.
 
 ## Module Split Rationale
 
-`runtime.ts` was refactored from ~1094 LOC into focused modules. The split follows single-responsibility: each internal module owns one concern (types, message construction, lifecycle, transcript, mailbox delivery). Only the four public classes are re-exported from `index.ts`; the rest are internal implementation details.
+`runtime.ts` was refactored from ~1094 LOC into focused modules. The split follows single-responsibility: each internal module owns one concern (types, message construction, lifecycle, transcript, mailbox delivery). Only runtime-facing classes and middleware are re-exported from `index.ts`; the rest are internal implementation details.
 
-Internal modules (`shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
+Internal modules (`background-store.ts`, `shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
 
 ## Dependencies
 

--- a/packages/openomni/src/subagent/index.ts
+++ b/packages/openomni/src/subagent/index.ts
@@ -3,4 +3,3 @@ export { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-polic
 export { BackgroundLimitsMiddleware } from "./middleware/background-limits.js";
 export { SubagentConsultation } from "./consultation.js";
 export { BackgroundManager } from "./background-manager.js";
-export { BackgroundStore } from "./background-store.js";


### PR DESCRIPTION
## Summary
- remove `BackgroundStore` from the subagent barrel export
- update the subagent domain doc to mark `background-store.ts` as internal

## Verification
- `bun test packages/openomni/src/subagent packages/openomni/test/execution-runtime/subagent-runtime.test.ts`
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- `bunx knip --include exports,types --reporter compact` (targeted `BackgroundStore` barrel finding removed; remaining findings pre-existing/unrelated)
- LSP diagnostics clean on `packages/openomni/src/subagent/index.ts`

## Review
- `codex-ultrawork-reviewer`: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `BackgroundStore` internal by removing it from the subagent barrel export and updating docs. No behavior changes; only the public export is removed.

- **Migration**
  - Remove any `BackgroundStore` imports from the subagent barrel.
  - Use `BackgroundManager` for background runs; do not import internal modules.

<sup>Written for commit 825753a67e15580663ddbce8ba43ef872badde76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

