### PR TITLE
refactor(llm): split processor responsibilities

### DIFF
--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -10,7 +10,12 @@ src/
 ├── run.ts            # run() — top-level entry: messages+tools → Run.Outcome via Sink
 ├── error.ts          # Re-exports NamedError classes from protocol
 ├── session/
-│   ├── processor.ts  # Processor.create() — drives streaming LLM call + tool turns
+│   ├── processor.ts  # Processor.create() namespace barrel/orchestrator — retry loop + stream driving
+│   ├── processor-events.ts # Stream event dispatch for text/reasoning/tool/step events
+│   ├── processor-sink.ts # Sink projection to Bus telemetry + noop sink
+│   ├── processor-steps.ts # step-start / step-finish token and cost accounting
+│   ├── processor-tools.ts # tool-call execution, result projection, interruption cleanup
+│   ├── processor-types.ts # Internal Processor implementation contracts
 │   ├── index.ts      # Re-exports protocol Message/Tool plus session helpers
 │   ├── convert.ts    # toModelMessages() — Message.WithParts[] → AI SDK messages
 │   └── retry.ts      # Retry.delay / sleep / isRetryable — exponential backoff + retry-after

--- a/packages/llm/src/session/processor-events.ts
+++ b/packages/llm/src/session/processor-events.ts
@@ -1,0 +1,200 @@
+import type { Message, Sink } from "@openomni/protocol";
+import type { Provider } from "../provider";
+import { generateId, type StreamEvent, type ToolResult } from "./processor-types.js";
+import { addStepFinish, addStepStart } from "./processor-steps.js";
+import { cleanupPendingTools, handleToolCall } from "./processor-tools.js";
+
+type MessagePartWriter = {
+  add(part: Message.Part): void;
+  update(part: Message.Part): void;
+};
+
+type StreamEventContext = {
+  readonly sessionID: string;
+  readonly assistantMessage: Message.AssistantMessage;
+  readonly model: Provider.Model;
+  readonly sink: Sink;
+  readonly pendingTools: Message.ToolPart[];
+  readonly messagePartWriter: MessagePartWriter;
+  readonly onToolCall?: (part: Message.ToolPart) => Promise<ToolResult>;
+};
+
+type StreamEventState = {
+  currentText?: Message.TextPart;
+  reasoningMap: Record<string, Message.ReasoningPart>;
+  textPartMap: Record<string, string[]>;
+  reasoningPartMap: Record<string, string[]>;
+};
+
+export function createStreamEventState(): StreamEventState {
+  return {
+    reasoningMap: {},
+    textPartMap: {},
+    reasoningPartMap: {},
+  };
+}
+
+export async function handleStreamEvent(
+  event: StreamEvent,
+  state: StreamEventState,
+  context: StreamEventContext,
+): Promise<void> {
+  switch (event.type) {
+    case "text-start": {
+      startText(event, state, context);
+      break;
+    }
+    case "text-delta": {
+      appendText(event, state, context);
+      break;
+    }
+    case "text-end": {
+      finishText(event, state, context);
+      break;
+    }
+    case "reasoning-start": {
+      startReasoning(event, state, context);
+      break;
+    }
+    case "reasoning-delta": {
+      appendReasoning(event, state, context);
+      break;
+    }
+    case "reasoning-end": {
+      finishReasoning(event, state, context);
+      break;
+    }
+    case "tool-call": {
+      await handleToolCall(event, context);
+      break;
+    }
+    case "step-start": {
+      addStepStart(context);
+      break;
+    }
+    case "step-finish": {
+      addStepFinish(event, context);
+      break;
+    }
+    case "finish": {
+      break;
+    }
+    case "error": {
+      throw event.error;
+    }
+    default: {
+      break;
+    }
+  }
+}
+
+export { cleanupPendingTools };
+
+function startText(event: StreamEvent, state: StreamEventState, context: StreamEventContext): void {
+  const now = Date.now();
+  state.currentText = {
+    id: generateId(),
+    sessionID: context.sessionID,
+    messageID: context.assistantMessage.id,
+    type: "text",
+    text: "",
+    time: { start: now },
+    metadata: (event.providerMetadata as Record<string, unknown>) || {},
+  };
+  state.textPartMap[state.currentText.id] = [];
+  context.messagePartWriter.add(state.currentText);
+}
+
+function appendText(
+  event: StreamEvent,
+  state: StreamEventState,
+  context: StreamEventContext,
+): void {
+  if (!state.currentText) return;
+  const textParts = state.textPartMap[state.currentText.id] ?? [];
+  state.textPartMap[state.currentText.id] = textParts;
+  textParts.push(String(event.text || ""));
+  if (event.providerMetadata) {
+    state.currentText.metadata = event.providerMetadata as Record<string, unknown>;
+  }
+  context.messagePartWriter.update(state.currentText);
+}
+
+function finishText(
+  event: StreamEvent,
+  state: StreamEventState,
+  context: StreamEventContext,
+): void {
+  if (state.currentText?.time) {
+    state.currentText.text = (state.textPartMap[state.currentText.id] ?? []).join("").trimEnd();
+    delete state.textPartMap[state.currentText.id];
+    state.currentText.time = {
+      start: state.currentText.time.start,
+      end: Date.now(),
+    };
+    if (event.providerMetadata) {
+      state.currentText.metadata = event.providerMetadata as Record<string, unknown>;
+    }
+    context.messagePartWriter.update(state.currentText);
+  }
+  state.currentText = undefined;
+}
+
+function startReasoning(
+  event: StreamEvent,
+  state: StreamEventState,
+  context: StreamEventContext,
+): void {
+  const reasoningId = String(event.id);
+  if (reasoningId in state.reasoningMap) return;
+  const now = Date.now();
+  const part: Message.ReasoningPart = {
+    id: generateId(),
+    sessionID: context.sessionID,
+    messageID: context.assistantMessage.id,
+    type: "reasoning",
+    text: "",
+    time: { start: now, end: undefined },
+    metadata: (event.providerMetadata as Record<string, unknown>) || {},
+  };
+  state.reasoningMap[reasoningId] = part;
+  state.reasoningPartMap[part.id] = [];
+  context.messagePartWriter.add(part);
+}
+
+function appendReasoning(
+  event: StreamEvent,
+  state: StreamEventState,
+  context: StreamEventContext,
+): void {
+  const part = state.reasoningMap[String(event.id)];
+  if (part == null) return;
+  const reasoningParts = state.reasoningPartMap[part.id] ?? [];
+  state.reasoningPartMap[part.id] = reasoningParts;
+  reasoningParts.push(String(event.text || ""));
+  if (event.providerMetadata) {
+    part.metadata = event.providerMetadata as Record<string, unknown>;
+  }
+  context.messagePartWriter.update(part);
+}
+
+function finishReasoning(
+  event: StreamEvent,
+  state: StreamEventState,
+  context: StreamEventContext,
+): void {
+  const reasoningId = String(event.id);
+  const part = state.reasoningMap[reasoningId];
+  if (part == null) return;
+  part.text = (state.reasoningPartMap[part.id] ?? []).join("").trimEnd();
+  delete state.reasoningPartMap[part.id];
+  part.time = {
+    start: part.time?.start ?? Date.now(),
+    end: Date.now(),
+  };
+  if (event.providerMetadata) {
+    part.metadata = event.providerMetadata as Record<string, unknown>;
+  }
+  context.messagePartWriter.update(part);
+  delete state.reasoningMap[reasoningId];
+}

--- a/packages/llm/src/session/processor-sink.ts
+++ b/packages/llm/src/session/processor-sink.ts
@@ -1,0 +1,82 @@
+import { Operational, type Run, type Sink, type Tool } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { generateId } from "./processor-types.js";
+
+export interface ProjectedSink extends Sink {
+  flush(): Promise<void>;
+}
+
+export function createProjectedSink(sink: Sink, sessionID: string): ProjectedSink {
+  function publish(message: string, data?: Record<string, unknown>): void {
+    if (!sessionID) return;
+    Bus.publish(Operational.Info, {
+      traceId: sessionID,
+      time: Date.now(),
+      sessionId: sessionID,
+      component: "llm.processor",
+      msg: message,
+      context: data,
+    });
+  }
+
+  return {
+    onMessage(message) {
+      sink.onMessage(message);
+      publish("sink.message", {
+        role: message.info.role,
+        messageId: message.info.id,
+        partCount: message.parts.length,
+      });
+    },
+
+    onToolCall(call: Tool.Call) {
+      sink.onToolCall(call);
+      publish("sink.tool.started", {
+        toolCallId: call.id,
+        toolName: call.tool,
+        inputSummary: summarizeRecord(call.input),
+      });
+    },
+
+    onToolResult(result: Tool.Result) {
+      sink.onToolResult(result);
+      publish("sink.tool.completed", {
+        toolCallId: result.toolCallId,
+        outputLength: result.output.length,
+        isError: result.isError,
+      });
+    },
+
+    onSnapshot(snapshot: Run.Snapshot) {
+      sink.onSnapshot(snapshot);
+      publish("sink.snapshot", { stateType: String(snapshot.state.type ?? "unknown") });
+    },
+
+    flush() {
+      return Promise.resolve();
+    },
+  };
+}
+
+export function createNoopSink(): Sink {
+  return {
+    onMessage: () => void 0,
+    onToolCall: () => void 0,
+    onToolResult: () => void 0,
+    onSnapshot: () => void 0,
+  };
+}
+
+export function publishStatus(sink: Sink, sessionID: string, state: Record<string, unknown>): void {
+  sink.onSnapshot({
+    id: generateId(),
+    sessionID,
+    timestamp: Date.now(),
+    state,
+  });
+}
+
+function summarizeRecord(input: Record<string, unknown>): string {
+  const keys = Object.keys(input).sort();
+  return keys.length === 0 ? "empty" : keys.join(",");
+}

--- a/packages/llm/src/session/processor-steps.ts
+++ b/packages/llm/src/session/processor-steps.ts
@@ -1,0 +1,103 @@
+import type { Message } from "@openomni/protocol";
+import { TokenTracker } from "../token";
+import type { Provider } from "../provider";
+import { generateId, type StreamEvent } from "./processor-types.js";
+
+export type StepEventContext = {
+  readonly sessionID: string;
+  readonly assistantMessage: Message.AssistantMessage;
+  readonly model: Provider.Model;
+  readonly messagePartWriter: {
+    add(part: Message.Part): void;
+  };
+};
+
+export function addStepStart(context: StepEventContext): void {
+  context.messagePartWriter.add({
+    id: generateId(),
+    sessionID: context.sessionID,
+    messageID: context.assistantMessage.id,
+    type: "step-start",
+  });
+}
+
+export function addStepFinish(event: StreamEvent, context: StepEventContext): void {
+  const finishReason = String(event.finishReason || "end_turn");
+  const usage = TokenTracker.extractUsage({
+    usage: event.usage as
+      | {
+          inputTokens?: number;
+          outputTokens?: number;
+          promptTokens?: number;
+          completionTokens?: number;
+          inputTokenDetails?: {
+            cacheReadTokens?: number;
+            cacheWriteTokens?: number;
+          };
+          outputTokenDetails?: {
+            reasoningTokens?: number;
+          };
+          reasoningTokens?: number;
+          reasoning_tokens?: number;
+          cache_creation_input_tokens?: number;
+          cache_read_input_tokens?: number;
+          raw?: {
+            completion_tokens_details?: {
+              reasoning_tokens?: number;
+            };
+          };
+        }
+      | undefined,
+    providerMetadata: event.providerMetadata as
+      | {
+          anthropic?: {
+            reasoningTokens?: number;
+            cacheCreationInputTokens?: number;
+            cacheReadInputTokens?: number;
+          };
+          openai?: {
+            reasoningTokens?: number;
+            cachedPromptTokens?: number;
+          };
+        }
+      | undefined,
+  });
+
+  const tokenCost = TokenTracker.calculateCost(
+    usage,
+    context.model.cost
+      ? {
+          input: context.model.cost.input,
+          output: context.model.cost.output,
+          cacheRead: context.model.cost.cache?.read,
+          cacheWrite: context.model.cost.cache?.write,
+        }
+      : undefined,
+  );
+
+  context.assistantMessage.finish = finishReason;
+  context.assistantMessage.cost += tokenCost.totalCost;
+  context.assistantMessage.tokens.input += usage.inputTokens;
+  context.assistantMessage.tokens.output += usage.outputTokens;
+  context.assistantMessage.tokens.reasoning += usage.reasoningTokens ?? 0;
+  context.assistantMessage.tokens.cache.read += usage.cacheReadTokens ?? 0;
+  context.assistantMessage.tokens.cache.write += usage.cacheWriteTokens ?? 0;
+
+  context.messagePartWriter.add({
+    id: generateId(),
+    sessionID: context.sessionID,
+    messageID: context.assistantMessage.id,
+    type: "step-finish",
+    reason: finishReason,
+    cost: tokenCost.totalCost,
+    tokens: {
+      input: usage.inputTokens,
+      output: usage.outputTokens,
+      reasoning: usage.reasoningTokens ?? 0,
+      cache: {
+        read: usage.cacheReadTokens ?? 0,
+        write: usage.cacheWriteTokens ?? 0,
+      },
+    },
+  });
+}

--- a/packages/llm/src/session/processor-tools.ts
+++ b/packages/llm/src/session/processor-tools.ts
@@ -1,0 +1,123 @@
+import type { Message, Sink } from "@openomni/protocol";
+import { generateId, type StreamEvent, type ToolResult } from "./processor-types.js";
+
+export type ToolEventContext = {
+  readonly sessionID: string;
+  readonly assistantMessage: Message.AssistantMessage;
+  readonly sink: Sink;
+  readonly pendingTools: Message.ToolPart[];
+  readonly messagePartWriter: {
+    add(part: Message.Part): void;
+    update(part: Message.Part): void;
+  };
+  readonly onToolCall?: (part: Message.ToolPart) => Promise<ToolResult>;
+};
+
+type RunningToolEventContext = Omit<ToolEventContext, "onToolCall"> & {
+  readonly onToolCall: (part: Message.ToolPart) => Promise<ToolResult>;
+};
+
+export async function handleToolCall(event: StreamEvent, context: ToolEventContext): Promise<void> {
+  const toolPart: Message.ToolPart = {
+    id: generateId(),
+    sessionID: context.sessionID,
+    messageID: context.assistantMessage.id,
+    type: "tool",
+    callID: String(event.toolCallId),
+    tool: String(event.toolName),
+    state: {
+      status: "pending",
+      input: (event.args as Record<string, unknown>) || {},
+    },
+  };
+  context.messagePartWriter.add(toolPart);
+  context.pendingTools.push(toolPart);
+  context.sink.onToolCall({
+    id: toolPart.callID,
+    tool: toolPart.tool,
+    input: toolPart.state.input,
+  });
+
+  if (!context.onToolCall) return;
+  await runToolCall(toolPart, { ...context, onToolCall: context.onToolCall });
+}
+
+export function cleanupPendingTools(
+  pendingTools: Message.ToolPart[],
+  updateMessagePart: (part: Message.Part) => void,
+  sink: Sink,
+): void {
+  for (const tool of pendingTools) {
+    if (tool.state.status === "pending" || tool.state.status === "running") {
+      tool.state = {
+        status: "error",
+        input: tool.state.input,
+        error: "Processing was interrupted",
+        time: {
+          start: tool.state.status === "running" ? tool.state.time.start : Date.now(),
+          end: Date.now(),
+        },
+      };
+      updateMessagePart(tool);
+      sink.onToolResult({
+        id: generateId(),
+        toolCallId: tool.callID,
+        output: "Processing was interrupted",
+        isError: true,
+      });
+    }
+  }
+}
+
+async function runToolCall(
+  toolPart: Message.ToolPart,
+  context: RunningToolEventContext,
+): Promise<void> {
+  toolPart.state = {
+    status: "running",
+    input: toolPart.state.input,
+    time: { start: Date.now() },
+  };
+  context.messagePartWriter.update(toolPart);
+
+  try {
+    const result = await context.onToolCall(toolPart);
+    toolPart.state = {
+      status: "completed",
+      input: toolPart.state.input,
+      output: result.output,
+      title: result.title,
+      metadata: result.metadata ?? {},
+      time: {
+        start: toolPart.state.status === "running" ? toolPart.state.time.start : Date.now(),
+        end: Date.now(),
+      },
+    };
+    context.messagePartWriter.update(toolPart);
+    context.sink.onToolResult({
+      id: generateId(),
+      toolCallId: toolPart.callID,
+      output: result.output,
+    });
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    toolPart.state = {
+      status: "error",
+      input: toolPart.state.input,
+      error: errorMessage,
+      time: {
+        start: toolPart.state.status === "running" ? toolPart.state.time.start : Date.now(),
+        end: Date.now(),
+      },
+    };
+    context.messagePartWriter.update(toolPart);
+    context.sink.onToolResult({
+      id: generateId(),
+      toolCallId: toolPart.callID,
+      output: errorMessage,
+      isError: true,
+    });
+  }
+  const idx = context.pendingTools.indexOf(toolPart);
+  if (idx >= 0) context.pendingTools.splice(idx, 1);
+}

--- a/packages/llm/src/session/processor-types.ts
+++ b/packages/llm/src/session/processor-types.ts
@@ -1,0 +1,53 @@
+import type { Message, Sink } from "@openomni/protocol";
+import type { Provider } from "../provider";
+
+export type ProcessResult = "stop" | "continue" | "compact";
+
+export interface ToolResult {
+  output: string;
+  title: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StreamInput {
+  messages: unknown[];
+  model: Provider.Model;
+  system: string;
+}
+
+export interface StreamEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface Stream {
+  fullStream: AsyncIterable<StreamEvent>;
+}
+
+export interface ProcessorOptions {
+  assistantMessage: Message.AssistantMessage;
+  sessionID: string;
+  model: Provider.Model;
+  abort: AbortSignal;
+  sink?: Sink;
+  onToolCall?: (part: Message.ToolPart) => Promise<ToolResult>;
+  createStream?: (input: StreamInput) => Promise<Stream>;
+  trace?: { traceId: string; sessionId: string; runId?: string; provider?: string };
+}
+
+export interface ProcessorInfo {
+  message: Message.AssistantMessage;
+  process(streamInput: StreamInput): Promise<ProcessResult>;
+}
+
+export function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export function defaultStream(_input: StreamInput): Promise<Stream> {
+  return Promise.resolve({
+    fullStream: (async function* () {
+      yield { type: "finish" };
+    })(),
+  });
+}

--- a/packages/llm/src/session/processor.ts
+++ b/packages/llm/src/session/processor.ts
@@ -1,68 +1,24 @@
-import {
-  LlmCall,
-  Operational,
-  type Message,
-  type Run,
-  type Sink,
-  type Tool,
-} from "@openomni/protocol";
+import { LlmCall, type Message } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import { TokenTracker } from "../token";
-import { Retry } from "./retry";
 import { APIError } from "../error";
-import type { Provider } from "../provider";
+import { Retry } from "./retry";
+import {
+  cleanupPendingTools,
+  createStreamEventState,
+  handleStreamEvent,
+} from "./processor-events.js";
+import { createNoopSink, createProjectedSink, publishStatus } from "./processor-sink.js";
+import {
+  defaultStream,
+  type ProcessResult,
+  type ProcessorInfo,
+  type ProcessorOptions as ProcessorOptionsInternal,
+  type StreamInput as StreamInputInternal,
+} from "./processor-types.js";
 
 export namespace Processor {
-  type ProcessResult = "stop" | "continue" | "compact";
-
-  interface ToolResult {
-    output: string;
-    title: string;
-    metadata?: Record<string, unknown>;
-  }
-
-  export interface StreamInput {
-    messages: unknown[];
-    model: Provider.Model;
-    system: string;
-  }
-
-  interface StreamEvent {
-    type: string;
-    [key: string]: unknown;
-  }
-
-  interface Stream {
-    fullStream: AsyncIterable<StreamEvent>;
-  }
-
-  export interface ProcessorOptions {
-    assistantMessage: Message.AssistantMessage;
-    sessionID: string;
-    model: Provider.Model;
-    abort: AbortSignal;
-    sink?: Sink;
-    onToolCall?: (part: Message.ToolPart) => Promise<ToolResult>;
-    createStream?: (input: StreamInput) => Promise<Stream>;
-    trace?: { traceId: string; sessionId: string; runId?: string; provider?: string };
-  }
-
-  interface ProcessorInfo {
-    message: Message.AssistantMessage;
-    process(streamInput: StreamInput): Promise<ProcessResult>;
-  }
-
-  function generateId(): string {
-    return crypto.randomUUID();
-  }
-
-  function defaultStream(_input: StreamInput): Promise<Stream> {
-    return Promise.resolve({
-      fullStream: (async function* () {
-        yield { type: "finish" };
-      })(),
-    });
-  }
+  export interface StreamInput extends StreamInputInternal {}
+  export interface ProcessorOptions extends ProcessorOptionsInternal {}
 
   export function create(options: ProcessorOptions): ProcessorInfo {
     const {
@@ -77,9 +33,7 @@ export namespace Processor {
     } = options;
 
     const sink = createProjectedSink(configuredSink, sessionID);
-
     let attempt = 0;
-
     const messageParts: Message.Part[] = [];
 
     function addMessagePart(part: Message.Part): void {
@@ -97,327 +51,36 @@ export namespace Processor {
       sink.onMessage({ info: assistantMessage, parts: [...messageParts] });
     }
 
-    function publishStatus(state: Record<string, unknown>): void {
-      sink.onSnapshot({
-        id: generateId(),
-        sessionID,
-        timestamp: Date.now(),
-        state,
-      });
-    }
-
     return {
       get message() {
         return assistantMessage;
       },
 
       async process(streamInput: StreamInput): Promise<ProcessResult> {
-        publishStatus({ type: "busy" });
+        publishStatus(sink, sessionID, { type: "busy" });
         const pendingTools: Message.ToolPart[] = [];
 
         try {
           while (true) {
             try {
-              let currentText: Message.TextPart | undefined;
-              const reasoningMap: Record<string, Message.ReasoningPart> = {};
-              const textPartMap: Record<string, string[]> = {};
-              const reasoningPartMap: Record<string, string[]> = {};
-
               const stream = await createStream(streamInput);
+              const eventState = createStreamEventState();
 
               for await (const event of stream.fullStream) {
                 abort.throwIfAborted();
-
-                switch (event.type) {
-                  case "text-start": {
-                    const now = Date.now();
-                    currentText = {
-                      id: generateId(),
-                      sessionID,
-                      messageID: assistantMessage.id,
-                      type: "text",
-                      text: "",
-                      time: { start: now },
-                      metadata: (event.providerMetadata as Record<string, unknown>) || {},
-                    };
-                    textPartMap[currentText.id] = [];
-                    addMessagePart(currentText);
-                    break;
-                  }
-
-                  case "text-delta": {
-                    if (currentText) {
-                      const textParts = textPartMap[currentText.id] ?? [];
-                      textPartMap[currentText.id] = textParts;
-                      textParts.push(String(event.text || ""));
-                      if (event.providerMetadata) {
-                        currentText.metadata = event.providerMetadata as Record<string, unknown>;
-                      }
-                      updateMessagePart(currentText);
-                    }
-                    break;
-                  }
-
-                  case "text-end": {
-                    if (currentText?.time) {
-                      currentText.text = (textPartMap[currentText.id] ?? []).join("").trimEnd();
-                      delete textPartMap[currentText.id];
-                      currentText.time = {
-                        start: currentText.time.start,
-                        end: Date.now(),
-                      };
-                      if (event.providerMetadata) {
-                        currentText.metadata = event.providerMetadata as Record<string, unknown>;
-                      }
-                      updateMessagePart(currentText);
-                    }
-                    currentText = undefined;
-                    break;
-                  }
-
-                  case "reasoning-start": {
-                    const reasoningId = String(event.id);
-                    if (!(reasoningId in reasoningMap)) {
-                      const now = Date.now();
-                      const part: Message.ReasoningPart = {
-                        id: generateId(),
-                        sessionID,
-                        messageID: assistantMessage.id,
-                        type: "reasoning",
-                        text: "",
-                        time: { start: now, end: undefined },
-                        metadata: (event.providerMetadata as Record<string, unknown>) || {},
-                      };
-                      reasoningMap[reasoningId] = part;
-                      reasoningPartMap[part.id] = [];
-                      addMessagePart(part);
-                    }
-                    break;
-                  }
-
-                  case "reasoning-delta": {
-                    const reasoningId = String(event.id);
-                    const part = reasoningMap[reasoningId];
-                    if (part != null) {
-                      const reasoningParts = reasoningPartMap[part.id] ?? [];
-                      reasoningPartMap[part.id] = reasoningParts;
-                      reasoningParts.push(String(event.text || ""));
-                      if (event.providerMetadata) {
-                        part.metadata = event.providerMetadata as Record<string, unknown>;
-                      }
-                      updateMessagePart(part);
-                    }
-                    break;
-                  }
-
-                  case "reasoning-end": {
-                    const reasoningId = String(event.id);
-                    const part = reasoningMap[reasoningId];
-                    if (part != null) {
-                      part.text = (reasoningPartMap[part.id] ?? []).join("").trimEnd();
-                      delete reasoningPartMap[part.id];
-                      part.time = {
-                        start: part.time?.start ?? Date.now(),
-                        end: Date.now(),
-                      };
-                      if (event.providerMetadata) {
-                        part.metadata = event.providerMetadata as Record<string, unknown>;
-                      }
-                      updateMessagePart(part);
-                      delete reasoningMap[reasoningId];
-                    }
-                    break;
-                  }
-
-                  case "tool-call": {
-                    const toolPart: Message.ToolPart = {
-                      id: generateId(),
-                      sessionID,
-                      messageID: assistantMessage.id,
-                      type: "tool",
-                      callID: String(event.toolCallId),
-                      tool: String(event.toolName),
-                      state: {
-                        status: "pending",
-                        input: (event.args as Record<string, unknown>) || {},
-                      },
-                    };
-                    addMessagePart(toolPart);
-                    pendingTools.push(toolPart);
-                    sink.onToolCall({
-                      id: toolPart.callID,
-                      tool: toolPart.tool,
-                      input: toolPart.state.input,
-                    });
-
-                    if (onToolCall) {
-                      toolPart.state = {
-                        status: "running",
-                        input: toolPart.state.input,
-                        time: { start: Date.now() },
-                      };
-                      updateMessagePart(toolPart);
-
-                      try {
-                        const result = await onToolCall(toolPart);
-                        toolPart.state = {
-                          status: "completed",
-                          input: toolPart.state.input,
-                          output: result.output,
-                          title: result.title,
-                          metadata: result.metadata ?? {},
-                          time: {
-                            start:
-                              toolPart.state.status === "running"
-                                ? toolPart.state.time.start
-                                : Date.now(),
-                            end: Date.now(),
-                          },
-                        };
-                        updateMessagePart(toolPart);
-                        sink.onToolResult({
-                          id: generateId(),
-                          toolCallId: toolPart.callID,
-                          output: result.output,
-                        });
-                      } catch (err) {
-                        const errorMessage = err instanceof Error ? err.message : String(err);
-                        toolPart.state = {
-                          status: "error",
-                          input: toolPart.state.input,
-                          error: errorMessage,
-                          time: {
-                            start:
-                              toolPart.state.status === "running"
-                                ? toolPart.state.time.start
-                                : Date.now(),
-                            end: Date.now(),
-                          },
-                        };
-                        updateMessagePart(toolPart);
-                        sink.onToolResult({
-                          id: generateId(),
-                          toolCallId: toolPart.callID,
-                          output: errorMessage,
-                          isError: true,
-                        });
-                      }
-                      const idx = pendingTools.indexOf(toolPart);
-                      if (idx >= 0) pendingTools.splice(idx, 1);
-                    }
-                    break;
-                  }
-
-                  case "step-start": {
-                    const stepPart: Message.StepStartPart = {
-                      id: generateId(),
-                      sessionID,
-                      messageID: assistantMessage.id,
-                      type: "step-start",
-                    };
-                    addMessagePart(stepPart);
-                    break;
-                  }
-
-                  case "step-finish": {
-                    const finishReason = String(event.finishReason || "end_turn");
-                    const usage = TokenTracker.extractUsage({
-                      usage: event.usage as
-                        | {
-                            inputTokens?: number;
-                            outputTokens?: number;
-                            promptTokens?: number;
-                            completionTokens?: number;
-                            inputTokenDetails?: {
-                              cacheReadTokens?: number;
-                              cacheWriteTokens?: number;
-                            };
-                            outputTokenDetails?: {
-                              reasoningTokens?: number;
-                            };
-                            reasoningTokens?: number;
-                            reasoning_tokens?: number;
-                            cache_creation_input_tokens?: number;
-                            cache_read_input_tokens?: number;
-                            raw?: {
-                              completion_tokens_details?: {
-                                reasoning_tokens?: number;
-                              };
-                            };
-                          }
-                        | undefined,
-                      providerMetadata: event.providerMetadata as
-                        | {
-                            anthropic?: {
-                              reasoningTokens?: number;
-                              cacheCreationInputTokens?: number;
-                              cacheReadInputTokens?: number;
-                            };
-                            openai?: {
-                              reasoningTokens?: number;
-                              cachedPromptTokens?: number;
-                            };
-                          }
-                        | undefined,
-                    });
-
-                    const tokenCost = TokenTracker.calculateCost(
-                      usage,
-                      model.cost
-                        ? {
-                            input: model.cost.input,
-                            output: model.cost.output,
-                            cacheRead: model.cost.cache?.read,
-                            cacheWrite: model.cost.cache?.write,
-                          }
-                        : undefined,
-                    );
-
-                    assistantMessage.finish = finishReason;
-                    assistantMessage.cost += tokenCost.totalCost;
-                    assistantMessage.tokens.input += usage.inputTokens;
-                    assistantMessage.tokens.output += usage.outputTokens;
-                    assistantMessage.tokens.reasoning += usage.reasoningTokens ?? 0;
-                    assistantMessage.tokens.cache.read += usage.cacheReadTokens ?? 0;
-                    assistantMessage.tokens.cache.write += usage.cacheWriteTokens ?? 0;
-
-                    const stepFinishPart: Message.StepFinishPart = {
-                      id: generateId(),
-                      sessionID,
-                      messageID: assistantMessage.id,
-                      type: "step-finish",
-                      reason: finishReason,
-                      cost: tokenCost.totalCost,
-                      tokens: {
-                        input: usage.inputTokens,
-                        output: usage.outputTokens,
-                        reasoning: usage.reasoningTokens ?? 0,
-                        cache: {
-                          read: usage.cacheReadTokens ?? 0,
-                          write: usage.cacheWriteTokens ?? 0,
-                        },
-                      },
-                    };
-                    addMessagePart(stepFinishPart);
-                    break;
-                  }
-
-                  case "finish": {
-                    break;
-                  }
-
-                  case "error": {
-                    throw event.error;
-                  }
-
-                  default: {
-                    break;
-                  }
-                }
+                await handleStreamEvent(event, eventState, {
+                  sessionID,
+                  assistantMessage,
+                  model,
+                  sink,
+                  pendingTools,
+                  messagePartWriter: { add: addMessagePart, update: updateMessagePart },
+                  onToolCall,
+                });
               }
 
               assistantMessage.time.completed = Date.now();
-              publishStatus({ type: "idle" });
+              publishStatus(sink, sessionID, { type: "idle" });
               return "stop";
             } catch (e: unknown) {
               const retryReason = Retry.isRetryable(e);
@@ -449,7 +112,7 @@ export namespace Processor {
                   }
                 }
 
-                publishStatus({
+                publishStatus(sink, sessionID, {
                   type: "retry",
                   attempt,
                   message: String(retryReason),
@@ -461,7 +124,7 @@ export namespace Processor {
                 } catch (sleepError) {
                   if (sleepError instanceof DOMException && sleepError.name === "AbortError") {
                     cleanupPendingTools(pendingTools, updateMessagePart, sink);
-                    publishStatus({ type: "idle" });
+                    publishStatus(sink, sessionID, { type: "idle" });
                     throw sleepError;
                   }
                   throw sleepError;
@@ -472,121 +135,24 @@ export namespace Processor {
 
               if (e instanceof DOMException && e.name === "AbortError") {
                 cleanupPendingTools(pendingTools, updateMessagePart, sink);
-                publishStatus({ type: "idle" });
+                publishStatus(sink, sessionID, { type: "idle" });
                 throw e;
               }
 
               cleanupPendingTools(pendingTools, updateMessagePart, sink);
               assistantMessage.time.completed = Date.now();
-              publishStatus({ type: "idle" });
+              publishStatus(sink, sessionID, { type: "idle" });
               throw e;
             }
           }
         } catch (e) {
           cleanupPendingTools(pendingTools, updateMessagePart, sink);
-          publishStatus({ type: "idle" });
+          publishStatus(sink, sessionID, { type: "idle" });
           throw e;
         } finally {
           await sink.flush();
         }
       },
     };
-  }
-
-  interface ProjectedSink extends Sink {
-    flush(): Promise<void>;
-  }
-
-  function createProjectedSink(sink: Sink, sessionID: string): ProjectedSink {
-    function publish(message: string, data?: Record<string, unknown>): void {
-      if (!sessionID) return;
-      Bus.publish(Operational.Info, {
-        traceId: sessionID,
-        time: Date.now(),
-        sessionId: sessionID,
-        component: "llm.processor",
-        msg: message,
-        context: data,
-      });
-    }
-
-    return {
-      onMessage(message) {
-        sink.onMessage(message);
-        publish("sink.message", {
-          role: message.info.role,
-          messageId: message.info.id,
-          partCount: message.parts.length,
-        });
-      },
-
-      onToolCall(call: Tool.Call) {
-        sink.onToolCall(call);
-        publish("sink.tool.started", {
-          toolCallId: call.id,
-          toolName: call.tool,
-          inputSummary: summarizeRecord(call.input),
-        });
-      },
-
-      onToolResult(result: Tool.Result) {
-        sink.onToolResult(result);
-        publish("sink.tool.completed", {
-          toolCallId: result.toolCallId,
-          outputLength: result.output.length,
-          isError: result.isError,
-        });
-      },
-
-      onSnapshot(snapshot: Run.Snapshot) {
-        sink.onSnapshot(snapshot);
-        publish("sink.snapshot", { stateType: String(snapshot.state.type ?? "unknown") });
-      },
-
-      flush() {
-        return Promise.resolve();
-      },
-    };
-  }
-
-  function summarizeRecord(input: Record<string, unknown>): string {
-    const keys = Object.keys(input).sort();
-    return keys.length === 0 ? "empty" : keys.join(",");
-  }
-
-  function createNoopSink(): Sink {
-    return {
-      onMessage: () => void 0,
-      onToolCall: () => void 0,
-      onToolResult: () => void 0,
-      onSnapshot: () => void 0,
-    };
-  }
-
-  function cleanupPendingTools(
-    pendingTools: Message.ToolPart[],
-    updateMessagePart: (part: Message.Part) => void,
-    sink: Sink,
-  ): void {
-    for (const tool of pendingTools) {
-      if (tool.state.status === "pending" || tool.state.status === "running") {
-        tool.state = {
-          status: "error",
-          input: tool.state.input,
-          error: "Processing was interrupted",
-          time: {
-            start: tool.state.status === "running" ? tool.state.time.start : Date.now(),
-            end: Date.now(),
-          },
-        };
-        updateMessagePart(tool);
-        sink.onToolResult({
-          id: generateId(),
-          toolCallId: tool.callID,
-          output: "Processing was interrupted",
-          isError: true,
-        });
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary
- split the oversized `Processor.create()` implementation into focused session processor modules
- keep the public `Processor` namespace surface in `processor.ts`
- update the LLM package map in `packages/llm/AGENTS.md`

## Verification
- `bunx biome check packages/llm/src/session/processor.ts packages/llm/src/session/processor-types.ts packages/llm/src/session/processor-sink.ts packages/llm/src/session/processor-events.ts packages/llm/src/session/processor-tools.ts packages/llm/src/session/processor-steps.ts`
- `bun run --cwd packages/llm check-types`
- `bun test test/session/processor.test.ts test/session/integration.test.ts test/run.test.ts` from `packages/llm` (43 pass)
- LSP diagnostics on `packages/llm/src/session` (0 diagnostics)
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bunx knip --no-config-hints`
- `git diff --check`
- `bun test packages/openomni/src/execution-runtime/workspace-lock.test.ts --timeout 30000` (18 pass)
- `bun run test` (turbo 9/9 successful)
- pre-push `dep-check` and `type-check` passed; dep-check reported stale docs warnings only
- `codex-ultrawork-reviewer` PASS; no concrete behavior regression found

Note: Claude Fable oracle could not be used because the local CLI returned 404 for `claude-fable-5`; no fallback model was substituted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the LLM session processor into small, focused modules while keeping the `Processor` API and behavior unchanged. This improves readability and testability with no migration required.

- **Refactors**
  - Moved stream event handling to `processor-events.ts` (text, reasoning, tools, steps).
  - Extracted tool execution + interruption cleanup to `processor-tools.ts`.
  - Extracted step token/cost accounting to `processor-steps.ts`.
  - Extracted sink projection and telemetry to `processor-sink.ts` (adds `publishStatus`, keeps `createNoopSink`).
  - Introduced `processor-types.ts` for internal contracts (`StreamInput`, `StreamEvent`, `Stream`, `ProcessorOptions`, etc.).
  - Slimmed `processor.ts` to an orchestrator that delegates to the modules and preserves the `Processor` namespace surface.
  - Updated `packages/llm/AGENTS.md` to reflect the new layout.

<sup>Written for commit b8a7f57d77fb16efab8ec59f910110120a27762b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored internal LLM session processing architecture into modular components for improved code maintainability. No user-facing changes or behavior modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->