### PR TITLE
refactor(server): trim internal type surface

### DIFF
--- a/apps/server/src/channel/types.ts
+++ b/apps/server/src/channel/types.ts
@@ -1,4 +1,4 @@
-import type { Adapter, Ingress } from "@openomni/protocol";
+import type { Adapter } from "@openomni/protocol";
 
 /**
  * Platform API calls: send messages, typing indicators, authentication, rate limiting.
@@ -16,21 +16,4 @@ export interface ChannelClient {
  */
 export interface InboundNormalizer<TPayload = unknown> {
   normalize(payload: TPayload): Adapter.InboundMessage | null;
-}
-
-/**
- * IngressResult → platform-specific send operations via ChannelClient.
- * MUST NOT: interpret business logic, call IngressEngine, manage adapter lifecycle.
- */
-export interface OutboundFormatter {
-  format(result: Ingress.IngressResult, channelId: string, client: ChannelClient): Promise<void>;
-}
-
-/**
- * Lifecycle management: start/stop/reconnect, handler wiring, deduplication.
- * MUST NOT: inline platform API calls directly (use ChannelClient for that).
- */
-export interface ChannelSurface {
-  start(handler: Adapter.MessageHandler): Promise<void>;
-  stop(): Promise<void>;
 }

--- a/apps/server/src/context/assembler.ts
+++ b/apps/server/src/context/assembler.ts
@@ -1,7 +1,7 @@
 import { InstructionLoader } from "./instructions";
 import { SkillLoader } from "./skills";
 
-export interface AssembleConfig {
+interface AssembleConfig {
   workspaceRoot: string;
   globalConfigDir?: string;
 }

--- a/apps/server/src/context/instructions.ts
+++ b/apps/server/src/context/instructions.ts
@@ -8,7 +8,7 @@ import { findUp } from "./find-up";
 const FILE_MAX_CHARS = 12_000;
 const TOTAL_MAX_CHARS = 60_000;
 
-export interface InstructionFile {
+interface InstructionFile {
   path: string;
   priority: number;
   label: string;

--- a/apps/server/src/context/skills.ts
+++ b/apps/server/src/context/skills.ts
@@ -8,7 +8,7 @@ import { findUp } from "./find-up";
 
 const MAX_SKILLS = 200;
 
-export interface SkillMeta {
+interface SkillMeta {
   name: string;
   description: string;
   path: string;

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -156,7 +156,7 @@ function createWorkerDispatchRuntime(options: {
   };
 }
 
-export interface WorkerRunIpcServer {
+interface WorkerRunIpcServer {
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   notify(method: string, params?: Record<string, unknown>): void;
 }

--- a/apps/server/test/context/skills.test.ts
+++ b/apps/server/test/context/skills.test.ts
@@ -2,7 +2,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { SkillLoader, type SkillMeta } from "../../src/context/skills";
+import { SkillLoader } from "../../src/context/skills";
+
+type SkillMeta = ReturnType<typeof SkillLoader.discover>[number];
 
 let tempRoot: string;
 let emptyGlobalDir: string;


### PR DESCRIPTION
## Summary
- remove unused channel OutboundFormatter and ChannelSurface contracts
- keep context and worker-runner helper shapes module-local instead of exported
- update SkillLoader tests to derive the local skill shape from the public discover contract

## Verification
- bun test apps/server/test/context apps/server/test/execution/worker-runner.test.ts apps/server/test/channel
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on all changed files
- bunx knip --include exports,types --workspace @openomni/server --no-progress --no-exit-code
- bunx knip --include exports,types --no-progress --no-exit-code

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim the server’s internal type surface to reduce exports and clarify public vs internal boundaries. Removes unused channel contracts and scopes helper interfaces to modules; tests now derive skill shape from the public `SkillLoader.discover` API.

- **Refactors**
  - Removed unused `OutboundFormatter` and `ChannelSurface` from `apps/server/src/channel/types.ts`.
  - Scoped internal interfaces to module (no export): `AssembleConfig`, `InstructionFile`, `SkillMeta`, `WorkerRunIpcServer`.
  - Updated tests to derive `SkillMeta` from `ReturnType<typeof SkillLoader.discover>[number]`.
  - Dropped unused `Ingress` import from `@openomni/protocol`.

<sup>Written for commit 46d0cd6e5165c299f8bfa1c53f97e180990da22c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

