### PR TITLE
refactor(openomni): remove unused workspace lock surface

### DIFF
--- a/packages/openomni/src/execution-runtime/workspace-lock.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock.ts
@@ -336,10 +336,6 @@ export namespace WorkspaceLock {
     rejectWaiters(workspace, unsafeWorkspaceError(workspace, state));
   }
 
-  export function isUnsafe(workspace: string): boolean {
-    return readUnsafeMeta(workspace) !== undefined;
-  }
-
   export function clearUnsafe(workspace: string, token?: string): void {
     const state = readUnsafeMeta(workspace);
     if (token !== undefined) {


### PR DESCRIPTION
## Summary
- Remove unused `WorkspaceLock.isUnsafe` from the `@openomni/openomni` execution runtime public namespace.
- Preserve the active workspace lock API: `acquire`, `release`, `markUnsafe`, and `clearUnsafe`.
- No behavior changes to workspace lock acquisition, unsafe marking, or settlement cleanup.

## Verification
- `bun test packages/openomni/src/execution-runtime/workspace-lock.test.ts` — 18 pass / 0 fail / 44 expect calls
- `bun run --cwd packages/openomni check-types`
- `bunx biome check packages/openomni/src/execution-runtime/workspace-lock.ts`
- LSP diagnostics clean on `packages/openomni/src/execution-runtime/workspace-lock.ts`
- `bun run check-types` — 10 successful / 10 total
- `bun run build` — 4 successful / 4 total
- `bun run lint:guards` — scanned 709 TypeScript files
- Knip target filter no longer reports `WorkspaceLock` / `isUnsafe` / `workspace-lock` except unrelated configuration hints
- `bun run lint`
- `git diff --check`
- `bun test` rerun — 2911 pass / 10 skip / 0 fail / 9299 expect calls

Note: an earlier broad `bun test` run reported 1 failure, but the immediate logged rerun passed with the counts above. The focused workspace lock test passed consistently.

## Review
- `codex-ultrawork-reviewer`: unconditional approval; verified exact 4-line deletion, no remaining callsites, preserved useful API, clean local gates, and full logged test rerun.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `WorkspaceLock.isUnsafe` from the `@openomni/openomni` execution runtime public API to simplify the surface area. No behavior changes; `acquire`, `release`, `markUnsafe`, and `clearUnsafe` are unchanged.

<sup>Written for commit f374d2cd4c8388095f55232ea399d314ef1b96ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

