### PR TITLE
refactor(agent): split policy engine responsibilities

### DIFF
--- a/packages/agent/src/core/policy/engine-audit.ts
+++ b/packages/agent/src/core/policy/engine-audit.ts
@@ -1,0 +1,117 @@
+import { Operational, type Policy, PolicyEvent, type TraceContext } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import { auditPoint } from "./engine-points";
+import type { AuditDispatchContext, PolicyEngineConfig } from "./engine-types";
+import type { PolicyContext, PolicyRegistration } from "./types";
+
+function buildActor(traceContext: TraceContext.Type | undefined): Record<string, unknown> {
+  return {
+    kind: "agent",
+    ...(traceContext?.agentName !== undefined && { name: traceContext.agentName }),
+    ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
+    ...(traceContext?.taskId !== undefined && { taskId: traceContext.taskId }),
+  };
+}
+
+function resolveAction(timing: Policy.Timing): string {
+  if (timing === "invoke.prepare" || timing === "invoke.result") return "tool.call";
+  return `middleware.${timing}`;
+}
+
+function resolveResource(reg: PolicyRegistration, ctx: PolicyContext): string {
+  return ctx.toolName ?? reg.name;
+}
+
+function resolveComposedResource(ctx: AuditDispatchContext): string {
+  return ctx.toolName ?? ctx.resourceDescriptor?.id ?? "policy.composed";
+}
+
+function auditReason(decision: Policy.PolicyDecision): string {
+  if (decision.reasonCodes.length > 0) return decision.reasonCodes.join(",");
+  return decision.verdict;
+}
+
+export function publishPolicyEvent(
+  options: PolicyEngineConfig,
+  decision: Policy.PolicyDecision,
+  reg: PolicyRegistration,
+  ctx: AuditDispatchContext,
+): void {
+  if (options.audit === false) return;
+
+  const traceContext = ctx.traceContext ?? options.traceContext;
+  const traceId = traceContext?.traceId;
+  const sessionId = options.audit?.sessionId ?? traceContext?.sessionId;
+  if (!sessionId || !traceId) return;
+  const point = auditPoint(ctx.timing, ctx.resourceDescriptor);
+
+  Bus.publish(PolicyEvent.Evaluated, {
+    traceId,
+    sessionId,
+    ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
+    time: Date.now(),
+    policyId: decision.policyId,
+    actor: options.audit?.actor ?? buildActor(traceContext),
+    action: options.audit?.action ?? resolveAction(ctx.timing),
+    resource: options.audit?.resource ?? resolveResource(reg, ctx),
+    verdict: decision.verdict,
+    reason: auditReason(decision),
+    effects: decision.effects,
+    ...(decision.obligations !== undefined && { obligations: decision.obligations }),
+    reasonCodes: decision.reasonCodes,
+    ...(decision.factsUsed !== undefined && { factsUsed: decision.factsUsed }),
+    durationMs: decision.durationMs,
+    ...point,
+    ...(ctx.resourceDescriptor !== undefined && { resourceDescriptor: ctx.resourceDescriptor }),
+  });
+}
+
+export function publishComposedDecision(
+  options: PolicyEngineConfig,
+  timing: Policy.Timing,
+  ctx: AuditDispatchContext,
+  decision: Policy.PolicyDecision,
+): void {
+  if (options.audit === false) return;
+
+  const traceContext = ctx.traceContext ?? options.traceContext;
+  const traceId = traceContext?.traceId;
+  const sessionId = options.audit?.sessionId ?? traceContext?.sessionId;
+  if (!sessionId || !traceId) return;
+
+  Bus.publish(PolicyEvent.DecisionComposed, {
+    traceId,
+    sessionId,
+    ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
+    time: Date.now(),
+    actor: options.audit?.actor ?? buildActor(traceContext),
+    action: options.audit?.action ?? resolveAction(timing),
+    resource: options.audit?.resource ?? resolveComposedResource(ctx),
+    verdict: decision.verdict,
+    reason: auditReason(decision),
+    effects: decision.effects,
+    reasonCodes: decision.reasonCodes,
+    ...(decision.obligations !== undefined && { obligations: decision.obligations }),
+    ...(decision.factsUsed !== undefined && { factsUsed: decision.factsUsed }),
+    durationMs: decision.durationMs,
+    ...auditPoint(timing, ctx.resourceDescriptor),
+    ...(ctx.resourceDescriptor !== undefined && { resourceDescriptor: ctx.resourceDescriptor }),
+  });
+}
+
+export function publishDecisionObserverError(
+  options: PolicyEngineConfig,
+  ctx: AuditDispatchContext,
+  decision: Policy.PolicyDecision,
+  err: unknown,
+): void {
+  const traceContext = ctx.traceContext ?? options.traceContext;
+  Bus.publish(Operational.Warn, {
+    traceId: traceContext?.traceId ?? crypto.randomUUID(),
+    time: Date.now(),
+    ...(traceContext?.sessionId !== undefined && { sessionId: traceContext.sessionId }),
+    component: "agent.policy",
+    msg: "onDecision observer error",
+    context: { timing: ctx.timing, policyId: decision.policyId, error: String(err) },
+  });
+}

--- a/packages/agent/src/core/policy/engine-decisions.ts
+++ b/packages/agent/src/core/policy/engine-decisions.ts
@@ -1,0 +1,157 @@
+import { Policy, PolicyDecision, type RuntimeResource } from "@openomni/protocol";
+import { composeEffects } from "./effect-composition";
+import { allowedEffectTypes, isPreBoundary, policyPointIdsForDescriptor } from "./engine-points";
+import type { PolicyRegistration } from "./types";
+
+export const COMPOSED_POLICY_ID = "agent.policy.composed";
+
+const EFFECT_VALIDATION_REASON = "policy.effect_not_allowed";
+const MIDDLEWARE_ERROR_REASON = "middleware-error";
+
+function totalDurationMs(decisions: readonly Policy.PolicyDecision[]): number {
+  return decisions.reduce((total, decision) => total + (decision.durationMs ?? 0), 0);
+}
+
+function validationFailure(
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+  effects: readonly Policy.PolicyEffect[],
+): Policy.PolicyDecision | undefined {
+  const allowed = allowedEffectTypes(timing, descriptor);
+  const invalid = effects.find((effect) => !allowed.has(effect.type));
+  if (!invalid) return undefined;
+
+  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
+  const annotation =
+    pointId === undefined
+      ? `${EFFECT_VALIDATION_REASON}: ${invalid.type} is not allowed at ${timing}`
+      : `${EFFECT_VALIDATION_REASON}: ${invalid.type} is not allowed at ${pointId}`;
+
+  return PolicyDecision.deny({
+    policyId: COMPOSED_POLICY_ID,
+    effects: [{ type: "audit.annotate", annotation, severity: "error" }],
+    reasonCodes: [EFFECT_VALIDATION_REASON],
+  });
+}
+
+function enforceDenyAbort(
+  decision: Policy.PolicyDecision,
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Policy.PolicyDecision {
+  if (decision.verdict !== "deny") return decision;
+  if (decision.effects.some((effect) => effect.type === "run.abort")) return decision;
+  if (!isPreBoundary(timing, descriptor)) return decision;
+  if (!allowedEffectTypes(timing, descriptor).has("run.abort")) return decision;
+
+  const reason = decision.reasonCodes[0] ?? "policy.deny";
+  return {
+    ...decision,
+    effects: [{ type: "run.abort", reason }, ...decision.effects],
+  };
+}
+
+function composedDecision(
+  effective: Policy.EffectiveDecision,
+  decisions: readonly Policy.PolicyDecision[],
+): Policy.PolicyDecision {
+  const reasonSources =
+    effective.verdict === "deny"
+      ? decisions.filter((decision) => decision.verdict === "deny")
+      : effective.verdict === "pending"
+        ? decisions.filter((decision) => decision.verdict === "pending")
+        : decisions;
+  const reasonCodes = reasonSources.flatMap((decision) => decision.reasonCodes);
+  const obligations = effective.obligations.length === 0 ? undefined : effective.obligations;
+
+  return {
+    policyId: COMPOSED_POLICY_ID,
+    verdict: effective.verdict,
+    effects: effective.mergedEffects,
+    ...(obligations !== undefined && { obligations }),
+    reasonCodes: [...new Set(reasonCodes)],
+    durationMs: totalDurationMs(decisions),
+  };
+}
+
+export function composeFinalDecision(
+  decisions: readonly Policy.PolicyDecision[],
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Policy.PolicyDecision {
+  const effective = composeEffects([...decisions]);
+  const decision =
+    validationFailure(timing, descriptor, effective.mergedEffects) ??
+    composedDecision(effective, decisions);
+  return enforceDenyAbort(decision, timing, descriptor);
+}
+
+export function middlewareErrorDecision(
+  reg: PolicyRegistration,
+  durationMs: number,
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Policy.PolicyDecision {
+  const effects: Policy.PolicyEffect[] = [
+    {
+      type: "audit.annotate",
+      annotation: `${reg.name}: ${MIDDLEWARE_ERROR_REASON}`,
+      severity: "error",
+    },
+  ];
+  if (allowedEffectTypes(timing, descriptor).has("run.abort")) {
+    effects.unshift({ type: "run.abort", reason: MIDDLEWARE_ERROR_REASON });
+  }
+
+  return PolicyDecision.deny({
+    policyId: reg.name,
+    reasonCodes: [MIDDLEWARE_ERROR_REASON],
+    durationMs,
+    priority: reg.priority,
+    effects,
+  });
+}
+
+function invalidDecision(
+  reg: PolicyRegistration,
+  durationMs: number,
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Policy.PolicyDecision {
+  const reason = "policy.invalid_decision";
+  const effects: Policy.PolicyEffect[] = [
+    {
+      type: "audit.annotate",
+      annotation: `${reg.name}: ${reason}`,
+      severity: "error",
+    },
+  ];
+  if (allowedEffectTypes(timing, descriptor).has("run.abort")) {
+    effects.unshift({ type: "run.abort", reason });
+  }
+
+  return PolicyDecision.deny({
+    policyId: reg.name,
+    reasonCodes: [reason],
+    durationMs,
+    priority: reg.priority,
+    effects,
+  });
+}
+
+export function normalizeDecision(
+  decision: unknown,
+  reg: PolicyRegistration,
+  durationMs: number,
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Policy.PolicyDecision {
+  const parsed = Policy.PolicyDecision.safeParse(decision);
+  if (!parsed.success) return invalidDecision(reg, durationMs, timing, descriptor);
+
+  return {
+    ...parsed.data,
+    durationMs,
+    priority: reg.priority,
+  };
+}

--- a/packages/agent/src/core/policy/engine-points.ts
+++ b/packages/agent/src/core/policy/engine-points.ts
@@ -1,0 +1,82 @@
+import { Policy, type RuntimeResource } from "@openomni/protocol";
+import type { PolicyPointId } from "./engine-types";
+
+export function policyPointIdsForDescriptor(
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): PolicyPointId[] {
+  const aliases = Policy.PolicyPoint.MigrationMapping[timing];
+  if (descriptor === undefined) return aliases;
+
+  if (timing === "invoke.prepare") {
+    if (descriptor.kind === "worker") {
+      return descriptor.labels.includes("delegation.background")
+        ? ["delegation.background.pre"]
+        : ["delegation.subagent.pre"];
+    }
+    if (descriptor.kind === "tool") {
+      return descriptor.source?.type === "mcp" || descriptor.source?.type === "skill-mcp"
+        ? ["tool.mcp.pre"]
+        : ["tool.native.pre"];
+    }
+  }
+
+  if (timing === "invoke.result") {
+    if (descriptor.kind === "worker") {
+      return descriptor.labels.includes("delegation.background")
+        ? ["delegation.background.post"]
+        : ["delegation.subagent.post"];
+    }
+    if (descriptor.kind === "tool") {
+      return descriptor.source?.type === "mcp" || descriptor.source?.type === "skill-mcp"
+        ? ["tool.mcp.post"]
+        : ["tool.native.post"];
+    }
+  }
+
+  return aliases;
+}
+
+export function auditPoint(
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): { readonly pointId?: PolicyPointId; readonly pointVersion?: number } {
+  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
+  if (pointId === undefined) return {};
+
+  return { pointId, pointVersion: Policy.PolicyPoint.Registry[pointId].version };
+}
+
+export function defaultFailPolicy(
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Policy.FailPolicy {
+  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
+  if (pointId === undefined) return "fail-open";
+  return Policy.PolicyPoint.Registry[pointId].defaultFailPolicy;
+}
+
+export function allowedEffectTypes(
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): Map<Policy.PolicyEffectType, PolicyPointId> {
+  const allowed = new Map<Policy.PolicyEffectType, PolicyPointId>();
+
+  for (const pointId of policyPointIdsForDescriptor(timing, descriptor)) {
+    const point = Policy.PolicyPoint.Registry[pointId];
+    for (const effectType of point.allowedEffects) {
+      if (!allowed.has(effectType)) allowed.set(effectType, pointId);
+    }
+  }
+
+  return allowed;
+}
+
+export function isPreBoundary(
+  timing: Policy.Timing,
+  descriptor: RuntimeResource.Descriptor | undefined,
+): boolean {
+  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
+  if (pointId === undefined) return false;
+  return Policy.PolicyPoint.Registry[pointId].sideEffectBoundary;
+}

--- a/packages/agent/src/core/policy/engine-selection.ts
+++ b/packages/agent/src/core/policy/engine-selection.ts
@@ -1,0 +1,25 @@
+import type { Policy } from "@openomni/protocol";
+import type { PolicyRegistration } from "./types";
+
+function matchesTiming(reg: PolicyRegistration, timing: Policy.Timing): boolean {
+  return Array.isArray(reg.timing) ? reg.timing.includes(timing) : reg.timing === timing;
+}
+
+function matchesScope(reg: PolicyRegistration, agentType: string | undefined): boolean {
+  const allowed = reg.scope?.agentType;
+  if (!allowed || allowed.length === 0) return true;
+  if (!agentType) return false;
+  return allowed.includes(agentType);
+}
+
+export function selectRegistrations(
+  registrations: readonly PolicyRegistration[],
+  timing: Policy.Timing,
+  agentType: string | undefined,
+): PolicyRegistration[] {
+  return registrations
+    .map((reg, index) => ({ index, reg }))
+    .filter(({ reg }) => matchesTiming(reg, timing) && matchesScope(reg, agentType))
+    .sort((a, b) => a.reg.priority - b.reg.priority || a.index - b.index)
+    .map(({ reg }) => reg);
+}

--- a/packages/agent/src/core/policy/engine-snapshot.ts
+++ b/packages/agent/src/core/policy/engine-snapshot.ts
@@ -1,0 +1,51 @@
+import type { AuditDispatchContext } from "./engine-types";
+
+export function immutableSnapshot(value: AuditDispatchContext): Readonly<AuditDispatchContext> {
+  const snapshot: AuditDispatchContext = {
+    ...value,
+    steps: [...value.steps],
+    usage: Object.freeze({ ...value.usage }),
+    ...(value.toolInput !== undefined && { toolInput: cloneRecord(value.toolInput) }),
+    ...(value.toolLabels !== undefined && { toolLabels: [...value.toolLabels] }),
+    ...(value.messages !== undefined && { messages: [...value.messages] }),
+    ...(value.traceContext !== undefined && {
+      traceContext: Object.freeze({ ...value.traceContext }),
+    }),
+    ...(value.labels !== undefined && {
+      labels: value.labels.map((entry) => Object.freeze({ ...entry })),
+    }),
+  };
+
+  Object.freeze(snapshot.steps);
+  if (snapshot.toolLabels !== undefined) Object.freeze(snapshot.toolLabels);
+  if (snapshot.messages !== undefined) Object.freeze(snapshot.messages);
+  if (snapshot.labels !== undefined) Object.freeze(snapshot.labels);
+
+  return Object.freeze(snapshot);
+}
+
+function cloneRecord(record: Record<string, unknown>): Readonly<Record<string, unknown>> {
+  const clone: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    clone[key] = cloneValue(value);
+  }
+
+  return Object.freeze(clone);
+}
+
+function cloneArray(values: readonly unknown[]): readonly unknown[] {
+  return Object.freeze(values.map(cloneValue));
+}
+
+function cloneValue(value: unknown): unknown {
+  if (Array.isArray(value)) return cloneArray(value);
+  if (isPlainRecord(value)) return cloneRecord(value);
+  return value;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/agent/src/core/policy/engine-types.ts
+++ b/packages/agent/src/core/policy/engine-types.ts
@@ -1,0 +1,35 @@
+import type { Policy, RuntimeResource, TraceContext } from "@openomni/protocol";
+import type { PolicyContext, PolicyRegistration } from "./types";
+
+type AuditVisibility = "internal" | "llm_reason" | "user_audit";
+export type PolicyPointId = keyof typeof Policy.PolicyPoint.Registry;
+
+export type AuditDispatchContext = PolicyContext & {
+  readonly resourceDescriptor?: RuntimeResource.Descriptor;
+};
+
+export type DispatchContext = Omit<PolicyContext, "timing"> & {
+  readonly resourceDescriptor?: RuntimeResource.Descriptor;
+};
+
+export type PolicyDecision = Policy.PolicyDecision;
+
+export interface PolicyAuditConfig {
+  readonly sessionId?: string;
+  readonly actor?: Record<string, unknown>;
+  readonly action?: string;
+  readonly resource?: string;
+  readonly visibility?: AuditVisibility;
+  readonly parentActionId?: string;
+}
+
+export interface PolicyEngineConfig {
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+  readonly traceContext?: TraceContext.Type;
+  readonly audit?: PolicyAuditConfig | false;
+}
+
+export interface PolicyEngineInstance {
+  register(reg: PolicyRegistration): void;
+  dispatch(timing: Policy.Timing, ctx: DispatchContext): Promise<Policy.PolicyDecision>;
+}

--- a/packages/agent/src/core/policy/engine.ts
+++ b/packages/agent/src/core/policy/engine.ts
@@ -1,440 +1,87 @@
+import { Operational, type Policy, PolicyDecision } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import {
-  Operational,
-  Policy,
-  PolicyDecision as Decision,
-  PolicyEvent,
-  type RuntimeResource,
-  type TraceContext,
-} from "@openomni/protocol";
-import { composeEffects } from "./effect-composition";
-import type { PolicyContext, PolicyRegistration } from "./types";
+  COMPOSED_POLICY_ID,
+  composeFinalDecision,
+  middlewareErrorDecision,
+  normalizeDecision,
+} from "./engine-decisions";
+import { defaultFailPolicy } from "./engine-points";
+import { selectRegistrations } from "./engine-selection";
+import { immutableSnapshot } from "./engine-snapshot";
+import {
+  publishComposedDecision,
+  publishDecisionObserverError,
+  publishPolicyEvent,
+} from "./engine-audit";
+import type {
+  AuditDispatchContext,
+  DispatchContext,
+  PolicyEngineConfig,
+  PolicyEngineInstance,
+} from "./engine-types";
+import type { PolicyRegistration } from "./types";
 
-const COMPOSED_POLICY_ID = "agent.policy.composed";
-const EFFECT_VALIDATION_REASON = "policy.effect_not_allowed";
-const MIDDLEWARE_ERROR_REASON = "middleware-error";
+export type {
+  DispatchContext,
+  PolicyAuditConfig,
+  PolicyDecision,
+  PolicyEngineConfig,
+  PolicyEngineInstance,
+} from "./engine-types";
 
-type AuditVisibility = "internal" | "llm_reason" | "user_audit";
-type PolicyPointId = keyof typeof Policy.PolicyPoint.Registry;
-type AuditDispatchContext = PolicyContext & {
-  readonly resourceDescriptor?: RuntimeResource.Descriptor;
-};
-
-export type DispatchContext = Omit<PolicyContext, "timing"> & {
-  readonly resourceDescriptor?: RuntimeResource.Descriptor;
-};
-
-export type PolicyDecision = Policy.PolicyDecision;
-
-export interface PolicyAuditConfig {
-  readonly sessionId?: string;
-  readonly actor?: Record<string, unknown>;
-  readonly action?: string;
-  readonly resource?: string;
-  readonly visibility?: AuditVisibility;
-  readonly parentActionId?: string;
-}
-
-export interface PolicyEngineConfig {
-  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-  readonly traceContext?: TraceContext.Type;
-  readonly audit?: PolicyAuditConfig | false;
-}
-
-export interface PolicyEngineInstance {
-  register(reg: PolicyRegistration): void;
-  dispatch(timing: Policy.Timing, ctx: DispatchContext): Promise<Policy.PolicyDecision>;
-}
-
-function matchesTiming(reg: PolicyRegistration, timing: Policy.Timing): boolean {
-  return Array.isArray(reg.timing) ? reg.timing.includes(timing) : reg.timing === timing;
-}
-
-function matchesScope(reg: PolicyRegistration, agentType: string | undefined): boolean {
-  const allowed = reg.scope?.agentType;
-  if (!allowed || allowed.length === 0) return true;
-  if (!agentType) return false;
-  return allowed.includes(agentType);
-}
-
-function selectRegistrations(
-  registrations: PolicyRegistration[],
-  timing: Policy.Timing,
-  agentType: string | undefined,
-): PolicyRegistration[] {
-  return registrations
-    .map((reg, index) => ({ index, reg }))
-    .filter(({ reg }) => matchesTiming(reg, timing) && matchesScope(reg, agentType))
-    .sort((a, b) => a.reg.priority - b.reg.priority || a.index - b.index)
-    .map(({ reg }) => reg);
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
-
-function immutableSnapshot<T>(value: T): T {
-  if (Array.isArray(value)) {
-    return Object.freeze(value.map((entry) => immutableSnapshot(entry))) as T;
-  }
-
-  if (isPlainRecord(value)) {
-    const snapshot: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      snapshot[key] = immutableSnapshot(entry);
-    }
-    return Object.freeze(snapshot) as T;
-  }
-
-  return value;
-}
-
-function buildActor(traceContext: TraceContext.Type | undefined): Record<string, unknown> {
-  return {
-    kind: "agent",
-    ...(traceContext?.agentName !== undefined && { name: traceContext.agentName }),
-    ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
-    ...(traceContext?.taskId !== undefined && { taskId: traceContext.taskId }),
-  };
-}
-
-function resolveAction(timing: Policy.Timing): string {
-  if (timing === "invoke.prepare" || timing === "invoke.result") return "tool.call";
-  return `middleware.${timing}`;
-}
-
-function resolveResource(reg: PolicyRegistration, ctx: PolicyContext): string {
-  return ctx.toolName ?? reg.name;
-}
-
-function resolveComposedResource(ctx: AuditDispatchContext): string {
-  return ctx.toolName ?? ctx.resourceDescriptor?.id ?? "policy.composed";
-}
-
-function auditReason(decision: Policy.PolicyDecision): string {
-  if (decision.reasonCodes.length > 0) return decision.reasonCodes.join(",");
-  return decision.verdict;
-}
-
-function policyPointIdsForDescriptor(
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): PolicyPointId[] {
-  const aliases = Policy.PolicyPoint.MigrationMapping[timing];
-  if (descriptor === undefined) return aliases;
-
-  if (timing === "invoke.prepare") {
-    if (descriptor.kind === "worker") {
-      return descriptor.labels.includes("delegation.background")
-        ? ["delegation.background.pre"]
-        : ["delegation.subagent.pre"];
-    }
-    if (descriptor.kind === "tool") {
-      return descriptor.source?.type === "mcp" || descriptor.source?.type === "skill-mcp"
-        ? ["tool.mcp.pre"]
-        : ["tool.native.pre"];
-    }
-  }
-
-  if (timing === "invoke.result") {
-    if (descriptor.kind === "worker") {
-      return descriptor.labels.includes("delegation.background")
-        ? ["delegation.background.post"]
-        : ["delegation.subagent.post"];
-    }
-    if (descriptor.kind === "tool") {
-      return descriptor.source?.type === "mcp" || descriptor.source?.type === "skill-mcp"
-        ? ["tool.mcp.post"]
-        : ["tool.native.post"];
-    }
-  }
-
-  return aliases;
-}
-
-function auditPoint(
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): { readonly pointId?: PolicyPointId; readonly pointVersion?: number } {
-  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
-  if (pointId === undefined) return {};
-
-  return { pointId, pointVersion: Policy.PolicyPoint.Registry[pointId].version };
-}
-
-function defaultFailPolicy(
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): Policy.FailPolicy {
-  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
-  if (pointId === undefined) return "fail-open";
-  return Policy.PolicyPoint.Registry[pointId].defaultFailPolicy;
-}
-
-function totalDurationMs(decisions: readonly Policy.PolicyDecision[]): number {
-  return decisions.reduce((total, decision) => total + (decision.durationMs ?? 0), 0);
-}
-
-function allowedEffectTypes(
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): Map<Policy.PolicyEffectType, PolicyPointId> {
-  const allowed = new Map<Policy.PolicyEffectType, PolicyPointId>();
-
-  for (const pointId of policyPointIdsForDescriptor(timing, descriptor)) {
-    const point = Policy.PolicyPoint.Registry[pointId];
-    for (const effectType of point.allowedEffects) {
-      if (!allowed.has(effectType)) allowed.set(effectType, pointId);
-    }
-  }
-
-  return allowed;
-}
-
-function validationFailure(
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-  effects: readonly Policy.PolicyEffect[],
-): Policy.PolicyDecision | undefined {
-  const allowed = allowedEffectTypes(timing, descriptor);
-  const invalid = effects.find((effect) => !allowed.has(effect.type));
-  if (!invalid) return undefined;
-
-  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
-  const annotation =
-    pointId === undefined
-      ? `${EFFECT_VALIDATION_REASON}: ${invalid.type} is not allowed at ${timing}`
-      : `${EFFECT_VALIDATION_REASON}: ${invalid.type} is not allowed at ${pointId}`;
-
-  return Decision.deny({
-    policyId: COMPOSED_POLICY_ID,
-    effects: [{ type: "audit.annotate", annotation, severity: "error" }],
-    reasonCodes: [EFFECT_VALIDATION_REASON],
-  });
-}
-
-function isPreBoundary(
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): boolean {
-  const pointId = policyPointIdsForDescriptor(timing, descriptor)[0];
-  if (pointId === undefined) return false;
-  return Policy.PolicyPoint.Registry[pointId].sideEffectBoundary;
-}
-
-// pre-boundary deny must include run.abort so downstream callers stop execution
-function enforceDenyAbort(
+function recordDecision(
+  options: PolicyEngineConfig,
+  reg: PolicyRegistration,
+  ctx: AuditDispatchContext,
   decision: Policy.PolicyDecision,
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
 ): Policy.PolicyDecision {
-  if (decision.verdict !== "deny") return decision;
-  if (decision.effects.some((effect) => effect.type === "run.abort")) return decision;
-  if (!isPreBoundary(timing, descriptor)) return decision;
-  if (!allowedEffectTypes(timing, descriptor).has("run.abort")) return decision;
-
-  const reason = decision.reasonCodes[0] ?? "policy.deny";
-  return {
-    ...decision,
-    effects: [{ type: "run.abort", reason }, ...decision.effects],
-  };
-}
-
-function composedDecision(
-  effective: Policy.EffectiveDecision,
-  decisions: readonly Policy.PolicyDecision[],
-): Policy.PolicyDecision {
-  const reasonSources =
-    effective.verdict === "deny"
-      ? decisions.filter((decision) => decision.verdict === "deny")
-      : effective.verdict === "pending"
-        ? decisions.filter((decision) => decision.verdict === "pending")
-        : decisions;
-  const reasonCodes = reasonSources.flatMap((decision) => decision.reasonCodes);
-  const obligations = effective.obligations.length === 0 ? undefined : effective.obligations;
-
-  return {
-    policyId: COMPOSED_POLICY_ID,
-    verdict: effective.verdict,
-    effects: effective.mergedEffects,
-    ...(obligations !== undefined && { obligations }),
-    reasonCodes: [...new Set(reasonCodes)],
-    durationMs: totalDurationMs(decisions),
-  };
-}
-
-function middlewareErrorDecision(
-  reg: PolicyRegistration,
-  durationMs: number,
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): Policy.PolicyDecision {
-  const effects: Policy.PolicyEffect[] = [
-    {
-      type: "audit.annotate",
-      annotation: `${reg.name}: ${MIDDLEWARE_ERROR_REASON}`,
-      severity: "error",
-    },
-  ];
-  if (allowedEffectTypes(timing, descriptor).has("run.abort")) {
-    effects.unshift({ type: "run.abort", reason: MIDDLEWARE_ERROR_REASON });
+  publishPolicyEvent(options, decision, reg, ctx);
+  try {
+    void Promise.resolve(options.onDecision?.(decision)).catch((err) => {
+      publishDecisionObserverError(options, ctx, decision, err);
+    });
+  } catch (err) {
+    publishDecisionObserverError(options, ctx, decision, err);
   }
+  return decision;
+}
 
-  return Decision.deny({
-    policyId: reg.name,
-    reasonCodes: [MIDDLEWARE_ERROR_REASON],
-    durationMs,
-    priority: reg.priority,
-    effects,
+function publishMiddlewareError(
+  options: PolicyEngineConfig,
+  timing: Policy.Timing,
+  name: string,
+  err: unknown,
+  failPolicy: Policy.FailPolicy,
+  durationMs: number,
+): void {
+  Bus.publish(Operational.Warn, {
+    traceId: options.traceContext?.traceId ?? crypto.randomUUID(),
+    time: Date.now(),
+    component: "agent.policy",
+    msg: "middleware error",
+    context: { timing, name, error: String(err), failPolicy, durationMs },
   });
 }
 
-function invalidDecision(
-  reg: PolicyRegistration,
-  durationMs: number,
+function publishMiddlewareDebug(
+  options: PolicyEngineConfig,
   timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): Policy.PolicyDecision {
-  const reason = "policy.invalid_decision";
-  const effects: Policy.PolicyEffect[] = [
-    {
-      type: "audit.annotate",
-      annotation: `${reg.name}: ${reason}`,
-      severity: "error",
-    },
-  ];
-  if (allowedEffectTypes(timing, descriptor).has("run.abort")) {
-    effects.unshift({ type: "run.abort", reason });
-  }
-
-  return Decision.deny({
-    policyId: reg.name,
-    reasonCodes: [reason],
-    durationMs,
-    priority: reg.priority,
-    effects,
+  name: string,
+  verdict: Policy.PolicyDecision["verdict"],
+  durationMs: number,
+): void {
+  Bus.publish(Operational.Debug, {
+    traceId: options.traceContext?.traceId ?? crypto.randomUUID(),
+    time: Date.now(),
+    component: "agent.policy",
+    msg: "middleware dispatch",
+    context: { timing, name, verdict, durationMs },
   });
-}
-
-function normalizeDecision(
-  decision: unknown,
-  reg: PolicyRegistration,
-  durationMs: number,
-  timing: Policy.Timing,
-  descriptor: RuntimeResource.Descriptor | undefined,
-): Policy.PolicyDecision {
-  const parsed = Policy.PolicyDecision.safeParse(decision);
-  if (!parsed.success) return invalidDecision(reg, durationMs, timing, descriptor);
-
-  return {
-    ...parsed.data,
-    durationMs,
-    priority: reg.priority,
-  };
 }
 
 function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
   const registrations: PolicyRegistration[] = [];
-
-  function publishPolicyEvent(
-    decision: Policy.PolicyDecision,
-    reg: PolicyRegistration,
-    ctx: AuditDispatchContext,
-  ): void {
-    if (options.audit === false) return;
-
-    const traceContext = ctx.traceContext ?? options.traceContext;
-    const traceId = traceContext?.traceId;
-    const sessionId = options.audit?.sessionId ?? traceContext?.sessionId;
-    if (!sessionId || !traceId) return;
-    const point = auditPoint(ctx.timing, ctx.resourceDescriptor);
-
-    Bus.publish(PolicyEvent.Evaluated, {
-      traceId,
-      sessionId,
-      ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
-      time: Date.now(),
-      policyId: decision.policyId,
-      actor: options.audit?.actor ?? buildActor(traceContext),
-      action: options.audit?.action ?? resolveAction(ctx.timing),
-      resource: options.audit?.resource ?? resolveResource(reg, ctx),
-      verdict: decision.verdict,
-      reason: auditReason(decision),
-      effects: decision.effects,
-      ...(decision.obligations !== undefined && { obligations: decision.obligations }),
-      reasonCodes: decision.reasonCodes,
-      ...(decision.factsUsed !== undefined && { factsUsed: decision.factsUsed }),
-      durationMs: decision.durationMs,
-      ...point,
-      ...(ctx.resourceDescriptor !== undefined && { resourceDescriptor: ctx.resourceDescriptor }),
-    });
-  }
-
-  function publishComposedDecision(
-    timing: Policy.Timing,
-    ctx: AuditDispatchContext,
-    decision: Policy.PolicyDecision,
-  ): void {
-    if (options.audit === false) return;
-
-    const traceContext = ctx.traceContext ?? options.traceContext;
-    const traceId = traceContext?.traceId;
-    const sessionId = options.audit?.sessionId ?? traceContext?.sessionId;
-    if (!sessionId || !traceId) return;
-
-    Bus.publish(PolicyEvent.DecisionComposed, {
-      traceId,
-      sessionId,
-      ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
-      time: Date.now(),
-      actor: options.audit?.actor ?? buildActor(traceContext),
-      action: options.audit?.action ?? resolveAction(timing),
-      resource: options.audit?.resource ?? resolveComposedResource(ctx),
-      verdict: decision.verdict,
-      reason: auditReason(decision),
-      effects: decision.effects,
-      reasonCodes: decision.reasonCodes,
-      ...(decision.obligations !== undefined && { obligations: decision.obligations }),
-      ...(decision.factsUsed !== undefined && { factsUsed: decision.factsUsed }),
-      durationMs: decision.durationMs,
-      ...auditPoint(timing, ctx.resourceDescriptor),
-      ...(ctx.resourceDescriptor !== undefined && { resourceDescriptor: ctx.resourceDescriptor }),
-    });
-  }
-
-  function publishDecisionObserverError(
-    ctx: AuditDispatchContext,
-    decision: Policy.PolicyDecision,
-    err: unknown,
-  ): void {
-    const traceContext = ctx.traceContext ?? options.traceContext;
-    Bus.publish(Operational.Warn, {
-      traceId: traceContext?.traceId ?? crypto.randomUUID(),
-      time: Date.now(),
-      ...(traceContext?.sessionId !== undefined && { sessionId: traceContext.sessionId }),
-      component: "agent.policy",
-      msg: "onDecision observer error",
-      context: { timing: ctx.timing, policyId: decision.policyId, error: String(err) },
-    });
-  }
-
-  function recordDecision(
-    reg: PolicyRegistration,
-    ctx: AuditDispatchContext,
-    decision: Policy.PolicyDecision,
-  ): Policy.PolicyDecision {
-    publishPolicyEvent(decision, reg, ctx);
-    try {
-      void Promise.resolve(options.onDecision?.(decision)).catch((err) => {
-        publishDecisionObserverError(ctx, decision, err);
-      });
-    } catch (err) {
-      publishDecisionObserverError(ctx, decision, err);
-    }
-    return decision;
-  }
 
   async function dispatch(
     timing: Policy.Timing,
@@ -445,18 +92,14 @@ function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
     const decisions: Policy.PolicyDecision[] = [];
 
     function composeAndPublish(): Policy.PolicyDecision {
-      const effective = composeEffects(decisions);
-      const decision =
-        validationFailure(timing, ctx.resourceDescriptor, effective.mergedEffects) ??
-        composedDecision(effective, decisions);
-      const enforced = enforceDenyAbort(decision, timing, ctx.resourceDescriptor);
-      publishComposedDecision(timing, fullCtx, enforced);
-      return enforced;
+      const decision = composeFinalDecision(decisions, timing, ctx.resourceDescriptor);
+      publishComposedDecision(options, timing, fullCtx, decision);
+      return decision;
     }
 
     if (selected.length === 0) {
-      const decision = Decision.allow({ policyId: COMPOSED_POLICY_ID });
-      publishComposedDecision(timing, fullCtx, decision);
+      const decision = PolicyDecision.allow({ policyId: COMPOSED_POLICY_ID });
+      publishComposedDecision(options, timing, fullCtx, decision);
       return decision;
     }
 
@@ -468,13 +111,7 @@ function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
       } catch (err) {
         const durationMs = Date.now() - startTime;
         const failPolicy = reg.failPolicy ?? defaultFailPolicy(timing, ctx.resourceDescriptor);
-        Bus.publish(Operational.Warn, {
-          traceId: options.traceContext?.traceId ?? crypto.randomUUID(),
-          time: Date.now(),
-          component: "agent.policy",
-          msg: "middleware error",
-          context: { timing, name: reg.name, error: String(err), failPolicy, durationMs },
-        });
+        publishMiddlewareError(options, timing, reg.name, err, failPolicy, durationMs);
         if (failPolicy === "fail-open") continue;
 
         decision = middlewareErrorDecision(reg, durationMs, timing, ctx.resourceDescriptor);
@@ -488,15 +125,8 @@ function create(options: PolicyEngineConfig = {}): PolicyEngineInstance {
         timing,
         ctx.resourceDescriptor,
       );
-      decisions.push(recordDecision(reg, fullCtx, normalized));
-
-      Bus.publish(Operational.Debug, {
-        traceId: options.traceContext?.traceId ?? crypto.randomUUID(),
-        time: Date.now(),
-        component: "agent.policy",
-        msg: "middleware dispatch",
-        context: { timing, name: reg.name, verdict: normalized.verdict, durationMs },
-      });
+      decisions.push(recordDecision(options, reg, fullCtx, normalized));
+      publishMiddlewareDebug(options, timing, reg.name, normalized.verdict, durationMs);
 
       if (normalized.verdict === "deny") return composeAndPublish();
     }


### PR DESCRIPTION
## Summary
- split `packages/agent/src/core/policy/engine.ts` into focused audit, decision, policy-point, selection, snapshot, and type modules
- keep `PolicyEngine.create/register/dispatch` and existing policy engine type exports available from the same public barrel path
- preserve immutable policy request snapshots without freezing caller-owned stream state arrays

## Verification
- baseline focused policy tests before edit: 59 pass / 10 skip / 0 fail
- `bunx biome check packages/agent/src/core/policy/engine*.ts --write`
- LSP diagnostics on `packages/agent/src/core/policy`: 0
- strict assertion/suppression scan over `engine*.ts`: no matches
- `bun test test/core/policy/engine.test.ts test/core/policy/engine-v2-integration.test.ts test/core/policy/engine-composition.test.ts test/core/policy/audit-emission.test.ts test/core/policy/conformance/determinism.test.ts test/core/policy/conformance/no-bypass.test.ts test/core/policy/dispatch-completion.test.ts test/core/policy/engine-deny-terminal.test.ts` from `packages/agent`
- `bun test test/core/policy/engine.test.ts test/core/policy/conformance/determinism.test.ts test/agent.test.ts test/core/run-delegation.test.ts` from `packages/agent`
- `bun run --cwd packages/agent check-types`
- `bunx knip --no-config-hints`
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `git diff --check`
- `bun run test`

## Review
- Goal/constraint reviewer: PASS
- Hands-on QA reviewer: PASS
- Code-quality reviewer: PASS after assertion blocker fix
- Security/policy-enforcement reviewer: PASS after snapshot regression fix
- Context/API compatibility reviewer: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `packages/agent/src/core/policy/engine.ts` into focused modules for decisions, audit, points, selection, snapshot, and types. Public API stays the same; request snapshots are now cloned and frozen safely without freezing caller-owned arrays.

- **Refactors**
  - Moved logic into `engine-audit.ts`, `engine-decisions.ts`, `engine-points.ts`, `engine-selection.ts`, `engine-snapshot.ts`, and `engine-types.ts`.
  - Centralized decision composition and effect validation in `engine-decisions` (includes `COMPOSED_POLICY_ID` and deny-abort enforcement).
  - Isolated audit event publishing and observer error handling in `engine-audit`.
  - Extracted policy point resolution, allowed effects, and default fail policy to `engine-points`.
  - Kept `PolicyEngine.create/register/dispatch` and type exports at the same public path.

- **Bug Fixes**
  - Snapshots are immutable without freezing caller-owned stream state arrays, preventing unintended side effects.

<sup>Written for commit c3ccfd2cbfd5c52904dba02cf56ab325a3192455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

