### PR TITLE
refactor(llm): remove provider dead surface

### DIFF
--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -150,14 +150,6 @@ export namespace Provider {
     };
   }
 
-  export const BUNDLED_PROVIDERS = {
-    "@ai-sdk/anthropic": true,
-    "@ai-sdk/openai": true,
-    "@ai-sdk/openai-compatible": true,
-  } as const;
-
-  export type ProviderID = string;
-
   export async function listModels(
     providerID: string,
     authType?: "proxy" | "api",

--- a/packages/llm/test/provider/registry.test.ts
+++ b/packages/llm/test/provider/registry.test.ts
@@ -12,6 +12,18 @@ function makeModel(providerID: string, npm: string, id?: string): Provider.Model
 }
 
 describe("Provider Registry", () => {
+  describe("public surface", () => {
+    it("does not expose removed dead provider namespace members", async () => {
+      const providerSource = await Bun.file(
+        new URL("../../src/provider/index.ts", import.meta.url),
+      ).text();
+
+      expect(Object.hasOwn(Provider, "BUNDLED_PROVIDERS")).toBe(false);
+      expect(providerSource).not.toMatch(/\bexport\s+const\s+BUNDLED_PROVIDERS\b/);
+      expect(providerSource).not.toMatch(/\bexport\s+type\s+ProviderID\b/);
+    });
+  });
+
   describe("getSDK", () => {
     it("should return configured Anthropic provider with API auth", () => {
       const auth: Auth.Info = { type: "api", key: "test-api-key" };


### PR DESCRIPTION
## Summary
- remove unused Provider.BUNDLED_PROVIDERS and Provider.ProviderID namespace members from packages/llm/src/provider/index.ts
- keep runtime provider SDK wiring intact, including the file-local SDK provider registry in provider.ts
- add focused public-surface regression coverage for the removed members

## Verification
- bun test packages/llm/test/provider/registry.test.ts packages/llm/test/provider/integration.test.ts
- bun run --cwd packages/llm check-types
- bunx knip --include nsExports,nsTypes --workspace @openomni/llm --no-progress --no-exit-code
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused provider namespace exports to reduce the public API surface in `@openomni/llm` without changing runtime behavior. Added tests to ensure these members stay unexposed.

- **Refactors**
  - Removed Provider.BUNDLED_PROVIDERS and Provider.ProviderID from `packages/llm/src/provider/index.ts`; runtime SDK wiring and local provider registry remain intact.
  - Added public-surface regression tests verifying the removed members are not exported.

<sup>Written for commit 15388bf78ff88b105838f18fb7727c895e6ab70a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

