### PR TITLE
refactor(server): remove worker heartbeat send export

### DIFF
--- a/apps/server/src/execution/worker-heartbeat.ts
+++ b/apps/server/src/execution/worker-heartbeat.ts
@@ -46,10 +46,6 @@ export namespace WorkerHeartbeat {
     };
   }
 
-  export async function send(options: Options): Promise<void> {
-    await sendParsed(Options.parse(options));
-  }
-
   export function start(options: Options): ReturnType<typeof setInterval> {
     const parsed = Options.parse(options);
     return setInterval(() => {

--- a/apps/server/test/execution/worker-heartbeat.test.ts
+++ b/apps/server/test/execution/worker-heartbeat.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, mock } from "bun:test";
 import { WorkerHeartbeat } from "../../src/execution/worker-heartbeat";
 
 describe("worker heartbeat", () => {
+  interface TimerRef {
+    current?: ReturnType<typeof setInterval>;
+  }
+
   it("creates worker snapshots from active run state", () => {
     const snapshot = WorkerHeartbeat.createSnapshot({
       activeRunIds: ["run-1", "run-2"],
@@ -20,10 +24,18 @@ describe("worker heartbeat", () => {
     });
   });
 
-  it("sends heartbeat payloads", async () => {
+  it("sends heartbeat payloads through the interval entrypoint", async () => {
+    const timer: TimerRef = {};
     const serverCall = mock(async () => ({ ok: true }));
+    const callObserved = new Promise<void>((resolve) => {
+      serverCall.mockImplementation(async () => {
+        if (timer.current) clearInterval(timer.current);
+        resolve();
+        return { ok: true };
+      });
+    });
 
-    await WorkerHeartbeat.send({
+    timer.current = WorkerHeartbeat.start({
       workerId: "worker-1",
       ipcAuthToken: "token",
       server: { call: serverCall },
@@ -31,7 +43,10 @@ describe("worker heartbeat", () => {
       getConfigEpoch: () => "epoch-1",
       readMemoryRssMb: () => 10,
       nowMs: () => 123,
+      intervalMs: 1,
     });
+
+    await callObserved;
 
     expect(serverCall).toHaveBeenCalledTimes(1);
     expect(serverCall).toHaveBeenCalledWith("worker.heartbeat", {
@@ -50,20 +65,31 @@ describe("worker heartbeat", () => {
   });
 
   it("ignores supervisor send failures", async () => {
+    const timer: TimerRef = {};
     const serverCall = mock(async () => {
       throw new Error("not connected yet");
     });
+    const callObserved = new Promise<void>((resolve) => {
+      serverCall.mockImplementation(async () => {
+        if (timer.current) clearInterval(timer.current);
+        resolve();
+        throw new Error("not connected yet");
+      });
+    });
 
-    await expect(
-      WorkerHeartbeat.send({
-        workerId: "worker-1",
-        ipcAuthToken: "token",
-        server: { call: serverCall },
-        getActiveRunIds: () => ["run-1"],
-        getConfigEpoch: () => "epoch-1",
-        readMemoryRssMb: () => 10,
-        nowMs: () => 123,
-      }),
-    ).resolves.toBeUndefined();
+    timer.current = WorkerHeartbeat.start({
+      workerId: "worker-1",
+      ipcAuthToken: "token",
+      server: { call: serverCall },
+      getActiveRunIds: () => ["run-1"],
+      getConfigEpoch: () => "epoch-1",
+      readMemoryRssMb: () => 10,
+      nowMs: () => 123,
+      intervalMs: 1,
+    });
+
+    await callObserved;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(serverCall).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- remove the test-only WorkerHeartbeat.send namespace export
- keep heartbeat payload/failure coverage by driving WorkerHeartbeat.start through the interval entrypoint
- confirm server nsExports/nsTypes cleanup now has no exported namespace/type findings beyond known test-file noise

## Verification
- bun test apps/server/test/execution/worker-heartbeat.test.ts apps/server/test/execution/worker-full-stack.test.ts
- LSP diagnostics clean on apps/server/src/execution/worker-heartbeat.ts and apps/server/test/execution/worker-heartbeat.test.ts
- bunx knip --include nsExports,nsTypes --workspace @openomni/server --no-progress --no-exit-code
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the test-only `WorkerHeartbeat.send` export and route heartbeats through `WorkerHeartbeat.start` in tests to keep payload and failure coverage. Also cleans up stray namespace/type exports in `@openomni/server`.

- **Refactors**
  - Deleted `WorkerHeartbeat.send`; use `start(...)` as the interval entrypoint.
  - Updated tests to start the interval with `intervalMs: 1` and clear it after the first call; verifies payload and that send failures are ignored.
  - Confirms no unintended namespace/type exports remain (nsExports/nsTypes) beyond known test-file noise.

<sup>Written for commit ab1ce8ff25568b27f4a41c026788a97e49922aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified worker heartbeat delivery by removing the manual trigger function; automatic interval-based heartbeats are now the primary mechanism.

* **Tests**
  * Updated worker heartbeat tests to verify automatic interval-based heartbeat delivery and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->