### PR TITLE
refactor(openomni): keep local cli helper types internal

### DIFF
--- a/packages/openomni/src/execution-runtime/local-cli-agent-env.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-agent-env.ts
@@ -10,13 +10,13 @@ export interface LocalCliTemplateValues {
 
 export type LocalCliCredentialMap = Readonly<Record<string, string>>;
 
-export interface LocalCliCredentialEnvSuccess {
+interface LocalCliCredentialEnvSuccess {
   readonly ok: true;
   readonly env: Record<string, string>;
   readonly redactions: readonly string[];
 }
 
-export interface LocalCliCredentialEnvFailure {
+interface LocalCliCredentialEnvFailure {
   readonly ok: false;
   readonly error: string;
 }

--- a/packages/openomni/src/execution-runtime/local-cli-question-bridge.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-question-bridge.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export interface LocalCliQuestionBridgeRequest {
+interface LocalCliQuestionBridgeRequest {
   readonly runId: string;
   readonly sessionId: string;
   readonly residentSessionId: string;


### PR DESCRIPTION
## Summary

- Keep local CLI credential result helper interfaces file-local.
- Keep the local CLI question bridge request interface file-local.
- Preserve exported public shapes through `LocalCliCredentialEnvResult` and `LocalCliQuestionBridgeHandler`.

## Why

Knip reported these helper interface names as unused exported types. They are only needed to describe exported union/handler shapes inside their owning modules, so exporting the names themselves creates unnecessary public surface.

## Verification

- LSP diagnostics clean on `packages/openomni/src/execution-runtime/local-cli-agent-env.ts`
- LSP diagnostics clean on `packages/openomni/src/execution-runtime/local-cli-question-bridge.ts`
- `bun test packages/openomni/src/execution-runtime/local-cli-agent-env.test.ts packages/openomni/src/execution-runtime/local-cli-question-bridge-edge.test.ts packages/openomni/src/execution-runtime/local-cli-agent-process.test.ts packages/openomni/src/execution-runtime/local-cli-agent-runtime.test.ts` (28 pass, 0 fail)
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- `bunx knip --include exports,types --reporter compact` (expected remaining unrelated items; removed target types no longer listed)
- codex-ultrawork-reviewer PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the local CLI helper interfaces file‑local in `openomni` to shrink the public type surface. No API or runtime changes.

- **Refactors**
  - Stop exporting `LocalCliCredentialEnvSuccess`, `LocalCliCredentialEnvFailure`, and `LocalCliQuestionBridgeRequest` in `local-cli-agent-env.ts` and `local-cli-question-bridge.ts`.
  - Keep exported shapes via `LocalCliCredentialEnvResult` and `LocalCliQuestionBridgeHandler`.

<sup>Written for commit 893a3b3817613f7dba7835da2b37710f09fcc6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

