### PR TITLE
refactor(server): remove context cache reset exports

### DIFF
--- a/apps/server/src/context/instructions.ts
+++ b/apps/server/src/context/instructions.ts
@@ -109,9 +109,4 @@ export namespace InstructionLoader {
     loadCache.set(key, output);
     return output;
   }
-
-  export function _resetCache(): void {
-    discoverCache.clear();
-    loadCache.clear();
-  }
 }

--- a/apps/server/src/context/mcp-config.ts
+++ b/apps/server/src/context/mcp-config.ts
@@ -69,8 +69,4 @@ export namespace McpConfigLoader {
 
     return [...byName.values()];
   }
-
-  export function _resetCache(): void {
-    discoverCache.clear();
-  }
 }

--- a/apps/server/src/context/skills.ts
+++ b/apps/server/src/context/skills.ts
@@ -104,8 +104,4 @@ export namespace SkillLoader {
 
     return lines.join("\n");
   }
-
-  export function _resetCache(): void {
-    discoverCache.clear();
-  }
 }

--- a/apps/server/test/context/instructions.test.ts
+++ b/apps/server/test/context/instructions.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -177,10 +177,6 @@ describe("InstructionLoader.load", () => {
 });
 
 describe("InstructionLoader caching", () => {
-  afterEach(() => {
-    InstructionLoader._resetCache();
-  });
-
   it("discover returns cached result on repeated calls", () => {
     const ws = makeWorkspace("cache-discover");
     writeFileSync(join(ws, "AGENTS.md"), "# Original");
@@ -190,7 +186,7 @@ describe("InstructionLoader caching", () => {
     expect(second).toBe(first);
   });
 
-  it("discover returns stale global result after file deletion until cache reset", () => {
+  it("discover returns stale global result after file deletion for the same cache key", () => {
     const ws = makeWorkspace("cache-stale-discover");
     const globalDir = makeWorkspace("cache-stale-global-config");
     const agentsPath = join(globalDir, "AGENTS.md");
@@ -204,13 +200,12 @@ describe("InstructionLoader caching", () => {
     const cached = InstructionLoader.discover(ws, globalDir);
     expect(cached.some((f) => f.label === "Global")).toBe(true);
 
-    InstructionLoader._resetCache();
-
-    const fresh = InstructionLoader.discover(ws, globalDir);
+    const freshGlobalDir = makeWorkspace("cache-stale-fresh-global-config");
+    const fresh = InstructionLoader.discover(ws, freshGlobalDir);
     expect(fresh.some((f) => f.label === "Global")).toBe(false);
   });
 
-  it("load returns cached result on repeated calls with same files", () => {
+  it("load returns cached result on repeated calls with the same file list", () => {
     const ws = makeWorkspace("cache-load");
     const filePath = join(ws, "test.md");
     writeFileSync(filePath, "Content A");
@@ -224,9 +219,9 @@ describe("InstructionLoader caching", () => {
     const cached = InstructionLoader.load(files);
     expect(cached).toContain("Content A");
 
-    InstructionLoader._resetCache();
-
-    const fresh = InstructionLoader.load(files);
+    const freshPath = join(ws, "fresh.md");
+    writeFileSync(freshPath, "Content B");
+    const fresh = InstructionLoader.load([{ path: freshPath, priority: 0, label: "Fresh" }]);
     expect(fresh).toContain("Content B");
   });
 });

--- a/apps/server/test/context/mcp-config.test.ts
+++ b/apps/server/test/context/mcp-config.test.ts
@@ -22,7 +22,6 @@ afterAll(() => {
 
 afterEach(() => {
   Bus.reset();
-  McpConfigLoader._resetCache();
 });
 
 describe("McpConfigLoader.discover", () => {
@@ -209,7 +208,7 @@ describe("McpConfigLoader caching", () => {
     expect(first).toHaveLength(1);
   });
 
-  it("discover caches null for missing config", () => {
+  it("discover caches null for missing config for the same workspace path", () => {
     const dir = join(tempRoot, "cache-null");
     mkdirSync(dir, { recursive: true });
 
@@ -226,9 +225,14 @@ describe("McpConfigLoader caching", () => {
     const cached = McpConfigLoader.discover(dir);
     expect(cached).toBeNull();
 
-    McpConfigLoader._resetCache();
+    const freshDir = join(tempRoot, "cache-null-fresh");
+    mkdirSync(join(freshDir, ".openomni"), { recursive: true });
+    writeFileSync(
+      join(freshDir, ".openomni", "mcp.json"),
+      JSON.stringify([{ name: "late", transport: "stdio", command: "node" }]),
+    );
 
-    const fresh = McpConfigLoader.discover(dir);
+    const fresh = McpConfigLoader.discover(freshDir);
     expect(fresh).toHaveLength(1);
   });
 });

--- a/apps/server/test/context/skills.test.ts
+++ b/apps/server/test/context/skills.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -209,10 +209,6 @@ describe("SkillLoader.format", () => {
 });
 
 describe("SkillLoader caching", () => {
-  afterEach(() => {
-    SkillLoader._resetCache();
-  });
-
   it("discover returns cached result on repeated calls", () => {
     const ws = realpathSync(mkdtempSync(join(tempRoot, "cache1-")));
     const skillsDir = makeWorkspace(ws);
@@ -224,7 +220,7 @@ describe("SkillLoader caching", () => {
     expect(first).toHaveLength(1);
   });
 
-  it("discover returns stale result after skill added until cache reset", () => {
+  it("discover returns stale result after skill added for the same cache key", () => {
     const ws = realpathSync(mkdtempSync(join(tempRoot, "cache2-")));
     const skillsDir = makeWorkspace(ws);
     writeSkill(skillsDir, "original", "---\nname: original\ndescription: First\n---");
@@ -237,9 +233,12 @@ describe("SkillLoader caching", () => {
     const cached = SkillLoader.discover(ws, emptyGlobalDir);
     expect(cached).toHaveLength(1);
 
-    SkillLoader._resetCache();
+    const freshWs = realpathSync(mkdtempSync(join(tempRoot, "cache2-fresh-")));
+    const freshSkillsDir = makeWorkspace(freshWs);
+    writeSkill(freshSkillsDir, "original", "---\nname: original\ndescription: First\n---");
+    writeSkill(freshSkillsDir, "added", "---\nname: added\ndescription: Second\n---");
 
-    const fresh = SkillLoader.discover(ws, emptyGlobalDir);
+    const fresh = SkillLoader.discover(freshWs, emptyGlobalDir);
     expect(fresh).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- remove test-only _resetCache namespace exports from InstructionLoader, McpConfigLoader, and SkillLoader
- keep cache behavior covered through public discover/load calls using same-key stale and fresh-key scenarios
- reduce @openomni/server namespace/type knip findings from 4 to 1

## Verification
- bun test apps/server/test/context/instructions.test.ts apps/server/test/context/mcp-config.test.ts apps/server/test/context/skills.test.ts apps/server/test/context/integration.test.ts
- bun run --cwd apps/server check-types
- LSP diagnostics clean on changed context source files
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed internal cache reset exports from server context loaders and updated tests to exercise cache behavior via cache keys. This simplifies the public API with no runtime changes and reduces `@openomni/server` maintenance noise.

- **Refactors**
  - Dropped `_resetCache` from InstructionLoader, McpConfigLoader, and SkillLoader.
  - Tests now cover same-key stale vs new-key fresh scenarios using public `discover`/`load`.
  - Reduced `knip` namespace/type findings in `@openomni/server` from 4 to 1.

<sup>Written for commit 995de456e3ca75d95d6a55488d54dec2692a9199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

