### PR TITLE
refactor(session): trim drizzle schema surface

### DIFF
--- a/packages/session/src/storage/drizzle/actor-authority-tables.ts
+++ b/packages/session/src/storage/drizzle/actor-authority-tables.ts
@@ -1,0 +1,70 @@
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+export const actorIdentityTable = sqliteTable(
+  "actor_identity",
+  {
+    id: text("id").primaryKey(),
+    data: text("data").notNull(),
+    kind: text("kind").notNull(),
+    trust_tier: text("trust_tier").notNull(),
+    relationship: text("relationship").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [index("idx_actor_identity_trust_tier").on(t.trust_tier)],
+);
+
+export const actorEndpointTable = sqliteTable(
+  "actor_endpoint",
+  {
+    id: text("id").primaryKey(),
+    actor_id: text("actor_id")
+      .notNull()
+      .references(() => actorIdentityTable.id, { onDelete: "cascade" }),
+    data: text("data").notNull(),
+    channel: text("channel").notNull(),
+    workspace: text("workspace").notNull(),
+    external_id: text("external_id").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_actor_endpoint_actor").on(t.actor_id),
+    uniqueIndex("idx_actor_endpoint_lookup").on(t.channel, t.workspace, t.external_id),
+  ],
+);
+
+export const blacklistTable = sqliteTable(
+  "blacklist",
+  {
+    id: text("id").primaryKey(),
+    data: text("data").notNull(),
+    kind: text("kind").notNull(),
+    value: text("value").notNull(),
+    expires_at: integer("expires_at"),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_blacklist_kind_value").on(t.kind, t.value),
+    index("idx_blacklist_expires").on(t.expires_at),
+  ],
+);
+
+export const channelGrantTable = sqliteTable(
+  "channel_grant",
+  {
+    id: text("id").primaryKey(),
+    data: text("data").notNull(),
+    surface: text("surface").notNull(),
+    workspace: text("workspace").notNull().default(""),
+    channel: text("channel").notNull().default(""),
+    kind: text("kind").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_channel_grant_lookup").on(t.surface, t.workspace, t.channel),
+    index("idx_channel_grant_kind").on(t.kind),
+  ],
+);

--- a/packages/session/src/storage/drizzle/app-connector-tables.ts
+++ b/packages/session/src/storage/drizzle/app-connector-tables.ts
@@ -1,0 +1,17 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const appConnectorInstallationTable = sqliteTable(
+  "app_connector_installation",
+  {
+    id: text("id").primaryKey(),
+    connector_id: text("connector_id").notNull(),
+    status: text("status").notNull(),
+    data: text("data").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_app_connector_installation_connector").on(t.connector_id),
+    index("idx_app_connector_installation_status").on(t.status),
+  ],
+);

--- a/packages/session/src/storage/drizzle/core-tables.ts
+++ b/packages/session/src/storage/drizzle/core-tables.ts
@@ -1,0 +1,49 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const sessionTable = sqliteTable("session", {
+  id: text("id").primaryKey(),
+  data: text("data").notNull(),
+  time_created: integer("time_created").notNull(),
+  time_updated: integer("time_updated").notNull(),
+});
+
+export const messageTable = sqliteTable(
+  "message",
+  {
+    id: text("id").primaryKey(),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => sessionTable.id, { onDelete: "cascade" }),
+    data: text("data").notNull(),
+    role: text("role"),
+    status: text("status").notNull().default("completed"),
+    time_created: integer("time_created").notNull(),
+  },
+  (t) => [index("idx_message_session_time").on(t.session_id, t.time_created, t.id)],
+);
+
+export const partTable = sqliteTable(
+  "part",
+  {
+    id: text("id").primaryKey(),
+    message_id: text("message_id")
+      .notNull()
+      .references(() => messageTable.id, { onDelete: "cascade" }),
+    data: text("data").notNull(),
+    type: text("type"),
+    time_start: integer("time_start"),
+  },
+  (t) => [index("idx_part_message_id").on(t.message_id, t.id)],
+);
+
+export const surfaceKeyTable = sqliteTable(
+  "surface_key",
+  {
+    key: text("key").primaryKey(),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => sessionTable.id, { onDelete: "cascade" }),
+    time_created: integer("time_created").notNull(),
+  },
+  (t) => [index("idx_surface_key_session").on(t.session_id)],
+);

--- a/packages/session/src/storage/drizzle/db.ts
+++ b/packages/session/src/storage/drizzle/db.ts
@@ -1,9 +1,9 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import * as schema from "./schema";
 import { initializeSqliteDatabase } from "../sqlite-schema-lifecycle";
+import { drizzleSchema } from "./schema";
 
-export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
+export type DrizzleDb = ReturnType<typeof drizzle<typeof drizzleSchema>>;
 
 export function createDb(dbPath: string): { db: DrizzleDb; sqlite: Database } {
   const sqlite = new Database(dbPath);
@@ -11,7 +11,7 @@ export function createDb(dbPath: string): { db: DrizzleDb; sqlite: Database } {
   try {
     initializeSqliteDatabase(sqlite);
 
-    const db = drizzle(sqlite, { schema });
+    const db = drizzle(sqlite, { schema: drizzleSchema });
     return { db, sqlite };
   } catch (err) {
     sqlite.close();

--- a/packages/session/src/storage/drizzle/event-artifact-tables.ts
+++ b/packages/session/src/storage/drizzle/event-artifact-tables.ts
@@ -1,0 +1,39 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sessionTable } from "./core-tables";
+
+export const artifactTable = sqliteTable(
+  "artifact",
+  {
+    id: text("id").primaryKey(),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => sessionTable.id, { onDelete: "cascade" }),
+    meta: text("meta").notNull(),
+    content: text("content").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [index("idx_artifact_session").on(t.session_id)],
+);
+
+export const busEventTable = sqliteTable(
+  "bus_event",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    session_id: text("session_id").references(() => sessionTable.id, { onDelete: "cascade" }),
+    run_id: text("run_id"),
+    event_type: text("event_type").notNull(),
+    category: text("category").notNull(),
+    data: text("data").notNull(),
+    trace_id: text("trace_id").notNull(),
+    duration_ms: integer("duration_ms"),
+    time_created: integer("time_created").notNull(),
+  },
+  (t) => [
+    index("idx_bus_event_session_time").on(t.session_id, t.time_created),
+    index("idx_bus_event_run_time").on(t.run_id, t.time_created),
+    index("idx_bus_event_type_session").on(t.event_type, t.session_id),
+    index("idx_bus_event_category_session").on(t.category, t.session_id),
+    index("idx_bus_event_trace").on(t.trace_id),
+  ],
+);

--- a/packages/session/src/storage/drizzle/schema.ts
+++ b/packages/session/src/storage/drizzle/schema.ts
@@ -1,313 +1,36 @@
-import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
+import {
+  actorEndpointTable,
+  actorIdentityTable,
+  blacklistTable,
+  channelGrantTable,
+} from "./actor-authority-tables";
+import { appConnectorInstallationTable } from "./app-connector-tables";
+import { messageTable, partTable, sessionTable, surfaceKeyTable } from "./core-tables";
+import { artifactTable, busEventTable } from "./event-artifact-tables";
+import { cronJobTable, workItemTable } from "./work-scheduling-tables";
+import {
+  pendingAskTable,
+  pendingInteractionTable,
+  workerGrantTable,
+  workerRunStateTable,
+} from "./worker-communication-tables";
 
-export const sessionTable = sqliteTable("session", {
-  id: text("id").primaryKey(),
-  data: text("data").notNull(),
-  time_created: integer("time_created").notNull(),
-  time_updated: integer("time_updated").notNull(),
-});
-
-export const messageTable = sqliteTable(
-  "message",
-  {
-    id: text("id").primaryKey(),
-    session_id: text("session_id")
-      .notNull()
-      .references(() => sessionTable.id, { onDelete: "cascade" }),
-    data: text("data").notNull(),
-    role: text("role"),
-    status: text("status").notNull().default("completed"),
-    time_created: integer("time_created").notNull(),
-  },
-  (t) => [index("idx_message_session_time").on(t.session_id, t.time_created, t.id)],
-);
-
-export const partTable = sqliteTable(
-  "part",
-  {
-    id: text("id").primaryKey(),
-    message_id: text("message_id")
-      .notNull()
-      .references(() => messageTable.id, { onDelete: "cascade" }),
-    data: text("data").notNull(),
-    type: text("type"),
-    time_start: integer("time_start"),
-  },
-  (t) => [index("idx_part_message_id").on(t.message_id, t.id)],
-);
-
-export const surfaceKeyTable = sqliteTable(
-  "surface_key",
-  {
-    key: text("key").primaryKey(),
-    session_id: text("session_id")
-      .notNull()
-      .references(() => sessionTable.id, { onDelete: "cascade" }),
-    time_created: integer("time_created").notNull(),
-  },
-  (t) => [index("idx_surface_key_session").on(t.session_id)],
-);
-
-export const artifactTable = sqliteTable(
-  "artifact",
-  {
-    id: text("id").primaryKey(),
-    session_id: text("session_id")
-      .notNull()
-      .references(() => sessionTable.id, { onDelete: "cascade" }),
-    meta: text("meta").notNull(),
-    content: text("content").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [index("idx_artifact_session").on(t.session_id)],
-);
-
-export const busEventTable = sqliteTable(
-  "bus_event",
-  {
-    id: integer("id").primaryKey({ autoIncrement: true }),
-    session_id: text("session_id").references(() => sessionTable.id, { onDelete: "cascade" }),
-    run_id: text("run_id"),
-    event_type: text("event_type").notNull(),
-    category: text("category").notNull(),
-    data: text("data").notNull(),
-    trace_id: text("trace_id").notNull(),
-    duration_ms: integer("duration_ms"),
-    time_created: integer("time_created").notNull(),
-  },
-  (t) => [
-    index("idx_bus_event_session_time").on(t.session_id, t.time_created),
-    index("idx_bus_event_run_time").on(t.run_id, t.time_created),
-    index("idx_bus_event_type_session").on(t.event_type, t.session_id),
-    index("idx_bus_event_category_session").on(t.category, t.session_id),
-    index("idx_bus_event_trace").on(t.trace_id),
-  ],
-);
-
-export const workerRunStateTable = sqliteTable(
-  "worker_run_state",
-  {
-    run_id: text("run_id").primaryKey(),
-    session_id: text("session_id")
-      .notNull()
-      .references(() => sessionTable.id, { onDelete: "cascade" }),
-    parent_session_id: text("parent_session_id"),
-    agent_name: text("agent_name").notNull(),
-    status: text("status").notNull(),
-    executor_kind: text("executor_kind"),
-    title: text("title").notNull(),
-    prompt: text("prompt").notNull(),
-    resume_count: integer("resume_count").notNull().default(0),
-    assigned_step_id: text("assigned_step_id"),
-    error: text("error"),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [index("idx_worker_run_state_session_time").on(t.session_id, t.time_created)],
-);
-
-export const pendingAskTable = sqliteTable(
-  "pending_ask",
-  {
-    id: text("id").primaryKey(),
-    data: text("data").notNull(),
-    status: text("status").notNull(),
-    origin_session_id: text("origin_session_id")
-      .notNull()
-      .references(() => sessionTable.id, { onDelete: "cascade" }),
-    endpoint_id: text("endpoint_id"),
-    channel_id: text("channel_id"),
-    external_message_id: text("external_message_id"),
-    reply_to_message_id: text("reply_to_message_id"),
-    thread_id: text("thread_id"),
-    token_hash: text("token_hash"),
-    external_conversation_id: text("external_conversation_id"),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_pending_ask_status").on(t.status),
-    index("idx_pending_ask_origin").on(t.origin_session_id, t.time_created),
-    index("idx_pending_ask_correlation").on(
-      t.endpoint_id,
-      t.channel_id,
-      t.external_message_id,
-      t.reply_to_message_id,
-      t.thread_id,
-    ),
-    index("idx_pending_ask_token_hash").on(t.token_hash),
-    index("idx_pending_ask_external_conversation").on(t.external_conversation_id),
-  ],
-);
-
-export const pendingInteractionTable = sqliteTable(
-  "pending_interaction",
-  {
-    id: text("id").primaryKey(),
-    worker_run_id: text("worker_run_id")
-      .notNull()
-      .references(() => workerRunStateTable.run_id, { onDelete: "cascade" }),
-    session_id: text("session_id")
-      .notNull()
-      .references(() => sessionTable.id, { onDelete: "cascade" }),
-    data: text("data").notNull(),
-    status: text("status").notNull(),
-    endpoint_id: text("endpoint_id").notNull(),
-    channel_id: text("channel_id").notNull(),
-    reply_to_message_id: text("reply_to_message_id"),
-    thread_id: text("thread_id"),
-    token_hash: text("token_hash"),
-    external_conversation_id: text("external_conversation_id"),
-    expires_at: integer("expires_at").notNull(),
-    follow_up_until: integer("follow_up_until"),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_pending_interaction_status").on(t.status),
-    index("idx_pending_interaction_worker").on(t.worker_run_id, t.time_created),
-    index("idx_pending_interaction_session").on(t.session_id, t.time_created),
-    index("idx_pending_interaction_correlation").on(
-      t.endpoint_id,
-      t.channel_id,
-      t.reply_to_message_id,
-      t.thread_id,
-    ),
-    index("idx_pending_interaction_token_hash").on(t.token_hash),
-    index("idx_pending_interaction_external_conversation").on(t.external_conversation_id),
-  ],
-);
-
-export const workerGrantTable = sqliteTable(
-  "worker_grant",
-  {
-    id: text("id").primaryKey(),
-    worker_run_id: text("worker_run_id")
-      .notNull()
-      .references(() => workerRunStateTable.run_id, { onDelete: "cascade" }),
-    data: text("data").notNull(),
-    status: text("status").notNull(),
-    version: integer("version").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-    expires_at: integer("expires_at"),
-  },
-  (t) => [
-    index("idx_worker_grant_worker").on(t.worker_run_id),
-    index("idx_worker_grant_status").on(t.status),
-  ],
-);
-
-export const workItemTable = sqliteTable(
-  "work_item",
-  {
-    hash: text("hash").primaryKey(),
-    data: text("data").notNull(),
-    status: text("status").notNull(),
-    assignee_id: text("assignee_id"),
-    session_id: text("session_id"),
-    parent_hash: text("parent_hash"),
-    source_channel: text("source_channel").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_work_item_status").on(t.status),
-    index("idx_work_item_assignee").on(t.assignee_id),
-    index("idx_work_item_session").on(t.session_id),
-    index("idx_work_item_parent").on(t.parent_hash),
-  ],
-);
-
-export const cronJobTable = sqliteTable("cron_job", {
-  id: text("id").primaryKey(),
-  data: text("data").notNull(),
-  time_created: integer("time_created").notNull(),
-  time_updated: integer("time_updated").notNull(),
-});
-
-export const actorIdentityTable = sqliteTable(
-  "actor_identity",
-  {
-    id: text("id").primaryKey(),
-    data: text("data").notNull(),
-    kind: text("kind").notNull(),
-    trust_tier: text("trust_tier").notNull(),
-    relationship: text("relationship").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [index("idx_actor_identity_trust_tier").on(t.trust_tier)],
-);
-
-export const actorEndpointTable = sqliteTable(
-  "actor_endpoint",
-  {
-    id: text("id").primaryKey(),
-    actor_id: text("actor_id")
-      .notNull()
-      .references(() => actorIdentityTable.id, { onDelete: "cascade" }),
-    data: text("data").notNull(),
-    channel: text("channel").notNull(),
-    workspace: text("workspace").notNull(),
-    external_id: text("external_id").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_actor_endpoint_actor").on(t.actor_id),
-    uniqueIndex("idx_actor_endpoint_lookup").on(t.channel, t.workspace, t.external_id),
-  ],
-);
-
-export const blacklistTable = sqliteTable(
-  "blacklist",
-  {
-    id: text("id").primaryKey(),
-    data: text("data").notNull(),
-    kind: text("kind").notNull(),
-    value: text("value").notNull(),
-    expires_at: integer("expires_at"),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_blacklist_kind_value").on(t.kind, t.value),
-    index("idx_blacklist_expires").on(t.expires_at),
-  ],
-);
-
-export const channelGrantTable = sqliteTable(
-  "channel_grant",
-  {
-    id: text("id").primaryKey(),
-    data: text("data").notNull(),
-    surface: text("surface").notNull(),
-    workspace: text("workspace").notNull().default(""),
-    channel: text("channel").notNull().default(""),
-    kind: text("kind").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_channel_grant_lookup").on(t.surface, t.workspace, t.channel),
-    index("idx_channel_grant_kind").on(t.kind),
-  ],
-);
-
-export const appConnectorInstallationTable = sqliteTable(
-  "app_connector_installation",
-  {
-    id: text("id").primaryKey(),
-    connector_id: text("connector_id").notNull(),
-    status: text("status").notNull(),
-    data: text("data").notNull(),
-    time_created: integer("time_created").notNull(),
-    time_updated: integer("time_updated").notNull(),
-  },
-  (t) => [
-    index("idx_app_connector_installation_connector").on(t.connector_id),
-    index("idx_app_connector_installation_status").on(t.status),
-  ],
-);
+export const drizzleSchema = {
+  actorEndpointTable,
+  actorIdentityTable,
+  appConnectorInstallationTable,
+  artifactTable,
+  blacklistTable,
+  busEventTable,
+  channelGrantTable,
+  cronJobTable,
+  messageTable,
+  partTable,
+  pendingAskTable,
+  pendingInteractionTable,
+  sessionTable,
+  surfaceKeyTable,
+  workerGrantTable,
+  workerRunStateTable,
+  workItemTable,
+} as const;

--- a/packages/session/src/storage/drizzle/work-scheduling-tables.ts
+++ b/packages/session/src/storage/drizzle/work-scheduling-tables.ts
@@ -1,0 +1,29 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const workItemTable = sqliteTable(
+  "work_item",
+  {
+    hash: text("hash").primaryKey(),
+    data: text("data").notNull(),
+    status: text("status").notNull(),
+    assignee_id: text("assignee_id"),
+    session_id: text("session_id"),
+    parent_hash: text("parent_hash"),
+    source_channel: text("source_channel").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_work_item_status").on(t.status),
+    index("idx_work_item_assignee").on(t.assignee_id),
+    index("idx_work_item_session").on(t.session_id),
+    index("idx_work_item_parent").on(t.parent_hash),
+  ],
+);
+
+export const cronJobTable = sqliteTable("cron_job", {
+  id: text("id").primaryKey(),
+  data: text("data").notNull(),
+  time_created: integer("time_created").notNull(),
+  time_updated: integer("time_updated").notNull(),
+});

--- a/packages/session/src/storage/drizzle/worker-communication-tables.ts
+++ b/packages/session/src/storage/drizzle/worker-communication-tables.ts
@@ -1,0 +1,116 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sessionTable } from "./core-tables";
+
+export const workerRunStateTable = sqliteTable(
+  "worker_run_state",
+  {
+    run_id: text("run_id").primaryKey(),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => sessionTable.id, { onDelete: "cascade" }),
+    parent_session_id: text("parent_session_id"),
+    agent_name: text("agent_name").notNull(),
+    status: text("status").notNull(),
+    executor_kind: text("executor_kind"),
+    title: text("title").notNull(),
+    prompt: text("prompt").notNull(),
+    resume_count: integer("resume_count").notNull().default(0),
+    assigned_step_id: text("assigned_step_id"),
+    error: text("error"),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [index("idx_worker_run_state_session_time").on(t.session_id, t.time_created)],
+);
+
+export const pendingAskTable = sqliteTable(
+  "pending_ask",
+  {
+    id: text("id").primaryKey(),
+    data: text("data").notNull(),
+    status: text("status").notNull(),
+    origin_session_id: text("origin_session_id")
+      .notNull()
+      .references(() => sessionTable.id, { onDelete: "cascade" }),
+    endpoint_id: text("endpoint_id"),
+    channel_id: text("channel_id"),
+    external_message_id: text("external_message_id"),
+    reply_to_message_id: text("reply_to_message_id"),
+    thread_id: text("thread_id"),
+    token_hash: text("token_hash"),
+    external_conversation_id: text("external_conversation_id"),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_pending_ask_status").on(t.status),
+    index("idx_pending_ask_origin").on(t.origin_session_id, t.time_created),
+    index("idx_pending_ask_correlation").on(
+      t.endpoint_id,
+      t.channel_id,
+      t.external_message_id,
+      t.reply_to_message_id,
+      t.thread_id,
+    ),
+    index("idx_pending_ask_token_hash").on(t.token_hash),
+    index("idx_pending_ask_external_conversation").on(t.external_conversation_id),
+  ],
+);
+
+export const pendingInteractionTable = sqliteTable(
+  "pending_interaction",
+  {
+    id: text("id").primaryKey(),
+    worker_run_id: text("worker_run_id")
+      .notNull()
+      .references(() => workerRunStateTable.run_id, { onDelete: "cascade" }),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => sessionTable.id, { onDelete: "cascade" }),
+    data: text("data").notNull(),
+    status: text("status").notNull(),
+    endpoint_id: text("endpoint_id").notNull(),
+    channel_id: text("channel_id").notNull(),
+    reply_to_message_id: text("reply_to_message_id"),
+    thread_id: text("thread_id"),
+    token_hash: text("token_hash"),
+    external_conversation_id: text("external_conversation_id"),
+    expires_at: integer("expires_at").notNull(),
+    follow_up_until: integer("follow_up_until"),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+  },
+  (t) => [
+    index("idx_pending_interaction_status").on(t.status),
+    index("idx_pending_interaction_worker").on(t.worker_run_id, t.time_created),
+    index("idx_pending_interaction_session").on(t.session_id, t.time_created),
+    index("idx_pending_interaction_correlation").on(
+      t.endpoint_id,
+      t.channel_id,
+      t.reply_to_message_id,
+      t.thread_id,
+    ),
+    index("idx_pending_interaction_token_hash").on(t.token_hash),
+    index("idx_pending_interaction_external_conversation").on(t.external_conversation_id),
+  ],
+);
+
+export const workerGrantTable = sqliteTable(
+  "worker_grant",
+  {
+    id: text("id").primaryKey(),
+    worker_run_id: text("worker_run_id")
+      .notNull()
+      .references(() => workerRunStateTable.run_id, { onDelete: "cascade" }),
+    data: text("data").notNull(),
+    status: text("status").notNull(),
+    version: integer("version").notNull(),
+    time_created: integer("time_created").notNull(),
+    time_updated: integer("time_updated").notNull(),
+    expires_at: integer("expires_at"),
+  },
+  (t) => [
+    index("idx_worker_grant_worker").on(t.worker_run_id),
+    index("idx_worker_grant_status").on(t.status),
+  ],
+);

--- a/packages/session/test/storage/drizzle-db.test.ts
+++ b/packages/session/test/storage/drizzle-db.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { createDb } from "../../src/storage/drizzle/db";
-import { appConnectorInstallationTable } from "../../src/storage/drizzle/schema";
+import { drizzleSchema } from "../../src/storage/drizzle/schema";
 
 function tempDbPath(): string {
   return join(tmpdir(), `test-drizzle-db-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
@@ -95,8 +95,10 @@ describe("drizzle createDb migrations", () => {
       expect(sqlite.query("SELECT id FROM pending_ask").get()).toEqual({ id: "ask-1" });
       expect(sqlite.query("SELECT id FROM worker_grant").get()).toEqual({ id: "grant-1" });
       const indexes = sqlite
-        .query("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'pending_ask'")
-        .all() as Array<{ name: string }>;
+        .query<{ name: string }, []>(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'pending_ask'",
+        )
+        .all();
       expect(indexes.map((row) => row.name)).toEqual(
         expect.arrayContaining([
           "idx_pending_ask_token_hash",
@@ -116,7 +118,7 @@ describe("drizzle createDb migrations", () => {
 
     const { db, sqlite } = createDb(dbPath);
     try {
-      await db.insert(appConnectorInstallationTable).values({
+      await db.insert(drizzleSchema.appConnectorInstallationTable).values({
         id: "install:app.codex",
         connector_id: "app.codex",
         status: "registered",
@@ -125,7 +127,7 @@ describe("drizzle createDb migrations", () => {
         time_updated: 1,
       });
 
-      const rows = await db.select().from(appConnectorInstallationTable);
+      const rows = await db.select().from(drizzleSchema.appConnectorInstallationTable);
       expect(rows).toEqual([
         {
           id: "install:app.codex",
@@ -137,10 +139,10 @@ describe("drizzle createDb migrations", () => {
         },
       ]);
       const indexes = sqlite
-        .query(
+        .query<{ name: string }, []>(
           "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'app_connector_installation'",
         )
-        .all() as Array<{ name: string }>;
+        .all();
       expect(indexes.map((row) => row.name)).toEqual(
         expect.arrayContaining([
           "idx_app_connector_installation_connector",


### PR DESCRIPTION
## Summary

- split the internal Drizzle table definitions by responsibility under `packages/session/src/storage/drizzle/`
- replace `import * as schema` with the canonical `drizzleSchema` object passed to Drizzle
- update the typed Drizzle migration test to use `drizzleSchema.appConnectorInstallationTable`

## Why

Knip's remaining export scan was only the `schema.ts` namespace import surface. The table definitions are internal Drizzle wiring, not a package-level public contract, so this narrows the exposed schema surface while keeping the typed database path intact.

## Verification

- `bun test packages/session/test/storage/drizzle-db.test.ts` — 4 pass, 0 fail
- `bun run --filter @openomni/session check-types` — passed
- `bunx knip --include exports,types,nsExports,nsTypes --no-progress --no-exit-code` — no output
- `bun run check-types` — 10 successful / 10 total
- `bun run build` — 4 successful / 4 total
- `bun run lint:guards` — passed
- `bun run lint` — passed
- changed-file LSP diagnostics — clean
- `bun test` — 2910 pass / 10 skip / 0 fail
- codex-ultrawork-reviewer — APPROVE / CLEAR

Claude Fable oracle could not run because the local `claude-fable-5` model returned 404 / unavailable; no fallback model was used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Drizzle schema to expose a single `drizzleSchema` object and split table definitions by domain, reducing the exported surface with no behavior changes. Updated DB wiring and tests to use `drizzleSchema`.

- **Refactors**
  - Split tables into domain files under `packages/session/src/storage/drizzle/`.
  - Replaced `import * as schema` with `drizzleSchema` in `drizzle(...)`.
  - Updated `createDb` and tests to reference `drizzleSchema.appConnectorInstallationTable`.
  - Narrowed namespace exports to satisfy Knip’s export scan.

<sup>Written for commit fbdd2341abc580d237d2dcfa8d4b861aad68bdb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

