### PR TITLE
refactor(openomni): internalize ingress authority types

### DIFF
--- a/packages/openomni/src/ingress/middleware/ingress-authority.ts
+++ b/packages/openomni/src/ingress/middleware/ingress-authority.ts
@@ -32,6 +32,20 @@ interface PreRunState {
   target?: Ingress.Target;
 }
 
+interface PreRunContext {
+  readonly event: unknown;
+  readonly coordinator?: CoordinatorLike;
+  readonly traceContext?: TraceContext.Type;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
+interface PreRunResult {
+  readonly event: Ingress.InboundEvent;
+  readonly coordinator?: CoordinatorLike;
+  readonly mode: Ingress.InboundEvent["mode"];
+  readonly target: Ingress.Target;
+}
+
 function allowDecision(policyId: string, reason: string): Policy.PolicyDecision {
   return PolicyDecision.allow({ policyId, reasonCodes: [reason] });
 }
@@ -456,20 +470,6 @@ export namespace IngressAuthorityMiddleware {
     priority: 35,
     failPolicy: "fail-closed",
   } as const satisfies Policy.Definition;
-
-  export interface PreRunContext {
-    readonly event: unknown;
-    readonly coordinator?: CoordinatorLike;
-    readonly traceContext?: TraceContext.Type;
-    readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-  }
-
-  export interface PreRunResult {
-    readonly event: Ingress.InboundEvent;
-    readonly coordinator?: CoordinatorLike;
-    readonly mode: Ingress.InboundEvent["mode"];
-    readonly target: Ingress.Target;
-  }
 
   export function registrations(state: PreRunState): PolicyRegistration[] {
     return [


### PR DESCRIPTION
## Summary
- Internalize unused `IngressAuthorityMiddleware.PreRunContext` and `PreRunResult` namespace helper types
- Preserve `IngressAuthorityMiddleware.runPreRun()` and `registrations()` runtime behavior

## Verification
- `bun test packages/openomni/test/policy/middleware-integration.test.ts packages/openomni/test/ingress/engine.test.ts packages/openomni/test/ingress/session-resolver.test.ts`
- `bun run --filter @openomni/openomni check-types`
- `bunx biome check packages/openomni/src/ingress/middleware/ingress-authority.ts`
- `bunx knip --include nsExports,nsTypes --no-progress --no-exit-code | rg -n 'PreRunContext|PreRunResult|IngressAuthorityMiddleware' || true`\n- `git diff --check origin/main..HEAD`\n- `bun run check-types`\n- `bun run build`\n- `bun run lint:guards`\n- `bun run lint`\n- `bun test`\n\n## Review\n- codex-ultrawork-reviewer: PASS / APPROVE / CLEAR\n- Claude Fable oracle: unavailable (`claude-fable-5` returned 404); no fallback model used\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized unused ingress authority helper types in `@openomni/openomni` by moving `IngressAuthorityMiddleware.PreRunContext` and `PreRunResult` to file-local interfaces. No public API or runtime changes; `IngressAuthorityMiddleware.runPreRun()` and `IngressAuthorityMiddleware.registrations()` behave the same.

<sup>Written for commit 2c7f9ac271c554dcf5dced66743577a9a0b3d147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

