### PR TITLE
refactor(server): split mcp provider responsibilities

### DIFF
--- a/apps/server/src/tool/mcp/provider-execution.ts
+++ b/apps/server/src/tool/mcp/provider-execution.ts
@@ -1,0 +1,108 @@
+import type { Tool } from "@openomni/protocol";
+import { Mcp, PolicyDecision, PolicyEvent, ToolExecution } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import type { NativeTool, ToolExecutionContext } from "@openomni/openomni";
+import { McpPrefixGuardMiddleware } from "./mcp-prefix-guard";
+import { MCP_TOOL_ACTION, buildActor, readSessionId } from "./provider-audit";
+import { createResultSummary } from "./provider-metadata";
+
+interface ExecuteMcpToolInput {
+  readonly call: Tool.Call;
+  readonly context: ToolExecutionContext | undefined;
+  readonly tools: NativeTool[];
+  readonly isServerConnected: (serverName: string) => boolean;
+}
+
+export async function executeMcpTool(input: ExecuteMcpToolInput): Promise<Tool.Result> {
+  const { call, context } = input;
+  const guard = await McpPrefixGuardMiddleware.evaluatePreToolUse({
+    call,
+    tools: input.tools,
+    isServerConnected: input.isServerConnected,
+  });
+  const tool = guard.tool;
+  if (PolicyDecision.isBlocking(guard.verdict) || !tool) {
+    return publishBlockedResult(
+      call,
+      tool,
+      PolicyDecision.reason(guard.verdict, `Unknown tool: ${call.tool}`),
+    );
+  }
+
+  const sessionId = readSessionId(call) ?? "";
+  const actionId = crypto.randomUUID();
+  const actor = buildActor(sessionId);
+
+  Bus.publish(PolicyEvent.ActionRequested, {
+    traceId: crypto.randomUUID(),
+    sessionId,
+    time: Date.now(),
+    actionId,
+    actor,
+    action: MCP_TOOL_ACTION,
+    resource: tool.spec.name,
+    context: { input: call.input },
+  });
+
+  const startTime = Date.now();
+  const result = await (context === undefined
+    ? tool.execute({ ...call, tool: tool.spec.name })
+    : tool.execute({ ...call, tool: tool.spec.name }, context));
+  const durationMs = Date.now() - startTime;
+
+  Bus.publish(ToolExecution.Completed, {
+    traceId: crypto.randomUUID(),
+    sessionId,
+    time: Date.now(),
+    actor,
+    toolCallId: call.id,
+    toolName: tool.spec.name,
+    durationMs,
+    isError: result.isError ?? false,
+  });
+
+  if (!result.isError) {
+    const resultSummary = createResultSummary(result.output);
+    const serverName = tool.spec.name.split(".")[0] ?? "unknown";
+
+    Bus.publish(Mcp.ToolCompleted, {
+      traceId: crypto.randomUUID(),
+      serverName,
+      toolName: tool.spec.name,
+      toolCallId: call.id,
+      durationMs,
+      resultSummary,
+      time: Date.now(),
+    });
+  }
+
+  return result;
+}
+
+function publishBlockedResult(
+  call: Tool.Call,
+  tool: NativeTool | undefined,
+  reason: string,
+): Tool.Result {
+  const result = {
+    id: crypto.randomUUID(),
+    toolCallId: call.id,
+    output: reason,
+    isError: true,
+  };
+  const sessionId = readSessionId(call);
+  if (sessionId) {
+    Bus.publish(PolicyEvent.ActionBlocked, {
+      traceId: crypto.randomUUID(),
+      sessionId,
+      time: Date.now(),
+      actionId: crypto.randomUUID(),
+      actor: buildActor(sessionId),
+      action: MCP_TOOL_ACTION,
+      resource: tool?.spec.name ?? call.tool,
+      verdict: "deny" as const,
+      reason,
+    });
+  }
+  return result;
+}

--- a/apps/server/src/tool/mcp/provider-tool-listing.ts
+++ b/apps/server/src/tool/mcp/provider-tool-listing.ts
@@ -1,0 +1,51 @@
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
+import type { NativeTool } from "@openomni/openomni";
+import { mcpToolMetadata } from "./provider-metadata";
+import type { McpClientLike } from "./provider-types";
+
+function createAbortError(): Error {
+  const error = new Error("MCP tool execution aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export async function refreshMcpTools(
+  clients: ReadonlyMap<string, McpClientLike>,
+): Promise<NativeTool[]> {
+  const tools: NativeTool[] = [];
+  for (const [serverName, client] of clients) {
+    try {
+      const specs = await client.listTools();
+      for (const spec of specs) {
+        const metadata = mcpToolMetadata(serverName, spec);
+        tools.push({
+          spec: { ...spec, labels: metadata.labels },
+          labels: metadata.labels,
+          descriptor: metadata.descriptor,
+          riskTier: 1,
+          isReadOnly: false,
+          isDestructive: false,
+          isConcurrencySafe: false,
+          source: "mcp",
+          execute: (call, context) => {
+            if (context?.signal?.aborted) return Promise.reject(createAbortError());
+            return client.callTool(call.tool, call.input, call.id, context);
+          },
+        });
+      }
+    } catch (err) {
+      Bus.publish(Operational.Warn, {
+        traceId: crypto.randomUUID(),
+        time: Date.now(),
+        component: "server",
+        msg: "failed to list tools from mcp server",
+        context: {
+          serverName,
+          err: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+  return tools;
+}

--- a/apps/server/src/tool/mcp/provider.ts
+++ b/apps/server/src/tool/mcp/provider.ts
@@ -1,6 +1,5 @@
 import { McpClient } from "@openomni/agent";
 import type { McpServerConfig, Tool } from "@openomni/protocol";
-import { Mcp, PolicyDecision, PolicyEvent, ToolExecution } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import type {
@@ -9,18 +8,15 @@ import type {
   ToolExecutionContext,
   ToolProvider,
 } from "@openomni/openomni";
-import { McpPrefixGuardMiddleware } from "./mcp-prefix-guard";
 import {
-  MCP_TOOL_ACTION,
-  buildActor,
   publishLifecycleApproved,
   publishLifecycleBlocked,
   publishLifecycleRequested,
-  readSessionId,
   resolveLifecycleAudit,
   summarizeServerConfig,
 } from "./provider-audit";
-import { createResultSummary, mcpToolMetadata } from "./provider-metadata";
+import { executeMcpTool } from "./provider-execution";
+import { refreshMcpTools } from "./provider-tool-listing";
 import type {
   McpClientLike,
   McpLifecycleAuditContext,
@@ -28,12 +24,6 @@ import type {
 } from "./provider-types";
 
 export type { McpLifecycleAuditContext, McpToolProviderOptions } from "./provider-types";
-
-function createAbortError(): Error {
-  const error = new Error("MCP tool execution aborted");
-  error.name = "AbortError";
-  return error;
-}
 
 export class McpToolProvider implements ToolProvider {
   readonly name = "mcp";
@@ -169,123 +159,17 @@ export class McpToolProvider implements ToolProvider {
   }
 
   async refreshTools(): Promise<void> {
-    const tools: NativeTool[] = [];
-    for (const [serverName, client] of this.clients) {
-      try {
-        const specs = await client.listTools();
-        for (const spec of specs) {
-          const metadata = mcpToolMetadata(serverName, spec);
-          tools.push({
-            spec: { ...spec, labels: metadata.labels },
-            labels: metadata.labels,
-            descriptor: metadata.descriptor,
-            riskTier: 1,
-            isReadOnly: false,
-            isDestructive: false,
-            isConcurrencySafe: false,
-            source: "mcp",
-            execute: (call, context) => {
-              if (context?.signal?.aborted) return Promise.reject(createAbortError());
-              return client.callTool(call.tool, call.input, call.id, context);
-            },
-          });
-        }
-      } catch (err) {
-        Bus.publish(Operational.Warn, {
-          traceId: crypto.randomUUID(),
-          time: Date.now(),
-          component: "server",
-          msg: "failed to list tools from mcp server",
-          context: {
-            serverName,
-            err: err instanceof Error ? err.message : String(err),
-          },
-        });
-      }
-    }
-    this.cachedTools = tools;
+    this.cachedTools = await refreshMcpTools(this.clients);
   }
 
   async execute(call: Tool.Call, context?: ToolExecutionContext): Promise<Tool.Result> {
-    const guard = await McpPrefixGuardMiddleware.evaluatePreToolUse({
+    return executeMcpTool({
       call,
+      context,
       tools: this.listTools(),
       isServerConnected: (serverName) =>
         this.clients.has(serverName) && this.connected.has(serverName),
     });
-    const tool = guard.tool;
-    if (PolicyDecision.isBlocking(guard.verdict) || !tool) {
-      const result = {
-        id: crypto.randomUUID(),
-        toolCallId: call.id,
-        output: PolicyDecision.reason(guard.verdict, `Unknown tool: ${call.tool}`),
-        isError: true,
-      };
-      const sessionId = readSessionId(call);
-      if (sessionId) {
-        Bus.publish(PolicyEvent.ActionBlocked, {
-          traceId: crypto.randomUUID(),
-          sessionId,
-          time: Date.now(),
-          actionId: crypto.randomUUID(),
-          actor: buildActor(sessionId),
-          action: MCP_TOOL_ACTION,
-          resource: tool?.spec.name ?? call.tool,
-          verdict: "deny" as const,
-          reason: PolicyDecision.reason(guard.verdict, `Unknown tool: ${call.tool}`),
-        });
-      }
-      return result;
-    }
-
-    const sessionId = readSessionId(call) ?? "";
-    const actionId = crypto.randomUUID();
-    const actor = buildActor(sessionId);
-
-    Bus.publish(PolicyEvent.ActionRequested, {
-      traceId: crypto.randomUUID(),
-      sessionId,
-      time: Date.now(),
-      actionId,
-      actor,
-      action: MCP_TOOL_ACTION,
-      resource: tool.spec.name,
-      context: { input: call.input },
-    });
-
-    const startTime = Date.now();
-    const result = await (context === undefined
-      ? tool.execute({ ...call, tool: tool.spec.name })
-      : tool.execute({ ...call, tool: tool.spec.name }, context));
-    const durationMs = Date.now() - startTime;
-
-    Bus.publish(ToolExecution.Completed, {
-      traceId: crypto.randomUUID(),
-      sessionId,
-      time: Date.now(),
-      actor,
-      toolCallId: call.id,
-      toolName: tool.spec.name,
-      durationMs,
-      isError: result.isError ?? false,
-    });
-
-    if (!result.isError) {
-      const resultSummary = createResultSummary(result.output);
-      const serverName = tool.spec.name.split(".")[0] ?? "unknown";
-
-      Bus.publish(Mcp.ToolCompleted, {
-        traceId: crypto.randomUUID(),
-        serverName,
-        toolName: tool.spec.name,
-        toolCallId: call.id,
-        durationMs,
-        resultSummary,
-        time: Date.now(),
-      });
-    }
-
-    return result;
   }
 
   get serverCount(): number {

--- a/script/lint-side-effects.ts
+++ b/script/lint-side-effects.ts
@@ -31,7 +31,7 @@ interface SourceMatch {
 const hotFiles = [
   "packages/openomni/src/execution-runtime/tool/executor.ts",
   "packages/openomni/src/execution-runtime/tool/executor-events.ts",
-  "apps/server/src/tool/mcp/provider.ts",
+  "apps/server/src/tool/mcp/provider-execution.ts",
   "packages/llm/src/session/processor.ts",
   "packages/openomni/src/ingress/event-projector.ts",
   "packages/openomni/src/ingress/session-bridge.ts",
@@ -62,10 +62,10 @@ const rules: readonly SideEffectRule[] = [
   },
   {
     ruleId: "mcp-ledger-before-execute",
-    filePath: "apps/server/src/tool/mcp/provider.ts",
+    filePath: "apps/server/src/tool/mcp/provider-execution.ts",
     sideEffect: /tool\.execute\(\{ \.\.\.call, tool: tool\.spec\.name \}(?:, context)?\)/g,
     scopeStart:
-      /async execute\(call: Tool\.Call(?:, context\?: ToolExecutionContext)?\): Promise<Tool\.Result> \{/g,
+      /export async function executeMcpTool\(input: ExecuteMcpToolInput\): Promise<Tool\.Result> \{/g,
     requiredBefore: ["Bus.publish(PolicyEvent.ActionRequested, {", "actionId", "tool.spec.name"],
     message: "MCP tool execution must be preceded by a mandatory action_requested ledger append",
   },


### PR DESCRIPTION
## Summary
- split MCP provider tool listing and execution/audit flow into focused package-local helpers
- keep `McpToolProvider` as the public server tool provider and preserve its existing lifecycle and test-visible state fields
- move the MCP ledger-before-execute side-effect guard to the new execution helper so the invariant still tracks the actual side effect

## Verification
- `bun test apps/server/test/tool/mcp/provider.test.ts apps/server/test/execution/tool-catalog.test.ts`
- `bun run --cwd apps/server check-types`
- LSP diagnostics on `apps/server/src/tool/mcp`: 0 diagnostics
- `bun run lint:guards`
- `bun run lint:side-effects`
- `bunx biome check apps/server/src/tool/mcp script/lint-side-effects.ts apps/server/test/tool/mcp/provider.test.ts apps/server/test/execution/tool-catalog.test.ts`
- `bun run build`
- `bun run check-types`
- `bunx biome check .`
- `bunx knip --no-config-hints`
- `bun run test`
- independent ultrawork reviewer: PASS
- pre-push dep-check/type-check: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split MCP tool provider responsibilities into small helpers for listing and executing tools. Keeps `McpToolProvider` API and lifecycle behavior unchanged while preserving the audit/ledger invariant before execution.

- **Refactors**
  - Added `provider-tool-listing.ts` to build `NativeTool`s from MCP servers; handles abort and logs list failures.
  - Added `provider-execution.ts` to run tools, enforce prefix guard, and publish policy/telemetry events with an ActionRequested entry before execute.
  - Updated `provider.ts` to delegate to the new helpers; existing state and lifecycle events remain.
  - Updated `script/lint-side-effects.ts` to enforce the ledger-before-execute rule in the new execution file.

<sup>Written for commit 45cd1fab1a6ce67e1b5a8b7dd3047095c6db1703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

