### PR TITLE
test(server): close namespace bypass in ingress boundary checker

### DIFF
--- a/apps/server/test/ingress-routing-boundary.test.ts
+++ b/apps/server/test/ingress-routing-boundary.test.ts
@@ -75,7 +75,7 @@ function staticMember(expression: ts.Expression): StaticMember | undefined {
 
 type Binding = Readonly<{
   name: string;
-  importKind?: "engine" | "namespace" | "store";
+  importKind?: "engine" | "namespace" | "kernel-namespace" | "store";
   importedName?: string;
   initializer?: ts.Expression;
   propertyName?: string;
@@ -172,6 +172,12 @@ function lexicalModel(source: ts.SourceFile): LexicalModel {
             addBinding(scope, {
               name: clause.namedBindings.name.text,
               importKind: "namespace",
+            });
+          }
+          if (moduleName === "@openomni/openomni") {
+            addBinding(scope, {
+              name: clause.namedBindings.name.text,
+              importKind: "kernel-namespace",
             });
           }
         } else {
@@ -284,7 +290,10 @@ function lexicalModel(source: ts.SourceFile): LexicalModel {
   return { scopeOf, resolveIdentifier };
 }
 
-type Provenance = Readonly<{ kind: "engine" | "method" | "namespace" | "store"; name?: string }>;
+type Provenance = Readonly<{
+  kind: "engine" | "method" | "namespace" | "kernel-namespace" | "engine-factory" | "store";
+  name?: string;
+}>;
 
 function provenanceResolver(model: LexicalModel): (binding: Binding) => Provenance | undefined {
   const memo = new Map<Binding, Provenance | undefined>();
@@ -300,6 +309,9 @@ function provenanceResolver(model: LexicalModel): (binding: Binding) => Provenan
     if (receiver?.kind === "namespace" && ROUTING_STORES.has(member.name)) {
       return { kind: "store", name: member.name };
     }
+    if (receiver?.kind === "kernel-namespace" && member.name === "createIngressEngine") {
+      return { kind: "engine-factory" };
+    }
     return undefined;
   };
   const resolve = (binding: Binding | undefined): Provenance | undefined => {
@@ -310,6 +322,7 @@ function provenanceResolver(model: LexicalModel): (binding: Binding) => Provenan
     let result: Provenance | undefined;
     if (binding.importKind === "engine") result = { kind: "engine" };
     else if (binding.importKind === "namespace") result = { kind: "namespace" };
+    else if (binding.importKind === "kernel-namespace") result = { kind: "kernel-namespace" };
     else if (binding.importKind === "store") result = { kind: "store", name: binding.importedName };
     else if (binding.initializer) {
       const source = expressionProvenance(binding.initializer);
@@ -318,6 +331,11 @@ function provenanceResolver(model: LexicalModel): (binding: Binding) => Provenan
         result = { kind: "method" };
       } else if (source?.kind === "namespace" && ROUTING_STORES.has(binding.propertyName)) {
         result = { kind: "store", name: binding.propertyName };
+      } else if (
+        source?.kind === "kernel-namespace" &&
+        binding.propertyName === "createIngressEngine"
+      ) {
+        result = { kind: "engine-factory" };
       }
     }
     active.delete(binding);
@@ -466,6 +484,22 @@ function detectRoutingBoundaryViolations(parsed: readonly ParsedSource[]): reado
           ROUTING_STORES.has(member.name)
         ) {
           violations.push(`${path}: accesses routing store ${member.name}`);
+        }
+        // #558 review: `import * as OO` + OO.createIngressEngine bypassed the
+        // named-import rule — flag namespace-qualified factory access too.
+        if (
+          member &&
+          expressionProvenance(member.receiver)?.kind === "kernel-namespace" &&
+          member.name === "createIngressEngine"
+        ) {
+          violations.push(`${path}: imports createIngressEngine`);
+        }
+      }
+
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        const callee = resolve(model.resolveIdentifier(node.expression));
+        if (callee?.kind === "engine-factory") {
+          violations.push(`${path}: imports createIngressEngine`);
         }
       }
 
@@ -656,6 +690,16 @@ describe("server ingress routing ownership boundary", () => {
       "wrapped static session member",
       'import * as Session from "@openomni/session"; ((Session as typeof Session)!)[("ChannelGrantStore" as const)].get("id");',
       "accesses routing store ChannelGrantStore",
+    ],
+    [
+      "namespace-qualified engine construction",
+      'import * as OpenOmni from "@openomni/openomni"; const engine = OpenOmni.createIngressEngine();',
+      "imports createIngressEngine",
+    ],
+    [
+      "destructured namespace engine factory alias",
+      'import * as OpenOmni from "@openomni/openomni"; const { createIngressEngine: make } = OpenOmni; make();',
+      "imports createIngressEngine",
     ],
   ] as const;
 


### PR DESCRIPTION
Follow-up to PR #558 — dispositions for the five CodeRabbit findings:

- **Valid, fixed here**: `import * as OO from "@openomni/openomni"` + `OO.createIngressEngine()` (or a destructured alias) bypassed the boundary checker's named-import rule. The checker now tracks kernel namespace imports and flags qualified factory access and aliased factory calls; two adversarial fixtures added (58 tests green).
- **False positive** (evidence-replied): "duplicate `observed` declaration" — the three declarations live in three different test function scopes (lines 763/903/1185); the file loads and runs 33/33 green.
- **False positive**: "reset Bus in no-bypass test" — `Bus.reset()` already runs in both beforeEach (line 46) and afterEach (line 59) at the merged head.
- **Contained** (no change): "release Bus.observe subscription" — the conformance file resets the Bus in beforeEach/afterEach (lines 94/110), so observers cannot leak across tests.
- **Deferred with rationale**: "`runtime` noun on new kernel surfaces" — `IngressEngineDeps.residentRuntime/dispatchRuntime` mirror the pre-existing exported type names (`ResidentRuntime`, `DispatchRuntime`); renaming the field without the types would add a second vocabulary. Owned by the #498/#505 vocabulary-convergence leaves.

Env note recorded on #552: local pre-push dep-check/lint scan untracked `tmp/` research clones and nested worktrees — proper ignore rules belong to the C8 gates leaf.

## Verification
`bun test apps/server/test/ingress-routing-boundary.test.ts` 58 pass / 0 fail; check-types, scoped lint (`bunx biome check packages apps script` — 974 files), dep-check green at push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hole in the ingress routing boundary checker where namespace imports from `@openomni/openomni` could call createIngressEngine without being flagged. The checker now detects namespace-qualified and aliased factory calls, and adds tests to prevent regressions.

- **Bug Fixes**
  - Track kernel namespace imports from `@openomni/openomni`.
  - Flag OpenOmni.createIngressEngine and destructured aliases as engine factory imports.
  - Add two adversarial fixtures; suite passes 58 tests.

<sup>Written for commit ca90161cf41cde60d18acf198a05bd342a3c8429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

