### PR TITLE
feat(llm): typed retry decisions with ratelimit parsing and delay cap (#532 candidate 3)

### DIFF
--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -144,20 +144,33 @@ export namespace Processor {
               return;
             } catch (e: unknown) {
               const apiError = coerceApiError(e);
-              const retryReason = Retry.isRetryable(apiError ?? e);
+              const decision = Retry.decide(attempt + 1, apiError ?? e);
 
-              if (retryReason === undefined || ++attempt > retryAttemptLimit) {
+              if (!decision.retryable || ++attempt > retryAttemptLimit) {
+                if (!decision.retryable && decision.reason !== "non_retryable" && trace) {
+                  // A retryable error declined for another reason (e.g. the
+                  // server-directed wait exceeded the cap) must say why.
+                  Bus.publish(Operational.Error, {
+                    traceId: trace.traceId,
+                    time: Date.now(),
+                    sessionId: trace.sessionId,
+                    component: "llm.retry",
+                    msg: "retry declined",
+                    error: decision.reason,
+                  });
+                }
                 if (!(e instanceof DOMException && e.name === "AbortError")) {
                   assistantMessage.time.completed = Date.now();
                 }
                 throw e;
               }
+              const retryReason = decision.reason;
 
               // Tool calls from the failed attempt will never receive a
               // result from the next attempt's stream — settle them now.
               settlePendingTools();
 
-              const delayMs = Retry.delay(attempt, apiError);
+              const delayMs = decision.delayMs;
               if (trace) {
                 Bus.publish(LlmCall.RetryDecided, {
                   traceId: trace.traceId,

--- a/packages/llm/src/retry/index.ts
+++ b/packages/llm/src/retry/index.ts
@@ -27,39 +27,132 @@ export namespace Retry {
     });
   }
 
+  /**
+   * Server-directed waits above this cap fail fast instead of silently
+   * stalling a run mid-flight: the headless backoff already tops out at 30s,
+   * so a server asking for more than twice that budget surfaces as a visible
+   * failure whose retry policy belongs to the caller.
+   */
+  export const RETRY_HEADER_DELAY_CAP = 60_000;
+
+  export type Decision =
+    | {
+        readonly retryable: true;
+        readonly reason: string;
+        readonly delayMs: number;
+        readonly source: "header" | "backoff";
+      }
+    | { readonly retryable: false; readonly reason: string };
+
+  /**
+   * Typed retry decision (#532 candidate 3): classification + delay in one
+   * call, failing fast when the server asks for a wait above the cap.
+   */
+  export function decide(attempt: number, error: unknown): Decision {
+    const reason = isRetryable(error);
+    if (reason === undefined) {
+      return { retryable: false, reason: "non_retryable" };
+    }
+    const apiError = APIError.isInstance(error) ? error : undefined;
+    const header = headerDelay(apiError);
+    if (header !== undefined) {
+      if (header.ms > RETRY_HEADER_DELAY_CAP) {
+        // Only an explicit retry-after directive fails fast; an out-of-range
+        // ratelimit reset is an inference we made, so it demotes to backoff
+        // rather than killing the run.
+        if (header.directive) {
+          return {
+            retryable: false,
+            reason: `${reason}: server asked to wait ${header.ms}ms, above the ${RETRY_HEADER_DELAY_CAP}ms cap`,
+          };
+        }
+        return { retryable: true, reason, delayMs: backoffDelayMs(attempt), source: "backoff" };
+      }
+      return { retryable: true, reason, delayMs: Math.max(0, header.ms), source: "header" };
+    }
+    return { retryable: true, reason, delayMs: backoffDelayMs(attempt), source: "backoff" };
+  }
+
   export function delay(
     attempt: number,
     error?: InstanceType<typeof APIError>,
     initialDelay?: number,
   ): number {
+    const header = headerDelay(error);
+    if (header !== undefined) {
+      return header.ms;
+    }
+    return backoffDelayMs(attempt, initialDelay);
+  }
+
+  function backoffDelayMs(attempt: number, initialDelay?: number): number {
     const baseDelay = initialDelay ?? RETRY_INITIAL_DELAY;
+    return Math.min(baseDelay * RETRY_BACKOFF_FACTOR ** (attempt - 1), RETRY_MAX_DELAY_NO_HEADERS);
+  }
 
-    if (error) {
-      const headers = error.data.responseHeaders;
-      if (headers) {
-        const retryAfterMs = headers["retry-after-ms"];
-        if (retryAfterMs) {
-          const parsedMs = Number.parseFloat(retryAfterMs);
-          if (!Number.isNaN(parsedMs)) {
-            return parsedMs;
-          }
-        }
+  /** directive: an explicit server instruction (retry-after) vs an inferred
+   * wait from ratelimit reset metadata. */
+  function headerDelay(
+    error?: InstanceType<typeof APIError>,
+  ): { ms: number; directive: boolean } | undefined {
+    const headers = error?.data.responseHeaders;
+    if (!headers) return undefined;
 
-        const retryAfter = headers["retry-after"];
-        if (retryAfter) {
-          const parsedSeconds = Number.parseFloat(retryAfter);
-          if (!Number.isNaN(parsedSeconds)) {
-            return Math.ceil(parsedSeconds * 1000);
-          }
-          const parsed = Date.parse(retryAfter) - Date.now();
-          if (!Number.isNaN(parsed) && parsed > 0) {
-            return Math.ceil(parsed);
-          }
-        }
+    const retryAfterMs = headers["retry-after-ms"];
+    if (retryAfterMs) {
+      const parsedMs = Number.parseFloat(retryAfterMs);
+      if (!Number.isNaN(parsedMs)) {
+        return { ms: parsedMs, directive: true };
       }
     }
 
-    return Math.min(baseDelay * RETRY_BACKOFF_FACTOR ** (attempt - 1), RETRY_MAX_DELAY_NO_HEADERS);
+    const retryAfter = headers["retry-after"];
+    if (retryAfter) {
+      const parsedSeconds = Number.parseFloat(retryAfter);
+      if (!Number.isNaN(parsedSeconds)) {
+        return { ms: Math.ceil(parsedSeconds * 1000), directive: true };
+      }
+      const parsed = Date.parse(retryAfter) - Date.now();
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        return { ms: Math.ceil(parsed), directive: true };
+      }
+    }
+
+    // Structured ratelimit resets are the fallback signal when retry-after is
+    // absent: Anthropic sends RFC3339 timestamps, OpenAI sends Go-style
+    // durations ("1s", "1m30s"). Take the earliest reset across buckets.
+    let earliest: number | undefined;
+    for (const [name, value] of Object.entries(headers)) {
+      if (!/^(anthropic-ratelimit|x-ratelimit)-.*reset/.test(name)) continue;
+      const ms = parseResetValue(value);
+      if (ms === undefined) continue;
+      if (earliest === undefined || ms < earliest) earliest = ms;
+    }
+    return earliest === undefined ? undefined : { ms: earliest, directive: false };
+  }
+
+  function parseResetValue(value: string): number | undefined {
+    // Durations before Date.parse: a bare number like "2027" would otherwise
+    // parse as a year.
+    const duration = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+(?:\.\d+)?)s)?(?:(\d+)ms)?$/.exec(value.trim());
+    if (duration && duration[0] !== "") {
+      const [, h, m, s, ms] = duration;
+      if (h !== undefined || m !== undefined || s !== undefined || ms !== undefined) {
+        return (
+          Number(h ?? 0) * 3_600_000 +
+          Number(m ?? 0) * 60_000 +
+          Math.ceil(Number(s ?? 0) * 1000) +
+          Number(ms ?? 0)
+        );
+      }
+    }
+    if (!/[-T:]/.test(value)) return undefined; // timestamps only — never bare numbers
+    const asDate = Date.parse(value);
+    if (!Number.isNaN(asDate)) {
+      const ms = asDate - Date.now();
+      return ms > 0 ? Math.ceil(ms) : undefined;
+    }
+    return undefined;
   }
 
   export function isRetryable(error: unknown): string | undefined {

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -93,3 +93,39 @@ describe("Processor retry cap", () => {
     expect(retries).toEqual([2, 2]);
   });
 });
+
+describe("Processor retry header-delay cap (#532 candidate 3)", () => {
+  afterEach(() => {
+    Bus.reset();
+  });
+
+  test("a server-directed wait above the cap fails fast instead of stalling", async () => {
+    const processor = Processor.create({
+      assistantMessage: assistantMessage(),
+      sessionID: "session-retry-cap",
+      model,
+      abort: new AbortController().signal,
+      sink: {
+        onMessage: () => undefined,
+        onToolCall: () => undefined,
+        onToolResult: () => undefined,
+        onSnapshot: () => undefined,
+      },
+      createStream: async () => ({
+        fullStream: (async function* () {
+          yield { type: "text-start", id: "t" };
+          throw new APIError({
+            message: JSON.stringify({ type: "error", error: { type: "too_many_requests" } }),
+            isRetryable: true,
+            responseHeaders: { "retry-after": "3600" },
+          });
+        })(),
+      }),
+    });
+
+    const startedAt = Date.now();
+    await expect(processor.process({ system: "" })).rejects.toBeDefined();
+    // Under the old policy this would have slept for an hour mid-run.
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+});

--- a/packages/llm/test/retry/retry.test.ts
+++ b/packages/llm/test/retry/retry.test.ts
@@ -364,3 +364,116 @@ describe("Retry", () => {
     });
   });
 });
+
+describe("Retry.delay ratelimit-reset parsing (#532 candidate 3)", () => {
+  function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
+    return new APIError({
+      name: "APIError",
+      message: "rate limited",
+      isRetryable: true,
+      statusCode: 429,
+      responseHeaders: headers,
+    });
+  }
+
+  test("x-ratelimit-reset-requests duration is used when retry-after is absent", () => {
+    expect(Retry.delay(1, apiError({ "x-ratelimit-reset-requests": "3s" }))).toBe(3000);
+  });
+
+  test("x-ratelimit-reset duration with compound units parses", () => {
+    expect(Retry.delay(1, apiError({ "x-ratelimit-reset-tokens": "1m30s" }))).toBe(90_000);
+  });
+
+  test("anthropic-ratelimit reset timestamp is used when retry-after is absent", () => {
+    const resetAt = new Date(Date.now() + 5000).toISOString();
+    const ms = Retry.delay(1, apiError({ "anthropic-ratelimit-requests-reset": resetAt }));
+    expect(ms).toBeGreaterThan(3500);
+    expect(ms).toBeLessThanOrEqual(5100);
+  });
+
+  test("retry-after still wins over ratelimit resets", () => {
+    expect(
+      Retry.delay(1, apiError({ "retry-after": "2", "x-ratelimit-reset-requests": "9s" })),
+    ).toBe(2000);
+  });
+});
+
+describe("Retry.decide (#532 candidate 3)", () => {
+  function apiError(headers?: Record<string, string>): InstanceType<typeof APIError> {
+    return new APIError({
+      name: "APIError",
+      message: "rate limited",
+      isRetryable: true,
+      statusCode: 429,
+      ...(headers && { responseHeaders: headers }),
+    });
+  }
+
+  test("non-retryable errors decide against retry", () => {
+    const decision = Retry.decide(1, new Error("plain"));
+    expect(decision.retryable).toBe(false);
+  });
+
+  test("header delay within the cap is honored", () => {
+    const decision = Retry.decide(1, apiError({ "retry-after": "45" }));
+    expect(decision).toEqual({
+      retryable: true,
+      reason: "Rate Limited",
+      delayMs: 45_000,
+      source: "header",
+    });
+  });
+
+  test("header delay above the cap fails fast instead of silently stalling", () => {
+    const decision = Retry.decide(1, apiError({ "retry-after": "3600" }));
+    expect(decision.retryable).toBe(false);
+    if (!decision.retryable) {
+      expect(decision.reason).toContain("3600000");
+    }
+  });
+
+  test("headless retry keeps the exponential backoff and its 30s cap", () => {
+    expect(Retry.decide(1, apiError())).toEqual({
+      retryable: true,
+      reason: "Rate Limited",
+      delayMs: Retry.RETRY_INITIAL_DELAY,
+      source: "backoff",
+    });
+    const late = Retry.decide(10, apiError());
+    if (late.retryable) {
+      expect(late.delayMs).toBe(Retry.RETRY_MAX_DELAY_NO_HEADERS);
+    }
+  });
+});
+
+describe("Retry.decide cap semantics for inferred resets", () => {
+  function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
+    return new APIError({
+      name: "APIError",
+      message: "rate limited",
+      isRetryable: true,
+      statusCode: 429,
+      responseHeaders: headers,
+    });
+  }
+
+  test("an out-of-range ratelimit reset demotes to backoff instead of failing", () => {
+    const decision = Retry.decide(1, apiError({ "x-ratelimit-reset-requests": "30m" }));
+    expect(decision).toEqual({
+      retryable: true,
+      reason: "Rate Limited",
+      delayMs: Retry.RETRY_INITIAL_DELAY,
+      source: "backoff",
+    });
+  });
+
+  test("bare numbers in reset headers are never parsed as years", () => {
+    const decision = Retry.decide(1, apiError({ "x-ratelimit-reset-requests": "2027" }));
+    expect(decision).toEqual({
+      retryable: true,
+      reason: "Rate Limited",
+      delayMs: Retry.RETRY_INITIAL_DELAY,
+      source: "backoff",
+    });
+  });
+});


### PR DESCRIPTION
Part of #532, candidate 3. llm-internal, no protocol change.

## Reconcile-first
At head: retry-after / retry-after-ms parsing exists (#518), headless backoff caps at 30s — but a **header-provided wait is effectively unbounded** (`RETRY_MAX_DELAY` = 2^31−1 ms: a `retry-after: 3600` silently stalls the run for an hour), and `x-ratelimit-*` / `anthropic-ratelimit-*` reset headers are ignored (falls back to blind exponential backoff).

## What
- **`Retry.decide(attempt, error)`** — typed decision (`{retryable, reason, delayMs, source}` union) folding classification + delay; the processor consumes it, keeping the exact `RetryDecided`/`RateLimited` event payloads.
- **Fail-fast cap**: server-directed waits above `RETRY_HEADER_DELAY_CAP` (60s = 2× the headless cap) decide non-retryable → the error surfaces through the normal `LlmCall.Failed` path where the caller's retry policy owns long waits. Headless 30s backoff cap unchanged.
- **Structured ratelimit resets** as the fallback delay when retry-after is absent: Anthropic RFC3339 reset timestamps and OpenAI Go-style durations (`"1s"`, `"1m30s"`); earliest bucket wins; same cap applies. retry-after still takes priority (pinned).

## Verification
- Red-first: ratelimit-reset parsing tests and the cap tests fail on the parent commit; processor pin proves an above-cap wait rejects in <1s (a true behavioral red would have slept an hour).
- Gates: check-types 11/11 · full suite 3582 pass / 0 fail · ratchet 24 none new · lint / lint:tools / check-deps OK.

Merging under the Owner's blanket authorization for this track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed retry decisions and structured rate limit parsing to make LLM retries safer and predictable. Caps server-directed delays at 60s; out-of-range inferred reset waits fall back to backoff. Part of #532.

- **New Features**
  - Added `Retry.decide(attempt, error)` returning a typed decision with reason, delay, and source (header/backoff).
  - Parsed `retry-after`/`retry-after-ms` and fallback to structured rate limit resets (Anthropic RFC3339 timestamps, OpenAI Go-style durations with compound units); earliest reset wins; `retry-after` still takes priority; bare numbers are ignored.
  - Processor now consumes the decision and uses the provided delay; headless exponential backoff remains with a 30s cap.

- **Bug Fixes**
  - Prevented unbounded waits from server headers. If `retry-after` asks for >60s we fail fast; out-of-range ratelimit reset metadata demotes to backoff instead of stalling.

<sup>Written for commit 0842c51a5b19a7f49e770d37a606882153852e32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

