### PR TITLE
refactor(coordinator): centralize ipc socket data access

### DIFF
--- a/packages/coordinator/src/ipc/server.ts
+++ b/packages/coordinator/src/ipc/server.ts
@@ -46,8 +46,16 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
   }
 
   interface BunSocket {
-    data: unknown;
+    data: SocketData;
     write(data: Buffer | Uint8Array | string): number;
+  }
+
+  function setConnectionId(socket: BunSocket, id: string): void {
+    socket.data = { id } satisfies SocketData;
+  }
+
+  function connectionId(socket: BunSocket): string {
+    return socket.data.id;
   }
 
   const connections = new Map<string, { socket: BunSocket; decoder: LineDecoder }>();
@@ -90,11 +98,11 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
     socket: {
       open(socket: BunSocket) {
         const id = `conn-${++connCounter}`;
-        (socket.data as unknown as SocketData) = { id };
+        setConnectionId(socket, id);
         connections.set(id, { socket, decoder: new LineDecoder() });
       },
       data(socket: BunSocket, raw: Buffer) {
-        const state = connections.get((socket.data as unknown as SocketData).id);
+        const state = connections.get(connectionId(socket));
         if (!state) return;
 
         let messages: unknown[];
@@ -146,13 +154,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
               socket.write(encode(Ipc.createNotification(method, params)));
             };
             try {
-              handler(
-                parsed.method,
-                parsed.params,
-                respond,
-                notify,
-                (socket.data as unknown as SocketData).id,
-              );
+              handler(parsed.method, parsed.params, respond, notify, connectionId(socket));
             } catch (err) {
               socket.write(
                 encode(
@@ -172,7 +174,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
                 parsed.params,
                 () => undefined,
                 () => undefined,
-                (socket.data as unknown as SocketData).id,
+                connectionId(socket),
               );
             } catch (error) {
               console.warn(
@@ -184,11 +186,11 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
         }
       },
       close(socket: BunSocket) {
-        const id = (socket.data as unknown as SocketData).id;
+        const id = connectionId(socket);
         removeConnection(id, "socket closed");
       },
       error(socket: BunSocket, _err: Error) {
-        const id = (socket.data as unknown as SocketData).id;
+        const id = connectionId(socket);
         void socket;
         removeConnection(id, "socket error");
       },


### PR DESCRIPTION
## Summary
- type the IPC server socket data as `SocketData` instead of `unknown`
- centralize connection id assignment and lookup through local helpers
- remove repeated `socket.data as unknown as SocketData` casts without changing IPC request/notification flow

## Verification
- bun test packages/coordinator/src/ipc/ipc-bidirectional.test.ts packages/coordinator/test/harness/smoke.test.ts
- bun run --cwd packages/coordinator check-types
- bunx biome check packages/coordinator/src/ipc/server.ts
- LSP diagnostics on packages/coordinator/src/ipc/server.ts
- bun run lint:guards
- bun run lint:side-effects
- bun run build
- bun run check-types
- bunx biome check .
- bunx knip --no-config-hints
- bun run test
- codex-ultrawork-reviewer: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized IPC socket connection ID handling and typed socket data to remove unsafe casts and simplify the IPC server logic. No behavior changes; improves type safety and readability.

- **Refactors**
  - Typed `BunSocket.data` as `SocketData`.
  - Added `setConnectionId` and `connectionId` helpers.
  - Replaced inline casts with helpers across the IPC server.

<sup>Written for commit d8622201039bef2097d2a569000df178f50aaaaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

