### PR TITLE
fix(server): expose custom tools to workers

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -90,7 +90,8 @@ export async function main(): Promise<void> {
     msg: "server running in coordinator mode",
   });
   const workerScript = new URL("../execution/worker-entry.ts", import.meta.url).pathname;
-  const bootstrap = await assembleBootstrap(mcpProvider);
+  const customProvider = new CustomToolProvider();
+  const bootstrap = await assembleBootstrap(mcpProvider, undefined, customProvider);
   const hasAnyChannel = Boolean(
     config.telegram.token || config.github.secret || config.discord.token,
   );
@@ -99,8 +100,7 @@ export async function main(): Promise<void> {
     ? await createResidentProfile({ model: { provider: model.providerID, id: model.id } })
     : undefined;
   if (residentProfile) registerAgent(residentProfile.factory, residentProfile.metadata);
-  const customProvider = new CustomToolProvider();
-  const toolDispatcher = buildToolDispatcher([mcpProvider]);
+  const toolDispatcher = buildToolDispatcher([mcpProvider, customProvider]);
   const coordinator = createExecutionCoordinator({
     workerScript,
     bootstrap,

--- a/apps/server/src/bootstrap/worker-bootstrap.ts
+++ b/apps/server/src/bootstrap/worker-bootstrap.ts
@@ -1,8 +1,9 @@
 import { Auth } from "@openomni/llm";
 import type { WorkerBootstrap } from "@openomni/protocol";
-import { resolveCategory } from "@openomni/openomni";
+import { resolveCategory, type NativeTool } from "@openomni/openomni";
 import { createAllAgents } from "../agents";
 import { RuntimeAgentDefinition } from "../agents/runtime-definition";
+import type { CustomToolProvider } from "../tool/custom";
 import type { McpToolProvider } from "../tool/mcp";
 
 function djb2Hash(s: string): string {
@@ -16,21 +17,14 @@ function djb2Hash(s: string): string {
 export async function assembleBootstrap(
   mcpProvider: Pick<McpToolProvider, "listTools">,
   authEntries?: Awaited<ReturnType<typeof Auth.all>>,
+  customProvider?: Pick<CustomToolProvider, "listTools">,
 ): Promise<WorkerBootstrap.Bootstrap> {
   const agents = [...createAllAgents().values()].map(RuntimeAgentDefinition.create);
 
-  const toolCatalog = mcpProvider.listTools().map(
-    (tool): WorkerBootstrap.RuntimeToolCatalogEntry => ({
-      canonicalName: tool.spec.name,
-      exposedName: tool.spec.name,
-      source: "mcp",
-      category: resolveCategory(tool.spec.name, "mcp", tool.category),
-      riskTier: tool.riskTier,
-      spec: tool.spec,
-      ...(tool.descriptor !== undefined && { descriptor: tool.descriptor }),
-      mcpServer: tool.spec.name.includes(".") ? tool.spec.name.split(".")[0] : undefined,
-    }),
-  );
+  const toolCatalog = [
+    ...mcpProvider.listTools().map((tool) => createToolCatalogEntry(tool, "mcp")),
+    ...(customProvider?.listTools().map((tool) => createToolCatalogEntry(tool, "server")) ?? []),
+  ];
 
   const resolvedAuthEntries = authEntries ?? (await Auth.all());
   const credentials: Record<string, string> = {};
@@ -51,4 +45,28 @@ export async function assembleBootstrap(
   const configEpoch = djb2Hash(epochInput);
 
   return { configEpoch, agents, toolCatalog, credentials };
+}
+
+function createToolCatalogEntry(
+  tool: NativeTool,
+  source: WorkerBootstrap.RuntimeToolCatalogEntry["source"],
+): WorkerBootstrap.RuntimeToolCatalogEntry {
+  const mcpServer = source === "mcp" ? getMcpServerName(tool.spec.name) : undefined;
+
+  return {
+    canonicalName: tool.spec.name,
+    exposedName: tool.spec.name,
+    source,
+    category: resolveCategory(tool.spec.name, source, tool.category),
+    riskTier: tool.riskTier,
+    spec: tool.spec,
+    ...(tool.descriptor !== undefined && { descriptor: tool.descriptor }),
+    ...(mcpServer !== undefined && { mcpServer }),
+  };
+}
+
+function getMcpServerName(toolName: string): string | undefined {
+  if (!toolName.includes(".")) return undefined;
+  const [serverName] = toolName.split(".");
+  return serverName;
 }

--- a/apps/server/src/execution/worker-bootstrap-handler.ts
+++ b/apps/server/src/execution/worker-bootstrap-handler.ts
@@ -95,7 +95,7 @@ export namespace WorkerBootstrapHandler {
         context: {
           workerId: options.workerId,
           agents: bootstrap.agents.length,
-          mcpTools: bootstrap.toolCatalog.length,
+          runtimeTools: bootstrap.toolCatalog.length,
         },
       });
       options.respond({ ok: true });

--- a/apps/server/test/bootstrap/credential-bootstrap.test.ts
+++ b/apps/server/test/bootstrap/credential-bootstrap.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AppConnector, Dispatch, Execution } from "@openomni/protocol";
+import type { NativeTool } from "@openomni/openomni";
 import { createServerDispatchOwners } from "../../src/bootstrap/dispatch-owners";
 import { assembleBootstrap } from "../../src/bootstrap/worker-bootstrap";
+import type { CustomToolProvider } from "../../src/tool/custom";
 import type { McpToolProvider } from "../../src/tool/mcp";
 
 const tempRoots: string[] = [];
@@ -25,6 +27,55 @@ function fakeMcpProvider(): McpToolProvider {
   return {
     listTools: () => [],
   } as unknown as McpToolProvider;
+}
+
+function fakeMcpProviderWithTool(): McpToolProvider {
+  return {
+    listTools: () => [
+      makeTool({
+        name: "filesystem.read",
+        category: "mcp",
+      }),
+    ],
+  } as unknown as McpToolProvider;
+}
+
+function fakeCustomProvider(): Pick<CustomToolProvider, "listTools"> {
+  return {
+    listTools: () => [
+      makeTool({
+        name: "web_search",
+        category: "custom",
+      }),
+      makeTool({
+        name: "web_fetch",
+        category: "custom",
+      }),
+    ],
+  };
+}
+
+function makeTool(input: {
+  readonly name: string;
+  readonly category: NativeTool["category"];
+}): NativeTool {
+  return {
+    spec: {
+      name: input.name,
+      description: `${input.name} tool`,
+      inputSchema: { type: "object", properties: {} },
+    },
+    riskTier: 0,
+    isReadOnly: true,
+    isDestructive: false,
+    isConcurrencySafe: true,
+    category: input.category,
+    execute: async (call) => ({
+      id: crypto.randomUUID(),
+      toolCallId: call.id,
+      output: `${input.name} result`,
+    }),
+  };
 }
 
 function fakeConnector(command: string, args: readonly string[]): AppConnector.Definition {
@@ -108,6 +159,31 @@ function request(workspaceRoot: string): Execution.Request {
 }
 
 describe("server bootstrap connector endpoint credentials", () => {
+  test("includes custom server tools in the worker runtime catalog", async () => {
+    const bootstrap = await assembleBootstrap(fakeMcpProviderWithTool(), {}, fakeCustomProvider());
+    const byName = Object.fromEntries(
+      bootstrap.toolCatalog.map((entry) => [entry.canonicalName, entry]),
+    );
+
+    expect(byName["filesystem.read"]).toMatchObject({
+      source: "mcp",
+      category: "mcp",
+      mcpServer: "filesystem",
+    });
+    expect(byName.web_search).toMatchObject({
+      source: "server",
+      category: "custom",
+      riskTier: 0,
+    });
+    expect(byName.web_fetch).toMatchObject({
+      source: "server",
+      category: "custom",
+      riskTier: 0,
+    });
+    expect(byName.web_search?.mcpServer).toBeUndefined();
+    expect(byName.web_fetch?.mcpServer).toBeUndefined();
+  });
+
   test("passes Auth.all credentials through bootstrap into the default connector driver with redacted output", async () => {
     const workspaceRoot = tempDir("server-bootstrap-credential-runtime");
     const scriptPath = join(workspaceRoot, "fake-bootstrap-credential.ts");


### PR DESCRIPTION
## Summary
- include server custom tools in the worker bootstrap runtime catalog
- register the custom provider in the worker tool dispatcher so proxied worker calls can execute `web_search` and `web_fetch`
- add regression coverage for custom server tools in worker bootstrap

## Verification
- `bun run build`
- `bun run check-types`
- `bun test`
- `bun -e 'import { assembleBootstrap } from "./apps/server/src/bootstrap/worker-bootstrap"; import { McpToolProvider } from "./apps/server/src/tool/mcp"; import { CustomToolProvider } from "./apps/server/src/tool/custom"; const bootstrap = await assembleBootstrap(new McpToolProvider(), {}, new CustomToolProvider()); console.log(bootstrap.toolCatalog.filter((t) => t.canonicalName === "web_search" || t.canonicalName === "web_fetch"));'`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose custom server tools to workers by adding them to the bootstrap tool catalog and registering the `CustomToolProvider` in the dispatcher. Workers can now run `web_search` and `web_fetch` via proxied calls.

- **Bug Fixes**
  - Include custom server tools in the worker catalog (`source: "server"`) via `assembleBootstrap(..., customProvider)`.
  - Register `CustomToolProvider` in the tool dispatcher (`buildToolDispatcher([mcpProvider, customProvider])`).
  - Use a shared catalog helper to set categories and `mcpServer` correctly; only MCP tools get `mcpServer`.
  - Add tests covering custom tool inclusion, `filesystem.read` `mcpServer` detection, and credential passthrough.
  - Rename telemetry context from `mcpTools` to `runtimeTools`.

<sup>Written for commit efa6cfeb13dafa73663e8877f6f421fcf0eaee7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

