### PR TITLE
refactor(server): trim config public surface

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { parseMcpServerConfigs, type McpServerConfig } from "./config/mcp-server-config";
-export type { McpServerConfig } from "./config/mcp-server-config";
 
 const DEFAULT_CONFIG_PATH = join(homedir(), ".openomni", "config.json");
 
@@ -136,9 +135,4 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH): ServerConfig {
   _config = resolve(loadRaw(configPath), configPath);
   _configPath = configPath;
   return _config;
-}
-
-export function resetConfig(): void {
-  _config = null;
-  _configPath = null;
 }

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { Operational } from "@openomni/protocol";
+import { Operational, type McpServerConfig } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import { resetConfig, loadConfig, type McpServerConfig } from "../src/config";
+import { loadConfig } from "../src/config";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -22,13 +22,11 @@ describe("config", () => {
       GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
       WS_AUTH_TOKEN: process.env.WS_AUTH_TOKEN,
     };
-    resetConfig();
     Bus.reset();
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
-    resetConfig();
     Bus.reset();
     Object.entries(originalEnv).forEach(([key, value]) => {
       if (value === undefined) {

--- a/apps/server/test/context/mcp-config.test.ts
+++ b/apps/server/test/context/mcp-config.test.ts
@@ -2,10 +2,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { Operational } from "@openomni/protocol";
+import { Operational, type McpServerConfig } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { McpConfigLoader } from "../../src/context/mcp-config";
-import type { McpServerConfig } from "../../src/config";
 
 let tempRoot: string;
 
@@ -166,9 +165,7 @@ describe("McpConfigLoader.merge", () => {
     const result = McpConfigLoader.merge(globalServers, conflictProject);
 
     const overridden = result.find((s) => s.name === "global-a");
-    expect(overridden?.transport).toBe("sse");
-    expect(overridden?.url).toBe("http://override");
-    expect(overridden?.command).toBeUndefined();
+    expect(overridden).toEqual({ name: "global-a", transport: "sse", url: "http://override" });
   });
 
   it("project overrides preserve protocol MCP fields", () => {


### PR DESCRIPTION
## Summary
- remove the test-only `resetConfig()` export from server config
- remove the redundant `McpServerConfig` type re-export from server config
- update config tests to import MCP config types from `@openomni/protocol`

## Verification
- `bun test apps/server/test/config.test.ts apps/server/test/context/mcp-config.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on all changed files
- `bunx knip --include exports,types --reporter compact` now reports unused exports 6 and unused exported types 17, with `apps/server/src/config.ts` gone
- `codex-ultrawork-reviewer` PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the server config public API by removing the test-only `resetConfig()` and the redundant `McpServerConfig` re-export. Tests now import MCP types from `@openomni/protocol` and adjust one assertion to compare the full overridden object.

<sup>Written for commit 0ba473256b72ce8b47d20f838d2dd509d98da365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

