### PR TITLE
refactor(server): trim connector discovery barrel types

### DIFF
--- a/apps/server/src/connector/index.ts
+++ b/apps/server/src/connector/index.ts
@@ -7,10 +7,6 @@ import {
 export { ServerConnectorDefinitions } from "./definitions.js";
 export { ServerConnectorDiscovery } from "./discovery.js";
 export { ServerConnectorRegistry } from "./registry.js";
-export type {
-  DetectCommandRunner,
-  DiscoveryCandidate,
-} from "./discovery.js";
 export type { ConnectorQuestionBridgeHandler };
 
 export interface ConnectorEndpointDriverOptions {


### PR DESCRIPTION
## Summary
- remove unused DetectCommandRunner and DiscoveryCandidate type re-exports from the server connector barrel
- keep the direct discovery.ts exports intact for internal registry/discovery imports

## Verification
- bunx biome check apps/server/src/connector/index.ts
- bun run --cwd packages/protocol build
- bun run --cwd apps/server check-types
- bun test apps/server/test/connector
- bun run build
- bun run check-types
- bun run lint:guards
- bunx knip | rg "DetectCommandRunner|DiscoveryCandidate|connector/index.ts" || true
- git diff --check
- LSP diagnostics clean for apps/server/src/connector/index.ts
- Codex ultrawork reviewer 019ec7ea-b168-7963-b3b2-5096c95211aa: APPROVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `DetectCommandRunner` and `DiscoveryCandidate` type re-exports from the server connector barrel to reduce the public API surface and prevent ambiguous imports. These types remain exported from `discovery.ts`; import them directly where needed.

<sup>Written for commit e2aad0eb86afdd507ac4b240fc4e4c8a5919103b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

