### PR TITLE
refactor(server): keep connector registry options internal

### DIFF
--- a/apps/server/src/connector/index.ts
+++ b/apps/server/src/connector/index.ts
@@ -14,11 +14,6 @@ export type {
   ServerConnectorDiscoveryOptions,
   ServerConnectorDiscoveryStatus,
 } from "./discovery.js";
-export type {
-  ServerConnectorConsentOptions,
-  ServerConnectorRegistrationOptions,
-  ServerConnectorSmokeVerifyOptions,
-} from "./registry.js";
 export type { ConnectorQuestionBridgeHandler };
 
 export interface ConnectorEndpointDriverOptions {

--- a/apps/server/src/connector/registry.ts
+++ b/apps/server/src/connector/registry.ts
@@ -8,11 +8,11 @@ const MAX_VERIFICATION_DIAGNOSTIC_LENGTH = 512;
 const sensitiveDiagnosticPattern =
   /\b([A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*)=([^\s]+)/gi;
 
-export interface ServerConnectorRegistrationOptions {
+interface ServerConnectorRegistrationOptions {
   readonly registeredBy: string;
 }
 
-export const ServerConnectorConsentOptions = z
+const ServerConnectorConsentOptions = z
   .object({
     grantedBy: z.string().min(1),
     credentials: z.array(z.string().min(1)).optional(),
@@ -20,9 +20,9 @@ export const ServerConnectorConsentOptions = z
     permissions: z.array(Policy.Permission).optional(),
   })
   .strict();
-export type ServerConnectorConsentOptions = z.infer<typeof ServerConnectorConsentOptions>;
+type ServerConnectorConsentOptions = z.infer<typeof ServerConnectorConsentOptions>;
 
-export interface ServerConnectorSmokeVerifyOptions {
+interface ServerConnectorSmokeVerifyOptions {
   readonly detectTimeoutMs?: number;
   readonly runDetectCommand?: DetectCommandRunner;
 }


### PR DESCRIPTION
## Summary
- keep connector registry option schemas/types file-local
- remove unused registry option type re-exports from the server connector barrel
- preserve `ServerConnectorRegistry` and its runtime behavior

## Verification
- `bunx biome check apps/server/src/connector/registry.ts apps/server/src/connector/index.ts`
- `bun run --cwd packages/protocol build`
- `bun test apps/server/test/connector/registry.test.ts apps/server/test/connector/registry-smoke-verify.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run build`
- `bun run check-types`
- `bun run lint:guards`
- LSP diagnostics on changed files
- target `bunx knip` check no longer reports the three registry option names

## Review
- Claude Fable oracle was attempted but local CLI returned 404 for `claude-fable-5`.
- Codex ultrawork reviewer approved and checked declaration emit/downstream compile probes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made connector registry option schemas and types internal to reduce the connector’s public API surface. Removed unused type re-exports; `ServerConnectorRegistry` and runtime behavior are unchanged.

- **Refactors**
  - Scoped `ServerConnectorConsentOptions`, `ServerConnectorRegistrationOptions`, and `ServerConnectorSmokeVerifyOptions` to `registry.ts` and removed their barrel re-exports.

<sup>Written for commit 5b9fd9b55e72270c240dc138a22ec796585acd73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

