### PR TITLE
refactor(openomni): trim tool barrel type surface

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/index.ts
@@ -14,7 +14,6 @@ export { SystemToolProvider } from "./system/index.js";
 export type { CatalogEntry } from "./catalog.js";
 export type { ToolExecutorContext } from "./executor.js";
 export type {
-  ImplicitInputSource,
   NativeTool,
   ToolCategory,
   ToolExecutionContext,
@@ -22,6 +21,5 @@ export type {
   ToolMetaValue,
   ToolProvider,
   ToolRiskTier,
-  ToolRuntimeContext,
   ToolSource,
 } from "./types.js";


### PR DESCRIPTION
## Summary

- Remove unused `ImplicitInputSource` and `ToolRuntimeContext` type re-exports from the execution-runtime tool barrel.
- Keep the canonical leaf definitions in `tool/types.ts` unchanged for internal use.
- Preserve the package/root execution-runtime public surface, which did not expose these two types.

## Why

Knip reported these two types as unused exports from `packages/openomni/src/execution-runtime/tool/index.ts`. Internal code imports them directly from the canonical leaf module, so the barrel re-export is unnecessary public surface.

## Verification

- LSP diagnostics clean on `packages/openomni/src/execution-runtime/tool/index.ts`
- `bun test packages/openomni/src/execution-runtime/tool packages/openomni/test/execution-runtime` (162 pass, 0 fail)
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- `bunx knip --include exports,types --reporter compact` (expected remaining unrelated items; removed barrel types no longer listed)
- codex-ultrawork-reviewer PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `ImplicitInputSource` and `ToolRuntimeContext` re-exports from `packages/openomni/src/execution-runtime/tool/index.ts` to trim the barrel’s type surface. Canonical definitions stay in `./types.ts`; no changes to the package’s public API.

<sup>Written for commit 4029c515a9c73daf34f6dc0ae2a77ca684dbb610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

