### PR TITLE
refactor(agent): keep compaction result internal

### DIFF
--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -10,7 +10,7 @@ export interface CompactionOptions {
   onSummarize?: (messages: Message.WithParts[]) => Promise<string>;
 }
 
-export interface CompactionResult {
+interface CompactionResult {
   messages: Message.WithParts[];
   compacted: boolean;
   removedCount: number;


### PR DESCRIPTION
## Type
- [x] refactor

## Affected Packages
- [x] agent

## Breaking Changes
- [x] No breaking changes

## Summary
- keep the InMemoryCompactor compact return helper interface file-local
- preserve InMemoryCompactor runtime behavior and CompactionOptions as the public config type
- remove one unused exported type from the deep agent compaction surface

## Verification
- bun test packages/agent/test/core/execution/compaction.test.ts packages/agent/test/core/policy/builtin/compaction.test.ts packages/agent/test/core/policy/builtin-snapshots.test.ts
- bun run --cwd packages/agent check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from unrelated remaining unused exports/types; target CompactionResult removed)
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `CompactionResult` internal in the `agent` compaction module to reduce the public API surface and remove an unused export. Runtime behavior is unchanged; `CompactionOptions` remains the public config type.

<sup>Written for commit db307ee378495516cf8832e075990848953b5f55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

