### PR TITLE
refactor(session): remove dead snapshot provider api

### DIFF
--- a/packages/session/src/snapshot/index.ts
+++ b/packages/session/src/snapshot/index.ts
@@ -112,14 +112,6 @@ const SnapshotEvents = {
 export namespace Snapshot {
   let provider: Provider = new InMemorySnapshotProvider();
 
-  export function configure(newProvider: Provider): void {
-    provider = newProvider;
-  }
-
-  export function getProvider(): Provider {
-    return provider;
-  }
-
   export function track(sessionID: string): string {
     const snapshotID = provider.track(sessionID);
     Bus.publish(SnapshotEvents.Tracked, { sessionID, snapshotID });


### PR DESCRIPTION
## Summary
- remove unused exported `Snapshot.configure()` and `Snapshot.getProvider()` APIs
- keep `Snapshot.track()`, `restore()`, `diff()`, `reset()`, `Snapshot.Provider`, `Snapshot.Diff`, and `InMemorySnapshotProvider` behavior intact
- reduce Knip unused exported namespace members from 34 to 32 with no remaining Snapshot findings

## Verification
- bun test packages/session/test/snapshot/snapshot.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts
- bun run --cwd packages/session check-types
- bunx biome check packages/session/src/snapshot/index.ts packages/session/test/snapshot/snapshot.test.ts packages/session/test/bus-persistence/bus-persistence.test.ts
- LSP diagnostics on packages/session/src/snapshot/index.ts
- bunx knip --no-config-hints
- bun run lint:guards
- git diff --check
- runtime export probe for Snapshot exports
- bun run check-types
- bun run build

Note: `bun run --cwd packages/session build` is N/A because `packages/session` has no build script; root build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `Snapshot.configure()` and `Snapshot.getProvider()` from `packages/session` to reduce the public API surface and clean up dead code. Existing behavior (`Snapshot.track()`, `restore()`, `diff()`, `reset()`) and the default `InMemorySnapshotProvider` remain unchanged.

<sup>Written for commit 1611f4f30f0fb24a5e7b8ca71d926010b170129f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

