### PR TITLE
refactor(openomni): keep connector executor kind internal

### DIFF
--- a/packages/openomni/src/dispatch/handlers/connector-endpoint-worker.ts
+++ b/packages/openomni/src/dispatch/handlers/connector-endpoint-worker.ts
@@ -8,8 +8,7 @@ import {
 import { projectConnectorCompletion } from "./connector-completion-projector.js";
 import { createWorkerSpawnWorkItem, failWorkerSpawnExecutor } from "./worker-work-item.js";
 
-export const CONNECTOR_ENDPOINT_EXECUTOR_KIND =
-  "connector_endpoint" satisfies WorkItem.ExecutorKind;
+const CONNECTOR_ENDPOINT_EXECUTOR_KIND = "connector_endpoint" satisfies WorkItem.ExecutorKind;
 
 export interface ConnectorEndpointWorkerSpawnPayload {
   readonly prompt: string;


### PR DESCRIPTION
## Summary
- internalize the connector endpoint executor kind constant
- preserve connector endpoint worker spawn behavior and exported handler API

## Verification
- bunx biome check packages/openomni/src/dispatch/handlers/connector-endpoint-worker.ts
- bun run --cwd packages/openomni test test/dispatch/worker-spawn-connector-endpoint.test.ts test/dispatch/worker-spawn-connector-telemetry.test.ts
- bun run --cwd packages/openomni check-types
- git diff --check
- LSP diagnostics on changed file
- reviewer PASS/APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized the connector endpoint executor kind by removing the export of `CONNECTOR_ENDPOINT_EXECUTOR_KIND` in `packages/openomni/src/dispatch/handlers/connector-endpoint-worker.ts`. No behavior change; worker spawn logic and the public handler API remain the same.

<sup>Written for commit 69b6e6221818bc6e4c52266bde481c333b6c1b22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

