### PR TITLE
chore: stabilize benchmark gate with repeated runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Number of repeated benchmark runs to summarize
+        required: false
+        default: "5"
 
 concurrency:
   group: bench-${{ github.ref }}
@@ -37,32 +43,33 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bunx turbo run build --filter=@openomni/protocol
 
-      - name: Bench (session)
-        run: bun run bench
-        working-directory: packages/session
-
-      - name: Bench (agent)
-        run: bun run bench
-        working-directory: packages/agent
-
-      - name: Bench (openomni)
-        run: bun run bench
-        working-directory: packages/openomni
-
-      - name: Combine results
+      - name: Run repeated benchmarks
+        env:
+          BENCHMARK_RUNS: ${{ github.event.inputs.runs || '5' }}
         run: |
-          mkdir -p bench-results
-          combined="[]"
-          for f in packages/*/bench-results/*.json; do
-            if [ -f "$f" ]; then
-              combined=$(echo "$combined" | bun -e "
-                const existing = JSON.parse(await Bun.stdin.text());
-                const added = JSON.parse(await Bun.file('$f').text());
-                console.log(JSON.stringify([...existing, ...added]));
-              ")
-            fi
+          set -euo pipefail
+          rm -rf bench-results packages/*/bench-results
+          mkdir -p bench-results/runs
+
+          for run in $(seq 1 "$BENCHMARK_RUNS"); do
+            echo "Benchmark run $run/$BENCHMARK_RUNS"
+            rm -rf packages/*/bench-results
+
+            bun run --cwd packages/session bench
+            bun run --cwd packages/agent bench
+            bun run --cwd packages/openomni bench
+
+            mkdir -p "bench-results/runs/$run"
+            cp packages/session/bench-results/session.json "bench-results/runs/$run/session.json"
+            cp packages/agent/bench-results/agent.json "bench-results/runs/$run/agent.json"
+            cp packages/openomni/bench-results/openomni.json "bench-results/runs/$run/openomni.json"
           done
-          echo "$combined" > bench-results/combined.json
+
+      - name: Summarize benchmark runs
+        run: bun run script/summarize-benchmark-runs.ts
+
+      - name: Publish benchmark summary
+        run: cat bench-results/summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check gh-pages exists
         id: ghp
@@ -81,7 +88,7 @@ jobs:
           fi
 
       - name: Bootstrap gh-pages branch
-        if: steps.ghp.outputs.exists == 'false' && github.event_name == 'push'
+        if: steps.ghp.outputs.exists == 'false' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
         run: |
           git checkout --orphan gh-pages
           git reset --hard
@@ -100,7 +107,7 @@ jobs:
           tool: customSmallerIsBetter
           output-file-path: bench-results/combined.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' }}
+          auto-push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           alert-threshold: "150%"

--- a/script/summarize-benchmark-runs.ts
+++ b/script/summarize-benchmark-runs.ts
@@ -1,0 +1,175 @@
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+type BenchmarkMetric = {
+  readonly name: string;
+  readonly unit: "ns/op";
+  readonly value: number;
+};
+
+type BenchmarkStats = BenchmarkMetric & {
+  readonly runs: number;
+  readonly mean: number;
+  readonly min: number;
+  readonly max: number;
+  readonly p50: number;
+  readonly p95: number;
+};
+
+const DEFAULT_INPUT_DIR = "bench-results/runs";
+const DEFAULT_GATE_OUTPUT = "bench-results/combined.json";
+const DEFAULT_STATS_OUTPUT = "bench-results/statistics.json";
+const DEFAULT_SUMMARY_OUTPUT = "bench-results/summary.md";
+
+const inputDir = Bun.argv[2] ?? DEFAULT_INPUT_DIR;
+const gateOutputPath = Bun.argv[3] ?? DEFAULT_GATE_OUTPUT;
+const statsOutputPath = Bun.argv[4] ?? DEFAULT_STATS_OUTPUT;
+const summaryOutputPath = Bun.argv[5] ?? DEFAULT_SUMMARY_OUTPUT;
+
+const metrics = await readBenchmarkMetrics(inputDir);
+const stats = summarizeMetrics(metrics);
+
+if (stats.length === 0) {
+  throw new Error(`No benchmark metrics found under ${inputDir}`);
+}
+
+writeJson(gateOutputPath, toGateMetrics(stats));
+writeJson(statsOutputPath, stats);
+await Bun.write(summaryOutputPath, renderSummary(stats));
+
+async function readBenchmarkMetrics(root: string): Promise<BenchmarkMetric[]> {
+  const entries = collectJsonFiles(root);
+  const metrics: BenchmarkMetric[] = [];
+
+  for (const path of entries) {
+    const parsed: unknown = JSON.parse(await Bun.file(path).text());
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Benchmark file must contain an array: ${path}`);
+    }
+
+    for (const item of parsed) {
+      if (!isBenchmarkMetric(item)) {
+        throw new Error(`Invalid benchmark metric in ${path}`);
+      }
+      metrics.push(item);
+    }
+  }
+
+  return metrics;
+}
+
+function collectJsonFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJsonFiles(path));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    files.push(path);
+  }
+  return files.sort();
+}
+
+function isBenchmarkMetric(value: unknown): value is BenchmarkMetric {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    "unit" in value &&
+    "value" in value &&
+    typeof value.name === "string" &&
+    value.unit === "ns/op" &&
+    typeof value.value === "number" &&
+    Number.isFinite(value.value)
+  );
+}
+
+function summarizeMetrics(metrics: readonly BenchmarkMetric[]): BenchmarkStats[] {
+  const groups = new Map<string, BenchmarkMetric[]>();
+
+  for (const metric of metrics) {
+    const group = groups.get(metric.name);
+    if (group) {
+      group.push(metric);
+      continue;
+    }
+    groups.set(metric.name, [metric]);
+  }
+
+  return [...groups.entries()]
+    .map(([name, group]) => {
+      const values = group.map((metric) => metric.value).sort((left, right) => left - right);
+      const unit = group[0]?.unit;
+      if (unit !== "ns/op") {
+        throw new Error(`Unsupported benchmark unit for ${name}`);
+      }
+
+      return {
+        name,
+        unit,
+        value: percentile(values, 50),
+        runs: values.length,
+        mean: mean(values),
+        min: values[0] ?? 0,
+        max: values[values.length - 1] ?? 0,
+        p50: percentile(values, 50),
+        p95: percentile(values, 95),
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function toGateMetrics(stats: readonly BenchmarkStats[]): BenchmarkMetric[] {
+  return stats.map((metric) => ({
+    name: metric.name,
+    unit: metric.unit,
+    value: Math.round(metric.p50),
+  }));
+}
+
+function percentile(sortedValues: readonly number[], percentileValue: number): number {
+  if (sortedValues.length === 0) return 0;
+  if (sortedValues.length === 1) return sortedValues[0] ?? 0;
+
+  const rank = (percentileValue / 100) * (sortedValues.length - 1);
+  const lowerIndex = Math.floor(rank);
+  const upperIndex = Math.ceil(rank);
+  const lower = sortedValues[lowerIndex] ?? 0;
+  const upper = sortedValues[upperIndex] ?? lower;
+  const weight = rank - lowerIndex;
+  return lower + (upper - lower) * weight;
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function renderSummary(stats: readonly BenchmarkStats[]): string {
+  const rows = stats.map(
+    (metric) =>
+      `| ${metric.name} | ${metric.runs} | ${format(metric.p50)} | ${format(metric.p95)} | ${format(metric.mean)} | ${format(metric.min)} | ${format(metric.max)} |`,
+  );
+
+  return [
+    "# Benchmark Summary",
+    "",
+    "The CI gate compares the p50 column through github-action-benchmark. Tail latency remains visible in p95.",
+    "",
+    "| Benchmark | Runs | p50 ns/op | p95 ns/op | mean ns/op | min ns/op | max ns/op |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+function format(value: number): string {
+  return Math.round(value).toLocaleString("en-US");
+}


### PR DESCRIPTION
## Summary
- run package benchmarks repeatedly in CI instead of taking a single sample
- summarize repeated run values into p50/p95/min/max/mean artifacts
- keep github-action-benchmark gate on p50 values while publishing p95 tail latency in the job summary
- add workflow_dispatch so main baseline can be refreshed intentionally

## Verification
- `BENCHMARK_RUNS=2` local smoke ran session/agent/openomni benchmarks twice and produced `combined.json`, `statistics.json`, and `summary.md`
- `bun run script/summarize-benchmark-runs.ts` fixture smoke
- `bunx tsc --noEmit --skipLibCheck --types bun --module ESNext --moduleResolution Bundler --target ES2022 script/summarize-benchmark-runs.ts`
- `bunx biome check .github/workflows/benchmark.yml script/summarize-benchmark-runs.ts`
- `bun run lint:guards`
- pre-push `turbo run check-types`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the CI benchmark gate by running package benchmarks multiple times and gating on p50 for less noise, while surfacing p95 tail latency in the job summary. Adds a manual `workflow_dispatch` to refresh the `main` baseline and control run count.

- **New Features**
  - Run `session`, `agent`, and `openomni` benchmarks multiple times (default 5) and collect per-run JSONs.
  - Add `script/summarize-benchmark-runs.ts` to compute p50/p95/min/max/mean; outputs `bench-results/combined.json` (p50 for `github-action-benchmark`), `bench-results/statistics.json`, and `bench-results/summary.md` (posted to `$GITHUB_STEP_SUMMARY`).
  - Enable `workflow_dispatch` to refresh the `main` baseline and set run count; update `gh-pages` bootstrap and `auto-push` to allow manual publish from `main`.

<sup>Written for commit 631b87888a2e7b638b95e04371f2ca273dfc8ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

