### PR TITLE
chore: remove deprecated AgentProfile.permissions field

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -26,7 +26,7 @@ The 2026-07-09 **determinism/verification round** (red-team + durable-execution 
 | #215 ActorIdentity + PendingInteraction migration | Open | 🚧 Core Actor/PI schemas, stores, resolver, correlation routing, boot cleanup, and executorKind are wired; full outbound ask proof, partial-response dependency semantics, and complete restart proof remain the issue gate |
 | #216 installed app connector runtime | Open | 🚧 AppConnector ABI, discovery/register/consent storage, endpoint dispatch, log ingestion, stall detection, and evidence projection are wired; CLI UX, full smoke-verify lifecycle, durable question suspension/resumption, and real Claude Code proof remain |
 | #217 durable boot contract | Open | 🚧 Cron persistence/runner and PI boot cleanup are wired; interrupted-run resume-offer surface and combined boot integration proof remain |
-| #222 remove deprecated `AgentProfile.permissions` | Open | 🚧 Runtime warning path is gone, but the schema field remains and needs removal or wiring plus a migration note |
+| #222 remove deprecated `AgentProfile.permissions` | Open | ✅ Field removed from `AgentProfile.Definition`; the live tool-permission plumbing (ingress `AgentDef.permissions`, execution request, worker-bootstrap — the #462 path) is untouched. Migration note: no stored data carried the field; profiles passing it were silently stripped by Zod, so removal is behavior-neutral |
 | #469 stakes computation (kernel-observed windowed state) | Open | 📋 New in the 2026-07-09 handoff-hardening round; P2 milestone; no code yet — evidence-gate θ, Voice auto-reply, and objection intensity will consume it |
 | #467 kernel contract conformance gate | Open | 🚧 Increments 1–3 (P0 exit slice) shipped: `script/lint-tools.ts` (vocab grandfather+ratchet vs core-model Tier-1/2, tool lint, #465 naming rules, earned check, Greg Young schema-snapshot lint over 165 protocol types) wired into lefthook pre-push + CI with a `--self-test` discrimination bench, plus the native-JSON round-trip property test (`packages/openomni/src/execution-runtime/tool/round-trip.test.ts`). Increments 4–5 (sandboxed verifier registry, replay conformance) co-land with P2 #455 |
 
@@ -128,7 +128,6 @@ Everything else behavior-shaping (delegation judgment, session hygiene, evidence
 
 | Item | Action |
 | --- | --- |
-| `AgentProfile.Definition.permissions` remains in the protocol schema after the ignored-config warning path was removed | Remove the field or wire it; a schema field that lies violates ADR-002's intent. Tracked by #222 |
 | `docs/vision.local.md` (v0.2) predates single-mode ingress and current package layout | Refresh or mark archived |
 | `docs/persona-runtime-roadmap.local.md` uses pre-ADR-009 vocabulary (Main/Sub Persona) | Re-vocabulary or fold into ADR-010 ordering |
 

--- a/packages/protocol/src/agent/index.ts
+++ b/packages/protocol/src/agent/index.ts
@@ -56,7 +56,6 @@ export namespace AgentProfile {
     systemPrompt: z.string().optional(),
     tools: z.string().array().default([]),
     model: Model.Ref.optional(),
-    permissions: Policy.Permission.optional(),
     policyPlan: Policy.PolicyPlan.optional(),
     variant: z.string().optional(),
     temperature: z.number().min(0).max(2).optional(),

--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -20,7 +20,6 @@ describe("AgentProfile.Definition", () => {
       systemPrompt: "You are a coder.",
       tools: ["read_file", "write_file"],
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
-      permissions: { action: "tool.call", allowlist: ["read_file"] },
       policyPlan: {
         policies: [{ id: "builtin:tool-permission", required: true }],
         labels: ["runtime"],
@@ -31,8 +30,6 @@ describe("AgentProfile.Definition", () => {
     });
     expect(result.model?.provider).toBe("anthropic");
     expect(result.model?.id).toBe("claude-3-haiku-20240307");
-    expect(result.permissions?.action).toBe("tool.call");
-    expect(result.permissions?.allowlist).toEqual(["read_file"]);
     expect(result.policyPlan?.policies[0]?.id).toBe("builtin:tool-permission");
     expect(result.policyPlan?.labels).toEqual(["runtime"]);
     expect(result.variant).toBe("high");

--- a/script/conformance/schema-snapshot.json
+++ b/script/conformance/schema-snapshot.json
@@ -53,7 +53,6 @@
     "description",
     "model",
     "name",
-    "permissions",
     "policyPlan",
     "systemPrompt",
     "temperature",


### PR DESCRIPTION
## Summary

Removes the deprecated `AgentProfile.Definition.permissions` field (#222, rides P0 #453). The field has been ignored config since the warning path was removed — `policyPlan` superseded it, and a schema field that lies violates the Zod-first contract (architecture § Code Conventions).

**Consumer audit (why this is safe):**
- Zero production reads of the field. The only repo-wide `.permissions` accesses on agent shapes trace to **different, live schemas**: ingress `AgentDefSchema.permissions`, execution request `permissions`, and `WorkerBootstrap.RuntimeAgentDefinition.permissions` (the #462 gate-stamping path) — all untouched. `apps/server`'s `AgentDefinition` extends the WorkerBootstrap type, not `AgentProfile`.
- `AgentProfile.Definition` is a non-strict Zod object, so callers passing `permissions` were already silently stripped — removal is behavior-neutral. No stored data carried the field.

**Conformance gate sign-off surface, working as designed:** the Greg Young schema-snapshot lint (#467) flagged `AgentProfile.Definition — field(s) removed: permissions` and blocked until `--update`. The regenerated snapshot diff in this PR is exactly that one line — this PR review is the Owner sign-off the gate exists to force.

**Migration note:** none needed at runtime; profiles that still pass `permissions` keep parsing (key stripped). `docs/implementation-status.md` #222 row flipped and the schema-debt row removed in the same change.

## Verification

- `bun run lint:tools` + `--self-test`: pass after snapshot update
- turbo check-types 11/11; protocol/agent/openomni/server suites: 1,784 tests, 0 fail

Refs #222 #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `AgentProfile.Definition.permissions` field in favor of `policyPlan`, addressing #222. Behavior is unchanged: the key was already ignored and stripped on parse; live permission plumbing remains intact.

- **Migration**
  - No runtime changes required; profiles that include `permissions` still parse with the key dropped.
  - Tool-permission paths are unchanged: ingress `AgentDef.permissions`, execution request `permissions`, and worker-bootstrap `RuntimeAgentDefinition.permissions` (#462).

<sup>Written for commit d5ce53bf625a703ea97f86107b2eb27d241d042b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

