### PR TITLE
refactor(server): trim worker ipc type surface

### DIFF
--- a/apps/server/src/execution/worker-ipc-handlers.ts
+++ b/apps/server/src/execution/worker-ipc-handlers.ts
@@ -1,73 +1,64 @@
 import type { InjectionQueue } from "@openomni/openomni";
-import { z } from "zod";
 import type { WorkerRunState } from "./worker-run-state";
 
 export namespace WorkerIpcHandlers {
-  export interface SharedOptions {
+  interface SharedOptions {
     readonly ipcAuthToken: string;
     readonly workerId: string;
   }
 
-  export interface CancelRunOptions extends Pick<SharedOptions, "ipcAuthToken"> {
+  interface CancelRunOptions extends Pick<SharedOptions, "ipcAuthToken"> {
     readonly params: Record<string, unknown> | undefined;
     readonly activeRuns: Pick<WorkerRunState.ReadableActiveRuns, "get">;
   }
 
-  export interface DeliverMessageOptions extends SharedOptions {
+  interface DeliverMessageOptions extends SharedOptions {
     readonly params: Record<string, unknown> | undefined;
     readonly activeRuns: Pick<WorkerRunState.ReadableActiveRuns, "get">;
     readonly injectionQueue: InjectionQueue.Instance;
   }
 
-  export interface ShutdownIdleOptions extends Pick<SharedOptions, "ipcAuthToken"> {
+  interface ShutdownIdleOptions extends Pick<SharedOptions, "ipcAuthToken"> {
     readonly params: Record<string, unknown> | undefined;
     readonly activeRuns: Pick<WorkerRunState.ReadableActiveRuns, "size">;
   }
 
-  export interface ToolCallSettledOptions extends Pick<SharedOptions, "ipcAuthToken"> {
+  interface ToolCallSettledOptions extends Pick<SharedOptions, "ipcAuthToken"> {
     readonly params: Record<string, unknown> | undefined;
     readonly clearUnsafe: (workspaceRoot: string, callId: string) => void;
   }
 
-  export const CancelRunResponse = z.discriminatedUnion("cancelled", [
-    z.object({
-      cancelled: z.literal(true),
-      runId: z.string(),
-      sessionId: z.string(),
-    }),
-    z.object({
-      cancelled: z.literal(false),
-      error: z.string(),
-    }),
-  ]);
-  export type CancelRunResponse = z.infer<typeof CancelRunResponse>;
+  type CancelRunResponse =
+    | {
+        readonly cancelled: true;
+        readonly runId: string;
+        readonly sessionId: string;
+      }
+    | {
+        readonly cancelled: false;
+        readonly error: string;
+      };
 
-  export const DeliverMessageResponse = z.discriminatedUnion("accepted", [
-    z.object({ accepted: z.literal(true) }),
-    z.object({
-      accepted: z.literal(false),
-      error: z.string(),
-    }),
-  ]);
-  export type DeliverMessageResponse = z.infer<typeof DeliverMessageResponse>;
+  type DeliverMessageResponse =
+    | { readonly accepted: true }
+    | {
+        readonly accepted: false;
+        readonly error: string;
+      };
 
-  export const ShutdownIdleResponse = z.discriminatedUnion("acknowledged", [
-    z.object({ acknowledged: z.literal(true) }),
-    z.object({
-      acknowledged: z.literal(false),
-      error: z.string(),
-    }),
-  ]);
-  export type ShutdownIdleResponse = z.infer<typeof ShutdownIdleResponse>;
+  type ShutdownIdleResponse =
+    | { readonly acknowledged: true }
+    | {
+        readonly acknowledged: false;
+        readonly error: string;
+      };
 
-  export const ToolCallSettledResponse = z.discriminatedUnion("acknowledged", [
-    z.object({ acknowledged: z.literal(true) }),
-    z.object({
-      acknowledged: z.literal(false),
-      error: z.string(),
-    }),
-  ]);
-  export type ToolCallSettledResponse = z.infer<typeof ToolCallSettledResponse>;
+  type ToolCallSettledResponse =
+    | { readonly acknowledged: true }
+    | {
+        readonly acknowledged: false;
+        readonly error: string;
+      };
 
   export function cancelRun(options: CancelRunOptions): CancelRunResponse {
     const { params, ipcAuthToken, activeRuns } = options;


### PR DESCRIPTION
## Summary
- remove unused WorkerIpcHandlers response Zod schema objects that were only used for type inference
- keep worker IPC option/response helper aliases namespace-internal instead of exported
- preserve all worker IPC handler return object shapes and runtime call paths

## Verification
- bun test apps/server/test/execution/worker-ipc-handlers.test.ts apps/server/test/execution/worker-full-stack.test.ts
- bun run --cwd apps/server check-types
- bun run --cwd apps/server build
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- LSP diagnostics clean on changed file
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code

## Review
- codex-ultrawork-reviewer: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the worker IPC type surface by removing unused `zod` response schemas and making options/response types internal. No runtime changes; handler return shapes and call paths are unchanged.

- **Refactors**
  - Replaced exported `zod` response schemas with internal TypeScript union types.
  - Scoped handler option and response types to the `WorkerIpcHandlers` namespace (no exports).
  - Removed the `zod` import and simplified `worker-ipc-handlers.ts` public API.

<sup>Written for commit afb67bdd5356cba87b56dbfb5cdd5e67da2cbe38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

