### PR TITLE
refactor(openomni): split background manager responsibilities

### DIFF
--- a/packages/openomni/src/subagent/background-manager-events.ts
+++ b/packages/openomni/src/subagent/background-manager-events.ts
@@ -1,0 +1,65 @@
+import { PolicyDecision, type Policy, type RuntimeResource, Subagent } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+
+export function createBackgroundLaunchDescriptor(agentName: string): RuntimeResource.Descriptor {
+  return {
+    id: "worker:agent:background_launch",
+    kind: "worker",
+    source: { type: "agent", agentId: agentName },
+    labels: ["source.agent", "delegation.background"],
+    capabilities: ["delegation.background"],
+    effects: ["session.create"],
+  };
+}
+
+export function backgroundLaunchFailureReason(decision: Policy.PolicyDecision): string | undefined {
+  if (!PolicyDecision.isBlocking(decision)) return undefined;
+  return PolicyDecision.reason(decision, `background launch policy returned ${decision.verdict}`);
+}
+
+export function publishBackgroundTaskLaunched(input: {
+  readonly taskId: string;
+  readonly agentName: string;
+  readonly parentSessionId: string;
+}): void {
+  Bus.publish(Subagent.Events.BackgroundTaskLaunched, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    payload: {
+      taskId: input.taskId,
+      agentName: input.agentName,
+      parentSessionId: input.parentSessionId,
+      status: "running",
+    },
+  });
+}
+
+export function publishBackgroundTaskCompleted(input: {
+  readonly taskId: string;
+  readonly sessionId: string;
+}): void {
+  Bus.publish(Subagent.Events.BackgroundTaskCompleted, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    payload: { taskId: input.taskId, status: "completed", sessionId: input.sessionId },
+  });
+}
+
+export function publishBackgroundTaskFailed(input: {
+  readonly taskId: string;
+  readonly error: string | undefined;
+}): void {
+  Bus.publish(Subagent.Events.BackgroundTaskFailed, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    payload: { taskId: input.taskId, error: input.error },
+  });
+}
+
+export function publishBackgroundTaskCancelled(taskId: string): void {
+  Bus.publish(Subagent.Events.BackgroundTaskCancelled, {
+    traceId: crypto.randomUUID(),
+    time: Date.now(),
+    payload: { taskId },
+  });
+}

--- a/packages/openomni/src/subagent/background-manager-queue.ts
+++ b/packages/openomni/src/subagent/background-manager-queue.ts
@@ -1,0 +1,60 @@
+import type { Subagent } from "@openomni/protocol";
+import type { BackgroundLaunchInput, QueuedBackgroundLaunch } from "./background-manager-types.js";
+
+export type BackgroundQueue = {
+  enqueue(item: QueuedBackgroundLaunch): void;
+  remove(taskId: string): void;
+  drain(input: {
+    readonly getTask: (taskId: string) => Subagent.BackgroundTask | undefined;
+    readonly spawnTask: (taskId: string, input: BackgroundLaunchInput) => void;
+  }): void;
+  markActive(taskId: string): void;
+  releaseActive(taskId: string): void;
+  activeCount(): number;
+  pendingSize(): number;
+};
+
+export function createBackgroundQueue(maxConcurrentTotal: number): BackgroundQueue {
+  const pendingQueue: QueuedBackgroundLaunch[] = [];
+  const activeTaskIds = new Set<string>();
+  let activeCount = 0;
+
+  return {
+    enqueue(item) {
+      pendingQueue.push(item);
+    },
+    remove(taskId) {
+      const queueIdx = pendingQueue.findIndex((item) => item.id === taskId);
+      if (queueIdx !== -1) {
+        pendingQueue.splice(queueIdx, 1);
+      }
+    },
+    drain(input) {
+      while (pendingQueue.length > 0 && activeCount < maxConcurrentTotal) {
+        const next = pendingQueue.shift();
+        if (next === undefined) break;
+
+        const task = input.getTask(next.id);
+        if (task === undefined || task.status !== "pending") continue;
+
+        this.markActive(next.id);
+        input.spawnTask(next.id, next.input);
+      }
+    },
+    markActive(taskId) {
+      if (activeTaskIds.has(taskId)) return;
+      activeTaskIds.add(taskId);
+      activeCount++;
+    },
+    releaseActive(taskId) {
+      if (!activeTaskIds.delete(taskId)) return;
+      activeCount--;
+    },
+    activeCount() {
+      return activeCount;
+    },
+    pendingSize() {
+      return pendingQueue.length;
+    },
+  };
+}

--- a/packages/openomni/src/subagent/background-manager-runner.ts
+++ b/packages/openomni/src/subagent/background-manager-runner.ts
@@ -1,0 +1,217 @@
+import { type Message, Subagent } from "@openomni/protocol";
+import { Bus, Session } from "@openomni/session";
+import { BackgroundStore } from "./background-store.js";
+import {
+  publishBackgroundTaskCompleted,
+  publishBackgroundTaskFailed,
+  publishBackgroundTaskLaunched,
+} from "./background-manager-events.js";
+import type { BackgroundQueue } from "./background-manager-queue.js";
+import type { BackgroundManagerState } from "./background-manager-state.js";
+import type {
+  BackgroundLaunchInput,
+  ResolvedBackgroundManagerConfig,
+} from "./background-manager-types.js";
+import { SubagentRuntime } from "./runtime.js";
+
+export type BackgroundRunner = {
+  spawnTask(taskId: string, input: BackgroundLaunchInput): Promise<void>;
+};
+
+export function createBackgroundRunner(input: {
+  readonly config: ResolvedBackgroundManagerConfig;
+  readonly state: BackgroundManagerState;
+  readonly queue: BackgroundQueue;
+  readonly drainQueue: () => void;
+}): BackgroundRunner {
+  const { config, state, queue, drainQueue } = input;
+
+  function finishCancelledOrMissing(taskId: string): void {
+    state.controllers.delete(taskId);
+    queue.releaseActive(taskId);
+    drainQueue();
+  }
+
+  function setTaskUnsub(taskId: string, unsubs: readonly (() => void)[]): void {
+    const cleanupRunSubs = () => unsubs.forEach((unsubscribe) => unsubscribe());
+    state.taskUnsubs.set(taskId, cleanupRunSubs);
+  }
+
+  function completeTask(taskId: string, sessionId: string): void {
+    const current = state.tasks.get(taskId);
+    if (current === undefined || current.status === "cancelled") {
+      finishCancelledOrMissing(taskId);
+      return;
+    }
+
+    state.controllers.delete(taskId);
+    queue.releaseActive(taskId);
+
+    const completed: Subagent.BackgroundTask = {
+      ...current,
+      status: "completed",
+      completedAt: Date.now(),
+    };
+    state.tasks.set(taskId, completed);
+
+    const output = extractAssistantOutput(sessionId);
+    const result: Subagent.BackgroundTaskResult = {
+      taskId,
+      status: "completed",
+      output,
+    };
+    state.results.set(taskId, result);
+    BackgroundStore.persist(completed, output);
+    config.onTaskComplete?.(result);
+
+    publishBackgroundTaskCompleted({ taskId, sessionId });
+    drainQueue();
+  }
+
+  function failTask(taskId: string, error: string): void {
+    const current = state.tasks.get(taskId);
+    if (current === undefined || current.status === "cancelled") {
+      finishCancelledOrMissing(taskId);
+      return;
+    }
+
+    state.controllers.delete(taskId);
+    queue.releaseActive(taskId);
+
+    const failed: Subagent.BackgroundTask = {
+      ...current,
+      status: "failed",
+      completedAt: Date.now(),
+      error,
+    };
+    state.tasks.set(taskId, failed);
+    BackgroundStore.persist(failed);
+
+    const result: Subagent.BackgroundTaskResult = { taskId, status: "failed" };
+    state.results.set(taskId, result);
+    config.onTaskComplete?.(result);
+
+    publishBackgroundTaskFailed({ taskId, error });
+    drainQueue();
+  }
+
+  function subscribeRunSettlement(taskId: string, sessionId: string, runId: string): void {
+    const runUnsubs: Array<() => void> = [];
+    const cleanupRunSubs = () => {
+      runUnsubs.forEach((unsubscribe) => unsubscribe());
+      state.taskUnsubs.delete(taskId);
+    };
+
+    runUnsubs.push(
+      Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
+        if (data.payload.sessionId !== sessionId || data.payload.runId !== runId) return;
+        cleanupRunSubs();
+        completeTask(taskId, sessionId);
+      }),
+    );
+
+    runUnsubs.push(
+      Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
+        if (data.payload.sessionId !== sessionId || data.payload.runId !== runId) return;
+        cleanupRunSubs();
+        failTask(taskId, data.payload.error ?? "unknown error");
+      }),
+    );
+
+    setTaskUnsub(taskId, runUnsubs);
+  }
+
+  return {
+    spawnTask(taskId, launchInput) {
+      const controller = new AbortController();
+      state.controllers.set(taskId, controller);
+
+      return Promise.resolve()
+        .then(() =>
+          SubagentRuntime.spawnBackground({
+            agentName: launchInput.agentName,
+            prompt: launchInput.prompt,
+            title: launchInput.prompt.slice(0, 50),
+            model: launchInput.model,
+            auth: config.resolveAuth?.(launchInput.model.provider),
+            allowAuthFallback: config.allowAuthFallback,
+            permissions: launchInput.permissions,
+            systemPrompt: launchInput.systemPrompt,
+            tools: launchInput.tools,
+            toolExecutor: launchInput.toolExecutor,
+            middleware: launchInput.middleware,
+            childMiddleware: launchInput.childMiddleware,
+            signal: controller.signal,
+          }),
+        )
+        .then(
+          async ({ sessionId, runId }) => {
+            const currentTask = state.tasks.get(taskId);
+            if (currentTask === undefined || currentTask.status === "cancelled") {
+              await SubagentRuntime.cancel({ sessionId, runId }).catch(() => undefined);
+              finishCancelledOrMissing(taskId);
+              return;
+            }
+
+            const running: Subagent.BackgroundTask = {
+              ...currentTask,
+              status: "running",
+              sessionId,
+              runId,
+              startedAt: Date.now(),
+            };
+            state.tasks.set(taskId, running);
+            BackgroundStore.persist(running);
+
+            subscribeRunSettlement(taskId, sessionId, runId);
+            publishBackgroundTaskLaunched({
+              taskId,
+              agentName: launchInput.agentName,
+              parentSessionId: launchInput.parentSessionId,
+            });
+          },
+          (error) => {
+            state.controllers.delete(taskId);
+            queue.releaseActive(taskId);
+
+            const current = state.tasks.get(taskId);
+            if (current === undefined || current.status === "cancelled") {
+              drainQueue();
+              return;
+            }
+
+            const failed: Subagent.BackgroundTask = {
+              ...current,
+              status: "failed",
+              completedAt: Date.now(),
+              error: error instanceof Error ? error.message : String(error),
+            };
+            state.tasks.set(taskId, failed);
+            BackgroundStore.persist(failed);
+            publishBackgroundTaskFailed({ taskId, error: failed.error });
+
+            drainQueue();
+          },
+        );
+    },
+  };
+}
+
+function extractAssistantOutput(sessionId: string): string | undefined {
+  try {
+    const messages = Session.getMessages(sessionId);
+    const lastAssistant = [...messages].reverse().find((message) => message.role === "assistant");
+    if (lastAssistant === undefined) return undefined;
+
+    const parts = Session.getParts(lastAssistant.id);
+    return (
+      parts
+        .filter((part): part is Message.TextPart => part.type === "text")
+        .map((part) => part.text)
+        .filter(Boolean)
+        .join("\n") || undefined
+    );
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/openomni/src/subagent/background-manager-state.ts
+++ b/packages/openomni/src/subagent/background-manager-state.ts
@@ -1,0 +1,85 @@
+import type { Subagent } from "@openomni/protocol";
+import { BackgroundStore } from "./background-store.js";
+import type { BackgroundLaunchInput } from "./background-manager-types.js";
+
+export type BackgroundManagerState = {
+  readonly tasks: Map<string, Subagent.BackgroundTask>;
+  readonly results: Map<string, Subagent.BackgroundTaskResult>;
+  readonly controllers: Map<string, AbortController>;
+  readonly taskUnsubs: Map<string, () => void>;
+};
+
+export function createBackgroundManagerState(): BackgroundManagerState {
+  const state: BackgroundManagerState = {
+    tasks: new Map<string, Subagent.BackgroundTask>(),
+    results: new Map<string, Subagent.BackgroundTaskResult>(),
+    controllers: new Map<string, AbortController>(),
+    taskUnsubs: new Map<string, () => void>(),
+  };
+
+  for (const interrupted of BackgroundStore.loadInterrupted()) {
+    state.tasks.set(interrupted.id, interrupted);
+    state.results.set(interrupted.id, { taskId: interrupted.id, status: "failed" });
+  }
+
+  return state;
+}
+
+export function activeBackgroundTasks(state: BackgroundManagerState): Subagent.BackgroundTask[] {
+  return [...state.tasks.values()].filter((task) => {
+    return task.status === "running" || task.status === "pending";
+  });
+}
+
+export function makeFailedBackgroundTask(
+  input: BackgroundLaunchInput,
+  error: string,
+): Subagent.BackgroundTask {
+  return {
+    id: `bg_${crypto.randomUUID().slice(0, 8)}`,
+    agentName: input.agentName,
+    prompt: input.prompt,
+    status: "failed",
+    parentSessionId: input.parentSessionId,
+    queuedAt: Date.now(),
+    error,
+    depth: input.depth ?? 0,
+  };
+}
+
+export function cleanupExpiredBackgroundTasks(
+  state: BackgroundManagerState,
+  taskTtlMs: number,
+): void {
+  const now = Date.now();
+  for (const [id, task] of state.tasks) {
+    if (task.completedAt !== undefined && now - task.completedAt > taskTtlMs) {
+      state.tasks.delete(id);
+      state.results.delete(id);
+      state.controllers.delete(id);
+      state.taskUnsubs.delete(id);
+      BackgroundStore.deleteTask(id);
+    }
+  }
+}
+
+export function getBackgroundTask(
+  state: BackgroundManagerState,
+  taskId: string,
+): Subagent.BackgroundTask | undefined {
+  return state.tasks.get(taskId) ?? BackgroundStore.getTask(taskId);
+}
+
+export function getBackgroundResult(
+  state: BackgroundManagerState,
+  taskId: string,
+): Subagent.BackgroundTaskResult | undefined {
+  return state.results.get(taskId) ?? BackgroundStore.getResult(taskId);
+}
+
+export function listBackgroundTasksByParent(
+  state: BackgroundManagerState,
+  parentSessionId: string,
+): Subagent.BackgroundTask[] {
+  return [...state.tasks.values()].filter((task) => task.parentSessionId === parentSessionId);
+}

--- a/packages/openomni/src/subagent/background-manager-types.ts
+++ b/packages/openomni/src/subagent/background-manager-types.ts
@@ -1,0 +1,72 @@
+import type { Model, Policy, Subagent } from "@openomni/protocol";
+import type { RuntimeConfig } from "./transcript.js";
+
+export type BackgroundLaunchInput = {
+  readonly agentName: string;
+  readonly prompt: string;
+  readonly model: Model.Ref;
+  readonly parentSessionId: string;
+  readonly depth?: number;
+  readonly permissions?: Policy.Permission;
+  readonly systemPrompt?: RuntimeConfig["systemPrompt"];
+  readonly tools?: RuntimeConfig["tools"];
+  readonly toolExecutor?: RuntimeConfig["toolExecutor"];
+  readonly middleware?: RuntimeConfig["middleware"];
+  readonly childMiddleware?: RuntimeConfig["childMiddleware"];
+};
+
+export type BackgroundManagerConfig = {
+  readonly maxConcurrentPerAgent?: number;
+  readonly maxConcurrentTotal?: number;
+  readonly maxDepth?: number;
+  readonly maxDescendants?: number;
+  readonly taskTtlMs?: number;
+  readonly maxQueueSize?: number;
+  readonly resolveAuth?: (provider: string) => RuntimeConfig["auth"];
+  readonly allowAuthFallback?: RuntimeConfig["allowAuthFallback"];
+  readonly onTaskComplete?: (result: Subagent.BackgroundTaskResult) => void;
+};
+
+export type ResolvedBackgroundManagerConfig = {
+  readonly maxConcurrentPerAgent: number;
+  readonly maxConcurrentTotal: number;
+  readonly maxDepth: number;
+  readonly maxDescendants: number;
+  readonly taskTtlMs: number;
+  readonly maxQueueSize: number;
+  readonly resolveAuth?: (provider: string) => RuntimeConfig["auth"];
+  readonly allowAuthFallback?: RuntimeConfig["allowAuthFallback"];
+  readonly onTaskComplete?: (result: Subagent.BackgroundTaskResult) => void;
+};
+
+export type BackgroundManagerInstance = {
+  launch(input: BackgroundLaunchInput): Promise<Subagent.BackgroundTask>;
+  getTask(taskId: string): Subagent.BackgroundTask | undefined;
+  getResult(taskId: string): Subagent.BackgroundTaskResult | undefined;
+  cancel(taskId: string): Promise<boolean>;
+  listByParent(parentSessionId: string): Subagent.BackgroundTask[];
+  cleanup(): void;
+  stats(): { active: number; pending: number; total: number };
+  dispose(): void;
+};
+
+export type QueuedBackgroundLaunch = {
+  readonly input: BackgroundLaunchInput;
+  readonly id: string;
+};
+
+export function resolveBackgroundManagerConfig(
+  config?: BackgroundManagerConfig,
+): ResolvedBackgroundManagerConfig {
+  return {
+    maxConcurrentPerAgent: config?.maxConcurrentPerAgent ?? 3,
+    maxConcurrentTotal: config?.maxConcurrentTotal ?? 10,
+    maxDepth: config?.maxDepth ?? 5,
+    maxDescendants: config?.maxDescendants ?? 10,
+    taskTtlMs: config?.taskTtlMs ?? 1_800_000,
+    maxQueueSize: config?.maxQueueSize ?? 100,
+    resolveAuth: config?.resolveAuth,
+    allowAuthFallback: config?.allowAuthFallback,
+    onTaskComplete: config?.onTaskComplete,
+  };
+}

--- a/packages/openomni/src/subagent/background-manager.ts
+++ b/packages/openomni/src/subagent/background-manager.ts
@@ -1,103 +1,55 @@
-import {
-  type Message,
-  type Model,
-  PolicyDecision,
-  type Policy,
-  Subagent,
-  type RuntimeResource,
-} from "@openomni/protocol";
-import { Bus, Session } from "@openomni/session";
+import type { Subagent } from "@openomni/protocol";
 import { startSweep, stopSweep } from "./abort-registry";
+import {
+  backgroundLaunchFailureReason,
+  createBackgroundLaunchDescriptor,
+  publishBackgroundTaskCancelled,
+} from "./background-manager-events.js";
+import { createBackgroundQueue } from "./background-manager-queue.js";
+import { createBackgroundRunner } from "./background-manager-runner.js";
+import {
+  activeBackgroundTasks,
+  cleanupExpiredBackgroundTasks,
+  createBackgroundManagerState,
+  getBackgroundResult,
+  getBackgroundTask,
+  listBackgroundTasksByParent,
+  makeFailedBackgroundTask,
+} from "./background-manager-state.js";
+import {
+  type BackgroundLaunchInput,
+  type BackgroundManagerConfig,
+  type BackgroundManagerInstance,
+  resolveBackgroundManagerConfig,
+} from "./background-manager-types.js";
 import { BackgroundStore } from "./background-store.js";
 import { BackgroundLimitsMiddleware } from "./middleware/background-limits.js";
-import { SubagentRuntime } from "./runtime.js";
-import type { RuntimeConfig } from "./transcript.js";
 
-type LaunchInput = {
-  agentName: string;
-  prompt: string;
-  model: Model.Ref;
-  parentSessionId: string;
-  depth?: number;
-  permissions?: Policy.Permission;
-  systemPrompt?: RuntimeConfig["systemPrompt"];
-  tools?: RuntimeConfig["tools"];
-  toolExecutor?: RuntimeConfig["toolExecutor"];
-  middleware?: RuntimeConfig["middleware"];
-  childMiddleware?: RuntimeConfig["childMiddleware"];
-};
-
-type Config = {
-  maxConcurrentPerAgent?: number;
-  maxConcurrentTotal?: number;
-  maxDepth?: number;
-  maxDescendants?: number;
-  taskTtlMs?: number;
-  maxQueueSize?: number;
-  resolveAuth?: (provider: string) => RuntimeConfig["auth"];
-  allowAuthFallback?: RuntimeConfig["allowAuthFallback"];
-  onTaskComplete?: (result: Subagent.BackgroundTaskResult) => void;
-};
-
-type BackgroundManagerInstance = {
-  launch(input: LaunchInput): Promise<Subagent.BackgroundTask>;
-  getTask(taskId: string): Subagent.BackgroundTask | undefined;
-  getResult(taskId: string): Subagent.BackgroundTaskResult | undefined;
-  cancel(taskId: string): Promise<boolean>;
-  listByParent(parentSessionId: string): Subagent.BackgroundTask[];
-  cleanup(): void;
-  stats(): { active: number; pending: number; total: number };
-  dispose(): void;
-};
-
-function createBackgroundLaunchDescriptor(agentName: string): RuntimeResource.Descriptor {
-  return {
-    id: "worker:agent:background_launch",
-    kind: "worker",
-    source: { type: "agent", agentId: agentName },
-    labels: ["source.agent", "delegation.background"],
-    capabilities: ["delegation.background"],
-    effects: ["session.create"],
-  };
-}
-
-function backgroundLaunchFailureReason(decision: Policy.PolicyDecision): string | undefined {
-  if (!PolicyDecision.isBlocking(decision)) return undefined;
-  return PolicyDecision.reason(decision, `background launch policy returned ${decision.verdict}`);
-}
+type LaunchInput = BackgroundLaunchInput;
+type Config = BackgroundManagerConfig;
 
 export const BackgroundManager = {
   create(config?: Config): BackgroundManagerInstance {
-    const maxConcurrentPerAgent = config?.maxConcurrentPerAgent ?? 3;
-    const maxConcurrentTotal = config?.maxConcurrentTotal ?? 10;
-    const maxDepth = config?.maxDepth ?? 5;
-    const maxDescendants = config?.maxDescendants ?? 10;
-    const taskTtlMs = config?.taskTtlMs ?? 1_800_000;
-    const maxQueueSize = config?.maxQueueSize ?? 100;
-    const resolveAuth = config?.resolveAuth;
-    const allowAuthFallback = config?.allowAuthFallback;
-    const onTaskComplete = config?.onTaskComplete;
+    const resolvedConfig = resolveBackgroundManagerConfig(config);
+    const state = createBackgroundManagerState();
+    const queue = createBackgroundQueue(resolvedConfig.maxConcurrentTotal);
+    const cleanup = () => cleanupExpiredBackgroundTasks(state, resolvedConfig.taskTtlMs);
+    const drainQueue = () => {
+      queue.drain({
+        getTask: (taskId) => state.tasks.get(taskId),
+        spawnTask: (taskId, input) => {
+          void runner.spawnTask(taskId, input);
+        },
+      });
+    };
+    const runner = createBackgroundRunner({
+      config: resolvedConfig,
+      state,
+      queue,
+      drainQueue,
+    });
 
-    const tasks = new Map<string, Subagent.BackgroundTask>();
-    const results = new Map<string, Subagent.BackgroundTaskResult>();
-    const controllers = new Map<string, AbortController>();
-    const taskUnsubs = new Map<string, () => void>();
-
-    type QueuedItem = { input: LaunchInput; id: string };
-    const pendingQueue: QueuedItem[] = [];
-    // Tracks spawning + running tasks synchronously before async spawn completes.
-    let activeCount = 0;
-    const activeTaskIds = new Set<string>();
     let launchLock: Promise<void> = Promise.resolve();
-
-    for (const interrupted of BackgroundStore.loadInterrupted()) {
-      tasks.set(interrupted.id, interrupted);
-      results.set(interrupted.id, { taskId: interrupted.id, status: "failed" });
-    }
-
-    function activeTasks(): Subagent.BackgroundTask[] {
-      return [...tasks.values()].filter((t) => t.status === "running" || t.status === "pending");
-    }
 
     async function withLaunchLock<T>(fn: () => Promise<T>): Promise<T> {
       const previous = launchLock;
@@ -114,325 +66,77 @@ export const BackgroundManager = {
       }
     }
 
-    function makeFailedTask(input: LaunchInput, error: string): Subagent.BackgroundTask {
-      return {
-        id: `bg_${crypto.randomUUID().slice(0, 8)}`,
-        agentName: input.agentName,
-        prompt: input.prompt,
-        status: "failed",
-        parentSessionId: input.parentSessionId,
-        queuedAt: Date.now(),
-        error,
-        depth: input.depth ?? 0,
-      };
-    }
-
-    function cleanup(): void {
-      const now = Date.now();
-      for (const [id, task] of tasks) {
-        if (task.completedAt !== undefined && now - task.completedAt > taskTtlMs) {
-          tasks.delete(id);
-          results.delete(id);
-          controllers.delete(id);
-          taskUnsubs.delete(id);
-          BackgroundStore.deleteTask(id);
-        }
-      }
-    }
-
     const cleanupInterval = setInterval(cleanup, 60_000);
     startSweep();
-
-    function drainQueue(): void {
-      while (pendingQueue.length > 0 && activeCount < maxConcurrentTotal) {
-        const next = pendingQueue.shift();
-        if (!next) break;
-
-        const task = tasks.get(next.id);
-        // task may have been cancelled while queued
-        if (!task || task.status !== "pending") continue;
-
-        markActive(next.id);
-        spawnTask(next.id, next.input);
-      }
-    }
-
-    function markActive(taskId: string): void {
-      if (activeTaskIds.has(taskId)) return;
-      activeTaskIds.add(taskId);
-      activeCount++;
-    }
-
-    function releaseActive(taskId: string): void {
-      if (!activeTaskIds.delete(taskId)) return;
-      activeCount--;
-    }
-
-    function spawnTask(id: string, input: LaunchInput): Promise<void> {
-      const controller = new AbortController();
-      controllers.set(id, controller);
-
-      return Promise.resolve()
-        .then(() =>
-          SubagentRuntime.spawnBackground({
-            agentName: input.agentName,
-            prompt: input.prompt,
-            title: input.prompt.slice(0, 50),
-            model: input.model,
-            auth: resolveAuth?.(input.model.provider),
-            allowAuthFallback,
-            permissions: input.permissions,
-            systemPrompt: input.systemPrompt,
-            tools: input.tools,
-            toolExecutor: input.toolExecutor,
-            middleware: input.middleware,
-            childMiddleware: input.childMiddleware,
-            signal: controller.signal,
-          }),
-        )
-        .then(
-          async ({ sessionId, runId }) => {
-            const currentTask = tasks.get(id);
-            if (!currentTask || currentTask.status === "cancelled") {
-              try {
-                await SubagentRuntime.cancel({ sessionId, runId });
-              } catch {
-                // The run may already be terminal; local background accounting still needs cleanup.
-              }
-              controllers.delete(id);
-              releaseActive(id);
-              drainQueue();
-              return;
-            }
-
-            const running: Subagent.BackgroundTask = {
-              ...currentTask,
-              status: "running",
-              sessionId,
-              runId,
-              startedAt: Date.now(),
-            };
-            tasks.set(id, running);
-            BackgroundStore.persist(running);
-
-            const runUnsubs: Array<() => void> = [];
-            const cleanupRunSubs = () => runUnsubs.forEach((u) => u());
-            taskUnsubs.set(id, cleanupRunSubs);
-
-            runUnsubs.push(
-              Bus.subscribe(Subagent.Events.WorkerRunCompleted, (data) => {
-                if (data.payload.sessionId !== sessionId || data.payload.runId !== runId) return;
-                cleanupRunSubs();
-                taskUnsubs.delete(id);
-
-                const current = tasks.get(id);
-                if (!current || current.status === "cancelled") {
-                  controllers.delete(id);
-                  releaseActive(id);
-                  drainQueue();
-                  return;
-                }
-
-                controllers.delete(id);
-                releaseActive(id);
-
-                const completed: Subagent.BackgroundTask = {
-                  ...current,
-                  status: "completed",
-                  completedAt: Date.now(),
-                };
-                tasks.set(id, completed);
-
-                let output: string | undefined;
-                try {
-                  const msgs = Session.getMessages(sessionId);
-                  const lastAssistant = [...msgs].reverse().find((m) => m.role === "assistant");
-                  if (lastAssistant) {
-                    const parts = Session.getParts(lastAssistant.id);
-                    output =
-                      parts
-                        .filter((p): p is Message.TextPart => p.type === "text")
-                        .map((p) => p.text)
-                        .filter(Boolean)
-                        .join("\n") || undefined;
-                  }
-                } catch {
-                  // session may have been cleaned up
-                }
-                const result: Subagent.BackgroundTaskResult = {
-                  taskId: id,
-                  status: "completed",
-                  output,
-                };
-                results.set(id, result);
-                BackgroundStore.persist(completed, output);
-                onTaskComplete?.(result);
-
-                Bus.publish(Subagent.Events.BackgroundTaskCompleted, {
-                  traceId: crypto.randomUUID(),
-                  time: Date.now(),
-                  payload: { taskId: id, status: "completed" as const, sessionId },
-                });
-
-                drainQueue();
-              }),
-            );
-
-            runUnsubs.push(
-              Bus.subscribe(Subagent.Events.WorkerRunFailed, (data) => {
-                if (data.payload.sessionId !== sessionId || data.payload.runId !== runId) return;
-                cleanupRunSubs();
-                taskUnsubs.delete(id);
-
-                const current = tasks.get(id);
-                if (!current || current.status === "cancelled") {
-                  controllers.delete(id);
-                  releaseActive(id);
-                  drainQueue();
-                  return;
-                }
-
-                controllers.delete(id);
-                releaseActive(id);
-
-                const failed: Subagent.BackgroundTask = {
-                  ...current,
-                  status: "failed",
-                  completedAt: Date.now(),
-                  error: data.payload.error ?? "unknown error",
-                };
-                tasks.set(id, failed);
-                BackgroundStore.persist(failed);
-
-                const result: Subagent.BackgroundTaskResult = { taskId: id, status: "failed" };
-                results.set(id, result);
-                onTaskComplete?.(result);
-
-                Bus.publish(Subagent.Events.BackgroundTaskFailed, {
-                  traceId: crypto.randomUUID(),
-                  time: Date.now(),
-                  payload: { taskId: id, error: data.payload.error ?? "unknown error" },
-                });
-
-                drainQueue();
-              }),
-            );
-
-            Bus.publish(Subagent.Events.BackgroundTaskLaunched, {
-              traceId: crypto.randomUUID(),
-              time: Date.now(),
-              payload: {
-                taskId: id,
-                agentName: input.agentName,
-                parentSessionId: input.parentSessionId,
-                status: "running" as const,
-              },
-            });
-          },
-          (err) => {
-            controllers.delete(id);
-            releaseActive(id);
-
-            const current = tasks.get(id);
-            if (!current || current.status === "cancelled") {
-              drainQueue();
-              return;
-            }
-
-            const failed: Subagent.BackgroundTask = {
-              ...current,
-              status: "failed",
-              completedAt: Date.now(),
-              error: err instanceof Error ? err.message : String(err),
-            };
-            tasks.set(id, failed);
-            BackgroundStore.persist(failed);
-            Bus.publish(Subagent.Events.BackgroundTaskFailed, {
-              traceId: crypto.randomUUID(),
-              time: Date.now(),
-              payload: { taskId: id, error: failed.error },
-            });
-
-            drainQueue();
-          },
-        );
-    }
 
     async function launch(input: LaunchInput): Promise<Subagent.BackgroundTask> {
       return withLaunchLock(async () => {
         const depth = input.depth ?? 0;
+        const taskInput: LaunchInput = { ...input, depth };
         const resourceDescriptor = createBackgroundLaunchDescriptor(input.agentName);
         const policy = await BackgroundLimitsMiddleware.evaluatePreLaunch({
-          input: { ...input, depth },
-          activeTasks: activeTasks(),
-          activeCount,
-          pendingQueueSize: pendingQueue.length,
-          maxConcurrentPerAgent,
-          maxConcurrentTotal,
-          maxDepth,
-          maxDescendants,
-          maxQueueSize,
+          input: taskInput,
+          activeTasks: activeBackgroundTasks(state),
+          activeCount: queue.activeCount(),
+          pendingQueueSize: queue.pendingSize(),
+          maxConcurrentPerAgent: resolvedConfig.maxConcurrentPerAgent,
+          maxConcurrentTotal: resolvedConfig.maxConcurrentTotal,
+          maxDepth: resolvedConfig.maxDepth,
+          maxDescendants: resolvedConfig.maxDescendants,
+          maxQueueSize: resolvedConfig.maxQueueSize,
           resourceDescriptor,
         });
         const launchFailureReason = backgroundLaunchFailureReason(policy.verdict);
         if (launchFailureReason !== undefined) {
-          return makeFailedTask(input, launchFailureReason);
+          return makeFailedBackgroundTask(taskInput, launchFailureReason);
         }
 
         const id = `bg_${crypto.randomUUID().slice(0, 8)}`;
         const task: Subagent.BackgroundTask = {
           id,
-          agentName: input.agentName,
-          prompt: input.prompt,
+          agentName: taskInput.agentName,
+          prompt: taskInput.prompt,
           status: "pending",
-          parentSessionId: input.parentSessionId,
+          parentSessionId: taskInput.parentSessionId,
           queuedAt: Date.now(),
           depth,
         };
-        tasks.set(id, task);
+        state.tasks.set(id, task);
 
         if (policy.shouldQueue) {
-          pendingQueue.push({ input, id });
+          queue.enqueue({ input: taskInput, id });
           drainQueue();
-          return tasks.get(id) ?? task;
+          return state.tasks.get(id) ?? task;
         }
 
-        markActive(id);
-        await spawnTask(id, input);
-        return tasks.get(id) ?? task;
+        queue.markActive(id);
+        await runner.spawnTask(id, taskInput);
+        return state.tasks.get(id) ?? task;
       });
     }
 
     async function cancel(taskId: string): Promise<boolean> {
-      const task = tasks.get(taskId);
-      if (!task) return false;
+      const task = state.tasks.get(taskId);
+      if (task === undefined) return false;
       if (task.status === "completed" || task.status === "failed" || task.status === "cancelled")
         return false;
 
-      const queueIdx = pendingQueue.findIndex((item) => item.id === taskId);
-      if (queueIdx !== -1) {
-        pendingQueue.splice(queueIdx, 1);
-      }
+      queue.remove(taskId);
+      state.controllers.get(taskId)?.abort();
+      state.taskUnsubs.get(taskId)?.();
+      state.taskUnsubs.delete(taskId);
+      state.controllers.delete(taskId);
 
-      controllers.get(taskId)?.abort();
-      taskUnsubs.get(taskId)?.();
-      taskUnsubs.delete(taskId);
-      controllers.delete(taskId);
       const cancelled: Subagent.BackgroundTask = {
         ...task,
         status: "cancelled",
         completedAt: Date.now(),
       };
-      tasks.set(taskId, cancelled);
+      state.tasks.set(taskId, cancelled);
       BackgroundStore.persist(cancelled);
-      releaseActive(taskId);
+      queue.releaseActive(taskId);
 
-      Bus.publish(Subagent.Events.BackgroundTaskCancelled, {
-        traceId: crypto.randomUUID(),
-        time: Date.now(),
-        payload: { taskId },
-      });
-
+      publishBackgroundTaskCancelled(taskId);
       drainQueue();
 
       return true;
@@ -440,16 +144,15 @@ export const BackgroundManager = {
 
     return {
       launch,
-      getTask: (taskId) => tasks.get(taskId) ?? BackgroundStore.getTask(taskId),
-      getResult: (taskId) => results.get(taskId) ?? BackgroundStore.getResult(taskId),
+      getTask: (taskId) => getBackgroundTask(state, taskId),
+      getResult: (taskId) => getBackgroundResult(state, taskId),
       cancel,
-      listByParent: (parentSessionId) =>
-        [...tasks.values()].filter((t) => t.parentSessionId === parentSessionId),
+      listByParent: (parentSessionId) => listBackgroundTasksByParent(state, parentSessionId),
       cleanup,
       stats: () => ({
-        active: activeCount,
-        pending: pendingQueue.length,
-        total: tasks.size,
+        active: queue.activeCount(),
+        pending: queue.pendingSize(),
+        total: state.tasks.size,
       }),
       dispose: () => {
         clearInterval(cleanupInterval);


### PR DESCRIPTION
## Summary
- Split BackgroundManager into focused internal modules for events, queue accounting, runner lifecycle, state access, and types.
- Kept the public BackgroundManager export and API unchanged while reducing the facade below the cleanup LOC target.
- Removed an unused split-era type caught by knip.

## Verification
- bunx biome check packages/openomni/src/subagent/background-manager.ts packages/openomni/src/subagent/background-manager-events.ts packages/openomni/src/subagent/background-manager-queue.ts packages/openomni/src/subagent/background-manager-runner.ts packages/openomni/src/subagent/background-manager-state.ts packages/openomni/src/subagent/background-manager-types.ts --write
- LSP diagnostics: no diagnostics for all changed files
- bun run --cwd packages/openomni check-types
- bun test packages/openomni/test/subagent/background-manager.test.ts packages/openomni/test/subagent/background-queue.test.ts packages/openomni/test/subagent/background-integration.test.ts packages/openomni/src/subagent/background-manager.test.ts packages/openomni/test/subagent/descriptor.test.ts apps/server/test/execution/worker-runner.test.ts
- bun run check-types
- bun run build
- bun run lint:guards
- bun run lint:side-effects
- bunx knip --no-config-hints
- git diff --check
- bun run test

## Review
- codex-ultrawork-reviewer: PASS; verified BackgroundManager API, queue accounting, cancellation timing, event payloads, persistence fallback, auth/runtime config propagation, sweep lifecycle, and export boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `BackgroundManager` into small modules for events, queueing, runner lifecycle, state, and types. The public `BackgroundManager` API stays the same, with a thinner facade and clearer internals.

- **Refactors**
  - Extracted `background-manager-{events,queue,runner,state,types}` and kept `BackgroundManager` as the public entry.
  - Centralized config via `resolveBackgroundManagerConfig` and enforced concurrency with `createBackgroundQueue`.
  - Moved run lifecycle, cancellation, and event publishing to `createBackgroundRunner` with `publishBackgroundTask*` helpers.
  - Kept persistence and TTL cleanup via `BackgroundStore` and `createBackgroundManagerState`; removed an unused type flagged by `knip`.

<sup>Written for commit 4d419a6255bf922abf0f63960c4b601169a0918b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

