### PR TITLE
refactor(openomni): clarify resident tool policy

### DIFF
--- a/packages/openomni/src/agents/resident/prompt/claude.ts
+++ b/packages/openomni/src/agents/resident/prompt/claude.ts
@@ -105,6 +105,8 @@ Review and distill Worker output before presenting it. Do not forward raw output
 
 Normal Workers must not create new top-level work unless explicitly authorized. If a Worker proposes follow-up work, you decide whether it matters and whether to ask the user.
 
+Reserve Worker delegation for substantial independent work, not small cheap work that direct tools can finish in the current session.
+
 Illustrative examples (these show bottleneck reasoning, not lookup rules):
 
 - A user says "close the room door" and a working door-control CLI is known: the bottleneck is a simple digital command → Resident direct.
@@ -120,6 +122,8 @@ Use tools to improve truth, execution, coordination, or verification. Do not use
 
 When tools are available:
 
+- Keep the full tool surface available by default: filesystem, execution, delegation, MCP, and custom tools.
+- Use direct tools first for small cheap work when a direct tool can satisfy the request.
 - Inspect before modifying.
 - Prefer narrow, relevant context over broad context dumps.
 - Use source evidence for claims that depend on current or external facts.

--- a/packages/openomni/src/agents/resident/prompt/gpt.ts
+++ b/packages/openomni/src/agents/resident/prompt/gpt.ts
@@ -72,6 +72,8 @@ When delegating: provide context, goal, constraints, task-relevant user principl
 
 Review and distill Worker output before the user sees it. Do not let normal Workers create top-level work unless explicitly authorized.
 
+Reserve Worker delegation for substantial independent work, not small cheap work that direct tools can finish in the current session.
+
 Illustrative examples (bottleneck reasoning, not lookup rules):
 
 - Door-close with known CLI: bottleneck is a simple command → Resident direct.
@@ -84,6 +86,8 @@ Illustrative examples (bottleneck reasoning, not lookup rules):
     toolUse: `## Tools
 
 Use tools for truth, execution, coordination, and verification. Not performatively.
+
+Keep the full tool surface available by default: filesystem, execution, delegation, MCP, and custom tools. Use direct tools first for small cheap work when a direct tool can satisfy the request.
 
 Inspect before modifying. Prefer relevant context over broad dumps. Verify claims against sources. Perform clear permitted personal operations directly. Preserve boundaries. Treat failures as diagnostic signals. Report only meaningful outcomes.
 

--- a/packages/openomni/test/resident/prompt.test.ts
+++ b/packages/openomni/test/resident/prompt.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { ResidentAgent } from "../../src/agents";
 
+function sectionFrom(prompt: string, heading: string): string {
+  const start = prompt.indexOf(heading);
+  if (start < 0) throw new Error(`missing prompt section: ${heading}`);
+  const next = prompt.indexOf("\n## ", start + heading.length);
+  return prompt.slice(start, next < 0 ? undefined : next);
+}
+
 describe("ResidentAgent prompt public surface", () => {
   test("keeps getPrompt public while helper members stay internal", async () => {
     const promptSource = await Bun.file(
@@ -34,5 +41,21 @@ describe("ResidentAgent prompt public surface", () => {
     expect(promptSource).not.toMatch(/\bexport\s+const\s+buildPrompt\b/);
     expect(promptSource).not.toMatch(/\bexport\s+const\s+inferPromptFamily\b/);
     expect(promptSource).not.toMatch(/\bexport\s+function\s+getPromptVariant\b/);
+  });
+
+  test("instructs Resident to keep full tools while using direct tools first for cheap work", () => {
+    for (const family of ["claude", "gpt"] as const) {
+      const prompt = ResidentAgent.getPrompt({ family });
+      const toolSection = sectionFrom(prompt, family === "claude" ? "## Tool Use" : "## Tools");
+      const delegationSection = sectionFrom(prompt, "## Delegation");
+
+      for (const category of ["filesystem", "execution", "delegation", "mcp", "custom"] as const) {
+        expect(toolSection.toLowerCase()).toContain(category);
+      }
+      expect(toolSection.toLowerCase()).toContain("full tool");
+      expect(toolSection.toLowerCase()).toContain("direct tools");
+      expect(toolSection.toLowerCase()).toContain("small cheap");
+      expect(delegationSection.toLowerCase()).toContain("substantial independent work");
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Clarify that Resident keeps the full tool surface available by default: filesystem, execution, delegation, MCP, and custom tools.
- Tell Resident to use direct tools first for small cheap work and reserve Workers for substantial independent work.
- Add prompt regression coverage for both Claude and GPT prompt variants.

## Verification
- bun test packages/openomni/test/resident/prompt.test.ts
- bun run check-types --filter=@openomni/openomni
- bunx biome check packages/openomni/test/resident/prompt.test.ts packages/openomni/src/agents/resident/prompt/claude.ts packages/openomni/src/agents/resident/prompt/gpt.ts
- git diff --check origin/main..HEAD
- pre-push: turbo run check-types

Note: LSP diagnostics were unavailable locally because the LSP transport returned `Transport closed`; TypeScript checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Resident tool policy to keep the full tool surface available by default (filesystem, execution, delegation, MCP, custom tools), use direct tools first for small cheap tasks, and reserve Worker delegation for substantial independent work. Adds prompt regression tests for both Claude and GPT variants to lock in this guidance.

<sup>Written for commit e3f3744f7e09708b5d7b653e6a55bd38b47a9cfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined AI agent delegation and tool-usage strategy to prioritize direct tools for small, efficient tasks while reserving delegation for substantial independent work requiring separate sessions.

* **Tests**
  * Added validation tests for AI agent prompt instructions to verify proper tool-usage and delegation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->