### PR TITLE
refactor(openomni): internalize profile middleware config

### DIFF
--- a/packages/openomni/src/profile/index.ts
+++ b/packages/openomni/src/profile/index.ts
@@ -9,13 +9,13 @@ import { MEMORY_GUIDANCE } from "./guidance";
 const PROFILES_DIR = ".openomni/profiles";
 const SAFE_NAME = /^[A-Za-z0-9_-]+$/;
 
-export namespace Profile {
-  export const MiddlewareConfigSchema = z.object({
-    agentName: z.string(),
-    homeRoot: z.string().optional(),
-  });
-  export type MiddlewareConfig = z.infer<typeof MiddlewareConfigSchema>;
+const MiddlewareConfigSchema = z.object({
+  agentName: z.string(),
+  homeRoot: z.string().optional(),
+});
+type MiddlewareConfig = z.infer<typeof MiddlewareConfigSchema>;
 
+export namespace Profile {
   export function createMiddleware(config: MiddlewareConfig): PolicyRegistration[] {
     const home = config.homeRoot ?? homedir();
     const agent = sanitizeName(config.agentName);


### PR DESCRIPTION
## Summary
- internalize unused `Profile.MiddlewareConfigSchema` / `Profile.MiddlewareConfig` namespace members
- keep `Profile.createMiddleware(...)` as the public runtime API
- preserve profile middleware behavior and structural config shape

## Verification
- `bun test packages/openomni/test/profile/profile.test.ts` (`19 pass / 0 fail / 40 expect`)
- `bun run --filter @openomni/openomni check-types`
- `bunx biome check packages/openomni/src/profile/index.ts`
- `bunx knip --include nsExports,nsTypes --no-progress --no-exit-code | rg "Profile|MiddlewareConfig|profile/index"` (no target findings; existing config hints only)
- `bun run check-types` (`10 successful / 10 total`)
- `bun run build` (`4 successful / 4 total`)
- `bun run lint:guards` (`709 TypeScript files`)
- `bun run lint` (`737 files`)
- `git diff --check`
- LSP diagnostics on changed file: clean
- `bun test` (`2911 pass / 10 skip / 0 fail / 9299 expect`)

## Review Notes
- `codex-ultrawork-reviewer` passed with no blocking findings.
- Claude Fable oracle was attempted, but `claude-fable-5` returned 404/unavailable; no fallback model was used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized `Profile.MiddlewareConfigSchema` and `Profile.MiddlewareConfig` to shrink the public API and simplify the `Profile` namespace. `Profile.createMiddleware(...)` stays the public entry point with no behavior changes.

- **Refactors**
  - Moved `MiddlewareConfigSchema` and `MiddlewareConfig` to module scope as internal-only.
  - Preserved config shape and middleware behavior.

<sup>Written for commit 266e2d0e385cf1f313fb85f15c61a0ad75ed45c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

