### PR TITLE
refactor(openomni): remove policy resolver default export

### DIFF
--- a/packages/openomni/src/policy/resolver.ts
+++ b/packages/openomni/src/policy/resolver.ts
@@ -87,8 +87,6 @@ class StaticPolicyResolver implements PolicyResolverInstance {
 }
 
 export namespace PolicyResolver {
-  export const DefaultPolicies = [...defaultPolicyIds];
-
   export function create(rules: readonly PolicyResolverRule[] = []): PolicyResolverInstance {
     return new StaticPolicyResolver(rules);
   }


### PR DESCRIPTION
## Summary
- Remove unused `PolicyResolver.DefaultPolicies` namespace export
- Preserve file-local default policy IDs and `PolicyResolver.create()` behavior

## Verification
- `bun test packages/openomni/test/policy/resolver.test.ts packages/openomni/test/policy/integration.test.ts`
- `bun run --filter @openomni/openomni check-types`
- `bunx biome check packages/openomni/src/policy/resolver.ts`
- `bunx knip --include nsExports,nsTypes --no-progress --no-exit-code | rg -n 'DefaultPolicies|PolicyResolver' || true`\n- `git diff --check origin/main..HEAD`\n- `bun run check-types`\n- `bun run build`\n- `bun run lint:guards`\n- `bun run lint`\n- `bun test`\n\n## Review\n- codex-ultrawork-reviewer: PASS / APPROVE / CLEAR\n- Claude Fable oracle: unavailable (`claude-fable-5` returned 404); no fallback model used\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `PolicyResolver.DefaultPolicies` export to tighten the public API. No behavior changes; defaults remain internal and `PolicyResolver.create()` works the same.

- **Refactors**
  - Removed `PolicyResolver.DefaultPolicies` namespace export; kept internal default IDs and `PolicyResolver.create()` unchanged.

- **Migration**
  - If you used `PolicyResolver.DefaultPolicies`, replace it with your own policy ID list or rely on `PolicyResolver.create()` defaults.

<sup>Written for commit 80787a13211cf5c8626bd960102b057cae1b49d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `DefaultPolicies` export from the policy resolver, simplifying the public API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->