### PR TITLE
docs: absorb native-tools-first and deferred-ingress rationale

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,8 @@ Each ring depends only inward. `check-deps` gets real rules (the current openomn
 - **Zod-first types.** Every cross-package contract is a Zod schema first, `z.infer<>` second, sharing one name. No standalone `interface` for shared contracts; validate at boundaries with `.parse()`; discriminated unions for state shapes. Runtime-only members extend via `&` intersection.
 - **Strict inward dependencies.** Each ring depends only inward (see rings above); reverse imports are build failures; cross-package imports go through the root barrel only — no deep imports. The server must not import the agent loop directly; all agent work flows through the kernel. Enforced by `script/check-deps.ts` in CI.
 - **Stateless ChatAgent.** The agent loop is a function-style primitive (messages + tools in, events out via `AsyncGenerator`); it owns no session lifecycle or durable state — sinks and transports are injected. Session-backed orchestration lives above it. Extension happens through the policy engine, not subclassing.
+- **Native tools first.** First-party capabilities are in-process native tools; MCP is reserved for genuinely external boundaries. Wrapping our own code behind MCP adds a serialization hop and hides it from the policy pipeline.
+- **Scheduling is deferred ingress.** A scheduled job is `ingress.submit` with a later timestamp — there is no separate queue subsystem or queue tool; cron fires back into the same single entry path.
 
 ## Known Bugs (audit-confirmed)
 


### PR DESCRIPTION
Two one-line rationales rescued from retired local ADR drafts (005/008) into Architecture §Code Conventions, so future contributors don't re-litigate: native tools in-process with MCP only at external boundaries, and scheduling as deferred ingress.submit (no separate queue). Part of the 2026-07-03 local-docs cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Absorbed two rationales into Architecture Code Conventions: prefer native in-process tools (use MCP only at external boundaries) and treat scheduling as deferred `ingress.submit` with no separate queue. Clarifies expected patterns and prevents re-litigating these decisions.

<sup>Written for commit 501e1c40a40bcb271822e901a1269917e92c8509. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how first-party capabilities should be implemented, recommending in-process native tools and reserving external integrations for true outside boundaries.
  * Clarified the preferred approach to keep tools visible to the policy pipeline and reduce unnecessary overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->