### PR TITLE
refactor(openomni): remove background limits policy alias

### DIFF
--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -97,11 +97,6 @@ export {
   BackgroundManager,
 } from "./subagent";
 
-// Policy compatibility exports
-/**
- * @deprecated Use `BackgroundLimitsMiddleware` from the package root for new code.
- */
-export { BackgroundLimitsPolicy } from "./policy";
 export { PolicyResolver } from "./policy";
 export type {
   LabelMatcher,

--- a/packages/openomni/src/policy/background-limits.ts
+++ b/packages/openomni/src/policy/background-limits.ts
@@ -1,6 +1,0 @@
-/**
- * @deprecated Use `BackgroundLimitsMiddleware` from the package root for new code.
- * This alias preserves the older policy export while keeping one canonical
- * background-launch limit evaluator.
- */
-export { BackgroundLimitsMiddleware as BackgroundLimitsPolicy } from "../subagent/middleware/background-limits.js";

--- a/packages/openomni/src/policy/index.ts
+++ b/packages/openomni/src/policy/index.ts
@@ -1,7 +1,3 @@
-/**
- * @deprecated Use `BackgroundLimitsMiddleware` from the package root for new code.
- */
-export { BackgroundLimitsPolicy } from "./background-limits";
 export { PolicyResolver } from "./resolver";
 export type {
   LabelMatcher,

--- a/packages/openomni/test/policy/middleware-integration.test.ts
+++ b/packages/openomni/test/policy/middleware-integration.test.ts
@@ -9,12 +9,9 @@ import {
   type Subagent,
 } from "@openomni/protocol";
 import { ChannelGrantStore, Session, Storage } from "@openomni/session";
-import {
-  BackgroundLimitsMiddleware as RootBackgroundLimitsMiddleware,
-  BackgroundLimitsPolicy as RootBackgroundLimitsPolicy,
-} from "../../src";
+import { BackgroundLimitsMiddleware as RootBackgroundLimitsMiddleware } from "../../src";
 import { IngressAuthorityMiddleware } from "../../src/ingress/middleware/ingress-authority";
-import { BackgroundLimitsPolicy } from "../../src/policy/background-limits";
+import { BackgroundLimitsMiddleware } from "../../src/subagent/middleware/background-limits";
 import { SubagentSpawnPolicyMiddleware } from "../../src/subagent/middleware/subagent-spawn-policy";
 import { ToolRuntimePolicyMiddleware } from "../../src/execution-runtime/tool/middleware/tool-runtime-policy";
 import { buildWorkerMiddleware } from "../../src/execution-runtime/middleware";
@@ -437,7 +434,7 @@ describe("IngressAuthorityMiddleware integration", () => {
   });
 });
 
-describe("BackgroundLimitsPolicy integration", () => {
+describe("BackgroundLimitsMiddleware integration", () => {
   beforeEach(() => {
     Storage.reset();
     Storage.initialize({ dbPath: ":memory:" });
@@ -448,7 +445,7 @@ describe("BackgroundLimitsPolicy integration", () => {
   });
 
   test("allows launch when all limits are within bounds", async () => {
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest(),
       activeTasks: [],
       activeCount: 0,
@@ -467,7 +464,7 @@ describe("BackgroundLimitsPolicy integration", () => {
   test("denies when per-agent limit is exceeded", async () => {
     const tasks = Array.from({ length: 3 }, () => makeBackgroundTask({ agentName: "worker" }));
 
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ agentName: "worker" }),
       activeTasks: tasks,
       activeCount: 3,
@@ -484,7 +481,7 @@ describe("BackgroundLimitsPolicy integration", () => {
   });
 
   test("denies when depth limit is exceeded", async () => {
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ depth: 6 }),
       activeTasks: [],
       activeCount: 0,
@@ -505,7 +502,7 @@ describe("BackgroundLimitsPolicy integration", () => {
       makeBackgroundTask({ parentSessionId: "parent-session-1" }),
     );
 
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest(),
       activeTasks: tasks,
       activeCount: 5,
@@ -522,7 +519,7 @@ describe("BackgroundLimitsPolicy integration", () => {
   });
 
   test("queues when total concurrency is saturated but queue has capacity", async () => {
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ agentName: "fresh-agent" }),
       activeTasks: [],
       activeCount: 10,
@@ -539,7 +536,7 @@ describe("BackgroundLimitsPolicy integration", () => {
   });
 
   test("denies when total concurrency saturated and queue is full", async () => {
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ agentName: "fresh-agent" }),
       activeTasks: [],
       activeCount: 10,
@@ -568,7 +565,7 @@ describe("BackgroundLimitsPolicy integration", () => {
       maxDescendants: 5,
       maxQueueSize: 20,
     };
-    const regs = BackgroundLimitsPolicy.registrations(state);
+    const regs = BackgroundLimitsMiddleware.registrations(state);
 
     expect(regs).toHaveLength(5);
     const names = regs.map((r) => r.name);
@@ -581,18 +578,17 @@ describe("BackgroundLimitsPolicy integration", () => {
 
   test("package root exports canonical background limits symbols", () => {
     expect(RootBackgroundLimitsMiddleware).toBeDefined();
-    expect(RootBackgroundLimitsPolicy).toBe(BackgroundLimitsPolicy);
-    expect(RootBackgroundLimitsMiddleware).toBe(BackgroundLimitsPolicy);
-    expect(RootBackgroundLimitsMiddleware.PerAgent).toBe(BackgroundLimitsPolicy.PerAgent);
+    expect(RootBackgroundLimitsMiddleware).toBe(BackgroundLimitsMiddleware);
+    expect(RootBackgroundLimitsMiddleware.PerAgent).toBe(BackgroundLimitsMiddleware.PerAgent);
   });
 
   test("all definitions use Policy.Timing invoke.prepare", () => {
     const defs = [
-      BackgroundLimitsPolicy.PerAgent,
-      BackgroundLimitsPolicy.Depth,
-      BackgroundLimitsPolicy.Descendants,
-      BackgroundLimitsPolicy.Total,
-      BackgroundLimitsPolicy.Queue,
+      BackgroundLimitsMiddleware.PerAgent,
+      BackgroundLimitsMiddleware.Depth,
+      BackgroundLimitsMiddleware.Descendants,
+      BackgroundLimitsMiddleware.Total,
+      BackgroundLimitsMiddleware.Queue,
     ];
 
     for (const def of defs) {
@@ -603,7 +599,7 @@ describe("BackgroundLimitsPolicy integration", () => {
 
   test("evaluates background launch through a background worker descriptor", async () => {
     const decisions: Policy.PolicyDecision[] = [];
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ agentName: "worker" }),
       activeTasks: [],
       activeCount: 0,
@@ -942,7 +938,7 @@ describe("cross-middleware deny-wins", () => {
     });
     expect(ingressResult.mode).toBe("direct");
 
-    const bgResult = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const bgResult = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ depth: 10 }),
       activeTasks: [],
       activeCount: 0,
@@ -1050,7 +1046,7 @@ describe("cross-middleware deny-wins", () => {
       }),
     );
 
-    const result = await BackgroundLimitsPolicy.evaluatePreLaunch({
+    const result = await BackgroundLimitsMiddleware.evaluatePreLaunch({
       input: makeLaunchRequest({ agentName: "worker" }),
       activeTasks: tasks,
       activeCount: 3,


### PR DESCRIPTION
## Summary
- remove the deprecated BackgroundLimitsPolicy compatibility alias
- keep the canonical BackgroundLimitsMiddleware export as the only background limit surface
- update policy integration coverage to assert the canonical middleware export directly

## Verification
- bun test packages/openomni/test/policy/middleware-integration.test.ts packages/openomni/test/policy/integration.test.ts packages/openomni/test/policy/resolver.test.ts
- bun run --cwd packages/openomni check-types
- bun run check-types
- bun run lint:guards
- bun run lint
- bun run build
- bun test
- bunx knip --include exports,types,nsExports,nsTypes --no-progress --no-exit-code --workspace @openomni/openomni
- rg -n "BackgroundLimitsPolicy|policy/background-limits" packages apps docs README.md -S

Reviewer: codex-ultrawork-reviewer APPROVE / architectStatus CLEAR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `BackgroundLimitsPolicy` alias and made `BackgroundLimitsMiddleware` the single, canonical background-limits API. Tests now assert the middleware export directly.

- **Refactors**
  - Deleted `policy/background-limits` alias and its re-exports from `src/index.ts` and `src/policy/index.ts`.
  - Kept `BackgroundLimitsMiddleware` as the only background limit surface; updated integration tests accordingly.

- **Migration**
  - Replace all `BackgroundLimitsPolicy` usages with `BackgroundLimitsMiddleware`.
  - Import from the package root: `import { BackgroundLimitsMiddleware } from '@openomni/openomni'`.
  - Update static references as needed (e.g., `BackgroundLimitsMiddleware.PerAgent`, `Depth`, `Descendants`, `Total`, `Queue`).

<sup>Written for commit 83e97dfba8fa4c702cd45af61bcadbcb1c5f09bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

