### PR TITLE
refactor(openomni): keep resident prompt helpers internal

### DIFF
--- a/packages/openomni/src/agents/resident/prompt/index.ts
+++ b/packages/openomni/src/agents/resident/prompt/index.ts
@@ -11,15 +11,12 @@ export type {
 } from "./types";
 
 export namespace ResidentAgent {
-  export const promptVariants: Record<ResidentPromptFamily, ResidentPromptVariant> = {
+  const promptVariants: Record<ResidentPromptFamily, ResidentPromptVariant> = {
     claude: CLAUDE_RESIDENT_PROMPT_VARIANT,
     gpt: GPT_RESIDENT_PROMPT_VARIANT,
   };
 
-  export const buildPrompt = buildResidentPrompt;
-  export const inferPromptFamily = inferResidentPromptFamily;
-
-  export function getPromptVariant(options: ResidentPromptOptions = {}): ResidentPromptVariant {
+  function getPromptVariant(options: ResidentPromptOptions = {}): ResidentPromptVariant {
     if (options.family) return promptVariants[options.family];
     if (options.model) return promptVariants[inferResidentPromptFamily(options.model)];
     return promptVariants.claude;

--- a/packages/openomni/test/resident/prompt.test.ts
+++ b/packages/openomni/test/resident/prompt.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { ResidentAgent } from "../../src/agents";
+
+describe("ResidentAgent prompt public surface", () => {
+  test("keeps getPrompt public while helper members stay internal", async () => {
+    const promptSource = await Bun.file(
+      new URL("../../src/agents/resident/prompt/index.ts", import.meta.url),
+    ).text();
+
+    const gptPrompt = ResidentAgent.getPrompt({
+      family: "gpt",
+    });
+    const inferredGptPrompt = ResidentAgent.getPrompt({
+      model: { provider: "openai", id: "gpt-5" },
+    });
+    const claudePrompt = ResidentAgent.getPrompt({
+      family: "claude",
+    });
+    const inferredClaudePrompt = ResidentAgent.getPrompt({
+      model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+    });
+
+    expect(inferredGptPrompt).toBe(gptPrompt);
+    expect(inferredClaudePrompt).toBe(claudePrompt);
+    expect(gptPrompt).toContain("# OpenOmni Resident");
+    expect(claudePrompt).toContain("# OpenOmni Resident");
+    expect(gptPrompt).not.toBe(claudePrompt);
+    expect(Object.hasOwn(ResidentAgent, "getPrompt")).toBe(true);
+    expect(Object.hasOwn(ResidentAgent, "promptVariants")).toBe(false);
+    expect(Object.hasOwn(ResidentAgent, "buildPrompt")).toBe(false);
+    expect(Object.hasOwn(ResidentAgent, "inferPromptFamily")).toBe(false);
+    expect(Object.hasOwn(ResidentAgent, "getPromptVariant")).toBe(false);
+    expect(promptSource).not.toMatch(/\bexport\s+const\s+promptVariants\b/);
+    expect(promptSource).not.toMatch(/\bexport\s+const\s+buildPrompt\b/);
+    expect(promptSource).not.toMatch(/\bexport\s+const\s+inferPromptFamily\b/);
+    expect(promptSource).not.toMatch(/\bexport\s+function\s+getPromptVariant\b/);
+  });
+});


### PR DESCRIPTION
## Summary

- keep `ResidentAgent.getPrompt` as the only prompt selector exposed from the namespace
- internalize unused prompt helper members: `promptVariants`, `buildPrompt`, `inferPromptFamily`, and `getPromptVariant`
- add focused regression coverage for model/family selection and the narrowed runtime public surface

## Why

`ResidentAgent.getPrompt({ model })` is the documented package surface for resident prompt selection. The helper members were unused namespace exports and made implementation details externally addressable without being a real contract.

## Verification

- `bun test packages/openomni/test/resident/prompt.test.ts apps/server/test/resident-profile.test.ts apps/server/test/ingress-bridge.test.ts`
- `bun run --cwd packages/openomni check-types`
- `bunx knip --include nsExports,nsTypes --workspace @openomni/openomni --no-progress --no-exit-code`
- `bun run check-types`
- `bun run build`
- `bun run lint`
- `bun run lint:guards`
- `git diff --check`
- `bun test` → 2913 pass / 10 skip / 0 fail
- ultrawork reviewer: APPROVE

Note: local Claude Fable oracle could not be counted because `claude-fable-5` returned 404/unavailable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Kept resident prompt helpers internal in `@openomni/openomni`, leaving `ResidentAgent.getPrompt` as the only public selector. This tightens the API surface without changing behavior.

- **Refactors**
  - Internalized `promptVariants`, `buildPrompt`, `inferPromptFamily`, and `getPromptVariant`; only `getPrompt` remains exported.
  - Added regression tests to verify `model`/`family` selection and ensure helper members are not exported.

<sup>Written for commit 37a54744354942b7e96cfa5dc7070ad42f8da416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the ResidentAgent prompt module's public API for a cleaner interface. The `getPrompt` function is now accessed through `ResidentAgent.getPrompt` instead of top-level exports. Internal prompt helper functions are no longer publicly exported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->