### PR TITLE
refactor(openomni): remove app connector registry remove export

### DIFF
--- a/packages/openomni/src/app-connector/registry.ts
+++ b/packages/openomni/src/app-connector/registry.ts
@@ -56,10 +56,6 @@ export namespace AppConnectorRegistry {
     return AppConnectorInstallationStore.list();
   }
 
-  export function remove(id: string): boolean {
-    return AppConnectorInstallationStore.remove(id);
-  }
-
   export function disable(id: string): AppConnector.Installation {
     return AppConnectorInstallationStore.disable(id);
   }

--- a/packages/openomni/test/app-connector/registry.test.ts
+++ b/packages/openomni/test/app-connector/registry.test.ts
@@ -27,6 +27,17 @@ describe("AppConnectorRegistry", () => {
     await rm(tmpDir, { recursive: true });
   });
 
+  test("does not expose the removed duplicate remove lifecycle helper", async () => {
+    // Given
+    const registrySource = await Bun.file(
+      new URL("../../src/app-connector/registry.ts", import.meta.url),
+    ).text();
+
+    // When / Then
+    expect(Object.hasOwn(AppConnectorRegistry, "remove")).toBe(false);
+    expect(registrySource).not.toMatch(/\bexport\s+function\s+remove\b/);
+  });
+
   test("registers an available discovery candidate as a durable installation", async () => {
     // Given
     const connector = BuiltInAppConnectors.get("app.codex");


### PR DESCRIPTION
## Summary
- remove unused duplicate AppConnectorRegistry.remove namespace member
- keep AppConnectorRegistry.uninstall as the public app connector removal lifecycle API
- add regression coverage proving the removed registry namespace helper stays absent

## Verification
- bun test packages/openomni/test/app-connector/registry.test.ts packages/openomni/test/app-connector/registry-lifecycle.test.ts packages/openomni/test/app-connector/registry-smoke-verify.test.ts (12 pass, 0 fail)
- bun run --cwd packages/openomni check-types
- bunx knip --include nsExports,nsTypes --workspace @openomni/openomni --no-progress --no-exit-code (AppConnectorRegistry.remove no longer reported)
- LSP diagnostics clean on changed files
- git diff --check
- bun run check-types
- bun run build
- bun run lint
- bun run lint:guards
- bun test (2917 pass, 10 skip, 0 fail)
- codex-ultrawork-reviewer PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `AppConnectorRegistry.remove` export and standardized on `AppConnectorRegistry.uninstall` as the single app connector removal API. Added a regression test to ensure `remove` stays absent.

- **Refactors**
  - Deleted `remove` from `AppConnectorRegistry`.
  - Kept `uninstall` as the public removal lifecycle.
  - Added a test to verify `remove` isn’t exported or present in the source.

<sup>Written for commit 70684a497182d88510053c0584a6ee7107bcaf66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

