### PR TITLE
refactor(protocol): split communication contracts

### DIFF
--- a/packages/protocol/src/communication/envelope.ts
+++ b/packages/protocol/src/communication/envelope.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const Envelope = z
+  .object({
+    id: z.string().min(1),
+    direction: z.enum(["inbound", "outbound"]),
+    surface: z.string().min(1),
+    endpointId: z.string().min(1).optional(),
+    channelId: z.string().min(1).optional(),
+    threadId: z.string().min(1).optional(),
+    externalMessageId: z.string().min(1).optional(),
+    replyToMessageId: z.string().min(1).optional(),
+    correlationToken: z.string().min(1).optional(),
+    actorId: z.string().min(1).optional(),
+    payload: z.unknown(),
+    receivedAt: z.number().optional(),
+    sentAt: z.number().optional(),
+  })
+  .strict();
+export type Envelope = z.infer<typeof Envelope>;

--- a/packages/protocol/src/communication/index.ts
+++ b/packages/protocol/src/communication/index.ts
@@ -1,304 +1,75 @@
-import { z } from "zod";
-import { BusEvent } from "../bus/index.js";
+import { Envelope as EnvelopeSchema } from "./envelope.js";
+import * as PendingAskSchema from "./pending-ask.js";
+import * as PendingInteractionSchema from "./pending-interaction.js";
+import * as WorkerGrantSchema from "./worker-grant.js";
 
 export namespace Communication {
-  export const Envelope = z
-    .object({
-      id: z.string().min(1),
-      direction: z.enum(["inbound", "outbound"]),
-      surface: z.string().min(1),
-      endpointId: z.string().min(1).optional(),
-      channelId: z.string().min(1).optional(),
-      threadId: z.string().min(1).optional(),
-      externalMessageId: z.string().min(1).optional(),
-      replyToMessageId: z.string().min(1).optional(),
-      correlationToken: z.string().min(1).optional(),
-      actorId: z.string().min(1).optional(),
-      payload: z.unknown(),
-      receivedAt: z.number().optional(),
-      sentAt: z.number().optional(),
-    })
-    .strict();
-  export type Envelope = z.infer<typeof Envelope>;
+  export const Envelope = EnvelopeSchema;
+  export type Envelope = EnvelopeSchema;
 
   export namespace PendingAsk {
-    export const Status = z.enum(["open", "answered", "expired", "cancelled", "ambiguous"]);
-    export type Status = z.infer<typeof Status>;
+    export const Status = PendingAskSchema.Status;
+    export type Status = PendingAskSchema.Status;
 
-    export const TargetKind = z.enum([
-      "resident",
-      "worker",
-      "external_actor",
-      "scheduler",
-      "service",
-    ]);
-    export type TargetKind = z.infer<typeof TargetKind>;
+    export const TargetKind = PendingAskSchema.TargetKind;
+    export type TargetKind = PendingAskSchema.TargetKind;
 
-    export const Record = z
-      .object({
-        id: z.string().min(1),
-        originSessionId: z.string().min(1),
-        originRunId: z.string().min(1).optional(),
-        originActorKind: z.enum(["resident", "worker", "system"]),
-        targetKind: TargetKind,
-        targetActorId: z.string().min(1).optional(),
-        endpointId: z.string().min(1).optional(),
-        channelId: z.string().min(1).optional(),
-        correlation: z
-          .object({
-            externalMessageId: z.string().min(1).optional(),
-            replyToMessageId: z.string().min(1).optional(),
-            threadId: z.string().min(1).optional(),
-            tokenHash: z.string().min(1).optional(),
-            externalConversationId: z.string().min(1).optional(),
-          })
-          .strict()
-          .default({}),
-        status: Status,
-        createdAt: z.number(),
-        expiresAt: z.number().optional(),
-        answeredAt: z.number().optional(),
-        updatedAt: z.number(),
-      })
-      .strict();
-    export type Record = z.infer<typeof Record>;
+    export const Record = PendingAskSchema.Record;
+    export type Record = PendingAskSchema.Record;
 
-    export const Create = Record.omit({
-      status: true,
-      createdAt: true,
-      updatedAt: true,
-      answeredAt: true,
-    }).extend({
-      status: Status.optional(),
-      createdAt: z.number().optional(),
-      updatedAt: z.number().optional(),
-    });
-    export type Create = z.infer<typeof Create>;
+    export const Create = PendingAskSchema.Create;
+    export type Create = PendingAskSchema.Create;
 
-    export const CorrelationQuery = z
-      .object({
-        externalMessageId: z.string().min(1).optional(),
-        replyToMessageId: z.string().min(1).optional(),
-        threadId: z.string().min(1).optional(),
-        tokenHash: z.string().min(1).optional(),
-        externalConversationId: z.string().min(1).optional(),
-        endpointId: z.string().min(1).optional(),
-        channelId: z.string().min(1).optional(),
-      })
-      .strict()
-      .refine((query) => Object.values(query).some((value) => value !== undefined), {
-        message: "At least one correlation field is required",
-      });
-    export type CorrelationQuery = z.infer<typeof CorrelationQuery>;
+    export const CorrelationQuery = PendingAskSchema.CorrelationQuery;
+    export type CorrelationQuery = PendingAskSchema.CorrelationQuery;
 
-    const EventBase = z.object({
-      id: z.string().min(1),
-      status: Status,
-      originSessionId: z.string().min(1),
-      originRunId: z.string().min(1).optional(),
-      targetKind: TargetKind,
-      time: z.number(),
-    });
-
-    export namespace Events {
-      export const Opened = BusEvent.define("pending_ask.opened", EventBase);
-      export const Answered = BusEvent.define(
-        "pending_ask.answered",
-        EventBase.extend({ answeredAt: z.number() }),
-      );
-      export const Ambiguous = BusEvent.define("pending_ask.ambiguous", EventBase);
-      export const Cancelled = BusEvent.define("pending_ask.cancelled", EventBase);
-      export const Expired = BusEvent.define("pending_ask.expired", EventBase);
-    }
+    export const Events = PendingAskSchema.Events;
   }
 
   export namespace PendingInteraction {
-    export const Status = z.enum(["open", "resolved", "follow_up", "expired", "cancelled"]);
-    export type Status = z.infer<typeof Status>;
+    export const Status = PendingInteractionSchema.Status;
+    export type Status = PendingInteractionSchema.Status;
 
-    export const AllowedAction = z.enum([
-      "report_result",
-      "ask_clarification",
-      "attach_artifact",
-      "decline_task",
-    ]);
-    export type AllowedAction = z.infer<typeof AllowedAction>;
+    export const AllowedAction = PendingInteractionSchema.AllowedAction;
+    export type AllowedAction = PendingInteractionSchema.AllowedAction;
 
-    export const Correlation = z
-      .object({
-        replyToMessageId: z.string().min(1).optional(),
-        threadId: z.string().min(1).optional(),
-        tokenHash: z.string().min(1).optional(),
-        externalConversationId: z.string().min(1).optional(),
-      })
-      .strict()
-      .default({});
-    export type Correlation = z.infer<typeof Correlation>;
+    export const Correlation = PendingInteractionSchema.Correlation;
+    export type Correlation = PendingInteractionSchema.Correlation;
 
-    export const Record = z
-      .object({
-        id: z.string().min(1),
-        workerRunId: z.string().min(1),
-        sessionId: z.string().min(1),
-        targetActorId: z.string().min(1).optional(),
-        endpointId: z.string().min(1),
-        channelId: z.string().min(1),
-        correlation: Correlation,
-        allowedActions: z.array(AllowedAction).min(1),
-        status: Status,
-        createdAt: z.number(),
-        updatedAt: z.number(),
-        expiresAt: z.number(),
-        followUpWindow: z.number().int().nonnegative(),
-        resolvedAt: z.number().optional(),
-        cancelledAt: z.number().optional(),
-      })
-      .strict();
-    export type Record = z.infer<typeof Record>;
+    export const Record = PendingInteractionSchema.Record;
+    export type Record = PendingInteractionSchema.Record;
 
-    export const Create = Record.omit({
-      status: true,
-      createdAt: true,
-      updatedAt: true,
-      resolvedAt: true,
-      cancelledAt: true,
-    }).extend({
-      status: Status.optional(),
-      createdAt: z.number().optional(),
-      updatedAt: z.number().optional(),
-    });
-    export type Create = z.infer<typeof Create>;
+    export const Create = PendingInteractionSchema.Create;
+    export type Create = PendingInteractionSchema.Create;
 
-    export const CorrelationQuery = z
-      .object({
-        replyToMessageId: z.string().min(1).optional(),
-        threadId: z.string().min(1).optional(),
-        tokenHash: z.string().min(1).optional(),
-        externalConversationId: z.string().min(1).optional(),
-        endpointId: z.string().min(1),
-        channelId: z.string().min(1),
-      })
-      .strict();
-    export type CorrelationQuery = z.infer<typeof CorrelationQuery>;
+    export const CorrelationQuery = PendingInteractionSchema.CorrelationQuery;
+    export type CorrelationQuery = PendingInteractionSchema.CorrelationQuery;
 
-    const EventBase = z.object({
-      id: z.string().min(1),
-      workerRunId: z.string().min(1),
-      sessionId: z.string().min(1),
-      endpointId: z.string().min(1),
-      channelId: z.string().min(1),
-      status: Status,
-      time: z.number(),
-    });
-
-    export namespace Events {
-      export const Opened = BusEvent.define("pending_interaction.opened", EventBase);
-      export const Resolved = BusEvent.define(
-        "pending_interaction.resolved",
-        EventBase.extend({ resolvedAt: z.number() }),
-      );
-      export const FollowUp = BusEvent.define("pending_interaction.follow_up", EventBase);
-      export const Cancelled = BusEvent.define(
-        "pending_interaction.cancelled",
-        EventBase.extend({ cancelledAt: z.number() }),
-      );
-      export const Expired = BusEvent.define("pending_interaction.expired", EventBase);
-    }
+    export const Events = PendingInteractionSchema.Events;
   }
 
   export namespace WorkerGrant {
-    export const Status = z.enum(["active", "revoked", "expired"]);
-    export type Status = z.infer<typeof Status>;
+    export const Status = WorkerGrantSchema.Status;
+    export type Status = WorkerGrantSchema.Status;
 
-    export const Risk = z.enum(["low", "medium", "high"]);
-    export type Risk = z.infer<typeof Risk>;
+    export const Risk = WorkerGrantSchema.Risk;
+    export type Risk = WorkerGrantSchema.Risk;
 
-    export const ManagerGrant = z
-      .object({
-        allowedActorGroups: z.array(z.string().min(1)).optional(),
-        riskCeiling: Risk.optional(),
-      })
-      .strict();
-    export type ManagerGrant = z.infer<typeof ManagerGrant>;
+    export const ManagerGrant = WorkerGrantSchema.ManagerGrant;
+    export type ManagerGrant = WorkerGrantSchema.ManagerGrant;
 
-    export const Record = z
-      .object({
-        id: z.string().min(1),
-        workerRunId: z.string().min(1),
-        status: Status,
-        version: z.number().int().min(1),
-        allowedActions: z.array(z.string().min(1)),
-        allowedSessionIds: z.array(z.string().min(1)).optional(),
-        allowedActorIds: z.array(z.string().min(1)).optional(),
-        allowedEndpointIds: z.array(z.string().min(1)).optional(),
-        canCreateExternalTasks: z.boolean().default(false),
-        managerGrant: ManagerGrant.optional(),
-        createdAt: z.number(),
-        updatedAt: z.number(),
-        expiresAt: z.number().optional(),
-        revokedAt: z.number().optional(),
-      })
-      .strict();
-    export type Record = z.infer<typeof Record>;
+    export const Record = WorkerGrantSchema.Record;
+    export type Record = WorkerGrantSchema.Record;
 
-    export const Create = Record.omit({
-      status: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-      revokedAt: true,
-    }).extend({
-      status: Status.optional(),
-      version: z.number().int().min(1).optional(),
-      createdAt: z.number().optional(),
-      updatedAt: z.number().optional(),
-    });
-    export type Create = z.infer<typeof Create>;
+    export const Create = WorkerGrantSchema.Create;
+    export type Create = WorkerGrantSchema.Create;
 
-    export const Evaluation = z
-      .object({
-        workerRunId: z.string().min(1),
-        action: z.string().min(1),
-        sessionId: z.string().min(1).optional(),
-        actorId: z.string().min(1).optional(),
-        endpointId: z.string().min(1).optional(),
-        createsExternalTask: z.boolean().optional(),
-        actorGroup: z.string().min(1).optional(),
-        risk: Risk.optional(),
-      })
-      .strict();
-    export type Evaluation = z.infer<typeof Evaluation>;
+    export const Evaluation = WorkerGrantSchema.Evaluation;
+    export type Evaluation = WorkerGrantSchema.Evaluation;
 
-    export const EvaluationResult = z
-      .object({
-        allowed: z.boolean(),
-        reason: z.string().min(1),
-        grantId: z.string().min(1).optional(),
-      })
-      .strict();
-    export type EvaluationResult = z.infer<typeof EvaluationResult>;
+    export const EvaluationResult = WorkerGrantSchema.EvaluationResult;
+    export type EvaluationResult = WorkerGrantSchema.EvaluationResult;
 
-    const EventBase = z.object({
-      id: z.string().min(1),
-      workerRunId: z.string().min(1),
-      status: Status,
-      version: z.number().int().min(1),
-      time: z.number(),
-    });
-
-    export namespace Events {
-      export const Created = BusEvent.define("worker_grant.created", EventBase);
-      export const Updated = BusEvent.define("worker_grant.updated", EventBase);
-      export const Revoked = BusEvent.define("worker_grant.revoked", EventBase);
-      export const Expired = BusEvent.define("worker_grant.expired", EventBase);
-      export const Evaluated = BusEvent.define(
-        "worker_grant.evaluated",
-        EventBase.extend({
-          allowed: z.boolean(),
-          reason: z.string().min(1),
-          action: z.string().min(1),
-        }),
-      );
-    }
+    export const Events = WorkerGrantSchema.Events;
   }
 }

--- a/packages/protocol/src/communication/pending-ask.ts
+++ b/packages/protocol/src/communication/pending-ask.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { BusEvent } from "../bus/index.js";
+
+export const Status = z.enum(["open", "answered", "expired", "cancelled", "ambiguous"]);
+export type Status = z.infer<typeof Status>;
+
+export const TargetKind = z.enum(["resident", "worker", "external_actor", "scheduler", "service"]);
+export type TargetKind = z.infer<typeof TargetKind>;
+
+export const Record = z
+  .object({
+    id: z.string().min(1),
+    originSessionId: z.string().min(1),
+    originRunId: z.string().min(1).optional(),
+    originActorKind: z.enum(["resident", "worker", "system"]),
+    targetKind: TargetKind,
+    targetActorId: z.string().min(1).optional(),
+    endpointId: z.string().min(1).optional(),
+    channelId: z.string().min(1).optional(),
+    correlation: z
+      .object({
+        externalMessageId: z.string().min(1).optional(),
+        replyToMessageId: z.string().min(1).optional(),
+        threadId: z.string().min(1).optional(),
+        tokenHash: z.string().min(1).optional(),
+        externalConversationId: z.string().min(1).optional(),
+      })
+      .strict()
+      .default({}),
+    status: Status,
+    createdAt: z.number(),
+    expiresAt: z.number().optional(),
+    answeredAt: z.number().optional(),
+    updatedAt: z.number(),
+  })
+  .strict();
+export type Record = z.infer<typeof Record>;
+
+export const Create = Record.omit({
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  answeredAt: true,
+}).extend({
+  status: Status.optional(),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});
+export type Create = z.infer<typeof Create>;
+
+export const CorrelationQuery = z
+  .object({
+    externalMessageId: z.string().min(1).optional(),
+    replyToMessageId: z.string().min(1).optional(),
+    threadId: z.string().min(1).optional(),
+    tokenHash: z.string().min(1).optional(),
+    externalConversationId: z.string().min(1).optional(),
+    endpointId: z.string().min(1).optional(),
+    channelId: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine((query) => Object.values(query).some((value) => value !== undefined), {
+    message: "At least one correlation field is required",
+  });
+export type CorrelationQuery = z.infer<typeof CorrelationQuery>;
+
+const EventBase = z.object({
+  id: z.string().min(1),
+  status: Status,
+  originSessionId: z.string().min(1),
+  originRunId: z.string().min(1).optional(),
+  targetKind: TargetKind,
+  time: z.number(),
+});
+
+export const Events = {
+  Opened: BusEvent.define("pending_ask.opened", EventBase),
+  Answered: BusEvent.define("pending_ask.answered", EventBase.extend({ answeredAt: z.number() })),
+  Ambiguous: BusEvent.define("pending_ask.ambiguous", EventBase),
+  Cancelled: BusEvent.define("pending_ask.cancelled", EventBase),
+  Expired: BusEvent.define("pending_ask.expired", EventBase),
+} as const;

--- a/packages/protocol/src/communication/pending-interaction.ts
+++ b/packages/protocol/src/communication/pending-interaction.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { BusEvent } from "../bus/index.js";
+
+export const Status = z.enum(["open", "resolved", "follow_up", "expired", "cancelled"]);
+export type Status = z.infer<typeof Status>;
+
+export const AllowedAction = z.enum([
+  "report_result",
+  "ask_clarification",
+  "attach_artifact",
+  "decline_task",
+]);
+export type AllowedAction = z.infer<typeof AllowedAction>;
+
+export const Correlation = z
+  .object({
+    replyToMessageId: z.string().min(1).optional(),
+    threadId: z.string().min(1).optional(),
+    tokenHash: z.string().min(1).optional(),
+    externalConversationId: z.string().min(1).optional(),
+  })
+  .strict()
+  .default({});
+export type Correlation = z.infer<typeof Correlation>;
+
+export const Record = z
+  .object({
+    id: z.string().min(1),
+    workerRunId: z.string().min(1),
+    sessionId: z.string().min(1),
+    targetActorId: z.string().min(1).optional(),
+    endpointId: z.string().min(1),
+    channelId: z.string().min(1),
+    correlation: Correlation,
+    allowedActions: z.array(AllowedAction).min(1),
+    status: Status,
+    createdAt: z.number(),
+    updatedAt: z.number(),
+    expiresAt: z.number(),
+    followUpWindow: z.number().int().nonnegative(),
+    resolvedAt: z.number().optional(),
+    cancelledAt: z.number().optional(),
+  })
+  .strict();
+export type Record = z.infer<typeof Record>;
+
+export const Create = Record.omit({
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  resolvedAt: true,
+  cancelledAt: true,
+}).extend({
+  status: Status.optional(),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});
+export type Create = z.infer<typeof Create>;
+
+export const CorrelationQuery = z
+  .object({
+    replyToMessageId: z.string().min(1).optional(),
+    threadId: z.string().min(1).optional(),
+    tokenHash: z.string().min(1).optional(),
+    externalConversationId: z.string().min(1).optional(),
+    endpointId: z.string().min(1),
+    channelId: z.string().min(1),
+  })
+  .strict();
+export type CorrelationQuery = z.infer<typeof CorrelationQuery>;
+
+const EventBase = z.object({
+  id: z.string().min(1),
+  workerRunId: z.string().min(1),
+  sessionId: z.string().min(1),
+  endpointId: z.string().min(1),
+  channelId: z.string().min(1),
+  status: Status,
+  time: z.number(),
+});
+
+export const Events = {
+  Opened: BusEvent.define("pending_interaction.opened", EventBase),
+  Resolved: BusEvent.define(
+    "pending_interaction.resolved",
+    EventBase.extend({ resolvedAt: z.number() }),
+  ),
+  FollowUp: BusEvent.define("pending_interaction.follow_up", EventBase),
+  Cancelled: BusEvent.define(
+    "pending_interaction.cancelled",
+    EventBase.extend({ cancelledAt: z.number() }),
+  ),
+  Expired: BusEvent.define("pending_interaction.expired", EventBase),
+} as const;

--- a/packages/protocol/src/communication/worker-grant.ts
+++ b/packages/protocol/src/communication/worker-grant.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { BusEvent } from "../bus/index.js";
+
+export const Status = z.enum(["active", "revoked", "expired"]);
+export type Status = z.infer<typeof Status>;
+
+export const Risk = z.enum(["low", "medium", "high"]);
+export type Risk = z.infer<typeof Risk>;
+
+export const ManagerGrant = z
+  .object({
+    allowedActorGroups: z.array(z.string().min(1)).optional(),
+    riskCeiling: Risk.optional(),
+  })
+  .strict();
+export type ManagerGrant = z.infer<typeof ManagerGrant>;
+
+export const Record = z
+  .object({
+    id: z.string().min(1),
+    workerRunId: z.string().min(1),
+    status: Status,
+    version: z.number().int().min(1),
+    allowedActions: z.array(z.string().min(1)),
+    allowedSessionIds: z.array(z.string().min(1)).optional(),
+    allowedActorIds: z.array(z.string().min(1)).optional(),
+    allowedEndpointIds: z.array(z.string().min(1)).optional(),
+    canCreateExternalTasks: z.boolean().default(false),
+    managerGrant: ManagerGrant.optional(),
+    createdAt: z.number(),
+    updatedAt: z.number(),
+    expiresAt: z.number().optional(),
+    revokedAt: z.number().optional(),
+  })
+  .strict();
+export type Record = z.infer<typeof Record>;
+
+export const Create = Record.omit({
+  status: true,
+  version: true,
+  createdAt: true,
+  updatedAt: true,
+  revokedAt: true,
+}).extend({
+  status: Status.optional(),
+  version: z.number().int().min(1).optional(),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});
+export type Create = z.infer<typeof Create>;
+
+export const Evaluation = z
+  .object({
+    workerRunId: z.string().min(1),
+    action: z.string().min(1),
+    sessionId: z.string().min(1).optional(),
+    actorId: z.string().min(1).optional(),
+    endpointId: z.string().min(1).optional(),
+    createsExternalTask: z.boolean().optional(),
+    actorGroup: z.string().min(1).optional(),
+    risk: Risk.optional(),
+  })
+  .strict();
+export type Evaluation = z.infer<typeof Evaluation>;
+
+export const EvaluationResult = z
+  .object({
+    allowed: z.boolean(),
+    reason: z.string().min(1),
+    grantId: z.string().min(1).optional(),
+  })
+  .strict();
+export type EvaluationResult = z.infer<typeof EvaluationResult>;
+
+const EventBase = z.object({
+  id: z.string().min(1),
+  workerRunId: z.string().min(1),
+  status: Status,
+  version: z.number().int().min(1),
+  time: z.number(),
+});
+
+export const Events = {
+  Created: BusEvent.define("worker_grant.created", EventBase),
+  Updated: BusEvent.define("worker_grant.updated", EventBase),
+  Revoked: BusEvent.define("worker_grant.revoked", EventBase),
+  Expired: BusEvent.define("worker_grant.expired", EventBase),
+  Evaluated: BusEvent.define(
+    "worker_grant.evaluated",
+    EventBase.extend({
+      allowed: z.boolean(),
+      reason: z.string().min(1),
+      action: z.string().min(1),
+    }),
+  ),
+} as const;


### PR DESCRIPTION
## Summary
- split the oversized `Communication` protocol namespace into focused envelope, pending ask, pending interaction, and worker grant schema modules
- keep `packages/protocol/src/communication/index.ts` as the public namespace facade so existing `Communication.*` imports keep working
- preserve all event descriptor names and schema defaults/refinements while moving implementation details out of the facade

## Verification
- `bun test packages/protocol/test/communication/schema.test.ts packages/session/test/pending-ask/store.test.ts packages/session/test/pending-interaction/store.test.ts packages/session/test/worker-grant/store.test.ts`
- `bun run --cwd packages/protocol build`
- `bun run --cwd packages/protocol check-types`
- `bunx biome check packages/protocol/src/communication packages/protocol/test/communication/schema.test.ts`
- LSP diagnostics on `packages/protocol/src/communication`: 0 diagnostics
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bun run build`
- `bun run check-types`
- `bunx biome check .`
- `bunx knip --no-config-hints`
- `bun run test`
- independent ultrawork reviewer: PASS
- pre-push dep-check/type-check: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the oversized `Communication` protocol into focused modules (envelope, pending ask, pending interaction, worker grant) for clarity and easier maintenance. The public API stays the same via `packages/protocol/src/communication/index.ts`, so existing `Communication.*` imports continue to work.

- **Refactors**
  - Moved schemas/events into `envelope.ts`, `pending-ask.ts`, `pending-interaction.ts`, and `worker-grant.ts` under `packages/protocol/src/communication`.
  - `index.ts` now re-exports these as the `Communication` facade.
  - Kept all schema defaults/refinements and event descriptor names; no behavior changes.

<sup>Written for commit c764aa65a2b138184bd386e7a711f69914adf8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

