### PR TITLE
refactor(openomni): split tool executor responsibilities

### DIFF
--- a/packages/openomni/src/execution-runtime/tool/executor-abort.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor-abort.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { enforceTimeoutAndAbort } from "./executor-abort.js";
+import { ToolRuntimePolicyMiddleware } from "./middleware/tool-runtime-policy.js";
+
+describe("enforceTimeoutAndAbort", () => {
+  test("keeps timeout rejection authoritative when timeout callback throws", async () => {
+    const neverSettles = new Promise<unknown>(() => undefined);
+    let caught: unknown;
+
+    try {
+      await enforceTimeoutAndAbort(neverSettles, 1, undefined, () => {
+        throw Object.create(null);
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ToolRuntimePolicyMiddleware.TimeoutError);
+    expect(caught).toMatchObject({ timeoutMs: 1 });
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/executor-abort.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor-abort.ts
@@ -1,0 +1,88 @@
+import { ToolRuntimePolicyMiddleware } from "./middleware/tool-runtime-policy.js";
+
+export function createAbortError(): Error {
+  const error = new Error("Tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason;
+}
+
+export function linkAbortSignals(
+  localSignal: AbortSignal,
+  parentSignal: AbortSignal | undefined,
+): { readonly signal: AbortSignal; readonly cleanup: () => void } {
+  if (!parentSignal) return { signal: localSignal, cleanup: () => undefined };
+
+  const linked = new AbortController();
+  const forwardLocalAbort = () => {
+    if (!linked.signal.aborted) linked.abort(abortReason(localSignal));
+  };
+  const forwardParentAbort = () => {
+    if (!linked.signal.aborted) linked.abort(abortReason(parentSignal));
+  };
+
+  if (localSignal.aborted) forwardLocalAbort();
+  if (parentSignal.aborted) forwardParentAbort();
+
+  localSignal.addEventListener("abort", forwardLocalAbort, { once: true });
+  parentSignal.addEventListener("abort", forwardParentAbort, { once: true });
+
+  return {
+    signal: linked.signal,
+    cleanup: () => {
+      localSignal.removeEventListener("abort", forwardLocalAbort);
+      parentSignal.removeEventListener("abort", forwardParentAbort);
+    },
+  };
+}
+
+export async function enforceTimeoutAndAbort<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+  onTimeout: (error: ToolRuntimePolicyMiddleware.TimeoutError) => void,
+): Promise<T> {
+  if (signal?.aborted) throw createAbortError();
+
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timeoutFired = false;
+    const cleanup = () => {
+      globalThis.clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const onAbort = () => finish(() => reject(createAbortError()));
+    const timer = globalThis.setTimeout(() => {
+      timeoutFired = true;
+      const error = new ToolRuntimePolicyMiddleware.TimeoutError(timeoutMs);
+      finish(() => reject(error));
+      try {
+        onTimeout(error);
+      } catch {
+        return;
+      }
+    }, timeoutMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => finish(() => resolve(value)),
+      (error: unknown) => {
+        if (timeoutFired) return;
+        finish(() => reject(error));
+      },
+    );
+  });
+}

--- a/packages/openomni/src/execution-runtime/tool/executor-dispatch.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor-dispatch.ts
@@ -1,0 +1,48 @@
+import type { Tool } from "@openomni/protocol";
+import type { ImplicitInputSource, NativeTool, ToolRuntimeContext } from "./types.js";
+
+export function buildDispatchTable(tools: readonly NativeTool[]): Map<string, NativeTool> {
+  const dispatch = new Map<string, NativeTool>();
+  for (const tool of tools) {
+    dispatch.set(tool.spec.name, tool);
+    const sanitized = tool.spec.name.replace(/\./g, "_");
+    if (sanitized !== tool.spec.name) dispatch.set(sanitized, tool);
+  }
+  return dispatch;
+}
+
+function resolveImplicitValue(
+  source: ImplicitInputSource,
+  runtime: ToolRuntimeContext,
+): string | undefined {
+  switch (source) {
+    case "sessionId":
+      return runtime.sessionId;
+    case "runId":
+      return runtime.runId;
+    case "agentName":
+      return runtime.agentName;
+    case "workspaceRoot":
+      return runtime.workspaceRoot;
+  }
+}
+
+export function injectImplicitInputs(
+  call: Tool.Call,
+  tool: NativeTool,
+  runtime: ToolRuntimeContext | undefined,
+): Tool.Call {
+  if (!tool.implicitInputs || !runtime) return call;
+
+  const injected: Record<string, unknown> = { ...call.input };
+  for (const [param, source] of Object.entries(tool.implicitInputs)) {
+    const value = resolveImplicitValue(source, runtime);
+    if (value !== undefined) injected[param] = value;
+  }
+  return { ...call, input: injected };
+}
+
+export function resolveDispatchedCall(call: Tool.Call, tool: NativeTool): Tool.Call {
+  const originalName = tool.spec.name;
+  return originalName === call.tool ? call : { ...call, tool: originalName };
+}

--- a/packages/openomni/src/execution-runtime/tool/executor-events.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor-events.ts
@@ -1,0 +1,163 @@
+import {
+  Operational,
+  PolicyDecision,
+  PolicyEvent,
+  ToolExecution,
+  type Policy,
+} from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import type { ToolRuntimeContext } from "./types.js";
+
+const TOOL_CALL_ACTION = "tool.call";
+
+export type EventBase = {
+  readonly traceId: string;
+  readonly sessionId: string;
+  readonly runId?: string;
+  readonly time: number;
+};
+
+export type ToolActor = Record<string, unknown>;
+
+export function buildActor(runtime: ToolRuntimeContext | undefined): ToolActor {
+  return {
+    kind: "agent",
+    ...(runtime?.agentName !== undefined && { agentName: runtime.agentName }),
+    ...(runtime?.sessionId !== undefined && { sessionId: runtime.sessionId }),
+    ...(runtime?.runId !== undefined && { runId: runtime.runId }),
+  };
+}
+
+export function createEventBase(runtime: ToolRuntimeContext | undefined): EventBase {
+  return {
+    traceId: crypto.randomUUID(),
+    sessionId: runtime?.sessionId ?? "",
+    ...(runtime?.runId !== undefined && { runId: runtime.runId }),
+    time: Date.now(),
+  };
+}
+
+function summarizeInput(input: unknown): string {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return typeof input;
+  }
+  const keys = Object.keys(input).sort();
+  return keys.length === 0 ? "empty" : keys.join(",");
+}
+
+export function publishActionRequested(args: {
+  readonly base: EventBase;
+  readonly actionId: string;
+  readonly actor: ToolActor;
+  readonly resource: string;
+  readonly input: unknown;
+}): void {
+  Bus.publish(PolicyEvent.ActionRequested, {
+    ...args.base,
+    actionId: args.actionId,
+    actor: args.actor,
+    action: TOOL_CALL_ACTION,
+    resource: args.resource,
+    context: { inputSummary: summarizeInput(args.input) },
+  });
+}
+
+export function publishPolicyEvaluated(args: {
+  readonly base: EventBase;
+  readonly actor: ToolActor;
+  readonly resource: string;
+  readonly decision: Policy.PolicyDecision;
+}): void {
+  Bus.publish(PolicyEvent.Evaluated, {
+    ...args.base,
+    policyId: args.decision.policyId,
+    actor: args.actor,
+    action: TOOL_CALL_ACTION,
+    resource: args.resource,
+    verdict: args.decision.verdict,
+    reason: PolicyDecision.reason(args.decision, "runtime policy evaluated"),
+  });
+}
+
+export function publishActionBlocked(args: {
+  readonly base: EventBase;
+  readonly actionId: string;
+  readonly actor: ToolActor;
+  readonly resource: string;
+  readonly verdict: Policy.PolicyDecision["verdict"];
+  readonly reason: string;
+}): void {
+  Bus.publish(PolicyEvent.ActionBlocked, {
+    ...args.base,
+    actionId: args.actionId,
+    actor: args.actor,
+    action: TOOL_CALL_ACTION,
+    resource: args.resource,
+    verdict: args.verdict,
+    reason: args.reason,
+  });
+}
+
+export function publishToolStarted(args: {
+  readonly base: EventBase;
+  readonly actor: ToolActor;
+  readonly toolCallId: string;
+  readonly toolName: string;
+}): void {
+  Bus.publish(ToolExecution.Started, {
+    ...args.base,
+    actor: args.actor,
+    toolCallId: args.toolCallId,
+    toolName: args.toolName,
+  });
+}
+
+export function publishToolCompleted(args: {
+  readonly base: EventBase;
+  readonly actor: ToolActor;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly durationMs: number;
+  readonly isError: boolean;
+}): void {
+  Bus.publish(ToolExecution.Completed, {
+    ...args.base,
+    actor: args.actor,
+    toolCallId: args.toolCallId,
+    toolName: args.toolName,
+    durationMs: args.durationMs,
+    isError: args.isError,
+  });
+}
+
+export function publishToolTimedOut(args: {
+  readonly base: EventBase;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly timeoutMs: number;
+}): void {
+  Bus.publish(ToolExecution.TimedOut, {
+    ...args.base,
+    toolCallId: args.toolCallId,
+    toolName: args.toolName,
+    timeoutMs: args.timeoutMs,
+  });
+}
+
+export function publishTimeoutSettlementWarning(args: {
+  readonly base: EventBase;
+  readonly toolName: string;
+  readonly toolCallId: string;
+  readonly graceMs: number;
+}): void {
+  Bus.publish(Operational.Warn, {
+    ...args.base,
+    component: "executor",
+    msg: "timed-out tool did not settle before post-timeout grace elapsed",
+    context: {
+      toolName: args.toolName,
+      toolCallId: args.toolCallId,
+      graceMs: args.graceMs,
+    },
+  });
+}

--- a/packages/openomni/src/execution-runtime/tool/executor-result.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor-result.ts
@@ -1,0 +1,10 @@
+import type { Tool } from "@openomni/protocol";
+
+export function createErrorResult(call: Tool.Call, message: string): Tool.Result {
+  return {
+    id: crypto.randomUUID(),
+    toolCallId: call.id,
+    output: message,
+    isError: true,
+  };
+}

--- a/packages/openomni/src/execution-runtime/tool/executor-settlement.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor-settlement.ts
@@ -1,0 +1,77 @@
+import type { Tool } from "@openomni/protocol";
+import { WorkspaceLock } from "../workspace-lock.js";
+
+export type ToolSettlementOutcome =
+  | { readonly settled: true; readonly output: string }
+  | {
+      readonly settled: false;
+      readonly clearWhenToolSettles: boolean;
+      readonly unsafeToken?: string;
+    };
+
+export function hasUnknownSettlement(result: Tool.Result): boolean {
+  return result.settlement === "unknown";
+}
+
+export function waitForToolSettlement(
+  promise: Promise<Tool.Result>,
+  graceMs: number,
+): Promise<ToolSettlementOutcome> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const timer = globalThis.setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      resolve({ settled: false, clearWhenToolSettles: true });
+    }, graceMs);
+    const finish = (outcome: ToolSettlementOutcome) => {
+      if (resolved) return;
+      resolved = true;
+      globalThis.clearTimeout(timer);
+      resolve(outcome);
+    };
+
+    promise.then(
+      (result) => {
+        if (hasUnknownSettlement(result)) {
+          finish({
+            settled: false,
+            clearWhenToolSettles: false,
+            unsafeToken: result.toolCallId || result.id,
+          });
+          return;
+        }
+        finish({ settled: true, output: result.output });
+      },
+      (error: unknown) =>
+        finish({
+          settled: true,
+          output: error instanceof Error ? error.message : String(error),
+        }),
+    );
+  });
+}
+
+export function markUnsafeWorkspaceForUnsettledTool(args: {
+  readonly workspaceRoot: string | undefined;
+  readonly lockAcquired: boolean;
+  readonly toolName: string;
+  readonly toolCallId: string;
+  readonly outcome: Extract<ToolSettlementOutcome, { readonly settled: false }>;
+  readonly toolExecution: Promise<Tool.Result>;
+}): void {
+  if (!args.workspaceRoot || !args.lockAcquired) return;
+
+  const workspaceRoot = args.workspaceRoot;
+  const unsafeToken = args.outcome.unsafeToken ?? args.toolCallId;
+  WorkspaceLock.markUnsafe(
+    workspaceRoot,
+    `tool "${args.toolName}" did not settle after timeout/abort grace`,
+    unsafeToken,
+  );
+  if (args.outcome.clearWhenToolSettles) {
+    void args.toolExecution
+      .finally(() => WorkspaceLock.clearUnsafe(workspaceRoot, unsafeToken))
+      .catch(() => undefined);
+  }
+}

--- a/packages/openomni/src/execution-runtime/tool/executor.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor.ts
@@ -1,251 +1,40 @@
+import { PolicyDecision, type Tool } from "@openomni/protocol";
 import {
-  Operational,
-  PolicyDecision,
-  PolicyEvent,
-  ToolExecution,
-  type Policy,
-  type Tool,
-} from "@openomni/protocol";
-import { Bus } from "@openomni/session";
+  createAbortError,
+  enforceTimeoutAndAbort,
+  isAbortError,
+  linkAbortSignals,
+} from "./executor-abort.js";
+import {
+  buildDispatchTable,
+  injectImplicitInputs,
+  resolveDispatchedCall,
+} from "./executor-dispatch.js";
+import {
+  buildActor,
+  createEventBase,
+  publishActionBlocked,
+  publishActionRequested,
+  publishPolicyEvaluated,
+  publishTimeoutSettlementWarning,
+  publishToolCompleted,
+  publishToolStarted,
+  publishToolTimedOut,
+} from "./executor-events.js";
+import { createErrorResult } from "./executor-result.js";
+import {
+  hasUnknownSettlement,
+  markUnsafeWorkspaceForUnsettledTool,
+  waitForToolSettlement,
+} from "./executor-settlement.js";
 import { ToolRuntimePolicyMiddleware } from "./middleware/tool-runtime-policy.js";
-import type {
-  ImplicitInputSource,
-  NativeTool,
-  ToolExecutionContext,
-  ToolExecutorConfig,
-  ToolRuntimeContext,
-} from "./types.js";
-import { WorkspaceLock } from "../workspace-lock.js";
+import type { NativeTool, ToolExecutionContext, ToolExecutorConfig } from "./types.js";
 
-const TOOL_CALL_ACTION = "tool.call";
 const DEFAULT_POST_TIMEOUT_SETTLE_GRACE_MS = 5_000;
 
 export interface ToolExecutorContext {
   tools: NativeTool[];
   config?: ToolExecutorConfig;
-}
-
-function buildDispatchTable(tools: NativeTool[]): Map<string, NativeTool> {
-  const dispatch = new Map<string, NativeTool>();
-  for (const tool of tools) {
-    dispatch.set(tool.spec.name, tool);
-    const sanitized = tool.spec.name.replace(/\./g, "_");
-    if (sanitized !== tool.spec.name) dispatch.set(sanitized, tool);
-  }
-  return dispatch;
-}
-
-function createErrorResult(call: Tool.Call, message: string): Tool.Result {
-  return {
-    id: crypto.randomUUID(),
-    toolCallId: call.id,
-    output: message,
-    isError: true,
-  };
-}
-
-function createAbortError(): Error {
-  const error = new Error("Tool execution aborted");
-  error.name = "AbortError";
-  return error;
-}
-
-function hasUnknownSettlement(result: Tool.Result): boolean {
-  return result.settlement === "unknown";
-}
-
-function buildActor(runtime: ToolRuntimeContext | undefined): Record<string, unknown> {
-  return {
-    kind: "agent",
-    ...(runtime?.agentName !== undefined && { agentName: runtime.agentName }),
-    ...(runtime?.sessionId !== undefined && { sessionId: runtime.sessionId }),
-    ...(runtime?.runId !== undefined && { runId: runtime.runId }),
-  };
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
-}
-
-function abortReason(signal: AbortSignal): unknown {
-  return (signal as AbortSignal & { reason?: unknown }).reason;
-}
-
-function linkAbortSignals(
-  localSignal: AbortSignal,
-  parentSignal: AbortSignal | undefined,
-): { signal: AbortSignal; cleanup: () => void } {
-  if (!parentSignal) return { signal: localSignal, cleanup: () => undefined };
-
-  const linked = new AbortController();
-  const forwardLocalAbort = () => {
-    if (!linked.signal.aborted) linked.abort(abortReason(localSignal));
-  };
-  const forwardParentAbort = () => {
-    if (!linked.signal.aborted) linked.abort(abortReason(parentSignal));
-  };
-
-  if (localSignal.aborted) forwardLocalAbort();
-  if (parentSignal.aborted) forwardParentAbort();
-
-  localSignal.addEventListener("abort", forwardLocalAbort, { once: true });
-  parentSignal.addEventListener("abort", forwardParentAbort, { once: true });
-
-  return {
-    signal: linked.signal,
-    cleanup: () => {
-      localSignal.removeEventListener("abort", forwardLocalAbort);
-      parentSignal.removeEventListener("abort", forwardParentAbort);
-    },
-  };
-}
-
-function summarizeInput(input: unknown): string {
-  if (input === null || typeof input !== "object" || Array.isArray(input)) {
-    return typeof input;
-  }
-  const keys = Object.keys(input).sort();
-  return keys.length === 0 ? "empty" : keys.join(",");
-}
-
-function resolveImplicitValue(
-  source: ImplicitInputSource,
-  runtime: ToolRuntimeContext,
-): string | undefined {
-  switch (source) {
-    case "sessionId":
-      return runtime.sessionId;
-    case "runId":
-      return runtime.runId;
-    case "agentName":
-      return runtime.agentName;
-    case "workspaceRoot":
-      return runtime.workspaceRoot;
-  }
-}
-
-function injectImplicitInputs(
-  call: Tool.Call,
-  tool: NativeTool,
-  runtime: ToolRuntimeContext | undefined,
-): Tool.Call {
-  if (!tool.implicitInputs || !runtime) return call;
-
-  const injected: Record<string, unknown> = { ...(call.input as Record<string, unknown>) };
-  for (const [param, source] of Object.entries(tool.implicitInputs)) {
-    const value = resolveImplicitValue(source, runtime);
-    if (value !== undefined) injected[param] = value;
-  }
-  return { ...call, input: injected };
-}
-
-function publishPolicyEvaluated(
-  base: { traceId: string; sessionId: string; runId?: string; time: number },
-  actor: Record<string, unknown>,
-  resource: string,
-  decision: Policy.PolicyDecision,
-): void {
-  Bus.publish(PolicyEvent.Evaluated, {
-    ...base,
-    policyId: decision.policyId,
-    actor,
-    action: TOOL_CALL_ACTION,
-    resource,
-    verdict: decision.verdict,
-    reason: PolicyDecision.reason(decision, "runtime policy evaluated"),
-  });
-}
-
-type ToolSettlementOutcome =
-  | { readonly settled: true; readonly output: string }
-  | {
-      readonly settled: false;
-      readonly clearWhenToolSettles: boolean;
-      readonly unsafeToken?: string;
-    };
-
-function waitForToolSettlement(
-  promise: Promise<Tool.Result>,
-  graceMs: number,
-): Promise<ToolSettlementOutcome> {
-  return new Promise((resolve) => {
-    let resolved = false;
-    const timer = globalThis.setTimeout(() => {
-      if (resolved) return;
-      resolved = true;
-      resolve({ settled: false, clearWhenToolSettles: true });
-    }, graceMs);
-    const finish = (outcome: ToolSettlementOutcome) => {
-      if (resolved) return;
-      resolved = true;
-      globalThis.clearTimeout(timer);
-      resolve(outcome);
-    };
-
-    promise.then(
-      (result) => {
-        if (hasUnknownSettlement(result)) {
-          finish({
-            settled: false,
-            clearWhenToolSettles: false,
-            unsafeToken: result.toolCallId || result.id,
-          });
-          return;
-        }
-        finish({ settled: true, output: result.output });
-      },
-      (error: unknown) =>
-        finish({
-          settled: true,
-          output: error instanceof Error ? error.message : String(error),
-        }),
-    );
-  });
-}
-
-async function enforceTimeoutAndAbort<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  signal: AbortSignal | undefined,
-  onTimeout: (error: ToolRuntimePolicyMiddleware.TimeoutError) => void,
-): Promise<T> {
-  if (signal?.aborted) throw createAbortError();
-
-  return await new Promise<T>((resolve, reject) => {
-    let settled = false;
-    let timeoutFired = false;
-    const cleanup = () => {
-      globalThis.clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-    };
-    const finish = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      fn();
-    };
-    const onAbort = () => finish(() => reject(createAbortError()));
-    const timer = globalThis.setTimeout(() => {
-      timeoutFired = true;
-      const error = new ToolRuntimePolicyMiddleware.TimeoutError(timeoutMs);
-      finish(() => reject(error));
-      try {
-        onTimeout(error);
-      } catch {
-        // Timeout rejection is authoritative; cleanup callbacks must not
-        // escape the timer turn as uncaught exceptions.
-      }
-    }, timeoutMs);
-
-    signal?.addEventListener("abort", onAbort, { once: true });
-    promise.then(
-      (value) => finish(() => resolve(value)),
-      (error: unknown) => {
-        if (timeoutFired) return;
-        finish(() => reject(error));
-      },
-    );
-  });
 }
 
 export function createToolExecutor(
@@ -258,14 +47,7 @@ export function createToolExecutor(
   const { workspaceRoot } = config;
   const runtime = config.runtime;
 
-  function eventBase() {
-    return {
-      traceId: crypto.randomUUID(),
-      sessionId: runtime?.sessionId ?? "",
-      ...(runtime?.runId !== undefined && { runId: runtime.runId }),
-      time: Date.now(),
-    };
-  }
+  const eventBase = () => createEventBase(runtime);
 
   return async (call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> => {
     const tool = dispatch.get(call.tool);
@@ -286,18 +68,16 @@ export function createToolExecutor(
     cleanupAbortSignal = linkedAbort.cleanup;
     if (linkedAbort.signal.aborted) throw createAbortError();
 
-    Bus.publish(PolicyEvent.ActionRequested, {
-      ...eventBase(),
+    publishActionRequested({
+      base: eventBase(),
       actionId,
       actor,
-      action: TOOL_CALL_ACTION,
       resource: originalName,
-      context: { inputSummary: summarizeInput(call.input) },
+      input: call.input,
     });
 
     const enrichedCall = injectImplicitInputs(call, tool, runtime);
-    const dispatchedCall =
-      originalName === enrichedCall.tool ? enrichedCall : { ...enrichedCall, tool: originalName };
+    const dispatchedCall = resolveDispatchedCall(enrichedCall, tool);
     let policy: ToolRuntimePolicyMiddleware.PreToolResult | undefined;
     let shouldEvaluatePostTool = false;
     let postToolDeferred = false;
@@ -316,41 +96,38 @@ export function createToolExecutor(
         output: postToolOutput,
         handle: policy.handle,
       });
-      publishPolicyEvaluated(eventBase(), actor, originalName, postDecision);
+      publishPolicyEvaluated({
+        base: eventBase(),
+        actor,
+        resource: originalName,
+        decision: postDecision,
+      });
     }
 
     function deferPostToolUntilExecutionSettles(fallbackOutput: string): void {
       if (!toolExecution || !policy || !shouldEvaluatePostTool || postToolDeferred) return;
 
+      const currentPolicy = policy;
+      const currentToolExecution = toolExecution;
       postToolDeferred = true;
-      void waitForToolSettlement(toolExecution, postTimeoutSettleGraceMs).then((outcome) => {
+      void waitForToolSettlement(currentToolExecution, postTimeoutSettleGraceMs).then((outcome) => {
         if (outcome.settled) {
           postToolOutput = outcome.output;
         } else {
           postToolOutput = fallbackOutput;
-          if (policy?.handle.workspaceRoot && policy.handle.lockAcquired) {
-            WorkspaceLock.markUnsafe(
-              policy.handle.workspaceRoot,
-              `tool "${originalName}" did not settle after timeout/abort grace`,
-              outcome.unsafeToken ?? call.id,
-            );
-            const unsafeWorkspace = policy.handle.workspaceRoot;
-            const unsafeToken = outcome.unsafeToken ?? call.id;
-            if (outcome.clearWhenToolSettles) {
-              void toolExecution
-                ?.finally(() => WorkspaceLock.clearUnsafe(unsafeWorkspace, unsafeToken))
-                .catch(() => undefined);
-            }
-          }
-          Bus.publish(Operational.Warn, {
-            ...eventBase(),
-            component: "executor",
-            msg: "timed-out tool did not settle before post-timeout grace elapsed",
-            context: {
-              toolName: originalName,
-              toolCallId: call.id,
-              graceMs: postTimeoutSettleGraceMs,
-            },
+          markUnsafeWorkspaceForUnsettledTool({
+            workspaceRoot: currentPolicy.handle.workspaceRoot,
+            lockAcquired: currentPolicy.handle.lockAcquired,
+            toolName: originalName,
+            toolCallId: call.id,
+            outcome,
+            toolExecution: currentToolExecution,
+          });
+          publishTimeoutSettlementWarning({
+            base: eventBase(),
+            toolName: originalName,
+            toolCallId: call.id,
+            graceMs: postTimeoutSettleGraceMs,
           });
         }
         postToolDeferred = false;
@@ -371,24 +148,28 @@ export function createToolExecutor(
         signal: linkedAbort.signal,
       });
 
-      publishPolicyEvaluated(eventBase(), actor, originalName, policy.decision);
+      publishPolicyEvaluated({
+        base: eventBase(),
+        actor,
+        resource: originalName,
+        decision: policy.decision,
+      });
 
       if (PolicyDecision.isBlocking(policy.decision)) {
         const result = createErrorResult(
           call,
           PolicyDecision.reason(policy.decision, "tool runtime policy aborted"),
         );
-        Bus.publish(PolicyEvent.ActionBlocked, {
-          ...eventBase(),
+        publishActionBlocked({
+          base: eventBase(),
           actionId,
           actor,
-          action: TOOL_CALL_ACTION,
           resource: originalName,
           verdict: policy.decision.verdict,
           reason: PolicyDecision.reason(policy.decision, "tool runtime policy aborted"),
         });
-        Bus.publish(ToolExecution.Completed, {
-          ...eventBase(),
+        publishToolCompleted({
+          base: eventBase(),
           actor,
           toolCallId: call.id,
           toolName: originalName,
@@ -402,8 +183,8 @@ export function createToolExecutor(
       const startTime = Date.now();
       if (linkedAbort.signal.aborted) throw createAbortError();
 
-      Bus.publish(ToolExecution.Started, {
-        ...eventBase(),
+      publishToolStarted({
+        base: eventBase(),
         actor,
         toolCallId: call.id,
         toolName: originalName,
@@ -421,8 +202,8 @@ export function createToolExecutor(
 
       if (hasUnknownSettlement(result)) {
         deferPostToolUntilExecutionSettles(result.output);
-        Bus.publish(ToolExecution.Completed, {
-          ...eventBase(),
+        publishToolCompleted({
+          base: eventBase(),
           actor,
           toolCallId: call.id,
           toolName: originalName,
@@ -434,8 +215,8 @@ export function createToolExecutor(
 
       evaluatePostToolOnce();
 
-      Bus.publish(ToolExecution.Completed, {
-        ...eventBase(),
+      publishToolCompleted({
+        base: eventBase(),
         actor,
         toolCallId: call.id,
         toolName: originalName,
@@ -450,12 +231,11 @@ export function createToolExecutor(
       postToolOutput = message;
 
       if (isTimeout && policy) {
-        const timeoutMs = (error as ToolRuntimePolicyMiddleware.TimeoutError).timeoutMs;
-        Bus.publish(ToolExecution.TimedOut, {
-          ...eventBase(),
+        publishToolTimedOut({
+          base: eventBase(),
           toolCallId: call.id,
           toolName: originalName,
-          timeoutMs,
+          timeoutMs: error.timeoutMs,
         });
       }
 
@@ -467,18 +247,17 @@ export function createToolExecutor(
 
       const result = createErrorResult(call, message);
       if (isTimeout || isAbort) {
-        Bus.publish(PolicyEvent.ActionBlocked, {
-          ...eventBase(),
+        publishActionBlocked({
+          base: eventBase(),
           actionId,
           actor,
-          action: TOOL_CALL_ACTION,
           resource: originalName,
           verdict: "deny" as const,
           reason: message,
         });
       }
-      Bus.publish(ToolExecution.Completed, {
-        ...eventBase(),
+      publishToolCompleted({
+        base: eventBase(),
         actor,
         toolCallId: call.id,
         toolName: originalName,

--- a/script/lint-side-effects.ts
+++ b/script/lint-side-effects.ts
@@ -30,6 +30,7 @@ interface SourceMatch {
 
 const hotFiles = [
   "packages/openomni/src/execution-runtime/tool/executor.ts",
+  "packages/openomni/src/execution-runtime/tool/executor-events.ts",
   "apps/server/src/tool/mcp/provider.ts",
   "packages/llm/src/session/processor.ts",
   "packages/openomni/src/ingress/event-projector.ts",
@@ -44,12 +45,20 @@ const rules: readonly SideEffectRule[] = [
     sideEffect: /tool\.execute\(dispatchedCall(?:, \{ signal: linkedAbort\.signal \})?\)/g,
     scopeStart:
       /return async \(call: Tool\.Call(?:, context\?: ToolExecutionContext)?\): Promise<Tool\.Result> => \{/g,
-    requiredBefore: [
-      "Bus.publish(ToolExecution.Started, {",
-      "toolCallId: call.id",
-      "toolName: originalName",
-    ],
+    requiredBefore: ["publishToolStarted({", "toolCallId: call.id", "toolName: originalName"],
     message: "tool.execute must be preceded by a before-side-effect audit publish",
+  },
+  {
+    ruleId: "tool-ledger-before-execute",
+    filePath: "packages/openomni/src/execution-runtime/tool/executor-events.ts",
+    sideEffect: /export function publishToolStarted\(args: \{/g,
+    requiredBefore: [],
+    requiredInScope: [
+      "Bus.publish(ToolExecution.Started, {",
+      "toolCallId: args.toolCallId",
+      "toolName: args.toolName",
+    ],
+    message: "publishToolStarted must append the tool execution started ledger event",
   },
   {
     ruleId: "mcp-ledger-before-execute",


### PR DESCRIPTION
## Summary
- split `createToolExecutor` helpers into focused abort, dispatch, event, result, and settlement modules
- preserve the public `createToolExecutor` / `ToolExecutorContext` surface while reducing `executor.ts` below the local 250 LOC cleanup threshold
- extend side-effect lint so `ToolExecution.Started` publication remains guarded after extraction
- add regression coverage that timeout callback failures do not escape or override the authoritative timeout rejection

## Verification
- `bun test packages/openomni/src/execution-runtime/tool/executor-abort.test.ts packages/openomni/src/execution-runtime/tool/executor.test.ts packages/openomni/src/execution-runtime/workspace-lock.test.ts`
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bunx knip --no-config-hints`
- `git diff --check`
- `bun run test`
- pre-push hook: `dep-check`, `type-check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the tool executor into focused modules (abort, dispatch, events, result, settlement) while keeping the `createToolExecutor` API stable. This reduces complexity (executor now under the 250 LOC threshold) and hardens timeout/event behavior.

- **Refactors**
  - Moved helpers into `executor-abort`, `executor-dispatch`, `executor-events`, `executor-result`, and `executor-settlement`.
  - Preserved the public `createToolExecutor` and `ToolExecutorContext` surface.
  - Centralized policy and tool ledger publishes in `executor-events` (`Started`, `Completed`, `TimedOut`).
  - Extracted implicit input injection and dispatch mapping into dedicated helpers.

- **Bug Fixes**
  - Timeout callback failures no longer escape or override the authoritative timeout rejection (`executor-abort.test.ts` adds coverage).
  - Extended side-effect lint to guard `ToolExecution.Started` publication after extraction; updated `script/lint-side-effects.ts` to watch `executor-events.ts`.

<sup>Written for commit d0f7f956d9b7084f003a48d655492aa29831e9c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool execution with improved timeout and abort signal handling
  * Added comprehensive lifecycle event tracking for tool execution (started, completed, timed out, blocked)
  * Improved handling of unsettled tool execution states with grace-period recovery

* **Refactor**
  * Reorganized tool execution logic into modular, specialized utility components for better maintainability

* **Tests**
  * Added test suite for timeout and abort enforcement behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->