### PR TITLE
refactor(server): keep connector log path helper internal

### DIFF
--- a/apps/server/src/connector/log-path.ts
+++ b/apps/server/src/connector/log-path.ts
@@ -49,7 +49,7 @@ export function readConnectorLogSnapshot(
   return { path, mtimeMs: stats.mtimeMs, size: stats.size };
 }
 
-export function encodeWorktreeForClaudeProjects(workspace: string): string {
+function encodeWorktreeForClaudeProjects(workspace: string): string {
   return workspace.split("/").join("-").split("\\").join("-");
 }
 

--- a/apps/server/src/connector/log.ts
+++ b/apps/server/src/connector/log.ts
@@ -5,8 +5,6 @@ import { type ConnectorTemplateValues, redactConnectorCredentialValues } from ".
 import { newestConnectorGlobMatch, resolveConnectorLogPath } from "./log-path.js";
 import { aggregateConnectorLogUsage, buildConnectorLogEvent } from "./log-telemetry.js";
 
-export { encodeWorktreeForClaudeProjects } from "./log-path.js";
-
 type ExecutionArtifact = NonNullable<Execution.Result["artifacts"]>[number];
 type ExecutionLogEvent = NonNullable<Execution.Result["logEvents"]>[number];
 

--- a/apps/server/test/connector/process-driver.test.ts
+++ b/apps/server/test/connector/process-driver.test.ts
@@ -5,7 +5,7 @@ import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
 import { AppConnectorInstallationStore, Artifact, Storage, WorkItemStore } from "@openomni/session";
 import { z } from "zod";
 import { createWorkerDispatchHandlers } from "../../../../packages/openomni/src/dispatch/handlers/worker";
-import { encodeWorktreeForClaudeProjects } from "../../src/connector/log.js";
+import { resolveConnectorLogPath } from "../../src/connector/log-path.js";
 import { createConnectorEndpointProcessDriver } from "../../src/connector/process-driver.js";
 
 const tempRoots: string[] = [];
@@ -587,12 +587,14 @@ describe("createConnectorEndpointProcessDriver", () => {
     // Given
     const workspaceRoot = tempDir("connector-runtime-log-glob-worktree");
     const homeRoot = tempDir("connector-runtime-log-glob-home");
-    const projectDir = join(
-      homeRoot,
-      ".claude",
-      "projects",
-      encodeWorktreeForClaudeProjects(workspaceRoot),
-    );
+    const previousHome = process.env.HOME;
+    process.env.HOME = homeRoot;
+    const projectDir = resolveConnectorLogPath("~/.claude/projects/{{workspaceHash}}", {
+      prompt: "ship it",
+      runId: "run_fake",
+      sessionId: "ses_fake",
+      worktree: workspaceRoot,
+    });
     mkdirSync(projectDir, { recursive: true });
     const olderLogPath = join(projectDir, "older.jsonl");
     const newerLogPath = join(projectDir, "newer.jsonl");
@@ -605,8 +607,6 @@ describe("createConnectorEndpointProcessDriver", () => {
     utimesSync(newerLogPath, new Date(1_700_000_010_000), new Date(1_700_000_010_000));
     const scriptPath = join(workspaceRoot, "fake-glob-log.ts");
     writeFileSync(scriptPath, "console.log('stdout should not be final');");
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeRoot;
     const definition = {
       ...fakeConnector("bun", [scriptPath], {}, { credentials: ["FAKE_API_KEY"] }),
       logs: {
@@ -896,12 +896,14 @@ describe("createConnectorEndpointProcessDriver", () => {
     // Given
     const workspaceRoot = tempDir("connector-runtime-glob-log-liveness-worktree");
     const homeRoot = tempDir("connector-runtime-glob-log-liveness-home");
-    const projectDir = join(
-      homeRoot,
-      ".claude",
-      "projects",
-      encodeWorktreeForClaudeProjects(workspaceRoot),
-    );
+    const previousHome = process.env.HOME;
+    process.env.HOME = homeRoot;
+    const projectDir = resolveConnectorLogPath("~/.claude/projects/{{workspaceHash}}", {
+      prompt: "ship it",
+      runId: "run_fake",
+      sessionId: "ses_fake",
+      worktree: workspaceRoot,
+    });
     mkdirSync(projectDir, { recursive: true });
     const logPath = join(projectDir, "session.jsonl");
     const scriptPath = join(workspaceRoot, "fake-glob-log-liveness.ts");
@@ -916,8 +918,6 @@ describe("createConnectorEndpointProcessDriver", () => {
         "}",
       ].join("\n"),
     );
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeRoot;
     const definition = {
       ...fakeConnector("bun", [scriptPath], {
         timeoutMs: 1_000,


### PR DESCRIPTION
## Summary
- keep `encodeWorktreeForClaudeProjects` file-local inside connector log path handling
- remove the leaked re-export from `connector/log`
- update process-driver tests to exercise the public `resolveConnectorLogPath` behavior for Claude-style project logs

## Verification
- `bun test test/connector/process-driver.test.ts` from `apps/server` (26 pass / 0 fail / 95 expects)
- `bunx biome check apps/server/src/connector/log-path.ts apps/server/src/connector/log.ts apps/server/test/connector/process-driver.test.ts`
- LSP diagnostics clean for touched files
- `bun run --cwd apps/server check-types`
- `bun run lint:guards`
- `git diff --check`
- `bun run check-types`
- `bun run build`
- `bunx knip` no longer reports `encodeWorktreeForClaudeProjects`; remaining findings are pre-existing/unrelated

## Review
- codex-ultrawork-reviewer: PASS/APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Claude worktree encoding helper private to the log-path module and shift tests to use the public `resolveConnectorLogPath` API. This tightens the server connector logging surface and stops leaking an internal utility.

- **Refactors**
  - Scoped `encodeWorktreeForClaudeProjects` to file-local in `apps/server/src/connector/log-path.ts`.
  - Removed its re-export from `apps/server/src/connector/log.ts`.
  - Updated process-driver tests to construct Claude-style paths via `resolveConnectorLogPath("~/.claude/projects/{{workspaceHash}}", ...)`.

<sup>Written for commit 04348116711ea8cc90e5ffdbfe82f0270817f2d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

