### PR TITLE
refactor(llm): internalize transform option type

### DIFF
--- a/packages/llm/src/transform/index.ts
+++ b/packages/llm/src/transform/index.ts
@@ -21,7 +21,7 @@ export namespace ProviderTransform {
     }
   }
 
-  export interface NormalizeOptions {
+  interface NormalizeOptions {
     npm: string;
     modelId: string;
   }

--- a/packages/llm/test/transform/transform.test.ts
+++ b/packages/llm/test/transform/transform.test.ts
@@ -35,6 +35,15 @@ describe("ProviderTransform.normalizeMessages", () => {
   };
   const openaiModel = { npm: "@ai-sdk/openai", modelId: "gpt-4o" };
 
+  test("does not expose NormalizeOptions as a public namespace member", async () => {
+    const transformSource = await Bun.file(
+      new URL("../../src/transform/index.ts", import.meta.url),
+    ).text();
+
+    expect(Object.hasOwn(ProviderTransform, "NormalizeOptions")).toBe(false);
+    expect(transformSource).not.toMatch(/\bexport\s+interface\s+NormalizeOptions\b/);
+  });
+
   test("openai is passthrough", () => {
     const msgs: ModelMessage[] = [
       { role: "user", content: "" },


### PR DESCRIPTION
## Summary
- make ProviderTransform.NormalizeOptions namespace-internal instead of an exported namespace member
- preserve normalizeMessages structural support for { npm, modelId } and Provider.Model inputs
- add regression coverage that the helper type is not re-exported

## Verification
- bun test packages/llm/test/transform/transform.test.ts
- bun run --cwd packages/llm check-types
- bunx knip --include nsExports,nsTypes --workspace @openomni/llm --no-progress --no-exit-code
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized `ProviderTransform.NormalizeOptions` (no longer exported) to reduce the public API surface with no runtime behavior changes. `normalizeMessages` still accepts `{ npm, modelId }` and `Provider.Model` inputs, and a regression test ensures the type is not re-exported.

<sup>Written for commit 6d7566b7f190fa057bf5248da0cf6276fb753b23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

