### PR TITLE
refactor(session): remove dead worker grant surface

### DIFF
--- a/packages/session/src/worker-grant/index.ts
+++ b/packages/session/src/worker-grant/index.ts
@@ -84,12 +84,9 @@ function evaluateRecord(
 }
 
 export namespace WorkerGrantStore {
-  export type Record = Communication.WorkerGrant.Record;
-  export type Create = Communication.WorkerGrant.Create;
-  export type Evaluation = Communication.WorkerGrant.Evaluation;
-  export type EvaluationResult = Communication.WorkerGrant.EvaluationResult;
-
-  export function create(input: Create): Record {
+  export function create(
+    input: Communication.WorkerGrant.Create,
+  ): Communication.WorkerGrant.Record {
     const adapter = requireAdapter();
     const record = createRecord(input);
     if (adapter.get(record.id)) throw new Error(`WorkerGrant already exists: ${record.id}`);
@@ -98,19 +95,15 @@ export namespace WorkerGrantStore {
     return record;
   }
 
-  export function get(id: string): Record | undefined {
+  export function get(id: string): Communication.WorkerGrant.Record | undefined {
     return requireAdapter().get(id);
-  }
-
-  export function list(workerRunId?: string): Record[] {
-    return requireAdapter().list(workerRunId);
   }
 
   function persistUpdate(
     id: string,
-    patch: Partial<Omit<Record, "id" | "workerRunId">>,
+    patch: Partial<Omit<Communication.WorkerGrant.Record, "id" | "workerRunId">>,
     event: "updated" | "revoked" | "expired",
-  ): Record {
+  ): Communication.WorkerGrant.Record {
     const adapter = requireAdapter();
     const current = adapter.get(id);
     if (!current) throw new Error(`WorkerGrant not found: ${id}`);
@@ -131,33 +124,31 @@ export namespace WorkerGrantStore {
     return updated;
   }
 
-  export function update(id: string, patch: Partial<Omit<Record, "id" | "workerRunId">>): Record {
-    return persistUpdate(id, patch, "updated");
-  }
-
-  export function revoke(id: string): Record {
+  export function revoke(id: string): Communication.WorkerGrant.Record {
     return persistUpdate(id, { status: "revoked", revokedAt: Date.now() }, "revoked");
   }
 
-  export function expire(id: string): Record {
+  function expire(id: string): Communication.WorkerGrant.Record {
     return persistUpdate(id, { status: "expired" }, "expired");
   }
 
-  export function cleanupExpired(workerRunId?: string): Record[] {
+  export function cleanupExpired(workerRunId?: string): Communication.WorkerGrant.Record[] {
     return requireAdapter()
       .list(workerRunId)
       .filter((grant) => isPastExpiry(grant))
       .map((grant) => expire(grant.id));
   }
 
-  export function evaluate(input: Evaluation): EvaluationResult {
+  export function evaluate(
+    input: Communication.WorkerGrant.Evaluation,
+  ): Communication.WorkerGrant.EvaluationResult {
     const parsedInput = Communication.WorkerGrant.Evaluation.safeParse(input);
     if (!parsedInput.success) {
       return { allowed: false, reason: "worker_grant.evaluation.invalid" };
     }
     const parsed = parsedInput.data;
     const grants = requireAdapter().list(parsed.workerRunId);
-    let firstDenial: EvaluationResult | undefined;
+    let firstDenial: Communication.WorkerGrant.EvaluationResult | undefined;
     for (const grant of grants) {
       const result = evaluateRecord(grant, parsed);
       Bus.publish(Communication.WorkerGrant.Events.Evaluated, {
@@ -170,9 +161,5 @@ export namespace WorkerGrantStore {
       firstDenial ??= result;
     }
     return firstDenial ?? { allowed: false, reason: "worker_grant.no_matching_grant" };
-  }
-
-  export function remove(id: string): boolean {
-    return requireAdapter().remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused exported `WorkerGrantStore.Record`, `Create`, `Evaluation`, and `EvaluationResult` namespace aliases
- remove unused exported `WorkerGrantStore.list()`, `update()`, and `remove()` wrappers
- keep `expire()` as an internal lifecycle helper used by `cleanupExpired()`
- preserve live `create/get/revoke/cleanupExpired/evaluate` behavior
- keep low-level `Storage.WorkerGrantSubAdapter` list/set/remove contract intact
- reduce Knip unused exported namespace members from 14 to 6

## Verification
- `bunx biome check packages/session/src/worker-grant/index.ts packages/session/test/worker-grant/store.test.ts`
- `bun test packages/session/test/worker-grant/store.test.ts`
- `bun run --cwd packages/session check-types`
- LSP diagnostics on `packages/session/src/worker-grant/index.ts`
- `bunx knip --no-config-hints`
- runtime export probe for `WorkerGrantStore` exports
- `rg` call-site scan for removed `WorkerGrantStore` exports
- `git diff --check`
- `bun run lint:guards`
- `bun run check-types`
- `bun run build`
- `bun run test`
- independent ultrawork reviewer approval

Note: a direct broad Bun invocation including openomni tests failed before this edit because of workspace alias resolution in the fresh worktree. Focused session grant tests and workspace-aware Turbo tests pass after the cleanup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor the worker grant store to remove dead exported types and wrappers, reducing unused exports while keeping runtime behavior and the storage adapter contract unchanged.

- **Refactors**
  - Removed exported alias types (`Record`, `Create`, `Evaluation`, `EvaluationResult`) and wrappers (`list`, `update`, `remove`).
  - Kept `expire()` internal; `create/get/revoke/cleanupExpired/evaluate` unchanged.
  - Adapter contract (`Storage.WorkerGrantSubAdapter`) unchanged; Knip unused exports reduced from 14 to 6.

<sup>Written for commit c7ef1848b7771f44884fad2c983322d1dee4e226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

