### PR TITLE
refactor(llm): remove models dev init export

### DIFF
--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -27,7 +27,7 @@ src/
 ├── agent/
 │   └── index.ts      # Agent.Info schema + defaults (lightweight agent profile)
 ├── model/
-│   └── index.ts      # ModelsDev.get / refresh / init — fetches models.dev catalog
+│   └── index.ts      # ModelsDev.get / refresh — fetches models.dev catalog
 └── util/
     └── lazy.ts       # Lazy initialization helper
 ```

--- a/packages/llm/src/model/index.ts
+++ b/packages/llm/src/model/index.ts
@@ -134,21 +134,4 @@ export namespace ModelsDev {
       /* non-fatal */
     }
   }
-
-  let initialized = false;
-
-  export function init(): void {
-    if (initialized) return;
-    initialized = true;
-
-    if (!process.env.OPENOMNI_DISABLE_MODELS_FETCH) {
-      ModelsDev.refresh();
-      setInterval(
-        () => {
-          ModelsDev.refresh();
-        },
-        60 * 60 * 1000,
-      ).unref();
-    }
-  }
 }

--- a/packages/llm/test/model/models.test.ts
+++ b/packages/llm/test/model/models.test.ts
@@ -15,6 +15,12 @@ describe("ModelsDev", () => {
     process.env = { ...originalEnv };
   });
 
+  describe("public API", () => {
+    it("should expose only the supported catalog operations", () => {
+      expect("init" in ModelsDev).toBe(false);
+    });
+  });
+
   describe("schemas", () => {
     it("should validate a well-formed Model", () => {
       const result = ModelsDev.Model.safeParse({
@@ -174,7 +180,12 @@ describe("ModelsDev", () => {
       process.env.OPENOMNI_MODELS_PATH = fakePath;
 
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() => Promise.reject(new Error("offline"))) as typeof fetch;
+      globalThis.fetch = Object.assign(
+        mock(() => Promise.reject(new Error("offline"))),
+        {
+          preconnect: originalFetch.preconnect,
+        },
+      );
 
       try {
         const data = await ModelsDev.get();
@@ -191,7 +202,12 @@ describe("ModelsDev", () => {
       process.env.OPENOMNI_MODELS_PATH = fakePath;
       process.env.OPENOMNI_DISABLE_MODELS_FETCH = "true";
 
-      const fetchSpy = mock(() => Promise.resolve(new Response("ok"))) as typeof fetch;
+      const fetchSpy = Object.assign(
+        mock(() => Promise.resolve(new Response("ok"))),
+        {
+          preconnect: globalThis.fetch.preconnect,
+        },
+      );
       const originalFetch = globalThis.fetch;
       globalThis.fetch = fetchSpy;
 
@@ -209,7 +225,12 @@ describe("ModelsDev", () => {
   describe("snapshot fallback", () => {
     it("should return data from snapshot when fetch and cache fail", async () => {
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() => Promise.reject(new Error("offline"))) as typeof fetch;
+      globalThis.fetch = Object.assign(
+        mock(() => Promise.reject(new Error("offline"))),
+        {
+          preconnect: originalFetch.preconnect,
+        },
+      );
 
       const fakePath = join(tmpdir(), `openomni-test-${Date.now()}`, "models.json");
       process.env.OPENOMNI_MODELS_PATH = fakePath;
@@ -226,7 +247,12 @@ describe("ModelsDev", () => {
 
     it("should return empty object as final fallback when snapshot unavailable", async () => {
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() => Promise.reject(new Error("offline"))) as typeof fetch;
+      globalThis.fetch = Object.assign(
+        mock(() => Promise.reject(new Error("offline"))),
+        {
+          preconnect: originalFetch.preconnect,
+        },
+      );
 
       const fakePath = join(tmpdir(), `openomni-test-${Date.now()}`, "models.json");
       process.env.OPENOMNI_MODELS_PATH = fakePath;


### PR DESCRIPTION
## Summary
- remove unused `ModelsDev.init` and its private initialized/interval state
- keep `ModelsDev.get`, `refresh`, `Data`, schemas, cache, snapshot fallback, and env behavior intact
- update the model catalog tests and LLM package AGENTS map to reflect the supported public surface

## Verification
- bun test packages/llm/test/model/models.test.ts
- bunx knip --include nsExports,nsTypes --workspace @openomni/llm --no-progress --no-exit-code
- LSP diagnostics clean on changed TS files
- bun run --cwd packages/llm check-types
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `ModelsDev.init()` and its background timer from `@openomni/llm`. Kept `get`/`refresh`, schemas, caching, snapshot fallback, and env flags unchanged.

- **Refactors**
  - Dropped `ModelsDev.init()` and internal `initialized`/interval state to avoid background refresh on import.
  - Updated `AGENTS.md` and tests to reflect the public API (`get`, `refresh`).

- **Migration**
  - Remove any calls to `ModelsDev.init()`; it no longer exists and is not needed.

<sup>Written for commit 2d2798f4ec586f075a924fe7fd1862bdf85bacb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

