### PR TITLE
refactor(openomni): reuse work item readback envelope

### DIFF
--- a/packages/openomni/src/dispatch/handlers/worker-completion.ts
+++ b/packages/openomni/src/dispatch/handlers/worker-completion.ts
@@ -26,6 +26,10 @@ const ReadBackRequest = WorkItem.ReadBackRequest.superRefine((request, ctx) => {
 
 type ReadBackRequest = z.infer<typeof ReadBackRequest>;
 
+const ReadBackRequestEnvelope = WorkItem.ReadBackRequestEnvelope.extend({
+  request: ReadBackRequest,
+});
+
 const CompletionReportDraft = z
   .object({
     summary: z.string().min(1),
@@ -47,15 +51,7 @@ const CompletionReportDraft = z
 const CompletionEnvelope = z
   .object({
     completionReport: CompletionReportDraft,
-    readBackRequests: z
-      .array(
-        z.object({
-          claimIndex: z.number().int().nonnegative(),
-          request: ReadBackRequest,
-        }),
-      )
-      .max(MAX_READ_BACK_REQUESTS)
-      .default([]),
+    readBackRequests: z.array(ReadBackRequestEnvelope).max(MAX_READ_BACK_REQUESTS).default([]),
   })
   .superRefine((envelope, ctx) => {
     for (const [requestIndex, readBack] of envelope.readBackRequests.entries()) {


### PR DESCRIPTION
## Summary
- reuse WorkItem.ReadBackRequestEnvelope when parsing worker completion read-back requests
- keep the local runtime request limits by extending the protocol schema

## Verification
- bun run --cwd packages/protocol build
- bun test packages/openomni/test/dispatch packages/openomni/test/evidence packages/openomni/test/execution-runtime
- bun run check-types
- bun run build
- bunx biome check packages/openomni/src/dispatch/handlers/worker-completion.ts
- bunx knip --no-config-hints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the `worker-completion` handler to reuse `WorkItem.ReadBackRequestEnvelope` for read-back requests, reducing duplicate schema code and aligning with the protocol. Validation stays the same and local runtime limits are preserved.

- **Refactors**
  - Extended `WorkItem.ReadBackRequestEnvelope` with the refined `request` type and replaced the inline `readBackRequests` schema.
  - Kept `MAX_READ_BACK_REQUESTS` enforcement by applying `.max()` to the envelope array.

<sup>Written for commit 9ed844ddb3a61b3b048695f6a33b9fd7fc292897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

