### PR TITLE
refactor(session): remove dead snapshot removal api

### DIFF
--- a/packages/session/src/snapshot/index.ts
+++ b/packages/session/src/snapshot/index.ts
@@ -8,7 +8,6 @@ export namespace Snapshot {
     track(sessionID: string): string;
     restore(sessionID: string, snapshotID: string): void;
     diff(sessionID: string, snapshotID: string): Diff;
-    remove(snapshotID: string): void;
   }
 
   export interface Diff {
@@ -94,10 +93,6 @@ export class InMemorySnapshotProvider implements Snapshot.Provider {
     return { added, removed, modified };
   }
 
-  remove(snapshotID: string): void {
-    this.snapshots.delete(snapshotID);
-  }
-
   reset(): void {
     this.snapshots.clear();
   }
@@ -138,10 +133,6 @@ export namespace Snapshot {
 
   export function diff(sessionID: string, snapshotID: string): Diff {
     return provider.diff(sessionID, snapshotID);
-  }
-
-  export function remove(snapshotID: string): void {
-    provider.remove(snapshotID);
   }
 
   export function reset(): void {


### PR DESCRIPTION
## Summary
- remove unused `Snapshot.remove()` export
- remove the provider `remove()` contract and in-memory implementation that only backed that dead export
- preserve snapshot track/restore/diff/reset/provider configuration behavior
- reduce Knip unused exported namespace members from 48 to 47

## Verification
- bun test packages/session/test/snapshot/snapshot.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts
- bunx biome check packages/session/src/snapshot/index.ts packages/session/test/snapshot/snapshot.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts
- bun run --cwd packages/session check-types
- bunx knip --no-config-hints
- bun run lint:guards
- bun run check-types
- bun run build
- git diff --check
- LSP diagnostics: packages/session/src/snapshot/index.ts clean
- pure LOC: packages/session/src/snapshot/index.ts = 118
- independent reviewer 019ec84e-9799-7320-885b-6cdac56436dd: APPROVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `Snapshot.remove()` API and its provider method from `packages/session` to simplify the snapshot module. No changes to track/restore/diff/reset behavior; this removes dead code and reduces `knip`-reported unused exports.

<sup>Written for commit bb17834b23a6a5c5278d458fd7e4eb54df1208a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

