### PR TITLE
chore(ci): early gate batch — dist smoke, schema drift, scanner scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,26 @@ jobs:
             apps/*/coverage/
           if-no-files-found: ignore
 
+  smoke-dist:
+    name: Dist Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - run: bun run build:dist
+      - run: bun run smoke:dist
+
   quality:
     name: Quality
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
           bun run script/check-coverage-ratchet.ts --self-test
           bun run script/check-dead-exports.ts --self-test
       - run: bun run script/check-dead-exports.ts
+      - run: bun run script/check-ledger-schema-drift.ts
       - run: bun run script/report-source-metrics.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-error.log*
 # Local AI instructions (not committed)
 *.local.md
 
+# Research clones pinned by commit (#533) — never a dependency, never scanned
+/tmp/
+
 # Misc
 .DS_Store
 *.pem

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -402,11 +402,9 @@ async function validateDeepRelativeImports(): Promise<string[]> {
 
 // See docs/golden-principles.local.md for the full list.
 
-// Allowed `as any` locations:
-// - protocol/error: sole exception per golden-principles.local.md #5
-// - remaining entries: pre-existing tech debt (do not extend)
+// Allowed `as any` locations (pre-existing tech debt — do not extend).
+// protocol/error was removed 2026-08 (#552 item 5): zero remaining hits.
 const ALLOWED_AS_ANY_FILES = new Set([
-  "packages/protocol/src/error/index.ts",
   "packages/openomni/src/ingress/event-projector.ts",
   "packages/agent/src/runtime/messenger/transport.ts",
 ]);

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -189,6 +189,25 @@ function isTestFile(path: string): boolean {
   );
 }
 
+/**
+ * Paths never scanned: build output, dependencies, tests, the gate scripts
+ * themselves, and untracked local dirs — research clones pinned under tmp/
+ * (#533) and nested worktrees under .claude/ — which would otherwise break
+ * local runs while CI stays green (#552).
+ */
+function isExcludedFromScan(filePath: string): boolean {
+  return (
+    filePath.includes("/node_modules/") ||
+    filePath.startsWith("node_modules/") ||
+    filePath.includes("/dist/") ||
+    filePath.startsWith("dist/") ||
+    filePath.startsWith("tmp/") ||
+    filePath.startsWith(".claude/") ||
+    isTestFile(filePath) ||
+    filePath.startsWith("script/")
+  );
+}
+
 function lineNumberForOffset(source: string, offset: number): number {
   let line = 1;
   for (let i = 0; i < offset; i += 1) {
@@ -261,14 +280,7 @@ async function validateSourceImportDirection(): Promise<string[]> {
     onlyFiles: true,
     followSymlinks: false,
   })) {
-    if (
-      filePath.includes("/node_modules/") ||
-      filePath.startsWith("node_modules/") ||
-      filePath.includes("/dist/") ||
-      filePath.startsWith("dist/") ||
-      isTestFile(filePath) ||
-      filePath.startsWith("script/")
-    ) {
+    if (isExcludedFromScan(filePath)) {
       continue;
     }
 
@@ -307,14 +319,7 @@ async function validateDeepImports(): Promise<string[]> {
     onlyFiles: true,
     followSymlinks: false,
   })) {
-    if (
-      filePath.includes("/node_modules/") ||
-      filePath.startsWith("node_modules/") ||
-      filePath.includes("/dist/") ||
-      filePath.startsWith("dist/") ||
-      isTestFile(filePath) ||
-      filePath.startsWith("script/")
-    ) {
+    if (isExcludedFromScan(filePath)) {
       continue;
     }
 
@@ -357,14 +362,7 @@ async function validateDeepRelativeImports(): Promise<string[]> {
     onlyFiles: true,
     followSymlinks: false,
   })) {
-    if (
-      filePath.includes("/node_modules/") ||
-      filePath.startsWith("node_modules/") ||
-      filePath.includes("/dist/") ||
-      filePath.startsWith("dist/") ||
-      isTestFile(filePath) ||
-      filePath.startsWith("script/")
-    ) {
+    if (isExcludedFromScan(filePath)) {
       continue;
     }
 
@@ -431,14 +429,7 @@ async function validateGoldenPrinciples(): Promise<string[]> {
     onlyFiles: true,
     followSymlinks: false,
   })) {
-    if (
-      filePath.includes("/node_modules/") ||
-      filePath.startsWith("node_modules/") ||
-      filePath.includes("/dist/") ||
-      filePath.startsWith("dist/") ||
-      isTestFile(filePath) ||
-      filePath.startsWith("script/")
-    ) {
+    if (isExcludedFromScan(filePath)) {
       continue;
     }
 

--- a/script/check-ledger-schema-drift.ts
+++ b/script/check-ledger-schema-drift.ts
@@ -1,0 +1,149 @@
+/**
+ * Ledger DDL drift gate (#552 item 4). packages/session/src/ledger-core/
+ * schema.ts is the DDL source of truth and the hand-written migration SQL is
+ * the applied truth (blueprint "Storage decisions", drizzle.config.ts); this
+ * check fails when the two would produce different SQLite schemas for the
+ * tables drizzle defines.
+ *
+ * Method: apply the real migration chain to one in-memory database (via the
+ * production lifecycle runner) and drizzle-kit's generated DDL for schema.ts
+ * to another, then compare the introspected shape — columns, declared types,
+ * NOT NULL, primary keys, unique indexes — of every drizzle-defined table.
+ *
+ * Normalization: a declared PRIMARY KEY column counts as NOT NULL on both
+ * sides. SQLite's legacy quirk leaves non-INTEGER pk columns nullable unless
+ * spelled out; drizzle always spells it out, while the applied hand SQL
+ * predates this gate and applied migrations are immutable.
+ */
+import { Database } from "bun:sqlite";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const sessionDir = join(root, "packages", "session");
+
+// drizzle-kit is a devDependency of @openomni/session; under bun's isolated
+// linker it is only resolvable from that package, not from root scripts.
+const drizzleKitApi = (await import(Bun.resolveSync("drizzle-kit/api", sessionDir))) as {
+  generateSQLiteDrizzleJson: (
+    imports: Record<string, unknown>,
+    prevId?: string,
+    casing?: "snake_case" | "camelCase",
+  ) => Promise<{ id: string }>;
+  generateSQLiteMigration: (prev: { id: string }, cur: { id: string }) => Promise<string[]>;
+};
+const schema = (await import(join(sessionDir, "src", "ledger-core", "schema.ts"))) as Record<
+  string,
+  unknown
+>;
+const { initializeSqliteDatabase } = (await import(
+  join(sessionDir, "src", "storage", "sqlite-schema-lifecycle.ts")
+)) as { initializeSqliteDatabase: (db: Database) => void };
+
+type ColumnShape = {
+  name: string;
+  type: string;
+  notNull: boolean;
+  defaultValue: string | null;
+  primaryKeyOrdinal: number;
+};
+
+type TableShape = {
+  columns: ColumnShape[];
+  uniqueIndexes: string[][];
+};
+
+type TableInfoRow = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+type IndexListRow = { name: string; unique: number; origin: string };
+
+function tableShape(db: Database, table: string): TableShape {
+  const columns = (db.query(`PRAGMA table_info("${table}")`).all() as TableInfoRow[]).map(
+    (row) => ({
+      name: row.name,
+      type: row.type.toUpperCase(),
+      // pk implies NOT NULL on both sides — see header normalization note.
+      notNull: row.notnull !== 0 || row.pk > 0,
+      defaultValue: row.dflt_value ?? null,
+      primaryKeyOrdinal: row.pk,
+    }),
+  );
+  const uniqueIndexes = (db.query(`PRAGMA index_list("${table}")`).all() as IndexListRow[])
+    .filter((index) => index.unique !== 0 && index.origin !== "pk")
+    .map((index) =>
+      (db.query(`PRAGMA index_info("${index.name}")`).all() as { name: string }[]).map(
+        (column) => column.name,
+      ),
+    )
+    .sort((a, b) => a.join(",").localeCompare(b.join(",")));
+  return { columns, uniqueIndexes };
+}
+
+function tableNames(db: Database): string[] {
+  return (
+    db
+      .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+      .all() as { name: string }[]
+  ).map((row) => row.name);
+}
+
+// Applied truth: the full hand-written migration chain via the real runner.
+const migrated = new Database(":memory:");
+initializeSqliteDatabase(migrated);
+
+// DDL source of truth: drizzle-kit's generated statements for schema.ts.
+const generated = new Database(":memory:");
+const emptySnapshot = await drizzleKitApi.generateSQLiteDrizzleJson({}, undefined, "snake_case");
+const currentSnapshot = await drizzleKitApi.generateSQLiteDrizzleJson(
+  schema,
+  emptySnapshot.id,
+  "snake_case",
+);
+for (const statement of await drizzleKitApi.generateSQLiteMigration(
+  emptySnapshot,
+  currentSnapshot,
+)) {
+  generated.exec(statement);
+}
+
+const drizzleTables = tableNames(generated).sort();
+if (drizzleTables.length === 0) {
+  console.error("DRIFT: drizzle schema.ts defines no tables — the gate has nothing to check");
+  process.exit(1);
+}
+
+const migratedTables = new Set(tableNames(migrated));
+const failures: string[] = [];
+for (const table of drizzleTables) {
+  if (!migratedTables.has(table)) {
+    failures.push(`DRIFT: table ${table} exists in schema.ts but no applied migration creates it`);
+    continue;
+  }
+  const expected = JSON.stringify(tableShape(generated, table), null, 2);
+  const actual = JSON.stringify(tableShape(migrated, table), null, 2);
+  if (expected !== actual) {
+    failures.push(
+      `DRIFT: table ${table} — schema.ts (drizzle) and applied migration SQL disagree\n` +
+        `--- schema.ts would create:\n${expected}\n--- applied migrations create:\n${actual}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(failure);
+  }
+  console.error(
+    "\nschema.ts is the DDL source of truth and hand SQL is the applied truth — reconcile them (new migration or schema fix), never rewrite an applied migration.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OK: ledger DDL drift check — ${drizzleTables.length} table(s) match between schema.ts and applied migrations (${drizzleTables.join(", ")})`,
+);

--- a/script/smoke-dist.ts
+++ b/script/smoke-dist.ts
@@ -4,11 +4,31 @@
  * gate — it proves the bundle layout (worker entry + migration resolution)
  * actually starts, not just that the build emitted files.
  */
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const root = join(import.meta.dir, "..");
+
+// #552: the published surface stays bin-only until a library surface is
+// deliberately frozen. A root `exports`/`main`/`types`/`module` field would
+// silently publish importable internals, so it fails the gate here.
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")) as Record<
+  string,
+  unknown
+>;
+if (!pkg.bin || typeof pkg.bin !== "object") {
+  console.error("package.json must declare a bin entry — the published surface is the CLI");
+  process.exit(1);
+}
+const libraryFields = ["exports", "main", "types", "module"].filter((field) => field in pkg);
+if (libraryFields.length > 0) {
+  console.error(
+    `package.json declares ${libraryFields.join(", ")} — the published surface is bin-only (#552); remove the field(s) or deliberately freeze a library surface first`,
+  );
+  process.exit(1);
+}
+
 const cli = join(root, "dist", "bin", "cli.js");
 if (!existsSync(cli)) {
   console.error("dist/bin/cli.js missing — run script/build-dist.ts first");


### PR DESCRIPTION
Early (dependency-free) items of #552 (leaf C8; item 1's judgment-name tripwire stays blocked by #502). Every new gate ships with a red-then-green proof (synthetic violation shown failing, then removed).

## What

- **Published surface stays bin-only**: `script/smoke-dist.ts` now asserts the root package.json has `bin` and none of exports/main/types/module — adding an `exports` field fails the smoke with a typed message.
- **`smoke-dist` CI job**: builds `dist` and runs the full smoke (non-interactive onboard + /health) on every PR — previously prepack-only.
- **`script/check-ledger-schema-drift.ts`** (+ Quality job step): applies the real hand-SQL migration chain and drizzle-kit's generated DDL to two in-memory DBs and compares introspected shapes for all drizzle-defined tables. `createLedgerDb` thereby gains its production consumer (the #552 "no consumerless surface" rule). Documented normalization: declared-PK columns are treated as NOT NULL on both sides (SQLite legacy quirk in the applied migration; rewriting it would fork existing installs) — non-PK notnull drift still fails (proven).
- **Stale check-deps exception removed**: the protocol-error `as any` allowance had zero hits.
- **Scanner scope fixed**: `check-deps` ignores `tmp/` and `.claude/` (research clones and nested worktrees were breaking local runs while CI stayed green); `/tmp/` added to .gitignore per #533's pinned-peers convention; root lint inherits via `vcs.useIgnoreFile`.

## Verification

Red/green proof per gate (in commit bodies); check-deps, dead-exports (24 known/0 new), schema-drift, lint:guards/side-effects/tools, biome (983 files), check-types, build, `bun test script` 119/0, smoke:dist end-to-end — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds early CI gates to keep the publish surface bin-only, detect ledger schema drift, and narrow the dependency scanner’s scope. Improves release safety and local dev parity per #552.

- **New Features**
  - Dist smoke gate: builds `dist`, boots the CLI, and fails if `package.json` lacks `bin` or declares `exports`/`main`/`types`/`module` (publish stays bin-only). Runs as the Dist Smoke job in CI.
  - Ledger schema drift gate: generates DDL from `schema.ts` with `drizzle-kit` and diffs against applied migrations; PK implies NOT NULL normalization. Runs in the Quality job.

- **Bug Fixes**
  - `check-deps` skips `tmp/` and `.claude/` to avoid local false positives; `/tmp/` added to `.gitignore`, and root lint inherits VCS ignores.
  - Removed stale `as any` exception for the protocol error path.

<sup>Written for commit 712ad53ec56f0ae2bfd4798c7a39637b579428ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

