### PR TITLE
refactor(llm): internalize processor helper types

### DIFF
--- a/packages/llm/src/session/processor.ts
+++ b/packages/llm/src/session/processor.ts
@@ -13,9 +13,9 @@ import { APIError } from "../error";
 import type { Provider } from "../provider";
 
 export namespace Processor {
-  export type ProcessResult = "stop" | "continue" | "compact";
+  type ProcessResult = "stop" | "continue" | "compact";
 
-  export interface ToolResult {
+  interface ToolResult {
     output: string;
     title: string;
     metadata?: Record<string, unknown>;
@@ -47,7 +47,7 @@ export namespace Processor {
     trace?: { traceId: string; sessionId: string; runId?: string; provider?: string };
   }
 
-  export interface ProcessorInfo {
+  interface ProcessorInfo {
     message: Message.AssistantMessage;
     process(streamInput: StreamInput): Promise<ProcessResult>;
   }

--- a/packages/llm/test/session/processor.test.ts
+++ b/packages/llm/test/session/processor.test.ts
@@ -123,6 +123,19 @@ describe("Processor", () => {
   });
 
   describe("Processor.create(input)", () => {
+    test("does not expose removed helper type namespace members", async () => {
+      const processorSource = await Bun.file(
+        new URL("../../src/session/processor.ts", import.meta.url),
+      ).text();
+
+      expect(Object.hasOwn(Processor, "ProcessResult")).toBe(false);
+      expect(Object.hasOwn(Processor, "ToolResult")).toBe(false);
+      expect(Object.hasOwn(Processor, "ProcessorInfo")).toBe(false);
+      expect(processorSource).not.toMatch(/\bexport\s+type\s+ProcessResult\b/);
+      expect(processorSource).not.toMatch(/\bexport\s+interface\s+ToolResult\b/);
+      expect(processorSource).not.toMatch(/\bexport\s+interface\s+ProcessorInfo\b/);
+    });
+
     test("creates a processor with required input", () => {
       const processor = Processor.create({
         assistantMessage: mockAssistantMessage,


### PR DESCRIPTION
## Summary
- internalize unused Processor helper types: ProcessResult, ToolResult, ProcessorInfo
- preserve Processor.create, ProcessorOptions, StreamInput, process runtime returns, onToolCall handling, stream processing, retry handling, cost accounting, and sink projection behavior
- add focused public-surface regression coverage proving the removed Processor namespace members and type/interface exports do not reappear

## Verification
- bun test packages/llm/test/session/processor.test.ts (26 pass, 0 fail)
- bun run --cwd packages/llm check-types
- bunx knip --include nsExports,nsTypes --workspace @openomni/llm --no-progress --no-exit-code (no output)
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- git diff --check
- bun test (2916 pass, 10 skip, 0 fail)
- LSP diagnostics clean on changed files
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized unused `Processor` helper types to shrink the public API surface with no behavior changes. Added a regression test to ensure these types stay internal.

- **Refactors**
  - Stop exporting `Processor.ProcessResult`, `Processor.ToolResult`, and `Processor.ProcessorInfo` while keeping `Processor.create`, `ProcessorOptions`, `StreamInput`, and processing behavior unchanged.
  - Add a focused test to assert the removed namespace members are not exposed.

<sup>Written for commit bc0b62be754939da08a48528837f70e39616ded9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

