### PR TITLE
refactor(session): remove dead channel grant accessors

### DIFF
--- a/packages/session/src/channel-grant/index.ts
+++ b/packages/session/src/channel-grant/index.ts
@@ -48,14 +48,6 @@ export namespace ChannelGrantStore {
     return grant;
   }
 
-  export function get(id: string): Grant | undefined {
-    return requireAdapter().get(id);
-  }
-
-  export function list(): Grant[] {
-    return requireAdapter().list();
-  }
-
   export function remove(id: string): boolean {
     return requireAdapter().remove(id);
   }


### PR DESCRIPTION
## Summary
- remove unused exported `ChannelGrantStore.get()` and `ChannelGrantStore.list()` wrappers
- keep storage adapter `get/list` contract intact for low-level storage and `resolve()` internals
- keep `ChannelGrantStore.Grant`, `put()`, `remove()`, and `resolve()` behavior intact
- reduce Knip unused exported namespace members from 32 to 30

## Verification
- bun test packages/session/test/channel-grant/persistence.test.ts
- bun run --cwd packages/session check-types
- bunx biome check packages/session/src/channel-grant/index.ts packages/session/test/channel-grant/persistence.test.ts
- LSP diagnostics on packages/session/src/channel-grant/index.ts
- bunx knip --no-config-hints
- bun run lint:guards
- git diff --check
- runtime export probe for ChannelGrantStore exports
- bun run check-types
- bun run build

Note: a broader direct Bun invocation including packages/openomni tests failed before the edit because that invocation did not resolve workspace aliases from the fresh worktree. The focused session test passed before and after; root/turbo gates passed after the edit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused `ChannelGrantStore.get()` and `ChannelGrantStore.list()` exports to clean up dead APIs. Adapter `get/list` remain for internals (including `resolve()`), and `put`, `remove`, and `resolve` behavior is unchanged; reduces Knip-unused exports by 2.

<sup>Written for commit b5a0c07ce34f2982784db809c05a6959795772d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

