### PR TITLE
refactor(session): keep bus query record types internal

### DIFF
--- a/packages/session/src/bus-persistence/query.ts
+++ b/packages/session/src/bus-persistence/query.ts
@@ -33,6 +33,13 @@ interface TypeCountRow extends CountRow {
   readonly event_type: string;
 }
 
+const QueryStats = z.object({
+  totalEvents: z.number().describe("Total number of events"),
+  byCategory: z.record(z.number()).describe("Event count by category"),
+  byType: z.record(z.number()).describe("Event count by type"),
+});
+type QueryStats = z.infer<typeof QueryStats>;
+
 interface WorkerRunRow {
   readonly run_id: string;
   readonly status: string;
@@ -40,6 +47,16 @@ interface WorkerRunRow {
   readonly time_updated: number;
   readonly event_count: number;
 }
+
+const AuditChainRecord = z.object({
+  seq: z.number(),
+  sessionId: z.string().optional(),
+  eventType: z.string(),
+  eventHash: z.string(),
+  prevHash: z.string(),
+  timeCreated: z.number(),
+});
+type AuditChainRecord = z.infer<typeof AuditChainRecord>;
 
 export namespace BusQuery {
   /**
@@ -69,16 +86,6 @@ export namespace BusQuery {
     limit: z.number().int().positive().optional().describe("Maximum number of results"),
   });
   export type QueryOptions = z.infer<typeof QueryOptions>;
-
-  /**
-   * Statistics about bus events in a session.
-   */
-  export const QueryStats = z.object({
-    totalEvents: z.number().describe("Total number of events"),
-    byCategory: z.record(z.number()).describe("Event count by category"),
-    byType: z.record(z.number()).describe("Event count by type"),
-  });
-  export type QueryStats = z.infer<typeof QueryStats>;
 
   /**
    * List all bus events for a session with optional filtering.
@@ -224,16 +231,6 @@ export namespace BusQuery {
 
     return Promise.resolve(walkChain(rows));
   }
-
-  export const AuditChainRecord = z.object({
-    seq: z.number(),
-    sessionId: z.string().optional(),
-    eventType: z.string(),
-    eventHash: z.string(),
-    prevHash: z.string(),
-    timeCreated: z.number(),
-  });
-  export type AuditChainRecord = z.infer<typeof AuditChainRecord>;
 
   /**
    * Read the append-only audit chain for a session. This table survives


### PR DESCRIPTION
## Summary
- internalize BusQuery QueryStats and AuditChainRecord schemas/types
- preserve BusQuery getStats and listAuditChain runtime return shapes
- reduce Knip unused exported namespace members from 54 to 52

## Verification
- bun test packages/session/test/bus-persistence/query.test.ts packages/session/test/bus-persistence/hash-chain.test.ts
- bunx biome check packages/session/src/bus-persistence/query.ts
- bun run --cwd packages/session check-types
- bunx knip --no-config-hints
- bun run lint:guards
- git diff --check
- bun run check-types
- bun run build
- LSP diagnostics on packages/session/src/bus-persistence/query.ts
- codex ultrawork reviewer: UNCONDITIONAL APPROVAL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized bus query record types to reduce the public API surface. `getStats` and `listAuditChain` keep the same return shapes.

- **Refactors**
  - Moved `QueryStats` and `AuditChainRecord` schemas/types out of `BusQuery` exports into file-scoped definitions.
  - Reduced Knip-reported unused exported members from 54 to 52.

<sup>Written for commit 942e424714852255a9f709f3745499ef9a68c9af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

