### PR TITLE
refactor(server): trim agent registry barrel

### DIFF
--- a/apps/server/src/agents/index.ts
+++ b/apps/server/src/agents/index.ts
@@ -1,13 +1,1 @@
-export {
-  getAgentDefinition,
-  getAllAgentNames,
-  createAllAgents,
-  agentMetadata,
-  registerAgent,
-} from "./registry";
-export type {
-  AgentDefinition,
-  AgentFactory,
-  AgentPromptMetadata,
-} from "./types";
-export { RuntimeAgentDefinition } from "./runtime-definition";
+export { createAllAgents, registerAgent } from "./registry";

--- a/apps/server/test/ingress-bridge.test.ts
+++ b/apps/server/test/ingress-bridge.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Adapter, Tool } from "@openomni/protocol";
 import type { NativeTool, ToolProvider } from "@openomni/openomni";
 import { PendingAskStore, Storage } from "@openomni/session";
-import { agentMetadata, getAgentDefinition, registerAgent } from "../src/agents";
+import { registerAgent } from "../src/agents";
+import { agentMetadata, getAgentDefinition } from "../src/agents/registry";
 import { buildAgentDef, buildInboundEvent } from "../src/ingress/bridge";
 
 function createSessionFixture(id: string): void {


### PR DESCRIPTION
## Summary
- keep the server agents barrel limited to the two bootstrap-facing registry APIs
- move ingress bridge test setup imports for registry internals to the registry leaf module
- remove unused barrel re-exports for agent lookup helpers, agent types, and runtime definition projection

## Verification
- bun test apps/server/test/ingress-bridge.test.ts apps/server/test/agent-routing.test.ts apps/server/test/agents/runtime-definition.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from remaining unrelated entries; apps/server/src/agents/index.ts removed from report)

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the server agents barrel to only expose bootstrap APIs and updated tests to import registry internals directly. Reduces public surface and removes unused exports.

- **Refactors**
  - Restrict `apps/server/src/agents/index.ts` to `createAllAgents` and `registerAgent`.
  - Move test imports of `agentMetadata` and `getAgentDefinition` to `../src/agents/registry`.
  - Remove re-exports for lookup helpers, agent types, and `RuntimeAgentDefinition`.

<sup>Written for commit 51ccbfbb61615a81bc384a5fa3192b7a482abbda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

