### PR TITLE
refactor(openomni): split subagent runtime internals

### DIFF
--- a/packages/openomni/src/subagent/AGENTS.md
+++ b/packages/openomni/src/subagent/AGENTS.md
@@ -13,6 +13,9 @@ Session-backed subagent execution runtime for the openomni orchestration layer.
 | `shared.ts` | `RuntimeModel`, `RuntimeMessage` types and message factory helpers (parameterized agent field) | no |
 | `message-builder.ts` | Message construction and serialization for subagent communication | no |
 | `run-lifecycle.ts` | Abort, timeout, and finalize functions for `WorkerRun` lifecycle | no |
+| `runtime-admission.ts` | Parent-scoped delegation admission, child runtime policy summary, and child-run middleware assembly | no |
+| `runtime-cancel.ts` | Cancel orchestration for active or explicit worker runs | no |
+| `runtime-wait.ts` | Event-driven wait orchestration and `WorkerRun` output projection | no |
 | `transcript.ts` | Compaction bridge and `runWithTranscript` (imports from `@openomni/agent` barrel, no relative cross-package imports) | no |
 | `session-mailbox.ts` | Mailbox abstraction for queued message delivery to a session | no |
 | `abort-registry.ts` | Global registry mapping run IDs to abort controllers | no |
@@ -21,7 +24,7 @@ Session-backed subagent execution runtime for the openomni orchestration layer.
 
 `runtime.ts` was refactored from ~1094 LOC into focused modules. The split follows single-responsibility: each internal module owns one concern (types, message construction, lifecycle, transcript, mailbox delivery). Only runtime-facing classes and middleware are re-exported from `index.ts`; the rest are internal implementation details.
 
-Internal modules (`background-store.ts`, `shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `transcript.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
+Internal modules (`background-store.ts`, `shared.ts`, `message-builder.ts`, `run-lifecycle.ts`, `runtime-admission.ts`, `runtime-cancel.ts`, `runtime-wait.ts`, `transcript.ts`, `session-mailbox.ts`, `abort-registry.ts`) are not exported from the barrel. Import them only from within this domain.
 
 ## Dependencies
 

--- a/packages/openomni/src/subagent/runtime-admission.ts
+++ b/packages/openomni/src/subagent/runtime-admission.ts
@@ -1,0 +1,231 @@
+import {
+  PolicyEngine,
+  createToolPermissionPolicy,
+  type PolicyContext,
+  type PolicyRegistration,
+} from "@openomni/agent";
+import { Policy, PolicyDecision, type RuntimeResource } from "@openomni/protocol";
+import {
+  buildAgentLifecycleMiddleware,
+  registrationsAbsentFrom,
+} from "../execution-runtime/middleware.js";
+import { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-policy.js";
+import type { RuntimeConfig } from "./transcript";
+
+const emptyDelegationUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+type ResourcePolicyContext = Omit<PolicyContext, "timing"> & {
+  readonly resourceDescriptor: RuntimeResource.Descriptor;
+};
+
+export type PreDelegationOperation = "spawn" | "spawn_background" | "send";
+
+interface ChildRuntimeAdmissionSummary {
+  readonly toolNames?: readonly string[];
+  readonly permissions?: Policy.Permission;
+  readonly childRuntimeMiddlewareNames?: readonly string[];
+  readonly hasExplicitRuntimePolicy: boolean;
+}
+
+type RuntimePolicyConfig = RuntimeConfig & { permissions?: Policy.Permission };
+type DelegationConstraintConfig = {
+  permissions?: Policy.Permission;
+  softTimeoutMs?: number;
+  hardTimeoutMs?: number;
+};
+
+export function hasExplicitRuntimePolicy(config: RuntimePolicyConfig): boolean {
+  return config.permissions !== undefined || config.childMiddleware !== undefined;
+}
+
+export function summarizeChildRuntimeAdmission(
+  config: RuntimePolicyConfig,
+): ChildRuntimeAdmissionSummary | undefined {
+  const toolNames = config.tools?.map((tool) => tool.name);
+  const permissions = config.admissionPermissions ?? config.permissions;
+  const childRuntimeMiddlewareNames = config.childMiddleware?.map(
+    (registration) => registration.name,
+  );
+  if (
+    toolNames === undefined &&
+    permissions === undefined &&
+    childRuntimeMiddlewareNames === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(toolNames !== undefined && { toolNames }),
+    ...(permissions !== undefined && { permissions }),
+    ...(childRuntimeMiddlewareNames !== undefined && { childRuntimeMiddlewareNames }),
+    hasExplicitRuntimePolicy: hasExplicitRuntimePolicy(config),
+  };
+}
+
+export async function dispatchPreDelegation(input: {
+  readonly middleware?: readonly PolicyRegistration[];
+  readonly childAgent: string;
+  readonly parentSessionId?: string;
+  readonly operation: PreDelegationOperation;
+  readonly prompt: string;
+  readonly childRuntime?: ChildRuntimeAdmissionSummary;
+}): Promise<Policy.PolicyDecision> {
+  if (!input.middleware?.length) {
+    return PolicyDecision.allow({
+      policyId: "subagent.delegation",
+      reasonCodes: ["no middleware registered"],
+    });
+  }
+
+  const traceContext = createDelegationTrace(input.parentSessionId);
+  const engine = PolicyEngine.create({
+    traceContext,
+    audit:
+      traceContext === undefined
+        ? false
+        : {
+            sessionId: traceContext.sessionId,
+            action: `delegation.${input.operation}`,
+            resource: `agent.${input.childAgent}`,
+          },
+  });
+  for (const reg of input.middleware) {
+    engine.register(reg);
+  }
+
+  const resourceDescriptor = createSubagentDescriptor(input.childAgent, input.operation);
+  const policyContext: ResourcePolicyContext = {
+    steps: [],
+    usage: emptyDelegationUsage,
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    toolName: "subagent",
+    toolLabels: resourceDescriptor.labels,
+    toolInput: {
+      operation: input.operation,
+      childAgent: input.childAgent,
+      prompt: input.prompt,
+      ...(input.parentSessionId !== undefined && { parentSessionId: input.parentSessionId }),
+      ...childRuntimeAdmissionFields(input.childRuntime),
+    },
+    labels: [
+      { value: `actor.child:${input.childAgent}`, source: "system" },
+      ...(input.parentSessionId !== undefined
+        ? [{ value: `actor.parent:${input.parentSessionId}`, source: "system" as const }]
+        : []),
+    ],
+    resourceDescriptor,
+    traceContext,
+  };
+
+  return engine.dispatch("invoke.prepare", policyContext);
+}
+
+export function applyPreDelegationDecision(
+  config: DelegationConstraintConfig,
+  decision: Policy.PolicyDecision,
+  fallbackReason: string,
+): void {
+  if (PolicyDecision.isBlocking(decision)) {
+    throw new Error(PolicyDecision.reason(decision, fallbackReason));
+  }
+  applyDelegationConstraints(config, decision);
+}
+
+export function buildChildRunMiddleware(
+  config: RuntimePolicyConfig,
+  hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config),
+): PolicyRegistration[] {
+  const childRuntimeMiddleware = SubagentSpawnPolicyMiddleware.buildChildRuntimeMiddleware({
+    middleware: config.childMiddleware,
+    hasExplicitRuntimePolicy: hasExplicitChildRuntimePolicy,
+  });
+  return [
+    ...registrationsAbsentFrom(buildAgentLifecycleMiddleware(undefined), childRuntimeMiddleware),
+    ...(config.permissions ? [createToolPermissionPolicy({ permission: config.permissions })] : []),
+    ...childRuntimeMiddleware,
+  ];
+}
+
+function childRuntimeAdmissionFields(
+  summary: ChildRuntimeAdmissionSummary | undefined,
+): Record<string, unknown> {
+  if (summary === undefined) return {};
+  return {
+    childRuntime: summary,
+    ...(summary.toolNames !== undefined && { childToolNames: summary.toolNames.join(",") }),
+    ...(summary.childRuntimeMiddlewareNames !== undefined && {
+      childRuntimeMiddlewareNames: summary.childRuntimeMiddlewareNames.join(","),
+    }),
+    childHasExplicitRuntimePolicy: String(summary.hasExplicitRuntimePolicy),
+  };
+}
+
+function createDelegationTrace(parentSessionId: string | undefined) {
+  if (parentSessionId === undefined) return undefined;
+  return { traceId: crypto.randomUUID(), sessionId: parentSessionId };
+}
+
+function createSubagentDescriptor(
+  childAgent: string,
+  operation: PreDelegationOperation,
+): RuntimeResource.Descriptor {
+  if (operation === "send") {
+    return {
+      id: "worker:agent:subagent_send",
+      kind: "worker",
+      source: { type: "agent", agentId: childAgent },
+      labels: ["source.agent", "delegation.subagent"],
+      capabilities: ["delegation.send"],
+      effects: ["session.message"],
+    };
+  }
+
+  if (operation === "spawn_background") {
+    return {
+      id: "worker:agent:background_launch",
+      kind: "worker",
+      source: { type: "agent", agentId: childAgent },
+      labels: ["source.agent", "delegation.background"],
+      capabilities: ["delegation.background"],
+      effects: ["session.create"],
+    };
+  }
+
+  return {
+    id: "worker:agent:subagent_spawn",
+    kind: "worker",
+    source: { type: "agent", agentId: childAgent },
+    labels: ["source.agent", "delegation.subagent"],
+    capabilities: ["delegation.spawn"],
+    effects: ["session.create"],
+  };
+}
+
+function applyDelegationConstraints(
+  config: DelegationConstraintConfig,
+  decision: Policy.PolicyDecision,
+): void {
+  const constraints = decision.effects
+    .filter(
+      (effect): effect is Extract<Policy.PolicyEffect, { type: "delegation.set_constraints" }> =>
+        effect.type === "delegation.set_constraints",
+    )
+    .at(-1)?.constraints;
+
+  if (!constraints) return;
+  const permissions = constraints.permissions;
+  if (permissions !== undefined) {
+    const parsed = Policy.Permission.safeParse(permissions);
+    if (!parsed.success) {
+      throw new Error("invoke.prepare policy returned invalid delegation constraints");
+    }
+    config.permissions = parsed.data;
+  }
+  if (typeof constraints.softTimeoutMs === "number")
+    config.softTimeoutMs = constraints.softTimeoutMs;
+  if (typeof constraints.hardTimeoutMs === "number")
+    config.hardTimeoutMs = constraints.hardTimeoutMs;
+}

--- a/packages/openomni/src/subagent/runtime-cancel.ts
+++ b/packages/openomni/src/subagent/runtime-cancel.ts
@@ -1,0 +1,80 @@
+import { PolicyDecision, Subagent } from "@openomni/protocol";
+import { WorkerRun } from "@openomni/session";
+import { get as getAbortEntry } from "./abort-registry";
+import { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-policy.js";
+import { isTerminalStatus, raceAbortCompletion } from "./run-lifecycle";
+import { publishEvent } from "./shared";
+
+export interface RuntimeCancelConfig {
+  readonly sessionId: string;
+  readonly runId?: string;
+  readonly hardTimeoutMs?: number;
+}
+
+export async function cancelRuntimeRun(config: RuntimeCancelConfig): Promise<void> {
+  const policy = await SubagentSpawnPolicyMiddleware.evaluatePreSpawn({
+    operation: "cancel",
+    sessionId: config.sessionId,
+    hardTimeoutMs: config.hardTimeoutMs,
+  });
+  if (PolicyDecision.isBlocking(policy.verdict)) return;
+  const session = policy.session;
+  if (!session) return;
+
+  const hardTimeoutMs = policy.cancelHardTimeoutMs;
+
+  if (config.runId) {
+    await cancelSpecificRun(config.sessionId, config.runId, hardTimeoutMs);
+    return;
+  }
+
+  await cancelActiveRun(config.sessionId, hardTimeoutMs);
+}
+
+async function cancelSpecificRun(
+  sessionId: string,
+  runId: string,
+  hardTimeoutMs: number,
+): Promise<void> {
+  const entry = getAbortEntry(sessionId, runId);
+  const hasInFlightOp = !!entry;
+
+  if (hasInFlightOp) {
+    entry.controller.abort();
+    await raceAbortCompletion(sessionId, runId, hardTimeoutMs);
+  } else {
+    const run = await WorkerRun.get(sessionId, runId);
+    if (run && !isTerminalStatus(run.status)) {
+      await WorkerRun.updateStatus(sessionId, runId, "cancelled", {
+        endedAt: Date.now(),
+      });
+    }
+  }
+
+  publishEvent(Subagent.Events.WorkerSessionCancelled, { sessionId, runId });
+}
+
+async function cancelActiveRun(sessionId: string, hardTimeoutMs: number): Promise<void> {
+  const runs = await WorkerRun.listBySession(sessionId);
+  const activeRun = runs.find((run) => run.status === "running" || run.status === "starting");
+  const abortEntry = activeRun ? getAbortEntry(sessionId, activeRun.runId) : undefined;
+
+  if (abortEntry) {
+    abortEntry.controller.abort();
+  }
+
+  if (activeRun) {
+    if (abortEntry) {
+      await raceAbortCompletion(sessionId, activeRun.runId, hardTimeoutMs);
+    } else {
+      await WorkerRun.updateStatus(sessionId, activeRun.runId, "cancelled", {
+        endedAt: Date.now(),
+      });
+    }
+  }
+
+  publishEvent(Subagent.Events.WorkerSessionCancelled, {
+    sessionId,
+    runId: activeRun?.runId,
+  });
+}

--- a/packages/openomni/src/subagent/runtime-wait.ts
+++ b/packages/openomni/src/subagent/runtime-wait.ts
@@ -1,0 +1,86 @@
+import { type Message, Subagent } from "@openomni/protocol";
+import { Bus, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
+import { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-policy.js";
+import { isTerminalStatus } from "./run-lifecycle";
+
+export interface RuntimeWaitConfig {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly timeoutMs?: number;
+}
+
+export interface RuntimeWaitResult {
+  readonly status: WorkerRunRecord["status"];
+  readonly output?: string;
+}
+
+export async function waitForRuntimeRun(config: RuntimeWaitConfig): Promise<RuntimeWaitResult> {
+  const policy = await SubagentSpawnPolicyMiddleware.runPreSpawn({
+    operation: "wait",
+    sessionId: config.sessionId,
+    timeoutMs: config.timeoutMs,
+  });
+  const run = await WorkerRun.get(config.sessionId, config.runId);
+  if (!run) {
+    throw new Error(`Worker run ${config.runId} not found in session ${config.sessionId}`);
+  }
+
+  if (isTerminalStatus(run.status)) {
+    return getWaitResult(run);
+  }
+
+  return new Promise<RuntimeWaitResult>((resolve, reject) => {
+    let settled = false;
+
+    const unsubscribeCompleted = Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
+      if (data.payload.sessionId === config.sessionId && data.payload.runId === config.runId) {
+        settle();
+      }
+    });
+
+    const unsubscribeFailed = Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
+      if (data.payload.sessionId === config.sessionId && data.payload.runId === config.runId) {
+        settle();
+      }
+    });
+
+    const timeoutHandle = SubagentSpawnPolicyMiddleware.enforceWaitTimeout(
+      policy.waitTimeoutMs,
+      () => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(new Error(`wait() timeout exceeded after ${config.timeoutMs}ms`));
+        }
+      },
+    );
+
+    function cleanup() {
+      unsubscribeCompleted();
+      unsubscribeFailed();
+      timeoutHandle?.cancel();
+    }
+
+    async function settle() {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      const finalRun = await WorkerRun.get(config.sessionId, config.runId);
+      if (finalRun) {
+        resolve(getWaitResult(finalRun));
+      } else {
+        reject(new Error(`Worker run ${config.runId} disappeared during wait`));
+      }
+    }
+  });
+}
+
+function getWaitResult(run: WorkerRunRecord): RuntimeWaitResult {
+  let output: string | undefined;
+  if (run.lastMessageId) {
+    const parts = Session.getParts(run.lastMessageId);
+    output = parts.find((part): part is Message.TextPart => part.type === "text")?.text;
+  }
+
+  return { status: run.status, output };
+}

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -1,31 +1,18 @@
-import {
-  PolicyEngine,
-  createToolPermissionPolicy,
-  type ChatAgent,
-  type PolicyContext,
-  type PolicyRegistration,
-} from "@openomni/agent";
-import {
-  PolicyDecision,
-  type Policy,
-  type Message,
-  Subagent,
-  type RuntimeResource,
-} from "@openomni/protocol";
-import { Bus, Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
-import {
-  buildAgentLifecycleMiddleware,
-  registrationsAbsentFrom,
-} from "../execution-runtime/middleware.js";
-import { get as getAbortEntry, register as registerAbortController } from "./abort-registry";
+import type { ChatAgent } from "@openomni/agent";
+import { PolicyDecision, type Policy, Subagent } from "@openomni/protocol";
+import { Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
+import { register as registerAbortController } from "./abort-registry";
 import { SubagentSpawnPolicyMiddleware } from "./middleware/subagent-spawn-policy.js";
 import {
-  buildAbortSignal,
-  executeRun,
-  isTerminalStatus,
-  raceAbortCompletion,
-  setupRunTimeouts,
-} from "./run-lifecycle";
+  applyPreDelegationDecision,
+  buildChildRunMiddleware,
+  dispatchPreDelegation,
+  hasExplicitRuntimePolicy,
+  summarizeChildRuntimeAdmission,
+} from "./runtime-admission";
+import { cancelRuntimeRun } from "./runtime-cancel";
+import { waitForRuntimeRun } from "./runtime-wait";
+import { buildAbortSignal, executeRun, setupRunTimeouts } from "./run-lifecycle";
 import { sendToMailbox } from "./session-mailbox.js";
 import {
   type RuntimeMessage,
@@ -41,219 +28,6 @@ import {
   maybeCompactSendTranscript,
   runWithTranscript,
 } from "./transcript";
-
-const emptyDelegationUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-
-type ResourcePolicyContext = Omit<PolicyContext, "timing"> & {
-  readonly resourceDescriptor: RuntimeResource.Descriptor;
-};
-
-type PreDelegationOperation = "spawn" | "spawn_background" | "send";
-
-interface ChildRuntimeAdmissionSummary {
-  readonly toolNames?: string[];
-  readonly permissions?: Policy.Permission;
-  readonly childRuntimeMiddlewareNames?: string[];
-  readonly hasExplicitRuntimePolicy: boolean;
-}
-
-function hasExplicitRuntimePolicy(config: RuntimeConfig & { permissions?: Policy.Permission }) {
-  return config.permissions !== undefined || config.childMiddleware !== undefined;
-}
-
-function summarizeChildRuntimeAdmission(
-  config: RuntimeConfig & { permissions?: Policy.Permission },
-): ChildRuntimeAdmissionSummary | undefined {
-  const toolNames = config.tools?.map((tool) => tool.name);
-  const permissions = config.admissionPermissions ?? config.permissions;
-  const childRuntimeMiddlewareNames = config.childMiddleware?.map(
-    (registration) => registration.name,
-  );
-  if (
-    toolNames === undefined &&
-    permissions === undefined &&
-    childRuntimeMiddlewareNames === undefined
-  ) {
-    return undefined;
-  }
-
-  return {
-    ...(toolNames !== undefined && { toolNames }),
-    ...(permissions !== undefined && { permissions }),
-    ...(childRuntimeMiddlewareNames !== undefined && { childRuntimeMiddlewareNames }),
-    hasExplicitRuntimePolicy: hasExplicitRuntimePolicy(config),
-  };
-}
-
-function childRuntimeAdmissionFields(
-  summary: ChildRuntimeAdmissionSummary | undefined,
-): Record<string, unknown> {
-  if (summary === undefined) return {};
-  return {
-    childRuntime: summary,
-    ...(summary.toolNames !== undefined && { childToolNames: summary.toolNames.join(",") }),
-    ...(summary.childRuntimeMiddlewareNames !== undefined && {
-      childRuntimeMiddlewareNames: summary.childRuntimeMiddlewareNames.join(","),
-    }),
-    childHasExplicitRuntimePolicy: String(summary.hasExplicitRuntimePolicy),
-  };
-}
-
-function createDelegationTrace(parentSessionId: string | undefined) {
-  if (parentSessionId === undefined) return undefined;
-  return { traceId: crypto.randomUUID(), sessionId: parentSessionId };
-}
-
-function createSubagentDescriptor(
-  childAgent: string,
-  operation: PreDelegationOperation,
-): RuntimeResource.Descriptor {
-  if (operation === "send") {
-    return {
-      id: "worker:agent:subagent_send",
-      kind: "worker",
-      source: { type: "agent", agentId: childAgent },
-      labels: ["source.agent", "delegation.subagent"],
-      capabilities: ["delegation.send"],
-      effects: ["session.message"],
-    };
-  }
-
-  if (operation === "spawn_background") {
-    return {
-      id: "worker:agent:background_launch",
-      kind: "worker",
-      source: { type: "agent", agentId: childAgent },
-      labels: ["source.agent", "delegation.background"],
-      capabilities: ["delegation.background"],
-      effects: ["session.create"],
-    };
-  }
-
-  return {
-    id: "worker:agent:subagent_spawn",
-    kind: "worker",
-    source: { type: "agent", agentId: childAgent },
-    labels: ["source.agent", "delegation.subagent"],
-    capabilities: ["delegation.spawn"],
-    effects: ["session.create"],
-  };
-}
-
-async function dispatchPreDelegation(input: {
-  middleware?: PolicyRegistration[];
-  childAgent: string;
-  parentSessionId?: string;
-  operation: PreDelegationOperation;
-  prompt: string;
-  childRuntime?: ChildRuntimeAdmissionSummary;
-}): Promise<Policy.PolicyDecision> {
-  if (!input.middleware?.length) {
-    return PolicyDecision.allow({
-      policyId: "subagent.delegation",
-      reasonCodes: ["no middleware registered"],
-    });
-  }
-
-  const traceContext = createDelegationTrace(input.parentSessionId);
-  const engine = PolicyEngine.create({
-    traceContext,
-    audit:
-      traceContext === undefined
-        ? false
-        : {
-            sessionId: traceContext.sessionId,
-            action: `delegation.${input.operation}`,
-            resource: `agent.${input.childAgent}`,
-          },
-  });
-  for (const reg of input.middleware) {
-    engine.register(reg);
-  }
-
-  const resourceDescriptor = createSubagentDescriptor(input.childAgent, input.operation);
-  const policyContext: ResourcePolicyContext = {
-    steps: [],
-    usage: emptyDelegationUsage,
-    turnCount: 0,
-    isCompletion: false,
-    continuationCount: 0,
-    elapsedMs: 0,
-    toolName: "subagent",
-    toolLabels: resourceDescriptor.labels,
-    toolInput: {
-      operation: input.operation,
-      childAgent: input.childAgent,
-      prompt: input.prompt,
-      ...(input.parentSessionId !== undefined && { parentSessionId: input.parentSessionId }),
-      ...childRuntimeAdmissionFields(input.childRuntime),
-    },
-    labels: [
-      { value: `actor.child:${input.childAgent}`, source: "system" as const },
-      ...(input.parentSessionId !== undefined
-        ? [{ value: `actor.parent:${input.parentSessionId}`, source: "system" as const }]
-        : []),
-    ],
-    resourceDescriptor,
-    traceContext,
-  };
-
-  return engine.dispatch("invoke.prepare", policyContext);
-}
-
-function applyDelegationConstraints(
-  config: { permissions?: Policy.Permission; softTimeoutMs?: number; hardTimeoutMs?: number },
-  decision: Policy.PolicyDecision,
-): void {
-  const constraints = decision.effects
-    .filter(
-      (effect): effect is Extract<Policy.PolicyEffect, { type: "delegation.set_constraints" }> =>
-        effect.type === "delegation.set_constraints",
-    )
-    .at(-1)?.constraints;
-
-  if (!constraints) return;
-  const permissions = constraints.permissions;
-  if (permissions && typeof permissions === "object" && "action" in permissions) {
-    config.permissions = permissions as Policy.Permission;
-  }
-  if (typeof constraints.softTimeoutMs === "number")
-    config.softTimeoutMs = constraints.softTimeoutMs;
-  if (typeof constraints.hardTimeoutMs === "number")
-    config.hardTimeoutMs = constraints.hardTimeoutMs;
-}
-
-function applyPreDelegationDecision(
-  config: { permissions?: Policy.Permission; softTimeoutMs?: number; hardTimeoutMs?: number },
-  decision: Policy.PolicyDecision,
-  fallbackReason: string,
-): void {
-  if (PolicyDecision.isBlocking(decision)) {
-    throw new Error(PolicyDecision.reason(decision, fallbackReason));
-  }
-  applyDelegationConstraints(config, decision);
-}
-
-function buildChildRunMiddleware(
-  config: RuntimeConfig & { permissions?: Policy.Permission },
-  hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config),
-) {
-  // Used by spawn/send/resume for the child run itself. Delegation admission
-  // reads config.middleware separately when applicable, so parent-scoped
-  // policies are not reused as child runtime policies.
-  const childRuntimeMiddleware = SubagentSpawnPolicyMiddleware.buildChildRuntimeMiddleware({
-    middleware: config.childMiddleware,
-    hasExplicitRuntimePolicy: hasExplicitChildRuntimePolicy,
-  });
-  return [
-    ...registrationsAbsentFrom(buildAgentLifecycleMiddleware(undefined), childRuntimeMiddleware),
-    // Subagent run middleware preserves the prior child-run defaults:
-    // budget lifecycle + permission constraints only. Send transcript compaction
-    // is handled separately before resume; idle nudge is worker-runtime owned.
-    ...(config.permissions ? [createToolPermissionPolicy({ permission: config.permissions })] : []),
-    ...childRuntimeMiddleware,
-  ];
-}
 
 export namespace SubagentRuntime {
   export interface SpawnConfig extends RuntimeConfig {
@@ -297,11 +71,7 @@ export namespace SubagentRuntime {
   }
 
   export interface WaitResult {
-    status: Awaited<ReturnType<typeof WorkerRun.get>> extends infer T
-      ? T extends { status: infer S }
-        ? S
-        : never
-      : never;
+    status: WorkerRunRecord["status"];
     output?: string;
   }
 
@@ -500,137 +270,11 @@ export namespace SubagentRuntime {
   }
 
   export async function cancel(config: CancelConfig): Promise<void> {
-    const policy = await SubagentSpawnPolicyMiddleware.evaluatePreSpawn({
-      operation: "cancel",
-      sessionId: config.sessionId,
-      hardTimeoutMs: config.hardTimeoutMs,
-    });
-    if (PolicyDecision.isBlocking(policy.verdict)) return;
-    const session = policy.session;
-    if (!session) return;
-
-    const hardTimeoutMs = policy.cancelHardTimeoutMs;
-
-    if (config.runId) {
-      const entry = getAbortEntry(config.sessionId, config.runId);
-      const hasInFlightOp = !!entry;
-
-      if (hasInFlightOp) {
-        entry.controller.abort();
-        await raceAbortCompletion(config.sessionId, config.runId, hardTimeoutMs);
-      } else {
-        const run = await WorkerRun.get(config.sessionId, config.runId);
-        if (run && !isTerminalStatus(run.status)) {
-          await WorkerRun.updateStatus(config.sessionId, config.runId, "cancelled", {
-            endedAt: Date.now(),
-          });
-        }
-      }
-
-      publishEvent(Subagent.Events.WorkerSessionCancelled, {
-        sessionId: config.sessionId,
-        runId: config.runId,
-      });
-      return;
-    }
-
-    const runs = await WorkerRun.listBySession(config.sessionId);
-    const activeRun = runs.find((r) => r.status === "running" || r.status === "starting");
-    const abortEntry = activeRun ? getAbortEntry(config.sessionId, activeRun.runId) : undefined;
-
-    if (abortEntry) {
-      abortEntry.controller.abort();
-    }
-
-    if (activeRun) {
-      if (abortEntry) {
-        await raceAbortCompletion(config.sessionId, activeRun.runId, hardTimeoutMs);
-      } else {
-        await WorkerRun.updateStatus(config.sessionId, activeRun.runId, "cancelled", {
-          endedAt: Date.now(),
-        });
-      }
-    }
-
-    publishEvent(Subagent.Events.WorkerSessionCancelled, {
-      sessionId: config.sessionId,
-      runId: activeRun?.runId,
-    });
+    return cancelRuntimeRun(config);
   }
 
   export async function wait(config: WaitConfig): Promise<WaitResult> {
-    const policy = await SubagentSpawnPolicyMiddleware.runPreSpawn({
-      operation: "wait",
-      sessionId: config.sessionId,
-      timeoutMs: config.timeoutMs,
-    });
-    const run = await WorkerRun.get(config.sessionId, config.runId);
-    if (!run) {
-      throw new Error(`Worker run ${config.runId} not found in session ${config.sessionId}`);
-    }
-
-    const terminalStatuses = ["succeeded", "failed", "cancelled", "interrupted"] as const;
-    if (terminalStatuses.includes(run.status as (typeof terminalStatuses)[number])) {
-      return getWaitResult(run);
-    }
-
-    return new Promise<WaitResult>((resolve, reject) => {
-      let settled = false;
-
-      const unsubscribeCompleted = Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
-        if (data.payload.sessionId === config.sessionId && data.payload.runId === config.runId) {
-          settle();
-        }
-      });
-
-      const unsubscribeFailed = Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
-        if (data.payload.sessionId === config.sessionId && data.payload.runId === config.runId) {
-          settle();
-        }
-      });
-
-      const timeoutHandle = SubagentSpawnPolicyMiddleware.enforceWaitTimeout(
-        policy.waitTimeoutMs,
-        () => {
-          if (!settled) {
-            settled = true;
-            cleanup();
-            reject(new Error(`wait() timeout exceeded after ${config.timeoutMs}ms`));
-          }
-        },
-      );
-
-      function cleanup() {
-        unsubscribeCompleted();
-        unsubscribeFailed();
-        timeoutHandle?.cancel();
-      }
-
-      async function settle() {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        const finalRun = await WorkerRun.get(config.sessionId, config.runId);
-        if (finalRun) {
-          resolve(getWaitResult(finalRun));
-        } else {
-          reject(new Error(`Worker run ${config.runId} disappeared during wait`));
-        }
-      }
-    });
-  }
-
-  function getWaitResult(run: WorkerRunRecord): WaitResult {
-    let output: string | undefined;
-    if (run.lastMessageId) {
-      const parts = Session.getParts(run.lastMessageId);
-      output = parts.find((part): part is Message.TextPart => part.type === "text")?.text;
-    }
-
-    return {
-      status: run.status,
-      output,
-    };
+    return waitForRuntimeRun(config);
   }
 
   export function buildChildMessages(sessionId: string, repair?: boolean): RuntimeMessage[] {

--- a/packages/openomni/test/subagent/runtime.test.ts
+++ b/packages/openomni/test/subagent/runtime.test.ts
@@ -444,7 +444,8 @@ describe("SubagentRuntime", () => {
         middleware: [admissionOnlyPolicy],
       });
 
-      const childRuntimeMiddleware = createSpy.mock.calls[0]?.[0].middleware ?? [];
+      const childRuntimeMiddleware: PolicyRegistration[] =
+        createSpy.mock.calls[0]?.[0].middleware ?? [];
       expect(childRuntimeMiddleware.map((registration) => registration.name)).toContain(
         "subagent:default-denylist",
       );
@@ -491,10 +492,44 @@ describe("SubagentRuntime", () => {
       expect(config.softTimeoutMs).toBe(5000);
       expect(config.hardTimeoutMs).toBe(10000);
       expect(config.permissions).toEqual({ action: "tool.call", allowlist: ["read"] });
-      const childRuntimeMiddleware = createSpy.mock.calls[0]?.[0].middleware ?? [];
+      const childRuntimeMiddleware: PolicyRegistration[] =
+        createSpy.mock.calls[0]?.[0].middleware ?? [];
       expect(childRuntimeMiddleware.map((registration) => registration.name)).toContain(
         "subagent:default-denylist",
       );
+    });
+
+    it("spawn fails closed when invoke.prepare returns invalid permission constraints", async () => {
+      const invalidConstraintPolicy: PolicyRegistration = {
+        name: "test:invalid-constraint",
+        timing: "invoke.prepare",
+        priority: 0,
+        fn: () =>
+          PolicyDecision.allow({
+            policyId: "test:invalid-constraint",
+            effects: [
+              {
+                type: "delegation.set_constraints",
+                constraints: {
+                  permissions: { action: "tool.call", allowlist: [123] },
+                },
+              },
+            ],
+          }),
+      };
+
+      const error = await SubagentRuntime.spawn({
+        agentName: "worker",
+        title: "invalid constraint task",
+        prompt: "should not run",
+        model,
+        middleware: [invalidConstraintPolicy],
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      if (!(error instanceof Error)) throw new Error("expected invalid constraints to throw");
+      expect(error.message).toBe("invoke.prepare policy returned invalid delegation constraints");
+      expect(runCalls).toHaveLength(0);
     });
 
     it("invoke.prepare receives parent/child agent labels", async () => {


### PR DESCRIPTION
## Summary
- split SubagentRuntime admission, cancel, and wait internals into focused internal modules
- keep the public SubagentRuntime namespace and subagent barrel exports unchanged
- add a regression test that invalid delegation permission constraints fail closed before a child run starts

## Verification
- bunx biome check packages/openomni/src/subagent/runtime.ts packages/openomni/src/subagent/runtime-admission.ts packages/openomni/src/subagent/runtime-cancel.ts packages/openomni/src/subagent/runtime-wait.ts packages/openomni/test/subagent/runtime.test.ts
- bun run --cwd packages/openomni test test/subagent
- bun run --cwd packages/openomni check-types
- bun run lint:guards
- bun run check-types
- bun run build
- bun run --cwd packages/openomni test
- git diff --check
- LSP diagnostics on packages/openomni/src/subagent: 0 diagnostics
- independent ultrawork reviewer PASS after fail-closed fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `SubagentRuntime` internals into focused modules for admission, cancellation, and wait orchestration while keeping the public API unchanged. Adds strict validation so invalid delegation permission constraints fail closed before a child run starts.

- **Refactors**
  - Extracted logic into `runtime-admission.ts`, `runtime-cancel.ts`, and `runtime-wait.ts`; `runtime.ts` now delegates to these modules.
  - Kept `SubagentRuntime` namespace and subagent barrel exports unchanged.
  - Updated `AGENTS.md` to document the new modules.

- **Bug Fixes**
  - Validate `delegation.set_constraints.permissions` from `invoke.prepare` and throw on invalid schemas.
  - Added a regression test to ensure invalid constraints block spawning and no child run starts.

<sup>Written for commit eeac1482805788cff4dcffaf9c56c2606a457ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

