### PR TITLE
refactor(openomni): internalize subagent spawn policy types

### DIFF
--- a/packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts
@@ -39,6 +39,33 @@ interface PreSpawnState {
   waitTimeoutMs?: number;
 }
 
+interface PreSpawnContext {
+  readonly operation: PreSpawnOperation;
+  readonly sessionId: string;
+  readonly hardTimeoutMs?: number;
+  readonly timeoutMs?: number;
+  readonly traceContext?: TraceContext.Type;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
+interface PreSpawnResult {
+  readonly verdict: Policy.PolicyDecision;
+  readonly session?: SessionRecord;
+  readonly runs?: WorkerRunRecord[];
+  readonly latestRun?: WorkerRunRecord;
+  readonly cancelHardTimeoutMs: number;
+  readonly waitTimeoutMs?: number;
+}
+
+interface WaitTimeoutHandle {
+  readonly cancel: () => void;
+}
+
+interface ChildRuntimeMiddlewareInput {
+  readonly middleware?: PolicyRegistration[];
+  readonly hasExplicitRuntimePolicy: boolean;
+}
+
 function allowDecision(policyId: string, reason: string): Policy.PolicyDecision {
   return PolicyDecision.allow({ policyId, reasonCodes: [reason] });
 }
@@ -240,28 +267,6 @@ export namespace SubagentSpawnPolicyMiddleware {
     failPolicy: "fail-closed",
   } as const satisfies Policy.Definition;
 
-  export interface PreSpawnContext {
-    readonly operation: PreSpawnOperation;
-    readonly sessionId: string;
-    readonly hardTimeoutMs?: number;
-    readonly timeoutMs?: number;
-    readonly traceContext?: TraceContext.Type;
-    readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-  }
-
-  export interface PreSpawnResult {
-    readonly verdict: Policy.PolicyDecision;
-    readonly session?: SessionRecord;
-    readonly runs?: WorkerRunRecord[];
-    readonly latestRun?: WorkerRunRecord;
-    readonly cancelHardTimeoutMs: number;
-    readonly waitTimeoutMs?: number;
-  }
-
-  export interface WaitTimeoutHandle {
-    readonly cancel: () => void;
-  }
-
   export function createDefaultDenylist(): PolicyRegistration {
     return {
       ...DefaultDenylist,
@@ -277,11 +282,6 @@ export namespace SubagentSpawnPolicyMiddleware {
         );
       },
     };
-  }
-
-  export interface ChildRuntimeMiddlewareInput {
-    readonly middleware?: PolicyRegistration[];
-    readonly hasExplicitRuntimePolicy: boolean;
   }
 
   export function buildChildRuntimeMiddleware(


### PR DESCRIPTION
## Summary\n- move SubagentSpawnPolicyMiddleware helper interfaces to file-local scope\n- preserve exported middleware definitions and runtime functions\n- reduce unused public type surface without runtime behavior changes\n\n## Verification\n- bun test packages/openomni/test/subagent/subagent-spawn-policy.test.ts packages/openomni/test/policy/middleware-integration.test.ts\n- bun run --filter @openomni/openomni check-types\n- bunx biome check packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts\n- git diff --check\n- bun run check-types\n- bun run build\n- bun run lint:guards\n- bun run lint\n- bun test\n\nClaude Fable oracle note: attempted claude-fable-5 read-only review, but the configured model returned 404/unavailable; no fallback model was used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized subagent spawn policy helper types in `@openomni/openomni` to reduce the public type surface with no runtime changes.

- **Refactors**
  - Moved `PreSpawnContext`, `PreSpawnResult`, `WaitTimeoutHandle`, and `ChildRuntimeMiddlewareInput` to file-local scope.

<sup>Written for commit 6da8d8858d76dfd9ab23c098b42dc2c30514db1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal type interfaces reorganized from exported to module-scoped declarations with no impact to public API, exported functions, or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->