### PR TITLE
refactor(server): keep mcp prefix guard internal

### DIFF
--- a/apps/server/src/tool/mcp/index.ts
+++ b/apps/server/src/tool/mcp/index.ts
@@ -1,2 +1,1 @@
 export { McpToolProvider } from "./provider";
-export { McpPrefixGuardMiddleware } from "./mcp-prefix-guard";

--- a/apps/server/test/tool/mcp/provider.test.ts
+++ b/apps/server/test/tool/mcp/provider.test.ts
@@ -8,7 +8,8 @@ import { createToolExecutor, WorkspaceLock, type NativeTool } from "@openomni/op
 import type { RuntimeResource, Tool } from "@openomni/protocol";
 import { Mcp, PolicyDecision } from "@openomni/protocol";
 import { Bus, Session, Storage } from "@openomni/session";
-import { McpPrefixGuardMiddleware, McpToolProvider } from "../../../src/tool/mcp";
+import { McpPrefixGuardMiddleware } from "../../../src/tool/mcp/mcp-prefix-guard";
+import { McpToolProvider } from "../../../src/tool/mcp";
 
 beforeEach(() => {
   Storage.initialize({ dbPath: ":memory:" });
@@ -194,12 +195,18 @@ describe("McpToolProvider", () => {
     const controller = new AbortController();
     controller.abort(new Error("already cancelled"));
 
-    await expect(
-      provider.execute(
+    try {
+      await provider.execute(
         { id: "call-pre-abort", tool: "search.query", input: {} },
         { signal: controller.signal },
-      ),
-    ).rejects.toThrow("MCP tool execution aborted");
+      );
+      throw new Error("expected provider.execute to reject");
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error;
+      }
+      expect(error.message).toContain("MCP tool execution aborted");
+    }
     expect(client.callTool).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- remove McpPrefixGuardMiddleware from the server MCP barrel
- keep McpToolProvider as the public MCP provider export
- point focused tests at the guard implementation module and clear an LSP hint in the touched test

## Verification
- LSP diagnostics on changed files: clean
- bun test apps/server/test/tool/mcp/provider.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 for remaining unrelated findings; unused exports 10 -> 9, target row removed)

## Review
- codex-ultrawork-reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the MCP prefix guard internal by removing `McpPrefixGuardMiddleware` from the server MCP index so only `McpToolProvider` remains public. Tests now import the guard from its module and use a try/catch to assert the pre-abort error message.

<sup>Written for commit a08c799c80db188281ced5b91f2c3fdf567f5b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

