### PR TITLE
refactor(coordinator): trim ipc public surface

### DIFF
--- a/packages/coordinator/src/ipc/index.ts
+++ b/packages/coordinator/src/ipc/index.ts
@@ -1,5 +1,1 @@
-export { connectIpcClient, type IpcClient, type ConnectIpcClientOptions } from "./client";
-export { decodeMessage, type IpcMessage } from "./codec";
-export { IpcConnectionError, IpcProtocolError, IpcTimeoutError } from "./errors";
-export { encode, LineDecoder } from "./framing";
-export { createIpcServer, type IpcServer, type RequestHandler } from "./server";
+export { createIpcServer } from "./server";

--- a/packages/coordinator/src/ipc/server.ts
+++ b/packages/coordinator/src/ipc/server.ts
@@ -9,7 +9,7 @@ function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
-export type RequestHandler = (
+type RequestHandler = (
   method: string,
   params: Record<string, unknown> | undefined,
   respond: (result: unknown) => void,
@@ -17,7 +17,7 @@ export type RequestHandler = (
   connectionId: string,
 ) => void;
 
-export interface IpcServer {
+interface IpcServer {
   readonly socketPath: string;
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   notify(method: string, params?: Record<string, unknown>): void;


### PR DESCRIPTION
## Summary
- narrow the coordinator IPC directory barrel to the only live public export: `createIpcServer`
- make `RequestHandler` and `IpcServer` local to the IPC server implementation
- remove unused client/codec/framing/error helper re-exports from the IPC public surface

## Verification
- bun test packages/coordinator/test/harness packages/coordinator/test/worker-manager packages/coordinator/test/worker-pool packages/coordinator/test/ipc
- bun run --cwd packages/coordinator check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on packages/coordinator/src/ipc
- reviewer PASS via codex-ultrawork-reviewer

## Knip delta
- coordinator IPC barrel/type export findings removed
- remaining coordinator findings are outside this slice: `MAX_FRAME_BYTES`, `SessionRouting`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the coordinator IPC public API to only export `createIpcServer`. Made `RequestHandler` and `IpcServer` internal and removed unused client/codec/framing/error re-exports to reduce surface area.

<sup>Written for commit d71fd4a8d50c6624283c57e38a02dc3629bac3b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

