### PR TITLE
refactor(protocol): remove agent model ref alias

### DIFF
--- a/packages/protocol/src/agent/index.ts
+++ b/packages/protocol/src/agent/index.ts
@@ -3,9 +3,6 @@ import { Model } from "../model/index.js";
 import { Policy } from "../policy/index.js";
 
 export namespace AgentProfile {
-  export const ModelRef = Model.Ref;
-  export type ModelRef = Model.Ref;
-
   const budgetLimit = z
     .number()
     .int()
@@ -58,7 +55,7 @@ export namespace AgentProfile {
     description: z.string(),
     systemPrompt: z.string().optional(),
     tools: z.string().array().default([]),
-    model: ModelRef.optional(),
+    model: Model.Ref.optional(),
     permissions: Policy.Permission.optional(),
     policyPlan: Policy.PolicyPlan.optional(),
     variant: z.string().optional(),

--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -43,123 +43,123 @@ describe("AgentProfile.Definition", () => {
   });
 
   it("rejects missing required fields", () => {
-    expect(() => AgentProfile.Definition.parse({ name: "x" })).toThrow();
+    expect(AgentProfile.Definition.safeParse({ name: "x" }).success).toBe(false);
   });
 });
 
 describe("rejection (schema-enforced)", () => {
   it("rejects temperature < 0", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         temperature: -0.1,
-      }),
-    ).toThrow());
+      }).success,
+    ).toBe(false));
   it("rejects temperature > 2", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         temperature: 2.1,
-      }),
-    ).toThrow());
+      }).success,
+    ).toBe(false));
 
   it("rejects budget thresholds outside (0, 1)", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { warningThreshold: 1.1 },
-      }),
-    ).toThrow());
+      }).success,
+    ).toBe(false));
 
   it("rejects threshold endpoints", () => {
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { warningThreshold: 0 },
-      }),
-    ).toThrow();
+      }).success,
+    ).toBe(false);
 
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { reassuranceThreshold: 1 },
-      }),
-    ).toThrow();
+      }).success,
+    ).toBe(false);
   });
 
   it("rejects budget thresholds that invert the staged status order", () => {
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { warningThreshold: 0.4, reassuranceThreshold: 0.8 },
-      }),
-    ).toThrow();
+      }).success,
+    ).toBe(false);
 
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { warningThreshold: 0.6, reassuranceThreshold: 0.6 },
-      }),
-    ).toThrow();
+      }).success,
+    ).toBe(false);
 
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { warningThreshold: 0.5 },
-      }),
-    ).toThrow();
+      }).success,
+    ).toBe(false);
 
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { reassuranceThreshold: 0.9 },
-      }),
-    ).toThrow();
+      }).success,
+    ).toBe(false);
   });
 });
 
 describe("acceptance (documents current behavior)", () => {
   it("accepts variant string", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         variant: "high",
-      }),
-    ).not.toThrow());
+      }).success,
+    ).toBe(true));
   it("accepts temperature = 0", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         temperature: 0,
-      }),
-    ).not.toThrow());
+      }).success,
+    ).toBe(true));
   it("accepts temperature = 2", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         temperature: 2,
-      }),
-    ).not.toThrow());
+      }).success,
+    ).toBe(true));
   it("accepts budget with maxTurns", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         budget: { maxTurns: 10 },
-      }),
-    ).not.toThrow());
+      }).success,
+    ).toBe(true));
   it("exposes shared budget threshold defaults", () => {
     expect(AgentProfile.DEFAULT_REASSURANCE_THRESHOLD).toBe(0.6);
     expect(AgentProfile.DEFAULT_WARNING_THRESHOLD).toBe(0.8);
@@ -183,19 +183,25 @@ describe("acceptance (documents current behavior)", () => {
     }
     expect(Model.Status.safeParse("unknown").success).toBe(false);
   });
-  it("keeps AgentProfile.ModelRef as a compatibility alias", () =>
-    expect(AgentProfile.ModelRef.parse({ provider: "openai", id: "gpt-4o" })).toEqual({
+  it("accepts canonical model refs through agent definitions", () =>
+    expect(
+      AgentProfile.Definition.parse({
+        name: "x",
+        description: "x",
+        model: Model.Ref.parse({ provider: "openai", id: "gpt-4o" }),
+      }).model,
+    ).toEqual({
       provider: "openai",
       id: "gpt-4o",
     }));
   it("accepts empty name string", () =>
-    expect(() => AgentProfile.Definition.parse({ name: "", description: "x" })).not.toThrow());
+    expect(AgentProfile.Definition.safeParse({ name: "", description: "x" }).success).toBe(true));
   it("accepts action-only permissions", () =>
-    expect(() =>
-      AgentProfile.Definition.parse({
+    expect(
+      AgentProfile.Definition.safeParse({
         name: "x",
         description: "x",
         permissions: { action: "tool.call" },
-      }),
-    ).not.toThrow());
+      }).success,
+    ).toBe(true));
 });


### PR DESCRIPTION
## Summary
- remove the deprecated AgentProfile.ModelRef compatibility alias
- point AgentProfile.Definition.model at the canonical Model.Ref schema directly
- update protocol coverage to assert canonical model refs through AgentProfile.Definition

## Verification
- bun run --filter @openomni/protocol test -- agent.test.ts
- bun run --filter @openomni/protocol check-types
- bun run --filter @openomni/protocol build
- bun run check-types
- bun run build
- bun run lint:guards
- bun run lint
- bun test
- git diff --check
- LSP diagnostics clean on changed files
- codex-ultrawork-reviewer: APPROVE / CLEAR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `AgentProfile.ModelRef` alias and wired `AgentProfile.Definition.model` to the canonical `Model.Ref`. Tests now validate canonical model refs and use `safeParse` for clearer assertions.

- **Refactors**
  - Removed `AgentProfile.ModelRef` alias.
  - Set `AgentProfile.Definition.model` to `Model.Ref` directly.
  - Updated tests to use `safeParse` and assert canonical model refs via `AgentProfile.Definition`.

- **Migration**
  - Replace any usage of `AgentProfile.ModelRef` with `Model.Ref`.
  - No change to data shape; `Definition.model` still accepts a `Model.Ref`.

<sup>Written for commit 7148387e7679bb79bb900f7e207cf4a8fdd7f7c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `AgentProfile.ModelRef` export. Code referencing this type should migrate to using `Model.Ref` directly.
  * Updated agent profile definition model field type structure.

* **Tests**
  * Enhanced validation tests for agent profile definitions to use improved assertion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->