### PR TITLE
refactor(server): trim connector barrel values

### DIFF
--- a/apps/server/src/connector/index.ts
+++ b/apps/server/src/connector/index.ts
@@ -4,9 +4,6 @@ import {
   type ConnectorQuestionBridgeHandler,
 } from "./process-driver.js";
 
-export { ServerConnectorDefinitions } from "./definitions.js";
-export { ServerConnectorDiscovery } from "./discovery.js";
-export { ServerConnectorRegistry } from "./registry.js";
 export type { ConnectorQuestionBridgeHandler };
 
 export interface ConnectorEndpointDriverOptions {

--- a/apps/server/test/connector/definitions.test.ts
+++ b/apps/server/test/connector/definitions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { AppConnector } from "@openomni/protocol";
-import { ServerConnectorDefinitions } from "../../src/connector/index.js";
+import { ServerConnectorDefinitions } from "../../src/connector/definitions.js";
 
 describe("ServerConnectorDefinitions", () => {
   test("lists the server-owned connector endpoint definitions", () => {

--- a/apps/server/test/connector/discovery.test.ts
+++ b/apps/server/test/connector/discovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AppConnector } from "@openomni/protocol";
-import { ServerConnectorDiscovery } from "../../src/connector/index.js";
+import { ServerConnectorDiscovery } from "../../src/connector/discovery.js";
 
 describe("ServerConnectorDiscovery", () => {
   test("discovers installed server connector candidates from detect commands", async () => {

--- a/apps/server/test/connector/registry-lifecycle.test.ts
+++ b/apps/server/test/connector/registry-lifecycle.test.ts
@@ -3,11 +3,9 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SqliteStorageAdapter, Storage } from "@openomni/session";
-import {
-  ServerConnectorDiscovery,
-  ServerConnectorRegistry,
-  ServerConnectorDefinitions,
-} from "../../src/connector/index.js";
+import { ServerConnectorDefinitions } from "../../src/connector/definitions.js";
+import { ServerConnectorDiscovery } from "../../src/connector/discovery.js";
+import { ServerConnectorRegistry } from "../../src/connector/registry.js";
 
 async function registerCodexInstallation(): Promise<string> {
   const connector = ServerConnectorDefinitions.get("app.codex");

--- a/apps/server/test/connector/registry-smoke-verify.test.ts
+++ b/apps/server/test/connector/registry-smoke-verify.test.ts
@@ -9,11 +9,9 @@ import {
   SqliteStorageAdapter,
   Storage,
 } from "@openomni/session";
-import {
-  ServerConnectorDiscovery,
-  ServerConnectorRegistry,
-  ServerConnectorDefinitions,
-} from "../../src/connector/index.js";
+import { ServerConnectorDefinitions } from "../../src/connector/definitions.js";
+import { ServerConnectorDiscovery } from "../../src/connector/discovery.js";
+import { ServerConnectorRegistry } from "../../src/connector/registry.js";
 
 async function availableCodexCandidate(): Promise<AppConnector.Definition> {
   const connector = ServerConnectorDefinitions.get("app.codex");

--- a/apps/server/test/connector/registry.test.ts
+++ b/apps/server/test/connector/registry.test.ts
@@ -3,11 +3,9 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SqliteStorageAdapter, Storage } from "@openomni/session";
-import {
-  ServerConnectorDiscovery,
-  ServerConnectorRegistry,
-  ServerConnectorDefinitions,
-} from "../../src/connector/index.js";
+import { ServerConnectorDefinitions } from "../../src/connector/definitions.js";
+import { ServerConnectorDiscovery } from "../../src/connector/discovery.js";
+import { ServerConnectorRegistry } from "../../src/connector/registry.js";
 
 describe("ServerConnectorRegistry", () => {
   let tmpDir: string;


### PR DESCRIPTION
## Summary
- remove unused ServerConnectorDefinitions, ServerConnectorDiscovery, and ServerConnectorRegistry value re-exports from the server connector barrel
- update connector tests to import those namespaces from their owning modules directly
- keep createConnectorEndpointDriver and connector driver types exported from the barrel

## Verification
- bunx biome check changed files
- bun run --cwd packages/protocol build
- bun run --cwd apps/server check-types
- bun test apps/server/test/connector
- bun run build
- bun run check-types
- bun run lint:guards
- git diff --check
- LSP diagnostics clean for changed files
- bunx knip | rg "ServerConnectorDefinitions|ServerConnectorDiscovery|ServerConnectorRegistry|connector/index.ts" || true
- Codex ultrawork reviewer 019ec7f4-2926-7732-bb25-01450ce9329c: APPROVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the server connector barrel to remove unused value re-exports and keep only the endpoint driver APIs. Tests now import `ServerConnectorDefinitions`, `ServerConnectorDiscovery`, and `ServerConnectorRegistry` directly from their modules.

- **Refactors**
  - Stopped re-exporting `ServerConnectorDefinitions`, `ServerConnectorDiscovery`, and `ServerConnectorRegistry` from `apps/server/src/connector/index.ts`.
  - Updated connector tests to import from `../../src/connector/definitions.js`, `discovery.js`, and `registry.js`.
  - Result: smaller public surface and clearer module boundaries.

<sup>Written for commit 1f247e80808c74f56c2e17fd5ef50de13023372f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

