### PR TITLE
refactor(session): remove dead pending interaction surface

### DIFF
--- a/packages/session/src/pending-interaction/index.ts
+++ b/packages/session/src/pending-interaction/index.ts
@@ -81,11 +81,8 @@ function isPastExpiry(record: Communication.PendingInteraction.Record, now: numb
 
 export namespace PendingInteractionStore {
   export type Record = Communication.PendingInteraction.Record;
-  export type Create = Communication.PendingInteraction.Create;
-  export type Status = Communication.PendingInteraction.Status;
-  export type CorrelationQuery = Communication.PendingInteraction.CorrelationQuery;
 
-  export function create(input: Create): Record {
+  export function create(input: Communication.PendingInteraction.Create): Record {
     const adapter = requireAdapter();
     const record = nowRecord(input);
     if (adapter.get(record.id)) {
@@ -100,11 +97,10 @@ export namespace PendingInteractionStore {
     return requireAdapter().get(id);
   }
 
-  export function list(status?: Status[]): Record[] {
-    return requireAdapter().list(status);
-  }
-
-  export function findByCorrelation(query: CorrelationQuery, now = Date.now()): Record[] {
+  export function findByCorrelation(
+    query: Communication.PendingInteraction.CorrelationQuery,
+    now = Date.now(),
+  ): Record[] {
     return requireAdapter()
       .findByCorrelation(Communication.PendingInteraction.CorrelationQuery.parse(query))
       .filter((record) => stillAcceptsFollowUp(record, now));
@@ -151,7 +147,7 @@ export namespace PendingInteractionStore {
     return record;
   }
 
-  export function expire(id: string): Record {
+  function expire(id: string): Record {
     const { record, changed } = updateStatus(id, ["open", "resolved", "follow_up"], "expired");
     if (changed) {
       Bus.publish(Communication.PendingInteraction.Events.Expired, eventBase(record));
@@ -160,12 +156,9 @@ export namespace PendingInteractionStore {
   }
 
   export function cleanupExpired(now = Date.now()): Record[] {
-    return list(["open", "resolved", "follow_up"])
+    return requireAdapter()
+      .list(["open", "resolved", "follow_up"])
       .filter((record) => isPastExpiry(record, now))
       .map((record) => expire(record.id));
-  }
-
-  export function remove(id: string): boolean {
-    return requireAdapter().remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused exported `PendingInteractionStore.Create`, `Status`, and `CorrelationQuery` namespace aliases
- remove unused exported `PendingInteractionStore.list()` and `remove()` wrappers
- keep `expire()` as an internal lifecycle helper used by `markFollowUp()` and `cleanupExpired()`
- preserve live `create/get/findByCorrelation/resolve/markFollowUp/cancel/cleanupExpired` behavior and the `PendingInteractionStore.Record` type used by dispatch routing
- keep the low-level `Storage.PendingInteractionSubAdapter` list/remove contract intact
- reduce Knip unused exported namespace members from 21 to 15

## Verification
- `bun test packages/session/test/pending-interaction/store.test.ts`
- `bun run --cwd packages/session check-types`
- `bunx biome check packages/session/src/pending-interaction/index.ts packages/session/test/pending-interaction/store.test.ts`
- LSP diagnostics on `packages/session/src/pending-interaction/index.ts`
- `bunx knip --no-config-hints`
- runtime export probe for `PendingInteractionStore` exports
- `rg` call-site scan for removed `PendingInteractionStore` exports
- `git diff --check`
- `bun run lint:guards`
- `bun run check-types`
- `bun run build`
- `bun run test`
- independent ultrawork reviewer approval

Note: a direct multi-package `bun test <files...>` invocation in the fresh worktree failed before the edit on workspace alias resolution for app/openomni tests. The focused session PendingInteraction test and workspace-aware turbo test passed after the edit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead `PendingInteractionStore` surface to shrink the API while keeping behavior unchanged. This cleans up `packages/session` and reduces unused exports flagged by `knip`.

- **Refactors**
  - Removed exported type aliases `Create`, `Status`, `CorrelationQuery`; use `Communication.PendingInteraction.*` directly.
  - Deleted unused wrappers `list()` and `remove()`; `Storage.PendingInteractionSubAdapter` `list/remove` contract remains.
  - Made `expire()` internal; still used by `markFollowUp()` and `cleanupExpired()`.
  - Preserved `create/get/findByCorrelation/resolve/markFollowUp/cancel/cleanupExpired`.
  - Reduced unused exported members from 21 to 15.

- **Migration**
  - Replace `PendingInteractionStore.Create/Status/CorrelationQuery` with `Communication.PendingInteraction.Create/Status/CorrelationQuery`.
  - If you used `PendingInteractionStore.list/remove`, prefer `findByCorrelation()` or `cleanupExpired()`, or use your adapter via `Storage.PendingInteractionSubAdapter`.

<sup>Written for commit 4ef1d70cb0107f682c8003164d538c79758b59ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

