### PR TITLE
refactor(openomni): internalize worker child runtime type

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.ts
@@ -96,7 +96,7 @@ export type WorkerRuntimeConfig = {
   allowAuthFallback?: ChatAgentConfig["allowAuthFallback"];
 };
 
-export type WorkerChildRuntimeConfig = {
+type WorkerChildRuntimeConfig = {
   childDefinition?: RuntimeAgentDefinition;
   tools: ChatAgentConfig["tools"];
   toolExecutor: ChatAgentConfig["toolExecutor"];


### PR DESCRIPTION
## Summary
- Make WorkerChildRuntimeConfig module-local in the worker subagent runtime implementation
- Preserve exported buildWorkerChildRuntimeConfig and createWorkerSubagentRuntime behavior and barrel exports

## Why
WorkerChildRuntimeConfig is an implementation detail of buildWorkerChildRuntimeConfig. It was reported as an unused exported type and has no in-repo consumers, so keeping it exported expands the package surface without a contract need.

## Verification
- bunx knip --include exports,types,nsExports,nsTypes --workspace @openomni/openomni --no-progress --no-exit-code
- bun test packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
- LSP diagnostics on changed file: clean
- bun run --cwd packages/openomni check-types
- bun run lint:guards
- bun run check-types
- bun run build
- bun run lint
- git diff --check
- bun test
- codex-ultrawork-reviewer: APPROVE / architectStatus CLEAR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized the `WorkerChildRuntimeConfig` type in the `@openomni/openomni` worker subagent runtime to reduce the public API surface, with no changes to `buildWorkerChildRuntimeConfig`, `createWorkerSubagentRuntime`, or barrel exports.

<sup>Written for commit e7102a7c71bfa53e59bffd69a74ce112bfb47b29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

