### PR TITLE
refactor(openomni): internalize injection queue events

### DIFF
--- a/packages/openomni/src/execution-runtime/injection-queue.ts
+++ b/packages/openomni/src/execution-runtime/injection-queue.ts
@@ -2,7 +2,7 @@ import { Bus, BusEvent } from "@openomni/session";
 import { z } from "zod";
 
 export namespace InjectionQueue {
-  export const Events = {
+  const Events = {
     ResponseQueued: BusEvent.define(
       "injection_queue.response.queued",
       z.object({


### PR DESCRIPTION
## Summary
- Internalize `InjectionQueue.Events` so queue event descriptors are no longer part of the package namespace surface.
- Preserve `InjectionQueue.create`, `InjectionQueue.PendingResponse`, and `InjectionQueue.Instance`.
- Preserve response queued/drained bus publication names and payloads.

## Verification
- `bun test packages/openomni/test/execution-runtime/injection-queue.test.ts packages/openomni/test/execution-runtime/injection-queue-policy.test.ts` — 7 pass / 0 fail / 21 expect calls
- `bun run --cwd packages/openomni check-types`
- `bunx biome check packages/openomni/src/execution-runtime/injection-queue.ts`
- LSP diagnostics clean on `packages/openomni/src/execution-runtime/injection-queue.ts`
- Knip target filter no longer reports `InjectionQueue` / `Events` / `injection-queue`
- `bun run check-types` — 10 successful / 10 total
- `bun run build` — 4 successful / 4 total
- `bun run lint:guards` — scanned 709 TypeScript files
- `bun run lint`
- `git diff --check`
- `bun test` — 2911 pass / 10 skip / 0 fail / 9299 expect calls

## Review
- `codex-ultrawork-reviewer`: unconditional approval; verified exact one-line surface internalization, no callsites, preserved public API and event publication, and clean local gates.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized `InjectionQueue.Events` to remove event descriptors from the public namespace while keeping the `InjectionQueue` API the same. Bus publications stay unchanged (`injection_queue.response.queued`, `injection_queue.response.drained`) with the same payloads, so no consumer updates are needed.

<sup>Written for commit 7839a9591e1bab352687bd1e67bd65948d9fdd18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

