### PR TITLE
refactor(server): keep mcp parse options schema internal

### DIFF
--- a/apps/server/src/config/mcp-server-config.ts
+++ b/apps/server/src/config/mcp-server-config.ts
@@ -6,7 +6,7 @@ export type McpServerConfig = McpConfig.ServerConfig;
 
 const MAX_ZOD_ISSUES_PER_ENTRY = 3;
 
-export const McpServerConfigParseOptionsSchema = z.object({
+const McpServerConfigParseOptionsSchema = z.object({
   source: z.enum(["server-config", "project-config"]),
   configPath: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- keep `McpServerConfigParseOptionsSchema` file-local while preserving `parseMcpServerConfigs`
- reduce the server config unused export surface without changing runtime parsing behavior

## Verification
- `bun test apps/server/test/config.test.ts apps/server/test/context/mcp-config.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on `apps/server/src/config/mcp-server-config.ts`
- `bunx knip --include exports,types --reporter compact` no longer reports `McpServerConfigParseOptionsSchema`
- `codex-ultrawork-reviewer` PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `McpServerConfigParseOptionsSchema` internal (no longer exported) in the server config to reduce unused exports. No change to runtime parsing or behavior.

<sup>Written for commit 6b8383628d67a9d99c74ed93be017f68d25d8a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

