### PR TITLE
refactor(server): trim context barrel

### DIFF
--- a/apps/server/src/context/index.ts
+++ b/apps/server/src/context/index.ts
@@ -1,10 +1,2 @@
-export { findUp, _resetFindUpCache } from "./find-up";
-export { InstructionLoader } from "./instructions";
-export type { InstructionFile } from "./instructions";
-export { SkillLoader } from "./skills";
-export type { SkillMeta } from "./skills";
 export { McpConfigLoader } from "./mcp-config";
-export { ContextAssembler } from "./assembler";
-export type { AssembleConfig } from "./assembler";
 export { createContextMiddleware } from "./middleware";
-export type { ContextMiddlewareConfig } from "./middleware";

--- a/apps/server/test/context/integration.test.ts
+++ b/apps/server/test/context/integration.test.ts
@@ -5,42 +5,14 @@ import { join } from "node:path";
 const serverSrc = join(import.meta.dir, "../../src");
 
 describe("context barrel export", () => {
-  it("exports createContextMiddleware", async () => {
+  it("exports only production-facing context entrypoints", async () => {
     const mod = await import("../../src/context/index");
+
+    expect(Object.keys(mod).sort()).toEqual(["McpConfigLoader", "createContextMiddleware"]);
     expect(typeof mod.createContextMiddleware).toBe("function");
-  });
-
-  it("exports ContextAssembler", async () => {
-    const mod = await import("../../src/context/index");
-    expect(typeof mod.ContextAssembler).toBe("object");
-    expect(typeof mod.ContextAssembler.assemble).toBe("function");
-  });
-
-  it("exports McpConfigLoader", async () => {
-    const mod = await import("../../src/context/index");
     expect(typeof mod.McpConfigLoader).toBe("object");
     expect(typeof mod.McpConfigLoader.discover).toBe("function");
     expect(typeof mod.McpConfigLoader.merge).toBe("function");
-  });
-
-  it("exports findUp", async () => {
-    const mod = await import("../../src/context/index");
-    expect(typeof mod.findUp).toBe("function");
-  });
-
-  it("exports _resetFindUpCache", async () => {
-    const mod = await import("../../src/context/index");
-    expect(typeof mod._resetFindUpCache).toBe("function");
-  });
-
-  it("exports InstructionLoader", async () => {
-    const mod = await import("../../src/context/index");
-    expect(typeof mod.InstructionLoader).toBe("object");
-  });
-
-  it("exports SkillLoader", async () => {
-    const mod = await import("../../src/context/index");
-    expect(typeof mod.SkillLoader).toBe("object");
   });
 });
 
@@ -61,8 +33,9 @@ describe("worker-entry wiring", () => {
 describe("bootstrap/index.ts MCP config merging", () => {
   const bootstrapSrc = readFileSync(join(serverSrc, "bootstrap/index.ts"), "utf-8");
 
-  it("imports McpConfigLoader", () => {
+  it("imports McpConfigLoader from context/index", () => {
     expect(bootstrapSrc).toContain("McpConfigLoader");
+    expect(bootstrapSrc).toContain("../context/index");
   });
 
   it("calls McpConfigLoader.discover", () => {


### PR DESCRIPTION
## Summary
- keep the server context barrel limited to production-facing entrypoints: McpConfigLoader and createContextMiddleware
- remove unused context barrel re-exports for find-up, loaders, assembler, and related types
- update the context integration test to assert the narrowed barrel contract while keeping bootstrap and worker-runner wiring checks

## Verification
- bun test apps/server/test/context/integration.test.ts apps/server/test/context/find-up.test.ts apps/server/test/context/instructions.test.ts apps/server/test/context/skills.test.ts apps/server/test/context/assembler.test.ts apps/server/test/context/middleware.test.ts apps/server/test/context/mcp-config.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from remaining unrelated entries; apps/server/src/context/index.ts removed from report)

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the server context barrel to expose only `McpConfigLoader` and `createContextMiddleware`. Removed unused re-exports and updated tests to assert the narrower contract and bootstrap wiring.

- **Migration**
  - If you imported `findUp`, `_resetFindUpCache`, `InstructionLoader`/`InstructionFile`, `SkillLoader`/`SkillMeta`, `ContextAssembler`/`AssembleConfig`, or `ContextMiddlewareConfig` from the context barrel, import them directly from their modules instead: `find-up`, `instructions`, `skills`, `assembler`, or `middleware`.

<sup>Written for commit a5aa1a3a4fae994d63fd5bba3d117b9812022bc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

