### PR TITLE
refactor(llm): remove agent retry dead surface

### DIFF
--- a/packages/llm/src/session/retry.ts
+++ b/packages/llm/src/session/retry.ts
@@ -1,6 +1,6 @@
 import { APIError, RetryError } from "../error";
 import { Bus } from "@openomni/session";
-import { LlmCall, Operational, type Run } from "@openomni/protocol";
+import { LlmCall } from "@openomni/protocol";
 
 export namespace Retry {
   export const RETRY_INITIAL_DELAY = 2000;
@@ -112,7 +112,7 @@ export namespace Retry {
     }
   }
 
-  export interface WithRetryOptions {
+  interface WithRetryOptions {
     maxAttempts?: number;
     signal?: AbortSignal;
     initialDelay?: number;
@@ -203,118 +203,5 @@ export namespace Retry {
       attempts: maxAttempts,
       lastError: lastError?.message,
     });
-  }
-
-  // Agent-level retry logic (separate from provider-level retries)
-  export type AgentRetryReason = "timeout" | "tool_error" | "transient_error" | "validation_error";
-
-  export const DEFAULT_AGENT_RETRY_POLICY: Run.RetryPolicy = {
-    maxAttempts: 3,
-    backoffMs: { initial: 1000, multiplier: 2, max: 30_000 },
-    retryOn: ["timeout", "tool_error", "transient_error"],
-  };
-
-  export function calculateAgentBackoffMs(policy: Run.RetryPolicy, attempt: number): number {
-    const rawDelay =
-      policy.backoffMs.initial * policy.backoffMs.multiplier ** Math.max(0, attempt - 1);
-    return Math.min(rawDelay, policy.backoffMs.max);
-  }
-
-  export function classifyAgentRetryReason(errorMessage: string): AgentRetryReason {
-    const normalized = errorMessage.toLowerCase();
-    if (
-      normalized.includes("timeout") ||
-      normalized.includes("aborted") ||
-      normalized.includes("budget exceeded")
-    ) {
-      Bus.publish(Operational.Debug, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "error classified as timeout",
-        context: { error: errorMessage, reason: "timeout" },
-      });
-      return "timeout";
-    }
-    if (normalized.includes("tool")) {
-      Bus.publish(Operational.Debug, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "error classified as tool error",
-        context: { error: errorMessage, reason: "tool_error" },
-      });
-      return "tool_error";
-    }
-    if (normalized.includes("validation")) {
-      Bus.publish(Operational.Debug, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "error classified as validation error",
-        context: { error: errorMessage, reason: "validation_error" },
-      });
-      return "validation_error";
-    }
-    Bus.publish(Operational.Debug, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "llm.retry",
-      msg: "error classified as transient error",
-      context: { error: errorMessage, reason: "transient_error" },
-    });
-    return "transient_error";
-  }
-
-  export function shouldAgentRetry(
-    policy: Run.RetryPolicy,
-    reason: AgentRetryReason,
-    attempt: number,
-  ): boolean {
-    if (attempt >= policy.maxAttempts) {
-      Bus.publish(Operational.Warn, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "retry exhausted: max attempts reached",
-        context: { attempt, maxAttempts: policy.maxAttempts, reason, shouldRetry: false },
-      });
-      return false;
-    }
-    if (!policy.retryOn || policy.retryOn.length === 0) {
-      const backoffMs = calculateAgentBackoffMs(policy, attempt + 1);
-      Bus.publish(Operational.Warn, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "retry decision: will retry (no filter)",
-        context: { attempt, maxAttempts: policy.maxAttempts, reason, shouldRetry: true, backoffMs },
-      });
-      return true;
-    }
-    const willRetry = policy.retryOn.includes(reason);
-    if (willRetry) {
-      const backoffMs = calculateAgentBackoffMs(policy, attempt + 1);
-      Bus.publish(Operational.Warn, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "retry decision: will retry (reason allowed)",
-        context: { attempt, maxAttempts: policy.maxAttempts, reason, shouldRetry: true, backoffMs },
-      });
-    } else {
-      Bus.publish(Operational.Warn, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        component: "llm.retry",
-        msg: "retry decision: will not retry (reason not allowed)",
-        context: { attempt, maxAttempts: policy.maxAttempts, reason, shouldRetry: false },
-      });
-    }
-    return willRetry;
-  }
-
-  export function agentSleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, Math.max(0, Math.floor(ms))));
   }
 }

--- a/packages/llm/test/session/retry.test.ts
+++ b/packages/llm/test/session/retry.test.ts
@@ -3,6 +3,20 @@ import { Retry } from "../../src/session/retry";
 import { APIError, RetryError } from "../../src/error";
 
 describe("Retry", () => {
+  test("does not expose removed agent-level retry namespace members", async () => {
+    const retrySource = await Bun.file(
+      new URL("../../src/session/retry.ts", import.meta.url),
+    ).text();
+
+    expect(Object.hasOwn(Retry, "DEFAULT_AGENT_RETRY_POLICY")).toBe(false);
+    expect(Object.hasOwn(Retry, "calculateAgentBackoffMs")).toBe(false);
+    expect(Object.hasOwn(Retry, "classifyAgentRetryReason")).toBe(false);
+    expect(Object.hasOwn(Retry, "shouldAgentRetry")).toBe(false);
+    expect(Object.hasOwn(Retry, "agentSleep")).toBe(false);
+    expect(retrySource).not.toMatch(/\bexport\s+type\s+AgentRetryReason\b/);
+    expect(retrySource).not.toMatch(/\bexport\s+interface\s+WithRetryOptions\b/);
+  });
+
   describe("Constants", () => {
     test("RETRY_INITIAL_DELAY is 2000ms", () => {
       expect(Retry.RETRY_INITIAL_DELAY).toBe(2000);


### PR DESCRIPTION
## Summary
- remove unused agent-level retry helpers from the LLM Retry namespace
- keep provider-level retry behavior intact: constants, sleep, delay, isRetryable, withRetry, and retry telemetry
- make WithRetryOptions namespace-internal while preserving structural withRetry options
- add regression coverage that removed Retry namespace members stay absent

## Verification
- bun test packages/llm/test/session/retry.test.ts
- bun run --cwd packages/llm check-types
- bunx knip --include nsExports,nsTypes --workspace @openomni/llm --no-progress --no-exit-code
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove dead agent-level retry APIs from the `Retry` namespace in `@openomni/llm` to shrink the public surface and avoid misuse. Provider-level retry behavior and telemetry remain unchanged.

- **Refactors**
  - Removed `DEFAULT_AGENT_RETRY_POLICY`, `calculateAgentBackoffMs`, `classifyAgentRetryReason`, `shouldAgentRetry`, `agentSleep`, and `AgentRetryReason`.
  - Made `WithRetryOptions` namespace-internal; `withRetry` options behavior unchanged.
  - Added tests to confirm removed members are not exported.

<sup>Written for commit 3c76418edeaf5a037f3c5c96eca8959a6bcbe125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

