### PR TITLE
refactor(server): split bootstrap resident wait bridge

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -2,32 +2,21 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Adapter } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
-import {
-  initialize,
-  Bus,
-  BusPersistence,
-  PendingAskStore,
-  SurfaceKey,
-  TraceContext,
-  WorkerRun,
-} from "@openomni/session";
+import { initialize, Bus, BusPersistence } from "@openomni/session";
 import {
   AgentToolProvider,
   CronAdapter,
   CronJobRunner,
-  DispatchRuntime,
   IngressEngine,
-  IngressEventProjector,
-  IngressHandlers,
   ResidentRuntime,
   SystemToolProvider,
   createDefaultDispatchRuntime,
-  type DispatchHandler,
+  type DispatchRuntime,
 } from "@openomni/openomni";
 import { loadConfig } from "../config";
 import { McpConfigLoader } from "../context/index";
 import { createMessageHandler } from "../handler/conversation";
-import { buildAgentDef, buildResidentAgentDef } from "../ingress/bridge";
+import { buildAgentDef } from "../ingress/bridge";
 import { buildToolDispatcher, createExecutionCoordinator } from "../execution/coordinator";
 import { createRouter } from "../server/routes";
 import { McpToolProvider } from "../tool/mcp";
@@ -37,6 +26,7 @@ import { createServerDispatchOwners } from "./dispatch-owners";
 import { connectMcpServers } from "./mcp";
 import { resolveModel } from "./providers";
 import { runRecovery } from "./recovery";
+import { createResidentInboundWaitHandler } from "./resident-inbound-wait";
 import { installShutdownHandlers } from "./shutdown";
 import { registerAgent } from "../agents";
 import { createResidentProfile } from "../profile/resident";
@@ -115,164 +105,15 @@ export async function main(): Promise<void> {
     workerScript,
     bootstrap,
     toolDispatcher,
-    askResident: async ({ workerId, sessionId, runId, payload, workspaceRoot, signal }) => {
-      const requestId = crypto.randomUUID();
-      const resolvedWorkspace = workspaceRoot ?? config.workspace?.root ?? process.cwd();
-      if (signal?.aborted) {
-        return { requestId, accepted: false, error: "worker.inbound_wait aborted" };
-      }
-      if (!model) {
-        return {
-          requestId,
-          accepted: false,
-          error: "worker.inbound_wait requires a configured model",
-        };
-      }
-      const run = runId ? await WorkerRun.get(sessionId, runId) : undefined;
-      const mainSessionId = run?.parentSessionId;
-      if (!mainSessionId) {
-        return {
-          requestId,
-          accepted: false,
-          error: `worker.inbound_wait requires a worker run with parent Resident session: ${runId ?? "unknown"}`,
-        };
-      }
-
-      const current = runId ? await WorkerRun.get(sessionId, runId) : undefined;
-      if (runId && current && current.status === "starting") {
-        await WorkerRun.updateStatus(sessionId, runId, "running");
-      }
-      const running = runId ? await WorkerRun.get(sessionId, runId) : undefined;
-      if (runId && running?.status === "running") {
-        await WorkerRun.updateStatus(sessionId, runId, "waiting_input");
-      }
-
-      try {
-        const residentPayload = `Worker ${workerId}${runId ? ` run ${runId}` : ""} asks Resident:\n\n${payload}`;
-        const residentHandler: DispatchHandler = async (command, context) => {
-          const surfaceKeys = SurfaceKey.listBySession(mainSessionId);
-          const surfaceKey = surfaceKeys.length === 1 ? surfaceKeys[0] : undefined;
-          const surface = surfaceKey ? SurfaceKey.parse(surfaceKey) : undefined;
-          const tokenHash =
-            typeof command.correlation === "string" ? command.correlation : undefined;
-          PendingAskStore.create({
-            id: command.dispatchId,
-            originSessionId: sessionId,
-            ...(runId ? { originRunId: runId } : {}),
-            originActorKind: "worker",
-            targetKind: "resident",
-            ...(surface ? { endpointId: surface.namespace || surface.surface } : {}),
-            ...(surface?.id ? { channelId: surface.id } : {}),
-            correlation: {
-              ...(tokenHash ? { tokenHash } : {}),
-              ...(surfaceKey ? { externalConversationId: surfaceKey } : {}),
-              ...(surface?.threadId ? { threadId: surface.threadId } : {}),
-            },
-          });
-          try {
-            const trace = command.traceId
-              ? TraceContext.child({ traceId: command.traceId }, { sessionId: mainSessionId })
-              : TraceContext.create({ sessionId: mainSessionId });
-            const residentEvent = {
-              id: command.dispatchId,
-              surface: "dispatch",
-              workspace: resolvedWorkspace,
-              mode: "internal" as const,
-              agentName: "resident",
-              payload:
-                typeof command.payload === "string"
-                  ? command.payload
-                  : JSON.stringify(command.payload),
-              runtime: {
-                durableSessionId: mainSessionId,
-                lifecycle: "active" as const,
-                ...(context?.signal ? { signal: context.signal } : {}),
-              },
-              target: { kind: "resident" as const, sessionId: mainSessionId },
-              meta: {
-                actor: {
-                  role: "worker",
-                  trusted: true,
-                  workerId,
-                  sessionId,
-                  runId,
-                },
-                target: { kind: "resident" as const, sessionId: mainSessionId },
-                agentName: "resident",
-              },
-              agent: buildResidentAgentDef("resident", {
-                systemProvider,
-                agentProvider: requireAgentProvider(),
-                mcpProvider,
-                customProvider,
-                defaultModel: { provider: model.providerID, id: model.id },
-                providerOptions: config.model?.providerOptions,
-                workspaceRoot: resolvedWorkspace,
-              }),
-            };
-            IngressEventProjector.project(
-              residentEvent,
-              mainSessionId,
-              { providerID: model.providerID, modelID: model.id },
-              trace,
-            );
-            const result = await IngressHandlers.handleResident({
-              sessionId: mainSessionId,
-              event: residentEvent,
-              residentRuntime,
-              traceContext: trace,
-            });
-            PendingAskStore.answer(command.dispatchId);
-            return { output: result.result.output };
-          } catch (error) {
-            PendingAskStore.expire(command.dispatchId);
-            throw error;
-          }
-        };
-
-        const dispatchRuntime = new DispatchRuntime();
-        dispatchRuntime.register("resident.ask", residentHandler);
-        const dispatchResult = await dispatchRuntime.submit(
-          {
-            action: "resident.ask",
-            target: { kind: "resident", sessionId: mainSessionId },
-            payload: residentPayload,
-            wait: true,
-            correlation: requestId,
-          },
-          {
-            sessionId,
-            ...(runId ? { runId } : {}),
-            actorKind: "worker",
-            actorId: `${sessionId}:${runId ?? workerId}`,
-            agentName: "worker",
-            trustTier: "assigned_worker",
-            workspaceRoot: resolvedWorkspace,
-            ...(signal ? { signal } : {}),
-          },
-        );
-        if (dispatchResult.status !== "completed") {
-          return {
-            requestId,
-            accepted: false,
-            error:
-              dispatchResult.error ??
-              dispatchResult.reason ??
-              `worker.inbound_wait dispatch ${dispatchResult.status}`,
-          };
-        }
-        return {
-          requestId,
-          accepted: true,
-          output: typeof dispatchResult.output === "string" ? dispatchResult.output : "",
-        };
-      } finally {
-        const after = runId ? await WorkerRun.get(sessionId, runId) : undefined;
-        if (runId && after?.status === "waiting_input") {
-          await WorkerRun.updateStatus(sessionId, runId, "running");
-        }
-      }
-    },
+    askResident: createResidentInboundWaitHandler({
+      serverConfig: config,
+      model,
+      residentRuntime,
+      systemProvider,
+      requireAgentProvider,
+      mcpProvider,
+      customProvider,
+    }),
     maxWorkers: 10,
     workerIdleTimeoutMs: Number(process.env.OPENOMNI_WORKER_IDLE_TIMEOUT_MS ?? 30_000),
   });

--- a/apps/server/src/bootstrap/resident-inbound-wait.ts
+++ b/apps/server/src/bootstrap/resident-inbound-wait.ts
@@ -1,0 +1,218 @@
+import type { InboundWaitParams, InboundWaitResult } from "@openomni/coordinator";
+import {
+  DispatchRuntime,
+  IngressEventProjector,
+  IngressHandlers,
+  type AgentToolProvider,
+  type DispatchHandler,
+  type ResidentRuntime,
+  type SystemToolProvider,
+} from "@openomni/openomni";
+import { PendingAskStore, SurfaceKey, TraceContext, WorkerRun } from "@openomni/session";
+import type { ServerConfig } from "../config";
+import { buildResidentAgentDef } from "../ingress/bridge";
+import type { CustomToolProvider } from "../tool/custom";
+import type { McpToolProvider } from "../tool/mcp";
+
+type ResidentInboundWaitModel = {
+  readonly providerID: string;
+  readonly id: string;
+};
+
+export type ResidentInboundWaitConfig = {
+  readonly serverConfig: ServerConfig;
+  readonly model?: ResidentInboundWaitModel;
+  readonly residentRuntime: ResidentRuntime;
+  readonly systemProvider: SystemToolProvider;
+  readonly requireAgentProvider: () => AgentToolProvider;
+  readonly mcpProvider: McpToolProvider;
+  readonly customProvider: CustomToolProvider;
+};
+
+export function createResidentInboundWaitHandler(
+  config: ResidentInboundWaitConfig,
+): (params: InboundWaitParams) => Promise<InboundWaitResult> {
+  return async ({ workerId, sessionId, runId, payload, workspaceRoot, signal }) => {
+    const requestId = crypto.randomUUID();
+    const resolvedWorkspace = workspaceRoot ?? config.serverConfig.workspace?.root ?? process.cwd();
+    if (signal?.aborted) {
+      return { requestId, accepted: false, error: "worker.inbound_wait aborted" };
+    }
+    const model = config.model;
+    if (!model) {
+      return {
+        requestId,
+        accepted: false,
+        error: "worker.inbound_wait requires a configured model",
+      };
+    }
+
+    const run = runId ? await WorkerRun.get(sessionId, runId) : undefined;
+    const mainSessionId = run?.parentSessionId;
+    if (!mainSessionId) {
+      return {
+        requestId,
+        accepted: false,
+        error: `worker.inbound_wait requires a worker run with parent Resident session: ${runId ?? "unknown"}`,
+      };
+    }
+
+    const current = runId ? await WorkerRun.get(sessionId, runId) : undefined;
+    if (runId && current && current.status === "starting") {
+      await WorkerRun.updateStatus(sessionId, runId, "running");
+    }
+    const running = runId ? await WorkerRun.get(sessionId, runId) : undefined;
+    if (runId && running?.status === "running") {
+      await WorkerRun.updateStatus(sessionId, runId, "waiting_input");
+    }
+
+    try {
+      const residentPayload = `Worker ${workerId}${runId ? ` run ${runId}` : ""} asks Resident:\n\n${payload}`;
+      const residentHandler = createResidentAskHandler({
+        ...config,
+        model,
+        sessionId,
+        runId,
+        workerId,
+        mainSessionId,
+        resolvedWorkspace,
+      });
+      const dispatchRuntime = new DispatchRuntime();
+      dispatchRuntime.register("resident.ask", residentHandler);
+      const dispatchResult = await dispatchRuntime.submit(
+        {
+          action: "resident.ask",
+          target: { kind: "resident", sessionId: mainSessionId },
+          payload: residentPayload,
+          wait: true,
+          correlation: requestId,
+        },
+        {
+          sessionId,
+          ...(runId ? { runId } : {}),
+          actorKind: "worker",
+          actorId: `${sessionId}:${runId ?? workerId}`,
+          agentName: "worker",
+          trustTier: "assigned_worker",
+          workspaceRoot: resolvedWorkspace,
+          ...(signal ? { signal } : {}),
+        },
+      );
+      if (dispatchResult.status !== "completed") {
+        return {
+          requestId,
+          accepted: false,
+          error:
+            dispatchResult.error ??
+            dispatchResult.reason ??
+            `worker.inbound_wait dispatch ${dispatchResult.status}`,
+        };
+      }
+      return {
+        requestId,
+        accepted: true,
+        output: typeof dispatchResult.output === "string" ? dispatchResult.output : "",
+      };
+    } finally {
+      const after = runId ? await WorkerRun.get(sessionId, runId) : undefined;
+      if (runId && after?.status === "waiting_input") {
+        await WorkerRun.updateStatus(sessionId, runId, "running");
+      }
+    }
+  };
+}
+
+type ResidentAskHandlerConfig = Omit<ResidentInboundWaitConfig, "model"> & {
+  readonly model: ResidentInboundWaitModel;
+  readonly sessionId: string;
+  readonly runId?: string;
+  readonly workerId: string;
+  readonly mainSessionId: string;
+  readonly resolvedWorkspace: string;
+};
+
+function createResidentAskHandler(config: ResidentAskHandlerConfig): DispatchHandler {
+  return async (command, context) => {
+    const surfaceKeys = SurfaceKey.listBySession(config.mainSessionId);
+    const surfaceKey = surfaceKeys.length === 1 ? surfaceKeys[0] : undefined;
+    const surface = surfaceKey ? SurfaceKey.parse(surfaceKey) : undefined;
+    const tokenHash = typeof command.correlation === "string" ? command.correlation : undefined;
+    PendingAskStore.create({
+      id: command.dispatchId,
+      originSessionId: config.sessionId,
+      ...(config.runId ? { originRunId: config.runId } : {}),
+      originActorKind: "worker",
+      targetKind: "resident",
+      ...(surface ? { endpointId: surface.namespace || surface.surface } : {}),
+      ...(surface?.id ? { channelId: surface.id } : {}),
+      correlation: {
+        ...(tokenHash ? { tokenHash } : {}),
+        ...(surfaceKey ? { externalConversationId: surfaceKey } : {}),
+        ...(surface?.threadId ? { threadId: surface.threadId } : {}),
+      },
+    });
+    try {
+      const trace = command.traceId
+        ? TraceContext.child({ traceId: command.traceId }, { sessionId: config.mainSessionId })
+        : TraceContext.create({ sessionId: config.mainSessionId });
+      const residentEvent = {
+        id: command.dispatchId,
+        surface: "dispatch",
+        workspace: config.resolvedWorkspace,
+        mode: "internal" as const,
+        agentName: "resident",
+        payload:
+          typeof command.payload === "string" ? command.payload : JSON.stringify(command.payload),
+        runtime: {
+          durableSessionId: config.mainSessionId,
+          lifecycle: "active" as const,
+          ...(context?.signal ? { signal: context.signal } : {}),
+        },
+        target: { kind: "resident" as const, sessionId: config.mainSessionId },
+        meta: {
+          actor: {
+            role: "worker",
+            trusted: true,
+            workerId: config.workerId,
+            sessionId: config.sessionId,
+            runId: config.runId,
+          },
+          target: { kind: "resident" as const, sessionId: config.mainSessionId },
+          agentName: "resident",
+        },
+        agent: buildResidentAgentDef("resident", {
+          systemProvider: config.systemProvider,
+          agentProvider: config.requireAgentProvider(),
+          mcpProvider: config.mcpProvider,
+          customProvider: config.customProvider,
+          defaultModel: {
+            provider: config.model.providerID,
+            id: config.model.id,
+          },
+          providerOptions: config.serverConfig.model?.providerOptions,
+          workspaceRoot: config.resolvedWorkspace,
+        }),
+      };
+      IngressEventProjector.project(
+        residentEvent,
+        config.mainSessionId,
+        {
+          providerID: config.model.providerID,
+          modelID: config.model.id,
+        },
+        trace,
+      );
+      const result = await IngressHandlers.handleResident({
+        sessionId: config.mainSessionId,
+        event: residentEvent,
+        residentRuntime: config.residentRuntime,
+        traceContext: trace,
+      });
+      PendingAskStore.answer(command.dispatchId);
+      return { output: result.result.output };
+    } catch (error) {
+      PendingAskStore.expire(command.dispatchId);
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Extract worker-to-Resident `worker.inbound_wait` bridge from `bootstrap/index.ts` into `bootstrap/resident-inbound-wait.ts`.
- Keep server bootstrap public entrypoint and coordinator-mode startup wiring unchanged.
- Reduce `apps/server/src/bootstrap/index.ts` below the cleanup LOC target while keeping the new internal module below target too.

## Verification
- bun run --cwd packages/protocol build
- bunx biome check apps/server/src/bootstrap/index.ts apps/server/src/bootstrap/resident-inbound-wait.ts --write
- LSP diagnostics: no diagnostics for changed files
- bun run --cwd apps/server check-types
- bun test apps/server/test/execution/worker-runner.test.ts apps/server/test/bootstrap.test.ts apps/server/src/bootstrap
- bun run check-types
- bun run build
- bun run lint:guards
- bun run lint:side-effects
- bunx knip --no-config-hints
- git diff --check
- bun run test

## Review
- codex-ultrawork-reviewer initially blocked because the new file was untracked in diff evidence. After staging both files, re-review passed unconditionally and verified inbound wait behavior, WorkerRun transitions, PendingAskStore lifecycle, Resident projection, export boundaries, and LOC targets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the worker-to-Resident inbound wait bridge out of server bootstrap into a dedicated module. No functional changes; public bootstrap and coordinator-mode wiring remain the same, with a smaller bootstrap file.

- **Refactors**
  - Moved `askResident` into `bootstrap/resident-inbound-wait.ts` as `createResidentInboundWaitHandler`.
  - `bootstrap/index.ts` now delegates to the new handler and drops unused imports.
  - Preserves behavior: `WorkerRun` transitions, `PendingAskStore` lifecycle, Resident event projection/dispatch, and model/provider resolution; reduces `index.ts` by ~170 LOC and keeps the new module within targets.

<sup>Written for commit 1cb8d6a6ffb12ef8841ff521eace5d69a9c2e32a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

