### PR TITLE
refactor(server): trim namespace member surface

### DIFF
--- a/apps/server/src/agents/runtime-definition.ts
+++ b/apps/server/src/agents/runtime-definition.ts
@@ -4,9 +4,7 @@ import type { AgentDefinition } from "./types";
 export namespace RuntimeAgentDefinition {
   // Sole server-to-worker agent egress boundary: protocol parsing projects the
   // worker wire contract and intentionally strips server-only prompt metadata.
-  export function parse(definition: AgentDefinition): WorkerBootstrap.RuntimeAgentDefinition {
+  export function create(definition: AgentDefinition): WorkerBootstrap.RuntimeAgentDefinition {
     return WorkerBootstrap.RuntimeAgentDefinition.parse(definition);
   }
-
-  export const create = parse;
 }

--- a/apps/server/src/channel/channel-authn.ts
+++ b/apps/server/src/channel/channel-authn.ts
@@ -1,12 +1,5 @@
 export type { ChannelAuthnDecisionObserver } from "./authn/types";
 
-import {
-  DiscordTriggers as DiscordTriggersDefinition,
-  GitHubHmac as GitHubHmacDefinition,
-  GitHubTriggers as GitHubTriggersDefinition,
-  TelegramTriggers as TelegramTriggersDefinition,
-  WebSocketToken as WebSocketTokenDefinition,
-} from "./authn/definitions";
 import { authenticateGitHubWebhook as authenticateGitHubWebhookImpl } from "./authn/github";
 import {
   authenticateDiscordTriggers as authenticateDiscordTriggersImpl,
@@ -16,12 +9,6 @@ import {
 import { authenticateWebSocketUpgrade as authenticateWebSocketUpgradeImpl } from "./authn/websocket";
 
 export namespace ChannelAuthnMiddleware {
-  export const WebSocketToken = WebSocketTokenDefinition;
-  export const GitHubHmac = GitHubHmacDefinition;
-  export const DiscordTriggers = DiscordTriggersDefinition;
-  export const TelegramTriggers = TelegramTriggersDefinition;
-  export const GitHubTriggers = GitHubTriggersDefinition;
-
   export const authenticateDiscordTriggers = authenticateDiscordTriggersImpl;
   export const authenticateTelegramTriggers = authenticateTelegramTriggersImpl;
   export const authenticateGitHubTriggers = authenticateGitHubTriggersImpl;


### PR DESCRIPTION
## Summary
- remove the unused RuntimeAgentDefinition.parse namespace member while keeping create() as the worker bootstrap boundary
- stop re-exporting unused channel-authn policy definition constants from the ChannelAuthnMiddleware facade
- preserve all authenticate* channel authn methods and runtime call paths

## Verification
- bun test apps/server/test/agents/runtime-definition.test.ts apps/server/test/channel/channel-authn-triggers.test.ts apps/server/test/channel/github-authn.test.ts apps/server/test/channel/websocket.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on changed files
- bunx knip --include nsExports,nsTypes --no-progress --no-exit-code

## Review
- codex-ultrawork-reviewer: PASS
- Claude Fable oracle unavailable locally: claude-fable-5 returned 404/no access, no fallback model used


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed server namespaces to remove unused exports and make the worker bootstrap boundary explicit.

- **Refactors**
  - `RuntimeAgentDefinition`: removed `parse()`; `create()` now directly delegates to `WorkerBootstrap.RuntimeAgentDefinition.parse(...)` and is the sole server-to-worker boundary.
  - `ChannelAuthnMiddleware`: stopped re-exporting `WebSocketToken`, `GitHubHmac`, `DiscordTriggers`, `TelegramTriggers`, `GitHubTriggers`; all `authenticate*` methods are unchanged.

<sup>Written for commit ddd6a5a3ab4e96f4f5b44495754fe790545dba65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

