### PR TITLE
refactor(openomni): keep extension audit helpers internal

### DIFF
--- a/packages/openomni/src/extension/manager-types.ts
+++ b/packages/openomni/src/extension/manager-types.ts
@@ -16,13 +16,13 @@ export type ExtensionAction =
   | "extension.audit";
 
 export type AuditVisibility = "internal" | "llm_reason" | "user_audit";
-export type AuditOperationType =
+type AuditOperationType =
   | "action_requested"
   | "policy_evaluated"
   | "action_approved"
   | "action_blocked";
 
-export interface AuditBase {
+interface AuditBase {
   readonly actionId: string;
   readonly parentActionId?: string;
   readonly visibility: AuditVisibility;


### PR DESCRIPTION
## Summary
- keep `AuditOperationType` and `AuditBase` file-local inside extension manager types
- preserve the exported audit event and audit entry contracts
- remove two unused public type exports reported by knip

## Verification
- `bunx biome check packages/openomni/src/extension/manager-types.ts`
- `bun run --cwd packages/openomni check-types`
- `bun run --cwd packages/openomni build`
- `bun run build`
- `bun run check-types`
- `git diff --check`
- `bun run lint:guards`
- LSP diagnostics clean for `manager-types.ts`
- `bunx knip | rg "AuditOperationType|AuditBase|manager-types"` produced no target matches; remaining findings are unrelated

## Review
- codex-ultrawork-reviewer: PASS/APPROVE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalize extension audit helper types in `packages/openomni` to shrink the public API surface. Exported audit event and audit entry contracts are unchanged.

- **Refactors**
  - Made `AuditOperationType` and `AuditBase` file-local (non-exported) in `src/extension/manager-types.ts`, addressing `knip` unused-export findings.

<sup>Written for commit 76d61a9e7e95553f1fbd63ce11b2878ba6efa6e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed public exports for audit-related types. Code importing these types directly will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->