### PR TITLE
docs: sync package AGENTS.md after p0 dead-code sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,19 +18,16 @@ openomni/
 ├── packages/
 │   ├── protocol/        # Shared Zod schemas and cross-package contracts
 │   ├── policy/          # Protocol-only policy engine primitive: dispatch, effect composition, registry
-│   ├── session/         # Session CRUD, Bus pub/sub, Storage adapter (in-memory + SQLite), BusPersistence, Artifact, Snapshot, SurfaceKey, WorkerRun, WorkItemStore (universal work state), TraceContext
+│   ├── session/         # Session CRUD, Bus pub/sub, Storage adapter (in-memory + SQLite), BusPersistence, Artifact, SurfaceKey, WorkerRun, WorkItemStore (universal work state), TraceContext
 │   ├── llm/             # LLM abstraction: providers, auth (API key + proxy), streaming, retry, token/cost tracking, provider transforms
-│   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + runtime registry, messenger, MCP — depends on session for observability (Bus, TraceContext)
+│   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + MCP client runtime — depends on session for observability (Bus, TraceContext)
 │   │   ├── src/core/           # ChatAgent, budget, retry, policy engine, memory, delegation, telemetry
 │   │   │   ├── execution/      # StreamEngine, ToolExecutor, compaction, parallel-tools
-│   │   │   └── policy/         # Agent policy facade + builtins (budget, memory, tool-permission, compaction, post-tool, post-turn, idle-nudge)
-│   │   └── src/runtime/        # Multi-agent infrastructure
-│   │       ├── messenger/      # AgentMessenger
-│   │       ├── registry/       # AgentRegistry
-│   │       ├── tools/          # Runtime tool helpers
+│   │   │   └── policy/         # Agent policy facade + builtins (budget, compaction, idle-nudge, tool-guard)
+│   │   └── src/runtime/        # MCP client runtime
 │   │       └── mcp/            # McpClient
 │   ├── openomni/        # Product kernel: messaging, access, orchestration, ledger/evidence gates, tools runtime
-│   └── coordinator/     # Multiprocess execution coordinator: on-demand worker manager, worker internals, IPC transport, recovery, credentials, tool-permission
+│   └── coordinator/     # Multiprocess execution coordinator: on-demand worker manager, worker internals, IPC transport, recovery
 ├── turbo.json           # Build pipeline config
 └── package.json         # Workspace root (bun@1.3.6)
 ```
@@ -98,7 +95,7 @@ Existing `ingress/` and `dispatch/` are implementation stages of this kernel, no
 | Add policy timing | `packages/protocol/src/policy/index.ts` | 13 timings: pre_run, pre_turn, on_system_prompt, pre_tool_use, post_tool_use, post_turn, post_compaction, post_run, on_error, pre_ingress, pre_tool_selection, pre_delegation |
 | Agent profile schema | `packages/protocol/src/agent/index.ts` | `AgentProfile.Definition`, `AgentProfile.AgentBudget` |
 | Session CRUD | `packages/session/src/session/` | Namespace-based API |
-| Storage backend | `packages/session/src/storage/` | Implement `Storage.Adapter` (core session/message/part plus optional `artifact`, `eventLog`, `surfaceKey`, `backgroundTask`, `workItem`, `workerRunState`) |
+| Storage backend | `packages/session/src/storage/` | Implement `Storage.Adapter` (core session/message/part plus optional `artifact`, `eventLog`, `surfaceKey`, `workItem`, `workerRunState`) |
 | Bus persistence observer | `packages/session/src/bus-persistence/` | Bus.observe() handler that persists non-ephemeral events to bus_event table |
 | Bus query API | `packages/session/src/bus-persistence/query.ts` | BusQuery namespace for reading persisted events |
 | Surface → session mapping | `packages/session/src/surface-key/` | N:1 SurfaceKey registry |
@@ -115,11 +112,8 @@ Existing `ingress/` and `dispatch/` are implementation stages of this kernel, no
 | Policy engine primitive | `packages/policy/src/` | `PolicyEngine.create()`, `PolicyRegistry.create()`, effect composition |
 | Agent policy built-ins | `packages/agent/src/core/policy/` | Agent-scoped facade + built-ins in `builtin/` |
 | Agent execution engine | `packages/agent/src/core/execution/` | StreamEngine, ToolExecutor, compaction, parallel-tools |
-| Agent messenger | `packages/agent/src/runtime/messenger/` | AgentMessenger |
-| Agent registry | `packages/agent/src/runtime/registry/` | AgentRegistry |
 | MCP client | `packages/agent/src/runtime/mcp/` | McpClient |
 | Resident agent prompts | `packages/openomni/src/agents/resident/prompt/` | `ResidentAgent.getPrompt({ model })` — model-specific system prompt variants (Claude, GPT) |
-| DAG utilities | `packages/openomni/src/dag/` | Pure: `build`, `validateAcyclic`, `getReady`, `complete` |
 | Messaging kernel | `packages/openomni/src/{messaging,ingress,dispatch}/` | OpenOmni-owned envelope routing, access evaluation, correlation, session/target resolution, projection |
 | Ingress engine | `packages/openomni/src/ingress/` | Current inbound stage: authority middleware → session resolution → projection → resident/direct handler |
 | Resident runtime (in-process) | `packages/openomni/src/resident/` | `ResidentRuntime` — handles resident-target ingress in-process, bypassing coordinator |
@@ -172,7 +166,7 @@ Target direction: the user and Resident may submit new inbound work; ordinary Wo
 | --- | --- | --- |
 | Owner | The human operator | (No explicit type yet; identified by `ActorIdentity` with `TrustTier: owner`) |
 | Resident | Always-on user-facing assistant | Ingress target agent + future Resident policy |
-| Worker | Delegated execution actor (internal AI, external AI, human) | `AgentRegistry`, `WorkerRun`, `executorKind` |
+| Worker | Delegated execution actor (internal AI, external AI, human) | `WorkItem` attempts (formerly `WorkerRun`), `executorKind` |
 | Actor | Any external entity that interacts with the system | (Planned: `ActorIdentity` / `ActorEndpoint` in `packages/protocol/src/actor/`) |
 | System Governor | Low-privilege layer that adjusts Policy/Skill from execution evidence | Policy engine, Bus observers |
 
@@ -232,7 +226,7 @@ bun run --cwd apps/server dev        # Hono server with channels (set env tokens
 - CI pipeline: `.github/workflows/ci.yml` — build, check-types, dependency checks, and direct Bun package/app tests; app manifests may not define test scripts.
 - `dist/` dirs are gitignored but some exist locally — they are build artifacts, not source.
 - `@ai-sdk/anthropic` and `@ai-sdk/openai` are the two bundled providers. Custom provider endpoints use the OpenAI provider with their catalog API URL as `baseURL`.
-- `packages/agent` is organized as `src/core/` (ChatAgent + policy facade/built-ins) and `src/runtime/` (messenger, registry, tools, mcp). It has no durable session state ownership; session-backed orchestration lives in `packages/openomni`.
-- `packages/openomni` is the product kernel. It owns messaging, access, Resident/Worker orchestration, DAG utilities, ledger/evidence gates, and execution runtime tooling.
+- `packages/agent` is organized as `src/core/` (ChatAgent + policy facade/built-ins) and `src/runtime/` (mcp). It has no durable session state ownership; session-backed orchestration lives in `packages/openomni`.
+- `packages/openomni` is the product kernel. It owns messaging, access, Resident/Worker orchestration, ledger/evidence gates, and execution runtime tooling.
 - `packages/coordinator` owns multiprocess execution: on-demand worker lifecycle, IPC transport (Unix socket), recovery of interrupted runs, credentials injection, and tool-permission policy. It depends on all lower packages. See `packages/coordinator/AGENTS.md` for its module map.
 - WorkerRun lifecycle events live under `WorkerRun.Events.*` in `packages/protocol/src/worker-run/index.ts`.

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -12,7 +12,6 @@ Depends on `@openomni/protocol`, `@openomni/session`, `@openomni/llm`, `@openomn
 src/
 ├── index.ts              # Entry — calls bootstrap/main()
 ├── config.ts             # loadConfig() — reads env / config files into ServerConfig
-├── router.ts             # Transitional agent-name resolution; target direction is OpenOmni-owned routing
 ├── recovery.ts           # Crash-recovery glue (delegates to bootstrap/recovery)
 ├── bootstrap/
 │   ├── index.ts          # main() — wires storage, tool providers, model, channels, server, recovery, shutdown
@@ -147,7 +146,7 @@ Channel adapters must not:
 
 ## AGENT REGISTRY
 
-- `apps/server/src/agents/registry.ts` is a **server-local** agent registry (keyed by name) distinct from the `AgentRegistry` inside `@openomni/agent`.
+- `apps/server/src/agents/registry.ts` is the **server-local** agent registry (keyed by name); the former `AgentRegistry` in `@openomni/agent` was removed in the P0 dead-code sweep (#453).
 - Each entry is an `AgentDefinition` with `model`, `systemPrompt`, `tools`, optional `budget`, optional `permissions`, and trigger metadata (slash command / channel list).
 - `getAgentDefinition(name)` returns `undefined` when the agent is unknown, in which case `ingress/bridge.ts` falls back to a generic definition plus the configured default model.
 - `apps/server/src/agents/dev-agent/` is the default agent factory + prompt.

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/agent
 
-`ChatAgent` — a stateless LLM + tool ReAct loop driven by a policy engine — plus the runtime registry, messenger, and MCP client. Depends on `@openomni/protocol`, `@openomni/policy`, `@openomni/llm`, and `@openomni/session` (for observability: Log, Bus, Telemetry, TraceContext).
+`ChatAgent` — a stateless LLM + tool ReAct loop driven by a policy engine — plus the MCP client runtime. Depends on `@openomni/protocol`, `@openomni/policy`, `@openomni/llm`, and `@openomni/session` (for observability: Log, Bus, Telemetry, TraceContext).
 
 ## STRUCTURE
 
@@ -33,11 +33,7 @@ src/
 │           ├── idle-nudge.ts   # createIdleNudgePolicy (turn.start + invoke.result)
 │           └── tool-permission.ts # createToolPermissionPolicy (invoke.prepare, fail-closed)
 └── runtime/
-    ├── index.ts                # Re-exports registry / tools / mcp
-    ├── registry/
-    │   └── registry.ts         # AgentRegistry.define / get / list / override (generic in-memory profile store)
-    ├── tools/
-    │   └── index.ts            # Runtime tool helper exports
+    ├── index.ts                # Re-exports mcp
     └── mcp/
         ├── client.ts           # McpClient — connect / disconnect / listTools / callTool (stdio / sse / http)
 ```
@@ -68,7 +64,7 @@ Also exported from `@openomni/agent`:
 
 - Types: `ChatAgentConfig`, `ChatAgentInput`, `AgentResult`, `AgentStep`, `AgentEvent`, `AgentBudget`, `TokenUsage`, `Sink`, `AgentEventEmitter`
 - Policy: `PolicyEngine`, `PolicyContext`, `PolicyFn`, `PolicyRegistration`, `PolicyEngineInstance`
-- Runtime: `AgentRegistry`, `McpClient`, `McpServerConfig`
+- Runtime: `McpClient`, `McpServerConfig`
 
 ## ChatAgentConfig
 
@@ -159,7 +155,6 @@ When in doubt, keep the agent package as a loop engine and put product semantics
 
 ## RUNTIME PRIMITIVES
 
-- **AgentRegistry** — global in-memory store of `AgentProfile.Definition` entries keyed by `name`. `define`, `get`, `has`, `list`, `override`, `clear`.
 - **McpClient** — wraps the MCP SDK. Connects via stdio / SSE / streamable HTTP. `listTools()` / `callTool()` convert MCP tool specs and results to `Tool.Spec` / `Tool.Result`.
 
 ## KEY PATTERNS

--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -7,21 +7,16 @@ Product kernel for OpenOmni. Builds on `@openomni/agent`, `@openomni/policy`, `@
 | Domain | Purpose | Key exports |
 | --- | --- | --- |
 | `src/agents/` | Built-in agent definitions and model-specific prompt variants | `ResidentAgent` |
-| `src/dag/` | Pure dependency-graph utilities | `DAG` |
-| `src/profile/` | Agent profile middleware (soul/user/memory from `~/.openomni/profiles/`) | `Profile` |
 | `src/resident/` | Resident runtime lifecycle (in-process execution, direct mode) | `ResidentRuntime` |
 | `src/messaging/` | Target direction: canonical kernel facade for inbound/internal/outbound message envelopes | *(create here before adding new cross-boundary behavior)* |
 | `src/access/` | Target direction: principal/channel/delegation grant/effective-access decisions | *(create here before adding new access behavior)* |
 | `src/ingress/` | Current inbound stage: authority middleware, session resolution, projection, resident/direct execution | `IngressEngine`, `IngressEventProjector`, `IngressHandlers`, `IngressSessionResolver`, `SessionBridge`, `CronAdapter`, `resolveTarget`, `targetKey` |
 | `src/dispatch/` | Current egress/cross-boundary stage: command authorization, handler routing, PendingInteraction routing | `DispatchRuntime`, `DispatchRegistry`, `createDefaultDispatchRuntime` |
-| `src/runtime/` | Worker middleware and session utilities | *(no public exports; internal wiring only)* |
 | `src/execution-runtime/` | Tool system, workspace, worker middleware, and scheduled job runtime | `buildWorkerMiddleware`, `WorkspaceLock`, `AgentToolProvider`, `SystemToolProvider`, `ToolProxyProvider`, `Tool`, `buildToolCatalog`, `createToolExecutor`, `defineTool`, `InjectionQueue`, `CronJobRegistry`, `CronJobRunner` |
 
 ## Architecture
 
 - `src/agents/` contains built-in agent definitions. `src/agents/resident/prompt/` holds the Resident system prompt with model-specific variants (Claude, GPT) and a shared builder. `ResidentAgent.getPrompt({ model })` selects the right variant by provider.
-- `src/dag/` is structural only — it knows step topology, not runtime state.
-- `src/profile/` loads `SOUL.md`, `USER.md`, and `MEMORY.md` from the file system and injects them as `context.prepare` policy effects before agent execution.
 - `src/resident/` provides `ResidentRuntime` for in-process Resident execution without coordinator dispatch.
 - `src/messaging/` is the target home for the canonical kernel API. Until that facade exists, new behavior must still obey the same rule: OpenOmni owns principal resolution handoff, access checks, correlation, session/target resolution, projection, writeback, and response routing.
 - `src/access/` is the target home for blocklist, channel access rules, trust tier, delegation grants, PendingInteraction scope, and effective-access decisions. Store modules may answer indexed queries; access precedence belongs here.
@@ -30,7 +25,7 @@ Product kernel for OpenOmni. Builds on `@openomni/agent`, `@openomni/policy`, `@
 - `src/execution-runtime/tool/agent/tools/dispatch.ts` is the `dispatch` tool — the runtime-to-runtime/system egress gate. Worker-to-Resident awaited requests use `resident.ask`; scheduling uses `schedule.create`; cron fire remains internal ingress. `Dispatch.submit()` enforces PolicyEngine authorization and emits Bus audit events. See `src/dispatch/` for the runtime, handlers, and policy.
 - `src/execution-runtime/injection-queue.ts` (`InjectionQueue`) holds async responses keyed by `runId`. The worker middleware drains the queue at `turn.finish` and injects pending responses into the agent's next turn.
 - `src/execution-runtime/cron-job-registry.ts` (`CronJobRegistry`) stores scheduled jobs through the session storage adapter and keeps a process-local fallback map when durable storage is absent. `src/execution-runtime/cron-job-runner.ts` (`CronJobRunner`) polls the registry and accepts an injected fire implementation; server boot wires that to `CronAdapter.fire(job)`.
-- Target domain names are `messaging/`, `access/`, `orchestration/`, `tools/`, `extensions/`, `ledger/`, `profiles/`, and `runtime/`. Legacy folders (`ingress/`, `dispatch/`, `execution-runtime/`, `skill/`, `extension/`, `evidence/`, `profile/`) remain transitional until a compatibility-backed migration moves them.
+- Target domain names are `messaging/`, `access/`, `orchestration/`, `tools/`, `extensions/`, `ledger/`, `profiles/`, and `runtime/`. Legacy folders (`ingress/`, `dispatch/`, `execution-runtime/`, `evidence/`) remain transitional until a compatibility-backed migration moves them.
 - Resident/Worker orchestration seams, controlled inbound access, self-loop session creation, Worker delegation, durable external waits, ledger/evidence gates, and distilled writeback all belong in this package.
 
 WHY: each domain stays small and focused so the domain docs can stay source-of-truth instead of repeating.
@@ -61,8 +56,6 @@ Use these ownership boundaries when adding or moving code:
 
 ```
 agents/             → @openomni/protocol (Model.Ref only)
-dag/                → no internal deps
-profile/            → @openomni/session + @openomni/agent + @openomni/protocol
 resident/           → @openomni/session + @openomni/agent + @openomni/protocol
 tools/              → no orchestration deps (tool system, workspace, middleware) once migrated from execution-runtime/
 messaging/          → legacy ingress/dispatch/session/access concepts as kernel facade
@@ -80,10 +73,8 @@ ingress/            → no sibling deps
 Consumers should only use `@openomni/openomni` exports:
 
 - Resident agent prompts from `src/agents/`
-- DAG helpers from `src/dag/`
-- Profile middleware from `src/profile/`
 - Resident runtime from `src/resident/`
-- Messaging/ingress/dispatch kernel entry points from `src/messaging`, `src/ingress`, and `src/dispatch`
+- Messaging/ingress/dispatch kernel entry points from `src/ingress` and `src/dispatch`
 
 - Tool system, workspace lock, worker middleware, and cron runtime from `src/execution-runtime/`
 
@@ -105,8 +96,7 @@ If a symbol is not re-exported from `src/index.ts`, treat it as private to its d
 
 ## Domain Docs
 
-- `src/dag/AGENTS.md` — dependency-graph helpers
-- `src/profile/AGENTS.md` and `src/resident/AGENTS.md` do not exist yet; these are intentionally small modules.
+- `src/resident/AGENTS.md` does not exist yet; it is an intentionally small module.
 - `src/ingress/AGENTS.md` — inbound event handling and mode dispatch
 - `src/execution-runtime/AGENTS.md` — tool system, workspace lock, and worker middleware
 

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -38,7 +38,7 @@ src/
 
 ## KEY PATTERNS
 
-- **NamedError factory**: `NamedError.create(name, zodSchema)` produces typed error classes with `.isInstance()` guard, `.toObject()` serialization, and `.Schema` for validation. `AuthError`, `ProviderError`, etc. use this.
+- **NamedError factory**: `NamedError.create(name, zodSchema)` produces typed error classes with `.isInstance()` guard, `.toObject()` serialization, and `.Schema` for validation. `ProviderError` (in `@openomni/llm`) uses this.
 - **Namespace + Zod duality**: Schemas and types share the same name (e.g., `Tool.State` is both a Zod schema and a TS type). Access schema for validation, type for TS.
 - **Discriminated unions**: `Tool.State` on `status`, `Message.Part` on `type`, `Message.Info` on `role`, `Run.Outcome` on `type`, `ExecutionEvent` on `type`, `Policy.PolicyDecision` on `verdict`. `InboundEvent` is a discriminated union on `mode`: `DirectEvent` (`mode: "direct"`) for external inbound and `InternalEvent` (`mode: "internal"`) for system-origin events (e.g., cron). The external `ingest()` path rejects `mode: "internal"` for security.
 - **Sink interface**: Plain TS interface (NOT Zod) — the callback contract for streaming results. Uses `Tool.Call`, `Tool.Result`, `Run.Snapshot`.

--- a/packages/session/AGENTS.md
+++ b/packages/session/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/session
 
-Durable state substrate: session lifecycle, message/part storage, event bus, logs, telemetry, trace context, snapshots, artifacts, event log, surface-key records, worker-run records, and indexed stores used by the OpenOmni kernel. Depends only on `@openomni/protocol`.
+Durable state substrate: session lifecycle, message/part storage, event bus, logs, telemetry, trace context, artifacts, event log, surface-key records, worker-run records, and indexed stores used by the OpenOmni kernel. Depends only on `@openomni/protocol`.
 
 This package stores facts. It must not decide product meaning. Communication routing, actor authority, PendingInteraction/PendingAsk precedence, worker grant semantics, and writeback policy belong in `@openomni/openomni`.
 
@@ -23,13 +23,10 @@ src/
 │   ├── sqlite-*-adapter.ts # SQLite sub-adapters by storage seam
 │   ├── sqlite-schema-lifecycle.ts # PRAGMAs, migrations, and clear ordering
 │   ├── initialize.ts     # initialize({ dbPath }) — bootstraps the default SQLite adapter
-│   ├── part-time.ts      # Message-part timestamp helpers
-│   ├── wal-maintenance.ts # SQLite WAL checkpoint helpers
-│   └── drizzle/          # Drizzle schema + migration artifacts
+│   └── part-time.ts      # Message-part timestamp helpers
 ├── log/                  # Log namespace for observability records
 ├── telemetry/            # Telemetry helpers
 ├── trace/                # TraceContext helpers
-├── snapshot/             # Snapshot.Provider + InMemorySnapshotProvider; Snapshot.Diff
 ├── artifact/             # Artifact.store / get / list / versions with write-through caching
 ├── app-connector/        # AppConnectorInstallationStore for durable installed-app lifecycle records
 ├── event-log/            # EventLog.append / replay / listIncomplete / markComplete (crash recovery)
@@ -53,11 +50,10 @@ src/
 ## KEY PATTERNS
 
 - **Namespace API**: `Session.create()`, `Session.addMessage()`, `Session.addPart()`, `Session.createChild()`, `Session.getWorkerMeta()` / `updateWorkerMeta()`, etc. No class instances.
-- **Storage.Adapter**: Default is `InMemoryStorage`. `SqliteStorageAdapter` is the Bun SQLite persistent backend bootstrapped via `initialize({ dbPath })`. Its facade wires focused SQLite sub-adapter modules for required `session` / `message` / `part` and optional `artifact`, `surfaceKey`, `backgroundTask`, `cronJob`, `workItem`, `workerRunState`, and `appConnectorInstallation`. App connector installation records include Owner consent metadata plus disable/uninstall lifecycle operations because the installation record is the lifecycle SSOT. Schema lifecycle concerns that must evolve together (PRAGMAs, ordered migrations, clear ordering) live in `sqlite-schema-lifecycle.ts`. Unimplemented optional sub-objects gracefully degrade.
+- **Storage.Adapter**: Default is `InMemoryStorage`. `SqliteStorageAdapter` is the Bun SQLite persistent backend bootstrapped via `initialize({ dbPath })`. Its facade wires focused SQLite sub-adapter modules for required `session` / `message` / `part` and optional `artifact`, `surfaceKey`, `cronJob`, `workItem`, `workerRunState`, and `appConnectorInstallation`. App connector installation records include Owner consent metadata plus disable/uninstall lifecycle operations because the installation record is the lifecycle SSOT. Schema lifecycle concerns that must evolve together (PRAGMAs, ordered migrations, clear ordering) live in `sqlite-schema-lifecycle.ts`. Unimplemented optional sub-objects gracefully degrade.
 - **Migration 0006**: Legacy task/todo tables remain in SQLite for data preservation, but no TypeScript storage sub-adapters expose them.
 - **Bus events**: `Session.Event.Created`, `.Updated`, `.Deleted` are published on mutation; WorkerRun events flow through `WorkerRun.Events.*`.
 - **SurfaceKey records**: N:1 mapping from surface-specific keys (e.g. `telegram:botId:chat:chatId`) to session IDs. In-memory forward/reverse indexes plus optional `Storage.Adapter.surfaceKey` for persistence. This package stores and looks up the mapping; `openomni` decides when the mapping wins over PendingInteraction or other routing facts.
-- **Snapshot.Provider**: Interface for capturing and restoring session message state. `Snapshot.Diff` reports added / removed / modified message IDs.
 - **WorkItemStore namespace**: `WorkItemStore.create()`, `.get()`, `.list()`, `.remove()`, `.update()`, `.start()`, `.complete(hash, completionReport)`, `.fail()`, `.cancel()`, `.addBlocker()`, `.resolveBlocker()`, `.addEvidence()`, `.addReadBackEvidence()`, `.areDependenciesMet()`, `.retry()`. Publishes `WorkItem.Events.*` (Created, Updated, StatusChanged, Completed, Failed, Removed) on every mutation. Gracefully degrades when `Storage.Adapter.workItem` is absent. Terminal state transitions are validated; completion requires a report whose claim evidence IDs resolve to ledger evidence. `parentHash` is create-only immutable.
 - **WorkerRun**: Stored through the direct `workerRunState` adapter (`worker_run_state` table in SQLite). `WorkerRun.create()`, `WorkerRun.updateStatus()`, `WorkerRun.updateStatusIfCurrent()`, `WorkerRun.get()`, and `WorkerRun.listBySession()` publish lifecycle bus events but do not depend on event-log replay. State transitions such as `waiting_input → running` increment `resumeCount`.
 - **TTL / lazy deletion**: `Session.create({ ttlMs })` sets `expiresAt`; `Session.get()` and `.list()` check expiry and auto-delete.
@@ -84,7 +80,7 @@ If a store method starts combining multiple product facts into an allow/deny/rou
 
 ## ANTI-PATTERNS
 
-- **Storage API tiers**: `Storage.get()` is the public low-level API for accessing optional sub-adapters such as `backgroundTask`, `workItem`, and `workerRunState` from outside this package. For core session operations (session/message/part CRUD), prefer the namespace APIs (`Session.*`, `Artifact.*`, `EventLog.*`, `SurfaceKey.*`) for package-level invariants; note that bus publication is operation-specific. `Storage.getAdapter()` is an internal alias — both return the same adapter.
+- **Storage API tiers**: `Storage.get()` is the public low-level API for accessing optional sub-adapters such as `workItem` and `workerRunState` from outside this package. For core session operations (session/message/part CRUD), prefer the namespace APIs (`Session.*`, `Artifact.*`, `EventLog.*`, `SurfaceKey.*`) for package-level invariants; note that bus publication is operation-specific. `Storage.getAdapter()` is an internal alias — both return the same adapter.
 - Do NOT import internal paths from other packages — import from `@openomni/session` (index re-exports).
 - Do NOT persist ad-hoc delegated execution state alongside `Session`; use `WorkerRun` so delegated execution state stays in the dedicated worker-run store.
 - Do NOT write raw self-loop transcripts back into the original user session. Store internal work in child sessions and let `openomni` decide what distilled result belongs in the original session.


### PR DESCRIPTION
## Summary

Follow-up to #473 (flagged by its pre-merge review): package AGENTS.md files still documented deleted modules, which would mislead future agent sessions.

Removed/corrected references to modules deleted in #473 — `router.ts` (server tree), `AgentRegistry` (agent tree, exports, primitives; root module-map rows; Worker concept row now says `WorkItem` attempts), session `drizzle/`/`snapshot/`/`wal-maintenance.ts`/`backgroundTask` (trees, adapter lists, `Storage.get()` examples), openomni `profile/`/`skill/`/`extension/` (module map, architecture bullets, legacy-folder list, dependency shape, consumer exports, domain docs), llm `AuthError` (protocol `NamedError` example now cites surviving `ProviderError`).

Also fixed verifiably-stale entries sitting in the same blocks: openomni `src/dag/`/`src/runtime/` rows (directories do not exist), agent `runtime/messenger` (root tree/table), the agent builtin-policy list (actual: budget, compaction, idle-nudge, tool-guard), and coordinator `credentials`/`tool-permission` (deleted in #461).

Kept: server-local `SkillLoader`/`src/profile/` (server's own, live), `background_task` raw-SQL clear (table survives).

## Verification

Repo-wide grep over AGENTS.md for every deleted symbol returns only legitimate hits (server-local profile, the #453 back-reference). Pre-push dep-check + lint-tools + type-check green.

Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync AGENTS.md docs after the P0 dead‑code sweep to remove references to deleted modules and fix stale entries. Aligns package maps and examples with the current codebase (refs #453).

- **Bug Fixes**
  - Removed deleted modules across docs: server `router.ts`; `@openomni/agent` `AgentRegistry` and runtime `registry/` `messenger/` `tools/`; `@openomni/session` `drizzle/`, `snapshot/`, `wal-maintenance.ts`, `backgroundTask`; `@openomni/openomni` `src/dag/` and `src/profile/`; coordinator `credentials` and `tool-permission`.
  - Updated `@openomni/agent` docs: runtime is MCP‑only; dropped `AgentRegistry` from exports; policy built‑ins now budget, compaction, idle‑nudge, tool‑guard.
  - Updated `@openomni/session` docs: removed snapshot mentions and `backgroundTask`; kept `workItem` and `workerRunState`; refreshed anti‑patterns and storage seams.
  - Updated `@openomni/openomni` docs: removed `src/dag/` and `src/profile/` and the `src/runtime/` row; consumer exports focus on resident runtime and ingress/dispatch.
  - Updated `@openomni/protocol` docs: `NamedError` example now references `ProviderError`.
  - Synced root `AGENTS.md` maps/tables: worker row now `WorkItem` attempts; agent runtime description is MCP‑only; coordinator description trimmed.

<sup>Written for commit 226e52462d310e054e14431344a74550fb5c9ca5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several package guide files to reflect the current module layout and public surface.
  * Clarified where to find key runtime, storage, and messaging components across the monorepo.
  * Removed outdated references to deprecated or relocated areas, and refreshed ownership and API guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->