### PR TITLE
refactor(server): keep trigger prefix helper internal

### DIFF
--- a/apps/server/src/shared/trigger.ts
+++ b/apps/server/src/shared/trigger.ts
@@ -37,7 +37,7 @@ function evaluateRule(rule: Adapter.TriggerRule, ctx: Adapter.TriggerContext): b
   }
 }
 
-export function stripTriggerPrefix(text: string, rules: Adapter.TriggerRule[]): string {
+function stripTriggerPrefix(text: string, rules: Adapter.TriggerRule[]): string {
   const prefix = rules.find(
     (r): r is Extract<Adapter.TriggerRule, { type: "prefix" }> => r.type === "prefix",
   );


### PR DESCRIPTION
## Summary
- keep stripTriggerPrefix file-local inside the server trigger helper module
- preserve evaluateTriggers and normalizeContent public exports used by channel code

## Verification
- LSP diagnostics on apps/server/src/shared/trigger.ts: clean
- bun test apps/server/test apps/server/src
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 for remaining unrelated findings; unused exports 11 -> 10, target row removed)

## Review
- codex-ultrawork-reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped `stripTriggerPrefix` to file-local in `apps/server/src/shared/trigger.ts` to reduce the public surface of the server trigger helper. No breaking changes; `evaluateTriggers` and `normalizeContent` remain exported for channel code.

<sup>Written for commit 35faa07ffc38c9e856550d671d528cd6f0fc1386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

