### PR TITLE
refactor(agent): split mcp client responsibilities

### DIFF
--- a/packages/agent/src/runtime/mcp/client-connection.ts
+++ b/packages/agent/src/runtime/mcp/client-connection.ts
@@ -1,0 +1,42 @@
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { McpClientHandle } from "./client-types";
+
+export interface TransportCloseTracker {
+  readonly isClosed: () => boolean;
+}
+
+export function trackTransportCloseRequests(transport: Transport): TransportCloseTracker {
+  let closeRequested = false;
+  const close = transport.close.bind(transport);
+  transport.close = async () => {
+    closeRequested = true;
+    await close();
+  };
+
+  return {
+    isClosed: () => closeRequested,
+  };
+}
+
+export async function cleanupFailedConnection(
+  client: McpClientHandle,
+  transport: Transport,
+  closeTracker?: TransportCloseTracker,
+): Promise<unknown | undefined> {
+  let cleanupError: unknown;
+  try {
+    await client.close();
+  } catch (err) {
+    cleanupError = err;
+  }
+
+  if (!closeTracker?.isClosed()) {
+    try {
+      await transport.close();
+    } catch (err) {
+      cleanupError ??= err;
+    }
+  }
+
+  return cleanupError;
+}

--- a/packages/agent/src/runtime/mcp/client-descriptor.ts
+++ b/packages/agent/src/runtime/mcp/client-descriptor.ts
@@ -1,0 +1,34 @@
+import type { RuntimeResource, Tool } from "@openomni/protocol";
+
+type McpToolSpec = Tool.Spec & {
+  readonly descriptor: RuntimeResource.Descriptor;
+};
+
+function createMcpToolDescriptor(serverId: string, remoteName: string): RuntimeResource.Descriptor {
+  return {
+    id: `tool:mcp:${serverId}:${remoteName}`,
+    kind: "tool",
+    source: {
+      type: "mcp",
+      serverId,
+      remoteName,
+    },
+    labels: ["source.mcp", `mcp.${serverId}`],
+    capabilities: ["network.write"],
+    effects: ["external.write"],
+  };
+}
+
+export function attachMcpToolDescriptor(
+  spec: Tool.Spec,
+  serverId: string,
+  remoteName: string,
+): McpToolSpec {
+  const descriptor = createMcpToolDescriptor(serverId, remoteName);
+
+  return {
+    ...spec,
+    labels: descriptor.labels,
+    descriptor,
+  };
+}

--- a/packages/agent/src/runtime/mcp/client-options.ts
+++ b/packages/agent/src/runtime/mcp/client-options.ts
@@ -1,0 +1,22 @@
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { McpServerConfig } from "@openomni/protocol";
+
+export function requestOptions(
+  config: McpServerConfig,
+  context?: { readonly signal?: AbortSignal },
+): RequestOptions | undefined {
+  const timeout = normalizeTimeout(config.timeout);
+  if (context?.signal === undefined && timeout === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(context?.signal !== undefined && { signal: context.signal }),
+    ...(timeout !== undefined && { timeout, maxTotalTimeout: timeout }),
+  };
+}
+
+function normalizeTimeout(timeout: number | undefined): number | undefined {
+  if (timeout === undefined) return undefined;
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : undefined;
+}

--- a/packages/agent/src/runtime/mcp/client-transport.ts
+++ b/packages/agent/src/runtime/mcp/client-transport.ts
@@ -1,0 +1,91 @@
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  SSEClientTransport,
+  type SSEClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/sse.js";
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { McpServerConfig } from "@openomni/protocol";
+
+const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
+  initialReconnectionDelay: 1_000,
+  maxReconnectionDelay: 30_000,
+  reconnectionDelayGrowFactor: 1.5,
+} as const;
+
+export function createTransport(config: McpServerConfig): Transport {
+  switch (config.transport) {
+    case "stdio":
+      return new StdioClientTransport({
+        command: config.command,
+        args: config.args,
+      });
+    case "sse":
+      return new SSEClientTransport(new URL(config.url), sseTransportOptions(config));
+    case "streamable-http":
+      return new StreamableHTTPClientTransport(
+        new URL(config.url),
+        streamableHttpTransportOptions(config),
+      );
+    default:
+      throw new Error("Unknown transport");
+  }
+}
+
+function sseTransportOptions(config: McpServerConfig): SSEClientTransportOptions | undefined {
+  const headers = config.headers;
+  if (headers === undefined) return undefined;
+
+  return {
+    requestInit: { headers: { ...headers } },
+    eventSourceInit: { fetch: createSseHeaderFetch(headers) },
+  };
+}
+
+function streamableHttpTransportOptions(
+  config: McpServerConfig,
+): StreamableHTTPClientTransportOptions | undefined {
+  const requestInit = requestInitForHeaders(config);
+  const maxRetries = normalizeRetries(config.retries);
+  if (requestInit === undefined && maxRetries === undefined) return undefined;
+
+  return {
+    ...(requestInit !== undefined && { requestInit }),
+    ...(maxRetries !== undefined && {
+      reconnectionOptions: {
+        ...DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS,
+        maxRetries,
+      },
+    }),
+  };
+}
+
+function requestInitForHeaders(config: McpServerConfig): RequestInit | undefined {
+  if (config.headers === undefined) return undefined;
+  return { headers: { ...config.headers } };
+}
+
+type SseEventSourceFetch = NonNullable<
+  NonNullable<SSEClientTransportOptions["eventSourceInit"]>["fetch"]
+>;
+type FetchRequestInit = NonNullable<Parameters<typeof fetch>[1]>;
+
+function createSseHeaderFetch(headers: Record<string, string>): SseEventSourceFetch {
+  const headerSnapshot = { ...headers };
+  return ((url: string | URL, init?: Parameters<SseEventSourceFetch>[1]) => {
+    const mergedHeaders = new Headers(init?.headers as FetchRequestInit["headers"] | undefined);
+    for (const [name, value] of Object.entries(headerSnapshot)) {
+      mergedHeaders.set(name, value);
+    }
+
+    return fetch(url, { ...init, headers: mergedHeaders });
+  }) as SseEventSourceFetch;
+}
+
+function normalizeRetries(retries: number | undefined): number | undefined {
+  if (retries === undefined) return undefined;
+  return Number.isFinite(retries) && retries >= 0 ? Math.trunc(retries) : undefined;
+}

--- a/packages/agent/src/runtime/mcp/client-types.ts
+++ b/packages/agent/src/runtime/mcp/client-types.ts
@@ -1,0 +1,12 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { McpServerConfig } from "@openomni/protocol";
+
+export type McpClientHandle = Pick<Client, "connect" | "close" | "listTools" | "callTool">;
+
+export type McpTransportFactory = (config: McpServerConfig) => Transport;
+
+export interface McpClientDependencies {
+  readonly client?: McpClientHandle;
+  readonly createTransport?: McpTransportFactory;
+}

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -1,31 +1,25 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import {
-  SSEClientTransport,
-  type SSEClientTransportOptions,
-} from "@modelcontextprotocol/sdk/client/sse.js";
-import {
-  StreamableHTTPClientTransport,
-  type StreamableHTTPClientTransportOptions,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { randomUUID } from "node:crypto";
-import type { McpServerConfig, RuntimeResource, Tool } from "@openomni/protocol";
+import type { McpServerConfig, Tool } from "@openomni/protocol";
 import { Mcp, Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
+import {
+  cleanupFailedConnection,
+  type TransportCloseTracker,
+  trackTransportCloseRequests,
+} from "./client-connection";
+import { attachMcpToolDescriptor } from "./client-descriptor";
+import { requestOptions } from "./client-options";
+import { createTransport } from "./client-transport";
+import type { McpClientDependencies, McpClientHandle, McpTransportFactory } from "./client-types";
 import { convertMcpTool, convertMcpResult } from "./convert";
 
-/** @internal Test-oriented seam for replacing the underlying MCP SDK client. */
-export type McpClientHandle = Pick<Client, "connect" | "close" | "listTools" | "callTool">;
-/** @internal Test-oriented seam for replacing the underlying MCP transport factory. */
-export type McpTransportFactory = (config: McpServerConfig) => Transport;
-
-/** @internal Constructor dependencies are intended for tests and package-internal adapters. */
-export interface McpClientDependencies {
-  readonly client?: McpClientHandle;
-  readonly createTransport?: McpTransportFactory;
-}
+export type {
+  McpClientDependencies,
+  McpClientHandle,
+  McpTransportFactory,
+} from "./client-types";
 
 export class McpClient {
   private client: McpClientHandle;
@@ -115,8 +109,8 @@ export class McpClient {
 
   async listTools(context?: { readonly signal?: AbortSignal }): Promise<Tool.Spec[]> {
     const response = await this.client.listTools(undefined, requestOptions(this.config, context));
-    return response.tools.map((t) =>
-      attachMcpToolDescriptor(convertMcpTool(t, this.config.name), this.config.name, t.name),
+    return response.tools.map((tool) =>
+      attachMcpToolDescriptor(convertMcpTool(tool, this.config.name), this.config.name, tool.name),
     );
   }
 
@@ -151,8 +145,6 @@ export class McpClient {
         requestOptions(this.config, context),
       );
 
-      const _durationMs = Date.now() - startTime;
-
       return convertMcpResult(
         response as {
           content: Array<{ type: string; text?: string }>;
@@ -161,8 +153,6 @@ export class McpClient {
         toolCallId,
       );
     } catch (err) {
-      const _durationMs = Date.now() - startTime;
-
       Bus.publish(Mcp.ToolFailed, {
         traceId,
         serverName: this.config.name,
@@ -179,184 +169,4 @@ export class McpClient {
   get serverName(): string {
     return this.config.name;
   }
-}
-
-function requestOptions(
-  config: McpServerConfig,
-  context?: { readonly signal?: AbortSignal },
-): RequestOptions | undefined {
-  const timeout = normalizeTimeout(config.timeout);
-  if (context?.signal === undefined && timeout === undefined) {
-    return undefined;
-  }
-
-  return {
-    ...(context?.signal !== undefined && { signal: context.signal }),
-    ...(timeout !== undefined && { timeout, maxTotalTimeout: timeout }),
-  };
-}
-
-function normalizeTimeout(timeout: number | undefined): number | undefined {
-  if (timeout === undefined) return undefined;
-  return Number.isFinite(timeout) && timeout > 0 ? timeout : undefined;
-}
-
-interface TransportCloseTracker {
-  readonly isClosed: () => boolean;
-}
-
-function trackTransportCloseRequests(transport: Transport): TransportCloseTracker {
-  let closeRequested = false;
-  const close = transport.close.bind(transport);
-  // Wrap this freshly created transport so cleanup can tell whether the SDK
-  // client actually attempted to close it, independent of onclose callback timing.
-  transport.close = async () => {
-    closeRequested = true;
-    await close();
-  };
-
-  return {
-    isClosed: () => closeRequested,
-  };
-}
-
-async function cleanupFailedConnection(
-  client: McpClientHandle,
-  transport: Transport,
-  closeTracker?: TransportCloseTracker,
-): Promise<unknown | undefined> {
-  let cleanupError: unknown;
-  try {
-    await client.close();
-  } catch (err) {
-    cleanupError = err;
-  }
-
-  // The SDK client normally owns and closes the transport after connect() starts.
-  // If close() failed before it reached the transport, close it directly while
-  // still preserving the original connection error for callers.
-  if (!closeTracker?.isClosed()) {
-    try {
-      await transport.close();
-    } catch (err) {
-      cleanupError ??= err;
-    }
-  }
-
-  return cleanupError;
-}
-
-type McpToolSpec = Tool.Spec & {
-  readonly descriptor: RuntimeResource.Descriptor;
-};
-
-function createMcpToolDescriptor(serverId: string, remoteName: string): RuntimeResource.Descriptor {
-  return {
-    id: `tool:mcp:${serverId}:${remoteName}`,
-    kind: "tool",
-    source: {
-      type: "mcp",
-      serverId,
-      remoteName,
-    },
-    labels: ["source.mcp", `mcp.${serverId}`],
-    capabilities: ["network.write"],
-    effects: ["external.write"],
-  };
-}
-
-function attachMcpToolDescriptor(
-  spec: Tool.Spec,
-  serverId: string,
-  remoteName: string,
-): McpToolSpec {
-  const descriptor = createMcpToolDescriptor(serverId, remoteName);
-
-  return {
-    ...spec,
-    labels: descriptor.labels,
-    descriptor,
-  };
-}
-
-const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS = {
-  initialReconnectionDelay: 1_000,
-  maxReconnectionDelay: 30_000,
-  reconnectionDelayGrowFactor: 1.5,
-} as const;
-
-function createTransport(config: McpServerConfig): Transport {
-  switch (config.transport) {
-    case "stdio":
-      return new StdioClientTransport({
-        command: config.command,
-        args: config.args,
-      });
-    case "sse":
-      return new SSEClientTransport(new URL(config.url), sseTransportOptions(config));
-    case "streamable-http":
-      return new StreamableHTTPClientTransport(
-        new URL(config.url),
-        streamableHttpTransportOptions(config),
-      );
-    default:
-      throw new Error("Unknown transport");
-  }
-}
-
-function sseTransportOptions(config: McpServerConfig): SSEClientTransportOptions | undefined {
-  const headers = config.headers;
-  if (headers === undefined) return undefined;
-
-  // The SSE SDK transport exposes header injection but not a retry option; only
-  // streamable-http can apply `config.retries` below.
-  return {
-    requestInit: { headers: { ...headers } },
-    eventSourceInit: { fetch: createSseHeaderFetch(headers) },
-  };
-}
-
-function streamableHttpTransportOptions(
-  config: McpServerConfig,
-): StreamableHTTPClientTransportOptions | undefined {
-  const requestInit = requestInitForHeaders(config);
-  const maxRetries = normalizeRetries(config.retries);
-  if (requestInit === undefined && maxRetries === undefined) return undefined;
-
-  return {
-    ...(requestInit !== undefined && { requestInit }),
-    ...(maxRetries !== undefined && {
-      reconnectionOptions: {
-        ...DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS,
-        maxRetries,
-      },
-    }),
-  };
-}
-
-function requestInitForHeaders(config: McpServerConfig): RequestInit | undefined {
-  if (config.headers === undefined) return undefined;
-  return { headers: { ...config.headers } };
-}
-
-type SseEventSourceFetch = NonNullable<
-  NonNullable<SSEClientTransportOptions["eventSourceInit"]>["fetch"]
->;
-type FetchRequestInit = NonNullable<Parameters<typeof fetch>[1]>;
-
-function createSseHeaderFetch(headers: Record<string, string>): SseEventSourceFetch {
-  const headerSnapshot = { ...headers };
-  return ((url: string | URL, init?: Parameters<SseEventSourceFetch>[1]) => {
-    const mergedHeaders = new Headers(init?.headers as FetchRequestInit["headers"] | undefined);
-    for (const [name, value] of Object.entries(headerSnapshot)) {
-      mergedHeaders.set(name, value);
-    }
-
-    return fetch(url, { ...init, headers: mergedHeaders });
-  }) as SseEventSourceFetch;
-}
-
-function normalizeRetries(retries: number | undefined): number | undefined {
-  if (retries === undefined) return undefined;
-  return Number.isFinite(retries) && retries >= 0 ? Math.trunc(retries) : undefined;
 }

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -581,6 +581,47 @@ describe("McpClient connection cleanup", () => {
     expect(observedErrors[0]?.context?.cleanupError).toBeUndefined();
   });
 
+  test("preserves the explicit error for unknown runtime transports", async () => {
+    const serverName = "invalid-transport";
+    const observedErrors: Array<{
+      readonly component?: string;
+      readonly error?: string;
+      readonly context?: Record<string, unknown>;
+    }> = [];
+    const unsubscribe = Bus.observe((event, payload) => {
+      const errorPayload = payload as {
+        readonly component?: string;
+        readonly error?: string;
+        readonly context?: Record<string, unknown>;
+      };
+      if (
+        event.name === Operational.Error.name &&
+        errorPayload.component === "agent.mcp" &&
+        errorPayload.context?.serverName === serverName
+      ) {
+        observedErrors.push(errorPayload);
+      }
+    });
+    const client = new McpClient({
+      name: serverName,
+      transport: "invalid",
+      command: "mcp-server-filesystem",
+    } as never);
+
+    try {
+      await expect(client.connect()).rejects.toThrow("Unknown transport");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      unsubscribe();
+    }
+
+    expect(observedErrors).toHaveLength(1);
+    expect(observedErrors[0]?.component).toBe("agent.mcp");
+    expect(observedErrors[0]?.error).toBe("Error: Unknown transport");
+    expect(observedErrors[0]?.context?.serverName).toBe(serverName);
+    expect(observedErrors[0]?.context?.cleanupError).toBeUndefined();
+  });
+
   test("does not double-close when the client closes a transport that omits onclose", async () => {
     const connectError = new Error("connect failed");
     const sdkClient = createConnectableStubClient({ connectError });


### PR DESCRIPTION
## Summary
- Split `McpClient` helpers into focused MCP runtime modules for connection cleanup, descriptors, request options, transport construction, and dependency seams.
- Kept `McpClient` and its test-facing dependency types exported from `client.ts` to preserve the public import surface.
- Removed dead `_durationMs` assignments and added a regression test that preserves the explicit `Unknown transport` runtime error.

## Verification
- `bun test packages/agent/test/runtime/mcp/descriptor.test.ts packages/agent/test/runtime/mcp/convert.test.ts`
- `bun run --cwd packages/agent check-types`
- `bunx biome check packages/agent/src/runtime/mcp packages/agent/test/runtime/mcp`
- `bun run build`
- `bun run check-types`
- `bun run lint:guards && bun run lint:side-effects && bunx biome check . && bunx knip --no-config-hints`
- `bun run test`
- independent ultrawork reviewer: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the MCP client by extracting transport, options, descriptors, and connection cleanup into focused modules while keeping the public API unchanged. Also removes unused `_durationMs` writes and adds a regression test to preserve the explicit "Unknown transport" error.

- **Refactors**
  - Split helpers into `client-transport`, `client-options`, `client-descriptor`, `client-connection`, and `client-types`.
  - `client.ts` now only hosts `McpClient` and test seams to preserve existing imports.
  - Connection cleanup tracks transport close requests to avoid double-close cases.

<sup>Written for commit 8f96be50c08a308d6830ff42bf508fd8475b9b29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

