### PR TITLE
refactor(coordinator): keep ipc frame limit internal

### DIFF
--- a/packages/coordinator/src/ipc/framing.test.ts
+++ b/packages/coordinator/src/ipc/framing.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from "bun:test";
-import { LineDecoder, MAX_FRAME_BYTES } from "./framing";
+import { LineDecoder } from "./framing";
 import { IpcProtocolError } from "./errors";
+
+const FRAME_LIMIT_BYTES = 16 * 1024 * 1024;
 
 describe("LineDecoder", () => {
   test("decodes complete lines", () => {
@@ -56,13 +58,13 @@ describe("LineDecoder", () => {
   test("throws IpcProtocolError when buffer exceeds MAX_FRAME_BYTES", () => {
     const dec = new LineDecoder();
     // push slightly over the cap without a newline
-    const oversized = "x".repeat(MAX_FRAME_BYTES + 1);
+    const oversized = "x".repeat(FRAME_LIMIT_BYTES + 1);
     expect(() => dec.push(oversized)).toThrow(IpcProtocolError);
   });
 
   test("resets buffer after oversized rejection", () => {
     const dec = new LineDecoder();
-    const oversized = "x".repeat(MAX_FRAME_BYTES + 1);
+    const oversized = "x".repeat(FRAME_LIMIT_BYTES + 1);
     try {
       dec.push(oversized);
     } catch {
@@ -76,7 +78,7 @@ describe("LineDecoder", () => {
   test("resets streaming decoder state after oversized Uint8Array rejection", () => {
     const dec = new LineDecoder();
     const encoder = new TextEncoder();
-    const prefix = encoder.encode("x".repeat(MAX_FRAME_BYTES + 1));
+    const prefix = encoder.encode("x".repeat(FRAME_LIMIT_BYTES + 1));
     const oversizedWithPartialUtf8 = new Uint8Array(prefix.length + 2);
     oversizedWithPartialUtf8.set(prefix);
     oversizedWithPartialUtf8.set([0xf0, 0x9f], prefix.length);
@@ -87,7 +89,7 @@ describe("LineDecoder", () => {
 
   test("resets buffer after completed oversized frame rejection", () => {
     const dec = new LineDecoder();
-    const oversizedLine = `${JSON.stringify({ data: "y".repeat(MAX_FRAME_BYTES) })}\npartial`;
+    const oversizedLine = `${JSON.stringify({ data: "y".repeat(FRAME_LIMIT_BYTES) })}\npartial`;
 
     expect(() => dec.push(oversizedLine)).toThrow(IpcProtocolError);
     expect(dec.push('{"ok":true}\n')).toEqual([{ ok: true }]);
@@ -96,13 +98,13 @@ describe("LineDecoder", () => {
   test("allows frames just under the cap", () => {
     const dec = new LineDecoder();
     // a partial buffer right at the limit should not throw
-    const justUnder = "x".repeat(MAX_FRAME_BYTES);
+    const justUnder = "x".repeat(FRAME_LIMIT_BYTES);
     expect(() => dec.push(justUnder)).not.toThrow();
   });
 
   test("rejects completed frame exceeding MAX_FRAME_BYTES", () => {
     const dec = new LineDecoder();
-    const payload = JSON.stringify({ data: "y".repeat(MAX_FRAME_BYTES) });
+    const payload = JSON.stringify({ data: "y".repeat(FRAME_LIMIT_BYTES) });
     expect(() => dec.push(`${payload}\n`)).toThrow(IpcProtocolError);
   });
 
@@ -110,9 +112,9 @@ describe("LineDecoder", () => {
     const dec = new LineDecoder();
     // build a JSON line whose total length equals MAX_FRAME_BYTES
     const overhead = '{"d":""}';
-    const filler = "z".repeat(MAX_FRAME_BYTES - overhead.length);
+    const filler = "z".repeat(FRAME_LIMIT_BYTES - overhead.length);
     const line = `{"d":"${filler}"}`;
-    expect(line).toHaveLength(MAX_FRAME_BYTES);
+    expect(line).toHaveLength(FRAME_LIMIT_BYTES);
     const results = dec.push(`${line}\n`);
     expect(results).toHaveLength(1);
   });

--- a/packages/coordinator/src/ipc/framing.ts
+++ b/packages/coordinator/src/ipc/framing.ts
@@ -3,7 +3,7 @@ import { IpcProtocolError } from "./errors";
 const encoder = new TextEncoder();
 
 // 16 MiB — reject any single frame that exceeds this before unbounded growth
-export const MAX_FRAME_BYTES = 16 * 1024 * 1024;
+const MAX_FRAME_BYTES = 16 * 1024 * 1024;
 
 export function encode(msg: unknown): Uint8Array {
   return encoder.encode(`${JSON.stringify(msg)}\n`);


### PR DESCRIPTION
## Summary
- make the IPC frame-size limit constant file-local in `framing.ts`
- keep `LineDecoder` and `encode` as the only framing module exports
- update framing tests to use local test fixture data instead of importing the implementation constant

## Verification
- bun test packages/coordinator/src/ipc/framing.test.ts packages/coordinator/test/harness packages/coordinator/test/worker-manager
- bun run --cwd packages/coordinator check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on changed files
- reviewer PASS via codex-ultrawork-reviewer

## Knip delta
- removes `MAX_FRAME_BYTES` from coordinator unused export findings
- remaining coordinator export finding: `SessionRouting`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the IPC frame-size limit private to `framing.ts`, keeping the framing module’s public API limited to `LineDecoder` and `encode`. Tests now use a local `FRAME_LIMIT_BYTES` fixture instead of importing the constant; no runtime behavior changes.

<sup>Written for commit 7e39cd251e9816feaceff7fb7593b9aab6039c4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

