### PR TITLE
refactor(session): keep surface key parse types internal

### DIFF
--- a/packages/session/src/surface-key/index.ts
+++ b/packages/session/src/surface-key/index.ts
@@ -20,17 +20,17 @@
 
 import { Storage } from "../storage/storage";
 
-export namespace SurfaceKey {
-  /**
-   * Recognized channel/peer kinds for explicit key encoding.
-   * - dm: Direct message (1:1 peer conversation)
-   * - group: Group/multi-party channel
-   * - channel: Generic named channel (backward compat)
-   * - thread: Thread within a channel/group
-   * - chat: Generic chat (e.g., telegram)
-   */
-  export type ChannelKind = "dm" | "group" | "channel" | "thread" | "chat";
+type ChannelKind = "dm" | "group" | "channel" | "thread" | "chat";
 
+interface ParsedKey {
+  readonly surface: string;
+  readonly namespace: string;
+  readonly kind: ChannelKind | undefined;
+  readonly id: string | undefined;
+  readonly threadId: string | undefined;
+}
+
+export namespace SurfaceKey {
   export interface ChannelDescriptor {
     /** Surface type (e.g., "slack", "telegram", "tui") */
     surface: string;
@@ -82,14 +82,6 @@ export namespace SurfaceKey {
       parts.push("thread", descriptor.threadId);
     }
     return create(parts);
-  }
-
-  export interface ParsedKey {
-    surface: string;
-    namespace: string;
-    kind: ChannelKind | undefined;
-    id: string | undefined;
-    threadId: string | undefined;
   }
 
   export function parse(key: string): ParsedKey {


### PR DESCRIPTION
## Summary
- internalize SurfaceKey ChannelKind and ParsedKey types
- preserve SurfaceKey ChannelDescriptor plus create/fromChannel/parse runtime behavior
- reduce Knip unused exported namespace members from 52 to 50

## Verification
- bun test packages/session/test/surface-key.test.ts packages/session/test/surface-key/persistence.test.ts
- bunx biome check packages/session/src/surface-key/index.ts
- bun run --cwd packages/session check-types
- bunx knip --no-config-hints
- bun run lint:guards
- git diff --check
- bun run check-types
- bun run build
- LSP diagnostics on packages/session/src/surface-key/index.ts
- codex ultrawork reviewer: UNCONDITIONAL APPROVAL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized `SurfaceKey` parse types to slim the public API and cut unused exports. `ChannelDescriptor` and the behavior of `create`, `fromChannel`, and `parse` are unchanged.

- **Refactors**
  - Moved `ChannelKind` and `ParsedKey` to file-internal types in `packages/session/src/surface-key/index.ts`.
  - Kept `ChannelDescriptor` exported; removed type exports from the `SurfaceKey` namespace.
  - Reduced Knip-reported unused exported members from 52 to 50.

<sup>Written for commit 4148d275c33b5b7303430bd1bd25f8a22e9c2db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to enhance maintainability and clarity of type declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->