### PR TITLE
refactor(server): remove unused config getter

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -138,11 +138,6 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): ServerConfig {
   return _config;
 }
 
-export function getConfig(): ServerConfig {
-  if (!_config) throw new Error("Config not loaded. Call loadConfig() first.");
-  return _config;
-}
-
 export function resetConfig(): void {
   _config = null;
   _configPath = null;


### PR DESCRIPTION
## Summary
- remove the unused `getConfig()` export from server config
- preserve `loadConfig()`, `resetConfig()`, and config resolution behavior

## Verification
- `bun test apps/server/test/config.test.ts apps/server/test/context/mcp-config.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on `apps/server/src/config.ts`
- `rg "\\bgetConfig\\b" apps packages -g "*.ts"` returns no matches
- `codex-ultrawork-reviewer` PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the unused getConfig() export from the server config to simplify the API. Keep loadConfig(), resetConfig(), and config resolution unchanged with no behavior changes.

<sup>Written for commit 17db3925a7695a7bff76bf95bf7e6a954e20378b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

