### PR TITLE
refactor(openomni): split workspace lock responsibilities

### DIFF
--- a/packages/openomni/src/execution-runtime/workspace-lock-abort.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock-abort.ts
@@ -1,0 +1,30 @@
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createAbortError(): Error {
+  const error = new Error("Tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
+export function sleepAbortable(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (!signal) return sleep(ms);
+  throwIfAborted(signal);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/openomni/src/execution-runtime/workspace-lock-files.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock-files.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { sleepAbortable, throwIfAborted } from "./workspace-lock-abort.js";
+import {
+  LOCK_ROOT,
+  OWNER_FILE,
+  STALE_GRACE_MS,
+  type LockOwnerMeta,
+} from "./workspace-lock-types.js";
+
+export function lockKey(workspace: string): string {
+  return createHash("sha256").update(workspace).digest("hex");
+}
+
+function lockPath(workspace: string): string {
+  return join(LOCK_ROOT, lockKey(workspace));
+}
+
+function ownerFilePath(workspace: string): string {
+  return join(lockPath(workspace), OWNER_FILE);
+}
+
+function errnoCode(error: unknown): string | undefined {
+  if (error instanceof Error && "code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isLockOwnerMeta(value: unknown): value is LockOwnerMeta {
+  return (
+    isRecord(value) &&
+    typeof value.runId === "string" &&
+    typeof value.pid === "number" &&
+    typeof value.acquiredAt === "number"
+  );
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errnoCode(error) !== "ESRCH";
+  }
+}
+
+function readOwnerMeta(workspace: string): LockOwnerMeta | undefined {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(ownerFilePath(workspace), "utf-8"));
+    return isLockOwnerMeta(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function removeLockDir(workspace: string): void {
+  rmSync(lockPath(workspace), { recursive: true, force: true });
+}
+
+function shouldReapStaleLock(workspace: string): boolean {
+  const meta = readOwnerMeta(workspace);
+  if (meta) {
+    return !isProcessAlive(meta.pid);
+  }
+
+  try {
+    const ageMs = Date.now() - statSync(lockPath(workspace)).mtimeMs;
+    return ageMs >= STALE_GRACE_MS;
+  } catch {
+    return false;
+  }
+}
+
+export async function acquireExternal(
+  workspace: string,
+  runId: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  mkdirSync(LOCK_ROOT, { recursive: true });
+  const start = Date.now();
+
+  for (;;) {
+    throwIfAborted(signal);
+    try {
+      const path = lockPath(workspace);
+      mkdirSync(path);
+      try {
+        throwIfAborted(signal);
+        writeFileSync(
+          join(path, OWNER_FILE),
+          JSON.stringify({ runId, pid: process.pid, acquiredAt: Date.now() }),
+          "utf-8",
+        );
+        return;
+      } catch (error) {
+        removeLockDir(workspace);
+        throw error;
+      }
+    } catch (error) {
+      const code = errnoCode(error);
+      if (code !== "EEXIST") {
+        throw error;
+      }
+
+      if (shouldReapStaleLock(workspace)) {
+        removeLockDir(workspace);
+        continue;
+      }
+
+      if (Date.now() - start >= timeoutMs) {
+        throw new Error(`workspace lock timeout after ${timeoutMs}ms for "${workspace}"`);
+      }
+      await sleepAbortable(25, signal);
+    }
+  }
+}
+
+export function releaseExternal(workspace: string, runId: string): void {
+  const meta = readOwnerMeta(workspace);
+  if (!meta) return;
+  if (meta.pid !== process.pid || meta.runId !== runId) return;
+  removeLockDir(workspace);
+}

--- a/packages/openomni/src/execution-runtime/workspace-lock-regression.test.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock-regression.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkspaceLock } from "./workspace-lock.js";
+
+const LOCK_ROOT = join(tmpdir(), "openomni-workspace-locks");
+const OWNER_FILE = "owner.json";
+
+function makeWorkspace(): string {
+  return `/tmp/test-workspace-${crypto.randomUUID()}`;
+}
+
+function lockKey(workspace: string): string {
+  return createHash("sha256").update(workspace).digest("hex");
+}
+
+function lockPath(workspace: string): string {
+  return join(LOCK_ROOT, lockKey(workspace));
+}
+
+function unsafeFilePath(workspace: string): string {
+  return join(LOCK_ROOT, `${lockKey(workspace)}.unsafe.json`);
+}
+
+describe("WorkspaceLock regression coverage", () => {
+  test("rejects queued waiters when the workspace becomes unsafe", async () => {
+    const workspace = makeWorkspace();
+    await WorkspaceLock.acquire(workspace, "holder");
+
+    const waiter = WorkspaceLock.acquire(workspace, "waiter", 500).catch((error) => error);
+    await Bun.sleep(0);
+
+    WorkspaceLock.markUnsafe(workspace, "unknown settlement");
+
+    const blocked = await waiter;
+    expect(blocked).toBeInstanceOf(Error);
+    expect((blocked as Error).message).toContain("workspace marked unsafe");
+
+    WorkspaceLock.release(workspace, "holder");
+    WorkspaceLock.clearUnsafe(workspace);
+    await WorkspaceLock.acquire(workspace, "probe-after-unsafe", 50);
+    WorkspaceLock.release(workspace, "probe-after-unsafe");
+  });
+
+  test("reaps ownerless stale external lock directories", async () => {
+    const workspace = makeWorkspace();
+    const path = lockPath(workspace);
+    rmSync(path, { recursive: true, force: true });
+    mkdirSync(path, { recursive: true });
+    const staleTime = new Date(Date.now() - 2_000);
+    utimesSync(path, staleTime, staleTime);
+
+    await WorkspaceLock.acquire(workspace, "replacement", 50);
+
+    WorkspaceLock.release(workspace, "replacement");
+    rmSync(path, { recursive: true, force: true });
+  });
+
+  test("reaps external locks whose owner process is gone", async () => {
+    const workspace = makeWorkspace();
+    const path = lockPath(workspace);
+    rmSync(path, { recursive: true, force: true });
+    mkdirSync(path, { recursive: true });
+    writeFileSync(
+      join(path, OWNER_FILE),
+      JSON.stringify({ runId: "dead-owner", pid: 999_999_999, acquiredAt: Date.now() }),
+      "utf-8",
+    );
+
+    await WorkspaceLock.acquire(workspace, "replacement", 50);
+
+    WorkspaceLock.release(workspace, "replacement");
+    rmSync(path, { recursive: true, force: true });
+  });
+
+  test("does not reap external locks owned by a live process", async () => {
+    const workspace = makeWorkspace();
+    const path = lockPath(workspace);
+    rmSync(path, { recursive: true, force: true });
+    mkdirSync(path, { recursive: true });
+    writeFileSync(
+      join(path, OWNER_FILE),
+      JSON.stringify({ runId: "live-owner", pid: process.pid, acquiredAt: Date.now() }),
+      "utf-8",
+    );
+
+    const blocked = await WorkspaceLock.acquire(workspace, "waiter", 30).catch((error) => error);
+
+    expect(blocked).toBeInstanceOf(Error);
+    expect((blocked as Error).message).toContain("workspace lock timeout");
+    rmSync(path, { recursive: true, force: true });
+  });
+
+  test("malformed persisted unsafe markers fail closed", async () => {
+    const workspace = makeWorkspace();
+    mkdirSync(LOCK_ROOT, { recursive: true });
+    writeFileSync(unsafeFilePath(workspace), JSON.stringify({ markedAt: Date.now() }), "utf-8");
+
+    const blocked = await WorkspaceLock.acquire(workspace, "probe-malformed", 50).catch(
+      (error) => error,
+    );
+
+    expect(blocked).toBeInstanceOf(Error);
+    expect((blocked as Error).message).toContain("workspace marked unsafe");
+    WorkspaceLock.clearUnsafe(workspace);
+  });
+});

--- a/packages/openomni/src/execution-runtime/workspace-lock-types.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock-types.ts
@@ -1,0 +1,31 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export type WorkspaceLockWaiter = {
+  readonly runId: string;
+  resolve: () => void;
+  reject: (error: Error) => void;
+};
+
+export type LocalWorkspaceLock = {
+  readonly runId: string;
+  depth: number;
+  readonly pending: boolean;
+};
+
+export type LockOwnerMeta = {
+  readonly runId: string;
+  readonly pid: number;
+  readonly acquiredAt: number;
+};
+
+export type UnsafeWorkspace = {
+  readonly reason: string;
+  readonly markedAt: number;
+  readonly token?: string;
+};
+
+export const LOCK_ROOT = join(tmpdir(), "openomni-workspace-locks");
+export const OWNER_FILE = "owner.json";
+export const STALE_GRACE_MS = 1_000;
+export const SETTLED_TOKEN_TTL_MS = 5 * 60_000;

--- a/packages/openomni/src/execution-runtime/workspace-lock-unsafe.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock-unsafe.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { lockKey } from "./workspace-lock-files.js";
+import { LOCK_ROOT, SETTLED_TOKEN_TTL_MS, type UnsafeWorkspace } from "./workspace-lock-types.js";
+
+const unsafe = new Map<string, UnsafeWorkspace>();
+const settledUnsafeTokens = new Map<string, number>();
+
+function unsafeTokenKey(workspace: string, token: string): string {
+  return `${lockKey(workspace)}:${token}`;
+}
+
+function pruneSettledUnsafeTokens(): void {
+  const now = Date.now();
+  for (const [key, settledAt] of settledUnsafeTokens) {
+    if (now - settledAt >= SETTLED_TOKEN_TTL_MS) settledUnsafeTokens.delete(key);
+  }
+}
+
+function unsafeFilePath(workspace: string): string {
+  return join(LOCK_ROOT, `${lockKey(workspace)}.unsafe.json`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isUnsafeWorkspace(value: unknown): value is UnsafeWorkspace {
+  return (
+    isRecord(value) &&
+    typeof value.reason === "string" &&
+    typeof value.markedAt === "number" &&
+    (value.token === undefined || typeof value.token === "string")
+  );
+}
+
+export function readUnsafeMeta(workspace: string): UnsafeWorkspace | undefined {
+  const local = unsafe.get(workspace);
+  if (local) return local;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(unsafeFilePath(workspace), "utf-8"));
+    const state = isUnsafeWorkspace(parsed)
+      ? parsed
+      : { reason: "invalid unsafe marker", markedAt: Date.now() };
+    unsafe.set(workspace, state);
+    return state;
+  } catch {
+    return undefined;
+  }
+}
+
+export function unsafeWorkspaceError(workspace: string, state: UnsafeWorkspace): Error {
+  return new Error(`workspace marked unsafe for "${workspace}": ${state.reason}`);
+}
+
+export function markWorkspaceUnsafe(
+  workspace: string,
+  reason: string,
+  token?: string,
+): UnsafeWorkspace | undefined {
+  if (token !== undefined) {
+    pruneSettledUnsafeTokens();
+    if (settledUnsafeTokens.has(unsafeTokenKey(workspace, token))) {
+      return undefined;
+    }
+  }
+
+  const state: UnsafeWorkspace = {
+    reason,
+    markedAt: Date.now(),
+    ...(token !== undefined ? { token } : {}),
+  };
+  unsafe.set(workspace, state);
+  mkdirSync(LOCK_ROOT, { recursive: true });
+  writeFileSync(unsafeFilePath(workspace), JSON.stringify(state), "utf-8");
+  return state;
+}
+
+export function clearWorkspaceUnsafe(workspace: string, token?: string): void {
+  const state = readUnsafeMeta(workspace);
+  if (token !== undefined) {
+    pruneSettledUnsafeTokens();
+    settledUnsafeTokens.set(unsafeTokenKey(workspace, token), Date.now());
+    if (state?.token !== token) return;
+  }
+
+  unsafe.delete(workspace);
+  try {
+    unlinkSync(unsafeFilePath(workspace));
+  } catch {
+    return;
+  }
+}

--- a/packages/openomni/src/execution-runtime/workspace-lock.ts
+++ b/packages/openomni/src/execution-runtime/workspace-lock.ts
@@ -1,185 +1,15 @@
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { createAbortError, throwIfAborted } from "./workspace-lock-abort.js";
+import { acquireExternal, releaseExternal } from "./workspace-lock-files.js";
+import type { LocalWorkspaceLock, WorkspaceLockWaiter } from "./workspace-lock-types.js";
+import {
+  clearWorkspaceUnsafe,
+  markWorkspaceUnsafe,
+  readUnsafeMeta,
+  unsafeWorkspaceError,
+} from "./workspace-lock-unsafe.js";
 
-type Waiter = { runId: string; resolve: () => void; reject: (e: Error) => void };
-type LocalLock = { runId: string; depth: number; pending: boolean };
-type LockOwnerMeta = { runId: string; pid: number; acquiredAt: number };
-type UnsafeWorkspace = { reason: string; markedAt: number; token?: string };
-
-const active = new Map<string, LocalLock>();
-const queue = new Map<string, Waiter[]>();
-const unsafe = new Map<string, UnsafeWorkspace>();
-const settledUnsafeTokens = new Map<string, number>();
-const LOCK_ROOT = join(tmpdir(), "openomni-workspace-locks");
-const OWNER_FILE = "owner.json";
-const STALE_GRACE_MS = 1_000;
-const SETTLED_TOKEN_TTL_MS = 5 * 60_000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function createAbortError(): Error {
-  const error = new Error("Tool execution aborted");
-  error.name = "AbortError";
-  return error;
-}
-
-function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw createAbortError();
-}
-
-function sleepAbortable(ms: number, signal: AbortSignal | undefined): Promise<void> {
-  if (!signal) return sleep(ms);
-  throwIfAborted(signal);
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onAbort);
-      reject(createAbortError());
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
-function lockPath(workspace: string): string {
-  return join(LOCK_ROOT, lockKey(workspace));
-}
-
-function lockKey(workspace: string): string {
-  return createHash("sha256").update(workspace).digest("hex");
-}
-
-function unsafeTokenKey(workspace: string, token: string): string {
-  return `${lockKey(workspace)}:${token}`;
-}
-
-function pruneSettledUnsafeTokens(): void {
-  const now = Date.now();
-  for (const [key, settledAt] of settledUnsafeTokens) {
-    if (now - settledAt >= SETTLED_TOKEN_TTL_MS) settledUnsafeTokens.delete(key);
-  }
-}
-
-function ownerFilePath(workspace: string): string {
-  return join(lockPath(workspace), OWNER_FILE);
-}
-
-function unsafeFilePath(workspace: string): string {
-  return join(LOCK_ROOT, `${lockKey(workspace)}.unsafe.json`);
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return !(
-      error instanceof Error &&
-      "code" in error &&
-      (error as NodeJS.ErrnoException).code === "ESRCH"
-    );
-  }
-}
-
-function readOwnerMeta(workspace: string): LockOwnerMeta | undefined {
-  try {
-    return JSON.parse(readFileSync(ownerFilePath(workspace), "utf-8")) as LockOwnerMeta;
-  } catch {
-    return undefined;
-  }
-}
-
-function readUnsafeMeta(workspace: string): UnsafeWorkspace | undefined {
-  const local = unsafe.get(workspace);
-  if (local) return local;
-  try {
-    const parsed = JSON.parse(readFileSync(unsafeFilePath(workspace), "utf-8")) as UnsafeWorkspace;
-    unsafe.set(workspace, parsed);
-    return parsed;
-  } catch {
-    return undefined;
-  }
-}
-
-function removeLockDir(workspace: string): void {
-  rmSync(lockPath(workspace), { recursive: true, force: true });
-}
-
-function shouldReapStaleLock(workspace: string): boolean {
-  const meta = readOwnerMeta(workspace);
-  if (meta) {
-    return !isProcessAlive(meta.pid);
-  }
-
-  try {
-    const ageMs = Date.now() - statSync(lockPath(workspace)).mtimeMs;
-    return ageMs >= STALE_GRACE_MS;
-  } catch {
-    return false;
-  }
-}
-
-async function acquireExternal(
-  workspace: string,
-  runId: string,
-  timeoutMs: number,
-  signal?: AbortSignal,
-): Promise<void> {
-  mkdirSync(LOCK_ROOT, { recursive: true });
-  const start = Date.now();
-
-  for (;;) {
-    throwIfAborted(signal);
-    try {
-      const path = lockPath(workspace);
-      mkdirSync(path);
-      try {
-        throwIfAborted(signal);
-        writeFileSync(
-          join(path, OWNER_FILE),
-          JSON.stringify({ runId, pid: process.pid, acquiredAt: Date.now() }),
-          "utf-8",
-        );
-        return;
-      } catch (error) {
-        removeLockDir(workspace);
-        throw error;
-      }
-    } catch (error) {
-      const code =
-        error instanceof Error && "code" in error
-          ? (error as NodeJS.ErrnoException).code
-          : undefined;
-      if (code !== "EEXIST") {
-        throw error;
-      }
-
-      if (shouldReapStaleLock(workspace)) {
-        removeLockDir(workspace);
-        continue;
-      }
-
-      if (Date.now() - start >= timeoutMs) {
-        throw new Error(`workspace lock timeout after ${timeoutMs}ms for "${workspace}"`);
-      }
-      await sleepAbortable(25, signal);
-    }
-  }
-}
-
-function releaseExternal(workspace: string, runId: string): void {
-  const meta = readOwnerMeta(workspace);
-  if (!meta) return;
-  if (meta.pid !== process.pid || meta.runId !== runId) return;
-  removeLockDir(workspace);
-}
+const active = new Map<string, LocalWorkspaceLock>();
+const queue = new Map<string, WorkspaceLockWaiter[]>();
 
 function wakeNextWaiter(workspace: string): void {
   const unsafeState = readUnsafeMeta(workspace);
@@ -200,10 +30,6 @@ function wakeNextWaiter(workspace: string): void {
 
   active.set(workspace, { runId: next.runId, depth: 0, pending: true });
   next.resolve();
-}
-
-function unsafeWorkspaceError(workspace: string, state: UnsafeWorkspace): Error {
-  return new Error(`workspace marked unsafe for "${workspace}": ${state.reason}`);
 }
 
 function rejectWaiters(workspace: string, error: Error): void {
@@ -242,7 +68,7 @@ export namespace WorkspaceLock {
 
     const start = Date.now();
     await new Promise<void>((resolve, reject) => {
-      const entry: Waiter = {
+      const entry: WorkspaceLockWaiter = {
         runId,
         resolve: () => resolve(),
         reject,
@@ -320,35 +146,11 @@ export namespace WorkspaceLock {
   }
 
   export function markUnsafe(workspace: string, reason: string, token?: string): void {
-    if (token !== undefined) {
-      pruneSettledUnsafeTokens();
-      if (settledUnsafeTokens.has(unsafeTokenKey(workspace, token))) return;
-    }
-
-    const state: UnsafeWorkspace = {
-      reason,
-      markedAt: Date.now(),
-      ...(token !== undefined ? { token } : {}),
-    };
-    unsafe.set(workspace, state);
-    mkdirSync(LOCK_ROOT, { recursive: true });
-    writeFileSync(unsafeFilePath(workspace), JSON.stringify(state), "utf-8");
-    rejectWaiters(workspace, unsafeWorkspaceError(workspace, state));
+    const state = markWorkspaceUnsafe(workspace, reason, token);
+    if (state) rejectWaiters(workspace, unsafeWorkspaceError(workspace, state));
   }
 
   export function clearUnsafe(workspace: string, token?: string): void {
-    const state = readUnsafeMeta(workspace);
-    if (token !== undefined) {
-      pruneSettledUnsafeTokens();
-      settledUnsafeTokens.set(unsafeTokenKey(workspace, token), Date.now());
-      if (state?.token !== token) return;
-    }
-
-    unsafe.delete(workspace);
-    try {
-      unlinkSync(unsafeFilePath(workspace));
-    } catch {
-      // No unsafe marker exists.
-    }
+    clearWorkspaceUnsafe(workspace, token);
   }
 }


### PR DESCRIPTION
## Summary
- Split WorkspaceLock internals into abort, external file-lock, shared state, and unsafe-marker helpers while keeping the public WorkspaceLock surface unchanged.
- Added focused regression coverage for queued waiter rejection, stale external lock reaping, live-owner timeout behavior, and malformed unsafe marker fail-closed behavior.

## Verification
- bun test packages/openomni/src/execution-runtime/workspace-lock.test.ts packages/openomni/src/execution-runtime/workspace-lock-regression.test.ts
- bun test packages/openomni/src/execution-runtime/workspace-lock.test.ts packages/openomni/src/execution-runtime/workspace-lock-regression.test.ts apps/server/test/tool/mcp/provider.test.ts apps/server/test/execution/worker-runner.test.ts packages/openomni/src/execution-runtime/tool/executor.test.ts packages/openomni/test/policy/middleware-integration.test.ts
- bun run build
- bun run check-types
- bun run test
- bun run lint:guards && bun run lint:side-effects && bunx biome check . && bunx knip --no-config-hints
- LSP diagnostics clean on changed production files and new regression test
- codex-ultrawork-reviewer PASS after initial BLOCK findings were addressed

## Notes
- Pre-push dep-check passed with existing stale AGENTS.md warnings only; no dependency violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `WorkspaceLock` into small modules for abort handling, external file-lock I/O, types, and unsafe marker logic. Public API stays the same, with new regression tests covering stale lock reaping, unsafe state handling, and queued waiter rejection.

- **Refactors**
  - Extracted `workspace-lock-abort.ts`, `workspace-lock-files.ts`, `workspace-lock-unsafe.ts`, and `workspace-lock-types.ts`.
  - Simplified `workspace-lock.ts` while keeping `WorkspaceLock` API unchanged.

- **Bug Fixes**
  - Malformed persisted unsafe markers now fail closed and block acquisition.

<sup>Written for commit 117e2cddf50ba90ff8980015b24aadd81e07a591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace locking with abort-aware timeout handling and improved stale lock cleanup.
  * Added external filesystem-based lock management for safer multi-process coordination.

* **Tests**
  * Added regression test suite for workspace lock safety and timeout scenarios.

* **Refactor**
  * Reorganized workspace lock implementation for better modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->