### PR TITLE
refactor(server): split worker runner responsibilities

### DIFF
--- a/apps/server/src/execution/worker-runner-background.ts
+++ b/apps/server/src/execution/worker-runner-background.ts
@@ -1,0 +1,51 @@
+import {
+  type BackgroundManager,
+  buildWorkerChildRuntimeConfig,
+  buildWorkerMiddleware,
+  type createWorkerSubagentRuntime,
+} from "@openomni/openomni";
+import type { Execution } from "@openomni/protocol";
+
+export function buildDelegationAdmissionMiddleware(
+  request: Execution.Request,
+): ReturnType<typeof buildWorkerMiddleware> | undefined {
+  if (!request.policyPlan) return undefined;
+  return buildWorkerMiddleware({
+    permissions: request.permissions,
+    policyPlan: request.policyPlan,
+    includeLifecycle: false,
+    includeIdle: false,
+  }).map((registration) => ({ ...registration, propagate: true }));
+}
+
+export function createScopedBackgroundManager(options: {
+  readonly backgroundManager: ReturnType<typeof BackgroundManager.create>;
+  readonly workerSubagentConfig: Parameters<typeof createWorkerSubagentRuntime>[0];
+}): ReturnType<typeof BackgroundManager.create> {
+  const { backgroundManager, workerSubagentConfig } = options;
+  return {
+    launch(input: Parameters<typeof backgroundManager.launch>[0]) {
+      const childRuntime = buildWorkerChildRuntimeConfig(workerSubagentConfig, {
+        agentName: input.agentName,
+        depth: input.depth ?? 1,
+        middleware: input.middleware,
+      });
+      return backgroundManager.launch({
+        ...input,
+        systemPrompt: childRuntime.systemPrompt,
+        tools: childRuntime.tools,
+        toolExecutor: childRuntime.toolExecutor,
+        permissions: childRuntime.permissions,
+        middleware: childRuntime.middleware,
+        childMiddleware: childRuntime.childMiddleware,
+      });
+    },
+    getTask: (taskId) => backgroundManager.getTask(taskId),
+    getResult: (taskId) => backgroundManager.getResult(taskId),
+    cancel: (taskId) => backgroundManager.cancel(taskId),
+    listByParent: (parentSessionId) => backgroundManager.listByParent(parentSessionId),
+    cleanup: () => backgroundManager.cleanup(),
+    stats: () => backgroundManager.stats(),
+    dispose: () => backgroundManager.dispose(),
+  };
+}

--- a/apps/server/src/execution/worker-runner-events.ts
+++ b/apps/server/src/execution/worker-runner-events.ts
@@ -1,0 +1,60 @@
+import { Subagent } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+export function publishWorkerRunStarted(input: {
+  readonly traceId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly prompt: string;
+}): void {
+  Bus.publish(Subagent.Events.WorkerRunStarted, {
+    traceId: input.traceId,
+    sessionId: input.sessionId,
+    runId: input.runId,
+    time: Date.now(),
+    payload: { sessionId: input.sessionId, runId: input.runId, title: input.prompt.slice(0, 80) },
+  });
+}
+
+export function publishWorkerRunSucceeded(input: {
+  readonly traceId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+}): void {
+  Bus.publish(Subagent.Events.WorkerRunCompleted, {
+    traceId: input.traceId,
+    sessionId: input.sessionId,
+    runId: input.runId,
+    time: Date.now(),
+    payload: { sessionId: input.sessionId, runId: input.runId, status: "succeeded" },
+  });
+}
+
+export function publishWorkerRunCancelled(input: {
+  readonly traceId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+}): void {
+  Bus.publish(Subagent.Events.WorkerSessionCancelled, {
+    traceId: input.traceId,
+    sessionId: input.sessionId,
+    runId: input.runId,
+    time: Date.now(),
+    payload: { sessionId: input.sessionId, runId: input.runId },
+  });
+}
+
+export function publishWorkerRunFailed(input: {
+  readonly traceId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly errorMessage: string;
+}): void {
+  Bus.publish(Subagent.Events.WorkerRunFailed, {
+    traceId: input.traceId,
+    sessionId: input.sessionId,
+    runId: input.runId,
+    time: Date.now(),
+    payload: { sessionId: input.sessionId, runId: input.runId, error: input.errorMessage },
+  });
+}

--- a/apps/server/src/execution/worker-runner-ipc.ts
+++ b/apps/server/src/execution/worker-runner-ipc.ts
@@ -1,0 +1,203 @@
+import {
+  DispatchRuntime,
+  type DispatchHandler,
+  type DispatchToolRuntime,
+  ToolProxyProvider,
+} from "@openomni/openomni";
+import { Tool } from "@openomni/protocol";
+
+const WORKER_TOOL_CALL_IPC_TIMEOUT_MS = 5 * 60_000;
+const WORKER_RESIDENT_ASK_IPC_TIMEOUT_MS = 5 * 60_000;
+
+export interface WorkerRunIpcServer {
+  call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
+  notify(method: string, params?: Record<string, unknown>): void;
+}
+
+export function createWorkerDispatchRuntime(options: {
+  readonly server: WorkerRunIpcServer;
+  readonly ipcAuthToken: string;
+  readonly workerId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly workspaceRoot?: string;
+}): DispatchToolRuntime {
+  const runtime = new DispatchRuntime();
+  const handler: DispatchHandler = async (command, context) => {
+    if (!context?.wait) {
+      throw new Error("worker dispatch resident.ask requires wait: true");
+    }
+    if (command.target.kind !== "resident") {
+      throw new Error("worker dispatch resident.ask currently supports resident targets only");
+    }
+
+    const callId = command.dispatchId;
+    const payload =
+      typeof command.payload === "string" ? command.payload : JSON.stringify(command.payload);
+    const sessionId = context.sessionId ?? options.sessionId;
+    const runId = context.runId ?? options.runId;
+    const workspaceRoot = context.workspaceRoot ?? options.workspaceRoot;
+    const cancelInboundWait = () => {
+      void options.server
+        .call("worker.inbound_wait_cancel", { sessionId, runId, callId }, 5_000)
+        .catch(() => undefined);
+    };
+
+    const raw = await abortableIpcCall(
+      () =>
+        options.server.call(
+          "worker.inbound_wait",
+          {
+            authToken: options.ipcAuthToken,
+            workerId: options.workerId,
+            sessionId,
+            runId,
+            callId,
+            payload,
+            ...(workspaceRoot ? { workspaceRoot } : {}),
+          },
+          WORKER_RESIDENT_ASK_IPC_TIMEOUT_MS,
+        ),
+      context.signal,
+      cancelInboundWait,
+    );
+
+    if (raw === null || typeof raw !== "object") {
+      throw new Error("invalid worker.inbound_wait response");
+    }
+    const result = raw as { accepted?: unknown; output?: unknown; error?: unknown };
+    if (result.accepted !== true) {
+      throw new Error(
+        typeof result.error === "string" ? result.error : "worker.inbound_wait rejected",
+      );
+    }
+
+    return { output: typeof result.output === "string" ? result.output : "" };
+  };
+
+  runtime.register("resident.ask", handler);
+  return {
+    submit(input, context = {}) {
+      return runtime.submit(input, {
+        ...context,
+        sessionId: context.sessionId ?? options.sessionId,
+        runId: context.runId ?? options.runId,
+        workspaceRoot: context.workspaceRoot ?? options.workspaceRoot,
+        actorKind: context.actorKind ?? "worker",
+        actorId: context.actorId ?? `${options.sessionId}:${options.runId}`,
+        trustTier: context.trustTier ?? "assigned_worker",
+        labels: [...(context.labels ?? []), "worker-runner"],
+      });
+    },
+  };
+}
+
+export function createMcpProxyProvider(options: {
+  readonly toolCatalog: Parameters<typeof ToolProxyProvider.create>[0];
+  readonly server: WorkerRunIpcServer;
+  readonly runId: string;
+  readonly sessionId: string;
+  readonly workspaceRoot?: string;
+}): ReturnType<typeof ToolProxyProvider.create> {
+  const { toolCatalog, server, runId, sessionId, workspaceRoot } = options;
+  return ToolProxyProvider.create(toolCatalog, async (toolName, toolArgs, context) => {
+    const callId = crypto.randomUUID();
+    if (context?.signal?.aborted) {
+      return {
+        id: callId,
+        toolCallId: callId,
+        output: "Tool call aborted",
+        isError: true,
+      };
+    }
+
+    const cancelToolCall = () => {
+      void server
+        .call("worker.tool_call_cancel", { runId, sessionId, callId }, 5_000)
+        .catch(() => undefined);
+    };
+
+    try {
+      const raw = await abortableIpcCall(
+        () =>
+          server.call(
+            "worker.tool_call",
+            {
+              runId,
+              sessionId,
+              callId,
+              tool: toolName,
+              input: toolArgs,
+              ...(workspaceRoot ? { workspaceRoot } : {}),
+            },
+            WORKER_TOOL_CALL_IPC_TIMEOUT_MS,
+          ),
+        context?.signal,
+        cancelToolCall,
+      );
+      return Tool.Result.parse(raw);
+    } catch (error) {
+      return {
+        id: callId,
+        toolCallId: callId,
+        output: error instanceof Error ? error.message : String(error),
+        isError: true,
+        settlement: "unknown",
+      };
+    }
+  });
+}
+
+export function notifyWorkerRunCompleted(
+  server: WorkerRunIpcServer,
+  params: Record<string, unknown>,
+): void {
+  try {
+    server.notify("worker.run_completed", params);
+  } catch {
+    return;
+  }
+}
+
+function createToolCallAbortError(): Error {
+  const error = new Error("Tool call aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function abortableIpcCall<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal | undefined,
+  onAbort: () => void,
+): Promise<T> {
+  if (!signal) return operation();
+  if (signal.aborted) return Promise.reject(createToolCallAbortError());
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", handleAbort);
+    const finish = (complete: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      complete();
+    };
+    const handleAbort = () => {
+      onAbort();
+      finish(() => reject(createToolCallAbortError()));
+    };
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    let pending: Promise<T>;
+    try {
+      pending = operation();
+    } catch (error) {
+      finish(() => reject(error));
+      return;
+    }
+    pending.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error)),
+    );
+  });
+}

--- a/apps/server/src/execution/worker-runner-types.ts
+++ b/apps/server/src/execution/worker-runner-types.ts
@@ -1,0 +1,42 @@
+import type { ChatAgent } from "@openomni/agent";
+import type { Auth } from "@openomni/llm";
+import type { BackgroundManager, InjectionQueue } from "@openomni/openomni";
+import type { WorkerBootstrap } from "@openomni/protocol";
+import type { WorkerRunState } from "./worker-run-state";
+import type { WorkerRunIpcServer } from "./worker-runner-ipc";
+
+type WorkerRunnerChatAgentOptions = Parameters<typeof ChatAgent.create>[0];
+type WorkerRunnerAgent = Pick<ReturnType<typeof ChatAgent.create>, "run">;
+
+interface WorkerRunnerEnvironment {
+  readonly ipcAuthToken: string;
+  readonly workerId: string;
+  readonly server: WorkerRunIpcServer;
+  readonly activeRuns: WorkerRunState.ActiveRunRegistry;
+  readonly bootstrapReady: Promise<void>;
+  readonly backgroundManager: ReturnType<typeof BackgroundManager.create>;
+  readonly injectionQueue: InjectionQueue.Instance;
+  readonly defaultWorkspaceRoot: string | undefined;
+  readonly getBootstrap: () => WorkerBootstrap.Bootstrap | null;
+  readonly resolveAuth: (provider: string) => Auth.Info | undefined;
+  readonly createAgent?: (options: WorkerRunnerChatAgentOptions) => WorkerRunnerAgent;
+}
+
+export interface WorkerRunnerSpawnOptions extends WorkerRunnerEnvironment {
+  readonly params: Record<string, unknown> | undefined;
+  readonly respond: (result: unknown) => void;
+}
+
+export function respondSpawnRejected(options: {
+  readonly params: Record<string, unknown> | undefined;
+  readonly respond: (result: unknown) => void;
+  readonly error: string;
+}): void {
+  const { params, respond, error } = options;
+  respond({
+    runId: typeof params?.runId === "string" ? params.runId : "unknown",
+    sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
+    status: "failed",
+    error,
+  });
+}

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -1,190 +1,33 @@
 import { ChatAgent } from "@openomni/agent";
-import type { Auth } from "@openomni/llm";
 import {
   AgentToolProvider,
-  DispatchRuntime,
-  type BackgroundManager,
-  type DispatchHandler,
-  type DispatchToolRuntime,
-  type InjectionQueue,
   SystemToolProvider,
-  ToolProxyProvider,
   buildToolCatalog,
   buildWorkerMiddleware,
-  buildWorkerChildRuntimeConfig,
   createWorkerSubagentRuntime,
 } from "@openomni/openomni";
-import { Execution, Subagent, Tool, type WorkerBootstrap } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
+import { Execution, type WorkerBootstrap } from "@openomni/protocol";
 import { createContextMiddleware } from "../context/index";
-import type { WorkerRunState } from "./worker-run-state";
+import {
+  buildDelegationAdmissionMiddleware,
+  createScopedBackgroundManager,
+} from "./worker-runner-background";
+import {
+  publishWorkerRunCancelled,
+  publishWorkerRunFailed,
+  publishWorkerRunStarted,
+  publishWorkerRunSucceeded,
+} from "./worker-runner-events";
+import {
+  createMcpProxyProvider,
+  createWorkerDispatchRuntime,
+  notifyWorkerRunCompleted,
+} from "./worker-runner-ipc";
+import { respondSpawnRejected, type WorkerRunnerSpawnOptions } from "./worker-runner-types";
 import { buildWorkerInputMessages, createExecutionToolContext } from "./worker-runtime";
 
-const WORKER_TOOL_CALL_IPC_TIMEOUT_MS = 5 * 60_000;
-const WORKER_RESIDENT_ASK_IPC_TIMEOUT_MS = 5 * 60_000;
-
-function buildDelegationAdmissionMiddleware(
-  request: Execution.Request,
-): ReturnType<typeof buildWorkerMiddleware> | undefined {
-  if (!request.policyPlan) return undefined;
-  return buildWorkerMiddleware({
-    permissions: request.permissions,
-    policyPlan: request.policyPlan,
-    includeLifecycle: false,
-    includeIdle: false,
-  }).map((registration) => ({ ...registration, propagate: true }));
-}
-
-function createToolCallAbortError(): Error {
-  const error = new Error("Tool call aborted");
-  error.name = "AbortError";
-  return error;
-}
-
-function abortableIpcCall<T>(
-  operation: () => Promise<T>,
-  signal: AbortSignal | undefined,
-  onAbort: () => void,
-): Promise<T> {
-  if (!signal) return operation();
-  if (signal.aborted) return Promise.reject(createToolCallAbortError());
-
-  return new Promise<T>((resolve, reject) => {
-    let settled = false;
-    const cleanup = () => signal.removeEventListener("abort", handleAbort);
-    const finish = (complete: () => void) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      complete();
-    };
-    const handleAbort = () => {
-      onAbort();
-      finish(() => reject(createToolCallAbortError()));
-    };
-
-    signal.addEventListener("abort", handleAbort, { once: true });
-    let pending: Promise<T>;
-    try {
-      pending = operation();
-    } catch (error) {
-      finish(() => reject(error));
-      return;
-    }
-    pending.then(
-      (value) => finish(() => resolve(value)),
-      (error) => finish(() => reject(error)),
-    );
-  });
-}
-
-function createWorkerDispatchRuntime(options: {
-  readonly server: WorkerRunIpcServer;
-  readonly ipcAuthToken: string;
-  readonly workerId: string;
-  readonly sessionId: string;
-  readonly runId: string;
-  readonly workspaceRoot?: string;
-}): DispatchToolRuntime {
-  const runtime = new DispatchRuntime();
-  const handler: DispatchHandler = async (command, context) => {
-    if (!context?.wait) {
-      throw new Error("worker dispatch resident.ask requires wait: true");
-    }
-    if (command.target.kind !== "resident") {
-      throw new Error("worker dispatch resident.ask currently supports resident targets only");
-    }
-
-    const callId = command.dispatchId;
-    const payload =
-      typeof command.payload === "string" ? command.payload : JSON.stringify(command.payload);
-    const sessionId = context.sessionId ?? options.sessionId;
-    const runId = context.runId ?? options.runId;
-    const workspaceRoot = context.workspaceRoot ?? options.workspaceRoot;
-    const cancelInboundWait = () => {
-      void options.server
-        .call("worker.inbound_wait_cancel", { sessionId, runId, callId }, 5_000)
-        .catch(() => undefined);
-    };
-
-    const raw = await abortableIpcCall(
-      () =>
-        options.server.call(
-          "worker.inbound_wait",
-          {
-            authToken: options.ipcAuthToken,
-            workerId: options.workerId,
-            sessionId,
-            runId,
-            callId,
-            payload,
-            ...(workspaceRoot ? { workspaceRoot } : {}),
-          },
-          WORKER_RESIDENT_ASK_IPC_TIMEOUT_MS,
-        ),
-      context.signal,
-      cancelInboundWait,
-    );
-
-    if (raw === null || typeof raw !== "object") {
-      throw new Error("invalid worker.inbound_wait response");
-    }
-    const result = raw as { accepted?: unknown; output?: unknown; error?: unknown };
-    if (result.accepted !== true) {
-      throw new Error(
-        typeof result.error === "string" ? result.error : "worker.inbound_wait rejected",
-      );
-    }
-
-    return { output: typeof result.output === "string" ? result.output : "" };
-  };
-
-  runtime.register("resident.ask", handler);
-  return {
-    submit(input, context = {}) {
-      return runtime.submit(input, {
-        ...context,
-        sessionId: context.sessionId ?? options.sessionId,
-        runId: context.runId ?? options.runId,
-        workspaceRoot: context.workspaceRoot ?? options.workspaceRoot,
-        actorKind: context.actorKind ?? "worker",
-        actorId: context.actorId ?? `${options.sessionId}:${options.runId}`,
-        trustTier: context.trustTier ?? "assigned_worker",
-        labels: [...(context.labels ?? []), "worker-runner"],
-      });
-    },
-  };
-}
-
-interface WorkerRunIpcServer {
-  call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
-  notify(method: string, params?: Record<string, unknown>): void;
-}
-
 export namespace WorkerRunner {
-  type ChatAgentOptions = Parameters<typeof ChatAgent.create>[0];
-  type WorkerAgent = Pick<ReturnType<typeof ChatAgent.create>, "run">;
-
-  interface Environment {
-    readonly ipcAuthToken: string;
-    readonly workerId: string;
-    readonly server: WorkerRunIpcServer;
-    readonly activeRuns: WorkerRunState.ActiveRunRegistry;
-    readonly bootstrapReady: Promise<void>;
-    readonly backgroundManager: ReturnType<typeof BackgroundManager.create>;
-    readonly injectionQueue: InjectionQueue.Instance;
-    readonly defaultWorkspaceRoot: string | undefined;
-    readonly getBootstrap: () => WorkerBootstrap.Bootstrap | null;
-    readonly resolveAuth: (provider: string) => Auth.Info | undefined;
-    readonly createAgent?: (options: ChatAgentOptions) => WorkerAgent;
-  }
-
-  interface SpawnRunOptions extends Environment {
-    readonly params: Record<string, unknown> | undefined;
-    readonly respond: (result: unknown) => void;
-  }
-
-  export function spawnRun(options: SpawnRunOptions): void {
+  export function spawnRun(options: WorkerRunnerSpawnOptions): void {
     const {
       params,
       ipcAuthToken,
@@ -201,12 +44,7 @@ export namespace WorkerRunner {
     } = options;
 
     if (params?.authToken !== ipcAuthToken) {
-      respond({
-        runId: typeof params?.runId === "string" ? params.runId : "unknown",
-        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
-        status: "failed",
-        error: "unauthorized coordinator request",
-      });
+      respondSpawnRejected({ params, respond, error: "unauthorized coordinator request" });
       return;
     }
 
@@ -214,10 +52,9 @@ export namespace WorkerRunner {
     try {
       request = Execution.Request.parse(params);
     } catch (err) {
-      respond({
-        runId: typeof params?.runId === "string" ? params.runId : "unknown",
-        sessionId: typeof params?.sessionId === "string" ? params.sessionId : "unknown",
-        status: "failed",
+      respondSpawnRejected({
+        params,
+        respond,
         error: err instanceof Error ? err.message : String(err),
       });
       return;
@@ -241,13 +78,7 @@ export namespace WorkerRunner {
       try {
         activeRuns.set(runId, { sessionId, controller });
         server.notify("worker.run_started", { runId, sessionId });
-        Bus.publish(Subagent.Events.WorkerRunStarted, {
-          traceId,
-          sessionId,
-          runId,
-          time: Date.now(),
-          payload: { sessionId, runId, title: request.prompt.slice(0, 80) },
-        });
+        publishWorkerRunStarted({ traceId, sessionId, runId, prompt: request.prompt });
         await bootstrapReady;
         const bootstrap = getBootstrap();
         const messages = buildWorkerInputMessages(sessionId, request.prompt);
@@ -255,55 +86,13 @@ export namespace WorkerRunner {
           request.workspaceRoot ?? request.toolConfig?.workspaceRoot ?? defaultWorkspaceRoot;
         const systemProvider = new SystemToolProvider(workspaceRoot);
 
-        const mcpProxyProvider = ToolProxyProvider.create(
-          bootstrap?.toolCatalog ?? [],
-          async (toolName, toolArgs, context) => {
-            const callId = crypto.randomUUID();
-            if (context?.signal?.aborted) {
-              return {
-                id: callId,
-                toolCallId: callId,
-                output: "Tool call aborted",
-                isError: true,
-              };
-            }
-
-            const cancelToolCall = () => {
-              void server
-                .call("worker.tool_call_cancel", { runId, sessionId, callId }, 5_000)
-                .catch(() => undefined);
-            };
-
-            try {
-              const raw = await abortableIpcCall(
-                () =>
-                  server.call(
-                    "worker.tool_call",
-                    {
-                      runId,
-                      sessionId,
-                      callId,
-                      tool: toolName,
-                      input: toolArgs,
-                      ...(workspaceRoot ? { workspaceRoot } : {}),
-                    },
-                    WORKER_TOOL_CALL_IPC_TIMEOUT_MS,
-                  ),
-                context?.signal,
-                cancelToolCall,
-              );
-              return Tool.Result.parse(raw);
-            } catch (error) {
-              return {
-                id: callId,
-                toolCallId: callId,
-                output: error instanceof Error ? error.message : String(error),
-                isError: true,
-                settlement: "unknown",
-              };
-            }
-          },
-        );
+        const mcpProxyProvider = createMcpProxyProvider({
+          toolCatalog: bootstrap?.toolCatalog ?? [],
+          server,
+          runId,
+          sessionId,
+          ...(workspaceRoot ? { workspaceRoot } : {}),
+        });
 
         const toolsRef: Parameters<typeof createWorkerSubagentRuntime>[0]["toolsRef"] = {};
         const catalogRef: { catalog?: ReturnType<typeof buildToolCatalog> } = {};
@@ -322,31 +111,10 @@ export namespace WorkerRunner {
           parentSessionId: sessionId,
           parentPermissions: request.permissions,
         };
-        const scopedBackgroundManager: ReturnType<typeof BackgroundManager.create> = {
-          launch(input: Parameters<typeof backgroundManager.launch>[0]) {
-            const childRuntime = buildWorkerChildRuntimeConfig(workerSubagentConfig, {
-              agentName: input.agentName,
-              depth: input.depth ?? 1,
-              middleware: input.middleware,
-            });
-            return backgroundManager.launch({
-              ...input,
-              systemPrompt: childRuntime.systemPrompt,
-              tools: childRuntime.tools,
-              toolExecutor: childRuntime.toolExecutor,
-              permissions: childRuntime.permissions,
-              middleware: childRuntime.middleware,
-              childMiddleware: childRuntime.childMiddleware,
-            });
-          },
-          getTask: (taskId) => backgroundManager.getTask(taskId),
-          getResult: (taskId) => backgroundManager.getResult(taskId),
-          cancel: (taskId) => backgroundManager.cancel(taskId),
-          listByParent: (parentSessionId) => backgroundManager.listByParent(parentSessionId),
-          cleanup: () => backgroundManager.cleanup(),
-          stats: () => backgroundManager.stats(),
-          dispose: () => backgroundManager.dispose(),
-        };
+        const scopedBackgroundManager = createScopedBackgroundManager({
+          backgroundManager,
+          workerSubagentConfig,
+        });
 
         const agentProvider = new AgentToolProvider({
           subagentRuntime: createWorkerSubagentRuntime(workerSubagentConfig),
@@ -427,13 +195,7 @@ export namespace WorkerRunner {
             sessionId,
             status: "cancelled",
           });
-          Bus.publish(Subagent.Events.WorkerSessionCancelled, {
-            traceId,
-            sessionId,
-            runId,
-            time: Date.now(),
-            payload: { sessionId, runId },
-          });
+          publishWorkerRunCancelled({ traceId, sessionId, runId });
 
           respond({
             runId,
@@ -450,13 +212,7 @@ export namespace WorkerRunner {
           status: "succeeded",
           output: runResult.text,
         });
-        Bus.publish(Subagent.Events.WorkerRunCompleted, {
-          traceId,
-          sessionId,
-          runId,
-          time: Date.now(),
-          payload: { sessionId, runId, status: "succeeded" },
-        });
+        publishWorkerRunSucceeded({ traceId, sessionId, runId });
 
         respond({
           runId,
@@ -475,13 +231,7 @@ export namespace WorkerRunner {
             status: "cancelled",
             error: errorMessage,
           });
-          Bus.publish(Subagent.Events.WorkerSessionCancelled, {
-            traceId,
-            sessionId,
-            runId,
-            time: Date.now(),
-            payload: { sessionId, runId },
-          });
+          publishWorkerRunCancelled({ traceId, sessionId, runId });
 
           respond({
             runId,
@@ -497,13 +247,7 @@ export namespace WorkerRunner {
           status: "failed",
           error: errorMessage,
         });
-        Bus.publish(Subagent.Events.WorkerRunFailed, {
-          traceId,
-          sessionId,
-          runId,
-          time: Date.now(),
-          payload: { sessionId, runId, error: errorMessage },
-        });
+        publishWorkerRunFailed({ traceId, sessionId, runId, errorMessage });
 
         respond({
           runId,
@@ -516,16 +260,5 @@ export namespace WorkerRunner {
         activeRuns.delete(runId);
       }
     })();
-  }
-}
-
-function notifyWorkerRunCompleted(
-  server: WorkerRunIpcServer,
-  params: Record<string, unknown>,
-): void {
-  try {
-    server.notify("worker.run_completed", params);
-  } catch {
-    // Preserve coordinator response and active-run cleanup if notification fails.
   }
 }


### PR DESCRIPTION
## Summary
- split worker-runner IPC/dispatch proxy helpers into `worker-runner-ipc.ts`
- move background child-runtime scoping and lifecycle event publishing into focused helper modules
- keep `WorkerRunner.spawnRun` as the public entrypoint while reducing `worker-runner.ts` to 246 pure LOC

## Verification
- `bun run --cwd packages/protocol build`
- `bun test test/execution/worker-runner.test.ts` from `apps/server` (14 pass)
- `bun run --cwd apps/server check-types`
- LSP diagnostics on `apps/server/src/execution` (0 diagnostics)
- `bunx biome check` on touched files
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bunx knip --no-config-hints`
- `git diff --check`
- `bun run test`
- `codex-ultrawork-reviewer`: PASS

## Notes
- Claude Fable oracle was unavailable locally for this run: `claude-fable-5` returned 404/no access.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the worker runner into focused modules for IPC, background management, and event publishing. Keeps `WorkerRunner.spawnRun` intact while reducing `worker-runner.ts` by ~300 LOC for easier testing and maintenance.

- **Refactors**
  - Extracted IPC and tool dispatch to `worker-runner-ipc.ts` (`createWorkerDispatchRuntime`, `createMcpProxyProvider`, `notifyWorkerRunCompleted`) with abort-safe IPC calls.
  - Moved background child-runtime scoping to `worker-runner-background.ts` (`createScopedBackgroundManager`, `buildDelegationAdmissionMiddleware`).
  - Centralized lifecycle events in `worker-runner-events.ts` (`publishWorkerRunStarted|Succeeded|Cancelled|Failed`).
  - Added shared types/helpers in `worker-runner-types.ts` (`WorkerRunnerSpawnOptions`, `respondSpawnRejected`).
  - Simplified `worker-runner.ts` to wire helpers; behavior and public API unchanged.

<sup>Written for commit 82751bc7ced36c90ddf833219333599dd9fb81e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

