### PR TITLE
refactor(openomni): keep ingress model config internal

### DIFF
--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -15,7 +15,7 @@ interface ResolvableEvent {
   meta?: Ingress.Meta;
 }
 
-export interface ModelConfig {
+interface ModelConfig {
   providerID: string;
   modelID: string;
 }


### PR DESCRIPTION
## Type
- [x] refactor

## Affected Packages
- [x] openomni

## Breaking Changes
- [x] No breaking changes

## Summary
- keep the ingress session resolver's ModelConfig helper interface file-local
- preserve IngressSessionResolver.resolve runtime behavior and custom model object support
- remove one unused exported type from the deep openomni ingress surface

## Verification
- bun test packages/openomni/test/ingress/session-resolver.test.ts
- bun run --cwd packages/openomni check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from unrelated remaining unused exports; target ModelConfig removed)
- codex-ultrawork-reviewer PASS
