### PR TITLE
refactor(server): keep worker tool selection internal

### DIFF
--- a/apps/server/src/execution/worker-runtime.ts
+++ b/apps/server/src/execution/worker-runtime.ts
@@ -34,7 +34,7 @@ export function buildWorkerInputMessages(sessionId: string, prompt: string): Wor
   return [...messages, { role: "user", content: prompt }];
 }
 
-export function selectRequestedTools(
+function selectRequestedTools(
   availableTools: NativeTool[],
   requestedTools: Execution.Request["tools"],
 ): NativeTool[] {

--- a/apps/server/test/execution/worker-runtime.test.ts
+++ b/apps/server/test/execution/worker-runtime.test.ts
@@ -6,7 +6,6 @@ import {
   buildWorkerInputMessages,
   createExecutionToolContext,
   resolveWorkerDbPath,
-  selectRequestedTools,
 } from "../../src/execution/worker-runtime";
 
 const model = { providerID: "test", modelID: "fixture" };
@@ -72,12 +71,19 @@ describe("worker-runtime", () => {
   it("selects requested tools by sanitized protocol names", () => {
     const availableTools = new SystemToolProvider("/workspace/openomni").listTools();
 
-    const selected = selectRequestedTools(availableTools, [
-      { name: "bash", inputSchema: { type: "object" } },
-      { name: "grep_search", inputSchema: { type: "object" } },
-    ]);
+    const context = createExecutionToolContext(
+      {
+        tools: [
+          { name: "bash", inputSchema: { type: "object" } },
+          { name: "grep_search", inputSchema: { type: "object" } },
+        ],
+        toolConfig: { workspaceRoot: "/workspace/openomni" },
+      },
+      availableTools,
+    );
 
-    expect(selected.map((tool) => tool.spec.name)).toEqual(["bash", "grep.search"]);
+    expect(context.tools?.map((tool) => tool.name)).toEqual(["bash", "grep_search"]);
+    expect(context.toolExecutor).toBeDefined();
   });
 
   it("rebuilds a tool executor and leaves request permissions to agent policy", async () => {


### PR DESCRIPTION
## Summary
- keep selectRequestedTools file-local inside worker-runtime
- preserve worker tool selection behavior through createExecutionToolContext
- update the focused test to verify sanitized selection through the public execution context helper

## Verification
- LSP diagnostics on changed files: clean
- bun test apps/server/test/execution/worker-runtime.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 for remaining unrelated findings; unused exports 9 -> 8, target row removed)

## Review
- codex-ultrawork-reviewer: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalizes worker tool selection within `worker-runtime` and routes selection through `createExecutionToolContext` so external behavior stays the same while tests use the public API.

- **Refactors**
  - Made `selectRequestedTools` file-local (no longer exported).
  - Preserved selection via `createExecutionToolContext`.
  - Updated test to assert sanitized tool names and that `toolExecutor` is created.

<sup>Written for commit a712e72aff7d045d655410073a177050eedfde39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for tool selection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->