### PR TITLE
refactor(server): trim mcp prefix guard surface

### DIFF
--- a/apps/server/src/tool/mcp/mcp-prefix-guard.ts
+++ b/apps/server/src/tool/mcp/mcp-prefix-guard.ts
@@ -18,6 +18,20 @@ interface PrefixGuardState {
   serverName?: string;
 }
 
+interface PreToolUseContext {
+  readonly call: Tool.Call;
+  readonly tools: readonly NativeTool[];
+  readonly isServerConnected: (serverName: string) => boolean;
+  readonly traceContext?: TraceContext.Type;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
+interface PreToolUseResult {
+  readonly verdict: Policy.PolicyDecision;
+  readonly tool?: NativeTool;
+  readonly serverName?: string;
+}
+
 function evaluatePrefixGuard(input: {
   readonly call: Tool.Call;
   readonly resource: string;
@@ -138,6 +152,10 @@ function createMcpPrefixGuard(state: PrefixGuardState): PolicyRegistration {
   };
 }
 
+function registrations(state: PrefixGuardState): PolicyRegistration[] {
+  return [createMcpPrefixGuard(state)];
+}
+
 export namespace McpPrefixGuardMiddleware {
   export const Definition = {
     name: "mcp-prefix-guard",
@@ -145,24 +163,6 @@ export namespace McpPrefixGuardMiddleware {
     priority: 0,
     failPolicy: "fail-closed",
   } as const satisfies Policy.Definition;
-
-  export interface PreToolUseContext {
-    readonly call: Tool.Call;
-    readonly tools: readonly NativeTool[];
-    readonly isServerConnected: (serverName: string) => boolean;
-    readonly traceContext?: TraceContext.Type;
-    readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-  }
-
-  export interface PreToolUseResult {
-    readonly verdict: Policy.PolicyDecision;
-    readonly tool?: NativeTool;
-    readonly serverName?: string;
-  }
-
-  export function registrations(state: PrefixGuardState): PolicyRegistration[] {
-    return [createMcpPrefixGuard(state)];
-  }
 
   export async function evaluatePreToolUse(ctx: PreToolUseContext): Promise<PreToolUseResult> {
     const state: PrefixGuardState = {


### PR DESCRIPTION
## Summary
- keep MCP prefix guard context/result types file-local
- keep the registration builder file-local while preserving exported Definition and evaluatePreToolUse
- reduce @openomni/server namespace/type knip findings from 7 to 4

## Verification
- bun test apps/server/test/tool/mcp/provider.test.ts
- bun run --cwd apps/server check-types
- LSP diagnostics clean on apps/server/src/tool/mcp/mcp-prefix-guard.ts
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the MCP prefix guard public surface by making the context/result types and the registrations builder file‑local, while keeping `McpPrefixGuardMiddleware.Definition` and `evaluatePreToolUse` exported. This reduces unused namespace/type noise in `@openomni/server` with no runtime changes.

- **Refactors**
  - Moved `PreToolUseContext` and `PreToolUseResult` to file-local interfaces.
  - Made `registrations()` file-local; removed the exported `registrations` from the namespace.
  - Reduced knip namespace/type findings in `@openomni/server` from 7 to 4.

<sup>Written for commit 2131a12a418453c51e761341d9768d579767576f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

