### PR TITLE
feat(agent): enforce compaction commit-boundary invariant

### DIFF
--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -16,6 +16,20 @@ interface CompactionResult {
   removedCount: number;
 }
 
+/**
+ * Raised when compaction cannot commit a provider-valid kept window: no
+ * summary user message will anchor the window (onSummarize unset) and no user
+ * boundary exists at or before the cutoff. Thrown BEFORE anything is
+ * committed — the fail-closed `run.completion.pre` contract turns it into a
+ * deny plus a published middleware error, never commit-then-400.
+ */
+export class CompactionBoundaryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CompactionBoundaryError";
+  }
+}
+
 const DEFAULT_THRESHOLD_RATIO = 0.8;
 const DEFAULT_PROTECT_RECENT = 6;
 
@@ -35,14 +49,41 @@ export namespace InMemoryCompactor {
       return { messages, compacted: false, removedCount: 0 };
     }
 
-    const cutoff = messages.length - protectRecent;
+    // Commit boundary invariant (#531, representable since #557/#560).
+    //
+    // Tool-pair splits are unrepresentable at this seam by construction: a
+    // tool result is not a standalone message — it lives in `ToolPart.state`
+    // on the same assistant `Message.WithParts` that carries the call
+    // (protocol `Message.ToolPart` + `Tool.State`), and `Message.Info` has
+    // only user/assistant roles. Slicing at WithParts granularity therefore
+    // cannot separate a call from its result, so no pair guard exists here.
+    // Kept non-terminal (pending/running) tool parts are replay-safe too:
+    // `toModelMessages` (packages/llm/src/message/index.ts) expands every
+    // ToolPart into an atomic tool-call + tool-result block pair,
+    // synthesizing "[Tool execution was interrupted]" for pending/running
+    // states — that safety net makes a terminality guard here redundant.
+    //
+    // The one real hazard is the window START: without a summary user message
+    // anchoring the kept window, a window beginning with an assistant message
+    // violates provider first-message rules. Snap the cutoff back to the
+    // nearest user boundary; refuse loudly when none exists.
+    const naturalCutoff = messages.length - protectRecent;
+    const cutoff =
+      options.onSummarize === undefined
+        ? snapToUserBoundary(messages, naturalCutoff)
+        : naturalCutoff;
+    if (cutoff === 0) {
+      return { messages, compacted: false, removedCount: 0 };
+    }
+
     const toRemove = messages.slice(0, cutoff);
     const toKeep = messages.slice(cutoff);
 
     let summaryMessages: Message.WithParts[] = [];
-    if (options.onSummarize && toRemove.length > 0) {
+    const firstRemoved = toRemove[0];
+    if (options.onSummarize && firstRemoved !== undefined) {
       const summaryText = await options.onSummarize(toRemove);
-      summaryMessages = [buildSummaryMessage(summaryText)];
+      summaryMessages = [buildSummaryMessage(summaryText, firstRemoved.info.sessionID)];
     }
 
     const compacted = [...summaryMessages, ...toKeep];
@@ -86,9 +127,17 @@ function resolveReserveTokens(options: CompactionOptions): number | undefined {
   return Math.min(options.contextWindowTokens, Math.max(0, reserveTokens));
 }
 
-function buildSummaryMessage(summaryText: string): Message.WithParts {
+function snapToUserBoundary(messages: Message.WithParts[], naturalCutoff: number): number {
+  for (let index = naturalCutoff; index >= 0; index -= 1) {
+    if (messages[index]?.info.role === "user") return index;
+  }
+  throw new CompactionBoundaryError(
+    "no valid compaction boundary: the kept window would start with an assistant message and no summary user message anchors it (onSummarize unset); refusing to commit",
+  );
+}
+
+function buildSummaryMessage(summaryText: string, sessionID: string): Message.WithParts {
   const id = crypto.randomUUID();
-  const sessionID = "chat-agent";
   const now = Date.now();
   const info: Message.UserMessage = {
     id,

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -56,6 +56,27 @@ function makeAssistantMessage(text: string): Message.WithParts {
   return { info, parts: [part] };
 }
 
+function makeToolAssistantMessage(text: string, callID: string): Message.WithParts {
+  const base = makeAssistantMessage(text);
+  const toolPart: Message.ToolPart = {
+    id: nextId("tool-part"),
+    sessionID: "test",
+    messageID: base.info.id,
+    type: "tool",
+    callID,
+    tool: "read_file",
+    state: {
+      status: "completed",
+      input: { path: "/tmp/a" },
+      output: "file contents",
+      title: "read_file",
+      metadata: {},
+      time: { start: 1, end: 2 },
+    },
+  };
+  return { info: base.info, parts: [...base.parts, toolPart] };
+}
+
 describe("InMemoryCompactor", () => {
   describe("shouldCompact", () => {
     it("returns false when tokens are below threshold", () => {
@@ -221,6 +242,100 @@ describe("InMemoryCompactor", () => {
         protectRecentMessages: 6,
       });
       expect(result.compacted).toBe(false);
+    });
+  });
+
+  describe("commit boundary invariant", () => {
+    it("snaps the cutoff back to a user boundary when no summary anchors the kept window", async () => {
+      // onSummarize unset (it is optional everywhere): the natural cutoff lands
+      // on an assistant message, which no provider accepts as the first
+      // message of a conversation. The commit must snap back to the nearest
+      // user boundary instead of committing a leading-assistant window.
+      const messages = [
+        makeUserMessage("u0"),
+        makeAssistantMessage("a1"),
+        makeUserMessage("u2"),
+        makeAssistantMessage("a3"),
+        makeUserMessage("u4"),
+        makeToolAssistantMessage("a5", "call-1"),
+        makeUserMessage("u6"),
+        makeAssistantMessage("a7"),
+      ];
+      const result = await InMemoryCompactor.compact(messages, {
+        contextWindowTokens: 1000,
+        protectRecentMessages: 3,
+      });
+      expect(result.compacted).toBe(true);
+      expect(result.messages[0]?.info.role).toBe("user");
+      expect(result.removedCount).toBe(4);
+      expect(result.messages).toHaveLength(4);
+      // The kept tool call and its result travel in the same WithParts message:
+      // message-boundary slicing cannot split the pair.
+      const toolParts = result.messages.flatMap((message) =>
+        message.parts.filter((part): part is Message.ToolPart => part.type === "tool"),
+      );
+      expect(toolParts).toHaveLength(1);
+      expect(toolParts[0]?.state.status).toBe("completed");
+    });
+
+    it("fails loudly with a typed error when no valid user boundary exists", async () => {
+      // No user message at or before the cutoff: there is no boundary that can
+      // anchor the kept window without a summary. Committing anyway would be
+      // commit-then-400; the compactor must refuse with a typed error instead.
+      const messages = Array.from({ length: 8 }, (_, i) => makeAssistantMessage(`a${i}`));
+      let caught: unknown;
+      try {
+        await InMemoryCompactor.compact(messages, {
+          contextWindowTokens: 1000,
+          protectRecentMessages: 3,
+        });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).name).toBe("CompactionBoundaryError");
+    });
+
+    it("keeps the natural cutoff when a summary user message anchors the window", async () => {
+      // Pin: with onSummarize present, the prepended summary user message makes
+      // any message-boundary cutoff provider-valid — no snap-back happens.
+      const messages = [
+        makeUserMessage("u0"),
+        makeAssistantMessage("a1"),
+        makeUserMessage("u2"),
+        makeAssistantMessage("a3"),
+        makeUserMessage("u4"),
+        makeAssistantMessage("a5"),
+        makeUserMessage("u6"),
+        makeAssistantMessage("a7"),
+      ];
+      const result = await InMemoryCompactor.compact(messages, {
+        contextWindowTokens: 1000,
+        protectRecentMessages: 3,
+        onSummarize: async () => "anchored",
+      });
+      expect(result.compacted).toBe(true);
+      expect(result.removedCount).toBe(5);
+      expect(result.messages).toHaveLength(4);
+      expect(result.messages[0]?.info.role).toBe("user");
+    });
+
+    it("threads the history session id into the summary message", async () => {
+      const messages = Array.from({ length: 8 }, (_, i) =>
+        i % 2 === 0 ? makeUserMessage(`user ${i}`) : makeAssistantMessage(`assistant ${i}`),
+      );
+      const result = await InMemoryCompactor.compact(messages, {
+        contextWindowTokens: 1000,
+        protectRecentMessages: 4,
+        onSummarize: async () => "summary",
+      });
+      const summary = result.messages[0];
+      expect(summary?.info.role).toBe("user");
+      // History carries sessionID "test"; the summary must not introduce a
+      // foreign session id into the compacted history.
+      expect(summary?.info.sessionID).toBe("test");
+      expect(summary?.parts[0]?.sessionID).toBe("test");
+      expect(summary?.parts[0]?.messageID).toBe(summary?.info.id);
     });
   });
 });

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Message } from "@openomni/protocol";
-import { InMemoryCompactor } from "../../../src/core/execution/compaction";
+import { CompactionBoundaryError, InMemoryCompactor } from "../../../src/core/execution/compaction";
 
 let idCounter = 0;
 
@@ -292,7 +292,7 @@ describe("InMemoryCompactor", () => {
       } catch (error) {
         caught = error;
       }
-      expect(caught).toBeInstanceOf(Error);
+      expect(caught).toBeInstanceOf(CompactionBoundaryError);
       expect((caught as Error).name).toBe("CompactionBoundaryError");
     });
 

--- a/packages/agent/test/core/policy/compaction-policy-plan.test.ts
+++ b/packages/agent/test/core/policy/compaction-policy-plan.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import type { Message, Policy } from "@openomni/protocol";
+import type { BudgetState } from "../../../src/core/budget";
+import { defaultRegistry } from "../../../src/core/policy";
+import type { PolicyContext } from "../../../src/core/policy";
+import { effectOf } from "../../helpers/policy-decision";
+
+// #546 review F5: production configs never pass WorkerMiddlewareConfig.compaction,
+// but defaultRegistry() registers builtin:compaction, so an external PolicyPlan
+// can activate compaction anyway. This suite proves the commit boundary
+// invariant holds on that backdoor path over tool-bearing history.
+
+let idCounter = 0;
+
+function nextId(prefix: string): string {
+  idCounter += 1;
+  return `${prefix}-${idCounter}`;
+}
+
+function makeUserMessage(text: string): Message.WithParts {
+  const id = nextId("user-message");
+  const sessionID = "plan-session";
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "test",
+      model: { providerID: "", modelID: "" },
+    },
+    parts: [{ id: nextId("user-part"), sessionID, messageID: id, type: "text", text }],
+  };
+}
+
+function makeAssistantMessage(text: string, options?: { toolCallID?: string }): Message.WithParts {
+  const id = nextId("assistant-message");
+  const sessionID = "plan-session";
+  const parts: Message.Part[] = [
+    { id: nextId("assistant-part"), sessionID, messageID: id, type: "text", text },
+  ];
+  if (options?.toolCallID !== undefined) {
+    parts.push({
+      id: nextId("tool-part"),
+      sessionID,
+      messageID: id,
+      type: "tool",
+      callID: options.toolCallID,
+      tool: "read_file",
+      state: {
+        status: "completed",
+        input: { path: "/tmp/a" },
+        output: "file contents",
+        title: "read_file",
+        metadata: {},
+        time: { start: 1, end: 2 },
+      },
+    });
+  }
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: "",
+      providerID: "",
+      agent: "test",
+      path: { cwd: "/", root: "/" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts,
+  };
+}
+
+function budgetState(inputTokens: number, outputTokens: number): BudgetState {
+  return {
+    startTime: Date.now(),
+    turns: 1,
+    toolCalls: 0,
+    toolRuntimeMs: 0,
+    totalInputTokens: inputTokens,
+    totalOutputTokens: outputTokens,
+  };
+}
+
+function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
+  return {
+    timing: "turn.finish",
+    steps: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    turnCount: 0,
+    isCompletion: false,
+    continuationCount: 0,
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
+describe("policyPlan-activated compaction (builtin:compaction backdoor)", () => {
+  it("enforces the commit boundary invariant over tool-bearing history", async () => {
+    const plan: Policy.PolicyPlan = {
+      policies: [
+        {
+          id: "builtin:compaction",
+          required: true,
+          // onSummarize is not expressible through a serialized plan config,
+          // so the no-summary boundary hazard is the default on this path.
+          config: { contextWindowTokens: 1000, thresholdRatio: 0.8, protectRecentMessages: 3 },
+        },
+      ],
+      labels: [],
+    };
+    const registrations = defaultRegistry().resolve(plan, {});
+    const registration = registrations[0];
+    if (registration === undefined || !("kind" in registration)) {
+      throw new Error("expected canonical builtin:compaction registration");
+    }
+
+    // Natural cutoff (length - protectRecent = 5) lands on the tool-bearing
+    // assistant message: the invariant must produce a user-led kept window.
+    const messages = [
+      makeUserMessage("u0"),
+      makeAssistantMessage("a1"),
+      makeUserMessage("u2"),
+      makeAssistantMessage("a3"),
+      makeUserMessage("u4"),
+      makeAssistantMessage("a5", { toolCallID: "call-1" }),
+      makeUserMessage("u6"),
+      makeAssistantMessage("a7"),
+    ];
+    const ctx = baseCtx({ messages, budgetState: budgetState(700, 200) });
+
+    const verdict = await registration.fn(ctx);
+
+    expect(verdict.verdict).toBe("allow");
+    const replacement = effectOf(verdict, "run.replace_messages");
+    expect(replacement).toBeDefined();
+    const replaced = replacement?.messages ?? [];
+    expect(replaced.length).toBeLessThan(messages.length);
+    expect(replaced[0]?.info.role).toBe("user");
+    // The tool call and its result live inside the same kept WithParts
+    // message, so the committed window still carries the intact pair.
+    const toolParts = replaced.flatMap((message) =>
+      message.parts.filter((part): part is Message.ToolPart => part.type === "tool"),
+    );
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]?.callID).toBe("call-1");
+    expect(toolParts[0]?.state.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
History-track stage T4 — the successor of #531 (closed/redefined: blocked-on #546, now merged). With tool-bearing history real (#560), the compaction hazards are finally red-first representable. Also absorbs the two #531 side findings and the #546-review policyPlan-backdoor note.

## What

- **Commit-boundary invariant at the commit seam** (not a selector): without a summarizer, the cutoff snaps back to the nearest user boundary; snapping to index 0 degrades to an honest no-op (`compacted: false`, nothing committed). When no user boundary exists at all, a typed `CompactionBoundaryError` is thrown **pre-commit** — and `run.completion.pre` is fail-closed by contract, so the throw becomes a policy deny, never commit-then-400.
- **Pair-split verified impossible, not guarded**: a tool result lives inside `ToolPart.state` on the calling assistant WithParts (single message), so WithParts-boundary slicing cannot split a call/result pair — stated in a comment. Safety net documented: `toModelMessages` expands every ToolPart atomically and synthesizes interrupted results for non-terminal states, so kept windows are replay-valid without a terminality guard.
- **Hardcoded `sessionID: "chat-agent"`** in the summary message → real session id from the compacted history.
- **policyPlan backdoor covered**: `defaultRegistry()` exposes `builtin:compaction` to external plans even though production configs never enable it — a dedicated test activates compaction purely via a resolved policyPlan over tool-bearing history and proves the invariant holds there.

## Verification

- 4 red-first pins (verified failing pre-fix): leading-assistant window without summary, all-assistant commit instead of typed error, mixed session ids, policyPlan-path leading-assistant. 1 green pin: summary-anchored natural cutoff unchanged.
- Suites agent+llm 627 pass / 0 fail; check-types, build, lint, check-deps, dead-export ratchet green. Contract delta: one new export (`CompactionBoundaryError`); `CompactionResult` unchanged.

Known same-class leftovers (out of T4 scope, noted): `builtin/compaction.ts` event `sessionId: "chat-agent"` and `buildSummaryMessage`'s hardcoded `agent: "chat-agent"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a safe commit boundary during history compaction. Prevents leading-assistant windows, throws a typed error when no user boundary exists, and preserves the session id in summaries.

- **New Features**
  - Commit-boundary invariant in `InMemoryCompactor.compact`: snap to the nearest user when `onSummarize` is unset; no-op if it snaps to 0; throw `CompactionBoundaryError` pre-commit when no user boundary exists.
  - Summary messages use the real history `sessionID` (not `"chat-agent"`).
  - Tool call/result pairs can’t be split at message boundaries; replay stays valid.
  - Invariant also holds when `defaultRegistry()` activates `builtin:compaction`.

<sup>Written for commit 5bcfa331d9b71b2fd54b8568c65e5e5593e7cde2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

