### PR TITLE
refactor(openomni): internalize tool runtime policy types

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/middleware/tool-runtime-policy.ts
+++ b/packages/openomni/src/execution-runtime/tool/middleware/tool-runtime-policy.ts
@@ -65,6 +65,34 @@ function recordDecision(
   void onDecision?.(decision);
 }
 
+interface TimeoutOptions {
+  readonly onTimeout?: (error: ToolRuntimePolicyMiddleware.TimeoutError) => void;
+}
+
+interface PreToolContext {
+  readonly toolName: string;
+  readonly toolCallId?: string;
+  readonly input: Record<string, unknown>;
+  readonly riskTier: ToolRiskTier;
+  readonly descriptor?: RuntimeResource.Descriptor;
+  readonly timeoutConfig?: ToolExecutorConfig["timeoutMs"];
+  readonly workspaceRoot?: string;
+  readonly lockOwnerId: string;
+  readonly signal?: AbortSignal;
+  readonly traceContext?: TraceContext.Type;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
+interface PostToolContext {
+  readonly toolName: string;
+  readonly toolCallId?: string;
+  readonly input: Record<string, unknown>;
+  readonly output?: string;
+  readonly handle: ToolRuntimePolicyMiddleware.RuntimePolicyHandle;
+  readonly traceContext?: TraceContext.Type;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
 export namespace ToolRuntimePolicyMiddleware {
   export class TimeoutError extends Error {
     readonly timeoutMs: number;
@@ -76,10 +104,6 @@ export namespace ToolRuntimePolicyMiddleware {
     }
   }
 
-  export interface TimeoutOptions {
-    readonly onTimeout?: (error: TimeoutError) => void;
-  }
-
   export interface RuntimePolicyHandle {
     readonly timeoutMs: number;
     readonly lockOwnerId: string;
@@ -87,33 +111,9 @@ export namespace ToolRuntimePolicyMiddleware {
     lockAcquired: boolean;
   }
 
-  export interface PreToolContext {
-    readonly toolName: string;
-    readonly toolCallId?: string;
-    readonly input: Record<string, unknown>;
-    readonly riskTier: ToolRiskTier;
-    readonly descriptor?: RuntimeResource.Descriptor;
-    readonly timeoutConfig?: ToolExecutorConfig["timeoutMs"];
-    readonly workspaceRoot?: string;
-    readonly lockOwnerId: string;
-    readonly signal?: AbortSignal;
-    readonly traceContext?: TraceContext.Type;
-    readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-  }
-
   export interface PreToolResult {
     readonly decision: Policy.PolicyDecision;
     readonly handle: RuntimePolicyHandle;
-  }
-
-  export interface PostToolContext {
-    readonly toolName: string;
-    readonly toolCallId?: string;
-    readonly input: Record<string, unknown>;
-    readonly output?: string;
-    readonly handle: RuntimePolicyHandle;
-    readonly traceContext?: TraceContext.Type;
-    readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
   }
 
   export async function evaluatePreTool(ctx: PreToolContext): Promise<PreToolResult> {


### PR DESCRIPTION
## Summary
- internalize unused ToolRuntimePolicyMiddleware helper context/timeout types
- preserve exported runtime policy functions and consumed public members

## Verification
- bun test packages/openomni/test/policy/middleware-integration.test.ts packages/openomni/src/execution-runtime/tool/executor.test.ts packages/openomni/test/tool/descriptor-attachment.test.ts
- bun run --filter @openomni/openomni check-types
- bunx biome check packages/openomni/src/execution-runtime/tool/middleware/tool-runtime-policy.ts
- bunx knip --include nsExports,nsTypes --no-progress --no-exit-code | rg "ToolRuntimePolicyMiddleware|TimeoutOptions|PreToolContext|PostToolContext|tool-runtime-policy" (no target hits; unrelated config hints only)
- bun run check-types
- bun run build
- bun run lint:guards
- bun run lint
- git diff --check origin/main..HEAD
- bun test

## Review
- codex-ultrawork-reviewer: UNCONDITIONAL APPROVAL
- Claude Fable oracle unavailable: claude-fable-5 returned 404; no fallback model used


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized unused tool runtime policy helper types in `tool-runtime-policy.ts` to reduce the public API surface with no behavior changes. Exported runtime policy functions and `RuntimePolicyHandle` remain unchanged for `@openomni/openomni` consumers.

- **Refactors**
  - Moved `TimeoutOptions`, `PreToolContext`, and `PostToolContext` to file-local types; removed their exports from `ToolRuntimePolicyMiddleware`.
  - Kept `RuntimePolicyHandle`, `PreToolResult`, and `evaluatePreTool` API intact.

<sup>Written for commit bbe613b5e8cbd15e07b5dab9d20440e26688daad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

