### PR TITLE
refactor(openomni): remove unused skill loader discover

### DIFF
--- a/packages/openomni/src/skill/loader.ts
+++ b/packages/openomni/src/skill/loader.ts
@@ -39,12 +39,6 @@ export namespace SkillLoader {
     return sortSkillDefinitions(skills);
   }
 
-  export async function discover(options: SkillLoaderOptions = {}): Promise<Skill.Definition[]> {
-    const [local, global] = await Promise.all([discoverLocal(options), discoverGlobal(options)]);
-
-    return sortSkillDefinitions([...local, ...global]);
-  }
-
   export async function loadLocal(
     id: string,
     options: SkillLoaderOptions = {},


### PR DESCRIPTION
## Summary
- Remove unused `SkillLoader.discover` from the `@openomni/openomni` package skill loader namespace.
- Preserve explicit package APIs: `discoverLocal`, `discoverGlobal`, `loadLocal`, and `loadGlobal`.
- Leave the separate server-local `apps/server/src/context/skills.ts` `SkillLoader.discover` untouched.

## Verification
- `bun test packages/openomni/test/skill/skill-loader.test.ts packages/openomni/test/skill/descriptor.test.ts packages/openomni/test/skill/skill-manager.test.ts` — 21 pass / 0 fail / 73 expect calls
- `bun run --cwd packages/openomni check-types`
- `bunx biome check packages/openomni/src/skill/loader.ts`
- `bun run check-types` — 10 successful / 10 total
- `bun run build` — 4 successful / 4 total
- `bun run lint:guards` — scanned 709 TS files
- `bun run lint`
- `git diff --check`
- LSP diagnostics clean on `packages/openomni/src/skill/loader.ts`
- Knip target filter no longer reports `SkillLoader.discover` / `skill/loader`
- `bun test` — 2911 pass / 10 skip / 0 fail / 9299 expect calls

## Review
- `codex-ultrawork-reviewer`: unconditional approval; verified exact 6-line deletion, no package callsites, server-local loader distinction, preserved explicit APIs, and clean gates.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `SkillLoader.discover` from the `@openomni/openomni` skill loader to reduce the API surface and make discovery explicit. Kept `discoverLocal`, `discoverGlobal`, `loadLocal`, and `loadGlobal`; the server-local `SkillLoader.discover` in `apps/server/src/context/skills.ts` is unchanged.

<sup>Written for commit 8f2fd1fc15abe382668cee598e87435dd6cefbb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

