### PR TITLE
refactor(session): remove dead pending ask surface

### DIFF
--- a/packages/session/src/pending-ask/index.ts
+++ b/packages/session/src/pending-ask/index.ts
@@ -53,12 +53,7 @@ function updateStatus(
 }
 
 export namespace PendingAskStore {
-  export type Record = Communication.PendingAsk.Record;
-  export type Create = Communication.PendingAsk.Create;
-  export type Status = Communication.PendingAsk.Status;
-  export type CorrelationQuery = Communication.PendingAsk.CorrelationQuery;
-
-  export function create(input: Create): Record {
+  export function create(input: Communication.PendingAsk.Create): Communication.PendingAsk.Record {
     const adapter = requireAdapter();
     const record = nowRecord(input);
     if (adapter.get(record.id)) throw new Error(`PendingAsk already exists: ${record.id}`);
@@ -67,21 +62,28 @@ export namespace PendingAskStore {
     return record;
   }
 
-  export function get(id: string): Record | undefined {
+  export function get(id: string): Communication.PendingAsk.Record | undefined {
     return requireAdapter().get(id);
   }
 
-  export function list(status?: Status[]): Record[] {
+  export function list(
+    status?: Communication.PendingAsk.Status[],
+  ): Communication.PendingAsk.Record[] {
     return requireAdapter().list(status);
   }
 
-  export function findByCorrelation(query: CorrelationQuery): Record[] {
+  export function findByCorrelation(
+    query: Communication.PendingAsk.CorrelationQuery,
+  ): Communication.PendingAsk.Record[] {
     return requireAdapter().findByCorrelation(
       Communication.PendingAsk.CorrelationQuery.parse(query),
     );
   }
 
-  export function answer(id: string, patch: Partial<Pick<Record, "answeredAt">> = {}): Record {
+  export function answer(
+    id: string,
+    patch: Partial<Pick<Communication.PendingAsk.Record, "answeredAt">> = {},
+  ): Communication.PendingAsk.Record {
     const answeredAt = patch.answeredAt ?? Date.now();
     const { record, changed } = updateStatus(id, ["open", "ambiguous"], "answered", {
       answeredAt,
@@ -95,7 +97,7 @@ export namespace PendingAskStore {
     return record;
   }
 
-  export function markAmbiguous(id: string): Record {
+  export function markAmbiguous(id: string): Communication.PendingAsk.Record {
     const { record, changed } = updateStatus(id, ["open"], "ambiguous");
     if (changed) {
       Bus.publish(Communication.PendingAsk.Events.Ambiguous, eventBase(record));
@@ -103,7 +105,7 @@ export namespace PendingAskStore {
     return record;
   }
 
-  export function cancel(id: string): Record {
+  export function cancel(id: string): Communication.PendingAsk.Record {
     const { record, changed } = updateStatus(id, ["open", "ambiguous"], "cancelled");
     if (changed) {
       Bus.publish(Communication.PendingAsk.Events.Cancelled, eventBase(record));
@@ -111,15 +113,11 @@ export namespace PendingAskStore {
     return record;
   }
 
-  export function expire(id: string): Record {
+  export function expire(id: string): Communication.PendingAsk.Record {
     const { record, changed } = updateStatus(id, ["open", "ambiguous"], "expired");
     if (changed) {
       Bus.publish(Communication.PendingAsk.Events.Expired, eventBase(record));
     }
     return record;
-  }
-
-  export function remove(id: string): boolean {
-    return requireAdapter().remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused exported `PendingAskStore.Record`, `Create`, `Status`, and `CorrelationQuery` namespace aliases
- remove unused `PendingAskStore.remove()` wrapper
- keep live `create/get/list/findByCorrelation/answer/markAmbiguous/cancel/expire` behavior intact
- keep low-level `Storage.PendingAskSubAdapter.remove` contract intact
- reduce Knip unused exported namespace members from 26 to 21

## Verification
- `bun test packages/session/test/pending-ask/store.test.ts`
- `bun run --cwd packages/session check-types`
- `bunx biome check packages/session/src/pending-ask/index.ts packages/session/test/pending-ask/store.test.ts`
- LSP diagnostics on `packages/session/src/pending-ask/index.ts`
- `bunx knip --no-config-hints`
- `bun run lint:guards`
- `git diff --check`
- runtime export probe for `PendingAskStore` exports
- `bun run check-types`
- `bun run build`

Note: in the fresh worktree, broad direct Bun invocation including app/openomni tests failed before the edit because that invocation did not resolve workspace aliases from the worktree. The focused session pending-ask test passed before and after; root/turbo gates passed after the edit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up `PendingAskStore` by removing unused exported type aliases and the dead `remove()` wrapper. No runtime behavior changes; core methods stay the same and the adapter contract remains intact.

- **Refactors**
  - Removed unused exports: `Record`, `Create`, `Status`, `CorrelationQuery`.
  - Deleted `PendingAskStore.remove()`; kept `Storage.PendingAskSubAdapter.remove`.
  - Inlined `Communication.PendingAsk.*` types in public methods.
  - Reduced Knip unused exports from 26 to 21.

- **Migration**
  - Replace `PendingAskStore.Record|Create|Status|CorrelationQuery` with `Communication.PendingAsk.Record|Create|Status|CorrelationQuery`.
  - Replace any use of `PendingAskStore.remove` with `Storage.PendingAskSubAdapter.remove` (infra-only).

<sup>Written for commit 92e79ae73e211fb49f5784f3a0feed139e641a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

