### PR TITLE
refactor(openomni): trim effective authority helper surface

### DIFF
--- a/packages/openomni/src/dispatch/effective-authority.ts
+++ b/packages/openomni/src/dispatch/effective-authority.ts
@@ -1,5 +1,3 @@
-import type { Dispatch } from "@openomni/protocol";
-
 export namespace EffectiveAuthority {
   export type Axis =
     | "blacklist"
@@ -24,7 +22,7 @@ export namespace EffectiveAuthority {
     readonly factsUsed: readonly string[];
   }
 
-  export function axis(
+  function axis(
     axisName: Axis,
     verdict: Verdict,
     reason: string,
@@ -33,7 +31,7 @@ export namespace EffectiveAuthority {
     return { axis: axisName, verdict, reason, evidence };
   }
 
-  export function evaluate(axes: readonly AxisDecision[], allowReason: string): Result {
+  function evaluate(axes: readonly AxisDecision[], allowReason: string): Result {
     const denied = axes.find((entry) => entry.verdict === "deny");
     const factsUsed = axes.flatMap((entry) => [
       `effective_authority.${entry.axis}.${entry.verdict}`,
@@ -199,6 +197,4 @@ export namespace EffectiveAuthority {
     readonly allowed: boolean;
     readonly reason: string;
   };
-
-  export type ActorContext = Dispatch.ActorContext;
 }


### PR DESCRIPTION
## Summary
- Keep EffectiveAuthority.axis and EffectiveAuthority.evaluate namespace-private instead of exporting helper internals.
- Remove the unused EffectiveAuthority.ActorContext compatibility alias and its Dispatch import.
- Preserve the public decision constructors and Result type consumed by dispatch policy.

## Verification
- bun test packages/openomni/test/dispatch/runtime.test.ts packages/openomni/test/dispatch/handlers.test.ts packages/openomni/test/policy/middleware-integration.test.ts (106 pass / 0 fail)
- bun run --filter @openomni/openomni check-types
- bun run check-types (10 successful / 10 total)
- bun run build (4 successful / 4 total)
- bun run lint:guards
- bun run lint
- bun test (2676 pass / 10 skip / 0 fail)
- bunx knip --no-progress --no-exit-code | rg 'EffectiveAuthority|effective-authority' || true (axis/evaluate/ActorContext removed; Axis/Verdict/AxisDecision remain intentionally for Result.axes type surface)
- git diff --check
- LSP diagnostics clean for packages/openomni/src/dispatch/effective-authority.ts

## Review
- codex-ultrawork-reviewer: APPROVE/CLEAR
- Claude Fable oracle unavailable: claude-fable-5 returned 404; no fallback model used


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the EffectiveAuthority helper API in `@openomni/openomni` by making internal helpers non-exported and removing an unused alias, without changing the public decision/result types used by the dispatch policy.

- **Refactors**
  - Made `EffectiveAuthority.axis` and `EffectiveAuthority.evaluate` namespace-private.
  - Removed unused `EffectiveAuthority.ActorContext` alias and `Dispatch` import from `@openomni/protocol`.
  - Kept `Axis`, `Verdict`, `AxisDecision`, and `Result` types unchanged for consumers.

<sup>Written for commit 50a02522ab98499260a066c5b53ee26db31c2068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

