### PR TITLE
refactor(server): keep model catalog resolver internal

### DIFF
--- a/apps/server/src/agents/model-resolution.ts
+++ b/apps/server/src/agents/model-resolution.ts
@@ -79,7 +79,7 @@ function findConcreteSibling(
 // guess: if the requested ID is not in the catalog and has no concrete
 // sibling, surface the miss to the caller so a stale catalog does not silently
 // downgrade a newly-released model.
-export function resolveCatalogModel(
+function resolveCatalogModel(
   preferredID: string,
   models: CatalogModel[],
 ): CatalogModel | undefined {

--- a/apps/server/test/model-resolution.test.ts
+++ b/apps/server/test/model-resolution.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { Auth, Provider } from "@openomni/llm";
-import {
-  resolveCatalogModel,
-  resolveDefaultProviderModel,
-  resolveRuntimeModel,
-} from "../src/agents/model-resolution";
+import { resolveDefaultProviderModel, resolveRuntimeModel } from "../src/agents/model-resolution";
 
 function makeModel(
   id: string,
@@ -32,60 +28,54 @@ afterEach(() => {
   Provider.listModels = originalListModels;
 });
 
-describe("resolveCatalogModel", () => {
-  it("maps exact latest aliases to concrete dated model IDs", () => {
-    const models = [
-      makeModel("claude-sonnet-4-5", "Claude Sonnet 4.5 (latest)", "2025-09-29"),
-      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
-    ];
-
-    expect(resolveCatalogModel("claude-sonnet-4-5", models)?.id).toBe("claude-sonnet-4-5-20250929");
-  });
-
-  it("resolves version aliases by concrete prefix match when the alias entry is absent", () => {
-    const models = [
-      makeModel("claude-opus-4-5-20251101", "Claude Opus 4.5", "2025-11-01", "claude-opus"),
-    ];
-
-    expect(resolveCatalogModel("claude-opus-4-5", models)?.id).toBe("claude-opus-4-5-20251101");
-  });
-
-  it("returns undefined when the requested model has no exact or prefix match", () => {
-    const models = [
-      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
-      makeModel("claude-sonnet-4-20250514", "Claude Sonnet 4", "2025-05-22"),
-    ];
-
-    expect(resolveCatalogModel("claude-sonnet-4-6", models)).toBeUndefined();
-  });
-});
-
 describe("resolveRuntimeModel", () => {
-  it("resolves runtime agent models through the provider catalog", async () => {
+  it("maps exact latest aliases to concrete dated model IDs", async () => {
     Auth.get = async () => ({ type: "api", key: "test-key" });
     Provider.listModels = async () => [
       makeModel("claude-sonnet-4-5", "Claude Sonnet 4.5 (latest)", "2025-09-29"),
       makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
     ];
 
-    await expect(
-      resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-5" }),
-    ).resolves.toEqual({
+    const resolved = await resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-5" });
+    expect(resolved).toEqual({
       provider: "anthropic",
       id: "claude-sonnet-4-5-20250929",
     });
+  });
+
+  it("resolves version aliases by concrete prefix match when the alias entry is absent", async () => {
+    Auth.get = async () => ({ type: "api", key: "test-key" });
+    Provider.listModels = async () => [
+      makeModel("claude-opus-4-5-20251101", "Claude Opus 4.5", "2025-11-01", "claude-opus"),
+    ];
+
+    const resolved = await resolveRuntimeModel({ provider: "anthropic", id: "claude-opus-4-5" });
+    expect(resolved).toEqual({
+      provider: "anthropic",
+      id: "claude-opus-4-5-20251101",
+    });
+  });
+
+  it("passes the requested model through when the requested model has no exact or prefix match", async () => {
+    Auth.get = async () => ({ type: "api", key: "test-key" });
+    Provider.listModels = async () => [
+      makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
+      makeModel("claude-sonnet-4-20250514", "Claude Sonnet 4", "2025-05-22"),
+    ];
+
+    const resolved = await resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-6" });
+    expect(resolved).toEqual({ provider: "anthropic", id: "claude-sonnet-4-6" });
   });
 
   it("falls back to the server default model for the same provider when lookup misses", async () => {
     Auth.get = async () => ({ type: "api", key: "test-key" });
     Provider.listModels = async () => [];
 
-    await expect(
-      resolveRuntimeModel(
-        { provider: "anthropic", id: "claude-sonnet-4-6" },
-        { provider: "anthropic", id: "claude-opus-4-20250514" },
-      ),
-    ).resolves.toEqual({
+    const resolved = await resolveRuntimeModel(
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      { provider: "anthropic", id: "claude-opus-4-20250514" },
+    );
+    expect(resolved).toEqual({
       provider: "anthropic",
       id: "claude-opus-4-20250514",
     });
@@ -95,9 +85,8 @@ describe("resolveRuntimeModel", () => {
     Auth.get = async () => ({ type: "api", key: "test-key" });
     Provider.listModels = async () => [];
 
-    await expect(
-      resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-6" }),
-    ).resolves.toEqual({ provider: "anthropic", id: "claude-sonnet-4-6" });
+    const resolved = await resolveRuntimeModel({ provider: "anthropic", id: "claude-sonnet-4-6" });
+    expect(resolved).toEqual({ provider: "anthropic", id: "claude-sonnet-4-6" });
   });
 
   it("warns with the underlying catalog error and falls back to the default model when listModels throws", async () => {
@@ -106,12 +95,11 @@ describe("resolveRuntimeModel", () => {
       throw new Error("network down");
     };
 
-    await expect(
-      resolveRuntimeModel(
-        { provider: "anthropic", id: "claude-sonnet-4-6" },
-        { provider: "anthropic", id: "claude-opus-4-20250514" },
-      ),
-    ).resolves.toEqual({
+    const resolved = await resolveRuntimeModel(
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      { provider: "anthropic", id: "claude-opus-4-20250514" },
+    );
+    expect(resolved).toEqual({
       provider: "anthropic",
       id: "claude-opus-4-20250514",
     });
@@ -128,7 +116,8 @@ describe("resolveDefaultProviderModel", () => {
       makeModel("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5", "2025-09-29"),
     ];
 
-    await expect(resolveDefaultProviderModel()).resolves.toMatchObject({
+    const resolved = await resolveDefaultProviderModel();
+    expect(resolved).toMatchObject({
       providerID: "anthropic",
       id: "claude-sonnet-4-5-20250929",
     });


### PR DESCRIPTION
## Summary
- make `resolveCatalogModel` file-local inside server model resolution
- keep `resolveRuntimeModel` and `resolveDefaultProviderModel` as the public server model-resolution surface
- update tests to verify alias, prefix, miss, fallback, and default selection through public resolver APIs

## Verification
- `bun test apps/server/test/model-resolution.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on changed files
- `bunx knip --include exports,types --reporter compact` no longer reports `apps/server/src/agents/model-resolution.ts`
- `codex-ultrawork-reviewer` PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the catalog model resolver private and kept only the public model-resolution APIs. Improves encapsulation and tests now validate behavior through supported entry points.

- **Refactors**
  - Made `resolveCatalogModel` file-local in `apps/server/src/agents/model-resolution.ts`.
  - Kept `resolveRuntimeModel` and `resolveDefaultProviderModel` as the public API.
  - Updated tests to verify alias mapping, prefix resolution, miss passthrough, fallback, and default selection via the public resolvers.

<sup>Written for commit 71de98366666ee9bface23366fd8ddc3c081f28e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

