### PR TITLE
refactor(agent): remove legacy policy type exports

### DIFF
--- a/packages/agent/src/core/policy/types.ts
+++ b/packages/agent/src/core/policy/types.ts
@@ -37,20 +37,3 @@ export interface PolicyRegistration {
   fn: PolicyFn;
   propagate?: boolean;
 }
-
-export type PolicyRuntimeContext = Record<string, unknown>;
-
-export interface PolicyFactory {
-  readonly id: string;
-  create(config: unknown, runtime: PolicyRuntimeContext): PolicyRegistration;
-}
-
-export interface PolicyRegistry {
-  register(
-    id: string,
-    factory: (config: unknown, runtime: Record<string, unknown>) => PolicyRegistration,
-  ): void;
-  resolve(plan: unknown, runtime: Record<string, unknown>): PolicyRegistration[];
-  has(id: string): boolean;
-  list(): string[];
-}


### PR DESCRIPTION
## Type
- [x] refactor

## Affected Packages
- [x] agent

## Breaking Changes
- [x] No breaking changes

## Summary
- remove unused legacy policy factory/registry declarations from core policy types
- keep the actual PolicyRegistry and PolicyFactory public API from registry.ts intact
- reduce one stale Knip unused exported type row from the agent policy surface

## Verification
- bun test packages/agent/test/core/policy packages/agent/test/core/execution/tool-executor-verdicts.test.ts packages/agent/test/core/execution/tool-selection.test.ts
- bun run --cwd packages/agent check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from unrelated remaining unused exports/types; target policy types row removed)
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused legacy policy type exports from `packages/agent` to simplify the policy surface and clear a Knip unused-export warning. Runtime behavior is unchanged; the `PolicyRegistry` and `PolicyFactory` public APIs in `registry.ts` stay the same.

- **Refactors**
  - Deleted `PolicyRuntimeContext`, `PolicyFactory`, and `PolicyRegistry` interfaces from `core/policy/types.ts`.

<sup>Written for commit 55efb36e0440c09336042b1476f48de8145a9ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

