### PR TITLE
refactor(coordinator): remove session routing singleton

### DIFF
--- a/packages/coordinator/src/worker-pool/index.ts
+++ b/packages/coordinator/src/worker-pool/index.ts
@@ -1,4 +1,4 @@
-export { createSessionRouting, SessionRouting, type SessionRouter } from "./session-routing";
+export { createSessionRouting, type SessionRouter } from "./session-routing";
 export {
   WorkerSupervisor,
   type ToolCallCancelParams,

--- a/packages/coordinator/src/worker-pool/session-routing.ts
+++ b/packages/coordinator/src/worker-pool/session-routing.ts
@@ -86,5 +86,3 @@ export function createSessionRouting(): SessionRouter {
     },
   };
 }
-
-export const SessionRouting = createSessionRouting();

--- a/packages/coordinator/test/worker-pool/affinity.test.ts
+++ b/packages/coordinator/test/worker-pool/affinity.test.ts
@@ -1,23 +1,21 @@
-import { afterEach, describe, test, expect } from "bun:test";
-import { SessionRouting } from "../../src/worker-pool/session-routing";
+import { describe, test, expect } from "bun:test";
+import { createSessionRouting } from "../../src/worker-pool/session-routing";
 
 describe("session routing affinity", () => {
-  afterEach(() => {
-    SessionRouting.clear();
-  });
-
   test("same sessionId always routes to same worker", () => {
+    const routing = createSessionRouting();
     const workerCount = 4;
     const id = "stable-session-xyz";
-    const first = SessionRouting.route(id, workerCount);
-    expect(SessionRouting.route(id, workerCount)).toBe(first);
-    expect(SessionRouting.route(id, workerCount)).toBe(first);
+    const first = routing.route(id, workerCount);
+    expect(routing.route(id, workerCount)).toBe(first);
+    expect(routing.route(id, workerCount)).toBe(first);
   });
 
   test("routes are always within [0, workerCount)", () => {
+    const routing = createSessionRouting();
     for (let n = 1; n <= 16; n++) {
       for (let i = 0; i < 50; i++) {
-        const r = SessionRouting.route(`session-${i}-n${n}`, n);
+        const r = routing.route(`session-${i}-n${n}`, n);
         expect(r).toBeGreaterThanOrEqual(0);
         expect(r).toBeLessThan(n);
       }

--- a/packages/coordinator/test/worker-pool/facade-removal.test.ts
+++ b/packages/coordinator/test/worker-pool/facade-removal.test.ts
@@ -13,6 +13,7 @@ describe("worker pool public facade removal", () => {
 
     expect("createWorkerPool" in workerPool).toBe(false);
     expect("WorkerSupervisor" in workerPool).toBe(true);
-    expect("SessionRouting" in workerPool).toBe(true);
+    expect("SessionRouting" in workerPool).toBe(false);
+    expect("createSessionRouting" in workerPool).toBe(true);
   });
 });

--- a/packages/coordinator/test/worker-pool/session-routing.test.ts
+++ b/packages/coordinator/test/worker-pool/session-routing.test.ts
@@ -1,94 +1,95 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-import { createSessionRouting, SessionRouting } from "../../src/worker-pool/session-routing";
+import { createSessionRouting } from "../../src/worker-pool/session-routing";
 
-describe("SessionRouting", () => {
-  afterEach(() => {
-    SessionRouting.clear();
-  });
-
+describe("createSessionRouting", () => {
   test("same session always routes to same worker", () => {
+    const routing = createSessionRouting();
     const id = "ses_same_affinity";
-    const first = SessionRouting.route(id, 4);
-    const second = SessionRouting.route(id, 4);
+    const first = routing.route(id, 4);
+    const second = routing.route(id, 4);
     expect(second).toBe(first);
-    SessionRouting.complete(id);
-    SessionRouting.complete(id);
+    routing.complete(id);
+    routing.complete(id);
   });
 
   test("keeps same-session affinity until all concurrent routes complete", () => {
+    const routing = createSessionRouting();
     const ts = Date.now();
     const preload = `ses_concurrent_preload_${ts}`;
     const id = `ses_concurrent_${ts}`;
     const blocker = `ses_concurrent_block_${ts}`;
 
-    const preloaded = SessionRouting.route(preload, 2);
-    const first = SessionRouting.route(id, 2);
-    const second = SessionRouting.route(id, 2);
+    const preloaded = routing.route(preload, 2);
+    const first = routing.route(id, 2);
+    const second = routing.route(id, 2);
     expect(first).not.toBe(preloaded);
     expect(second).toBe(first);
 
-    SessionRouting.complete(id);
+    routing.complete(id);
 
-    SessionRouting.route(blocker, 2);
+    routing.route(blocker, 2);
 
-    expect(SessionRouting.route(id, 2)).toBe(first);
+    expect(routing.route(id, 2)).toBe(first);
 
-    SessionRouting.complete(id);
-    SessionRouting.complete(id);
-    SessionRouting.complete(preload);
-    SessionRouting.complete(blocker);
+    routing.complete(id);
+    routing.complete(id);
+    routing.complete(preload);
+    routing.complete(blocker);
 
-    const reassigned = SessionRouting.route(id, 2);
+    const reassigned = routing.route(id, 2);
     expect(reassigned).not.toBe(first);
 
-    SessionRouting.complete(id);
+    routing.complete(id);
   });
 
   test("different sessions can route to different workers", () => {
+    const routing = createSessionRouting();
     const ids = ["ses_a", "ses_b", "ses_c", "ses_d"];
-    const indices = ids.map((id) => SessionRouting.route(id, 4));
+    const indices = ids.map((id) => routing.route(id, 4));
     expect(new Set(indices).size).toBe(4);
-    for (const id of ids) SessionRouting.complete(id);
+    for (const id of ids) routing.complete(id);
   });
 
   test("complete() decrements load", () => {
+    const routing = createSessionRouting();
     const ts = Date.now();
     const a = `ses_fill_a_${ts}`;
     const b = `ses_fill_b_${ts}`;
     const id = `ses_load_decrement_${ts}`;
 
-    const idxA = SessionRouting.route(a, 2);
-    const idxB = SessionRouting.route(b, 2);
+    const idxA = routing.route(a, 2);
+    const idxB = routing.route(b, 2);
     expect(idxA).not.toBe(idxB);
 
-    SessionRouting.complete(a);
+    routing.complete(a);
 
-    const idx = SessionRouting.route(id, 2);
+    const idx = routing.route(id, 2);
     expect(idx).toBe(idxA);
 
-    SessionRouting.complete(b);
-    SessionRouting.complete(id);
+    routing.complete(b);
+    routing.complete(id);
   });
 
   test("after complete(), session can be reassigned to a different worker", () => {
+    const routing = createSessionRouting();
     const id = "ses_reassign";
     const workerCount = 2;
 
-    const first = SessionRouting.route(id, workerCount);
-    SessionRouting.complete(id);
+    const first = routing.route(id, workerCount);
+    routing.complete(id);
 
     const blockers = ["ses_block1", "ses_block2", "ses_block3"];
     for (const blocker of blockers) {
-      SessionRouting.route(blocker, workerCount);
+      routing.route(blocker, workerCount);
     }
 
-    const second = SessionRouting.route(id, workerCount);
+    const second = routing.route(id, workerCount);
     expect(second).not.toBe(first);
 
-    SessionRouting.complete(id);
+    routing.complete(id);
     for (const blocker of blockers) {
-      SessionRouting.complete(blocker);
+      routing.complete(blocker);
     }
   });
 


### PR DESCRIPTION
## Summary
- remove the unused exported `SessionRouting` singleton from worker-pool internals
- keep `createSessionRouting()` as the isolated routing factory used by `OnDemandWorkerManager`
- update worker-pool tests to use fresh router instances and assert the narrowed worker-pool barrel contract

## Verification
- bun test packages/coordinator/test/worker-pool packages/coordinator/test/worker-manager
- bun run --cwd packages/coordinator check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on changed files/test dir
- bunx knip --include exports,types --production --workspace packages/coordinator --no-exit-code (no output)
- reviewer PASS via codex-ultrawork-reviewer

## Knip delta
- removes the final coordinator unused export finding (`SessionRouting`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `SessionRouting` singleton from the coordinator worker-pool. Kept `createSessionRouting()` as the routing factory and updated tests to use fresh router instances, tightening the public API.

- **Refactors**
  - Removed `SessionRouting` export from `packages/coordinator/src/worker-pool/index.ts`; continue to export `createSessionRouting` and `SessionRouter`.
  - Deleted the singleton in `session-routing.ts` to avoid shared state; only the factory remains.
  - Updated worker-pool tests to create per-test routers and verify the narrowed barrel: `SessionRouting` is not exported, `createSessionRouting` is.
  - `OnDemandWorkerManager` continues to use `createSessionRouting()`.

<sup>Written for commit 672ad3d5a2e8431fd464b2dffb45eb574ed71b5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

