### PR TITLE
refactor(session): keep bus persistence options internal

### DIFF
--- a/packages/session/src/bus-persistence/index.ts
+++ b/packages/session/src/bus-persistence/index.ts
@@ -27,18 +27,18 @@ interface RuntimeState {
   readonly chains: Map<string, Promise<void>>;
 }
 
-export namespace BusPersistence {
-  export interface Options {
-    readonly resolveSessionId?: (
-      event: Bus.PublishedDescriptor,
-      payload: unknown,
-    ) => string | undefined;
-    readonly now?: () => Date;
-  }
+interface BusPersistenceOptions {
+  readonly resolveSessionId?: (
+    event: Bus.PublishedDescriptor,
+    payload: unknown,
+  ) => string | undefined;
+  readonly now?: () => Date;
+}
 
+export namespace BusPersistence {
   let state: RuntimeState | undefined;
 
-  export function start(options: Options = {}): () => void {
+  export function start(options: BusPersistenceOptions = {}): () => void {
     stop();
 
     const chains = new Map<string, Promise<void>>();


### PR DESCRIPTION
## Summary
- make the BusPersistence start options type module-local
- preserve BusPersistence.start/stop/flush exports and structural call compatibility
- reduce the Knip namespace-member surface without changing runtime behavior

## Verification
- `bunx biome check packages/session/src/bus-persistence/index.ts`
- `bun run --cwd packages/session check-types`
- `bun test packages/session/test/bus-persistence/*.test.ts`
- `bun run lint:guards`
- `bun run check-types`
- `bun run build`
- `git diff --check`
- LSP diagnostics clean on changed file
- `bunx knip --no-config-hints | rg "BusPersistence|Options" || true`

## Review
Independent ultrawork reviewer returned unconditional approval / architectStatus APPROVED.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the bus persistence options type to the module to keep it internal and reduce the public `BusPersistence` surface. API remains the same; `start/stop/flush` calls are unchanged and runtime behavior is unaffected.

- **Refactors**
  - Replace exported `BusPersistence.Options` with module-local `BusPersistenceOptions`.
  - Type `start` with `BusPersistenceOptions` while keeping structural call compatibility.
  - Shrinks Knip namespace-member surface without changing behavior.

<sup>Written for commit 9ca477545972938904c09702a0d6bd56113013fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

