### PR TITLE
refactor(openomni): split ingress handlers

### DIFF
--- a/packages/openomni/src/ingress/handler-events.ts
+++ b/packages/openomni/src/ingress/handler-events.ts
@@ -1,0 +1,54 @@
+import { IngressEvent, type Ingress } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import type { HandlerContext } from "./handler-types";
+import { resolveTarget } from "./target";
+
+export function summarizeTarget(event: Ingress.ResolvedInboundEvent): string | undefined {
+  return resolveTarget(event).kind;
+}
+
+export function publishModeDetected(ctx: HandlerContext, target: string | undefined): void {
+  if (!ctx.traceContext) return;
+  Bus.publish(IngressEvent.ModeDetected, {
+    traceId: ctx.traceContext.traceId,
+    sessionId: ctx.sessionId,
+    mode: ctx.event.mode,
+    ...(target ? { target } : {}),
+    time: Date.now(),
+  });
+}
+
+export function publishCompleted(
+  ctx: HandlerContext,
+  target: string | undefined,
+  start: number,
+): void {
+  if (!ctx.traceContext) return;
+  Bus.publish(IngressEvent.Completed, {
+    traceId: ctx.traceContext.traceId,
+    sessionId: ctx.sessionId,
+    mode: ctx.event.mode,
+    ...(target ? { target } : {}),
+    durationMs: Date.now() - start,
+    time: Date.now(),
+  });
+}
+
+export function publishFailed(
+  ctx: HandlerContext,
+  target: string | undefined,
+  start: number,
+  error: unknown,
+): void {
+  if (!ctx.traceContext) return;
+  const message = error instanceof Error ? error.message : String(error);
+  Bus.publish(IngressEvent.Failed, {
+    traceId: ctx.traceContext.traceId,
+    sessionId: ctx.sessionId,
+    mode: ctx.event.mode,
+    ...(target ? { target } : {}),
+    durationMs: Date.now() - start,
+    error: message,
+    time: Date.now(),
+  });
+}

--- a/packages/openomni/src/ingress/handler-prompt.ts
+++ b/packages/openomni/src/ingress/handler-prompt.ts
@@ -1,0 +1,12 @@
+export function extractPrompt(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "text" in payload &&
+    typeof (payload as { text: unknown }).text === "string"
+  ) {
+    return (payload as { text: string }).text;
+  }
+  return JSON.stringify(payload);
+}

--- a/packages/openomni/src/ingress/handler-request.ts
+++ b/packages/openomni/src/ingress/handler-request.ts
@@ -1,0 +1,25 @@
+import type { Execution } from "@openomni/protocol";
+import type { HandlerContext } from "./handler-types";
+import { extractPrompt } from "./handler-prompt";
+
+export function buildExecutionRequest(ctx: HandlerContext): Execution.Request {
+  return {
+    runId: crypto.randomUUID(),
+    sessionId: ctx.sessionId,
+    mode: "direct",
+    prompt: extractPrompt(ctx.event.payload),
+    model: ctx.event.agent.model,
+    systemPrompt: ctx.event.agent.systemPrompt,
+    tools: ctx.event.agent.tools,
+    toolConfig: ctx.event.agent.toolConfig,
+    permissions: ctx.event.agent.permissions,
+    credentials: undefined,
+    budget: ctx.event.agent.budget,
+    workspaceRoot: ctx.event.agent.toolConfig?.workspaceRoot,
+    policyPlan: ctx.event.agent.policyPlan,
+    providerOptions: (ctx.event.agent as { providerOptions?: Record<string, unknown> })
+      .providerOptions,
+    traceId: ctx.traceContext?.traceId,
+    agentName: typeof ctx.event.meta?.agentName === "string" ? ctx.event.meta.agentName : undefined,
+  };
+}

--- a/packages/openomni/src/ingress/handler-types.ts
+++ b/packages/openomni/src/ingress/handler-types.ts
@@ -1,0 +1,14 @@
+import type { PolicyDecision, PolicyRegistration } from "@openomni/agent";
+import type { Ingress, TraceContext as TraceContextProtocol } from "@openomni/protocol";
+import type { ResidentRuntime } from "../resident/runtime";
+import type { CoordinatorLike } from "./coordinator-like";
+
+export interface HandlerContext {
+  sessionId: string;
+  event: Ingress.ResolvedInboundEvent;
+  coordinator?: CoordinatorLike;
+  residentRuntime?: ResidentRuntime;
+  traceContext?: TraceContextProtocol.Type;
+  policies?: PolicyRegistration[];
+  onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
+}

--- a/packages/openomni/src/ingress/handler-worker-dispatch.ts
+++ b/packages/openomni/src/ingress/handler-worker-dispatch.ts
@@ -1,0 +1,119 @@
+import type { Execution, Ingress } from "@openomni/protocol";
+import { WorkerRun } from "@openomni/session";
+import type { HandlerContext } from "./handler-types";
+import { publishCompleted, publishFailed } from "./handler-events";
+import { extractPrompt } from "./handler-prompt";
+import { finishCoordinatorDispatch, markDispatchThrown } from "./handler-worker-run";
+import { dispatchWritebackCommit } from "./handler-writeback";
+import { SessionBridge } from "./session-bridge";
+import { resolveTarget } from "./target";
+
+export function isBackgroundWorkerIngress(ctx: HandlerContext): boolean {
+  return (ctx.event.runtime as { background?: unknown } | undefined)?.background === true;
+}
+
+export async function handleCancelRequest(
+  ctx: HandlerContext,
+): Promise<Ingress.IngressResult | undefined> {
+  if (ctx.event.runtime?.lifecycle !== "stopping") return undefined;
+  if (!ctx.coordinator?.cancelRun) {
+    throw new Error("coordinator cancellation is required for worker cancellation");
+  }
+
+  const requestedRunId = ctx.event.runtime?.runId;
+  const active = (await WorkerRun.listBySession(ctx.sessionId)).filter(
+    (run) =>
+      ["starting", "running", "waiting_input"].includes(run.status) &&
+      (!requestedRunId || run.runId === requestedRunId),
+  );
+  const results = await Promise.all(
+    active.map(async (run) => {
+      const result = await ctx.coordinator?.cancelRun?.(run.runId);
+      const cancelled =
+        result !== null &&
+        typeof result === "object" &&
+        (result as { cancelled?: unknown }).cancelled === true;
+      if (cancelled) {
+        await WorkerRun.updateStatus(ctx.sessionId, run.runId, "cancelled", {
+          endedAt: Date.now(),
+        });
+      }
+      return { runId: run.runId, cancelled, result };
+    }),
+  );
+  const output = await dispatchWritebackCommit(
+    ctx,
+    JSON.stringify({
+      cancelled: results.filter((run) => run.cancelled).length,
+      requested: results.length,
+      runs: results,
+    }),
+  );
+  SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
+  return {
+    mode: ctx.event.mode,
+    target: resolveTarget(ctx.event),
+    sessionId: ctx.sessionId,
+    result: { output, finishReason: "cancelled" },
+  };
+}
+
+export async function handleWorkerDelivery(
+  ctx: HandlerContext,
+): Promise<Ingress.IngressResult | undefined> {
+  const target = resolveTarget(ctx.event);
+  if (target.kind !== "worker" || !ctx.coordinator?.deliverMessage) return undefined;
+
+  const raw = await ctx.coordinator.deliverMessage(
+    ctx.sessionId,
+    extractPrompt(ctx.event.payload),
+    ctx.event.runtime?.runId,
+  );
+  const accepted =
+    raw !== null && typeof raw === "object" && (raw as { accepted?: unknown }).accepted === true;
+  if (!accepted) return undefined;
+
+  const output = await dispatchWritebackCommit(
+    ctx,
+    JSON.stringify({
+      delivered: true,
+      sessionId: ctx.sessionId,
+      runId: ctx.event.runtime?.runId,
+    }),
+  );
+  SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
+  return {
+    mode: ctx.event.mode,
+    target,
+    sessionId: ctx.sessionId,
+    result: { output, finishReason: "delivered" },
+  };
+}
+
+export function startBackgroundWorkerDispatch(
+  ctx: HandlerContext,
+  request: Execution.Request,
+  target: string | undefined,
+  start: number,
+): void {
+  if (!ctx.coordinator) throw new Error("coordinator is required for worker-targeted ingress");
+  const coordinator = ctx.coordinator;
+
+  void (async () => {
+    try {
+      const result = await coordinator.dispatch(ctx.sessionId, request);
+      await finishCoordinatorDispatch(ctx, request, result);
+      if (result.output) {
+        SessionBridge.storeDirectResult(ctx.sessionId, result.output, ctx.event.agent.model);
+      }
+      if (result.status === "succeeded" || result.status === "cancelled") {
+        publishCompleted(ctx, target, start);
+        return;
+      }
+      publishFailed(ctx, target, start, result.error ?? result.status);
+    } catch (error) {
+      publishFailed(ctx, target, start, error);
+      await markDispatchThrown(ctx, request, error);
+    }
+  })();
+}

--- a/packages/openomni/src/ingress/handler-worker-run.ts
+++ b/packages/openomni/src/ingress/handler-worker-run.ts
@@ -1,0 +1,72 @@
+import type { Execution } from "@openomni/protocol";
+import { WorkerRun } from "@openomni/session";
+import type { HandlerContext } from "./handler-types";
+import { extractPrompt } from "./handler-prompt";
+
+type TerminalWorkerRunStatus = "succeeded" | "failed" | "cancelled" | "interrupted";
+
+const terminalWorkerRunStatuses = new Set<string>([
+  "succeeded",
+  "failed",
+  "cancelled",
+  "interrupted",
+]);
+
+export async function createDurableWorkerRun(
+  ctx: HandlerContext,
+  request: Execution.Request,
+): Promise<void> {
+  const prompt = extractPrompt(ctx.event.payload);
+  await WorkerRun.create(ctx.sessionId, {
+    runId: request.runId,
+    title: prompt.slice(0, 80) || "Worker run",
+    prompt,
+    agentName: request.agentName ?? "worker",
+    parentSessionId:
+      typeof ctx.event.meta?.actor === "object" && ctx.event.meta.actor !== null
+        ? String((ctx.event.meta.actor as Record<string, unknown>).sessionId ?? "") || undefined
+        : undefined,
+  });
+  await WorkerRun.updateStatus(ctx.sessionId, request.runId, "starting");
+}
+
+async function completeDurableWorkerRun(
+  ctx: HandlerContext,
+  request: Execution.Request,
+  status: TerminalWorkerRunStatus,
+  error?: string,
+): Promise<void> {
+  const existing = await WorkerRun.get(ctx.sessionId, request.runId);
+  if (!existing) return;
+  if (terminalWorkerRunStatuses.has(existing.status)) return;
+  if (existing.status === "starting" && status === "succeeded") {
+    await WorkerRun.updateStatus(ctx.sessionId, request.runId, "running");
+  }
+  await WorkerRun.updateStatus(ctx.sessionId, request.runId, status, {
+    endedAt: Date.now(),
+    ...(error ? { error } : {}),
+  });
+}
+
+export async function finishCoordinatorDispatch(
+  ctx: HandlerContext,
+  request: Execution.Request,
+  coordinatorResult: Execution.Result,
+): Promise<void> {
+  if (coordinatorResult.status !== "succeeded") {
+    await completeDurableWorkerRun(ctx, request, coordinatorResult.status, coordinatorResult.error);
+    return;
+  }
+  await completeDurableWorkerRun(ctx, request, "succeeded");
+}
+
+export async function markDispatchThrown(
+  ctx: HandlerContext,
+  request: Execution.Request,
+  error: unknown,
+): Promise<void> {
+  const existing = await WorkerRun.get(ctx.sessionId, request.runId);
+  if (!existing || terminalWorkerRunStatuses.has(existing.status)) return;
+  const message = error instanceof Error ? error.message : String(error);
+  await completeDurableWorkerRun(ctx, request, "interrupted", message);
+}

--- a/packages/openomni/src/ingress/handler-writeback.ts
+++ b/packages/openomni/src/ingress/handler-writeback.ts
@@ -1,0 +1,56 @@
+import { PolicyEngine } from "@openomni/agent";
+import { PolicyDecision as Decision } from "@openomni/protocol";
+import type { HandlerContext } from "./handler-types";
+import { resolveTarget } from "./target";
+
+const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+export async function dispatchWritebackCommit(
+  ctx: HandlerContext,
+  output: string,
+): Promise<string> {
+  if (!ctx.policies?.length) return output;
+
+  const engine = PolicyEngine.create({
+    traceContext: ctx.traceContext,
+    onDecision: ctx.onPolicyDecision,
+  });
+  for (const reg of ctx.policies) {
+    engine.register(reg);
+  }
+
+  const decision = await engine.dispatch("writeback.commit", {
+    steps: [],
+    usage: emptyUsage,
+    turnCount: 0,
+    isCompletion: true,
+    continuationCount: 0,
+    elapsedMs: 0,
+    labels: [
+      { value: `surface.${ctx.event.surface}`, source: "system" },
+      { value: `target.${resolveTarget(ctx.event).kind}`, source: "system" },
+    ],
+    toolInput: {
+      sessionId: ctx.sessionId,
+      mode: ctx.event.mode,
+      target: resolveTarget(ctx.event).kind,
+      surface: ctx.event.surface,
+      output,
+    },
+    traceContext: ctx.traceContext,
+  });
+
+  return resolveWritebackDecision(decision, output);
+}
+
+function resolveWritebackDecision(decision: Decision, output: string): string {
+  if (Decision.isBlocking(decision)) {
+    throw new Error(Decision.reason(decision, "writeback.commit policy denied"));
+  }
+  const suppress = decision.effects.find((effect) => effect.type === "writeback.suppress");
+  if (suppress?.type === "writeback.suppress") {
+    throw new Error(suppress.reason ?? "writeback.commit policy suppressed output");
+  }
+  const rewrite = decision.effects.find((effect) => effect.type === "writeback.rewrite");
+  return rewrite?.type === "writeback.rewrite" ? rewrite.output : output;
+}

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -1,331 +1,39 @@
+import type { Execution, Ingress } from "@openomni/protocol";
 import {
-  IngressEvent,
-  type Execution,
-  type Ingress,
-  PolicyDecision as Decision,
-  type TraceContext as TraceContextProtocol,
-} from "@openomni/protocol";
-import { PolicyEngine, type PolicyDecision, type PolicyRegistration } from "@openomni/agent";
-import { Bus, WorkerRun } from "@openomni/session";
-import type { CoordinatorLike } from "./coordinator-like";
-import type { ResidentRuntime } from "../resident/runtime";
+  publishCompleted,
+  publishFailed,
+  publishModeDetected,
+  summarizeTarget,
+} from "./handler-events";
+import { buildExecutionRequest as buildRequest } from "./handler-request";
+import type { HandlerContext as IngressHandlerContext } from "./handler-types";
+import {
+  handleCancelRequest,
+  handleWorkerDelivery,
+  isBackgroundWorkerIngress,
+  startBackgroundWorkerDispatch,
+} from "./handler-worker-dispatch";
+import {
+  createDurableWorkerRun,
+  finishCoordinatorDispatch,
+  markDispatchThrown,
+} from "./handler-worker-run";
+import { dispatchWritebackCommit as commitWriteback } from "./handler-writeback";
 import { SessionBridge } from "./session-bridge";
 import { resolveTarget } from "./target";
 
-const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-
 export namespace IngressHandlers {
-  export interface HandlerContext {
-    sessionId: string;
-    event: Ingress.ResolvedInboundEvent;
-    coordinator?: CoordinatorLike;
-    residentRuntime?: ResidentRuntime;
-    traceContext?: TraceContextProtocol.Type;
-    policies?: PolicyRegistration[];
-    onPolicyDecision?: (decision: PolicyDecision) => void | Promise<void>;
-  }
+  export interface HandlerContext extends IngressHandlerContext {}
 
-  function extractPrompt(payload: unknown): string {
-    if (typeof payload === "string") return payload;
-    if (
-      payload &&
-      typeof payload === "object" &&
-      "text" in payload &&
-      typeof (payload as { text: unknown }).text === "string"
-    ) {
-      return (payload as { text: string }).text;
-    }
-    return JSON.stringify(payload);
+  export function buildExecutionRequest(ctx: HandlerContext): Execution.Request {
+    return buildRequest(ctx);
   }
 
   export async function dispatchWritebackCommit(
     ctx: HandlerContext,
     output: string,
   ): Promise<string> {
-    if (!ctx.policies?.length) return output;
-
-    const engine = PolicyEngine.create({
-      traceContext: ctx.traceContext,
-      onDecision: ctx.onPolicyDecision,
-    });
-    for (const reg of ctx.policies) {
-      engine.register(reg);
-    }
-
-    const decision = await engine.dispatch("writeback.commit", {
-      steps: [],
-      usage: emptyUsage,
-      turnCount: 0,
-      isCompletion: true,
-      continuationCount: 0,
-      elapsedMs: 0,
-      labels: [
-        { value: `surface.${ctx.event.surface}`, source: "system" },
-        { value: `target.${resolveTarget(ctx.event).kind}`, source: "system" },
-      ],
-      toolInput: {
-        sessionId: ctx.sessionId,
-        mode: ctx.event.mode,
-        target: resolveTarget(ctx.event).kind,
-        surface: ctx.event.surface,
-        output,
-      },
-      traceContext: ctx.traceContext,
-    });
-
-    return resolveWritebackDecision(decision, output);
-  }
-
-  function summarizeTarget(event: Ingress.ResolvedInboundEvent): string | undefined {
-    return resolveTarget(event).kind;
-  }
-
-  function resolveWritebackDecision(decision: Decision, output: string): string {
-    if (Decision.isBlocking(decision)) {
-      throw new Error(Decision.reason(decision, "writeback.commit policy denied"));
-    }
-    const suppress = decision.effects.find((effect) => effect.type === "writeback.suppress");
-    if (suppress?.type === "writeback.suppress") {
-      throw new Error(suppress.reason ?? "writeback.commit policy suppressed output");
-    }
-    const rewrite = decision.effects.find((effect) => effect.type === "writeback.rewrite");
-    return rewrite?.type === "writeback.rewrite" ? rewrite.output : output;
-  }
-
-  function isBackgroundWorkerIngress(ctx: HandlerContext): boolean {
-    return (ctx.event.runtime as { background?: unknown } | undefined)?.background === true;
-  }
-
-  async function createDurableWorkerRun(
-    ctx: HandlerContext,
-    request: Execution.Request,
-  ): Promise<void> {
-    await WorkerRun.create(ctx.sessionId, {
-      runId: request.runId,
-      title: extractPrompt(ctx.event.payload).slice(0, 80) || "Worker run",
-      prompt: extractPrompt(ctx.event.payload),
-      agentName: request.agentName ?? "worker",
-      parentSessionId:
-        typeof ctx.event.meta?.actor === "object" && ctx.event.meta.actor !== null
-          ? String((ctx.event.meta.actor as Record<string, unknown>).sessionId ?? "") || undefined
-          : undefined,
-    });
-    await WorkerRun.updateStatus(ctx.sessionId, request.runId, "starting");
-  }
-
-  async function completeDurableWorkerRun(
-    ctx: HandlerContext,
-    request: Execution.Request,
-    status: "succeeded" | "failed" | "cancelled" | "interrupted",
-    error?: string,
-  ): Promise<void> {
-    const existing = await WorkerRun.get(ctx.sessionId, request.runId);
-    if (!existing) return;
-    if (["succeeded", "failed", "cancelled", "interrupted"].includes(existing.status)) {
-      return;
-    }
-    if (existing.status === "starting" && status === "succeeded") {
-      await WorkerRun.updateStatus(ctx.sessionId, request.runId, "running");
-    }
-    await WorkerRun.updateStatus(ctx.sessionId, request.runId, status, {
-      endedAt: Date.now(),
-      ...(error ? { error } : {}),
-    });
-  }
-
-  async function handleCancelRequest(
-    ctx: HandlerContext,
-  ): Promise<Ingress.IngressResult | undefined> {
-    if (ctx.event.runtime?.lifecycle !== "stopping") return undefined;
-    if (!ctx.coordinator?.cancelRun) {
-      throw new Error("coordinator cancellation is required for worker cancellation");
-    }
-
-    const requestedRunId = ctx.event.runtime?.runId;
-    const active = (await WorkerRun.listBySession(ctx.sessionId)).filter(
-      (run) =>
-        ["starting", "running", "waiting_input"].includes(run.status) &&
-        (!requestedRunId || run.runId === requestedRunId),
-    );
-    const results = await Promise.all(
-      active.map(async (run) => {
-        const result = await ctx.coordinator?.cancelRun?.(run.runId);
-        const cancelled =
-          result !== null &&
-          typeof result === "object" &&
-          (result as { cancelled?: unknown }).cancelled === true;
-        if (cancelled) {
-          await WorkerRun.updateStatus(ctx.sessionId, run.runId, "cancelled", {
-            endedAt: Date.now(),
-          });
-        }
-        return { runId: run.runId, cancelled, result };
-      }),
-    );
-    const output = await dispatchWritebackCommit(
-      ctx,
-      JSON.stringify({
-        cancelled: results.filter((run) => run.cancelled).length,
-        requested: results.length,
-        runs: results,
-      }),
-    );
-    SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
-    return {
-      mode: ctx.event.mode,
-      target: resolveTarget(ctx.event),
-      sessionId: ctx.sessionId,
-      result: { output, finishReason: "cancelled" },
-    };
-  }
-
-  async function handleWorkerDelivery(
-    ctx: HandlerContext,
-  ): Promise<Ingress.IngressResult | undefined> {
-    const target = resolveTarget(ctx.event);
-    if (target.kind !== "worker" || !ctx.coordinator?.deliverMessage) return undefined;
-
-    const raw = await ctx.coordinator.deliverMessage(
-      ctx.sessionId,
-      extractPrompt(ctx.event.payload),
-      ctx.event.runtime?.runId,
-    );
-    const accepted =
-      raw !== null && typeof raw === "object" && (raw as { accepted?: unknown }).accepted === true;
-    if (!accepted) return undefined;
-
-    const output = await dispatchWritebackCommit(
-      ctx,
-      JSON.stringify({
-        delivered: true,
-        sessionId: ctx.sessionId,
-        runId: ctx.event.runtime?.runId,
-      }),
-    );
-    SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
-    return {
-      mode: ctx.event.mode,
-      target,
-      sessionId: ctx.sessionId,
-      result: { output, finishReason: "delivered" },
-    };
-  }
-
-  export function buildExecutionRequest(ctx: HandlerContext): Execution.Request {
-    return {
-      runId: crypto.randomUUID(),
-      sessionId: ctx.sessionId,
-      mode: "direct",
-      prompt: extractPrompt(ctx.event.payload),
-      model: ctx.event.agent.model,
-      systemPrompt: ctx.event.agent.systemPrompt,
-      tools: ctx.event.agent.tools,
-      toolConfig: ctx.event.agent.toolConfig,
-      permissions: ctx.event.agent.permissions,
-      credentials: undefined,
-      budget: ctx.event.agent.budget,
-      workspaceRoot: ctx.event.agent.toolConfig?.workspaceRoot,
-      policyPlan: ctx.event.agent.policyPlan,
-      providerOptions: (ctx.event.agent as { providerOptions?: Record<string, unknown> })
-        .providerOptions,
-      traceId: ctx.traceContext?.traceId,
-      agentName:
-        typeof ctx.event.meta?.agentName === "string" ? ctx.event.meta.agentName : undefined,
-    };
-  }
-
-  async function finishCoordinatorDispatch(
-    ctx: HandlerContext,
-    request: Execution.Request,
-    coordinatorResult: Execution.Result,
-  ): Promise<void> {
-    if (coordinatorResult.status !== "succeeded") {
-      await completeDurableWorkerRun(
-        ctx,
-        request,
-        coordinatorResult.status,
-        coordinatorResult.error,
-      );
-      return;
-    }
-    await completeDurableWorkerRun(ctx, request, "succeeded");
-  }
-
-  async function markDispatchThrown(
-    ctx: HandlerContext,
-    request: Execution.Request,
-    error: unknown,
-  ): Promise<void> {
-    const existing = await WorkerRun.get(ctx.sessionId, request.runId);
-    if (
-      existing &&
-      !["succeeded", "failed", "cancelled", "interrupted"].includes(existing.status)
-    ) {
-      const message = error instanceof Error ? error.message : String(error);
-      // A thrown coordinator dispatch means no terminal Execution.Result reached ingress.
-      // Treat the durable run as interrupted by infrastructure rather than inferring
-      // semantics from transport-specific error text.
-      await completeDurableWorkerRun(ctx, request, "interrupted", message);
-    }
-  }
-
-  function publishCompleted(ctx: HandlerContext, target: string | undefined, start: number): void {
-    if (!ctx.traceContext) return;
-    Bus.publish(IngressEvent.Completed, {
-      traceId: ctx.traceContext.traceId,
-      sessionId: ctx.sessionId,
-      mode: ctx.event.mode,
-      ...(target ? { target } : {}),
-      durationMs: Date.now() - start,
-      time: Date.now(),
-    });
-  }
-
-  function publishFailed(
-    ctx: HandlerContext,
-    target: string | undefined,
-    start: number,
-    error: unknown,
-  ): void {
-    if (!ctx.traceContext) return;
-    const message = error instanceof Error ? error.message : String(error);
-    Bus.publish(IngressEvent.Failed, {
-      traceId: ctx.traceContext.traceId,
-      sessionId: ctx.sessionId,
-      mode: ctx.event.mode,
-      ...(target ? { target } : {}),
-      durationMs: Date.now() - start,
-      error: message,
-      time: Date.now(),
-    });
-  }
-
-  function startBackgroundWorkerDispatch(
-    ctx: HandlerContext,
-    request: Execution.Request,
-    target: string | undefined,
-    start: number,
-  ): void {
-    if (!ctx.coordinator) throw new Error("coordinator is required for worker-targeted ingress");
-    const coordinator = ctx.coordinator;
-
-    void (async () => {
-      try {
-        const result = await coordinator.dispatch(ctx.sessionId, request);
-        await finishCoordinatorDispatch(ctx, request, result);
-        if (result.output) {
-          SessionBridge.storeDirectResult(ctx.sessionId, result.output, ctx.event.agent.model);
-        }
-        if (result.status === "succeeded" || result.status === "cancelled") {
-          publishCompleted(ctx, target, start);
-          return;
-        }
-        publishFailed(ctx, target, start, result.error ?? result.status);
-      } catch (error) {
-        publishFailed(ctx, target, start, error);
-        await markDispatchThrown(ctx, request, error);
-      }
-    })();
+    return commitWriteback(ctx, output);
   }
 
   export async function handleResident(ctx: HandlerContext): Promise<Ingress.IngressResult> {
@@ -333,15 +41,7 @@ export namespace IngressHandlers {
       throw new Error("resident runtime is required");
     }
 
-    if (ctx.traceContext) {
-      Bus.publish(IngressEvent.ModeDetected, {
-        traceId: ctx.traceContext.traceId,
-        sessionId: ctx.sessionId,
-        mode: ctx.event.mode,
-        target: "resident",
-        time: Date.now(),
-      });
-    }
+    publishModeDetected(ctx, "resident");
 
     const residentResult = await ctx.residentRuntime.run({
       sessionId: ctx.sessionId,
@@ -349,7 +49,7 @@ export namespace IngressHandlers {
       traceContext: ctx.traceContext,
       signal: (ctx.event.runtime as { signal?: AbortSignal } | undefined)?.signal,
     });
-    const output = await dispatchWritebackCommit(ctx, residentResult.output);
+    const output = await commitWriteback(ctx, residentResult.output);
     SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
 
     return {
@@ -365,15 +65,7 @@ export namespace IngressHandlers {
 
   export async function handleDirect(ctx: HandlerContext): Promise<Ingress.IngressResult> {
     const target = summarizeTarget(ctx.event);
-    if (ctx.traceContext) {
-      Bus.publish(IngressEvent.ModeDetected, {
-        traceId: ctx.traceContext.traceId,
-        sessionId: ctx.sessionId,
-        mode: ctx.event.mode,
-        ...(target ? { target } : {}),
-        time: Date.now(),
-      });
-    }
+    publishModeDetected(ctx, target);
 
     const cancelResult = await handleCancelRequest(ctx);
     if (cancelResult) return cancelResult;
@@ -381,16 +73,7 @@ export namespace IngressHandlers {
     const start = Date.now();
     const deliveryResult = await handleWorkerDelivery(ctx);
     if (deliveryResult) {
-      if (ctx.traceContext) {
-        Bus.publish(IngressEvent.Completed, {
-          traceId: ctx.traceContext.traceId,
-          sessionId: ctx.sessionId,
-          mode: ctx.event.mode,
-          ...(target ? { target } : {}),
-          durationMs: Date.now() - start,
-          time: Date.now(),
-        });
-      }
+      publishCompleted(ctx, target, start);
       return deliveryResult;
     }
 
@@ -399,7 +82,7 @@ export namespace IngressHandlers {
     await createDurableWorkerRun(ctx, request);
     if (isBackgroundWorkerIngress(ctx)) {
       startBackgroundWorkerDispatch(ctx, request, target, start);
-      const output = await dispatchWritebackCommit(
+      const output = await commitWriteback(
         ctx,
         JSON.stringify({
           accepted: true,
@@ -422,7 +105,7 @@ export namespace IngressHandlers {
       await finishCoordinatorDispatch(ctx, request, coordinatorResult);
       if (coordinatorResult.status !== "succeeded") {
         if (coordinatorResult.status === "cancelled") {
-          const output = await dispatchWritebackCommit(
+          const output = await commitWriteback(
             ctx,
             coordinatorResult.output ?? coordinatorResult.error ?? "cancelled",
           );
@@ -447,7 +130,7 @@ export namespace IngressHandlers {
       await markDispatchThrown(ctx, request, error);
       throw error;
     }
-    const output = await dispatchWritebackCommit(ctx, coordinatorResult.output ?? "");
+    const output = await commitWriteback(ctx, coordinatorResult.output ?? "");
     SessionBridge.storeDirectResult(ctx.sessionId, output, ctx.event.agent.model);
 
     publishCompleted(ctx, target, start);


### PR DESCRIPTION
## Summary
- split `IngressHandlers` internals into focused prompt, request, writeback, event, worker dispatch, and WorkerRun lifecycle modules
- keep the public `IngressHandlers` namespace, including `HandlerContext` as an exported interface, plus `buildExecutionRequest`, `dispatchWritebackCommit`, `handleResident`, and `handleDirect`
- reduce `handlers.ts` from an oversized orchestration file to a thin direct/resident facade with all ingress production files below 250 LOC

## Verification
- `bun run --cwd packages/openomni check-types`
- `bun run check-types`
- `bun run build`
- `bun test packages/openomni/test/ingress/handlers.test.ts`
- `find packages/openomni/test/ingress packages/openomni/src/ingress -name '*.test.ts' -print | sort | xargs bun test`
- `bun run lint:guards && bun run lint:side-effects`
- `bunx knip --no-config-hints`
- `git diff --check`
- `bun run test`
- pre-push hook: `dep-check`, `type-check`

## Review notes
- Claude Fable oracle was unavailable locally for `claude-fable-5` with a 404, so no fallback model was used.
- `codex-ultrawork-reviewer` initially caught an API drift blocker where `IngressHandlers.HandlerContext` had become a type alias; this PR fixes it by restoring an exported namespace interface.
- Follow-up reviewer pass reported no blockers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic ingress handlers into focused modules while keeping the `IngressHandlers` public API stable. This simplifies maintenance, reduces `handlers.ts` significantly, and fixes the `HandlerContext` export regression.

- **Refactors**
  - Extracted: `handler-prompt`, `handler-request`, `handler-writeback`, `handler-events`, `handler-worker-dispatch`, `handler-worker-run`.
  - `IngressHandlers` facade remains with `HandlerContext`, `buildExecutionRequest`, `dispatchWritebackCommit`, `handleResident`, `handleDirect`.
  - Background worker flows moved to dedicated dispatch/run modules; resident/direct paths now publish `ModeDetected`, `Completed`, `Failed`.
  - All ingress files now <250 LOC; `handlers.ts` is a thin facade.

- **Bug Fixes**
  - Restored `IngressHandlers.HandlerContext` as an exported interface to match the public API.
  - Aligned worker cancel/delivery with coordinator APIs and ensured durable run status updates and writeback policy evaluation run consistently.

<sup>Written for commit c9f990361811eef845abf811fdd50fc28bd44202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

