### PR TITLE
refactor(openomni): split resident runtime responsibilities

### DIFF
--- a/packages/openomni/src/resident/runtime-abort.ts
+++ b/packages/openomni/src/resident/runtime-abort.ts
@@ -1,0 +1,34 @@
+export function createAbortError(): Error {
+  const error = new Error("resident run aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
+export function abortRace(signal: AbortSignal | undefined): {
+  readonly promise: Promise<never>;
+  readonly cleanup: () => void;
+} {
+  if (!signal) {
+    return {
+      promise: new Promise<never>(() => undefined),
+      cleanup: () => undefined,
+    };
+  }
+  if (signal.aborted) {
+    return { promise: Promise.reject(createAbortError()), cleanup: () => undefined };
+  }
+  let cleanup: () => void = () => undefined;
+  const promise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  return { promise, cleanup };
+}

--- a/packages/openomni/src/resident/runtime-agent-config.ts
+++ b/packages/openomni/src/resident/runtime-agent-config.ts
@@ -1,0 +1,47 @@
+import { ChatAgent, type ChatAgentConfig, type ChatAgentInput } from "@openomni/agent";
+import type { Ingress } from "@openomni/protocol";
+import { buildWorkerMiddleware } from "../execution-runtime/middleware";
+import type { ResidentRunContext } from "./runtime-types";
+
+type RuntimeAgentDef = Ingress.AgentDef & {
+  readonly providerOptions?: Record<string, unknown>;
+};
+
+export function defaultRunAgent(config: ChatAgentConfig, input: ChatAgentInput) {
+  return ChatAgent.create(config).run(input);
+}
+
+export function buildResidentAgentConfig(ctx: ResidentRunContext, runId: string): ChatAgentConfig {
+  const workspaceRoot = ctx.event.agent.toolConfig?.workspaceRoot ?? ctx.event.workspace;
+  const toolExecutor = ctx.event.agent.toolExecutorFactory
+    ? ctx.event.agent.toolExecutorFactory({
+        sessionId: ctx.sessionId,
+        runId,
+        agentName: extractAgentName(ctx.event),
+        workspaceRoot,
+      })
+    : ctx.event.agent.toolExecutor;
+  const agent = ctx.event.agent as RuntimeAgentDef;
+
+  return {
+    model: ctx.event.agent.model,
+    systemPrompt: ctx.event.agent.systemPrompt,
+    budget: ctx.event.agent.budget,
+    tools: ctx.event.agent.tools,
+    toolExecutor,
+    ...(ctx.signal ? { signal: ctx.signal } : {}),
+    ...(agent.providerOptions ? { providerOptions: agent.providerOptions } : {}),
+    middleware: buildWorkerMiddleware({
+      permissions: ctx.event.agent.permissions,
+      ...(ctx.event.agent.policyPlan ? { policyPlan: ctx.event.agent.policyPlan } : {}),
+    }),
+  };
+}
+
+function extractAgentName(event: Ingress.ResolvedInboundEvent): string | undefined {
+  if (event.mode === "internal") {
+    return event.agentName;
+  }
+  const raw = event.meta?.agentName ?? event.meta?.agent;
+  return typeof raw === "string" ? raw : undefined;
+}

--- a/packages/openomni/src/resident/runtime-types.ts
+++ b/packages/openomni/src/resident/runtime-types.ts
@@ -1,0 +1,44 @@
+import type { ChatAgentConfig, ChatAgentInput } from "@openomni/agent";
+import type { Ingress, TraceContext as TraceContextProtocol } from "@openomni/protocol";
+
+export type ResidentLifecycle = "sleeping" | "hydrating" | "active" | "idle" | "releasing";
+
+export interface ResidentRunContext {
+  readonly sessionId: string;
+  readonly event: Ingress.ResolvedInboundEvent;
+  readonly traceContext?: TraceContextProtocol.Type;
+  readonly signal?: AbortSignal;
+}
+
+export interface ResidentRunResult {
+  readonly output: string;
+  readonly finishReason: string;
+  readonly runId: string;
+  readonly activationId: string;
+}
+
+export interface ResidentRuntimeOptions {
+  readonly maxActive?: number;
+  readonly idleTimeoutMs?: number;
+  readonly slotWaitTimeoutMs?: number;
+  readonly runAgent?: (
+    config: ChatAgentConfig,
+    input: ChatAgentInput,
+  ) => Promise<{
+    text: string;
+    finishReason: string;
+  }>;
+}
+
+export interface ActivationRecord {
+  activationId: string;
+  lifecycle: ResidentLifecycle;
+  idleTimer?: ReturnType<typeof setTimeout>;
+  queue: Promise<unknown>;
+  lastUsedAt: number;
+}
+
+export type SlotWaiter = {
+  readonly resolve: () => void;
+  readonly reject: (error: Error) => void;
+};

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -1,106 +1,23 @@
-import { ChatAgent, type ChatAgentConfig, type ChatAgentInput } from "@openomni/agent";
-import {
-  IngressEvent,
-  type Ingress,
-  type Tool,
-  type TraceContext as TraceContextProtocol,
-} from "@openomni/protocol";
+import { IngressEvent } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
-import { buildWorkerMiddleware } from "../execution-runtime/middleware";
 import { SessionBridge } from "../ingress/session-bridge";
+import { abortRace, createAbortError, throwIfAborted } from "./runtime-abort";
+import { buildResidentAgentConfig, defaultRunAgent } from "./runtime-agent-config";
+import type {
+  ActivationRecord,
+  ResidentLifecycle,
+  ResidentRunContext,
+  ResidentRunResult,
+  ResidentRuntimeOptions,
+  SlotWaiter,
+} from "./runtime-types";
 
-export type ResidentLifecycle = "sleeping" | "hydrating" | "active" | "idle" | "releasing";
-
-export interface ResidentRunContext {
-  readonly sessionId: string;
-  readonly event: Ingress.ResolvedInboundEvent;
-  readonly traceContext?: TraceContextProtocol.Type;
-  readonly signal?: AbortSignal;
-}
-
-export interface ResidentRunResult {
-  readonly output: string;
-  readonly finishReason: string;
-  readonly runId: string;
-  readonly activationId: string;
-}
-
-export interface ResidentRuntimeOptions {
-  readonly maxActive?: number;
-  readonly idleTimeoutMs?: number;
-  readonly slotWaitTimeoutMs?: number;
-  readonly runAgent?: (
-    config: ChatAgentConfig,
-    input: ChatAgentInput,
-  ) => Promise<{
-    text: string;
-    finishReason: string;
-  }>;
-}
-
-interface ActivationRecord {
-  activationId: string;
-  lifecycle: ResidentLifecycle;
-  idleTimer?: ReturnType<typeof setTimeout>;
-  queue: Promise<unknown>;
-  lastUsedAt: number;
-}
-
-type SlotWaiter = { resolve: () => void; reject: (error: Error) => void };
-
-function defaultRunAgent(config: ChatAgentConfig, input: ChatAgentInput) {
-  return ChatAgent.create(config).run(input);
-}
-
-function createAbortError(): Error {
-  const error = new Error("resident run aborted");
-  error.name = "AbortError";
-  return error;
-}
-
-function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw createAbortError();
-}
-
-function abortRace(signal: AbortSignal | undefined): {
-  readonly promise: Promise<never>;
-  readonly cleanup: () => void;
-} {
-  if (!signal) {
-    return {
-      promise: new Promise<never>(() => {
-        // No cancellation requested.
-      }),
-      cleanup: () => undefined,
-    };
-  }
-  if (signal.aborted) {
-    return { promise: Promise.reject(createAbortError()), cleanup: () => undefined };
-  }
-  let cleanup: () => void = () => undefined;
-  const promise = new Promise<never>((_, reject) => {
-    const onAbort = () => {
-      signal.removeEventListener("abort", onAbort);
-      reject(createAbortError());
-    };
-    cleanup = () => signal.removeEventListener("abort", onAbort);
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
-  return { promise, cleanup };
-}
-
-function extractAgentName(event: Ingress.ResolvedInboundEvent): string | undefined {
-  const internalEvent = event as unknown as {
-    mode?: string;
-    agentName?: unknown;
-    meta?: { agentName?: unknown; agent?: unknown };
-  };
-  if (internalEvent.mode === "internal") {
-    return typeof internalEvent.agentName === "string" ? internalEvent.agentName : undefined;
-  }
-  const raw = internalEvent.meta?.agentName ?? internalEvent.meta?.agent;
-  return typeof raw === "string" ? raw : undefined;
-}
+export type {
+  ResidentLifecycle,
+  ResidentRunContext,
+  ResidentRunResult,
+  ResidentRuntimeOptions,
+} from "./runtime-types";
 
 export class ResidentRuntime {
   private readonly activations = new Map<string, ActivationRecord>();
@@ -244,37 +161,6 @@ export class ResidentRuntime {
     }, this.idleTimeoutMs);
   }
 
-  private buildAgentConfig(ctx: ResidentRunContext, runId: string): ChatAgentConfig {
-    const workspaceRoot = ctx.event.agent.toolConfig?.workspaceRoot ?? ctx.event.workspace;
-    const toolExecutor = ctx.event.agent.toolExecutorFactory
-      ? ctx.event.agent.toolExecutorFactory({
-          sessionId: ctx.sessionId,
-          runId,
-          agentName: extractAgentName(ctx.event),
-          workspaceRoot,
-        })
-      : ctx.event.agent.toolExecutor;
-
-    const agentProviderOptions = (ctx.event.agent as { providerOptions?: Record<string, unknown> })
-      .providerOptions;
-
-    return {
-      model: ctx.event.agent.model,
-      systemPrompt: ctx.event.agent.systemPrompt,
-      budget: ctx.event.agent.budget,
-      tools: ctx.event.agent.tools,
-      toolExecutor: toolExecutor as
-        | ((call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>)
-        | undefined,
-      ...(ctx.signal ? { signal: ctx.signal } : {}),
-      ...(agentProviderOptions ? { providerOptions: agentProviderOptions } : {}),
-      middleware: buildWorkerMiddleware({
-        permissions: ctx.event.agent.permissions,
-        ...(ctx.event.agent.policyPlan ? { policyPlan: ctx.event.agent.policyPlan } : {}),
-      }),
-    };
-  }
-
   private async runExclusive(ctx: ResidentRunContext): Promise<ResidentRunResult> {
     let slotAcquired = false;
     await this.acquireSlot(ctx.signal);
@@ -299,7 +185,7 @@ export class ResidentRuntime {
           message.role === "user" || message.role === "assistant",
       );
       activation.lifecycle = "active";
-      const agentConfig = this.buildAgentConfig(ctx, runId);
+      const agentConfig = buildResidentAgentConfig(ctx, runId);
       const result = await this.runAgent(agentConfig, {
         messages,
         traceContext,

--- a/packages/openomni/test/resident/runtime.test.ts
+++ b/packages/openomni/test/resident/runtime.test.ts
@@ -113,13 +113,51 @@ describe("ResidentRuntime", () => {
       },
     });
 
-    expect(capturedConfig?.permissions).toBeUndefined();
-    await expect(evaluateTool(capturedConfig?.middleware, "tool:plan")).resolves.toMatchObject({
-      verdict: "allow",
+    const planDecision = await evaluateTool(capturedConfig?.middleware, "tool:plan");
+    expect(planDecision).toMatchObject({ verdict: "allow" });
+    const legacyDecision = await evaluateTool(capturedConfig?.middleware, "tool:legacy");
+    expect(legacyDecision).toMatchObject({ verdict: "deny" });
+  });
+
+  test("passes resolved worker execution context into tool executor factories", async () => {
+    let factoryInput:
+      | {
+          readonly sessionId: string;
+          readonly runId: string;
+          readonly agentName?: string;
+          readonly workspaceRoot?: string;
+        }
+      | undefined;
+    const manager = ResidentRuntime.create({
+      runAgent: async () => ({ text: "ok", finishReason: "stop" }),
     });
-    await expect(evaluateTool(capturedConfig?.middleware, "tool:legacy")).resolves.toMatchObject({
-      verdict: "deny",
+
+    await manager.run({
+      sessionId: "resident-tool-factory",
+      event: {
+        ...makeEvent(),
+        workspace: "/tmp/openomni-workspace",
+        meta: { target: { kind: "resident" }, agentName: "resident-worker" },
+        agent: {
+          model: { provider: "test", id: "fixture" },
+          toolExecutorFactory: (input) => {
+            factoryInput = input;
+            return async (call) => ({
+              id: crypto.randomUUID(),
+              toolCallId: call.id,
+              output: "ok",
+            });
+          },
+        },
+      },
     });
+
+    expect(factoryInput).toMatchObject({
+      sessionId: "resident-tool-factory",
+      agentName: "resident-worker",
+      workspaceRoot: "/tmp/openomni-workspace",
+    });
+    expect(factoryInput?.runId).toBeString();
   });
 });
 


### PR DESCRIPTION
## Summary

- Split ResidentRuntime support code into focused resident runtime modules for types, abort handling, and ChatAgent config construction.
- Kept `packages/openomni/src/resident/runtime.ts` as the public runtime facade and lifecycle orchestrator.
- Added characterization coverage for `toolExecutorFactory` receiving the resolved resident execution context.

## Why

`packages/openomni/src/resident/runtime.ts` was the largest remaining production file in the cleanup scan at 319 pure LOC. It mixed public contracts, abort helpers, agent config translation, and activation lifecycle coordination. This PR keeps behavior intact while reducing the main runtime file to 219 pure LOC.

## Validation

- `bun test packages/openomni/test/resident/runtime.test.ts`
- `bun test packages/openomni/test/resident/runtime.test.ts packages/openomni/test/ingress/engine.test.ts packages/openomni/test/ingress/engine-internal.test.ts packages/openomni/test/ingress/integration.test.ts packages/openomni/test/execution-runtime/cron-job-runner.test.ts`
- `bun run build`
- `bun run check-types`
- `bun run test`
- `bun run lint:guards && bun run lint:side-effects && bunx biome check . && bunx knip --no-config-hints && git diff --check`
- LSP diagnostics clean on changed files
- Independent reviewer pass: Verifier the 195th, PASS / UNCONDITIONAL APPROVAL

## Notes

- Pre-push `dep-check` reported stale AGENTS docs only; no dependency violations.
- Claude Fable oracle was unavailable locally for this run (`claude-fable-5` returned 404), so the independent review used Codex ultrawork reviewer instead.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split resident runtime responsibilities into focused modules and kept `packages/openomni/src/resident/runtime.ts` as the public facade and lifecycle orchestrator. No behavior changes; adds a test to verify tool executor factories get the resolved execution context.

- **Refactors**
  - Extracted abort helpers to `resident/runtime-abort.ts`, agent config builder and `defaultRunAgent` to `resident/runtime-agent-config.ts`, and shared types to `resident/runtime-types.ts` (re-exported from the facade).
  - Simplified `ResidentRuntime` to orchestrate lifecycle only; reduced `runtime.ts` size significantly.
  - `buildResidentAgentConfig` now centralizes `providerOptions`, middleware, and tool executor wiring.
  - Added characterization test to confirm `toolExecutorFactory` receives `sessionId`, `runId`, `agentName`, and `workspaceRoot`.

<sup>Written for commit a58b60cdc5a5178dffbd67d62ac47707438561ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added abort signal handling capabilities to the runtime system, enabling graceful operation cancellation.
  * Introduced improved agent configuration and execution workflow.

* **Refactor**
  * Reorganized runtime modules for better code separation and maintainability.
  * Extracted type definitions and utility helpers into dedicated modules.

* **Tests**
  * Enhanced test coverage with new assertions for tool permission policies.
  * Added validation tests for runtime context passing to execution factories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->