### PR TITLE
refactor(openomni): split subagent spawn policy

### DIFF
--- a/packages/openomni/src/subagent/middleware/subagent-spawn-decisions.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-decisions.ts
@@ -1,0 +1,84 @@
+import type { PolicyRegistration } from "@openomni/agent";
+import { Policy, PolicyDecision, type RuntimeResource } from "@openomni/protocol";
+import * as Definitions from "./subagent-spawn-definitions.js";
+import type { PreSpawnOperation } from "./subagent-spawn-types.js";
+
+export const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+export const defaultCancelHardTimeoutMs = 10_000;
+
+export function createSubagentOperationDescriptor(
+  operation: PreSpawnOperation,
+): RuntimeResource.Descriptor {
+  return {
+    id: `worker:subagent:${operation}`,
+    kind: "worker",
+    source: { type: "agent" },
+    labels: ["source.agent", "delegation.subagent", `operation.${operation}`],
+    capabilities: [`delegation.${operation}`],
+    effects: operation === "wait" ? [] : ["session.message"],
+  };
+}
+
+export function allowDecision(policyId: string, reason: string): Policy.PolicyDecision {
+  return PolicyDecision.allow({ policyId, reasonCodes: [reason] });
+}
+
+export function evaluateBooleanPolicy(input: {
+  readonly action: string;
+  readonly resource: string;
+  readonly field: string;
+  readonly allowed: boolean;
+  readonly allowReason: string;
+  readonly denyReason: string;
+  readonly metadata?: Record<string, unknown>;
+}): Policy.PolicyDecision {
+  return PolicyDecision.fromEvaluation(
+    Policy.evaluate(
+      {
+        action: input.action,
+        inputRules: [
+          {
+            toolPattern: input.resource,
+            field: input.field,
+            pattern: "^true$",
+            action: "allow",
+            reason: input.allowReason,
+            priority: 2,
+          },
+          {
+            toolPattern: input.resource,
+            field: input.field,
+            pattern: "^false$",
+            action: "deny",
+            reason: input.denyReason,
+            priority: 1,
+          },
+        ],
+      },
+      {
+        action: input.action,
+        resource: input.resource,
+        input: { [input.field]: String(input.allowed) },
+        metadata: input.metadata,
+      },
+    ),
+    { denyEffect: { type: "run.abort", reason: input.denyReason } },
+  );
+}
+
+export function createDefaultDenylist(): PolicyRegistration {
+  return {
+    ...Definitions.DefaultDenylist,
+    failPolicy: "fail-closed",
+    fn: (ctx) => {
+      const toolName = ctx.toolName ?? "";
+      return PolicyDecision.fromEvaluation(
+        Policy.evaluate(
+          { action: "tool.call", denylist: ["subagent"] },
+          { action: "tool.call", resource: toolName },
+        ),
+        { denyEffect: { type: "run.abort", reason: "subagent tool denied by default" } },
+      );
+    },
+  };
+}

--- a/packages/openomni/src/subagent/middleware/subagent-spawn-definitions.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-definitions.ts
@@ -1,0 +1,36 @@
+import type { Policy } from "@openomni/protocol";
+
+export const DefaultDenylist = {
+  name: "subagent:default-denylist",
+  timing: "invoke.prepare",
+  priority: 0,
+  failPolicy: "fail-closed",
+} as const satisfies Policy.Definition;
+
+export const SessionExistence = {
+  name: "subagent:session-existence",
+  timing: "invoke.prepare",
+  priority: 0,
+  failPolicy: "fail-closed",
+} as const satisfies Policy.Definition;
+
+export const ActiveRun = {
+  name: "subagent:active-run",
+  timing: "invoke.prepare",
+  priority: 10,
+  failPolicy: "fail-closed",
+} as const satisfies Policy.Definition;
+
+export const CancelTimeout = {
+  name: "subagent:cancel-timeout",
+  timing: "invoke.prepare",
+  priority: 20,
+  failPolicy: "fail-closed",
+} as const satisfies Policy.Definition;
+
+export const WaitTimeout = {
+  name: "subagent:wait-timeout",
+  timing: "invoke.prepare",
+  priority: 30,
+  failPolicy: "fail-closed",
+} as const satisfies Policy.Definition;

--- a/packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts
@@ -1,287 +1,31 @@
 import { PolicyEngine, type PolicyRegistration } from "@openomni/agent";
+import { PolicyDecision } from "@openomni/protocol";
+import * as Definitions from "./subagent-spawn-definitions.js";
 import {
-  Policy,
-  PolicyDecision,
-  type RuntimeResource,
-  type TraceContext,
-} from "@openomni/protocol";
-import { Session, WorkerRun, type WorkerRunRecord } from "@openomni/session";
-
-const emptyUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-const defaultCancelHardTimeoutMs = 10_000;
-
-type SessionRecord = NonNullable<ReturnType<typeof Session.get>>;
-
-type PreSpawnOperation = "send" | "resume" | "cancel" | "wait";
-
-function createSubagentOperationDescriptor(
-  operation: PreSpawnOperation,
-): RuntimeResource.Descriptor {
-  return {
-    id: `worker:subagent:${operation}`,
-    kind: "worker",
-    source: { type: "agent" },
-    labels: ["source.agent", "delegation.subagent", `operation.${operation}`],
-    capabilities: [`delegation.${operation}`],
-    effects: operation === "wait" ? [] : ["session.message"],
-  };
-}
-
-interface PreSpawnState {
-  readonly operation: PreSpawnOperation;
-  readonly sessionId: string;
-  readonly hardTimeoutMs?: number;
-  readonly timeoutMs?: number;
-  session?: SessionRecord;
-  runs?: WorkerRunRecord[];
-  latestRun?: WorkerRunRecord;
-  cancelHardTimeoutMs?: number;
-  waitTimeoutMs?: number;
-}
-
-interface PreSpawnContext {
-  readonly operation: PreSpawnOperation;
-  readonly sessionId: string;
-  readonly hardTimeoutMs?: number;
-  readonly timeoutMs?: number;
-  readonly traceContext?: TraceContext.Type;
-  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
-}
-
-interface PreSpawnResult {
-  readonly verdict: Policy.PolicyDecision;
-  readonly session?: SessionRecord;
-  readonly runs?: WorkerRunRecord[];
-  readonly latestRun?: WorkerRunRecord;
-  readonly cancelHardTimeoutMs: number;
-  readonly waitTimeoutMs?: number;
-}
-
-interface WaitTimeoutHandle {
-  readonly cancel: () => void;
-}
-
-interface ChildRuntimeMiddlewareInput {
-  readonly middleware?: PolicyRegistration[];
-  readonly hasExplicitRuntimePolicy: boolean;
-}
-
-function allowDecision(policyId: string, reason: string): Policy.PolicyDecision {
-  return PolicyDecision.allow({ policyId, reasonCodes: [reason] });
-}
-
-function evaluateBooleanPolicy(input: {
-  readonly action: string;
-  readonly resource: string;
-  readonly field: string;
-  readonly allowed: boolean;
-  readonly allowReason: string;
-  readonly denyReason: string;
-  readonly metadata?: Record<string, unknown>;
-}): Policy.PolicyDecision {
-  return PolicyDecision.fromEvaluation(
-    Policy.evaluate(
-      {
-        action: input.action,
-        inputRules: [
-          {
-            toolPattern: input.resource,
-            field: input.field,
-            pattern: "^true$",
-            action: "allow",
-            reason: input.allowReason,
-            priority: 2,
-          },
-          {
-            toolPattern: input.resource,
-            field: input.field,
-            pattern: "^false$",
-            action: "deny",
-            reason: input.denyReason,
-            priority: 1,
-          },
-        ],
-      },
-      {
-        action: input.action,
-        resource: input.resource,
-        input: { [input.field]: String(input.allowed) },
-        metadata: input.metadata,
-      },
-    ),
-    { denyEffect: { type: "run.abort", reason: input.denyReason } },
-  );
-}
-
-function createSessionExistence(state: PreSpawnState): PolicyRegistration {
-  return {
-    ...SubagentSpawnPolicyMiddleware.SessionExistence,
-    failPolicy: "fail-closed",
-    fn: () => {
-      if (state.operation === "wait") {
-        return evaluateBooleanPolicy({
-          action: "subagent.wait",
-          resource: state.sessionId,
-          field: "sessionCheckRequired",
-          allowed: true,
-          allowReason: "wait resolves worker run directly",
-          denyReason: "wait session check blocked",
-        });
-      }
-
-      const session = Session.get(state.sessionId);
-      if (!session) {
-        return evaluateBooleanPolicy({
-          action: `subagent.${state.operation}`,
-          resource: state.sessionId,
-          field: "sessionExists",
-          allowed: false,
-          allowReason: "session exists",
-          denyReason: `Session not found: ${state.sessionId}`,
-        });
-      }
-
-      state.session = session;
-      return evaluateBooleanPolicy({
-        action: `subagent.${state.operation}`,
-        resource: state.sessionId,
-        field: "sessionExists",
-        allowed: true,
-        allowReason: "session exists",
-        denyReason: `Session not found: ${state.sessionId}`,
-      });
-    },
-  };
-}
-
-function createActiveRunGuard(state: PreSpawnState): PolicyRegistration {
-  return {
-    ...SubagentSpawnPolicyMiddleware.ActiveRun,
-    failPolicy: "fail-closed",
-    async fn() {
-      if (state.operation !== "resume") {
-        return evaluateBooleanPolicy({
-          action: `subagent.${state.operation}`,
-          resource: state.sessionId,
-          field: "activeRunAllowed",
-          allowed: true,
-          allowReason: "active-run check not required",
-          denyReason: "Session already has an active run",
-        });
-      }
-
-      const runs = await WorkerRun.listBySession(state.sessionId);
-      const latestRun = runs.length > 0 ? runs[runs.length - 1] : undefined;
-      state.runs = runs;
-      state.latestRun = latestRun;
-
-      if (latestRun?.status === "running" || latestRun?.status === "starting") {
-        return evaluateBooleanPolicy({
-          action: "subagent.resume",
-          resource: state.sessionId,
-          field: "activeRunAllowed",
-          allowed: false,
-          allowReason: "session has no active latest run",
-          denyReason: "Session already has an active run",
-        });
-      }
-
-      return evaluateBooleanPolicy({
-        action: "subagent.resume",
-        resource: state.sessionId,
-        field: "activeRunAllowed",
-        allowed: true,
-        allowReason: "session has no active latest run",
-        denyReason: "Session already has an active run",
-      });
-    },
-  };
-}
-
-function createCancelTimeout(state: PreSpawnState): PolicyRegistration {
-  return {
-    ...SubagentSpawnPolicyMiddleware.CancelTimeout,
-    failPolicy: "fail-closed",
-    fn: () => {
-      if (state.operation !== "cancel") {
-        return allowDecision("subagent.cancel-timeout", "cancel timeout not required");
-      }
-
-      state.cancelHardTimeoutMs = state.hardTimeoutMs ?? defaultCancelHardTimeoutMs;
-      return allowDecision("subagent.cancel-timeout", "cancel timeout resolved");
-    },
-  };
-}
-
-function createWaitTimeout(state: PreSpawnState): PolicyRegistration {
-  return {
-    ...SubagentSpawnPolicyMiddleware.WaitTimeout,
-    failPolicy: "fail-closed",
-    fn: () => {
-      if (state.operation !== "wait") {
-        return allowDecision("subagent.wait-timeout", "wait timeout not required");
-      }
-
-      state.waitTimeoutMs = state.timeoutMs;
-      return allowDecision(
-        "subagent.wait-timeout",
-        state.timeoutMs === undefined ? "wait timeout disabled" : "wait timeout configured",
-      );
-    },
-  };
-}
+  createDefaultDenylist as createDefaultDenylistRegistration,
+  createSubagentOperationDescriptor,
+  defaultCancelHardTimeoutMs,
+  emptyUsage,
+} from "./subagent-spawn-decisions.js";
+import { createSubagentSpawnRegistrations } from "./subagent-spawn-registrations.js";
+import type {
+  ChildRuntimeMiddlewareInput,
+  PreSpawnContext,
+  PreSpawnPolicyContext,
+  PreSpawnResult,
+  PreSpawnState,
+  WaitTimeoutHandle,
+} from "./subagent-spawn-types.js";
 
 export namespace SubagentSpawnPolicyMiddleware {
-  export const DefaultDenylist = {
-    name: "subagent:default-denylist",
-    timing: "invoke.prepare",
-    priority: 0,
-    failPolicy: "fail-closed",
-  } as const satisfies Policy.Definition;
-
-  export const SessionExistence = {
-    name: "subagent:session-existence",
-    timing: "invoke.prepare",
-    priority: 0,
-    failPolicy: "fail-closed",
-  } as const satisfies Policy.Definition;
-
-  export const ActiveRun = {
-    name: "subagent:active-run",
-    timing: "invoke.prepare",
-    priority: 10,
-    failPolicy: "fail-closed",
-  } as const satisfies Policy.Definition;
-
-  export const CancelTimeout = {
-    name: "subagent:cancel-timeout",
-    timing: "invoke.prepare",
-    priority: 20,
-    failPolicy: "fail-closed",
-  } as const satisfies Policy.Definition;
-
-  export const WaitTimeout = {
-    name: "subagent:wait-timeout",
-    timing: "invoke.prepare",
-    priority: 30,
-    failPolicy: "fail-closed",
-  } as const satisfies Policy.Definition;
+  export const DefaultDenylist = Definitions.DefaultDenylist;
+  export const SessionExistence = Definitions.SessionExistence;
+  export const ActiveRun = Definitions.ActiveRun;
+  export const CancelTimeout = Definitions.CancelTimeout;
+  export const WaitTimeout = Definitions.WaitTimeout;
 
   export function createDefaultDenylist(): PolicyRegistration {
-    return {
-      ...DefaultDenylist,
-      failPolicy: "fail-closed",
-      fn: (ctx) => {
-        const toolName = ctx.toolName ?? "";
-        return PolicyDecision.fromEvaluation(
-          Policy.evaluate(
-            { action: "tool.call", denylist: ["subagent"] },
-            { action: "tool.call", resource: toolName },
-          ),
-          { denyEffect: { type: "run.abort", reason: "subagent tool denied by default" } },
-        );
-      },
-    };
+    return createDefaultDenylistRegistration();
   }
 
   export function buildChildRuntimeMiddleware(
@@ -300,12 +44,7 @@ export namespace SubagentSpawnPolicyMiddleware {
   }
 
   export function registrations(state: PreSpawnState): PolicyRegistration[] {
-    return [
-      createSessionExistence(state),
-      createActiveRunGuard(state),
-      createCancelTimeout(state),
-      createWaitTimeout(state),
-    ];
+    return createSubagentSpawnRegistrations(state);
   }
 
   export async function evaluatePreSpawn(ctx: PreSpawnContext): Promise<PreSpawnResult> {
@@ -325,7 +64,7 @@ export namespace SubagentSpawnPolicyMiddleware {
       engine.register(registration);
     }
 
-    const verdict = await engine.dispatch("invoke.prepare", {
+    const policyContext: PreSpawnPolicyContext = {
       steps: [],
       usage: emptyUsage,
       turnCount: 0,
@@ -341,7 +80,8 @@ export namespace SubagentSpawnPolicyMiddleware {
       },
       traceContext: ctx.traceContext,
       resourceDescriptor: createSubagentOperationDescriptor(ctx.operation),
-    });
+    };
+    const verdict = await engine.dispatch("invoke.prepare", policyContext);
 
     return {
       verdict,

--- a/packages/openomni/src/subagent/middleware/subagent-spawn-registrations.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-registrations.ts
@@ -1,0 +1,136 @@
+import type { PolicyRegistration } from "@openomni/agent";
+import { Session, WorkerRun } from "@openomni/session";
+import {
+  allowDecision,
+  defaultCancelHardTimeoutMs,
+  evaluateBooleanPolicy,
+} from "./subagent-spawn-decisions.js";
+import * as Definitions from "./subagent-spawn-definitions.js";
+import type { PreSpawnState } from "./subagent-spawn-types.js";
+
+function createSessionExistence(state: PreSpawnState): PolicyRegistration {
+  return {
+    ...Definitions.SessionExistence,
+    failPolicy: "fail-closed",
+    fn: () => {
+      if (state.operation === "wait") {
+        return evaluateBooleanPolicy({
+          action: "subagent.wait",
+          resource: state.sessionId,
+          field: "sessionCheckRequired",
+          allowed: true,
+          allowReason: "wait resolves worker run directly",
+          denyReason: "wait session check blocked",
+        });
+      }
+
+      const session = Session.get(state.sessionId);
+      if (!session) {
+        return evaluateBooleanPolicy({
+          action: `subagent.${state.operation}`,
+          resource: state.sessionId,
+          field: "sessionExists",
+          allowed: false,
+          allowReason: "session exists",
+          denyReason: `Session not found: ${state.sessionId}`,
+        });
+      }
+
+      state.session = session;
+      return evaluateBooleanPolicy({
+        action: `subagent.${state.operation}`,
+        resource: state.sessionId,
+        field: "sessionExists",
+        allowed: true,
+        allowReason: "session exists",
+        denyReason: `Session not found: ${state.sessionId}`,
+      });
+    },
+  };
+}
+
+function createActiveRunGuard(state: PreSpawnState): PolicyRegistration {
+  return {
+    ...Definitions.ActiveRun,
+    failPolicy: "fail-closed",
+    async fn() {
+      if (state.operation !== "resume") {
+        return evaluateBooleanPolicy({
+          action: `subagent.${state.operation}`,
+          resource: state.sessionId,
+          field: "activeRunAllowed",
+          allowed: true,
+          allowReason: "active-run check not required",
+          denyReason: "Session already has an active run",
+        });
+      }
+
+      const runs = await WorkerRun.listBySession(state.sessionId);
+      const latestRun = runs.length > 0 ? runs[runs.length - 1] : undefined;
+      state.runs = runs;
+      state.latestRun = latestRun;
+
+      if (latestRun?.status === "running" || latestRun?.status === "starting") {
+        return evaluateBooleanPolicy({
+          action: "subagent.resume",
+          resource: state.sessionId,
+          field: "activeRunAllowed",
+          allowed: false,
+          allowReason: "session has no active latest run",
+          denyReason: "Session already has an active run",
+        });
+      }
+
+      return evaluateBooleanPolicy({
+        action: "subagent.resume",
+        resource: state.sessionId,
+        field: "activeRunAllowed",
+        allowed: true,
+        allowReason: "session has no active latest run",
+        denyReason: "Session already has an active run",
+      });
+    },
+  };
+}
+
+function createCancelTimeout(state: PreSpawnState): PolicyRegistration {
+  return {
+    ...Definitions.CancelTimeout,
+    failPolicy: "fail-closed",
+    fn: () => {
+      if (state.operation !== "cancel") {
+        return allowDecision("subagent.cancel-timeout", "cancel timeout not required");
+      }
+
+      state.cancelHardTimeoutMs = state.hardTimeoutMs ?? defaultCancelHardTimeoutMs;
+      return allowDecision("subagent.cancel-timeout", "cancel timeout resolved");
+    },
+  };
+}
+
+function createWaitTimeout(state: PreSpawnState): PolicyRegistration {
+  return {
+    ...Definitions.WaitTimeout,
+    failPolicy: "fail-closed",
+    fn: () => {
+      if (state.operation !== "wait") {
+        return allowDecision("subagent.wait-timeout", "wait timeout not required");
+      }
+
+      state.waitTimeoutMs = state.timeoutMs;
+      return allowDecision(
+        "subagent.wait-timeout",
+        state.timeoutMs === undefined ? "wait timeout disabled" : "wait timeout configured",
+      );
+    },
+  };
+}
+
+export function createSubagentSpawnRegistrations(state: PreSpawnState): PolicyRegistration[] {
+  return [
+    createSessionExistence(state),
+    createActiveRunGuard(state),
+    createCancelTimeout(state),
+    createWaitTimeout(state),
+  ];
+}

--- a/packages/openomni/src/subagent/middleware/subagent-spawn-types.ts
+++ b/packages/openomni/src/subagent/middleware/subagent-spawn-types.ts
@@ -1,0 +1,52 @@
+import type { PolicyRegistration } from "@openomni/agent";
+import type { Policy, RuntimeResource, TraceContext } from "@openomni/protocol";
+import type { Session, WorkerRunRecord } from "@openomni/session";
+
+type SessionRecord = NonNullable<ReturnType<typeof Session.get>>;
+
+export type PreSpawnOperation = "send" | "resume" | "cancel" | "wait";
+
+export interface PreSpawnState {
+  readonly operation: PreSpawnOperation;
+  readonly sessionId: string;
+  readonly hardTimeoutMs?: number;
+  readonly timeoutMs?: number;
+  session?: SessionRecord;
+  runs?: WorkerRunRecord[];
+  latestRun?: WorkerRunRecord;
+  cancelHardTimeoutMs?: number;
+  waitTimeoutMs?: number;
+}
+
+export interface PreSpawnContext {
+  readonly operation: PreSpawnOperation;
+  readonly sessionId: string;
+  readonly hardTimeoutMs?: number;
+  readonly timeoutMs?: number;
+  readonly traceContext?: TraceContext.Type;
+  readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
+}
+
+export interface PreSpawnResult {
+  readonly verdict: Policy.PolicyDecision;
+  readonly session?: SessionRecord;
+  readonly runs?: WorkerRunRecord[];
+  readonly latestRun?: WorkerRunRecord;
+  readonly cancelHardTimeoutMs: number;
+  readonly waitTimeoutMs?: number;
+}
+
+export interface WaitTimeoutHandle {
+  readonly cancel: () => void;
+}
+
+export interface ChildRuntimeMiddlewareInput {
+  readonly middleware?: PolicyRegistration[];
+  readonly hasExplicitRuntimePolicy: boolean;
+}
+
+export type PreSpawnPolicyContext = Parameters<
+  ReturnType<typeof import("@openomni/agent").PolicyEngine.create>["dispatch"]
+>[1] & {
+  readonly resourceDescriptor?: RuntimeResource.Descriptor;
+};

--- a/script/lint-guards.ts
+++ b/script/lint-guards.ts
@@ -27,7 +27,7 @@ const excludedSuffixes = [".d.ts", ".generated.ts", ".gen.ts"];
 const canonicalPolicyEvaluator = new Set(["packages/protocol/src/policy/permission.ts"]);
 const canonicalPolicyRequiredFiles = new Set([
   "packages/openomni/src/ingress/middleware/ingress-authority-evaluation.ts",
-  "packages/openomni/src/subagent/middleware/subagent-spawn-policy.ts",
+  "packages/openomni/src/subagent/middleware/subagent-spawn-decisions.ts",
   "packages/openomni/src/subagent/middleware/background-limit-decisions.ts",
   "packages/agent/src/core/policy/builtin/messenger-allow-pattern.ts",
   "apps/server/src/tool/mcp/mcp-prefix-guard.ts",


### PR DESCRIPTION
## Summary
- split SubagentSpawnPolicyMiddleware internals into focused private sibling modules
- preserve public namespace constants, createDefaultDenylist, childMiddleware/buildChildRuntimeMiddleware, registrations, evaluatePreSpawn, runPreSpawn, and enforceWaitTimeout behavior
- move the guard lint canonical Policy.evaluate check to the extracted decision helper

## Verification
- bun install
- bun run --cwd packages/protocol build
- baseline focused tests before edit: 113 pass
- bun run --cwd packages/openomni check-types
- bun test packages/openomni/test/subagent/subagent-spawn-policy.test.ts packages/openomni/test/subagent/permissions.test.ts packages/openomni/test/policy/middleware-integration.test.ts packages/openomni/test/subagent/runtime.test.ts packages/openomni/src/execution-runtime/tool/agent/tools/subagent-runtime.test.ts
- bun run lint:guards && bun run lint:side-effects
- bun run check-types
- bun run build
- bun run test
- bunx biome check .
- bunx knip --no-config-hints
- git diff --check and git diff --staged --check
- LSP diagnostics on subagent-spawn-policy.ts, subagent-spawn-types.ts, subagent-spawn-decisions.ts, and subagent-spawn-registrations.ts
- independent codex-ultrawork-reviewer: PASS after staged-file blocker was fixed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `SubagentSpawnPolicyMiddleware` into focused modules for decisions, definitions, registrations, and types. No behavior changes; public API remains the same.

- **Refactors**
  - Extracted: `subagent-spawn-definitions.ts`, `subagent-spawn-decisions.ts`, `subagent-spawn-registrations.ts`, `subagent-spawn-types.ts`.
  - Preserved: namespace constants and `createDefaultDenylist`, `buildChildRuntimeMiddleware`, `registrations`, `evaluatePreSpawn`, `runPreSpawn`, and wait-timeout behavior.
  - Added helpers in decisions: `createSubagentOperationDescriptor`, `emptyUsage`, `defaultCancelHardTimeoutMs`.
  - Updated lint guard to use `packages/openomni/src/subagent/middleware/subagent-spawn-decisions.ts` as the canonical policy evaluation site.

<sup>Written for commit 2c95bd4a1dee8546a033a3e419c683d3a4b3a058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

