### PR TITLE
refactor(coordinator): split worker manager responsibilities

### DIFF
--- a/packages/coordinator/src/worker-manager/manager.ts
+++ b/packages/coordinator/src/worker-manager/manager.ts
@@ -1,76 +1,30 @@
 import fs from "node:fs";
-import net from "node:net";
-import path from "node:path";
-import { Operational, type WorkerBootstrap } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
-import { createSessionRouting, type SessionRouter } from "../worker-supervision/session-routing";
+import { createPrivateSocketDir } from "./worker-socket-dir";
+import { WorkerSlotCoordinator } from "./worker-slot-coordinator";
 import {
-  WorkerSupervisor,
-  type InboundWaitParams,
-  type InboundWaitResult,
-  type ToolCallCancelParams,
-  type ToolCallContext,
-  type ToolCallParams,
-  type ToolCallResult,
-} from "../worker-supervision/supervisor";
+  DEFAULT_IDLE_SHUTDOWN_MS,
+  DEFAULT_MAX_ACTIVE_WORKERS,
+  DEFAULT_MAX_QUEUED_DISPATCHES,
+  DEFAULT_SLOT_WAIT_TIMEOUT_MS,
+  HARD_MAX_ACTIVE_WORKERS,
+  type ActiveRun,
+  type WorkerManager,
+  type WorkerManagerConfig,
+  type WorkerManagerStats,
+  type WorkerSlot,
+} from "./worker-manager-types";
 
-const DEFAULT_MAX_ACTIVE_WORKERS = 10;
-const HARD_MAX_ACTIVE_WORKERS = 10;
-const DEFAULT_IDLE_SHUTDOWN_MS = 600_000;
-const DEFAULT_SLOT_WAIT_TIMEOUT_MS = 30_000;
-const DEFAULT_MAX_QUEUED_DISPATCHES = 100;
-
-export type { ToolCallCancelParams, ToolCallContext, ToolCallParams, ToolCallResult };
-export type { InboundWaitParams, InboundWaitResult };
-
-export type WorkerManagerConfig = {
-  workerScript: string;
-  socketDir?: string;
-  maxActiveWorkers?: number;
-  idleShutdownMs?: number;
-  slotWaitTimeoutMs?: number;
-  maxQueuedDispatches?: number;
-  bootstrap?: WorkerBootstrap.Bootstrap;
-  onToolCall?: (params: ToolCallParams, context?: ToolCallContext) => Promise<ToolCallResult>;
-  onInboundWait?: (params: InboundWaitParams) => Promise<InboundWaitResult>;
-  onWorkerSnapshot?: (workerId: number, snapshot: WorkerBootstrap.WorkerSnapshot) => void;
-};
-
-export type WorkerManagerStats = {
-  workers: number;
-  active: number;
-  idle: number;
-  ready: number;
-  activeRuns: number;
-  maxActiveWorkers: number;
-};
-
-export type WorkerManager = {
-  dispatch(sessionId: string, runId: string, params: Record<string, unknown>): Promise<unknown>;
-  cancelRun(runId: string): Promise<unknown>;
-  deliverMessage(sessionId: string, message: string, runId?: string): Promise<unknown>;
-  getStats(): WorkerManagerStats;
-  waitUntilReady(timeoutMs?: number): Promise<void>;
-  killWorker(index: number): void;
-  shutdown(): Promise<void>;
-};
-
-type WorkerSlot = {
-  readonly id: number;
-  ownerSessionId: string;
-  supervisor: WorkerSupervisor | null;
-  load: number;
-  reserved: boolean;
-  idleTimer: ReturnType<typeof setTimeout> | null;
-};
-
-type ActiveRun = {
-  sessionId: string;
-  slot?: WorkerSlot;
-  cancelled?: boolean;
-};
-
-type SlotWaiter = { resolve: () => void; reject: (error: Error) => void };
+export type {
+  InboundWaitParams,
+  InboundWaitResult,
+  ToolCallCancelParams,
+  ToolCallContext,
+  ToolCallParams,
+  ToolCallResult,
+  WorkerManager,
+  WorkerManagerConfig,
+  WorkerManagerStats,
+} from "./worker-manager-types";
 
 export function createWorkerManager(config: WorkerManagerConfig): WorkerManager {
   return new OnDemandWorkerManager(config);
@@ -82,19 +36,25 @@ export class OnDemandWorkerManager implements WorkerManager {
   private readonly idleShutdownMs: number;
   private readonly slotWaitTimeoutMs: number;
   private readonly maxQueuedDispatches: number;
-  private readonly slots = new Map<number, WorkerSlot>();
-  private readonly sessionRouting: SessionRouter = createSessionRouting();
   private readonly activeRuns = new Map<string, ActiveRun>();
-  private readonly waiters: SlotWaiter[] = [];
-  private nextWorkerId = 0;
+  private readonly slotCoordinator: WorkerSlotCoordinator;
   private stopping = false;
 
-  constructor(private readonly config: WorkerManagerConfig) {
+  constructor(config: WorkerManagerConfig) {
     this.socketDir = createPrivateSocketDir(config.socketDir ?? "/tmp");
     this.maxActiveWorkers = normalizeMaxActiveWorkers(config.maxActiveWorkers);
     this.idleShutdownMs = config.idleShutdownMs ?? DEFAULT_IDLE_SHUTDOWN_MS;
     this.slotWaitTimeoutMs = config.slotWaitTimeoutMs ?? DEFAULT_SLOT_WAIT_TIMEOUT_MS;
     this.maxQueuedDispatches = config.maxQueuedDispatches ?? DEFAULT_MAX_QUEUED_DISPATCHES;
+    this.slotCoordinator = new WorkerSlotCoordinator({
+      managerConfig: config,
+      socketDir: this.socketDir,
+      maxActiveWorkers: this.maxActiveWorkers,
+      idleShutdownMs: this.idleShutdownMs,
+      slotWaitTimeoutMs: this.slotWaitTimeoutMs,
+      maxQueuedDispatches: this.maxQueuedDispatches,
+      isStopping: () => this.stopping,
+    });
   }
 
   async dispatch(
@@ -113,7 +73,7 @@ export class OnDemandWorkerManager implements WorkerManager {
     this.activeRuns.set(runId, activeRun);
     let slot: WorkerSlot;
     try {
-      slot = await this.acquireSlot(sessionId);
+      slot = await this.slotCoordinator.acquireSlot(sessionId);
     } catch (error) {
       this.activeRuns.delete(runId);
       throw error;
@@ -121,11 +81,7 @@ export class OnDemandWorkerManager implements WorkerManager {
     activeRun.slot = slot;
     if (activeRun.cancelled) {
       this.activeRuns.delete(runId);
-      slot.reserved = false;
-      if (slot.load === 0) {
-        this.releaseOneWaiter();
-        this.scheduleIdleShutdown(slot);
-      }
+      this.slotCoordinator.releaseReservedSlot(slot);
       return {
         runId,
         sessionId,
@@ -133,12 +89,10 @@ export class OnDemandWorkerManager implements WorkerManager {
         error: "cancelled before worker delivery",
       };
     }
-    slot.load += 1;
-    slot.reserved = false;
-    this.clearIdleTimer(slot);
+    this.slotCoordinator.markSlotLoaded(slot);
 
     try {
-      const supervisor = this.ensureSupervisor(slot);
+      const supervisor = this.slotCoordinator.ensureSupervisor(slot);
       const generation = supervisor.getGeneration();
       await supervisor.waitReady();
       if (supervisor.getGeneration() !== generation) {
@@ -155,12 +109,7 @@ export class OnDemandWorkerManager implements WorkerManager {
       return await supervisor.dispatch(runId, { sessionId, ...params });
     } finally {
       this.activeRuns.delete(runId);
-      const wasLoaded = slot.load > 0;
-      if (wasLoaded) slot.load -= 1;
-      if (wasLoaded && slot.load === 0) {
-        this.releaseOneWaiter();
-        this.scheduleIdleShutdown(slot);
-      }
+      this.slotCoordinator.releaseLoadedSlot(slot);
     }
   }
 
@@ -201,56 +150,21 @@ export class OnDemandWorkerManager implements WorkerManager {
   }
 
   getStats(): WorkerManagerStats {
-    const slots = [...this.slots.values()];
-    const running = slots.filter((slot) => slot.supervisor?.isActive() === true);
-    return {
-      workers: running.length,
-      active: running.filter((slot) => slot.load > 0).length,
-      idle: running.filter((slot) => slot.load === 0).length,
-      ready: running.filter((slot) => slot.supervisor?.isReady() === true).length,
-      activeRuns: this.activeRuns.size,
-      maxActiveWorkers: this.maxActiveWorkers,
-    };
+    return this.slotCoordinator.getStats(this.activeRuns.size);
   }
 
   async waitUntilReady(timeoutMs = 15_000): Promise<void> {
-    await Promise.all(
-      [...this.slots.values()]
-        .map((slot) => slot.supervisor)
-        .filter((supervisor): supervisor is WorkerSupervisor => supervisor !== null)
-        .map((supervisor) => supervisor.waitReady(timeoutMs)),
-    );
+    await this.slotCoordinator.waitUntilReady(timeoutMs);
   }
 
   killWorker(index: number): void {
-    const slot = this.slots.get(index);
-    if (!slot) return;
-    if (slot.load > 0) {
-      slot.supervisor?.forceKill();
-      return;
-    }
-    const supervisor = slot.supervisor;
-    slot.supervisor = null;
-    this.forgetSlot(slot);
-    supervisor?.forceKill();
+    this.slotCoordinator.killWorker(index);
   }
 
   async shutdown(): Promise<void> {
     this.stopping = true;
-    const results = await Promise.allSettled(
-      [...this.slots.values()].map(async (slot) => {
-        this.clearIdleTimer(slot);
-        const supervisor = slot.supervisor;
-        slot.supervisor = null;
-        await supervisor?.stop();
-      }),
-    );
-    this.slots.clear();
-    this.sessionRouting.clear();
+    const results = await this.slotCoordinator.shutdown();
     this.activeRuns.clear();
-    for (const waiter of this.waiters.splice(0)) {
-      waiter.reject(new Error("worker manager is shutting down"));
-    }
     fs.rmSync(this.socketDir, { recursive: true, force: true });
 
     const failures = results.filter(
@@ -262,262 +176,10 @@ export class OnDemandWorkerManager implements WorkerManager {
       throw err;
     }
   }
-
-  private async acquireSlot(sessionId: string): Promise<WorkerSlot> {
-    while (!this.stopping) {
-      const slot = await this.tryAcquireSlot(sessionId);
-      if (slot) return slot;
-      await this.waitForSlot();
-    }
-    throw new Error("worker manager is shutting down");
-  }
-
-  private async tryAcquireSlot(sessionId: string): Promise<WorkerSlot | undefined> {
-    const affinityId = this.sessionRouting.get(sessionId);
-    const affinitySlot = affinityId === undefined ? undefined : this.slots.get(affinityId);
-    if (affinitySlot !== undefined && affinitySlot.ownerSessionId === sessionId) {
-      if (affinitySlot.load > 0 || affinitySlot.reserved) return undefined;
-      affinitySlot.reserved = true;
-      return affinitySlot;
-    }
-
-    if (this.slots.size < this.maxActiveWorkers) {
-      const slot = this.createSlot(sessionId);
-      this.sessionRouting.assign(sessionId, slot.id);
-      return slot;
-    }
-
-    const reusable = this.findReusableIdleSlot();
-    if (reusable) return this.reassignSlot(reusable, sessionId);
-    return undefined;
-  }
-
-  private waitForSlot(): Promise<void> {
-    if (this.waiters.length >= this.maxQueuedDispatches) {
-      return Promise.reject(new Error("worker manager dispatch queue is full"));
-    }
-    return new Promise((resolve, reject) => {
-      const waiter = {} as SlotWaiter;
-      const timer = setTimeout(() => {
-        const index = this.waiters.indexOf(waiter);
-        if (index >= 0) this.waiters.splice(index, 1);
-        reject(new Error(`worker manager slot wait timed out after ${this.slotWaitTimeoutMs}ms`));
-      }, this.slotWaitTimeoutMs);
-      waiter.resolve = () => {
-        clearTimeout(timer);
-        resolve();
-      };
-      waiter.reject = (error) => {
-        clearTimeout(timer);
-        reject(error);
-      };
-      this.waiters.push(waiter);
-    });
-  }
-
-  private releaseOneWaiter(): void {
-    this.waiters.shift()?.resolve();
-  }
-
-  private findReusableIdleSlot(): WorkerSlot | undefined {
-    for (const slot of this.slots.values()) {
-      if (slot.load === 0 && !slot.reserved) return slot;
-    }
-    return undefined;
-  }
-
-  private async reassignSlot(slot: WorkerSlot, sessionId: string): Promise<WorkerSlot> {
-    slot.reserved = true;
-    this.clearIdleTimer(slot);
-    this.sessionRouting.forgetWorker(slot.id);
-    const supervisor = slot.supervisor;
-    slot.supervisor = null;
-    await supervisor?.stop();
-    slot.ownerSessionId = sessionId;
-    this.sessionRouting.assign(sessionId, slot.id);
-    return slot;
-  }
-
-  private createSlot(ownerSessionId: string): WorkerSlot {
-    const slot: WorkerSlot = {
-      id: this.nextWorkerId,
-      ownerSessionId,
-      supervisor: null,
-      load: 0,
-      reserved: true,
-      idleTimer: null,
-    };
-    this.nextWorkerId += 1;
-    this.slots.set(slot.id, slot);
-    return slot;
-  }
-
-  private ensureSupervisor(slot: WorkerSlot): WorkerSupervisor {
-    if (slot.supervisor?.isActive() === true) return slot.supervisor;
-
-    slot.supervisor = new WorkerSupervisor(
-      slot.id,
-      this.config.workerScript,
-      this.socketDir,
-      this.config.bootstrap,
-      this.config.onToolCall,
-      this.config.onWorkerSnapshot,
-      this.config.onInboundWait,
-    );
-    return slot.supervisor;
-  }
-
-  private scheduleIdleShutdown(slot: WorkerSlot): void {
-    this.clearIdleTimer(slot);
-    if (this.idleShutdownMs < 0) return;
-
-    slot.idleTimer = setTimeout(() => {
-      slot.idleTimer = null;
-      if (this.stopping || slot.load > 0) return;
-      slot.reserved = true;
-      this.shutdownIdleSlot(slot).catch(() => {
-        slot.reserved = false;
-        this.releaseOneWaiter();
-      });
-    }, this.idleShutdownMs);
-  }
-
-  private async shutdownIdleSlot(slot: WorkerSlot): Promise<void> {
-    if (this.stopping || slot.load > 0) {
-      slot.reserved = false;
-      return;
-    }
-
-    const supervisor = slot.supervisor;
-    if (!supervisor) {
-      this.forgetSlot(slot);
-      this.releaseOneWaiter();
-      return;
-    }
-
-    const stopped = await supervisor.shutdownIdle();
-    if (slot.supervisor !== supervisor) return;
-
-    if (stopped) {
-      slot.supervisor = null;
-      this.forgetSlot(slot);
-      this.releaseOneWaiter();
-      return;
-    }
-
-    slot.reserved = false;
-    this.releaseOneWaiter();
-    if (slot.load === 0) {
-      this.scheduleIdleShutdown(slot);
-    }
-  }
-
-  private forgetSlot(slot: WorkerSlot): void {
-    this.clearIdleTimer(slot);
-    this.slots.delete(slot.id);
-    this.sessionRouting.forgetWorker(slot.id);
-  }
-
-  private clearIdleTimer(slot: WorkerSlot): void {
-    if (slot.idleTimer === null) return;
-    clearTimeout(slot.idleTimer);
-    slot.idleTimer = null;
-  }
 }
 
 function normalizeMaxActiveWorkers(value: number | undefined): number {
   const requested = value ?? DEFAULT_MAX_ACTIVE_WORKERS;
   if (!Number.isFinite(requested) || requested < 1) return DEFAULT_MAX_ACTIVE_WORKERS;
   return Math.min(Math.floor(requested), HARD_MAX_ACTIVE_WORKERS);
-}
-
-function createPrivateSocketDir(baseDir: string): string {
-  fs.mkdirSync(baseDir, { recursive: true, mode: 0o700 });
-  cleanupStaleSocketDirs(baseDir);
-  const dir = fs.mkdtempSync(path.join(baseDir, "openomni-workers-"));
-  fs.chmodSync(dir, 0o700);
-  return dir;
-}
-
-const SOCKET_PROBE_TIMEOUT_MS = 1000;
-
-function isSocketAlive(socketPath: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const conn = net.createConnection(socketPath);
-    conn.setTimeout(SOCKET_PROBE_TIMEOUT_MS);
-    conn.once("connect", () => {
-      conn.destroy();
-      resolve(true);
-    });
-    conn.once("error", () => {
-      conn.destroy();
-      resolve(false);
-    });
-    conn.once("timeout", () => {
-      conn.destroy();
-      resolve(false);
-    });
-  });
-}
-
-function warnCleanup(msg: string, context: Record<string, unknown>): void {
-  Bus.publish(Operational.Warn, {
-    traceId: crypto.randomUUID(),
-    time: Date.now(),
-    component: "coordinator.worker-manager",
-    msg,
-    context,
-  });
-}
-
-function cleanupStaleSocketDirs(baseDir: string): void {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(baseDir);
-  } catch (err) {
-    warnCleanup("failed to read socket base directory", {
-      baseDir,
-      error: String(err),
-    });
-    return;
-  }
-
-  for (const entry of entries) {
-    if (!entry.startsWith("openomni-workers-")) continue;
-    const dirPath = path.join(baseDir, entry);
-    try {
-      if (!fs.lstatSync(dirPath).isDirectory()) continue;
-    } catch (err) {
-      warnCleanup("failed to stat worker directory during cleanup", {
-        dirPath,
-        error: String(err),
-      });
-      continue;
-    }
-
-    void cleanupIfStale(dirPath);
-  }
-}
-
-async function cleanupIfStale(dirPath: string): Promise<void> {
-  try {
-    await cleanupIfStaleUnsafe(dirPath);
-  } catch (err) {
-    warnCleanup("stale worker directory cleanup failed", {
-      dirPath,
-      error: String(err),
-    });
-  }
-}
-
-async function cleanupIfStaleUnsafe(dirPath: string): Promise<void> {
-  const files = fs.readdirSync(dirPath);
-  const sockets = files.filter((f) => f.endsWith(".sock"));
-
-  if (sockets.length === 0) return;
-
-  const results = await Promise.all(sockets.map((sock) => isSocketAlive(path.join(dirPath, sock))));
-  if (results.some(Boolean)) return;
-
-  fs.rmSync(dirPath, { recursive: true, force: true });
 }

--- a/packages/coordinator/src/worker-manager/worker-manager-types.ts
+++ b/packages/coordinator/src/worker-manager/worker-manager-types.ts
@@ -1,0 +1,71 @@
+import type { WorkerBootstrap } from "@openomni/protocol";
+import type {
+  InboundWaitParams,
+  InboundWaitResult,
+  ToolCallCancelParams,
+  ToolCallContext,
+  ToolCallParams,
+  ToolCallResult,
+  WorkerSupervisor,
+} from "../worker-supervision/supervisor";
+
+export const DEFAULT_MAX_ACTIVE_WORKERS = 10;
+export const HARD_MAX_ACTIVE_WORKERS = 10;
+export const DEFAULT_IDLE_SHUTDOWN_MS = 600_000;
+export const DEFAULT_SLOT_WAIT_TIMEOUT_MS = 30_000;
+export const DEFAULT_MAX_QUEUED_DISPATCHES = 100;
+
+export type { ToolCallCancelParams, ToolCallContext, ToolCallParams, ToolCallResult };
+export type { InboundWaitParams, InboundWaitResult };
+
+export type WorkerManagerConfig = {
+  workerScript: string;
+  socketDir?: string;
+  maxActiveWorkers?: number;
+  idleShutdownMs?: number;
+  slotWaitTimeoutMs?: number;
+  maxQueuedDispatches?: number;
+  bootstrap?: WorkerBootstrap.Bootstrap;
+  onToolCall?: (params: ToolCallParams, context?: ToolCallContext) => Promise<ToolCallResult>;
+  onInboundWait?: (params: InboundWaitParams) => Promise<InboundWaitResult>;
+  onWorkerSnapshot?: (workerId: number, snapshot: WorkerBootstrap.WorkerSnapshot) => void;
+};
+
+export type WorkerManagerStats = {
+  workers: number;
+  active: number;
+  idle: number;
+  ready: number;
+  activeRuns: number;
+  maxActiveWorkers: number;
+};
+
+export type WorkerManager = {
+  dispatch(sessionId: string, runId: string, params: Record<string, unknown>): Promise<unknown>;
+  cancelRun(runId: string): Promise<unknown>;
+  deliverMessage(sessionId: string, message: string, runId?: string): Promise<unknown>;
+  getStats(): WorkerManagerStats;
+  waitUntilReady(timeoutMs?: number): Promise<void>;
+  killWorker(index: number): void;
+  shutdown(): Promise<void>;
+};
+
+export type WorkerSlot = {
+  readonly id: number;
+  ownerSessionId: string;
+  supervisor: WorkerSupervisor | null;
+  load: number;
+  reserved: boolean;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+};
+
+export type ActiveRun = {
+  sessionId: string;
+  slot?: WorkerSlot;
+  cancelled?: boolean;
+};
+
+export type SlotWaiter = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+};

--- a/packages/coordinator/src/worker-manager/worker-slot-coordinator.ts
+++ b/packages/coordinator/src/worker-manager/worker-slot-coordinator.ts
@@ -1,0 +1,265 @@
+import { createSessionRouting, type SessionRouter } from "../worker-supervision/session-routing";
+import { WorkerSupervisor } from "../worker-supervision/supervisor";
+import type {
+  SlotWaiter,
+  WorkerManagerConfig,
+  WorkerManagerStats,
+  WorkerSlot,
+} from "./worker-manager-types";
+
+export class WorkerSlotCoordinator {
+  private readonly slots = new Map<number, WorkerSlot>();
+  private readonly sessionRouting: SessionRouter = createSessionRouting();
+  private readonly waiters: SlotWaiter[] = [];
+  private nextWorkerId = 0;
+
+  constructor(
+    private readonly config: {
+      readonly managerConfig: WorkerManagerConfig;
+      readonly socketDir: string;
+      readonly maxActiveWorkers: number;
+      readonly idleShutdownMs: number;
+      readonly slotWaitTimeoutMs: number;
+      readonly maxQueuedDispatches: number;
+      readonly isStopping: () => boolean;
+    },
+  ) {}
+
+  async acquireSlot(sessionId: string): Promise<WorkerSlot> {
+    while (!this.config.isStopping()) {
+      const slot = await this.tryAcquireSlot(sessionId);
+      if (slot) return slot;
+      await this.waitForSlot();
+    }
+    throw new Error("worker manager is shutting down");
+  }
+
+  releaseReservedSlot(slot: WorkerSlot): void {
+    slot.reserved = false;
+    if (slot.load !== 0) return;
+    this.releaseOneWaiter();
+    this.scheduleIdleShutdown(slot);
+  }
+
+  markSlotLoaded(slot: WorkerSlot): void {
+    slot.load += 1;
+    slot.reserved = false;
+    this.clearIdleTimer(slot);
+  }
+
+  releaseLoadedSlot(slot: WorkerSlot): void {
+    const wasLoaded = slot.load > 0;
+    if (wasLoaded) slot.load -= 1;
+    if (wasLoaded && slot.load === 0) {
+      this.releaseOneWaiter();
+      this.scheduleIdleShutdown(slot);
+    }
+  }
+
+  ensureSupervisor(slot: WorkerSlot): WorkerSupervisor {
+    if (slot.supervisor?.isActive() === true) return slot.supervisor;
+
+    const managerConfig = this.config.managerConfig;
+    slot.supervisor = new WorkerSupervisor(
+      slot.id,
+      managerConfig.workerScript,
+      this.config.socketDir,
+      managerConfig.bootstrap,
+      managerConfig.onToolCall,
+      managerConfig.onWorkerSnapshot,
+      managerConfig.onInboundWait,
+    );
+    return slot.supervisor;
+  }
+
+  getStats(activeRuns: number): WorkerManagerStats {
+    const slots = [...this.slots.values()];
+    const running = slots.filter((slot) => slot.supervisor?.isActive() === true);
+    return {
+      workers: running.length,
+      active: running.filter((slot) => slot.load > 0).length,
+      idle: running.filter((slot) => slot.load === 0).length,
+      ready: running.filter((slot) => slot.supervisor?.isReady() === true).length,
+      activeRuns,
+      maxActiveWorkers: this.config.maxActiveWorkers,
+    };
+  }
+
+  async waitUntilReady(timeoutMs = 15_000): Promise<void> {
+    await Promise.all(
+      [...this.slots.values()]
+        .map((slot) => slot.supervisor)
+        .filter((supervisor): supervisor is WorkerSupervisor => supervisor !== null)
+        .map((supervisor) => supervisor.waitReady(timeoutMs)),
+    );
+  }
+
+  killWorker(index: number): void {
+    const slot = this.slots.get(index);
+    if (!slot) return;
+    if (slot.load > 0) {
+      slot.supervisor?.forceKill();
+      return;
+    }
+    const supervisor = slot.supervisor;
+    slot.supervisor = null;
+    this.forgetSlot(slot);
+    supervisor?.forceKill();
+  }
+
+  async shutdown(): Promise<PromiseSettledResult<void>[]> {
+    const results = await Promise.allSettled(
+      [...this.slots.values()].map(async (slot) => {
+        this.clearIdleTimer(slot);
+        const supervisor = slot.supervisor;
+        slot.supervisor = null;
+        await supervisor?.stop();
+      }),
+    );
+    this.slots.clear();
+    this.sessionRouting.clear();
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(new Error("worker manager is shutting down"));
+    }
+    return results;
+  }
+
+  private async tryAcquireSlot(sessionId: string): Promise<WorkerSlot | undefined> {
+    const affinityId = this.sessionRouting.get(sessionId);
+    const affinitySlot = affinityId === undefined ? undefined : this.slots.get(affinityId);
+    if (affinitySlot !== undefined && affinitySlot.ownerSessionId === sessionId) {
+      if (affinitySlot.load > 0 || affinitySlot.reserved) return undefined;
+      affinitySlot.reserved = true;
+      return affinitySlot;
+    }
+
+    if (this.slots.size < this.config.maxActiveWorkers) {
+      const slot = this.createSlot(sessionId);
+      this.sessionRouting.assign(sessionId, slot.id);
+      return slot;
+    }
+
+    const reusable = this.findReusableIdleSlot();
+    if (reusable) return this.reassignSlot(reusable, sessionId);
+    return undefined;
+  }
+
+  private waitForSlot(): Promise<void> {
+    if (this.waiters.length >= this.config.maxQueuedDispatches) {
+      return Promise.reject(new Error("worker manager dispatch queue is full"));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {} as SlotWaiter;
+      const timer = setTimeout(() => {
+        const index = this.waiters.indexOf(waiter);
+        if (index >= 0) this.waiters.splice(index, 1);
+        reject(
+          new Error(`worker manager slot wait timed out after ${this.config.slotWaitTimeoutMs}ms`),
+        );
+      }, this.config.slotWaitTimeoutMs);
+      waiter.resolve = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      waiter.reject = (error) => {
+        clearTimeout(timer);
+        reject(error);
+      };
+      this.waiters.push(waiter);
+    });
+  }
+
+  private releaseOneWaiter(): void {
+    this.waiters.shift()?.resolve();
+  }
+
+  private findReusableIdleSlot(): WorkerSlot | undefined {
+    for (const slot of this.slots.values()) {
+      if (slot.load === 0 && !slot.reserved) return slot;
+    }
+    return undefined;
+  }
+
+  private async reassignSlot(slot: WorkerSlot, sessionId: string): Promise<WorkerSlot> {
+    slot.reserved = true;
+    this.clearIdleTimer(slot);
+    this.sessionRouting.forgetWorker(slot.id);
+    const supervisor = slot.supervisor;
+    slot.supervisor = null;
+    await supervisor?.stop();
+    slot.ownerSessionId = sessionId;
+    this.sessionRouting.assign(sessionId, slot.id);
+    return slot;
+  }
+
+  private createSlot(ownerSessionId: string): WorkerSlot {
+    const slot: WorkerSlot = {
+      id: this.nextWorkerId,
+      ownerSessionId,
+      supervisor: null,
+      load: 0,
+      reserved: true,
+      idleTimer: null,
+    };
+    this.nextWorkerId += 1;
+    this.slots.set(slot.id, slot);
+    return slot;
+  }
+
+  private scheduleIdleShutdown(slot: WorkerSlot): void {
+    this.clearIdleTimer(slot);
+    if (this.config.idleShutdownMs < 0) return;
+
+    slot.idleTimer = setTimeout(() => {
+      slot.idleTimer = null;
+      if (this.config.isStopping() || slot.load > 0) return;
+      slot.reserved = true;
+      this.shutdownIdleSlot(slot).catch(() => {
+        slot.reserved = false;
+        this.releaseOneWaiter();
+      });
+    }, this.config.idleShutdownMs);
+  }
+
+  private async shutdownIdleSlot(slot: WorkerSlot): Promise<void> {
+    if (this.config.isStopping() || slot.load > 0) {
+      slot.reserved = false;
+      return;
+    }
+
+    const supervisor = slot.supervisor;
+    if (!supervisor) {
+      this.forgetSlot(slot);
+      this.releaseOneWaiter();
+      return;
+    }
+
+    const stopped = await supervisor.shutdownIdle();
+    if (slot.supervisor !== supervisor) return;
+
+    if (stopped) {
+      slot.supervisor = null;
+      this.forgetSlot(slot);
+      this.releaseOneWaiter();
+      return;
+    }
+
+    slot.reserved = false;
+    this.releaseOneWaiter();
+    if (slot.load === 0) {
+      this.scheduleIdleShutdown(slot);
+    }
+  }
+
+  private forgetSlot(slot: WorkerSlot): void {
+    this.clearIdleTimer(slot);
+    this.slots.delete(slot.id);
+    this.sessionRouting.forgetWorker(slot.id);
+  }
+
+  private clearIdleTimer(slot: WorkerSlot): void {
+    if (slot.idleTimer === null) return;
+    clearTimeout(slot.idleTimer);
+    slot.idleTimer = null;
+  }
+}

--- a/packages/coordinator/src/worker-manager/worker-socket-dir.ts
+++ b/packages/coordinator/src/worker-manager/worker-socket-dir.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+const SOCKET_PROBE_TIMEOUT_MS = 1000;
+
+export function createPrivateSocketDir(baseDir: string): string {
+  fs.mkdirSync(baseDir, { recursive: true, mode: 0o700 });
+  cleanupStaleSocketDirs(baseDir);
+  const dir = fs.mkdtempSync(path.join(baseDir, "openomni-workers-"));
+  fs.chmodSync(dir, 0o700);
+  return dir;
+}
+
+function cleanupStaleSocketDirs(baseDir: string): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(baseDir);
+  } catch (err) {
+    warnCleanup("failed to read socket base directory", {
+      baseDir,
+      error: String(err),
+    });
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.startsWith("openomni-workers-")) continue;
+    const dirPath = path.join(baseDir, entry);
+    try {
+      if (!fs.lstatSync(dirPath).isDirectory()) continue;
+    } catch (err) {
+      warnCleanup("failed to stat worker directory during cleanup", {
+        dirPath,
+        error: String(err),
+      });
+      continue;
+    }
+
+    void cleanupIfStale(dirPath);
+  }
+}
+
+async function cleanupIfStale(dirPath: string): Promise<void> {
+  try {
+    await cleanupIfStaleUnsafe(dirPath);
+  } catch (err) {
+    warnCleanup("stale worker directory cleanup failed", {
+      dirPath,
+      error: String(err),
+    });
+  }
+}
+
+async function cleanupIfStaleUnsafe(dirPath: string): Promise<void> {
+  const files = fs.readdirSync(dirPath);
+  const sockets = files.filter((f) => f.endsWith(".sock"));
+
+  if (sockets.length === 0) return;
+
+  const results = await Promise.all(sockets.map((sock) => isSocketAlive(path.join(dirPath, sock))));
+  if (results.some(Boolean)) return;
+
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function isSocketAlive(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const conn = net.createConnection(socketPath);
+    conn.setTimeout(SOCKET_PROBE_TIMEOUT_MS);
+    conn.once("connect", () => {
+      conn.destroy();
+      resolve(true);
+    });
+    conn.once("error", () => {
+      conn.destroy();
+      resolve(false);
+    });
+    conn.once("timeout", () => {
+      conn.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function warnCleanup(msg: string, context: Record<string, unknown>): void {
+  Bus.publish(Operational.Warn, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    component: "coordinator.worker-manager",
+    msg,
+    context,
+  });
+}


### PR DESCRIPTION
## Summary
- split worker-manager public/internal types into `worker-manager-types.ts`
- move slot/session-affinity/waiter/idle lifecycle handling into `worker-slot-coordinator.ts`
- move private socket directory cleanup into `worker-socket-dir.ts`
- keep `createWorkerManager` and `OnDemandWorkerManager` public surface unchanged while reducing `manager.ts` to 169 pure LOC

## Verification
- `bun install`
- `bun run --cwd packages/protocol build`
- baseline `bun test test/worker-manager/manager.test.ts test/worker-manager/dispatch.test.ts test/worker-manager/crash.test.ts` from `packages/coordinator` (23 pass)
- `bunx biome check` on touched files
- `bun run --cwd packages/coordinator check-types`
- focused worker-manager tests from `packages/coordinator` (23 pass)
- LSP diagnostics on `packages/coordinator/src/worker-manager` (0 diagnostics)
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bunx knip --no-config-hints`
- `git diff --check`
- `bun run test` (turbo 9/9 successful; coordinator 96 pass)
- `codex-ultrawork-reviewer`: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split worker manager into focused modules to simplify `manager.ts` and improve maintainability. Public API stays the same (`createWorkerManager`, `OnDemandWorkerManager`).

- **Refactors**
  - Moved public/internal types to `worker-manager-types.ts`.
  - Extracted slot/session-affinity/queue/idle lifecycle into `worker-slot-coordinator.ts`.
  - Extracted private socket directory creation and stale cleanup into `worker-socket-dir.ts`.
  - `manager.ts` now delegates to these modules; behavior unchanged.

<sup>Written for commit 4382d1015182fb4b747421398ed93f1dba6df532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved architecture of the worker management system for better resource handling.
  * Consolidated worker manager configuration, constants, and type definitions for improved maintainability.
  * Enhanced socket directory management with automatic cleanup of stale worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->