### PR TITLE
refactor(session): remove dead actor registry surface

### DIFF
--- a/packages/session/src/actor/index.ts
+++ b/packages/session/src/actor/index.ts
@@ -10,11 +10,7 @@ function requireAdapter(): NonNullable<Storage.Adapter["actorRegistry"]> {
 }
 
 export namespace ActorRegistry {
-  export type Identity = Actor.Identity;
-  export type Endpoint = Actor.Endpoint;
-  export type ResolvedEndpoint = Actor.ResolvedEndpoint;
-
-  export function registerIdentity(input: Identity): Identity {
+  export function registerIdentity(input: Actor.Identity): Actor.Identity {
     const adapter = requireAdapter();
     const identity = Actor.Identity.parse(
       withStoreTimestamps(input, adapter.getIdentity(input.id)),
@@ -23,19 +19,15 @@ export namespace ActorRegistry {
     return identity;
   }
 
-  export function getIdentity(id: string): Identity | undefined {
+  export function getIdentity(id: string): Actor.Identity | undefined {
     return requireAdapter().getIdentity(id);
-  }
-
-  export function listIdentities(): Identity[] {
-    return requireAdapter().listIdentities();
   }
 
   export function removeIdentity(id: string): boolean {
     return requireAdapter().removeIdentity(id);
   }
 
-  export function registerEndpoint(input: Endpoint): Endpoint {
+  export function registerEndpoint(input: Actor.Endpoint): Actor.Endpoint {
     const adapter = requireAdapter();
     const endpoint = Actor.Endpoint.parse(
       withStoreTimestamps(input, adapter.getEndpoint(input.id)),
@@ -57,28 +49,20 @@ export namespace ActorRegistry {
     return endpoint;
   }
 
-  export function getEndpoint(id: string): Endpoint | undefined {
+  export function getEndpoint(id: string): Actor.Endpoint | undefined {
     return requireAdapter().getEndpoint(id);
-  }
-
-  export function listEndpoints(actorId?: string, workspace?: string): Endpoint[] {
-    return requireAdapter().listEndpoints(actorId, workspace);
   }
 
   export function resolveEndpoint(
     channel: string,
     externalId: string,
     workspace?: string,
-  ): ResolvedEndpoint | undefined {
+  ): Actor.ResolvedEndpoint | undefined {
     const adapter = requireAdapter();
     const endpoint = adapter.findEndpoint(channel, externalId, workspace);
     if (!endpoint) return undefined;
     const identity = adapter.getIdentity(endpoint.actorId);
     if (!identity) return undefined;
     return { identity, endpoint };
-  }
-
-  export function removeEndpoint(id: string): boolean {
-    return requireAdapter().removeEndpoint(id);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused exported `ActorRegistry.Identity`, `Endpoint`, and `ResolvedEndpoint` namespace aliases
- remove unused exported `ActorRegistry.listIdentities()`, `listEndpoints()`, and `removeEndpoint()` wrappers
- preserve live `registerIdentity/getIdentity/removeIdentity/registerEndpoint/getEndpoint/resolveEndpoint` behavior
- keep canonical `Actor.*` protocol schemas and low-level `Storage.ActorRegistrySubAdapter` list/remove contract intact
- reduce Knip unused exported namespace members from 6 to 0

## Verification
- `bunx biome check packages/session/src/actor/index.ts packages/session/test/actor/persistence.test.ts`
- `bun test packages/session/test/actor/persistence.test.ts`
- `bun run --cwd packages/session check-types`
- LSP diagnostics on `packages/session/src/actor/index.ts`
- `rg` call-site scan for removed `ActorRegistry` exports
- `bunx knip --no-config-hints`
- runtime export probe for `ActorRegistry` exports
- `git diff --check`
- `bun run lint:guards`
- `bun run check-types`
- `bun run build`
- `bun run test`
- independent ultrawork reviewer approval


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove dead `ActorRegistry` surface to shrink the public API and clear Knip warnings. Core register/get/resolve behavior is unchanged (unused exports reduced from 6 to 0).

- **Refactors**
  - Drop exported type aliases: `Identity`, `Endpoint`, `ResolvedEndpoint`.
  - Remove unused wrappers: `listIdentities()`, `listEndpoints()`, `removeEndpoint()`.
  - Preserve `registerIdentity/getIdentity/removeIdentity/registerEndpoint/getEndpoint/resolveEndpoint`, canonical `Actor.*` schemas, and `Storage.ActorRegistrySubAdapter` list/remove contract.

<sup>Written for commit 51059581ba37cf91ad201c0f89fc448cf0fa9404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

