### PR TITLE
refactor(agent): keep policy runtime context internal

### DIFF
--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -8,5 +8,5 @@ export type {
   PolicyEngineInstance,
 } from "./engine";
 export { PolicyRegistry, defaultRegistry } from "./registry";
-export type { PolicyFactory, PolicyRegistryInstance, RuntimeContext } from "./registry";
+export type { PolicyFactory, PolicyRegistryInstance } from "./registry";
 export * from "./builtin";

--- a/packages/agent/src/core/policy/registry.ts
+++ b/packages/agent/src/core/policy/registry.ts
@@ -9,7 +9,7 @@ import {
 } from "./builtin";
 import type { PolicyRegistration } from "./types";
 
-export interface RuntimeContext {
+interface RuntimeContext {
   readonly workspaceRoot?: string;
   readonly sessionId?: string;
   readonly runId?: string;


### PR DESCRIPTION
## Type
- [x] refactor

## Affected Packages
- [x] agent

## Breaking Changes
- [x] No breaking changes

## Summary
- keep the policy registry RuntimeContext helper interface file-local
- remove the deep core/policy RuntimeContext type re-export
- preserve PolicyFactory, PolicyRegistryInstance, PolicyRegistry, and defaultRegistry public API

## Verification
- bun test packages/agent/test/core/policy/registry.test.ts packages/agent/test/core/policy packages/agent/test/core/execution/tool-executor-verdicts.test.ts
- bun run --cwd packages/agent check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from unrelated remaining unused exports/types; target RuntimeContext rows removed)
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalize the policy `RuntimeContext` in the `agent` package to reduce the public API surface. No changes needed for consumers.

- **Refactors**
  - Make `RuntimeContext` interface file-local in `core/policy/registry.ts`.
  - Remove `RuntimeContext` type re-export from `core/policy/index.ts`; keep `PolicyFactory`, `PolicyRegistryInstance`, `PolicyRegistry`, and `defaultRegistry` exports.

<sup>Written for commit 27ca2290a1e963fdf4362461c9c269dcb5a4f1a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

