### PR TITLE
refactor(openomni): type injection queue policy context

### DIFF
--- a/packages/openomni/src/execution-runtime/middleware/injection-queue-policy.ts
+++ b/packages/openomni/src/execution-runtime/middleware/injection-queue-policy.ts
@@ -6,6 +6,12 @@ import type { InjectionQueue } from "../injection-queue.js";
 
 const POLICY_ID = "builtin:injection-queue-drain";
 
+type InjectionQueuePolicyContext = PolicyContext & {
+  readonly runId?: string;
+  readonly sessionId?: string;
+  readonly agentName?: string;
+};
+
 export function createInjectionQueueDrainPolicy(
   queue: InjectionQueue.Instance,
 ): PolicyRegistration {
@@ -49,10 +55,10 @@ export function createInjectionQueueDrainPolicy(
 }
 
 function contextString(
-  ctx: PolicyContext,
+  ctx: InjectionQueuePolicyContext,
   key: "agentName" | "runId" | "sessionId",
 ): string | undefined {
-  const value = (ctx as unknown as Record<string, unknown>)[key];
+  const value = ctx[key];
   return typeof value === "string" ? value : undefined;
 }
 

--- a/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
+++ b/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { PolicyEngine } from "@openomni/agent";
+import { PolicyEngine, type PolicyEngineInstance } from "@openomni/agent";
 import { Session, Storage } from "@openomni/session";
 import { InjectionQueue } from "../../src/execution-runtime/injection-queue.js";
 import { createInjectionQueueDrainPolicy } from "../../src/execution-runtime/middleware/injection-queue-policy.js";
 import { buildWorkerMiddleware } from "../../src/execution-runtime/middleware.js";
+
+type DispatchContext = Parameters<PolicyEngineInstance["dispatch"]>[1];
+
+type LegacyFallbackContext = DispatchContext & {
+  readonly runId: string;
+  readonly sessionId: string;
+  readonly agentName: string;
+};
 
 function baseContext(runId: string, sessionId = "session-1") {
   return {
@@ -91,6 +99,41 @@ describe("createInjectionQueueDrainPolicy", () => {
     expect(Session.getParts("msg-2")).toEqual([
       expect.objectContaining({ type: "text", text: "durable", messageID: "msg-2" }),
     ]);
+  });
+
+  it("uses legacy top-level run and session identifiers when trace context is absent", async () => {
+    const session = Session.create({
+      title: "Legacy Context Policy Test",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    const queue = InjectionQueue.create();
+    queue.enqueue("legacy-run", {
+      messageId: "msg-legacy",
+      output: "legacy durable",
+      injectToHistory: true,
+      timestamp: 3,
+    });
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register(createInjectionQueueDrainPolicy(queue));
+    const context: LegacyFallbackContext = {
+      ...baseContext("unused-run", session.id),
+      traceContext: undefined,
+      runId: "legacy-run",
+      sessionId: session.id,
+      agentName: "legacy-agent",
+    };
+
+    const decision = await engine.dispatch("turn.finish", context);
+
+    expect(decision.effects).toEqual([
+      { type: "prompt.inject_message", message: "legacy durable", role: "assistant" },
+    ]);
+    expect(queue.hasPending("legacy-run")).toBe(false);
+    expect(Session.getMessages(session.id)[0]).toMatchObject({
+      id: "msg-legacy",
+      sessionID: session.id,
+      agent: "legacy-agent",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the `ctx as unknown as Record<string, unknown>` escape hatch from the injection queue drain policy
- add a local typed policy context for legacy top-level `runId`, `sessionId`, and `agentName` fallback
- add characterization coverage for trace-context-absent legacy fallback

## Verification
- bun test packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
- bun run --cwd packages/openomni check-types
- bunx biome check packages/openomni/src/execution-runtime/middleware/injection-queue-policy.ts packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
- LSP diagnostics on both changed files
- bun run build
- bun run check-types
- bunx biome check .
- bunx knip --no-config-hints
- bun run lint:guards && bun run lint:side-effects
- bun run test

## Review note
Independent reviewer/oracle checks were attempted but unavailable in this environment: codex-ultrawork-reviewer failed with revoked refresh token, and Claude Fable returned 404 for `claude-fable-5`. This PR is relying on local full gates plus GitHub CI/CodeRabbit for external validation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the injection queue drain policy context and removed the unsafe cast. Preserves legacy top‑level `runId`, `sessionId`, and `agentName` when trace context is missing.

- **Refactors**
  - Added `InjectionQueuePolicyContext` and updated `contextString` to read typed keys directly.
  - Added tests covering legacy fallback behavior and injection-queue integration.

<sup>Written for commit 8751726697498791dd1b4ec9179e877824c0826e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

