### PR TITLE
refactor(openomni): trim policy barrel middleware surface

### DIFF
--- a/packages/openomni/src/policy/index.ts
+++ b/packages/openomni/src/policy/index.ts
@@ -1,10 +1,7 @@
-export { IngressAuthorityMiddleware } from "../ingress/middleware/ingress-authority";
-export { SubagentSpawnPolicyMiddleware } from "../subagent/middleware/subagent-spawn-policy";
 /**
  * @deprecated Use `BackgroundLimitsMiddleware` from the package root for new code.
  */
 export { BackgroundLimitsPolicy } from "./background-limits";
-export { ToolRuntimePolicyMiddleware } from "../execution-runtime/tool/middleware/tool-runtime-policy";
 export { PolicyResolver } from "./resolver";
 export type {
   LabelMatcher,


### PR DESCRIPTION
## Summary
- remove duplicate middleware re-exports from the policy barrel
- keep `BackgroundLimitsPolicy`, `PolicyResolver`, and resolver types exported from `src/policy`
- preserve middleware availability through owning domains and the package root

## Verification
- `bun test packages/openomni/test/policy packages/openomni/test/subagent packages/openomni/test/tool/descriptor-attachment.test.ts`
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- `bunx knip --include exports,types --reporter compact` (targeted `policy/index.ts` middleware findings removed; remaining findings pre-existing/unrelated)
- LSP diagnostics clean on `packages/openomni/src/policy/index.ts`

## Review
- `codex-ultrawork-reviewer`: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the `policy` barrel in `openomni` by removing duplicate middleware re-exports. Kept `BackgroundLimitsPolicy`, `PolicyResolver`, and resolver types; no runtime changes.

- **Migration**
  - If you imported these from `openomni/policy`, switch to owning domains or the package root:
    - `IngressAuthorityMiddleware` → `openomni/ingress/middleware/ingress-authority` (or `openomni`)
    - `SubagentSpawnPolicyMiddleware` → `openomni/subagent/middleware/subagent-spawn-policy` (or `openomni`)
    - `ToolRuntimePolicyMiddleware` → `openomni/execution-runtime/tool/middleware/tool-runtime-policy` (or `openomni`)

<sup>Written for commit ff1becfd394d3ff6b8a499f9a8c0dd86600fd00c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

