### PR TITLE
refactor(openomni): internalize session resolver result type

### DIFF
--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -21,9 +21,9 @@ interface ModelConfig {
 }
 
 interface ResolveResult {
-  readonly session: Session.Info;
-  readonly isNew: boolean;
-  readonly trace?: TraceContextProtocol.Type;
+  session: Session.Info;
+  isNew: boolean;
+  trace?: TraceContextProtocol.Type;
 }
 
 export namespace IngressSessionResolver {

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -20,13 +20,13 @@ interface ModelConfig {
   modelID: string;
 }
 
-export namespace IngressSessionResolver {
-  export interface ResolveResult {
-    session: Session.Info;
-    isNew: boolean;
-    trace?: TraceContextProtocol.Type;
-  }
+interface ResolveResult {
+  readonly session: Session.Info;
+  readonly isNew: boolean;
+  readonly trace?: TraceContextProtocol.Type;
+}
 
+export namespace IngressSessionResolver {
   // Format: "surface:workspace:channel" for legacy events. Explicit ADR-008 targets append
   // `target:<target-key>` so resident and worker sessions do not collide.
   export function extractSurfaceKey(event: ResolvableEvent): string {


### PR DESCRIPTION
## Summary
- internalize unused `IngressSessionResolver.ResolveResult` namespace helper type
- preserve `IngressSessionResolver.resolve` runtime behavior and structural return shape
- keep `extractSurfaceKey` and `resolve` as the public runtime resolver API

## Verification
- `bun test packages/openomni/test/ingress/session-resolver.test.ts packages/openomni/test/ingress/engine.test.ts packages/openomni/test/policy/middleware-integration.test.ts` (`92 pass / 0 fail / 209 expect`)
- `bun run --filter @openomni/openomni check-types`
- `bunx biome check packages/openomni/src/ingress/session-resolver.ts`
- `bunx knip --include nsExports,nsTypes --no-progress --no-exit-code | rg "IngressSessionResolver|ResolveResult|session-resolver"` (no target findings; existing config hints only)
- `bun run check-types` (`10 successful / 10 total`)
- `bun run build` (`4 successful / 4 total`)
- `bun run lint:guards` (`709 TypeScript files`)
- `bun run lint` (`737 files`)
- `git diff --check`
- LSP diagnostics on changed file: clean
- `bun test` (`2911 pass / 10 skip / 0 fail / 9299 expect`)

## Review Notes
- Initial reviewer caught an accidental `readonly` return-shape change; follow-up commit removed it and preserves the original mutable structural fields.
- `codex-ultrawork-reviewer` passed after the fix.
- Claude Fable oracle was attempted, but `claude-fable-5` returned 404/unavailable; no fallback model was used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized the unused `IngressSessionResolver.ResolveResult` type in `@openomni/openomni` with no runtime behavior changes. `extractSurfaceKey` and `resolve` remain public, and the resolver return shape is unchanged and mutable.

<sup>Written for commit 5efd0466c82aa926022e6bb91a90f41e9d44484a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

