### PR TITLE
refactor(server): trim worker run state type surface

### DIFF
--- a/apps/server/src/execution/worker-run-state.ts
+++ b/apps/server/src/execution/worker-run-state.ts
@@ -1,5 +1,5 @@
 export namespace WorkerRunState {
-  export interface ActiveRun {
+  interface ActiveRun {
     readonly sessionId: string;
     readonly controller: AbortController;
   }

--- a/apps/server/test/execution/worker-ipc-handlers.test.ts
+++ b/apps/server/test/execution/worker-ipc-handlers.test.ts
@@ -4,7 +4,9 @@ import { InjectionQueue } from "@openomni/openomni";
 import { WorkerIpcHandlers } from "../../src/execution/worker-ipc-handlers";
 import type { WorkerRunState } from "../../src/execution/worker-run-state";
 
-function createRun(sessionId: string): WorkerRunState.ActiveRun {
+type ActiveRun = NonNullable<ReturnType<WorkerRunState.ActiveRunRegistry["get"]>>;
+
+function createRun(sessionId: string): ActiveRun {
   return { sessionId, controller: new AbortController() };
 }
 

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -7,6 +7,8 @@ import type { Tool, WorkerBootstrap } from "@openomni/protocol";
 import type { WorkerRunState } from "../../src/execution/worker-run-state";
 import { WorkerRunner } from "../../src/execution/worker-runner";
 
+type ActiveRun = NonNullable<ReturnType<WorkerRunState.ActiveRunRegistry["get"]>>;
+
 const successfulResult: AgentResult = {
   text: "done",
   steps: [],
@@ -110,7 +112,7 @@ describe("WorkerRunner", () => {
 
   it("rejects duplicate run ids without replacing the active run", () => {
     const responses: unknown[] = [];
-    const existingRun: WorkerRunState.ActiveRun = {
+    const existingRun: ActiveRun = {
       sessionId: "session-1",
       controller: new AbortController(),
     };
@@ -473,7 +475,7 @@ describe("WorkerRunner", () => {
                 isCompletion: true,
                 continuationCount: 0,
                 elapsedMs: 0,
-                traceContext: { runId: "run-1", sessionId: "session-1" },
+                traceContext: { traceId: "trace-1", runId: "run-1", sessionId: "session-1" },
               });
 
               expect(decision.effects).toEqual([
@@ -607,6 +609,7 @@ describe("WorkerRunner", () => {
     AgentRegistry.define({
       name: "child",
       description: "child",
+      tools: [],
       model: { provider: "test", id: "child" },
     });
     const responseReceived = new Promise<void>((resolve) => {
@@ -714,6 +717,7 @@ describe("WorkerRunner", () => {
     AgentRegistry.define({
       name: "child",
       description: "child",
+      tools: [],
       model: { provider: "test", id: "child" },
     });
     const backgroundManager = {
@@ -806,7 +810,7 @@ describe("WorkerRunner", () => {
 
   it("aborts a proxied tool IPC wait without waiting for the full IPC timeout", async () => {
     const responses: unknown[] = [];
-    const activeRuns = new Map<string, WorkerRunState.ActiveRun>();
+    const activeRuns = new Map<string, ActiveRun>();
     const serverCalls: Array<{
       method: string;
       params?: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- keep WorkerRunState.ActiveRun namespace-internal while preserving ActiveRunRegistry and ReadableActiveRuns as the server execution contracts
- update execution tests to derive the active-run value shape from ActiveRunRegistry instead of naming the removed helper export
- complete worker-runner test fixtures with source-accurate trace/agent fields so LSP diagnostics stay clean

## Verification
- bun test apps/server/test/execution/worker-runner.test.ts apps/server/test/execution/worker-ipc-handlers.test.ts apps/server/test/execution/worker-full-stack.test.ts
- bun test
- bun run --cwd apps/server check-types
- bun run --cwd apps/server build
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code
- LSP diagnostics clean on changed files

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `WorkerRunState.ActiveRun` internal and keeps `ActiveRunRegistry`/`ReadableActiveRuns` as the server-facing types. Updates tests to infer the active-run shape and fixes fixtures to match source types for clean diagnostics.

- **Refactors**
  - Stop exporting `WorkerRunState.ActiveRun`; keep `ActiveRunRegistry` and `ReadableActiveRuns` as the public API.
  - Tests derive the type via `NonNullable<ReturnType<WorkerRunState.ActiveRunRegistry["get"]>>`, and fixtures add `traceId` and `tools: []` to align with runtime shapes.

<sup>Written for commit 7384d8dd262181d7bba6971df4e27e8ec341e7dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

