### PR TITLE
refactor(llm): keep provider cache internals private

### DIFF
--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -201,9 +201,6 @@ export namespace Provider {
 export {
   getSDK,
   getLanguage,
-  ProviderCache,
-  PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES,
-  PROVIDER_SDK_CACHE_MAX_ENTRIES,
 } from "./provider";
 
 export { fetchProxyModels, enrichWithCatalog } from "./proxy-models";

--- a/packages/llm/src/provider/provider.ts
+++ b/packages/llm/src/provider/provider.ts
@@ -26,8 +26,8 @@ const BUNDLED_PROVIDERS: Record<string, (options: SdkOptions) => ProviderSDK> = 
 
 const SDK_CACHE = new Map<string, ProviderSDK>();
 const LANGUAGE_CACHE = new Map<string, LanguageModel>();
-export const PROVIDER_SDK_CACHE_MAX_ENTRIES = 64;
-export const PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES = 256;
+const PROVIDER_SDK_CACHE_MAX_ENTRIES = 64;
+const PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES = 256;
 
 type CustomModelLoader = (
   sdk: ProviderSDK,
@@ -144,20 +144,6 @@ function setCached<T>(cache: Map<string, T>, key: string, value: T, maxEntries: 
     cache.delete(oldestKey);
   }
 }
-
-export const ProviderCache = {
-  clear(): void {
-    SDK_CACHE.clear();
-    LANGUAGE_CACHE.clear();
-  },
-
-  stats(): { sdkEntries: number; languageEntries: number } {
-    return {
-      sdkEntries: SDK_CACHE.size,
-      languageEntries: LANGUAGE_CACHE.size,
-    };
-  },
-};
 
 function resolveLanguageModel(
   sdk: ProviderSDK,

--- a/packages/llm/test/provider/provider-cache.test.ts
+++ b/packages/llm/test/provider/provider-cache.test.ts
@@ -1,13 +1,9 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { Auth } from "../../src/auth";
-import {
-  getLanguage,
-  getSDK,
-  ProviderCache,
-  PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES,
-  PROVIDER_SDK_CACHE_MAX_ENTRIES,
-  type Provider,
-} from "../../src/provider/index";
+import { getLanguage, getSDK, type Provider } from "../../src/provider/index";
+
+const SDK_CACHE_LIMIT = 64;
+const LANGUAGE_CACHE_LIMIT = 256;
 
 function makeAnthropicModel(id = "claude-sonnet-4-20250514"): Provider.Model {
   return {
@@ -32,10 +28,6 @@ function makeOpenAIModel(id = "gpt-4o"): Provider.Model {
 }
 
 describe("provider caches", () => {
-  beforeEach(() => {
-    ProviderCache.clear();
-  });
-
   test("reuses SDK for the same provider and auth", () => {
     const auth: Auth.Info = { type: "api", key: "sk-test" };
 
@@ -91,11 +83,10 @@ describe("provider caches", () => {
     const firstAuth: Auth.Info = { type: "api", key: "sk-lru-0" };
     const first = getSDK(model, firstAuth);
 
-    for (let i = 1; i <= PROVIDER_SDK_CACHE_MAX_ENTRIES; i++) {
+    for (let i = 1; i <= SDK_CACHE_LIMIT; i++) {
       getSDK(model, { type: "api", key: `sk-lru-${i}` });
     }
 
-    expect(ProviderCache.stats().sdkEntries).toBe(PROVIDER_SDK_CACHE_MAX_ENTRIES);
     expect(getSDK(model, firstAuth)).not.toBe(first);
   });
 
@@ -104,23 +95,23 @@ describe("provider caches", () => {
     const firstAuth: Auth.Info = { type: "api", key: "sk-touch-0" };
     const first = getSDK(model, firstAuth);
 
-    for (let i = 1; i < PROVIDER_SDK_CACHE_MAX_ENTRIES; i++) {
+    for (let i = 1; i < SDK_CACHE_LIMIT; i++) {
       getSDK(model, { type: "api", key: `sk-touch-${i}` });
     }
     expect(getSDK(model, firstAuth)).toBe(first);
     getSDK(model, { type: "api", key: "sk-touch-evict" });
 
-    expect(ProviderCache.stats().sdkEntries).toBe(PROVIDER_SDK_CACHE_MAX_ENTRIES);
     expect(getSDK(model, firstAuth)).toBe(first);
   });
 
   test("bounds language model cache entries", () => {
     const auth: Auth.Info = { type: "proxy", baseURL: "http://localhost:8317" };
+    const first = getLanguage(makeAnthropicModel("claude-lru-0"), auth);
 
-    for (let i = 0; i <= PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES; i++) {
+    for (let i = 1; i <= LANGUAGE_CACHE_LIMIT; i++) {
       getLanguage(makeAnthropicModel(`claude-lru-${i}`), auth);
     }
 
-    expect(ProviderCache.stats().languageEntries).toBe(PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES);
+    expect(getLanguage(makeAnthropicModel("claude-lru-0"), auth)).not.toBe(first);
   });
 });


### PR DESCRIPTION
## Summary
- make provider cache limits private implementation constants
- remove the test-only `ProviderCache` public observer from the provider submodule
- keep cache behavior covered through public `getSDK` / `getLanguage` identity and LRU eviction behavior

## Verification
- bun test packages/llm/test/provider
- bun run --cwd packages/llm check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on changed files
- reviewer PASS via codex-ultrawork-reviewer

## Knip delta
- removes `ProviderCache` and provider cache-size constants from llm unused export findings
- remaining llm finding: `getSDK`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Privatizes provider cache internals in `packages/llm` to simplify the public surface while preserving behavior through `getSDK` and `getLanguage`.

- **Refactors**
  - Make `PROVIDER_SDK_CACHE_MAX_ENTRIES` and `PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES` module-private.
  - Remove `ProviderCache` and cache-limit exports from `provider/index`.
  - Update tests to validate reuse and LRU eviction via `getSDK`/`getLanguage` instead of inspecting cache internals (use local limits in tests).
  - Reduces Knip unused export findings in `llm`.

<sup>Written for commit 6b717a43717fe4a48d1045d8b006ff4adb827ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

