### PR TITLE
refactor(llm): remove codex model allowlist export

### DIFF
--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -201,7 +201,6 @@ export namespace Provider {
 export {
   getSDK,
   getLanguage,
-  CODEX_ALLOWED_MODELS,
   ProviderCache,
   PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES,
   PROVIDER_SDK_CACHE_MAX_ENTRIES,

--- a/packages/llm/src/provider/provider.ts
+++ b/packages/llm/src/provider/provider.ts
@@ -196,14 +196,6 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Provider.In
   };
 }
 
-export const CODEX_ALLOWED_MODELS = new Set([
-  "gpt-5.1-codex-max",
-  "gpt-5.1-codex-mini",
-  "gpt-5.2",
-  "gpt-5.2-codex",
-  "gpt-5.1-codex",
-]);
-
 export function filterModels(
   providerID: string,
   authType: "api" | "proxy",

--- a/packages/llm/test/provider/openai.test.ts
+++ b/packages/llm/test/provider/openai.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { getSDK, getLanguage, CODEX_ALLOWED_MODELS, type Provider } from "../../src/provider/index";
+import { getSDK, getLanguage, type Provider } from "../../src/provider/index";
 import type { Auth } from "../../src/auth";
 
 const originalFetch = globalThis.fetch;
@@ -70,17 +70,5 @@ describe("getSDK (OpenAI)", () => {
 
     expect(lm.modelId).toBe("gpt-5.4");
     expect(lm.config?.provider).toBe("openai.chat");
-  });
-});
-
-describe("CODEX_ALLOWED_MODELS", () => {
-  test("is a Set containing expected codex models", () => {
-    expect(CODEX_ALLOWED_MODELS).toBeInstanceOf(Set);
-    expect(CODEX_ALLOWED_MODELS.has("gpt-5.1-codex-max")).toBe(true);
-    expect(CODEX_ALLOWED_MODELS.has("gpt-5.1-codex-mini")).toBe(true);
-    expect(CODEX_ALLOWED_MODELS.has("gpt-5.2")).toBe(true);
-    expect(CODEX_ALLOWED_MODELS.has("gpt-5.2-codex")).toBe(true);
-    expect(CODEX_ALLOWED_MODELS.has("gpt-5.1-codex")).toBe(true);
-    expect(CODEX_ALLOWED_MODELS.has("gpt-4o")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- remove the unused `CODEX_ALLOWED_MODELS` provider submodule export
- delete the assertion-only test that existed solely to lock that stale allowlist
- leave provider model filtering and runtime SDK/language behavior unchanged

## Verification
- bun test packages/llm/test/provider
- bun run --cwd packages/llm check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on changed files
- reviewer PASS via codex-ultrawork-reviewer

## Knip delta
- removes `CODEX_ALLOWED_MODELS` from llm unused export findings
- remaining llm findings are getSDK/cache-related exports


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the unused `CODEX_ALLOWED_MODELS` export and its test to simplify the `llm` provider module. No runtime behavior changes.

- **Refactors**
  - Removed `CODEX_ALLOWED_MODELS` from `packages/llm/src/provider`.
  - Deleted the assertion-only test that locked the stale allowlist.
  - Kept `filterModels` and `getSDK`/`getLanguage` behavior unchanged.

<sup>Written for commit 7d6180afc5fb1de11b00a4c7ea45eae7f3729c29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

