### PR TITLE
refactor(session): remove test storage facade

### DIFF
--- a/apps/server/test/bootstrap/dispatch-owners.test.ts
+++ b/apps/server/test/bootstrap/dispatch-owners.test.ts
@@ -8,7 +8,7 @@ import {
   type Execution,
 } from "@openomni/protocol";
 import type { DispatchOwners } from "@openomni/openomni";
-import { Bus, PendingAskStore, Session, Storage } from "@openomni/session";
+import { Bus, PendingAskStore, Storage } from "@openomni/session";
 import { createServerDispatchOwners } from "../../src/bootstrap/dispatch-owners";
 
 const tempRoots: string[] = [];
@@ -17,7 +17,7 @@ beforeEach(() => {
   Bus.reset();
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
-  Session.storage.set("ses_fake", {
+  Storage.getAdapter().session.set("ses_fake", {
     id: "ses_fake",
     title: "Fake CLI session",
     model: { providerID: "anthropic", modelID: "claude-test" },
@@ -25,7 +25,7 @@ beforeEach(() => {
     spawnDepth: 1,
     parentSessionId: "ses_resident",
   });
-  Session.storage.set("ses_resident", {
+  Storage.getAdapter().session.set("ses_resident", {
     id: "ses_resident",
     title: "Resident session",
     model: { providerID: "anthropic", modelID: "claude-test" },

--- a/packages/openomni/src/execution-runtime/local-cli-agent-log-event.test.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-agent-log-event.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
-import { Session, Storage } from "@openomni/session";
+import { Storage } from "@openomni/session";
 import { createLocalCliAgentRuntime } from "./local-cli-agent-runtime.js";
 
 const tempRoots: string[] = [];
@@ -10,7 +10,7 @@ const tempRoots: string[] = [];
 beforeEach(() => {
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
-  Session.storage.set("ses_fake", {
+  Storage.getAdapter().session.set("ses_fake", {
     id: "ses_fake",
     title: "Fake CLI session",
     model: { providerID: "anthropic", modelID: "claude-test" },

--- a/packages/openomni/src/execution-runtime/local-cli-agent-log-telemetry.test.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-agent-log-telemetry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
-import { Session, Storage } from "@openomni/session";
+import { Storage } from "@openomni/session";
 import { createLocalCliAgentRuntime } from "./local-cli-agent-runtime.js";
 
 const tempRoots: string[] = [];
@@ -10,7 +10,7 @@ const tempRoots: string[] = [];
 beforeEach(() => {
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
-  Session.storage.set("ses_telemetry", {
+  Storage.getAdapter().session.set("ses_telemetry", {
     id: "ses_telemetry",
     title: "Telemetry CLI session",
     model: { providerID: "anthropic", modelID: "claude-test" },

--- a/packages/openomni/src/execution-runtime/local-cli-agent-runtime.test.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-agent-runtime.test.ts
@@ -2,13 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
-import {
-  AppConnectorInstallationStore,
-  Artifact,
-  Session,
-  Storage,
-  WorkItemStore,
-} from "@openomni/session";
+import { AppConnectorInstallationStore, Artifact, Storage, WorkItemStore } from "@openomni/session";
 import { z } from "zod";
 import { createWorkerDispatchHandlers } from "../dispatch/handlers/worker";
 import { encodeWorkspaceForClaudeProjects } from "./local-cli-agent-log.js";
@@ -37,7 +31,7 @@ const LocalCliDispatchOutput = z
 beforeEach(() => {
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
-  Session.storage.set("ses_fake", {
+  Storage.getAdapter().session.set("ses_fake", {
     id: "ses_fake",
     title: "Fake CLI session",
     model: { providerID: "anthropic", modelID: "claude-test" },

--- a/packages/openomni/src/execution-runtime/local-cli-question-bridge-edge.test.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-question-bridge-edge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
-import { Session, Storage } from "@openomni/session";
+import { Storage } from "@openomni/session";
 import { createLocalCliAgentRuntime } from "./local-cli-agent-runtime.js";
 import { startLocalCliQuestionBridgeServer } from "./local-cli-question-bridge.js";
 
@@ -11,7 +11,7 @@ const tempRoots: string[] = [];
 beforeEach(() => {
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
-  Session.storage.set("ses_fake", {
+  Storage.getAdapter().session.set("ses_fake", {
     id: "ses_fake",
     title: "Fake CLI session",
     model: { providerID: "anthropic", modelID: "claude-test" },

--- a/packages/openomni/src/execution-runtime/local-cli-question-bridge.test.ts
+++ b/packages/openomni/src/execution-runtime/local-cli-question-bridge.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
-import { Session, Storage } from "@openomni/session";
+import { Storage } from "@openomni/session";
 import { createLocalCliAgentRuntime } from "./local-cli-agent-runtime.js";
 
 const tempRoots: string[] = [];
@@ -10,7 +10,7 @@ const tempRoots: string[] = [];
 beforeEach(() => {
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
-  Session.storage.set("ses_fake", {
+  Storage.getAdapter().session.set("ses_fake", {
     id: "ses_fake",
     title: "Fake CLI session",
     model: { providerID: "anthropic", modelID: "claude-test" },

--- a/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
+++ b/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { PolicyEngine } from "@openomni/agent";
-import { Session } from "@openomni/session";
+import { Session, Storage } from "@openomni/session";
 import { InjectionQueue } from "../../src/execution-runtime/injection-queue.js";
 import { createInjectionQueueDrainPolicy } from "../../src/execution-runtime/middleware/injection-queue-policy.js";
 import { buildWorkerMiddleware } from "../../src/execution-runtime/middleware.js";
@@ -29,7 +29,7 @@ async function dispatchTurnFinish(
 
 describe("createInjectionQueueDrainPolicy", () => {
   afterEach(() => {
-    Session.storage.clear();
+    Storage.reset();
   });
 
   it("is a turn.finish policy with priority before idle nudge", () => {

--- a/packages/session/src/session/index.ts
+++ b/packages/session/src/session/index.ts
@@ -22,59 +22,6 @@ export namespace Session {
     Deleted: BusEvent.define("session.deleted", z.object({ id: z.string() })),
   };
 
-  // Backward compatibility: tests access Session["storage"].clear()
-  export const storage = {
-    clear() {
-      Storage.reset();
-    },
-    get(id: string) {
-      return Storage.getAdapter().session.get(id);
-    },
-    set(id: string, info: Info) {
-      Storage.getAdapter().session.set(id, info);
-    },
-    has(id: string) {
-      return Storage.getAdapter().session.get(id) !== undefined;
-    },
-    delete(id: string) {
-      return Storage.getAdapter().session.remove(id);
-    },
-    values() {
-      return Storage.getAdapter().session.list()[Symbol.iterator]();
-    },
-  };
-
-  // Backward compatibility: tests access Session["messages"].clear()
-  export const messages = {
-    clear() {
-      Storage.reset();
-    },
-    get(sessionID: string) {
-      return Storage.getAdapter().message.list(sessionID);
-    },
-    set(sessionID: string, msgs: Message.Info[]) {
-      const adapter = Storage.getAdapter();
-      const existing = adapter.message.list(sessionID);
-      for (const msg of existing) {
-        adapter.message.remove(sessionID, msg.id);
-      }
-      for (const msg of msgs) {
-        adapter.message.set(sessionID, msg);
-      }
-    },
-    has(sessionID: string) {
-      return Storage.getAdapter().message.list(sessionID).length > 0;
-    },
-    delete(sessionID: string) {
-      const adapter = Storage.getAdapter();
-      const msgs = adapter.message.list(sessionID);
-      for (const msg of msgs) {
-        adapter.message.remove(sessionID, msg.id);
-      }
-      return msgs.length > 0;
-    },
-  };
-
   export function create(input: {
     title: string;
     model: { providerID: string; modelID: string };

--- a/packages/session/test/ttl.test.ts
+++ b/packages/session/test/ttl.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun" />
+
 import { describe, expect, test, beforeEach } from "bun:test";
 import { Session } from "../src/session";
 import { Storage } from "../src/storage/storage";
@@ -58,7 +60,7 @@ describe("Session TTL", () => {
       const retrieved = Session.get(session.id);
       expect(retrieved).toBeUndefined();
 
-      const checkAgain = Session.storage.get(session.id);
+      const checkAgain = Storage.getAdapter().session.get(session.id);
       expect(checkAgain).toBeUndefined();
     });
 
@@ -110,7 +112,7 @@ describe("Session TTL", () => {
       expect(sessions.length).toBe(1);
       expect(sessions[0].id).toBe(activeSession.id);
 
-      const checkExpired = Session.storage.get(expiredSession.id);
+      const checkExpired = Storage.getAdapter().session.get(expiredSession.id);
       expect(checkExpired).toBeUndefined();
     });
 
@@ -155,12 +157,12 @@ describe("Session TTL", () => {
         ttlMs: -1000,
       });
 
-      const directCheck = Session.storage.get(session.id);
+      const directCheck = Storage.getAdapter().session.get(session.id);
       expect(directCheck).toBeDefined();
 
       Session.get(session.id);
 
-      const afterGet = Session.storage.get(session.id);
+      const afterGet = Storage.getAdapter().session.get(session.id);
       expect(afterGet).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary
- remove the Session.storage and Session.messages compatibility facades
- migrate test fixtures to canonical Storage APIs
- keep session TTL and local CLI/injection queue coverage intact

## Verification
- focused session TTL test: 9 pass / 0 fail
- focused server dispatch owners test: 4 pass / 0 fail
- focused openomni local CLI/injection queue tests: 40 pass / 0 fail
- bun run check-types
- bun run build
- bun run lint:guards
- bun run lint
- bun test
- git diff --check
- changed file LSP diagnostics clean
- codex-ultrawork-reviewer: APPROVE / CLEAR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the test-only `Session.storage` and `Session.messages` facades and migrated tests to the canonical `Storage` adapter APIs. This simplifies `@openomni/session` and keeps TTL and local CLI/injection queue behavior unchanged.

- **Refactors**
  - Deleted the `Session.storage` and `Session.messages` compatibility exports.
  - Updated tests to use `Storage.reset()` and `Storage.getAdapter().session`/`message`.
  - TTL eviction and local CLI/injection queue tests remain green.

- **Migration**
  - Replace `Session.storage.clear()` with `Storage.reset()`.
  - Replace `Session.storage.get/set/delete/has/values` with `Storage.getAdapter().session.<get|set|remove|list>`.
  - Replace `Session.messages.*` with `Storage.getAdapter().message.*`.

<sup>Written for commit 8de49197feb2e4f58c102a26c492b879abf4fa70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

