### PR TITLE
refactor(coordinator): split worker supervisor responsibilities

### DIFF
--- a/packages/coordinator/src/worker-supervision/supervisor-client.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor-client.ts
@@ -1,0 +1,50 @@
+import type { IpcClient } from "../ipc/client";
+import { resolveDispatchTimeoutMs } from "./supervisor-process.js";
+
+export async function dispatchWorkerRun(
+  client: IpcClient | null,
+  workerId: number,
+  authToken: string,
+  runId: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  if (!client?.connected) {
+    throw new Error(`worker ${workerId} not available`);
+  }
+  return client.call(
+    "coordinator.spawn_run",
+    { authToken, runId, ...params },
+    resolveDispatchTimeoutMs(params),
+  );
+}
+
+export async function cancelWorkerRun(
+  client: IpcClient | null,
+  workerId: number,
+  authToken: string,
+  runId: string,
+  sessionId: string,
+): Promise<unknown> {
+  if (!client?.connected) {
+    return { cancelled: false, error: `worker ${workerId} not available` };
+  }
+  return client.call("coordinator.cancel_run", { authToken, runId, sessionId }, 5_000);
+}
+
+export async function deliverWorkerMessage(
+  client: IpcClient | null,
+  workerId: number,
+  authToken: string,
+  sessionId: string,
+  message: string,
+  runId?: string,
+): Promise<unknown> {
+  if (!client?.connected) {
+    return { accepted: false, error: `worker ${workerId} not available` };
+  }
+  return client.call(
+    "worker.deliver_message",
+    { authToken, sessionId, ...(runId ? { runId } : {}), message },
+    5_000,
+  );
+}

--- a/packages/coordinator/src/worker-supervision/supervisor-process.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor-process.ts
@@ -1,0 +1,94 @@
+import type { Subprocess } from "bun";
+
+const DEFAULT_WORKER_STOP_GRACE_MS = 5_000;
+const MAX_RESTARTS_PER_WINDOW = 10;
+const MAX_BACKOFF_MS = 30_000;
+const MAX_DISPATCH_TIMEOUT_MS = 600_000;
+
+const workerEnvKeys = new Set([
+  "PATH",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "BUN_INSTALL",
+  "NODE_ENV",
+  "CI",
+  "OPENOMNI_DB_PATH",
+  "OPENOMNI_MODELS_URL",
+  "OPENOMNI_MODELS_PATH",
+  "OPENOMNI_DISABLE_MODELS_FETCH",
+  "OPENOMNI_WORKER_ENV_FIXTURE",
+  "OPENOMNI_WORKER_BOOTSTRAP_DELAY_MS",
+]);
+
+export function buildWorkerEnv(source: NodeJS.ProcessEnv): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of workerEnvKeys) {
+    const value = source[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+export function workerStopGraceMs(): number {
+  const raw = process.env.OPENOMNI_WORKER_STOP_GRACE_MS;
+  if (!raw) return DEFAULT_WORKER_STOP_GRACE_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_WORKER_STOP_GRACE_MS;
+}
+
+export async function waitForWorkerExit(
+  proc: Pick<Subprocess, "exited">,
+  timeoutMs: number,
+): Promise<"exited" | "timeout"> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      proc.exited.then(() => "exited" as const),
+      new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => resolve("timeout"), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function resolveRestartDelay(restartCount: number): number {
+  return restartCount > MAX_RESTARTS_PER_WINDOW
+    ? MAX_BACKOFF_MS
+    : Math.min(1000 * 2 ** (restartCount - 1), MAX_BACKOFF_MS);
+}
+
+export function resolveDispatchTimeoutMs(params: Record<string, unknown>): number {
+  const budget = (params as { budget?: { maxWallTimeMs?: number } }).budget;
+  return Math.min(
+    Math.max(budget?.maxWallTimeMs ?? 300_000, 300_000) + 30_000,
+    MAX_DISPATCH_TIMEOUT_MS,
+  );
+}
+
+export async function waitForSupervisorReady(
+  workerId: number,
+  isReady: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isReady()) return;
+    await new Promise<void>((r) => setTimeout(r, 200));
+  }
+  throw new Error(`worker ${workerId} not ready after ${timeoutMs}ms`);
+}
+
+export function isBootstrapAccepted(value: unknown): boolean {
+  return value !== null && typeof value === "object" && (value as { ok?: unknown }).ok === true;
+}
+
+export function isShutdownAcknowledged(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { acknowledged?: unknown }).acknowledged === true
+  );
+}

--- a/packages/coordinator/src/worker-supervision/supervisor-requests.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor-requests.ts
@@ -1,0 +1,252 @@
+import type { WorkerBootstrap } from "@openomni/protocol";
+import type {
+  ActiveRequest,
+  InboundWaitHandler,
+  InboundWaitResult,
+  SnapshotHandler,
+  ToolCallCancelParams,
+  ToolCallHandler,
+  ToolCallParams,
+} from "./supervisor-types.js";
+
+type RequestContext = {
+  readonly authToken: string;
+  readonly workerId: number;
+  readonly activeToolCalls: Map<string, ActiveRequest>;
+  readonly activeInboundWaitCalls: Map<string, ActiveRequest>;
+  readonly toolCallHandler?: ToolCallHandler;
+  readonly snapshotHandler?: SnapshotHandler;
+  readonly inboundWaitHandler?: InboundWaitHandler;
+  readonly notifyToolCallSettled: (
+    callId: string,
+    workspaceRoot: string | undefined,
+  ) => Promise<void>;
+};
+
+type Respond = (result: unknown) => void;
+
+export function handleWorkerRequest(
+  method: string,
+  params: Record<string, unknown> | undefined,
+  respond: Respond,
+  context: RequestContext,
+): void {
+  switch (method) {
+    case "worker.tool_call_cancel":
+      handleToolCallCancel(params, respond, context);
+      return;
+    case "worker.tool_call":
+      handleToolCall(params, respond, context);
+      return;
+    case "worker.inbound_wait_cancel":
+      handleInboundWaitCancel(params, respond, context);
+      return;
+    case "worker.heartbeat":
+      handleHeartbeat(params, respond, context);
+      return;
+    case "worker.inbound_wait":
+      handleInboundWait(params, respond, context);
+      return;
+    default:
+      respond(null);
+  }
+}
+
+function handleToolCallCancel(
+  params: Record<string, unknown> | undefined,
+  respond: Respond,
+  context: RequestContext,
+): void {
+  const p = parseToolCallCancelParams(params);
+  if (!p) {
+    respond({ cancelled: false, error: "invalid worker.tool_call_cancel params" });
+    return;
+  }
+  const active = context.activeToolCalls.get(p.callId);
+  if (!active || active.runId !== p.runId || active.sessionId !== p.sessionId) {
+    respond({ cancelled: false });
+    return;
+  }
+  active.controller.abort();
+  respondAndForget(context.activeToolCalls, p.callId, active, {
+    id: p.callId,
+    toolCallId: p.callId,
+    output: "Tool call aborted",
+    isError: true,
+    settlement: "unknown",
+  });
+  respond({ cancelled: true, settlement: "unknown" });
+}
+
+function handleToolCall(
+  params: Record<string, unknown> | undefined,
+  respond: Respond,
+  context: RequestContext,
+): void {
+  if (!context.toolCallHandler) {
+    respond(null);
+    return;
+  }
+  const p = params as ToolCallParams;
+  const controller = new AbortController();
+  const active: ActiveRequest = {
+    runId: p.runId,
+    sessionId: p.sessionId,
+    ...(typeof p.workspaceRoot === "string" ? { workspaceRoot: p.workspaceRoot } : {}),
+    controller,
+    respond,
+    completed: false,
+  };
+  context.activeToolCalls.set(p.callId, active);
+  context
+    .toolCallHandler(p, { signal: controller.signal })
+    .then((result) => respondAndForget(context.activeToolCalls, p.callId, active, result))
+    .catch((err) =>
+      respondAndForget(context.activeToolCalls, p.callId, active, {
+        id: p.callId,
+        toolCallId: p.callId,
+        output: err instanceof Error ? err.message : String(err),
+        isError: true,
+      }),
+    )
+    .finally(() => {
+      context.activeToolCalls.delete(p.callId);
+      void context.notifyToolCallSettled(p.callId, active.workspaceRoot);
+    });
+}
+
+function handleInboundWaitCancel(
+  params: Record<string, unknown> | undefined,
+  respond: Respond,
+  context: RequestContext,
+): void {
+  const p = parseInboundWaitCancelParams(params);
+  if (!p) {
+    respond({ cancelled: false, error: "invalid worker.inbound_wait_cancel params" });
+    return;
+  }
+  const callId = p.callId;
+  const active = context.activeInboundWaitCalls.get(callId);
+  if (!active || active.sessionId !== p.sessionId || (active.runId ?? "") !== (p.runId ?? "")) {
+    respond({ cancelled: false });
+    return;
+  }
+  active.controller.abort();
+  respondAndForget(context.activeInboundWaitCalls, callId, active, {
+    requestId: callId,
+    accepted: false,
+    error: "worker.inbound_wait aborted",
+  });
+  respond({ cancelled: true, settlement: "unknown" });
+}
+
+function handleHeartbeat(
+  params: Record<string, unknown> | undefined,
+  respond: Respond,
+  context: RequestContext,
+): void {
+  if (context.snapshotHandler && params?.snapshot) {
+    context.snapshotHandler(context.workerId, params.snapshot as WorkerBootstrap.WorkerSnapshot);
+  }
+  respond(null);
+}
+
+function handleInboundWait(
+  params: Record<string, unknown> | undefined,
+  respond: Respond,
+  context: RequestContext,
+): void {
+  const requestId = crypto.randomUUID();
+  if (params?.authToken !== context.authToken) {
+    respond({ requestId, accepted: false, error: "unauthorized worker request" });
+    return;
+  }
+  const sessionId = typeof params?.sessionId === "string" ? params.sessionId : "";
+  const callId =
+    typeof params?.callId === "string" && params.callId.length > 0 ? params.callId : requestId;
+  const payload = typeof params?.payload === "string" ? params.payload : "";
+  const workspaceRoot =
+    typeof params?.workspaceRoot === "string" ? params.workspaceRoot : undefined;
+  if (!context.inboundWaitHandler || !sessionId || !payload) {
+    respond({
+      requestId: callId,
+      accepted: false,
+      error: context.inboundWaitHandler
+        ? "worker.inbound_wait requires sessionId and payload"
+        : "worker.inbound_wait is not configured",
+    });
+    return;
+  }
+
+  const controller = new AbortController();
+  const runId = typeof params?.runId === "string" ? params.runId : undefined;
+  const active: ActiveRequest = {
+    ...(runId !== undefined && { runId }),
+    sessionId,
+    ...(workspaceRoot !== undefined && { workspaceRoot }),
+    controller,
+    respond,
+    completed: false,
+  };
+  context.activeInboundWaitCalls.set(callId, active);
+
+  context
+    .inboundWaitHandler({
+      workerId: String(context.workerId),
+      sessionId,
+      callId,
+      ...(runId !== undefined && { runId }),
+      ...(workspaceRoot !== undefined && { workspaceRoot }),
+      payload,
+      signal: controller.signal,
+    })
+    .then((result: InboundWaitResult) =>
+      respondAndForget(context.activeInboundWaitCalls, callId, active, result),
+    )
+    .catch((err: unknown) =>
+      respondAndForget(context.activeInboundWaitCalls, callId, active, {
+        requestId: callId,
+        accepted: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+    .finally(() => {
+      context.activeInboundWaitCalls.delete(callId);
+    });
+}
+
+function respondAndForget(
+  activeRequests: Map<string, ActiveRequest>,
+  callId: string,
+  active: ActiveRequest,
+  result: unknown,
+): void {
+  if (active.completed) return;
+  active.completed = true;
+  active.respond(result);
+  activeRequests.delete(callId);
+}
+
+function parseToolCallCancelParams(
+  params: Record<string, unknown> | undefined,
+): ToolCallCancelParams | undefined {
+  if (!params) return undefined;
+  const { runId, sessionId, callId } = params;
+  if (typeof runId !== "string" || typeof sessionId !== "string" || typeof callId !== "string") {
+    return undefined;
+  }
+  return { runId, sessionId, callId };
+}
+
+function parseInboundWaitCancelParams(
+  params: Record<string, unknown> | undefined,
+): { runId?: string; sessionId: string; callId: string } | undefined {
+  if (!params) return undefined;
+  const { runId, sessionId, callId } = params;
+  if (typeof sessionId !== "string" || typeof callId !== "string") return undefined;
+  return {
+    ...(typeof runId === "string" ? { runId } : {}),
+    sessionId,
+    callId,
+  };
+}

--- a/packages/coordinator/src/worker-supervision/supervisor-types.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor-types.ts
@@ -1,0 +1,57 @@
+import type { Tool, WorkerBootstrap } from "@openomni/protocol";
+
+export type ToolCallParams = {
+  runId: string;
+  sessionId: string;
+  callId: string;
+  tool: string;
+  input: Record<string, unknown>;
+  workspaceRoot?: string;
+};
+
+export type ToolCallCancelParams = {
+  runId: string;
+  sessionId: string;
+  callId: string;
+};
+
+export type ToolCallContext = {
+  readonly signal?: AbortSignal;
+};
+
+export type ToolCallResult = Tool.Result;
+
+export type InboundWaitParams = {
+  workerId: string;
+  sessionId: string;
+  callId?: string;
+  runId?: string;
+  workspaceRoot?: string;
+  payload: string;
+  signal?: AbortSignal;
+};
+
+export type InboundWaitResult = {
+  requestId: string;
+  accepted: boolean;
+  output?: string;
+  error?: string;
+};
+
+export type ActiveRequest = {
+  readonly runId?: string;
+  readonly sessionId: string;
+  readonly workspaceRoot?: string;
+  readonly controller: AbortController;
+  readonly respond: (result: unknown) => void;
+  completed: boolean;
+};
+
+export type ToolCallHandler = (
+  params: ToolCallParams,
+  context?: ToolCallContext,
+) => Promise<ToolCallResult>;
+
+export type SnapshotHandler = (workerId: number, snapshot: WorkerBootstrap.WorkerSnapshot) => void;
+
+export type InboundWaitHandler = (params: InboundWaitParams) => Promise<InboundWaitResult>;

--- a/packages/coordinator/src/worker-supervision/supervisor.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor.ts
@@ -1,62 +1,37 @@
 import fs from "node:fs";
 import type { Subprocess } from "bun";
-import { Operational, type Tool, type WorkerBootstrap } from "@openomni/protocol";
+import { Operational, type WorkerBootstrap } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { connectIpcClient, type IpcClient } from "../ipc/client";
+import { cancelWorkerRun, deliverWorkerMessage, dispatchWorkerRun } from "./supervisor-client.js";
+import {
+  buildWorkerEnv,
+  isBootstrapAccepted,
+  isShutdownAcknowledged,
+  resolveRestartDelay,
+  waitForSupervisorReady,
+  waitForWorkerExit,
+  workerStopGraceMs,
+} from "./supervisor-process.js";
+import { handleWorkerRequest } from "./supervisor-requests.js";
+import type {
+  ActiveRequest,
+  InboundWaitHandler,
+  SnapshotHandler,
+  ToolCallHandler,
+} from "./supervisor-types.js";
 
-const MAX_RESTARTS_PER_WINDOW = 10;
 const RESTART_WINDOW_MS = 60_000;
-const MAX_BACKOFF_MS = 30_000;
 const WORKER_CONNECT_TIMEOUT_MS = 10_000;
-const MAX_DISPATCH_TIMEOUT_MS = 600_000;
-const DEFAULT_WORKER_STOP_GRACE_MS = 5_000;
 
-export type ToolCallParams = {
-  runId: string;
-  sessionId: string;
-  callId: string;
-  tool: string;
-  input: Record<string, unknown>;
-  workspaceRoot?: string;
-};
-
-export type ToolCallCancelParams = {
-  runId: string;
-  sessionId: string;
-  callId: string;
-};
-
-export type ToolCallContext = {
-  readonly signal?: AbortSignal;
-};
-
-export type ToolCallResult = Tool.Result;
-
-export type InboundWaitParams = {
-  workerId: string;
-  sessionId: string;
-  callId?: string;
-  runId?: string;
-  workspaceRoot?: string;
-  payload: string;
-  signal?: AbortSignal;
-};
-
-export type InboundWaitResult = {
-  requestId: string;
-  accepted: boolean;
-  output?: string;
-  error?: string;
-};
-
-type ActiveRequest = {
-  readonly runId?: string;
-  readonly sessionId: string;
-  readonly workspaceRoot?: string;
-  readonly controller: AbortController;
-  readonly respond: (result: unknown) => void;
-  completed: boolean;
-};
+export type {
+  InboundWaitParams,
+  InboundWaitResult,
+  ToolCallCancelParams,
+  ToolCallContext,
+  ToolCallParams,
+  ToolCallResult,
+} from "./supervisor-types.js";
 
 export class WorkerSupervisor {
   private proc: Subprocess | null = null;
@@ -77,15 +52,9 @@ export class WorkerSupervisor {
     private readonly script: string,
     socketDir = "/tmp",
     private readonly bootstrap?: WorkerBootstrap.Bootstrap,
-    private readonly toolCallHandler?: (
-      params: ToolCallParams,
-      context?: ToolCallContext,
-    ) => Promise<ToolCallResult>,
-    private readonly snapshotHandler?: (
-      workerId: number,
-      snapshot: WorkerBootstrap.WorkerSnapshot,
-    ) => void,
-    private readonly inboundWaitHandler?: (params: InboundWaitParams) => Promise<InboundWaitResult>,
+    private readonly toolCallHandler?: ToolCallHandler,
+    private readonly snapshotHandler?: SnapshotHandler,
+    private readonly inboundWaitHandler?: InboundWaitHandler,
   ) {
     this.socketPath = `${socketDir}/openomni-worker-${id}.sock`;
     this.doStart();
@@ -118,9 +87,6 @@ export class WorkerSupervisor {
     const deadline = Date.now() + WORKER_CONNECT_TIMEOUT_MS;
     let lastError: Error | null = null;
     const bootstrap = this.bootstrap;
-    const toolCallHandler = this.toolCallHandler;
-    const snapshotHandler = this.snapshotHandler;
-    const workerId = this.id;
     const authToken = this.authToken;
 
     while (Date.now() < deadline && !this.stopping && this.running) {
@@ -132,173 +98,34 @@ export class WorkerSupervisor {
         const c = await connectIpcClient(this.socketPath, {
           connectTimeoutMs: 500,
           onRequest: (method, params, respond) => {
-            if (method === "worker.tool_call_cancel") {
-              const p = parseToolCallCancelParams(params);
-              if (!p) {
-                respond({ cancelled: false, error: "invalid worker.tool_call_cancel params" });
-                return;
-              }
-              const active = this.activeToolCalls.get(p.callId);
-              if (!active || active.runId !== p.runId || active.sessionId !== p.sessionId) {
-                respond({ cancelled: false });
-                return;
-              }
-              active.controller.abort();
-              this.respondAndForget(this.activeToolCalls, p.callId, active, {
-                id: p.callId,
-                toolCallId: p.callId,
-                output: "Tool call aborted",
-                isError: true,
-                settlement: "unknown",
-              });
-              respond({ cancelled: true, settlement: "unknown" });
-              return;
-            }
-
-            if (method === "worker.tool_call" && toolCallHandler) {
-              const p = params as ToolCallParams;
-              const controller = new AbortController();
-              const active: ActiveRequest = {
-                runId: p.runId,
-                sessionId: p.sessionId,
-                ...(typeof p.workspaceRoot === "string" ? { workspaceRoot: p.workspaceRoot } : {}),
-                controller,
-                respond,
-                completed: false,
-              };
-              this.activeToolCalls.set(p.callId, active);
-              toolCallHandler(p, { signal: controller.signal })
-                .then((result) =>
-                  this.respondAndForget(this.activeToolCalls, p.callId, active, result),
-                )
-                .catch((err) =>
-                  this.respondAndForget(this.activeToolCalls, p.callId, active, {
-                    id: p.callId,
-                    toolCallId: p.callId,
-                    output: err instanceof Error ? err.message : String(err),
-                    isError: true,
-                  }),
-                )
-                .finally(() => {
-                  this.activeToolCalls.delete(p.callId);
-                  void c
-                    .call(
-                      "worker.tool_call_settled",
-                      {
-                        authToken,
-                        callId: p.callId,
-                        ...(active.workspaceRoot ? { workspaceRoot: active.workspaceRoot } : {}),
-                      },
-                      5_000,
-                    )
-                    .catch((err) => {
-                      console.warn("worker.tool_call_settled notification failed", {
-                        callId: p.callId,
-                        workspaceRoot: active.workspaceRoot,
-                        error: err instanceof Error ? err.message : String(err),
-                      });
+            handleWorkerRequest(method, params, respond, {
+              authToken,
+              workerId: this.id,
+              activeToolCalls: this.activeToolCalls,
+              activeInboundWaitCalls: this.activeInboundWaitCalls,
+              toolCallHandler: this.toolCallHandler,
+              snapshotHandler: this.snapshotHandler,
+              inboundWaitHandler: this.inboundWaitHandler,
+              notifyToolCallSettled: async (callId, workspaceRoot) => {
+                await c
+                  .call(
+                    "worker.tool_call_settled",
+                    {
+                      authToken,
+                      callId,
+                      ...(workspaceRoot ? { workspaceRoot } : {}),
+                    },
+                    5_000,
+                  )
+                  .catch((err) => {
+                    console.warn("worker.tool_call_settled notification failed", {
+                      callId,
+                      workspaceRoot,
+                      error: err instanceof Error ? err.message : String(err),
                     });
-                });
-              return;
-            }
-
-            if (method === "worker.inbound_wait_cancel") {
-              const p = parseInboundWaitCancelParams(params);
-              if (!p) {
-                respond({ cancelled: false, error: "invalid worker.inbound_wait_cancel params" });
-                return;
-              }
-              const callId = p.callId;
-              const active = this.activeInboundWaitCalls.get(callId);
-              if (
-                !active ||
-                active.sessionId !== p.sessionId ||
-                (active.runId ?? "") !== (p.runId ?? "")
-              ) {
-                respond({ cancelled: false });
-                return;
-              }
-              active.controller.abort();
-              this.respondAndForget(this.activeInboundWaitCalls, callId, active, {
-                requestId: callId,
-                accepted: false,
-                error: "worker.inbound_wait aborted",
-              });
-              respond({ cancelled: true, settlement: "unknown" });
-              return;
-            }
-
-            if (method === "worker.heartbeat") {
-              if (snapshotHandler && params?.snapshot) {
-                snapshotHandler(workerId, params.snapshot as WorkerBootstrap.WorkerSnapshot);
-              }
-              respond(null);
-              return;
-            }
-
-            if (method === "worker.inbound_wait") {
-              const requestId = crypto.randomUUID();
-              if (params?.authToken !== authToken) {
-                respond({ requestId, accepted: false, error: "unauthorized worker request" });
-                return;
-              }
-              const sessionId = typeof params?.sessionId === "string" ? params.sessionId : "";
-              const callId =
-                typeof params?.callId === "string" && params.callId.length > 0
-                  ? params.callId
-                  : requestId;
-              const payload = typeof params?.payload === "string" ? params.payload : "";
-              const workspaceRoot =
-                typeof params?.workspaceRoot === "string" ? params.workspaceRoot : undefined;
-              if (!this.inboundWaitHandler || !sessionId || !payload) {
-                respond({
-                  requestId: callId,
-                  accepted: false,
-                  error: this.inboundWaitHandler
-                    ? "worker.inbound_wait requires sessionId and payload"
-                    : "worker.inbound_wait is not configured",
-                });
-                return;
-              }
-
-              const controller = new AbortController();
-              const runId = typeof params?.runId === "string" ? params.runId : undefined;
-              const active: ActiveRequest = {
-                ...(runId !== undefined && { runId }),
-                sessionId,
-                ...(workspaceRoot !== undefined && { workspaceRoot }),
-                controller,
-                respond,
-                completed: false,
-              };
-              this.activeInboundWaitCalls.set(callId, active);
-
-              this.inboundWaitHandler({
-                workerId: String(workerId),
-                sessionId,
-                callId,
-                ...(runId !== undefined && { runId }),
-                ...(workspaceRoot !== undefined && { workspaceRoot }),
-                payload,
-                signal: controller.signal,
-              })
-                .then((result: InboundWaitResult) =>
-                  this.respondAndForget(this.activeInboundWaitCalls, callId, active, result),
-                )
-                .catch((err: unknown) =>
-                  this.respondAndForget(this.activeInboundWaitCalls, callId, active, {
-                    requestId: callId,
-                    accepted: false,
-                    error: err instanceof Error ? err.message : String(err),
-                  }),
-                )
-                .finally(() => {
-                  this.activeInboundWaitCalls.delete(callId);
-                });
-              return;
-            }
-
-            respond(null);
+                  });
+              },
+            });
           },
           onNotification: (method, params) => {
             if (method === "worker.bootstrap_ready" && params?.authToken === authToken) {
@@ -347,26 +174,9 @@ export class WorkerSupervisor {
     }
     this.restartCount++;
 
-    const delay =
-      this.restartCount > MAX_RESTARTS_PER_WINDOW
-        ? MAX_BACKOFF_MS
-        : Math.min(1000 * 2 ** (this.restartCount - 1), MAX_BACKOFF_MS);
-
     setTimeout(() => {
       if (!this.stopping) this.doStart();
-    }, delay);
-  }
-
-  private respondAndForget(
-    activeRequests: Map<string, ActiveRequest>,
-    callId: string,
-    active: ActiveRequest,
-    result: unknown,
-  ): void {
-    if (active.completed) return;
-    active.completed = true;
-    active.respond(result);
-    activeRequests.delete(callId);
+    }, resolveRestartDelay(this.restartCount));
   }
 
   isActive(): boolean {
@@ -382,49 +192,19 @@ export class WorkerSupervisor {
   }
 
   async waitReady(timeoutMs = 10_000): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      if (this.isReady()) return;
-      await new Promise<void>((r) => setTimeout(r, 200));
-    }
-    throw new Error(`worker ${this.id} not ready after ${timeoutMs}ms`);
+    return waitForSupervisorReady(this.id, () => this.isReady(), timeoutMs);
   }
 
   async dispatch(runId: string, params: Record<string, unknown>): Promise<unknown> {
-    const c = this.client;
-    if (!c?.connected) {
-      throw new Error(`worker ${this.id} not available`);
-    }
-    const budget = (params as { budget?: { maxWallTimeMs?: number } }).budget;
-    const timeoutMs = Math.min(
-      Math.max(budget?.maxWallTimeMs ?? 300_000, 300_000) + 30_000,
-      MAX_DISPATCH_TIMEOUT_MS,
-    );
-    return c.call(
-      "coordinator.spawn_run",
-      { authToken: this.authToken, runId, ...params },
-      timeoutMs,
-    );
+    return dispatchWorkerRun(this.client, this.id, this.authToken, runId, params);
   }
 
   async cancel(runId: string, sessionId: string): Promise<unknown> {
-    const c = this.client;
-    if (!c?.connected) {
-      return { cancelled: false, error: `worker ${this.id} not available` };
-    }
-    return c.call("coordinator.cancel_run", { authToken: this.authToken, runId, sessionId }, 5_000);
+    return cancelWorkerRun(this.client, this.id, this.authToken, runId, sessionId);
   }
 
   async deliverMessage(sessionId: string, message: string, runId?: string): Promise<unknown> {
-    const c = this.client;
-    if (!c?.connected) {
-      return { accepted: false, error: `worker ${this.id} not available` };
-    }
-    return c.call(
-      "worker.deliver_message",
-      { authToken: this.authToken, sessionId, ...(runId ? { runId } : {}), message },
-      5_000,
-    );
+    return deliverWorkerMessage(this.client, this.id, this.authToken, sessionId, message, runId);
   }
 
   async shutdownIdle(): Promise<boolean> {
@@ -456,9 +236,7 @@ export class WorkerSupervisor {
   }
 
   forceKill(): void {
-    if (this.proc && this.running) {
-      this.proc.kill("SIGKILL");
-    }
+    if (this.proc && this.running) this.proc.kill("SIGKILL");
   }
 
   async stop(): Promise<void> {
@@ -485,89 +263,4 @@ export class WorkerSupervisor {
     this.proc = null;
     this.running = false;
   }
-}
-
-function workerStopGraceMs(): number {
-  const raw = process.env.OPENOMNI_WORKER_STOP_GRACE_MS;
-  if (!raw) return DEFAULT_WORKER_STOP_GRACE_MS;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_WORKER_STOP_GRACE_MS;
-}
-
-async function waitForWorkerExit(
-  proc: Pick<Subprocess, "exited">,
-  timeoutMs: number,
-): Promise<"exited" | "timeout"> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      proc.exited.then(() => "exited" as const),
-      new Promise<"timeout">((resolve) => {
-        timeout = setTimeout(() => resolve("timeout"), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
-}
-
-const workerEnvKeys = new Set([
-  "PATH",
-  "TMPDIR",
-  "TEMP",
-  "TMP",
-  "BUN_INSTALL",
-  "NODE_ENV",
-  "CI",
-  "OPENOMNI_DB_PATH",
-  "OPENOMNI_MODELS_URL",
-  "OPENOMNI_MODELS_PATH",
-  "OPENOMNI_DISABLE_MODELS_FETCH",
-  "OPENOMNI_WORKER_ENV_FIXTURE",
-  "OPENOMNI_WORKER_BOOTSTRAP_DELAY_MS",
-]);
-
-function buildWorkerEnv(source: NodeJS.ProcessEnv): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const key of workerEnvKeys) {
-    const value = source[key];
-    if (value !== undefined) env[key] = value;
-  }
-  return env;
-}
-
-function parseToolCallCancelParams(
-  params: Record<string, unknown> | undefined,
-): ToolCallCancelParams | undefined {
-  if (!params) return undefined;
-  const { runId, sessionId, callId } = params;
-  if (typeof runId !== "string" || typeof sessionId !== "string" || typeof callId !== "string") {
-    return undefined;
-  }
-  return { runId, sessionId, callId };
-}
-
-function parseInboundWaitCancelParams(
-  params: Record<string, unknown> | undefined,
-): { runId?: string; sessionId: string; callId: string } | undefined {
-  if (!params) return undefined;
-  const { runId, sessionId, callId } = params;
-  if (typeof sessionId !== "string" || typeof callId !== "string") return undefined;
-  return {
-    ...(typeof runId === "string" ? { runId } : {}),
-    sessionId,
-    callId,
-  };
-}
-
-function isBootstrapAccepted(value: unknown): boolean {
-  return value !== null && typeof value === "object" && (value as { ok?: unknown }).ok === true;
-}
-
-function isShutdownAcknowledged(value: unknown): boolean {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    (value as { acknowledged?: unknown }).acknowledged === true
-  );
 }


### PR DESCRIPTION
## Summary
- split `WorkerSupervisor` request, process, client-call, and type responsibilities into focused internal modules
- keep `supervisor.ts` as the public `WorkerSupervisor` orchestrator and type re-export surface
- reduce worker-supervision production files below the 250-line cleanup threshold

## Verification
- `bun install`
- `bun run --cwd packages/protocol build`
- baseline focused worker-supervision tests before edit: pass
- `bunx biome check packages/coordinator/src/worker-supervision/supervisor.ts packages/coordinator/src/worker-supervision/supervisor-client.ts packages/coordinator/src/worker-supervision/supervisor-process.ts packages/coordinator/src/worker-supervision/supervisor-requests.ts packages/coordinator/src/worker-supervision/supervisor-types.ts`
- `bun run --cwd packages/coordinator check-types`
- focused worker-supervision tests from `packages/coordinator`: 19 pass / 0 fail
- LSP diagnostics on `packages/coordinator/src/worker-supervision`: 0 diagnostics
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bunx knip --no-config-hints`
- `git diff --check`
- `bun run test` (turbo 9/9 successful; coordinator 96 pass / 0 fail)
- pre-push `dep-check` and `type-check` passed; dep-check reported stale-doc warnings only
- `codex-ultrawork-reviewer` PASS; no concrete behavior regression found


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `WorkerSupervisor` into focused internal modules to simplify the coordinator and keep the public API stable. No runtime behavior changes; existing tests pass.

- **Refactors**
  - Moved process and timing helpers to `supervisor-process.ts` (restart backoff, dispatch timeout, env, shutdown/exit handling).
  - Extracted IPC calls to `supervisor-client.ts` for `dispatch`, `cancel`, and `deliverMessage` with consistent availability checks and timeouts.
  - Centralized worker request handling in `supervisor-requests.ts` (tool call/cancel, inbound wait/cancel, heartbeat) with proper abort and settlement notification.
  - Added shared types in `supervisor-types.ts`; `supervisor.ts` remains the public orchestrator and re-export surface.
  - Reduced `supervisor.ts` below the 250-line cleanup threshold.

<sup>Written for commit a90d49925f1b698e3f29a58ad30045fb383964b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

