### PR TITLE
refactor(protocol): keep policy helpers internal

### DIFF
--- a/packages/protocol/src/policy/decision.ts
+++ b/packages/protocol/src/policy/decision.ts
@@ -1,20 +1,20 @@
 import type { PolicyEffects } from "./effects.js";
 import type { PolicyPermission } from "./permission.js";
 
-export namespace PolicyDecisionHelpers {
-  export interface Options {
-    readonly policyId: string;
-    readonly effects?: PolicyEffects.PolicyEffect[];
-    readonly reasonCodes?: string[];
-    readonly obligations?: PolicyEffects.PolicyObligation[];
-    readonly factsUsed?: string[];
-    readonly durationMs?: number;
-    readonly priority?: number;
-  }
+interface PolicyDecisionOptions {
+  readonly policyId: string;
+  readonly effects?: PolicyEffects.PolicyEffect[];
+  readonly reasonCodes?: string[];
+  readonly obligations?: PolicyEffects.PolicyObligation[];
+  readonly factsUsed?: string[];
+  readonly durationMs?: number;
+  readonly priority?: number;
+}
 
+export namespace PolicyDecisionHelpers {
   function create(
     verdict: PolicyEffects.PolicyDecision["verdict"],
-    options: Options,
+    options: PolicyDecisionOptions,
   ): PolicyEffects.PolicyDecision {
     return {
       policyId: options.policyId,
@@ -28,15 +28,15 @@ export namespace PolicyDecisionHelpers {
     };
   }
 
-  export function allow(options: Options): PolicyEffects.PolicyDecision {
+  export function allow(options: PolicyDecisionOptions): PolicyEffects.PolicyDecision {
     return create("allow", options);
   }
 
-  export function deny(options: Options): PolicyEffects.PolicyDecision {
+  export function deny(options: PolicyDecisionOptions): PolicyEffects.PolicyDecision {
     return create("deny", options);
   }
 
-  export function pending(options: Options): PolicyEffects.PolicyDecision {
+  export function pending(options: PolicyDecisionOptions): PolicyEffects.PolicyDecision {
     return create("pending", options);
   }
 

--- a/packages/protocol/src/policy/point-contract.ts
+++ b/packages/protocol/src/policy/point-contract.ts
@@ -5,15 +5,10 @@ import { PolicyEffects } from "./effects.js";
 export namespace PolicyPointContractModule {
   export const Timing = PolicyDefinition.Timing;
   export type Timing = PolicyDefinition.Timing;
-  export const FailPolicy = PolicyDefinition.FailPolicy;
-  export const PolicyEffectType = PolicyEffects.PolicyEffectType;
-  export type PolicyEffectType = PolicyEffects.PolicyEffectType;
+  const FailPolicy = PolicyDefinition.FailPolicy;
+  const PolicyEffectType = PolicyEffects.PolicyEffectType;
+  type PolicyEffectType = PolicyEffects.PolicyEffectType;
   const TimingValue = z.nativeEnum(Timing);
-
-  export type PolicyPointResolver = (
-    timing: Timing,
-    context?: { resourceKind?: string },
-  ) => string[];
 
   const policyPointIds = [
     "session.inbound.pre",

--- a/packages/protocol/src/policy/policy-point.ts
+++ b/packages/protocol/src/policy/policy-point.ts
@@ -3,9 +3,12 @@ import { PolicyPointContractModule } from "./point-contract.js";
 import { PolicyPointRegistryModule } from "./point-registry.js";
 import { policyKernelVersion } from "./version.js";
 
-export namespace PolicyPointModule {
-  export type PolicyPointResolver = PolicyPointContractModule.PolicyPointResolver;
+type PolicyPointResolver = (
+  timing: PolicyPointContractModule.Timing,
+  context?: { readonly resourceKind?: string },
+) => string[];
 
+export namespace PolicyPointModule {
   const resolvePolicyPoints: PolicyPointResolver = (timing, context) => {
     const pointIds = PolicyPointRegistryModule.policyPointMigrationMapping[timing];
     const resourceKind = context?.resourceKind;


### PR DESCRIPTION
## Summary
- keep policy decision helper options module-local instead of exporting an unused namespace member
- keep policy point fail-policy/effect-type aliases and resolver type internal
- preserve the root `Policy` and `PolicyDecision` public API

## Verification
- `bunx biome check packages/protocol/src/policy/decision.ts packages/protocol/src/policy/point-contract.ts packages/protocol/src/policy/policy-point.ts`
- `bun run --cwd packages/protocol check-types`
- `bun run --cwd packages/protocol build`
- `bun test packages/protocol/test/policy.test.ts packages/protocol/test/policy/decision-effect.test.ts packages/protocol/test/policy/module-surface.test.ts packages/protocol/test/policy/point-registry.test.ts packages/protocol/test/policy/migration-mapping.test.ts`
- `bun run lint:guards`
- `bun run check-types`
- `bun run build`
- `git diff --check`
- LSP diagnostics clean on changed files
- `bunx knip --no-config-hints` now reports 55 namespace-member findings, down from 59

## Review
Independent ultrawork reviewer returned unconditional approval / architectStatus PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the `packages/protocol` policy API by making helper types and aliases internal. No behavior changes; public surface remains the same.

- **Refactors**
  - `policy/decision.ts`: replace exported `PolicyDecisionHelpers.Options` with internal `PolicyDecisionOptions`; keep `allow/deny/pending` unchanged.
  - `policy/point-contract.ts`: make `FailPolicy` and `PolicyEffectType` internal; remove exported `PolicyPointResolver` type.
  - `policy/policy-point.ts`: use a local `PolicyPointResolver` type internally; keep `PolicyPointModule` API unchanged.

<sup>Written for commit 3974728d0b9361ca3eaaf9634e6545ea191773c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

