### PR TITLE
refactor(agent): keep policy boundary type internal

### DIFF
--- a/packages/agent/src/core/policy/effect-composition-types.ts
+++ b/packages/agent/src/core/policy/effect-composition-types.ts
@@ -1,6 +1,6 @@
 import type { Policy } from "@openomni/protocol";
 
-export type Boundary = "pre" | "post";
+type Boundary = "pre" | "post";
 
 export interface OrderedDecision {
   readonly decision: Policy.PolicyDecision;


### PR DESCRIPTION
## Summary
- internalize the policy effect composition `Boundary` type alias
- preserve `Conflict.boundary` typing and all other policy composition exports

## Verification
- bunx biome check packages/agent/src/core/policy/effect-composition-types.ts
- bun run --cwd packages/agent test test/core/policy/conformance/composition.test.ts test/core/policy/effect-composition.test.ts
- bun run --cwd packages/agent check-types
- git diff --check
- LSP diagnostics on changed file
- knip target filter for Boundary/effect-composition-types
- reviewer PASS/APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the policy effect composition boundary type internal by removing its export. This trims the public API while keeping all existing exports and Conflict.boundary typing unchanged.

<sup>Written for commit 8c543a2bc51d019aad0045ed36ecc0078011a367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

