### PR TITLE
refactor(server): trim worker heartbeat type surface

### DIFF
--- a/apps/server/src/execution/worker-heartbeat.ts
+++ b/apps/server/src/execution/worker-heartbeat.ts
@@ -4,21 +4,21 @@ import { z } from "zod";
 const DEFAULT_INTERVAL_MS = 15_000;
 
 export namespace WorkerHeartbeat {
-  export const SnapshotInput = z.object({
+  const SnapshotInput = z.object({
     activeRunIds: z.array(z.string()),
     configEpoch: z.string(),
     memoryRssMb: z.number(),
     lastHeartbeat: z.number(),
   });
-  export type SnapshotInput = z.infer<typeof SnapshotInput>;
+  type SnapshotInput = z.infer<typeof SnapshotInput>;
 
-  export const Server = z.object({
+  const Server = z.object({
     call: z
       .function()
       .args(z.literal("worker.heartbeat"), z.record(z.string(), z.unknown()))
       .returns(z.promise(z.unknown())),
   });
-  export type Server = {
+  type Server = {
     call(method: "worker.heartbeat", params: Record<string, unknown>): Promise<unknown>;
   };
 


### PR DESCRIPTION
## Summary
- make WorkerHeartbeat SnapshotInput and Server schema/type helpers namespace-internal
- preserve createSnapshot, send, and start runtime bodies and exported call behavior
- reduce server unused namespace-member findings from 12 to 10

## Verification
- bun test apps/server/test/execution/worker-heartbeat.test.ts apps/server/test/execution/worker-full-stack.test.ts
- bun run --cwd apps/server check-types
- bun run --cwd apps/server build
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code
- LSP diagnostics on changed file
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the WorkerHeartbeat public type surface by making SnapshotInput and Server schemas/types namespace-internal. No runtime or external API changes; reduces unused namespace-member findings from 12 to 10.

<sup>Written for commit febe66a18ed413059d6e9106ecd6ef53ae1442c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

