### PR TITLE
refactor(session): remove dead blacklist accessors

### DIFF
--- a/packages/session/src/blacklist/index.ts
+++ b/packages/session/src/blacklist/index.ts
@@ -49,28 +49,17 @@ function entryMatches(entry: Actor.BlacklistEntry, input: BlacklistMatchInput): 
 }
 
 export namespace BlacklistStore {
-  export type Entry = Actor.BlacklistEntry;
-
-  export function put(input: Entry): Entry {
+  export function put(input: Actor.BlacklistEntry): Actor.BlacklistEntry {
     const store = requireAdapter();
     const entry = Actor.BlacklistEntry.parse(withStoreTimestamps(input, store.get(input.id)));
     store.set(entry);
     return entry;
   }
 
-  export function get(id: string): Entry | undefined {
-    return requireAdapter().get(id);
-  }
-
-  export function list(): Entry[] {
-    return requireAdapter().list();
-  }
-
-  export function remove(id: string): boolean {
-    return requireAdapter().remove(id);
-  }
-
-  export function match(input: BlacklistMatchInput, now = Date.now()): Entry | undefined {
+  export function match(
+    input: BlacklistMatchInput,
+    now = Date.now(),
+  ): Actor.BlacklistEntry | undefined {
     const store = adapter();
     if (!store) return undefined;
     return store.list().find((entry) => isActive(entry, now) && entryMatches(entry, input));


### PR DESCRIPTION
## Summary
- remove unused exported `BlacklistStore.Entry`, `get()`, `list()`, and `remove()` namespace members
- keep storage adapter `get/list/remove` contract intact for low-level storage and `put()/match()` internals
- keep `BlacklistStore.put()` and `BlacklistStore.match()` behavior intact
- reduce Knip unused exported namespace members from 30 to 26

## Verification
- bun test packages/session/test/blacklist/persistence.test.ts
- bun run --cwd packages/session check-types
- bunx biome check packages/session/src/blacklist/index.ts packages/session/test/blacklist/persistence.test.ts
- LSP diagnostics on packages/session/src/blacklist/index.ts
- bunx knip --no-config-hints
- bun run lint:guards
- git diff --check
- runtime export probe for BlacklistStore exports
- bun run check-types
- bun run build

Note: the fresh worktree initially failed the focused test before dependency install because `zod` could not be imported. After `bun install`, the focused baseline test passed before the edit and passed again after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused blacklist accessors from `BlacklistStore` to simplify the session API and reduce dead code. Kept the storage adapter contract and `put`/`match` behavior unchanged.

- **Refactors**
  - Dropped exported `BlacklistStore.Entry`, `get()`, `list()`, and `remove()`.
  - Kept adapter-level `get/list/remove` for `put()`/`match()` internals; reduced Knip unused exports from 30 to 26.

<sup>Written for commit 48448048effd4a3516bc08f979abface32b11bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

