### PR TITLE
refactor(server): remove find-up cache reset export

### DIFF
--- a/apps/server/src/context/find-up.ts
+++ b/apps/server/src/context/find-up.ts
@@ -37,7 +37,3 @@ export function findUp(filename: string, startDir: string): string | undefined {
   cache.set(key, undefined);
   return undefined;
 }
-
-export function _resetFindUpCache(): void {
-  cache.clear();
-}

--- a/apps/server/test/context/find-up.test.ts
+++ b/apps/server/test/context/find-up.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, beforeAll, afterEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { findUp, _resetFindUpCache } from "../../src/context/find-up";
+import { findUp } from "../../src/context/find-up";
 
 let tempRoot: string;
 let level0: string;
@@ -74,8 +74,6 @@ describe("findUp", () => {
 });
 
 describe("findUp caching", () => {
-  afterEach(() => _resetFindUpCache());
-
   it("returns cached result even after file is deleted", () => {
     const dir = join(tempRoot, "cache-test");
     mkdirSync(dir, { recursive: true });
@@ -89,22 +87,6 @@ describe("findUp caching", () => {
 
     const second = findUp("cached.txt", dir);
     expect(second).toBe(filePath);
-  });
-
-  it("returns fresh result after cache reset", () => {
-    const dir = join(tempRoot, "cache-reset");
-    mkdirSync(dir, { recursive: true });
-    const filePath = join(dir, "resetme.txt");
-    writeFileSync(filePath, "exists");
-
-    const first = findUp("resetme.txt", dir);
-    expect(first).toBe(filePath);
-
-    unlinkSync(filePath);
-    _resetFindUpCache();
-
-    const second = findUp("resetme.txt", dir);
-    expect(second).toBeUndefined();
   });
 
   it("caches undefined for missing files", () => {

--- a/apps/server/test/context/instructions.test.ts
+++ b/apps/server/test/context/instructions.test.ts
@@ -3,7 +3,6 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { InstructionLoader } from "../../src/context/instructions";
-import { _resetFindUpCache } from "../../src/context/find-up";
 
 let tempRoot: string;
 
@@ -180,7 +179,6 @@ describe("InstructionLoader.load", () => {
 describe("InstructionLoader caching", () => {
   afterEach(() => {
     InstructionLoader._resetCache();
-    _resetFindUpCache();
   });
 
   it("discover returns cached result on repeated calls", () => {
@@ -192,24 +190,24 @@ describe("InstructionLoader caching", () => {
     expect(second).toBe(first);
   });
 
-  it("discover returns stale result after file deletion until cache reset", () => {
+  it("discover returns stale global result after file deletion until cache reset", () => {
     const ws = makeWorkspace("cache-stale-discover");
-    const agentsPath = join(ws, "AGENTS.md");
+    const globalDir = makeWorkspace("cache-stale-global-config");
+    const agentsPath = join(globalDir, "AGENTS.md");
     writeFileSync(agentsPath, "# Will be deleted");
 
-    const first = InstructionLoader.discover(ws, ws);
-    expect(first.some((f) => f.label === "Project")).toBe(true);
+    const first = InstructionLoader.discover(ws, globalDir);
+    expect(first.some((f) => f.label === "Global")).toBe(true);
 
     unlinkSync(agentsPath);
 
-    const cached = InstructionLoader.discover(ws, ws);
-    expect(cached.some((f) => f.label === "Project")).toBe(true);
+    const cached = InstructionLoader.discover(ws, globalDir);
+    expect(cached.some((f) => f.label === "Global")).toBe(true);
 
     InstructionLoader._resetCache();
-    _resetFindUpCache();
 
-    const fresh = InstructionLoader.discover(ws, ws);
-    expect(fresh.some((f) => f.label === "Project")).toBe(false);
+    const fresh = InstructionLoader.discover(ws, globalDir);
+    expect(fresh.some((f) => f.label === "Global")).toBe(false);
   });
 
   it("load returns cached result on repeated calls with same files", () => {

--- a/apps/server/test/context/skills.test.ts
+++ b/apps/server/test/context/skills.test.ts
@@ -3,7 +3,6 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "nod
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SkillLoader, type SkillMeta } from "../../src/context/skills";
-import { _resetFindUpCache } from "../../src/context/find-up";
 
 let tempRoot: string;
 let emptyGlobalDir: string;
@@ -210,7 +209,6 @@ describe("SkillLoader.format", () => {
 describe("SkillLoader caching", () => {
   afterEach(() => {
     SkillLoader._resetCache();
-    _resetFindUpCache();
   });
 
   it("discover returns cached result on repeated calls", () => {
@@ -238,7 +236,6 @@ describe("SkillLoader caching", () => {
     expect(cached).toHaveLength(1);
 
     SkillLoader._resetCache();
-    _resetFindUpCache();
 
     const fresh = SkillLoader.discover(ws, emptyGlobalDir);
     expect(fresh).toHaveLength(2);


### PR DESCRIPTION
## Summary
- remove the test-only _resetFindUpCache export from the context find-up helper
- keep findUp cache behavior coverage for stale cached hits and misses
- adjust InstructionLoader and SkillLoader cache tests so they verify loader-owned cache reset behavior without reaching into find-up internals

## Verification
- bun test apps/server/test/context/find-up.test.ts apps/server/test/context/instructions.test.ts apps/server/test/context/skills.test.ts apps/server/test/context/assembler.test.ts apps/server/test/context/middleware.test.ts apps/server/test/context/mcp-config.test.ts apps/server/test/context/integration.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --reporter compact (expected exit 1 from remaining unrelated entries; apps/server/src/context/find-up.ts removed from report)

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the test-only `_resetFindUpCache` from the server find-up helper and shifted cache reset responsibility to the loaders. This simplifies the internal API while keeping caching behavior fully tested.

- **Refactors**
  - Removed `_resetFindUpCache` from `find-up` and its test usage.
  - Updated `InstructionLoader` and `SkillLoader` tests to use their own `_resetCache` and avoid `find-up` internals.
  - Preserved tests for cached hits/misses and stale results; `knip` no longer flags the `find-up` export.

<sup>Written for commit 48808c7b3cc40cb8dea77c08c051831a2ed5a409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal module structure by removing an internal cache utility function. Test infrastructure was updated accordingly to maintain test isolation while reducing external dependencies. Core functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->