### PR TITLE
refactor(openomni): keep llm mock helper internal

### DIFF
--- a/packages/openomni/test/ingress/_llm-mock.ts
+++ b/packages/openomni/test/ingress/_llm-mock.ts
@@ -19,7 +19,7 @@ export function resetTestState(): void {
   testState.runFn = null;
 }
 
-export function createAssistantMessage(text: string, sessionID: string): Message.WithParts {
+function createAssistantMessage(text: string, sessionID: string): Message.WithParts {
   const id = crypto.randomUUID();
   const now = Date.now();
 


### PR DESCRIPTION
## Summary
- keep the ingress LLM mock's createAssistantMessage helper file-local
- preserve the test helper exports used by ingress tests

## Verification
- LSP diagnostics on packages/openomni/test/ingress/_llm-mock.ts: clean
- bun test packages/openomni/test/ingress
- bun run check-types
- bun run build
- bun run lint
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 for remaining unrelated findings; unused exports 13 -> 12, target row removed)

## Review
- codex-ultrawork-reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the ingress LLM mock’s `createAssistantMessage` helper file-local to keep it internal and reduce unused exports. All other test helper exports used by ingress tests remain unchanged.

<sup>Written for commit 65c96608eb01b628f11950949377eba78b1da694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

