### PR TITLE
refactor(server): require mcp audit session context

### DIFF
--- a/apps/server/src/tool/mcp/provider-audit.ts
+++ b/apps/server/src/tool/mcp/provider-audit.ts
@@ -1,6 +1,6 @@
 import type { McpServerConfig, Tool } from "@openomni/protocol";
 import { PolicyEvent } from "@openomni/protocol";
-import { Bus, Storage } from "@openomni/session";
+import { Bus } from "@openomni/session";
 import type { McpLifecycleAuditContext, ResolvedLifecycleAudit } from "./provider-types";
 
 /** @internal Package-local helper for McpToolProvider only. */
@@ -18,12 +18,7 @@ export function resolveLifecycleAudit(
 ): ResolvedLifecycleAudit | undefined {
   const sessionId = context?.audit?.sessionId;
   if (typeof sessionId !== "string" || sessionId.length === 0) {
-    const fallbackSession = latestSession();
-    if (!fallbackSession) return undefined;
-    return {
-      sessionId: fallbackSession.id,
-      ...(context?.actor !== undefined && { actor: context.actor }),
-    };
+    return undefined;
   }
   return {
     sessionId,
@@ -124,12 +119,6 @@ export function buildActor(
     kind: "mcp_provider",
     ...(sessionId !== undefined && { sessionId }),
   };
-}
-
-function latestSession(): { readonly id: string } | undefined {
-  return Storage.get()
-    .session.list()
-    .sort((left, right) => right.time.updated - left.time.updated)[0];
 }
 
 function lifecycleBase(audit: ResolvedLifecycleAudit) {

--- a/apps/server/test/tool/mcp/provider.test.ts
+++ b/apps/server/test/tool/mcp/provider.test.ts
@@ -715,8 +715,7 @@ describe("McpToolProvider", () => {
     }
   });
 
-  it("uses the latest session as default lifecycle audit context", async () => {
-    createLedgerSession();
+  it("omits lifecycle audit events when no audit session is provided", async () => {
     const client = makeClient();
     const provider = new McpToolProvider({ createClient: () => client.client });
 
@@ -731,12 +730,7 @@ describe("McpToolProvider", () => {
       const lifecycleEvents = events.filter(
         (e) => e.name === "policy.action.requested" || e.name === "policy.action.approved",
       );
-      expect(lifecycleEvents.map((e) => e.name)).toEqual([
-        "policy.action.requested",
-        "policy.action.approved",
-        "policy.action.requested",
-        "policy.action.approved",
-      ]);
+      expect(lifecycleEvents).toHaveLength(0);
     } finally {
       stop();
     }


### PR DESCRIPTION
## Summary
- remove the implicit latest-session fallback from MCP lifecycle audit resolution
- keep MCP lifecycle audit events tied only to an explicit audit session
- update provider coverage so lifecycle events are omitted when no audit session is provided

## Verification
- bun test apps/server/test/tool/mcp/provider.test.ts
- bun run --cwd apps/server check-types
- bun run check-types
- bun run build
- bunx biome check .
- bun run test
- bun run lint:guards && bun run lint:side-effects
- bunx knip --no-config-hints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an explicit audit session for MCP lifecycle audit events and remove the implicit “latest session” fallback. If no audit session is provided, lifecycle events are not emitted.

- **Refactors**
  - Removed fallback to the latest session and `Storage` usage from `@openomni/session`.
  - `resolveLifecycleAudit` now returns undefined without `audit.sessionId`.
  - Updated tests to expect zero lifecycle events when no audit session is passed.

- **Migration**
  - Always pass `audit.sessionId` in `McpLifecycleAuditContext` when invoking the provider.
  - Update any consumers or policies that rely on `policy.action.*` events to ensure a session is set.

<sup>Written for commit be912cab888cff25e51d3c28ad7409e6b10d4c06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit session handling now requires explicit session context for lifecycle operations. Operations performed without proper audit context will no longer generate audit events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->