### PR TITLE
refactor(agent): remove deprecated policy config fields

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -83,8 +83,6 @@ Also exported from `@openomni/agent`:
 | `budget?`        | `AgentBudget`                            | Max turns / tool calls / wall time / tool runtime (use `-1` for unlimited)  |
 | `toolExecutor?`  | `(call) => Promise<Tool.Result>`         | Custom tool executor; wrapped by `createToolExecutor`                       |
 | `signal?`        | `AbortSignal`                            | External cancellation                                                       |
-| `permissions?`   | `Policy.Permission`                      | Deprecated; ignored by ChatAgent core. Runtime builders must pass `createToolPermissionPolicy()` via `middleware` |
-| `compaction?`    | `{ contextWindowTokens, ... }`           | Deprecated; ignored by ChatAgent core. Runtime builders must pass `createCompactionPolicy()` via `middleware` |
 | `memory?`        | `Memory`                                 | Memory interface retrieved by the `memory` policy                           |
 | `middleware?`    | `PolicyRegistration[]`                   | Caller-owned policy registrations                                           |
 | `eventEmitter?`  | `AgentEventEmitter`                      | Optional event emitter for external observers                               |

--- a/packages/agent/src/core/execution/stream-events.ts
+++ b/packages/agent/src/core/execution/stream-events.ts
@@ -110,31 +110,6 @@ export function emitRunCompleted(
   });
 }
 
-export function emitIgnoredPolicyConfigWarning(
-  agentBase: StreamAgentBase,
-  options: {
-    readonly field: "permissions" | "compaction";
-    readonly replacement: string;
-    readonly middlewareName: string;
-    readonly replacementMiddlewarePresent: boolean;
-  },
-): void {
-  Bus.publish(Operational.Warn, {
-    traceId: agentBase.traceId,
-    ...(agentBase.sessionId !== "" && { sessionId: agentBase.sessionId }),
-    ...(agentBase.runId !== undefined && { runId: agentBase.runId }),
-    time: Date.now(),
-    component: "agent.policy",
-    msg: `ChatAgentConfig.${options.field} is deprecated and ignored`,
-    context: {
-      field: options.field,
-      replacement: options.replacement,
-      middlewareName: options.middlewareName,
-      replacementMiddlewarePresent: options.replacementMiddlewarePresent,
-    },
-  });
-}
-
 export function emitErrorRetry(
   state: StreamRunState,
   config: ChatAgentConfig,

--- a/packages/agent/src/core/execution/stream-policy-engine.ts
+++ b/packages/agent/src/core/execution/stream-policy-engine.ts
@@ -1,14 +1,12 @@
 import { PolicyEngine } from "../policy";
 import type { PolicyEngineInstance } from "../policy";
 import type { ChatAgentConfig } from "../types";
-import { emitIgnoredPolicyConfigWarning } from "./stream-events";
 import type { StreamAgentBase } from "./stream-state";
 
 export function buildPolicyEngine(
   config: ChatAgentConfig,
   agentBase: StreamAgentBase,
 ): PolicyEngineInstance {
-  publishIgnoredPolicyConfigWarnings(config, agentBase);
   const engine = PolicyEngine.create({
     traceContext: {
       traceId: agentBase.traceId,
@@ -20,40 +18,4 @@ export function buildPolicyEngine(
     engine.register(reg);
   }
   return engine;
-}
-
-function publishIgnoredPolicyConfigWarnings(
-  config: ChatAgentConfig,
-  agentBase: StreamAgentBase,
-): void {
-  publishIgnoredPolicyConfigWarning(config, agentBase, {
-    field: "permissions",
-    replacement: "createToolPermissionPolicy()",
-    middlewareName: "builtin:tool-permission",
-  });
-  publishIgnoredPolicyConfigWarning(config, agentBase, {
-    field: "compaction",
-    replacement: "createCompactionPolicy()",
-    middlewareName: "builtin:compaction",
-  });
-}
-
-function publishIgnoredPolicyConfigWarning(
-  config: ChatAgentConfig,
-  agentBase: StreamAgentBase,
-  options: {
-    readonly field: "permissions" | "compaction";
-    readonly replacement: string;
-    readonly middlewareName: string;
-  },
-): void {
-  if (config[options.field] === undefined) return;
-  const replacementMiddlewarePresent = config.middleware?.some(
-    (registration) => registration.name === options.middlewareName,
-  );
-
-  emitIgnoredPolicyConfigWarning(agentBase, {
-    ...options,
-    replacementMiddlewarePresent: replacementMiddlewarePresent ?? false,
-  });
 }

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -1,4 +1,4 @@
-import type { AgentProfile, Tool, Sink, Policy, Message, Token, Model } from "@openomni/protocol";
+import type { AgentProfile, Tool, Sink, Policy, Token, Model } from "@openomni/protocol";
 import type { Provider, RunInput } from "@openomni/llm";
 import type { PolicyRegistration } from "./policy/types";
 import type { AgentRuntimeContext } from "./runtime-context";
@@ -19,23 +19,6 @@ export interface ChatAgentConfig {
   onStepFinish?: (step: AgentStep) => void | Promise<void>;
   toolExecutor?: (call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>;
   signal?: AbortSignal;
-  /**
-   * @deprecated Runtime builders should pass createToolPermissionPolicy() via middleware.
-   * ChatAgent no longer auto-registers this field.
-   */
-  permissions?: Policy.Permission;
-  /**
-   * @deprecated Runtime builders should pass createCompactionPolicy() via middleware.
-   * ChatAgent no longer auto-registers this field.
-   */
-  compaction?: {
-    contextWindowTokens: number;
-    thresholdRatio?: number;
-    reserveTokens?: number;
-    reserveRatio?: number;
-    protectRecentMessages?: number;
-    onSummarize?: (messages: Message.WithParts[]) => Promise<string>;
-  };
   eventEmitter?: AgentEventEmitter;
   providerOptions?: Record<string, unknown>;
   auth?: RunInput["auth"];

--- a/packages/agent/test/core/execution/stream-dispatch.test.ts
+++ b/packages/agent/test/core/execution/stream-dispatch.test.ts
@@ -3,7 +3,7 @@ import { Bus } from "@openomni/session";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
 import type { ChatAgentConfig, ChatAgentInput, AgentEvent } from "../../../src/core/types";
-import { Operational, type TraceContext } from "@openomni/protocol";
+import type { TraceContext } from "@openomni/protocol";
 import {
   abortRun,
   allow,
@@ -1035,14 +1035,10 @@ describe("completion.prepare dispatch", () => {
 });
 
 describe("buildPolicyEngine policy ownership", () => {
-  it("registers only caller-supplied middleware", async () => {
+  it("does not register default middleware", async () => {
     Bus.reset();
-    const config = makeConfig({
-      permissions: { action: "tool.call", denylist: ["bash"] },
-      compaction: { contextWindowTokens: 1000 },
-    });
+    const engine = buildPolicyEngine(makeConfig(), makeAgentBase());
 
-    const engine = buildPolicyEngine(config, makeAgentBase());
     await expect(
       engine.dispatch("invoke.prepare", {
         steps: [],
@@ -1054,73 +1050,6 @@ describe("buildPolicyEngine policy ownership", () => {
         toolName: "bash",
       }),
     ).resolves.toMatchObject({ verdict: "allow" });
-  });
-
-  it("does not auto-register compaction from deprecated config", async () => {
-    Bus.reset();
-    const config = makeConfig({
-      compaction: { contextWindowTokens: 1, thresholdRatio: 0 },
-    });
-    const engine = buildPolicyEngine(config, makeAgentBase());
-    const state = makeState();
-    const originalMessages = state.messages;
-
-    await handleCompact(state, engine, config, makeAgentBase());
-
-    expect(state.messages).toBe(originalMessages);
-    expect(state.compactionCount).toBe(0);
-  });
-
-  it("publishes warnings for deprecated policy config fields that are ignored", async () => {
-    Bus.reset();
-    const warnings: Array<{ msg?: string; context?: Record<string, unknown> }> = [];
-    const unsubscribe = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
-
-    buildPolicyEngine(
-      makeConfig({
-        permissions: { action: "tool.call" },
-        compaction: { contextWindowTokens: 1 },
-      }),
-      { traceId: "trace-warning", sessionId: "sess-1" },
-    );
-    await Promise.resolve();
-    unsubscribe();
-
-    expect(warnings.map((warning) => warning.context?.field)).toEqual([
-      "permissions",
-      "compaction",
-    ]);
-    expect(warnings.every((warning) => warning.msg?.includes("deprecated and ignored"))).toBe(true);
-  });
-
-  it("warns for deprecated permissions even when replacement middleware is present", async () => {
-    Bus.reset();
-    const warnings: Array<{ context?: Record<string, unknown> }> = [];
-    const unsubscribe = Bus.subscribe(Operational.Warn, (data) => warnings.push(data));
-
-    buildPolicyEngine(
-      makeConfig({
-        permissions: { action: "tool.call", denylist: ["bash"] },
-        middleware: [
-          {
-            name: "builtin:tool-permission",
-            timing: "invoke.prepare",
-            priority: 0,
-            fn: () => allow(),
-          },
-        ],
-      }),
-      { traceId: "trace-replacement-warning", sessionId: "sess-1" },
-    );
-    await Promise.resolve();
-    unsubscribe();
-
-    expect(warnings.map((warning) => warning.context)).toContainEqual(
-      expect.objectContaining({
-        field: "permissions",
-        replacementMiddlewarePresent: true,
-      }),
-    );
   });
 
   it("honors explicit middleware supplied by the runtime builder", async () => {

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -8,13 +8,23 @@ import {
 } from "@openomni/agent";
 import type { ChatAgentConfig, PolicyRegistration } from "@openomni/agent";
 import { Policy } from "@openomni/protocol";
+import type { Message } from "@openomni/protocol";
 import type { InjectionQueue } from "./injection-queue.js";
 import { createInjectionQueueDrainPolicy } from "./middleware/injection-queue-policy.js";
+
+type WorkerCompactionConfig = {
+  readonly contextWindowTokens: number;
+  readonly thresholdRatio?: number;
+  readonly reserveTokens?: number;
+  readonly reserveRatio?: number;
+  readonly protectRecentMessages?: number;
+  readonly onSummarize?: (messages: Message.WithParts[]) => Promise<string>;
+};
 
 export interface WorkerMiddlewareConfig {
   permissions?: Policy.Permission;
   policyPlan?: Policy.PolicyPlan;
-  compaction?: ChatAgentConfig["compaction"];
+  compaction?: WorkerCompactionConfig;
   eventEmitter?: ChatAgentConfig["eventEmitter"];
   source?: string;
   includeLifecycle?: boolean;
@@ -54,7 +64,7 @@ function shouldAppendIdleNudge(
 }
 
 export function buildAgentLifecycleMiddleware(
-  compaction: ChatAgentConfig["compaction"],
+  compaction: WorkerMiddlewareConfig["compaction"],
 ): PolicyRegistration[] {
   return [
     createBudgetReassurancePolicy(),

--- a/packages/openomni/src/subagent/transcript.ts
+++ b/packages/openomni/src/subagent/transcript.ts
@@ -4,6 +4,7 @@ import {
   type ChatAgentConfig,
   type PolicyRegistration,
 } from "@openomni/agent";
+import type { Policy } from "@openomni/protocol";
 import type { RuntimeModel, RuntimeMessage } from "./shared";
 import {
   buildRuntimeMessages,
@@ -24,7 +25,7 @@ export type RuntimeConfig = {
   /** Child-run middleware assembled from explicit child context only. */
   childMiddleware?: PolicyRegistration[];
   /** Effective child authority exposed to parent-scoped delegation admission only. */
-  admissionPermissions?: ChatAgentConfig["permissions"];
+  admissionPermissions?: Policy.Permission;
 };
 
 export type SendCompactionConfig = {


### PR DESCRIPTION
## Summary
- remove deprecated ignored `ChatAgentConfig.permissions` / `compaction` fields and their warning plumbing
- keep ChatAgent policy ownership focused on caller-supplied middleware
- move OpenOmni runtime permission/compaction typing to canonical `Policy.Permission` and local worker compaction config

## Verification
- bun run --filter @openomni/agent test -- core/execution/stream-dispatch.test.ts
- bun run --filter @openomni/openomni test -- src/execution-runtime/middleware.test.ts test/subagent/compaction.test.ts
- bun run check-types
- bun run build
- bun run lint:guards
- bun run lint
- bun test
- git diff --check
- LSP diagnostics clean on changed source files
- codex-ultrawork-reviewer: APPROVE / CLEAR

## Notes
- This intentionally removes deprecated public type fields. Out-of-repo TypeScript callers still passing them will fail type-checking instead of receiving a runtime ignored-field warning.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed deprecated `ChatAgentConfig.permissions` and `compaction` from `@openomni/agent`, removed ignored-field warnings, and made policy ownership fully caller-controlled via `middleware`. Updated `@openomni/openomni` to use `Policy.Permission` and a local `WorkerCompactionConfig`.

- **Refactors**
  - Removed deprecated fields and warning plumbing from agent policy engine/events.
  - Policy engine no longer auto-registers default middleware; only caller `middleware` runs.
  - Adopted `Policy.Permission` for permissions and introduced `WorkerCompactionConfig` for worker compaction.
  - Updated tests and trimmed docs.

- **Migration**
  - Stop passing `permissions` and `compaction` on `ChatAgentConfig`; register policies via `middleware` (e.g., `createToolPermissionPolicy()`, `createCompactionPolicy()`).
  - For subagents, pass `admissionPermissions` as `Policy.Permission`.
  - For worker compaction in `@openomni/openomni`, use the new `WorkerCompactionConfig`.
  - TypeScript will now error if the removed fields are used; no runtime warnings are emitted.

<sup>Written for commit 15cb2e63ff1d4a6feba78cbcd692704ac3dbfc54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

