### PR TITLE
refactor(session): keep store signature types internal

### DIFF
--- a/packages/session/src/blacklist/index.ts
+++ b/packages/session/src/blacklist/index.ts
@@ -2,7 +2,7 @@ import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
-export interface BlacklistMatchInput {
+interface BlacklistMatchInput {
   readonly actorId?: string;
   readonly endpointId?: string;
   readonly channel?: string;

--- a/packages/session/src/channel-grant/index.ts
+++ b/packages/session/src/channel-grant/index.ts
@@ -2,13 +2,13 @@ import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
-export interface ChannelGrantMatchInput {
+interface ChannelGrantMatchInput {
   readonly surface: string;
   readonly workspace?: string;
   readonly channel?: string;
 }
 
-export interface ChannelGrantResolution {
+interface ChannelGrantResolution {
   readonly grant: Actor.ChannelGrant;
   readonly inboundTreatment: Actor.InboundTreatment;
 }


### PR DESCRIPTION
## Summary
- keep blacklist match input type module-local
- keep channel grant match input and resolution types module-local
- preserve BlacklistStore and ChannelGrantStore namespace APIs and runtime behavior

## Verification
- bun test packages/session/test/blacklist/persistence.test.ts packages/session/test/channel-grant/persistence.test.ts packages/openomni/test/ingress/blacklist.test.ts packages/openomni/test/ingress/channel-grant.test.ts packages/openomni/test/ingress/engine.test.ts packages/openomni/test/policy/middleware-integration.test.ts
- bun run --cwd packages/session check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on both changed files
- bunx knip --include exports,types --workspace @openomni/session --no-progress --no-exit-code
- bunx knip --include exports,types --no-progress --no-exit-code

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalizes `BlacklistMatchInput`, `ChannelGrantMatchInput`, and `ChannelGrantResolution` in `@openomni/session` to keep store signatures private and trim the public API. `BlacklistStore` and `ChannelGrantStore` APIs and runtime behavior are unchanged.

<sup>Written for commit 782bb1022bf40b7eb188588668689a52a9b1df06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

