### PR TITLE
refactor(openomni): keep subagent helpers internal

### DIFF
--- a/packages/openomni/src/subagent/message-builder.ts
+++ b/packages/openomni/src/subagent/message-builder.ts
@@ -3,7 +3,7 @@ import type { Message, Tool } from "@openomni/protocol";
 import { Session } from "@openomni/session";
 import { type RuntimeMessage, addTextPart } from "./shared";
 
-export function createCompletedToolState(call: Tool.Call, output: string): Tool.StateCompleted {
+function createCompletedToolState(call: Tool.Call, output: string): Tool.StateCompleted {
   const now = Date.now();
   return {
     status: "completed",
@@ -18,7 +18,7 @@ export function createCompletedToolState(call: Tool.Call, output: string): Tool.
   };
 }
 
-export function createErrorToolState(call: Tool.Call, error: string): Tool.StateError {
+function createErrorToolState(call: Tool.Call, error: string): Tool.StateError {
   const now = Date.now();
   return {
     status: "error",
@@ -31,7 +31,7 @@ export function createErrorToolState(call: Tool.Call, error: string): Tool.State
   };
 }
 
-export function addToolParts(
+function addToolParts(
   sessionId: string,
   messageId: string,
   steps: { toolCalls?: Tool.Call[]; toolResults?: Tool.Result[] }[],
@@ -64,7 +64,7 @@ export function addToolParts(
   }
 }
 
-export function serializeToolPart(part: Message.ToolPart, repair?: boolean): string {
+function serializeToolPart(part: Message.ToolPart, repair?: boolean): string {
   const input = JSON.stringify(part.state.input);
 
   switch (part.state.status) {
@@ -90,7 +90,7 @@ export function addAssistantResultParts(
   addToolParts(sessionId, messageId, result.steps);
 }
 
-export function toRuntimeMessage(
+function toRuntimeMessage(
   message: Message.WithParts,
   repair?: boolean,
 ): RuntimeMessage | undefined {

--- a/packages/openomni/src/subagent/run-lifecycle.ts
+++ b/packages/openomni/src/subagent/run-lifecycle.ts
@@ -17,7 +17,7 @@ export function buildAbortSignal(controller: AbortController, signal?: AbortSign
   );
 }
 
-export async function shouldSkipFailureUpdate(sessionId: string, runId: string): Promise<boolean> {
+async function shouldSkipFailureUpdate(sessionId: string, runId: string): Promise<boolean> {
   const run = await WorkerRun.get(sessionId, runId);
   if (run?.status === "cancelled" || run?.status === "interrupted") return true;
   // Cancel in progress: controller aborted but entry kept for completion tracking
@@ -34,7 +34,7 @@ export function isTerminalStatus(status: string): boolean {
   );
 }
 
-export function resolveMetaStatus(runStatus: string | undefined): string {
+function resolveMetaStatus(runStatus: string | undefined): string {
   switch (runStatus) {
     case "succeeded":
       return "idle";
@@ -47,7 +47,7 @@ export function resolveMetaStatus(runStatus: string | undefined): string {
   }
 }
 
-export async function finalizeRun(sessionId: string, runId: string): Promise<void> {
+async function finalizeRun(sessionId: string, runId: string): Promise<void> {
   const run = await WorkerRun.get(sessionId, runId);
   if (run && !isTerminalStatus(run.status) && !(await shouldSkipFailureUpdate(sessionId, runId))) {
     await WorkerRun.updateStatus(sessionId, runId, "failed", {
@@ -66,7 +66,7 @@ export async function finalizeRun(sessionId: string, runId: string): Promise<voi
   }
 }
 
-export async function waitForAbortEntryRemoval(sessionId: string, runId: string): Promise<void> {
+async function waitForAbortEntryRemoval(sessionId: string, runId: string): Promise<void> {
   for (let i = 0; i < 20; i++) {
     if (getAbortEntry(sessionId, runId) === undefined) return;
     await Promise.resolve();
@@ -178,7 +178,7 @@ export function setupRunTimeouts(
   return timers;
 }
 
-export function clearRunTimeouts(timers: TimeoutTimers): void {
+function clearRunTimeouts(timers: TimeoutTimers): void {
   if (timers.soft) clearTimeout(timers.soft);
   if (timers.hard) clearTimeout(timers.hard);
 }


### PR DESCRIPTION
## Summary

- Keep subagent message-building helpers file-local instead of exported.
- Keep run lifecycle helper functions file-local instead of exported.
- Preserve the runtime-facing subagent API; function bodies and internal call sites are unchanged.

## Why

These helpers were reported as unused exports by Knip and are only referenced inside their owning files. Keeping them internal reduces accidental consumer surface without changing behavior.

## Verification

- LSP diagnostics clean on packages/openomni/src/subagent/message-builder.ts
- LSP diagnostics clean on packages/openomni/src/subagent/run-lifecycle.ts
- bun test packages/openomni/src/subagent packages/openomni/test/subagent packages/openomni/test/execution-runtime/subagent-runtime.test.ts (183 pass, 0 fail)
- bun run --cwd packages/openomni check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected remaining unrelated items; removed helper exports no longer listed)
- codex-ultrawork-reviewer PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make subagent helper functions internal by unexporting them in `packages/openomni/src/subagent/message-builder.ts` and `packages/openomni/src/subagent/run-lifecycle.ts` to reduce the public surface. No runtime-facing API changes; this also removes Knip unused-export warnings.

<sup>Written for commit 6fec512d5ca2e9c62da285ae32d1e367b96857a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

