### PR TITLE
refactor(server): keep connector discovery helpers internal

### DIFF
--- a/apps/server/src/connector/discovery.ts
+++ b/apps/server/src/connector/discovery.ts
@@ -9,13 +9,13 @@ type ConnectorVersion = {
 
 const DEFAULT_DETECT_TIMEOUT_MS = 10_000;
 
-export type ServerConnectorDiscoveryStatus =
+type ServerConnectorDiscoveryStatus =
   | "available"
   | "missing"
   | "unsupported_version"
   | "detect_failed";
 
-export interface DetectCommandResult {
+interface DetectCommandResult {
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
@@ -31,7 +31,7 @@ export interface DiscoveryCandidate {
   readonly diagnostic?: string;
 }
 
-export interface ServerConnectorDiscoveryOptions {
+interface ServerConnectorDiscoveryOptions {
   readonly connectors?: readonly AppConnector.Definition[];
   readonly detectTimeoutMs?: number;
   readonly runDetectCommand?: DetectCommandRunner;

--- a/apps/server/src/connector/index.ts
+++ b/apps/server/src/connector/index.ts
@@ -8,11 +8,8 @@ export { ServerConnectorDefinitions } from "./definitions.js";
 export { ServerConnectorDiscovery } from "./discovery.js";
 export { ServerConnectorRegistry } from "./registry.js";
 export type {
-  DetectCommandResult,
   DetectCommandRunner,
   DiscoveryCandidate,
-  ServerConnectorDiscoveryOptions,
-  ServerConnectorDiscoveryStatus,
 } from "./discovery.js";
 export type { ConnectorQuestionBridgeHandler };
 


### PR DESCRIPTION
## Summary
- keep discovery helper status/result/options types file-local
- remove unused discovery helper type re-exports from the server connector barrel
- preserve `ServerConnectorDiscovery`, `DiscoveryCandidate`, and `DetectCommandRunner` exports

## Verification
- `bunx biome check apps/server/src/connector/discovery.ts apps/server/src/connector/index.ts`
- `bun run --cwd packages/protocol build`
- `bun test apps/server/test/connector/discovery.test.ts apps/server/test/connector/registry.test.ts apps/server/test/connector/registry-lifecycle.test.ts apps/server/test/connector/registry-smoke-verify.test.ts`
- `bun run --cwd apps/server check-types`
- `bun run build`
- `bun run check-types`
- `bun run lint:guards`
- LSP diagnostics on changed files
- target `bunx knip` check no longer reports the three removed discovery names

## Review
- Claude Fable oracle was attempted but local CLI returned 404 for `claude-fable-5`.
- Codex ultrawork reviewer approved and checked declaration emit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalizes connector discovery helper types and trims the server connector barrel to reduce the public API surface. Keeps `ServerConnectorDiscovery`, `DiscoveryCandidate`, and `DetectCommandRunner` available; no runtime behavior changes.

- **Refactors**
  - Scoped `ServerConnectorDiscoveryStatus`, `DetectCommandResult`, and `ServerConnectorDiscoveryOptions` to `discovery.ts`.
  - Removed their re-exports from `apps/server/src/connector/index.ts`; retained `DetectCommandRunner` and `DiscoveryCandidate`.

<sup>Written for commit 928674986a507192bfe114be538b67783071980b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

