### PR TITLE
refactor(agent): keep runtime tool specs internal

### DIFF
--- a/packages/agent/src/runtime/tools/background-cancel.ts
+++ b/packages/agent/src/runtime/tools/background-cancel.ts
@@ -6,7 +6,7 @@ export interface BackgroundCancelToolOptions {
   };
 }
 
-export interface BackgroundCancelToolSpec {
+interface BackgroundCancelToolSpec {
   spec: Tool.Spec;
   execute: (args: unknown) => Promise<Tool.Result>;
 }

--- a/packages/agent/src/runtime/tools/background-output.ts
+++ b/packages/agent/src/runtime/tools/background-output.ts
@@ -7,7 +7,7 @@ export interface BackgroundOutputToolOptions {
   };
 }
 
-export interface BackgroundOutputToolSpec {
+interface BackgroundOutputToolSpec {
   spec: Tool.Spec;
   execute: (args: unknown) => Promise<Tool.Result>;
 }

--- a/packages/agent/src/runtime/tools/index.ts
+++ b/packages/agent/src/runtime/tools/index.ts
@@ -1,6 +1,6 @@
 export { SubagentTool } from "./subagent";
-export type { SubagentToolOptions, SubagentToolSpec } from "./subagent";
+export type { SubagentToolOptions } from "./subagent";
 export { BackgroundOutputTool } from "./background-output";
-export type { BackgroundOutputToolOptions, BackgroundOutputToolSpec } from "./background-output";
+export type { BackgroundOutputToolOptions } from "./background-output";
 export { BackgroundCancelTool } from "./background-cancel";
-export type { BackgroundCancelToolOptions, BackgroundCancelToolSpec } from "./background-cancel";
+export type { BackgroundCancelToolOptions } from "./background-cancel";

--- a/packages/agent/src/runtime/tools/subagent.ts
+++ b/packages/agent/src/runtime/tools/subagent.ts
@@ -57,7 +57,7 @@ export interface SubagentToolExecutionContext {
   readonly signal?: AbortSignal;
 }
 
-export interface SubagentToolSpec {
+interface SubagentToolSpec {
   spec: Tool.Spec;
   execute: (args: unknown, context?: SubagentToolExecutionContext) => Promise<Tool.Result>;
 }


### PR DESCRIPTION
## Summary
- keep runtime tool spec return interfaces internal to their defining modules
- remove unused deep runtime/tools re-exports for SubagentToolSpec, BackgroundOutputToolSpec, and BackgroundCancelToolSpec
- preserve tool namespaces and Options type exports

## Verification
- LSP diagnostics on changed files: clean
- bun test packages/agent/test/runtime/tools/subagent.test.ts packages/agent/test/runtime/tools/subagent-runtime-required.test.ts packages/agent/test/runtime/tools/subagent-middleware.test.ts packages/agent/test/runtime/tools/subagent-background.test.ts packages/agent/test/runtime/tools/background-output.test.ts packages/agent/test/runtime/tools/background-cancel.test.ts
- bun run --cwd packages/agent check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 for remaining unrelated findings; target row removed, unused exported types 20 -> 19)

## Review
- codex-ultrawork-reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized runtime tool spec interfaces to reduce the public API surface while keeping tools and `*Options` types exported. No runtime behavior changes.

- **Refactors**
  - Made `SubagentToolSpec`, `BackgroundOutputToolSpec`, and `BackgroundCancelToolSpec` module-internal.
  - Removed their type re-exports from `packages/agent/src/runtime/tools/index.ts`.
  - Kept `SubagentTool`, `BackgroundOutputTool`, `BackgroundCancelTool`, and their `*ToolOptions` types exported.

- **Migration**
  - If you imported any `*ToolSpec` types, remove those imports and rely on public tool APIs or `Tool.Spec` as needed.

<sup>Written for commit 57db2bc029f43d5fa8387c8b5835d569a7ee7d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

