### PR TITLE
docs: rename driver-band packages to descriptive english names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,8 +189,8 @@ a satellite split) to violations of each one.
 - Do not add process semantics to `packages/openomni`; worker process lifecycle and IPC stay in `packages/coordinator`.
 - Do not add provider behavior outside `packages/llm`.
 - Prefer narrowing public barrels. A symbol exported from a package is a contract; do not export helper stages just for convenience.
-- Driver-band packages (approved target: `naru` channels, `chasa` remote execution, `masil` browser use, `dokkaebi` machine handles) may import only `@openomni/protocol` and `@openomni/ipc`; registration happens only in `apps/server`, and each must build/test standalone (repo-extractable). Korean package names are path-level only — exported symbols, protocol nouns, and LLM tool names stay English, and each band package's AGENTS.md opens with its one-line English gloss. See [Architecture § Execution Targets and the Driver Band](docs/architecture.md).
-- Outbound target selection (which model/machine/driver executes) is the ring-1 `@openomni/gantaek` pure decision package (approved target); do not grow placement decisions inside kernel dispatch or `apps/server`. Inbound routing (`resolveRoute`) stays in the kernel.
+- Driver-band packages (approved target: `channels` channel drivers, `remote` remote execution, `browser` browser use, `machines` machine handles) may import only `@openomni/protocol` and `@openomni/ipc`; registration happens only in `apps/server`, and each must build/test standalone (repo-extractable). Package names are path-level only — exported symbols, protocol nouns, and LLM tool names stay English. See [Architecture § Execution Targets and the Driver Band](docs/architecture.md).
+- Outbound target selection (which model/machine/driver executes) is the ring-1 `@openomni/placement` pure decision package (approved target); do not grow placement decisions inside kernel dispatch or `apps/server`. Inbound routing (`resolveRoute`) stays in the kernel.
 
 ## EXECUTION DISCIPLINE
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,19 +65,19 @@ Driver packages form a lateral band outside the ring tower:
 
 ```
 ring 0  @openomni/protocol
-ring 1  @openomni/ledger   @openomni/policy   @openomni/gantaek   ← gantaek joins ring 1
+ring 1  @openomni/ledger   @openomni/policy   @openomni/placement   ← placement joins ring 1
 ring 2  @openomni/llm   @openomni/coordinator   @openomni/ipc (#496)
 ring 3  @openomni/agent
 ring 4  @openomni/kernel
 ring 5  apps/server                       ← composition root: all band registration here
 ──────────────────────────────────────────────────────────────────
 driver band (outside the tower; repo-extractable):
-  @openomni/naru      channel drivers (telegram/discord/github/websocket)
-  @openomni/chasa     remote-execution drivers (ssh/reverse/attach; the shipped local
+  @openomni/channels  channel drivers (telegram/discord/github/websocket)
+  @openomni/remote    remote-execution drivers (ssh/reverse/attach; the shipped local
                       worker path becomes the local-process driver behind the same
                       contract per #500 — coordinator-side, not a band leaf)
-  @openomni/masil     browser-use driver
-  @openomni/dokkaebi  machine-handle SDK
+  @openomni/browser   browser-use driver
+  @openomni/machines  machine-handle SDK
 ```
 
 Band rules (enforced by `script/check-deps.ts`):
@@ -87,11 +87,11 @@ Band rules (enforced by `script/check-deps.ts`):
 3. The extraction test is normative: every band package builds and passes its tests standalone with only its declared dependencies, so it can be lifted into its own repository without touching kernel internals.
 4. Drivers start as folders inside their band package and split into packages only after a second consumer exists (the earned-abstraction rule).
 
-**Outbound target selection is `@openomni/gantaek`** (gantaek — court selection: pick one executor among capability-tagged candidates), a ring-1 pure decision package beside policy. It maps `(command, capability tags, declared facts, policy constraints) → target decision` with declared fallback chains (model error/refusal/timeout → next candidate). It decides placement only: policy alone owns allow/deny, admission alone closes work, and the selection result is consumed as an input, like Stakes. Inbound routing (`resolveRoute`) is a kernel gate concern and stays in the kernel. A network path (VPN, tailnet, proxy exit) is a capability tag and endpoint property on the target — never a kernel concern (*illustration*: per-command network wrapping as a `chasa`/`masil` execution-profile option); how the effective path is recorded belongs to the #510 attempt-identity and #492 effect contracts — this document does not extend their enumerations.
+**Outbound target selection is `@openomni/placement`** (pick one executor among capability-tagged candidates), a ring-1 pure decision package beside policy. It maps `(command, capability tags, declared facts, policy constraints) → target decision` with declared fallback chains (model error/refusal/timeout → next candidate). It decides placement only: policy alone owns allow/deny, admission alone closes work, and the selection result is consumed as an input, like Stakes. Inbound routing (`resolveRoute`) is a kernel gate concern and stays in the kernel. A network path (VPN, tailnet, proxy exit) is a capability tag and endpoint property on the target — never a kernel concern (*illustration*: per-command network wrapping as a `remote`/`browser` execution-profile option); how the effective path is recorded belongs to the #510 attempt-identity and #492 effect contracts — this document does not extend their enumerations.
 
 ## The Mailroom: One Boundary for External Communication
 
-All communication with the outside world crosses one seam, owned by `@openomni/naru` (naru — the ferry crossing: all external IO passes here with zero authority).
+All communication with the outside world crosses one seam, owned by `@openomni/channels` (the mailroom: all external IO passes here with zero authority).
 
 - **Inbound**: a channel driver receives a surface-native event, stamps provenance only (*illustration*: channel, external id, timestamps — the exact provenance field set is fixed by the #499 `Channel` contract), and emits the single canonical `Ingress.InboundEvent`. Every authority decision — blacklist, wait correlation, channel ceiling, actor identity, surface default — happens afterwards, inside the kernel's `resolveRoute` pipeline, which the band never re-implements.
 - **Outbound**: the kernel records the effect intent first (intent-event-ID as idempotency key, #492), then hands the authorized payload to a channel driver for delivery; the driver reports `confirmed | failed | unknown` and reconciliation owns the rest.
@@ -101,8 +101,7 @@ All communication with the outside world crosses one seam, owned by `@openomni/n
 
 ## Package Naming and Code Conventions for New Pieces
 
-- **Names are path-level only.** Band/ring package names may be Korean-flavored (`gantaek`, `naru`, `chasa`, `masil`, `dokkaebi`); exported symbols, protocol nouns, and LLM-facing tool names stay English under the #467/#500 gates (`naru` exports `ChannelDriver`, never `NaruDriver`; tools are verb-first snake_case like `open_page`, never a package name).
-- **Gloss is mandatory.** The first line of every such package's AGENTS.md carries its one-line English gloss (e.g., `gantaek (간택 — court selection: pick one executor among capability-tagged candidates)`).
+- **Names are path-level only.** Band/ring package names are plain descriptive English (`placement`, `channels`, `remote`, `browser`, `machines`); exported symbols, protocol nouns, and LLM-facing tool names stay English under the #467/#500 gates (`channels` exports `ChannelDriver`, never a package-branded name; tools are verb-first snake_case like `open_page`, never a package name).
 - **Uniform skeleton.** `src/index.ts` (public API only), Zod-first schema modules, one concept per file, and a `test/` mirror — a new-package convention; existing packages keep their current layouts.
 - **Decisions are pure functions; effects live behind driver interfaces; errors are typed unions** (`cooldown_suppressed`-style) — the same conventions the kernel already follows.
 

--- a/docs/clean-room-blueprint.md
+++ b/docs/clean-room-blueprint.md
@@ -16,9 +16,9 @@ Every piece of code answers exactly one question:
 | Effect | what do we do? | `kernel` (openomni renamed, #505) | Effectful services: assemble state, call protocol folds, record to ledger, execute. |
 
 Support tiers: `policy` (pure decision engine), `llm`, `agent` (loop), `ipc` (#496),
-`coordinator` (local-process Execution.Driver), driver band `naru`/`chasa`/`masil`/
-`dokkaebi` ({protocol, ipc} deps only), `gantaek` (deferred until a second execution
-target kind exists). `apps/server` is the composition root (bootstrap-only
+`coordinator` (local-process Execution.Driver), driver band `channels`/`remote`/
+`browser`/`machines` ({protocol, ipc} deps only), `placement` (deferred until a
+second execution target kind exists). `apps/server` is the composition root (bootstrap-only
 ledger, see #503) plus userland (`agents/`, `worker/` — recorded #504 exception).
 `@openomni/core` is REJECTED: every candidate util already has a natural owner.
 
@@ -50,8 +50,8 @@ J7 worker execution lives at `apps/server/src/worker/` (recorded #504 exception;
 promote to a package only when a second execution host exists). J8 loop/LLM event
 descriptors -> `execution/events.ts`, MCP -> `tool/events.ts`, pure telemetry
 defined package-locally. J9 consent-validation stays beside the ledger store.
-J10 band skeletons: naru immediately (real code moves), chasa/masil/dokkaebi at
-their leaf start. J11 coordinator keeps its name; public surface narrows to
+J10 band skeletons: channels immediately (real code moves), remote/browser/machines
+at their leaf start. J11 coordinator keeps its name; public surface narrows to
 Execution.Driver. J12 `owner-map-driver.ts` (rename from runtime-owner-driver).
 
 Storage decisions: Drizzle ORM pinned to stable (drizzle-orm 0.45.2 / drizzle-kit
@@ -76,11 +76,11 @@ sub-adapter ever guards a production write.
    domain stores ported, legacy DB ATTACH read-only; move session's 22
    authority-decision files' logic into kernel.
 3. **P3 acceleration** — #496 ipc extraction, #497–#500 protocol 30->13 and
-   vocabulary convergence, #502/#505 renames, naru extraction (fixes the two
+   vocabulary convergence, #502/#505 renames, channels extraction (fixes the two
    Discord gateway bugs by re-merging the split), #503/#504 server boundary.
 
 Known defects fixed en route: Discord heartbeat-ack never called + RESUME
-token:undefined (naru re-merge), empty `SurfaceKey.clear()` called by
+token:undefined (channels re-merge), empty `SurfaceKey.clear()` called by
 `IngressEngine.reset()` (FIXED — #522: fake API deleted, `Storage.reset()`
 is the enforcement layer), double tool pipeline (agent wraps kernel executor —
 duplicate events + double policy pass; agent half loses emission/policy),


### PR DESCRIPTION
## What / why

Owner decision (2026-08-10): the Korean-flavored band/ring package names were
hard to read. Rename to plain descriptive English across the three committed
docs that define them:

| Old | New |
| --- | --- |
| @openomni/naru | @openomni/channels |
| @openomni/chasa | @openomni/remote |
| @openomni/masil | @openomni/browser |
| @openomni/dokkaebi | @openomni/machines |
| @openomni/gantaek | @openomni/placement |

The "Korean names allowed path-level + mandatory gloss" convention is removed
(descriptive English needs no gloss); the path-level-only rule and English
exported-symbol/tool-name gates stay. Docs-only — no band package exists in
code yet (approved target, not shipped wiring). Open issue bodies referencing
the old names (#459, #495, #496, #499, #500, #216, #520) are being edited in
the same change set.

## Verification

- `grep -ri 'naru\|chasa\|masil\|dokkaebi\|gantaek' docs/*.md AGENTS.md` → no committed-doc matches
- pre-push: dep-check / lint-tools / type-check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed driver-band package names in docs to plain English for clarity and consistency. Updated the ring diagram, band rules, and mailroom/placement references; docs-only, no code changes.

- **Refactors**
  - Renamed: `@openomni/naru`→`@openomni/channels`, `@openomni/chasa`→`@openomni/remote`, `@openomni/masil`→`@openomni/browser`, `@openomni/dokkaebi`→`@openomni/machines`, `@openomni/gantaek`→`@openomni/placement`.
  - Naming rules: removed Korean-name allowance and gloss; kept path-level-only names and English exported symbols/tool names.
  - Updated docs: `AGENTS.md`; `docs/architecture.md` (driver band diagram, `@openomni/placement` selection, mailroom under `@openomni/channels`); `docs/clean-room-blueprint.md`.

<sup>Written for commit 369f4bb9e1e227c6674aa855add24fb2b74400d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

