### PR TITLE
refactor(server): trim channel authn type surface

### DIFF
--- a/apps/server/src/channel/authn/types.ts
+++ b/apps/server/src/channel/authn/types.ts
@@ -2,7 +2,7 @@ import type { Adapter, Policy } from "@openomni/protocol";
 
 export type ChannelAuthnPolicyId = string;
 
-export interface ChannelAuthnDecision {
+interface ChannelAuthnDecision {
   readonly timing: Policy.Timing;
   readonly name: string;
   readonly policyId: ChannelAuthnPolicyId;

--- a/apps/server/src/channel/channel-authn.ts
+++ b/apps/server/src/channel/channel-authn.ts
@@ -1,10 +1,4 @@
-export type {
-  ChannelAuthnDecision,
-  ChannelAuthnDecisionObserver,
-  ChannelTriggerAuthResult,
-  GitHubAuthResult,
-  WebSocketAuthResult,
-} from "./authn/types";
+export type { ChannelAuthnDecisionObserver } from "./authn/types";
 
 import {
   DiscordTriggers as DiscordTriggersDefinition,

--- a/apps/server/test/channel/channel-authn-triggers.test.ts
+++ b/apps/server/test/channel/channel-authn-triggers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { Adapter } from "@openomni/protocol";
-import { ChannelAuthnMiddleware, type ChannelAuthnDecision } from "../../src/channel/channel-authn";
+import type { ChannelAuthnDecisionObserver } from "../../src/channel/authn/types";
+import { ChannelAuthnMiddleware } from "../../src/channel/channel-authn";
+
+type ChannelAuthnDecision = Parameters<ChannelAuthnDecisionObserver>[0];
 
 describe("channel-authn trigger policy", () => {
   it("allows Discord mentions and records trigger metadata", () => {

--- a/apps/server/test/channel/github-authn.test.ts
+++ b/apps/server/test/channel/github-authn.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { Adapter } from "@openomni/protocol";
-import type { ChannelAuthnDecision } from "../../src/channel/channel-authn";
+import type { ChannelAuthnDecisionObserver } from "../../src/channel/authn/types";
 import { GitHubAdapter } from "../../src/channel/github/surface";
+
+type ChannelAuthnDecision = Parameters<ChannelAuthnDecisionObserver>[0];
 
 const secret = "github-webhook-secret";
 const config = {

--- a/apps/server/test/channel/websocket.test.ts
+++ b/apps/server/test/channel/websocket.test.ts
@@ -1,8 +1,11 @@
+import { describe, expect, it } from "bun:test";
 import type { Adapter } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import type { ChannelAuthnDecision } from "../../src/channel/channel-authn";
+import type { ChannelAuthnDecisionObserver } from "../../src/channel/authn/types";
 import { WebSocketHandler } from "../../src/channel/websocket";
+
+type ChannelAuthnDecision = Parameters<ChannelAuthnDecisionObserver>[0];
 
 function createHandler(decisions: ChannelAuthnDecision[] = []): WebSocketHandler {
   const handler: Adapter.MessageHandler = async () => ({ text: "ok" });


### PR DESCRIPTION
## Summary
- keep the channel authn facade type export limited to ChannelAuthnDecisionObserver
- make ChannelAuthnDecision module-private in the authn leaf types module
- update channel authn tests to derive decision shape from the observer contract and add the missing bun:test import in websocket coverage

## Verification
- bun test apps/server/test/channel/channel-authn-triggers.test.ts apps/server/test/channel/github-authn.test.ts apps/server/test/channel/websocket.test.ts
- bun run --cwd apps/server check-types
- bunx knip --include exports,types --workspace @openomni/server --no-progress --no-exit-code
- LSP diagnostics clean on all changed files
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the server channel authn type surface by only exporting `ChannelAuthnDecisionObserver` and scoping `ChannelAuthnDecision` to the authn types module. Tests now derive the decision type from the observer, and a missing `bun:test` import was added for WebSocket coverage.

- **Refactors**
  - Limit `channel-authn` exports to `ChannelAuthnDecisionObserver`; remove re-exports of `ChannelAuthnDecision`, `ChannelTriggerAuthResult`, `GitHubAuthResult`, and `WebSocketAuthResult`.
  - Make `ChannelAuthnDecision` module-private in `authn/types.ts`.
  - Update tests to infer `ChannelAuthnDecision` via `Parameters<ChannelAuthnDecisionObserver>[0]`.

<sup>Written for commit 5ccb6239be0f7a3c6cca409f5a75c0207bc51f68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

