### PR TITLE
ci: harden GitHub Actions workflows (SHA pins, least privilege, CodeQL, dependency review)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,8 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   benchmark:
@@ -26,15 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -71,6 +70,35 @@ jobs:
       - name: Publish benchmark summary
         run: cat bench-results/summary.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: benchmark-results
+          path: bench-results/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish benchmark history
+    needs: benchmark
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Download benchmark results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: benchmark-results
+          path: bench-results
+
       - name: Check gh-pages exists
         id: ghp
         run: |
@@ -100,8 +128,7 @@ jobs:
           git checkout -
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        if: steps.ghp.outputs.exists == 'true' || github.event_name == 'push'
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: OpenOmni Benchmarks
           tool: customSmallerIsBetter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,18 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+
   static:
     name: Static Analysis (${{ matrix.task }})
     runs-on: ubuntu-latest
@@ -19,13 +30,13 @@ jobs:
       matrix:
         task: [lint, check-types]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -39,13 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -64,13 +75,13 @@ jobs:
     timeout-minutes: 10
     needs: [static, deps]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -98,7 +109,7 @@ jobs:
       - name: Test (server)
         run: bun test
         working-directory: apps/server
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: coverage

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "31 5 * * 2"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        with:
+          languages: javascript-typescript
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/generate-models-snapshot.yml
+++ b/.github/workflows/generate-models-snapshot.yml
@@ -6,24 +6,52 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  refresh:
+  generate:
+    name: Generate snapshot patch
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.6"
       - name: Regenerate snapshot
         run: bun run script/generate-models-snapshot.ts
       - name: Format
         run: bun run format
+      - name: Upload snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: models-snapshot
+          path: packages/llm/src/model/models-snapshot.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Open snapshot PR
+    needs: generate
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Download snapshot
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: models-snapshot
+          path: packages/llm/src/model
       - name: Open PR if snapshot changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           commit-message: "chore(llm): refresh models-snapshot.json from models.dev"
           branch: chore/refresh-models-snapshot


### PR DESCRIPTION
## What

Publishes the prepared security-hardening candidate (manifest v2):

- **All 27 `uses:` references pinned to full commit SHAs** with verified release-tag comments (checkout v4.4.0, setup-bun v2.2.0, cache v4.3.0, upload/download-artifact v4.6.2/v4.3.0, dependency-review v4.9.0, codeql v3.37.3, benchmark-action v1.22.1, create-pull-request v7.0.11 — each SHA resolved upstream during review).
- **Least privilege**: workflow-level read-only defaults; write scopes only on the two main-gated publish jobs (benchmark gh-pages, snapshot PR). No write permission reachable from fork PRs.
- **New workflows**: CodeQL (javascript-typescript, PR + push + schedule) and Dependency Review (PR-only).
- **Protected-main safe**: the four existing required-check job names are preserved byte-for-byte; the only job rename is in the snapshot workflow, which has no PR trigger and is not a required check.

## Review

Independently security-reviewed this session: pin integrity resolved upstream, no `pull_request_target`/injection surfaces, artifact and cache flows verified, live branch-protection compatibility checked. The review's single MAJOR (missing version comments) is applied here; deferred minors (persist-credentials tightening, snapshot-PR check-trigger friction, checkout major bump) are recorded in manifest v2.

## Post-merge gates (in order)

1. One trusted run per new job (CodeQL analyze / Dependency Review run on this PR; benchmark publish + gh-pages bootstrap on the merge push).
2. Register `Dependency Review` and `CodeQL (javascript-typescript)` as required checks on protected main (existing four contexts unchanged).
3. Enable SHA-pinning enforcement only after this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI by pinning all `uses:` actions to full commit SHAs and defaulting workflows to least-privilege permissions. Added CodeQL and Dependency Review; write access is limited to main-only publish jobs, and existing required check names are unchanged.

- **New Features**
  - Code scanning via `github/codeql-action` for JavaScript/TypeScript on PRs, pushes to `main`, and a weekly schedule.
  - PR dependency scanning via `actions/dependency-review-action`.

- **Migration**
  - After merge, run each new job once, then mark `Dependency Review` and `CodeQL (javascript-typescript)` as required checks on `main`.
  - Enable SHA-pinning enforcement after the above.

<sup>Written for commit 544b474c50b5831455455c25afa70c4a58e623ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security across CI/CD workflows with pinned action versions and restricted permissions.
  * Added automated code security scanning to identify potential vulnerabilities.
  * Improved workflow reliability and artifact handling for benchmarks and model snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->