### PR TITLE
fix(session,openomni): delete no-op SurfaceKey.clear fake API (#522)

### DIFF
--- a/docs/clean-room-blueprint.md
+++ b/docs/clean-room-blueprint.md
@@ -81,7 +81,8 @@ sub-adapter ever guards a production write.
 
 Known defects fixed en route: Discord heartbeat-ack never called + RESUME
 token:undefined (naru re-merge), empty `SurfaceKey.clear()` called by
-`ingress/engine.ts:76`, double tool pipeline (agent wraps kernel executor —
+`IngressEngine.reset()` (FIXED — #522: fake API deleted, `Storage.reset()`
+is the enforcement layer), double tool pipeline (agent wraps kernel executor —
 duplicate events + double policy pass; agent half loses emission/policy),
 `storage.ts` warn-and-auto-init `:memory:` (plus the test pinning it),
 ~3,400 LOC of test harnesses exported from src barrels (move to test/),

--- a/packages/openomni/docs/ingress-engine.md
+++ b/packages/openomni/docs/ingress-engine.md
@@ -2,7 +2,7 @@
 
 | API | Signature |
 | --- | --- |
-| `IngressEngine.reset` | `reset(): void` — clears `SurfaceKey` + `Session` state (test-only) |
+| `IngressEngine.reset` | `reset(): void` — resets `Storage`/`Bus` and engine wiring; storage-backed state (sessions, surface keys) is swapped by `Storage.reset()` (test-only) |
 | `IngressEngine.ingest` | `ingest(event: InboundEvent): Promise<IngressResult>` |
 
 ### Architecture
@@ -34,7 +34,7 @@ Authority checks run before projection. If accepted work requires an independent
 
 ```typescript
 namespace IngressEngine {
-  // Test cleanup only — clears SurfaceKey + Session state
+  // Test cleanup only — resets Storage/Bus and engine wiring
   function reset(): void;
 
   // Main entry point — fully stateless

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -9,7 +9,7 @@ import {
   type RoutingDecisionPayload,
   type TraceContext as TraceContextProtocol,
 } from "@openomni/protocol";
-import { Bus, Storage, SurfaceKey, TraceContext } from "@openomni/session";
+import { Bus, Storage, TraceContext } from "@openomni/session";
 import type { CoordinatorLike } from "./coordinator-like";
 import type { DispatchRuntime } from "../dispatch/runtime";
 import type { ResidentRuntime } from "../resident/runtime";
@@ -170,7 +170,8 @@ function resolveAndRecordRoute<Event extends Ingress.InboundEvent>(
 
 export namespace IngressEngine {
   export function reset(): void {
-    SurfaceKey.clear();
+    // Storage-backed state (sessions, surface keys) is cleared by the
+    // Storage.reset() adapter swap; there is no separate SurfaceKey reset.
     Storage.reset();
     Bus.reset();
     _coordinator = undefined;

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { PolicyDecision, type Execution, type Message, type Ingress } from "@openomni/protocol";
 import type { PolicyRegistration } from "@openomni/agent";
-import { Bus, Session, Storage, SurfaceKey, WorkerRun } from "@openomni/session";
+import { Bus, Session, Storage, WorkerRun } from "@openomni/session";
 import { mockModelsGet, mockProviderFromModelsDevModel, resetTestState } from "./_llm-mock";
 import type { CoordinatorLike } from "../../src/ingress/coordinator-like";
 
@@ -20,7 +20,6 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  SurfaceKey.clear();
   Storage.reset();
   Storage.initialize({ dbPath: ":memory:" });
   Bus.reset();

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -4,7 +4,6 @@ import { IngressSessionResolver } from "../../src/ingress/session-resolver";
 
 describe("IngressSessionResolver", () => {
   beforeEach(() => {
-    SurfaceKey.clear();
     Storage.reset();
     Storage.initialize({ dbPath: ":memory:" });
   });

--- a/packages/session/src/surface-key/index.ts
+++ b/packages/session/src/surface-key/index.ts
@@ -173,8 +173,4 @@ export namespace SurfaceKey {
   export function listBySession(sessionId: string): string[] {
     return Storage.get().surfaceKey?.listBySession?.(sessionId) ?? [];
   }
-
-  export function clear(): void {
-    // Storage.reset() replaces the adapter with fresh state; nothing to clear here.
-  }
 }

--- a/packages/session/test/surface-key.test.ts
+++ b/packages/session/test/surface-key.test.ts
@@ -17,7 +17,6 @@ describe("SurfaceKey", () => {
   beforeEach(() => {
     Storage.reset();
     Storage.initialize({ dbPath: ":memory:" });
-    SurfaceKey.clear();
   });
 
   describe("create", () => {
@@ -443,8 +442,8 @@ describe("SurfaceKey", () => {
     });
   });
 
-  describe("clear", () => {
-    test("clears all mappings", () => {
+  describe("Storage.reset", () => {
+    test("adapter swap leaves no stale mappings", () => {
       const sessionId = "session-123";
       const key1 = "slack:workspaceA:channel:C123";
       const key2 = "slack:workspaceA:channel:C456";
@@ -455,7 +454,6 @@ describe("SurfaceKey", () => {
 
       Storage.reset();
       Storage.initialize({ dbPath: ":memory:" });
-      SurfaceKey.clear();
 
       expect(SurfaceKey.lookup(key1)).toBeUndefined();
       expect(SurfaceKey.lookup(key2)).toBeUndefined();

--- a/packages/session/test/surface-key/persistence.test.ts
+++ b/packages/session/test/surface-key/persistence.test.ts
@@ -17,12 +17,10 @@ describe("SurfaceKey SQLite persistence", () => {
     dbPath = join(tmpDir, "test.db");
     Storage.initialize({ dbPath: ":memory:" });
     Storage.configure(new SqliteStorageAdapter(dbPath));
-    SurfaceKey.clear();
   });
 
   afterEach(async () => {
     Storage.reset();
-    SurfaceKey.clear();
     await rm(tmpDir, { recursive: true });
   });
 
@@ -31,7 +29,6 @@ describe("SurfaceKey SQLite persistence", () => {
     SurfaceKey.register("telegram:bot:chat:123", session.id);
 
     Storage.configure(new SqliteStorageAdapter(dbPath));
-    SurfaceKey.clear();
 
     expect(SurfaceKey.lookup("telegram:bot:chat:123")).toBe(session.id);
   });
@@ -43,7 +40,6 @@ describe("SurfaceKey SQLite persistence", () => {
     SurfaceKey.unregister("slack:ws:dm:U1");
 
     Storage.configure(new SqliteStorageAdapter(dbPath));
-    SurfaceKey.clear();
 
     expect(SurfaceKey.lookup("slack:ws:dm:U1")).toBeUndefined();
   });
@@ -55,7 +51,6 @@ describe("SurfaceKey SQLite persistence", () => {
     SurfaceKey.register("slack:ws:channel:C1", session2.id);
 
     Storage.configure(new SqliteStorageAdapter(dbPath));
-    SurfaceKey.clear();
 
     expect(SurfaceKey.lookup("slack:ws:channel:C1")).toBe(session2.id);
   });


### PR DESCRIPTION
Fixes defect 1 of #522 (session/openomni side). Net −11 LOC.

## What

`SurfaceKey.clear()` was an empty function body behind a comment. Instead of implementing it, this PR deletes the fake API and every call site:

- `packages/session/src/surface-key/index.ts` — API deleted.
- `packages/openomni/src/ingress/engine.ts` — call removed from `IngressEngine.reset()`; a comment at the deletion site names the surviving layer (AGENTS.md rule 4).
- 4 test files — dead `SurfaceKey.clear()` calls removed; stale `describe("clear")` renamed to `describe("Storage.reset")`.
- Docs: `docs/clean-room-blueprint.md` defect list annotated FIXED; `packages/openomni/docs/ingress-engine.md` no longer claims `reset()` "clears SurfaceKey state".

## Why delete instead of implement

- Reconcile-first: tree-wide `rg` shows the only non-test caller was `IngressEngine.reset()`, and **every** caller of `IngressEngine.reset()` is a test. Zero production consumers expect a reset.
- Surface keys are durable session mappings; no consumer legitimately wants mass deletion. `persistence.test.ts` pins that mappings survive adapter re-configure — an implemented delete-all would have broken that pin.
- The adjacent `Storage.reset()` already performs the real state swap, so the deleted call was behavior-identical noise.

## Enforcement mapping (deleted check → living layer)

- Surviving enforcement: `Storage.reset()` adapter replacement (`packages/session/src/storage/storage.ts`).
- Pinning tests (pre-existing, now sole enforcement):
  - `packages/openomni/test/ingress/engine.test.ts` — ingest → `IngressEngine.reset()` → re-init → second ingest resolves a different session.
  - `packages/session/test/surface-key.test.ts` — reset + re-init → `lookup` undefined, `listBySession` empty.
  - `packages/session/test/surface-key/persistence.test.ts` — mappings persist across re-configure (guards against delete-all semantics returning).

## Adversarial review (3 independent lenses)

1. **Hidden consumers** — HOLDS. Exhaustive `rg` for direct/dynamic/string-based access, spies, barrels, `.d.ts`: zero remaining references. `SurfaceKey` holds no module-level state (all functions delegate to `Storage.get().surfaceKey`), so removal is behavior-identical under every call ordering. Found the stale `ingress-engine.md` claim → fixed in this PR.
2. **Enforcement mapping (mutation-tested)** — PASS. A simulated in-memory leak (module-level Map fallback) was injected and both pinning tests failed as required, then reverted. Note for the record: the engine.test.ts pin catches the leak via the fail-closed `resident target session not found` throw in `session-resolver.ts` (durableSessionId path), not via the id-inequality assertion — the pin depends on that path staying a throw. All pinned assertions use explicit `Storage.initialize` after reset; none depend on the `Storage.get()` auto-init being removed in defect 3.
3. **Process/doc-sync** — PASS. `docs/implementation-status.md` has no SurfaceKey row and no claim changes truth value → intentionally not edited. Blueprint annotation marks only defect 1 fixed; defects 2–3 remain unmarked.

Review also surfaced (out of scope here, noted on #522): `SurfaceKey.register`/`claim` fail open when the `surfaceKey` sub-adapter is absent (`surfaceKey?.register` skips persistence; `claim` fabricates a successful claim) — same fail-open family as defect 3, should be fixed with it.

## Gates

`check-types` ✅ · per-package tests 10/10 ✅ (root aggregate `bun test` dies with a pre-existing bun `WriteFailed` while printing the coverage text table — PR-independent, per-package runs match CI) · `lint:tools` ✅ · `check-deps` ✅ · `check-dead-exports` ✅ (38 known, none new) · commitlint ✅

## Owner sign-off

- [ ] Direction: delete the fake API rather than implement delete-all (durable-mapping argument above).
- [ ] Enforcement mapping accepted: `Storage.reset()` + the three pinning tests listed.
- [ ] `docs/implementation-status.md` intentionally untouched (no claim changes truth value).
- [ ] Defect 2 of #522 (double tool events, `packages/agent`) stays with the non-kernel track — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the no-op `SurfaceKey.clear()` API and its call sites. `IngressEngine.reset()` now relies on `Storage.reset()` and `Bus.reset()` for cleanup, clarifying reset behavior and fixing defect 1 in #522.

- **Bug Fixes**
  - Deleted `SurfaceKey.clear()` from `@openomni/session` and removed its use in `IngressEngine.reset()`.
  - Updated docs to describe `reset()` as a storage/bus reset, not a SurfaceKey clear.
  - Simplified tests by dropping dead calls and renaming the "clear" suite to "Storage.reset".
  - Preserved durability guarantees: storage-backed mappings persist across adapter reconfigure; in-memory state is swapped by `Storage.reset()`.

<sup>Written for commit 167788ced62d607d67592c548ea54d5a9ca284cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

