### PR TITLE
fix(ci): resolve workspace packages in pristine dist build

### DIFF
--- a/script/build-dist.ts
+++ b/script/build-dist.ts
@@ -35,6 +35,21 @@ const result = await Bun.build({
     "process.env.OPENOMNI_CLI_BUNDLE": JSON.stringify("1"),
     "process.env.OPENOMNI_CLI_VERSION": JSON.stringify(pkg.version),
   },
+  plugins: [
+    {
+      // @openomni/protocol is the one workspace package whose package.json
+      // points at tsc output (./dist/index.js), which does not exist in a
+      // pristine checkout (CI, fresh clone) — Bun.build then fails with
+      // `Could not resolve: "@openomni/protocol"`. Bundle it from source,
+      // exactly like every other workspace package already resolves.
+      name: "workspace-protocol-from-src",
+      setup(build) {
+        build.onResolve({ filter: /^@openomni\/protocol$/ }, () => ({
+          path: join(root, "packages/protocol/src/index.ts"),
+        }));
+      },
+    },
+  ],
 });
 
 if (!result.success) {


### PR DESCRIPTION
## Root cause

The `smoke-dist` job added in #566 fails on main because `@openomni/protocol` is the only workspace package whose `package.json` main/exports point at tsc output (`./dist/index.js`) instead of `./src/index.ts`. In a pristine checkout (frozen install, no prior builds) that file does not exist, so `Bun.build` in `script/build-dist.ts` fails resolution at every `@openomni/protocol` import site in `apps/server/src` and `packages/llm/src` — exactly the CI error. Local runs passed only because dev machines carried a previously built `packages/protocol/dist`. (Every other CI job that needs protocol already runs `turbo run build --filter=@openomni/protocol` first; `smoke-dist` did not, and a bundler should not depend on tsc output anyway.)

## Fix

Add a `Bun.build` `onResolve` plugin in `script/build-dist.ts` that maps the bare specifier `@openomni/protocol` to `packages/protocol/src/index.ts`, bundling it from source exactly like every other workspace package already resolves. This makes `build:dist` self-contained for CI, `prepack`, and `release` from a fresh clone — no extra CI prerequisite step, no job weakening.

## Pristine reproduction proof

`rm -rf node_modules apps/*/node_modules packages/*/node_modules dist migration` → `bun install --frozen-lockfile` → before the fix, `bun run build:dist` reproduces the CI failure verbatim; after the fix:

- `bun run build:dist` → `built dist/bin (cli.js, worker-entry.js) for openomni@0.1.0`
- `bun run smoke:dist` → `smoke ok: onboard + serve answered /health`
- `bun run script/check-ledger-schema-drift.ts` (also from #566) verified in the same pristine layout → `OK: ledger DDL drift check — 2 table(s) match` (its `Bun.resolveSync("drizzle-kit/api", packages/session)` handles the isolated linker correctly; no change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `smoke-dist` CI failures by bundling `@openomni/protocol` from source during the dist build. Builds now work from a pristine install without pre-building workspace packages, making `build:dist` self-contained for CI, `prepack`, and release.

- **Bug Fixes**
  - Add `onResolve` plugin to `Bun.build` in `script/build-dist.ts` mapping `@openomni/protocol` to `packages/protocol/src/index.ts`.
  - Removes reliance on `packages/protocol/dist` (tsc output) that doesn’t exist in fresh clones.

<sup>Written for commit 949b082169f42c39dfef90b51ef97d8f69f535d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

