### PR TITLE
refactor(openomni): keep subagent runtime types internal

### DIFF
--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -29,70 +29,70 @@ import {
   runWithTranscript,
 } from "./transcript";
 
+interface SpawnConfig extends RuntimeConfig {
+  parentSessionId?: string;
+  agentName: string;
+  title: string;
+  prompt: string;
+  category?: string;
+  signal?: AbortSignal;
+  softTimeoutMs?: number;
+  hardTimeoutMs?: number;
+  permissions?: Policy.Permission;
+}
+
+interface SendConfig extends RuntimeConfig {
+  sessionId: string;
+  prompt: string;
+  signal?: AbortSignal;
+  softTimeoutMs?: number;
+  hardTimeoutMs?: number;
+  permissions?: Policy.Permission;
+  compaction?: SendCompactionConfig;
+}
+
+interface WaitConfig {
+  sessionId: string;
+  runId: string;
+  timeoutMs?: number;
+}
+
+interface RunResult {
+  sessionId: string;
+  runId: string;
+  output: string;
+  finishReason: Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>["finishReason"];
+}
+
+interface SpawnBackgroundResult {
+  sessionId: string;
+  runId: string;
+}
+
+interface WaitResult {
+  status: WorkerRunRecord["status"];
+  output?: string;
+}
+
+interface ResumeConfig extends RuntimeConfig {
+  sessionId: string;
+}
+
+interface ResumeResult {
+  resumed: boolean;
+  sessionId: string;
+  runId: string | undefined;
+  output?: string;
+  finishReason?: RunResult["finishReason"];
+}
+
+interface CancelConfig {
+  sessionId: string;
+  runId?: string;
+  hardTimeoutMs?: number;
+}
+
 export namespace SubagentRuntime {
-  interface SpawnConfig extends RuntimeConfig {
-    parentSessionId?: string;
-    agentName: string;
-    title: string;
-    prompt: string;
-    category?: string;
-    signal?: AbortSignal;
-    softTimeoutMs?: number;
-    hardTimeoutMs?: number;
-    permissions?: Policy.Permission;
-  }
-
-  interface SendConfig extends RuntimeConfig {
-    sessionId: string;
-    prompt: string;
-    signal?: AbortSignal;
-    softTimeoutMs?: number;
-    hardTimeoutMs?: number;
-    permissions?: Policy.Permission;
-    compaction?: SendCompactionConfig;
-  }
-
-  interface WaitConfig {
-    sessionId: string;
-    runId: string;
-    timeoutMs?: number;
-  }
-
-  interface RunResult {
-    sessionId: string;
-    runId: string;
-    output: string;
-    finishReason: Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>["finishReason"];
-  }
-
-  interface SpawnBackgroundResult {
-    sessionId: string;
-    runId: string;
-  }
-
-  interface WaitResult {
-    status: WorkerRunRecord["status"];
-    output?: string;
-  }
-
-  interface ResumeConfig extends RuntimeConfig {
-    sessionId: string;
-  }
-
-  interface ResumeResult {
-    resumed: boolean;
-    sessionId: string;
-    runId: string | undefined;
-    output?: string;
-    finishReason?: RunResult["finishReason"];
-  }
-
-  interface CancelConfig {
-    sessionId: string;
-    runId?: string;
-    hardTimeoutMs?: number;
-  }
-
   export async function spawn(config: SpawnConfig): Promise<RunResult> {
     const hasExplicitChildRuntimePolicy = hasExplicitRuntimePolicy(config);
     const decision = await dispatchPreDelegation({

--- a/packages/openomni/src/subagent/runtime.ts
+++ b/packages/openomni/src/subagent/runtime.ts
@@ -30,7 +30,7 @@ import {
 } from "./transcript";
 
 export namespace SubagentRuntime {
-  export interface SpawnConfig extends RuntimeConfig {
+  interface SpawnConfig extends RuntimeConfig {
     parentSessionId?: string;
     agentName: string;
     title: string;
@@ -42,7 +42,7 @@ export namespace SubagentRuntime {
     permissions?: Policy.Permission;
   }
 
-  export interface SendConfig extends RuntimeConfig {
+  interface SendConfig extends RuntimeConfig {
     sessionId: string;
     prompt: string;
     signal?: AbortSignal;
@@ -52,34 +52,34 @@ export namespace SubagentRuntime {
     compaction?: SendCompactionConfig;
   }
 
-  export interface WaitConfig {
+  interface WaitConfig {
     sessionId: string;
     runId: string;
     timeoutMs?: number;
   }
 
-  export interface RunResult {
+  interface RunResult {
     sessionId: string;
     runId: string;
     output: string;
     finishReason: Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>["finishReason"];
   }
 
-  export interface SpawnBackgroundResult {
+  interface SpawnBackgroundResult {
     sessionId: string;
     runId: string;
   }
 
-  export interface WaitResult {
+  interface WaitResult {
     status: WorkerRunRecord["status"];
     output?: string;
   }
 
-  export interface ResumeConfig extends RuntimeConfig {
+  interface ResumeConfig extends RuntimeConfig {
     sessionId: string;
   }
 
-  export interface ResumeResult {
+  interface ResumeResult {
     resumed: boolean;
     sessionId: string;
     runId: string | undefined;
@@ -87,7 +87,7 @@ export namespace SubagentRuntime {
     finishReason?: RunResult["finishReason"];
   }
 
-  export interface CancelConfig {
+  interface CancelConfig {
     sessionId: string;
     runId?: string;
     hardTimeoutMs?: number;


### PR DESCRIPTION
## Summary
- move `SubagentRuntime` config/result interfaces out of the exported namespace
- preserve exported runtime functions and structural call patterns
- verify `SubagentRuntime.SpawnConfig` is no longer a consumer-visible type name while `Parameters<typeof SubagentRuntime.spawn>[0]` still compiles
- reduce Knip unused exported namespace members from 47 to 38

## Verification
- bun run --cwd packages/protocol build
- bun run --cwd packages/openomni build
- consumer probe: `SubagentRuntime.SpawnConfig` fails TS2694; `Parameters<typeof SubagentRuntime.spawn>[0]` compiles
- bun run --cwd packages/openomni check-types
- bun test packages/openomni/test/subagent/runtime.test.ts packages/openomni/test/subagent/wait.test.ts packages/openomni/test/subagent/spawn-background.test.ts
- bunx biome check packages/openomni/src/subagent/runtime.ts packages/openomni/test/subagent/runtime.test.ts packages/openomni/test/subagent/wait.test.ts packages/openomni/test/subagent/spawn-background.test.ts
- bunx knip --no-config-hints
- bun run lint:guards
- bun run check-types
- bun run build
- git diff --check
- LSP diagnostics: packages/openomni/src/subagent/runtime.ts clean
- independent reviewer 019ec85b-3f03-7f81-bdb7-159b4afefa98: APPROVE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized subagent runtime types in `openomni` to shrink the public API surface and avoid leaking type names. Public runtime functions are unchanged; behavior and call shapes stay the same.

- **Refactors**
  - Moved `SubagentRuntime` config/result interfaces to internal scope.
  - Structural typing still works (e.g., `Parameters<typeof SubagentRuntime.spawn>[0]`).
  - Reduced `knip`-reported unused exported members from 47 to 38.

- **Migration**
  - Replace named type imports like `SubagentRuntime.SpawnConfig` with inferred types (e.g., `Parameters<typeof SubagentRuntime.spawn>[0]`).
  - No runtime changes; update type references only.

<sup>Written for commit 2eb2c543f4755e41ceb186b26058a2306e483f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

