### PR TITLE
refactor(openomni): remove unused worker executor helper

### DIFF
--- a/packages/openomni/src/dispatch/handlers/worker-work-item.ts
+++ b/packages/openomni/src/dispatch/handlers/worker-work-item.ts
@@ -40,14 +40,6 @@ export async function createWorkerSpawnWorkItem(
   return workItem.hash;
 }
 
-export async function failUnsupportedWorkerExecutor(
-  workItemHash: string,
-  executorKind: WorkItem.ExecutorKind,
-): Promise<never> {
-  const reason = `worker.spawn executor ${executorKind} is not wired`;
-  return failWorkerSpawnExecutor(workItemHash, executorKind, reason);
-}
-
 export async function failWorkerSpawnExecutor(
   workItemHash: string,
   executorKind: WorkItem.ExecutorKind,


### PR DESCRIPTION
## Summary
- remove unused `failUnsupportedWorkerExecutor` helper
- keep worker spawn work item creation and connector failure handling unchanged

## Verification
- bunx biome check packages/openomni/src/dispatch/handlers/worker-work-item.ts
- bun run --cwd packages/openomni test test/dispatch/worker-spawn-connector-endpoint.test.ts test/dispatch/worker-spawn-connector-telemetry.test.ts
- bun run --cwd packages/openomni check-types
- git diff --check
- LSP diagnostics on changed file
- knip target filter for failUnsupportedWorkerExecutor/worker-work-item
- reviewer UNCONDITIONAL APPROVAL / PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `failUnsupportedWorkerExecutor` helper in `packages/openomni/src/dispatch/handlers/worker-work-item.ts` to clean up dead code. No runtime changes; worker spawn work item creation and executor failure handling continue to use `failWorkerSpawnExecutor`.

<sup>Written for commit 845f2966b1275646a2d8602a7ef7046b986d40bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

