### PR TITLE
refactor(server): trim worker runner type surface

### DIFF
--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -165,7 +165,7 @@ export namespace WorkerRunner {
   type ChatAgentOptions = Parameters<typeof ChatAgent.create>[0];
   type WorkerAgent = Pick<ReturnType<typeof ChatAgent.create>, "run">;
 
-  export interface Environment {
+  interface Environment {
     readonly ipcAuthToken: string;
     readonly workerId: string;
     readonly server: WorkerRunIpcServer;
@@ -179,7 +179,7 @@ export namespace WorkerRunner {
     readonly createAgent?: (options: ChatAgentOptions) => WorkerAgent;
   }
 
-  export interface SpawnRunOptions extends Environment {
+  interface SpawnRunOptions extends Environment {
     readonly params: Record<string, unknown> | undefined;
     readonly respond: (result: unknown) => void;
   }

--- a/apps/server/test/execution/worker-runner.test.ts
+++ b/apps/server/test/execution/worker-runner.test.ts
@@ -8,6 +8,8 @@ import type { WorkerRunState } from "../../src/execution/worker-run-state";
 import { WorkerRunner } from "../../src/execution/worker-runner";
 
 type ActiveRun = NonNullable<ReturnType<WorkerRunState.ActiveRunRegistry["get"]>>;
+type SpawnRunOptions = Parameters<typeof WorkerRunner.spawnRun>[0];
+type WorkerRunnerEnvironment = Omit<SpawnRunOptions, "params" | "respond">;
 
 const successfulResult: AgentResult = {
   text: "done",
@@ -19,8 +21,8 @@ const successfulResult: AgentResult = {
 function createSpawnOptions(
   params: Record<string, unknown> | undefined,
   respond: (result: unknown) => void,
-  overrides: Partial<WorkerRunner.Environment> = {},
-): WorkerRunner.SpawnRunOptions {
+  overrides: Partial<WorkerRunnerEnvironment> = {},
+): SpawnRunOptions {
   const activeRuns = overrides.activeRuns ?? new Map();
   return {
     params,


### PR DESCRIPTION
## Summary
- keep WorkerRunner.Environment and WorkerRunner.SpawnRunOptions namespace-internal while preserving WorkerRunner.spawnRun
- update worker-runner tests to derive the helper shape from Parameters<typeof WorkerRunner.spawnRun>[0]

## Verification
- bun test apps/server/test/execution/worker-runner.test.ts apps/server/test/execution/worker-full-stack.test.ts
- bun test
- bun run --cwd apps/server check-types
- bun run --cwd apps/server build
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code
- LSP diagnostics clean on changed files

Reviewer: codex-ultrawork-reviewer PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim the `WorkerRunner` public type surface by making `Environment` and `SpawnRunOptions` internal, while keeping `spawnRun` unchanged. Tests now infer the spawn options shape from `Parameters<typeof WorkerRunner.spawnRun>[0]` to avoid coupling to internal types.

<sup>Written for commit 615b1d52e3b7af783295b97d52dc60dc64365c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

