### PR TITLE
refactor(openomni): internalize effective authority types

### DIFF
--- a/packages/openomni/src/dispatch/effective-authority.ts
+++ b/packages/openomni/src/dispatch/effective-authority.ts
@@ -1,20 +1,20 @@
+type Axis =
+  | "blacklist"
+  | "channel_grant"
+  | "personal_or_channel_default_grant"
+  | "session_ownership_grant"
+  | "pending_interaction_scope";
+
+type Verdict = "allow" | "deny" | "not_required";
+
+interface AxisDecision {
+  readonly axis: Axis;
+  readonly verdict: Verdict;
+  readonly reason: string;
+  readonly evidence?: readonly string[];
+}
+
 export namespace EffectiveAuthority {
-  export type Axis =
-    | "blacklist"
-    | "channel_grant"
-    | "personal_or_channel_default_grant"
-    | "session_ownership_grant"
-    | "pending_interaction_scope";
-
-  export type Verdict = "allow" | "deny" | "not_required";
-
-  export interface AxisDecision {
-    readonly axis: Axis;
-    readonly verdict: Verdict;
-    readonly reason: string;
-    readonly evidence?: readonly string[];
-  }
-
   export interface Result {
     readonly allowed: boolean;
     readonly reason: string;


### PR DESCRIPTION
## Summary
- Internalize `EffectiveAuthority.Axis`, `EffectiveAuthority.Verdict`, and `EffectiveAuthority.AxisDecision` helper types so they are no longer public namespace members.
- Preserve `EffectiveAuthority.Result` and all effective-authority runtime functions.
- Preserve authority axis strings, verdict strings, facts, and dispatch policy behavior.

## Verification
- `bun test packages/openomni/test/dispatch/runtime.test.ts` — 33 pass / 0 fail / 120 expect calls
- `bun run --cwd packages/openomni check-types`
- `bunx biome check packages/openomni/src/dispatch/effective-authority.ts`
- LSP diagnostics clean on `packages/openomni/src/dispatch/effective-authority.ts`
- Knip target filter no longer reports `EffectiveAuthority` / `AxisDecision` / `Verdict` / `Axis` / `effective-authority`
- `git diff --check`
- `bun run check-types` — 10 successful / 10 total
- `bun run build` — 4 successful / 4 total
- `bun run lint:guards` — scanned 709 TypeScript files
- `bun run lint`
- `bun test` — 2911 pass / 10 skip / 0 fail / 9299 expect calls
- pre-push `dep-check` and `type-check`

## Review
- `codex-ultrawork-reviewer`: unconditional approval; verified public helper type internalization, no callsites, preserved exported `Result`, preserved runtime functions and authority strings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the public API surface of `EffectiveAuthority` by making helper types internal. No behavior changes; runtime functions and `EffectiveAuthority.Result` stay the same.

- **Refactors**
  - Internalized `Axis`, `Verdict`, and `AxisDecision` so they are no longer exported from the namespace.
  - Preserved authority axis/verdict strings, facts, dispatch policy, and all runtime functions.

<sup>Written for commit c782d487a6667404623cab7fadfb04e9c6607fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal type declarations in the dispatch module to improve code structure. This may impact external consumers who were directly importing specific types from the namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->