### PR TITLE
refactor(openomni): internalize background launch types

### DIFF
--- a/packages/openomni/src/subagent/middleware/background-limits.ts
+++ b/packages/openomni/src/subagent/middleware/background-limits.ts
@@ -48,6 +48,26 @@ interface BackgroundLimitState {
   shouldQueue?: boolean;
 }
 
+interface PreLaunchContext {
+  readonly input: LaunchRequest;
+  readonly activeTasks: readonly Subagent.BackgroundTask[];
+  readonly activeCount: number;
+  readonly pendingQueueSize: number;
+  readonly maxConcurrentPerAgent: number;
+  readonly maxConcurrentTotal: number;
+  readonly maxDepth: number;
+  readonly maxDescendants: number;
+  readonly maxQueueSize: number;
+  readonly traceContext?: TraceContext.Type;
+  readonly resourceDescriptor?: RuntimeResource.Descriptor;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
+interface PreLaunchResult {
+  readonly verdict: Policy.PolicyDecision;
+  readonly shouldQueue: boolean;
+}
+
 function allowDecision(policyId: string, reason: string): Policy.PolicyDecision {
   return PolicyDecision.allow({ policyId, reasonCodes: [reason] });
 }
@@ -328,26 +348,6 @@ export namespace BackgroundLimitsMiddleware {
     priority: 40,
     failPolicy: "fail-closed",
   } as const satisfies Policy.Definition;
-
-  export interface PreLaunchContext {
-    readonly input: LaunchRequest;
-    readonly activeTasks: readonly Subagent.BackgroundTask[];
-    readonly activeCount: number;
-    readonly pendingQueueSize: number;
-    readonly maxConcurrentPerAgent: number;
-    readonly maxConcurrentTotal: number;
-    readonly maxDepth: number;
-    readonly maxDescendants: number;
-    readonly maxQueueSize: number;
-    readonly traceContext?: TraceContext.Type;
-    readonly resourceDescriptor?: RuntimeResource.Descriptor;
-    readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-  }
-
-  export interface PreLaunchResult {
-    readonly verdict: Policy.PolicyDecision;
-    readonly shouldQueue: boolean;
-  }
 
   export function registrations(state: BackgroundLimitState): PolicyRegistration[] {
     return [


### PR DESCRIPTION
## Summary
- Internalize unused `BackgroundLimitsMiddleware.PreLaunchContext` and `PreLaunchResult` helper types by moving them to file-local scope.
- Preserve `BackgroundLimitsMiddleware.evaluatePreLaunch`, registrations, policy definitions, and all runtime behavior.

## Verification
- `bun test packages/openomni/test/policy/middleware-integration.test.ts packages/openomni/test/subagent/background-queue.test.ts packages/openomni/src/subagent/background-manager.test.ts packages/openomni/test/subagent/descriptor.test.ts`
- `bun run --filter @openomni/openomni check-types`
- `bunx biome check packages/openomni/src/subagent/middleware/background-limits.ts`
- `bunx knip --include nsExports,nsTypes --no-progress --no-exit-code | rg -n "PreLaunch(Context|Result)|BackgroundLimitsMiddleware|Configuration hints"`
- `git diff --check`
- LSP diagnostics on changed file
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint`
- `bun test`

## Review
- codex-ultrawork-reviewer: PASS / APPROVE
- Claude Fable oracle: unavailable (`claude-fable-5` returned 404); no fallback model used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized `PreLaunchContext` and `PreLaunchResult` in `background-limits.ts` to reduce the public API surface with no behavior changes.

- **Refactors**
  - Moved `PreLaunchContext` and `PreLaunchResult` from `BackgroundLimitsMiddleware` to file-local scope.
  - No changes to `BackgroundLimitsMiddleware.evaluatePreLaunch`, policy definitions, or registrations; background launch benchmarks rerun to validate no perf regressions.

<sup>Written for commit cd1b777e3431bcf599953503634aafb8f6832157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

