### PR TITLE
refactor(server): keep connector driver input internal

### DIFF
--- a/apps/server/src/connector/process-driver.ts
+++ b/apps/server/src/connector/process-driver.ts
@@ -12,7 +12,7 @@ import { applyConnectorReadBackBuilders } from "./read-back-builder.js";
 export type { ConnectorEndpointCredentialMap } from "./env.js";
 export type { ConnectorQuestionBridgeHandler } from "../../src/connector/question-bridge.js";
 
-export interface ConnectorEndpointProcessDriverInput {
+interface ConnectorEndpointProcessDriverInput {
   readonly command: Dispatch.Command;
   readonly executionRequest: Execution.Request;
   readonly installation: AppConnector.Installation;


### PR DESCRIPTION
## Summary
- keep `ConnectorEndpointProcessDriverInput` file-local instead of exporting an unused deep type
- preserve the public driver factory and dispatch interface behavior

## Verification
- `bunx biome check apps/server/src/connector/process-driver.ts`
- `bun run --cwd packages/protocol build`
- `bun test apps/server/test/connector/process-driver.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run build`
- `bun run check-types`
- `bun run lint:guards`
- LSP diagnostics on changed file
- `bunx knip | rg "ConnectorEndpointProcessDriverInput|process-driver" || true`

## Review
- Codex ultrawork reviewer approved; Claude Fable oracle was attempted but local CLI returned 404 for `claude-fable-5`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ConnectorEndpointProcessDriverInput` internal to `apps/server/src/connector/process-driver.ts` by removing its export, reducing the public surface area. Public driver factory and dispatch interfaces remain unchanged; no runtime behavior change.

<sup>Written for commit e9fff26d39b2a94d29530bf0351881cf7975b956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

