### PR TITLE
refactor(session): keep snapshot events internal

### DIFF
--- a/packages/session/src/snapshot/index.ts
+++ b/packages/session/src/snapshot/index.ts
@@ -103,19 +103,19 @@ export class InMemorySnapshotProvider implements Snapshot.Provider {
   }
 }
 
+const SnapshotEvents = {
+  Tracked: BusEvent.define(
+    "snapshot.tracked",
+    z.object({ sessionID: z.string(), snapshotID: z.string() }),
+  ),
+  Restored: BusEvent.define(
+    "snapshot.restored",
+    z.object({ sessionID: z.string(), snapshotID: z.string() }),
+  ),
+};
+
 export namespace Snapshot {
   let provider: Provider = new InMemorySnapshotProvider();
-
-  export const Event = {
-    Tracked: BusEvent.define(
-      "snapshot.tracked",
-      z.object({ sessionID: z.string(), snapshotID: z.string() }),
-    ),
-    Restored: BusEvent.define(
-      "snapshot.restored",
-      z.object({ sessionID: z.string(), snapshotID: z.string() }),
-    ),
-  };
 
   export function configure(newProvider: Provider): void {
     provider = newProvider;
@@ -127,13 +127,13 @@ export namespace Snapshot {
 
   export function track(sessionID: string): string {
     const snapshotID = provider.track(sessionID);
-    Bus.publish(Event.Tracked, { sessionID, snapshotID });
+    Bus.publish(SnapshotEvents.Tracked, { sessionID, snapshotID });
     return snapshotID;
   }
 
   export function restore(sessionID: string, snapshotID: string): void {
     provider.restore(sessionID, snapshotID);
-    Bus.publish(Event.Restored, { sessionID, snapshotID });
+    Bus.publish(SnapshotEvents.Restored, { sessionID, snapshotID });
   }
 
   export function diff(sessionID: string, snapshotID: string): Diff {


### PR DESCRIPTION
## Summary
- move snapshot bus event descriptors out of the exported `Snapshot` namespace
- preserve `Snapshot.track()` / `Snapshot.restore()` event names and payload shapes
- reduce Knip unused exported namespace members from 49 to 48

## Verification
- bun test packages/session/test/snapshot/snapshot.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts
- bunx biome check packages/session/src/snapshot/index.ts packages/session/test/snapshot/snapshot.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts
- bun run --cwd packages/session check-types
- bunx knip --no-config-hints
- bun run lint:guards
- bun run check-types
- bun run build
- git diff --check
- LSP diagnostics: packages/session/src/snapshot/index.ts clean
- independent reviewer 019ec846-ebd1-7812-a81a-fced5627ca22: APPROVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep snapshot bus event descriptors internal by moving them out of the `Snapshot` namespace. Event names and payloads are unchanged; `Snapshot.track()` and `Snapshot.restore()` still publish them.

- **Refactors**
  - Replaced exported `Snapshot.Event` with internal `SnapshotEvents`.
  - Still publishes "snapshot.tracked" and "snapshot.restored" with the same payload shape.
  - Reduces public API surface (removes an unused export).

<sup>Written for commit 6870988c9a10c30dc456bf0de418573d58937f2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

