### PR TITLE
refactor(session): keep recovered message type internal

### DIFF
--- a/packages/session/src/session/index.ts
+++ b/packages/session/src/session/index.ts
@@ -4,15 +4,15 @@ import { SessionInfo } from "./info";
 import { Storage } from "../storage/storage";
 import { Bus, BusEvent } from "../bus";
 
-export namespace Session {
-  export type RecoveredMessage = {
-    role: "assistant";
-    text: string;
-    timestamp: string;
-    sequence: number;
-    turnIndex: number;
-  };
+type RecoveredMessage = {
+  role: "assistant";
+  text: string;
+  timestamp: string;
+  sequence: number;
+  turnIndex: number;
+};
 
+export namespace Session {
   export const Info = SessionInfo;
   export type Info = SessionInfo;
 


### PR DESCRIPTION
## Summary
- move `RecoveredMessage` out of the exported `Session` namespace and keep it file-local
- preserve `Session.resume()` runtime behavior and returned object shape
- reduce Knip unused exported namespace members from 50 to 49

## Verification
- bun test packages/session/test/session/resume.test.ts
- bunx biome check packages/session/src/session/index.ts packages/session/test/session/resume.test.ts
- bun run --cwd packages/session check-types
- bunx knip --no-config-hints
- bun run lint:guards
- bun run check-types
- bun run build
- git diff --check
- LSP diagnostics: packages/session/src/session/index.ts clean
- independent reviewer 019ec83e-8862-7992-964d-1578c9d36963: APPROVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the recovered message type internal by moving it out of the exported `Session` namespace. Public API is unchanged (including `Session.resume()` behavior and return shape) and Knip unused exports drop by one.

<sup>Written for commit 28e8b4396a2e82b0f978bb052811df981e1d0b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

