### PR TITLE
refactor(server): keep channel payload subtypes internal

### DIFF
--- a/apps/server/src/channel/github/types.ts
+++ b/apps/server/src/channel/github/types.ts
@@ -1,13 +1,13 @@
-export interface GitHubUser {
+interface GitHubUser {
   login: string;
   type: string;
 }
 
-export interface GitHubLabel {
+interface GitHubLabel {
   name: string;
 }
 
-export interface GitHubRepository {
+interface GitHubRepository {
   full_name: string;
   owner: { login: string };
   name: string;

--- a/apps/server/src/channel/telegram/types.ts
+++ b/apps/server/src/channel/telegram/types.ts
@@ -5,7 +5,7 @@ export interface TelegramUser {
   username?: string;
 }
 
-export interface TelegramChat {
+interface TelegramChat {
   id: number;
   type: "private" | "group" | "supergroup" | "channel";
   title?: string;


### PR DESCRIPTION
## Summary
- make GitHub payload helper interfaces file-local
- make TelegramChat file-local
- keep exported payload/message types used by channel adapters intact

## Verification
- bun test apps/server/test/channel
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include exports,types --workspace @openomni/server --no-progress --no-exit-code

ULW reviewer: PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GitHub and Telegram channel payload subtypes internal to shrink the public API surface while keeping adapter-facing payload/message types unchanged.

- **Refactors**
  - GitHub: `GitHubUser`, `GitHubLabel`, `GitHubRepository` are now file-local (non-exported).
  - Telegram: `TelegramChat` is now file-local (non-exported).

<sup>Written for commit 2c968106138763c658dc72ddfd93a2b1f5d1ee5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

