### PR TITLE
refactor(tooling): configure knip workspaces

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://unpkg.com/knip/schema.json",
+  "ignoreBinaries": ["lefthook", "tsc", "turbo"],
+  "ignoreDependencies": ["@biomejs/biome", "@commitlint/cli", "lefthook", "turbo"],
+  "workspaces": {
+    ".": {
+      "entry": [
+        "package.json",
+        "script/**/*.ts",
+        "biome.json",
+        "lefthook.yml",
+        "commitlint.config.*"
+      ],
+      "project": ["script/**/*.ts", "*.json", "*.jsonc", "*.yml", "*.yaml"]
+    },
+    "apps/server": {
+      "entry": ["src/index.ts", "test/**/*.test.ts", "test/e2e/*.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
+    },
+    "packages/coordinator": {
+      "entry": ["src/index.ts", "test/**/*.test.ts", "test/harness/*.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
+    },
+    "packages/protocol": {
+      "entry": ["src/index.ts", "test/**/*.test.ts", "test/**/*.d.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts", "test/**/*.d.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a root Knip config for workspace-aware entry/project patterns
- include server/coordinator/protocol test surfaces so test files are not reported as unused
- ignore package-manager/tooling-only dependency and binary noise while preserving namespace-member findings

## Verification
- bunx biome check knip.json
- git diff --cached --check
- bunx knip --no-config-hints (now reports only unused exported namespace members)
- bun run lint:guards
- bun run check-types
- bun run build

## Notes
Knip still exits non-zero because real unused exported namespace member findings remain. This PR only removes false-positive file/dependency/binary noise so the next cleanup slices can target those findings directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure a root `knip` workspace to make unused-code checks workspace-aware and include tests. This removes false positives from tooling and tests, leaving only real unused namespace member findings.

- **Refactors**
  - Add `knip.json` with workspace entries for `.`, `apps/server`, `packages/coordinator`, and `packages/protocol` (entry and project patterns).
  - Include test surfaces (unit, e2e, harness, and `.d.ts`) so tests aren’t flagged as unused.
  - Ignore tooling-only deps and binaries: `@biomejs/biome`, `@commitlint/cli`, `lefthook`, `turbo`, `tsc`.

<sup>Written for commit 549798bcae73148d59abac8b06dc9ce720ed07de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

