### PR TITLE
refactor(agent): keep effect record helpers internal

### DIFF
--- a/packages/agent/src/core/policy/effect-records.ts
+++ b/packages/agent/src/core/policy/effect-records.ts
@@ -38,7 +38,7 @@ export function stableHash(value: unknown): string {
   return stableStringify(value);
 }
 
-export function stableStringify(value: unknown): string {
+function stableStringify(value: unknown): string {
   if (value === undefined) return "undefined";
   if (value === null) return "null";
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
@@ -53,7 +53,7 @@ export function stableStringify(value: unknown): string {
   return `${typeof value}:${JSON.stringify(value)}`;
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 


### PR DESCRIPTION
## Summary
- remove exported status from file-local effect record helpers
- keep behavior and sibling-module exports unchanged
- reduce knip unused export surface for policy effect composition internals

## Verification
- bunx biome check packages/agent/src/core/policy/effect-records.ts
- bun run --cwd packages/agent test test/core/policy/conformance/composition.test.ts test/core/policy/effect-composition.test.ts
- bun run --cwd packages/agent check-types
- git diff --check
- LSP diagnostics on packages/agent/src/core/policy/effect-records.ts: no diagnostics
- reviewer PASS
- pre-push dep-check/type-check passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `stableStringify` and `isRecord` internal (non-exported) in `packages/agent/src/core/policy/effect-records.ts` to reduce the public surface. No behavior or external API changes; this tightens the policy effect composition internals and cuts unused exports.

<sup>Written for commit 508f78ae1db4c3eadcfe13d16acfbc857f560eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->