### PR TITLE
refactor(openomni): internalize cron runner types

### DIFF
--- a/packages/openomni/src/execution-runtime/cron-job-runner.ts
+++ b/packages/openomni/src/execution-runtime/cron-job-runner.ts
@@ -7,6 +7,19 @@ const DEFAULT_INTERVAL_MS = 30_000;
 
 type FireJob = (job: CronJob.Info) => Promise<void>;
 
+interface TickOptions {
+  readonly nowMs?: () => number;
+  readonly fire?: FireJob;
+}
+
+interface StartOptions extends TickOptions {
+  readonly intervalMs?: number;
+}
+
+interface CronJobRunnerHandle {
+  stop(): void;
+}
+
 function parseInteger(value: string, field: string): number {
   if (!/^\d+$/.test(value)) throw new Error(`Invalid cron ${field} value: ${value}`);
   return Number.parseInt(value, 10);
@@ -91,19 +104,6 @@ async function missingFireJob(): Promise<void> {
 }
 
 export namespace CronJobRunner {
-  export interface TickOptions {
-    readonly nowMs?: () => number;
-    readonly fire?: FireJob;
-  }
-
-  export interface StartOptions extends TickOptions {
-    readonly intervalMs?: number;
-  }
-
-  export interface Handle {
-    stop(): void;
-  }
-
   export async function tick(options: TickOptions = {}): Promise<void> {
     const now = options.nowMs?.() ?? Date.now();
     const fire = options.fire ?? missingFireJob;
@@ -148,7 +148,7 @@ export namespace CronJobRunner {
     }
   }
 
-  export function start(options: StartOptions): Handle {
+  export function start(options: StartOptions): CronJobRunnerHandle {
     let running = false;
     let stopped = false;
     const run = async () => {


### PR DESCRIPTION
## Summary
- Internalize `CronJobRunner.TickOptions`, `CronJobRunner.StartOptions`, and `CronJobRunner.Handle` helper types so they are no longer public namespace members.
- Preserve `CronJobRunner.tick` and `CronJobRunner.start` structural options behavior.
- Preserve cron schedule parsing, persistence, event publication, boot tick, and stop handle behavior.

## Verification
- `bun test packages/openomni/test/execution-runtime/cron-job-runner.test.ts` — 13 pass / 0 fail / 30 expect calls
- `bun run --cwd packages/openomni check-types`
- `bunx biome check packages/openomni/src/execution-runtime/cron-job-runner.ts`
- LSP diagnostics clean on `packages/openomni/src/execution-runtime/cron-job-runner.ts`
- Knip target filter no longer reports `CronJobRunner` / `TickOptions` / `StartOptions` / `cron-job-runner`; broad `Handle` match is unrelated `WaitTimeoutHandle`
- `git diff --check`
- `bun run check-types` — 10 successful / 10 total
- `bun run build` — 4 successful / 4 total
- `bun run lint:guards` — scanned 709 TypeScript files
- `bun run lint`
- `bun test` — 2911 pass / 10 skip / 0 fail / 9299 expect calls
- pre-push `dep-check` and `type-check`

## Review
- `codex-ultrawork-reviewer`: unconditional approval; verified helper type internalization, no callsites, preserved exported `tick`/`start`, `start().stop()` shape, and cron runtime behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized helper types in `CronJobRunner` to narrow the public API while keeping `tick` and `start` behavior and shapes unchanged.

- **Refactors**
  - Moved `CronJobRunner.TickOptions`, `StartOptions`, and `Handle` to file-internal interfaces; `tick`/`start` remain structurally compatible.
  - No changes to cron parsing, persistence, event publication, boot tick, or stop semantics.

<sup>Written for commit b1c3cd223aa4584e1b9dddce2b33812c65045e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

