### PR TITLE
fix(session): merge injected responses into transcript resume (#562)

### DIFF
--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -176,13 +176,17 @@ export namespace WorkerRunner {
             onToolCall: () => undefined,
             onToolResult: () => undefined,
             onSnapshot: () => undefined,
-            // #547 C3: the single wiring point for WORKER sessions where the
+            // #547 C3: the wiring point for WORKER sessions where the
             // transcript fact stream meets durable recording —
             // TranscriptStore.record commits the fact and its message/part
             // projection in one storage transaction (recording tier;
-            // packages/session/src/session/transcript.ts). Resident direct
-            // runs (defaultRunAgent, no sink) and child-agent LLM streams are
-            // projection-only today (follow-up issue).
+            // packages/session/src/session/transcript.ts). Injected
+            // responses into this session record synthesized facts at the
+            // injection-queue persistResponse seam (#562). Resident direct
+            // runs stay sinkless on purpose and child-agent streams record
+            // nothing (bounded) — see defaultRunAgent in
+            // packages/openomni/src/resident/runtime-agent-config.ts and the
+            // writer census in Session.resume.
             onFact: (fact) => TranscriptStore.record(sessionId, fact),
           },
         );

--- a/packages/openomni/src/execution-runtime/middleware/injection-queue-policy.ts
+++ b/packages/openomni/src/execution-runtime/middleware/injection-queue-policy.ts
@@ -1,6 +1,6 @@
 import type { Message, Policy } from "@openomni/protocol";
 import { PolicyDecision } from "@openomni/protocol";
-import { Session } from "@openomni/session";
+import { Storage, TranscriptStore } from "@openomni/session";
 import type { CanonicalPolicyRegistration, PolicyContext } from "@openomni/agent";
 import type { InjectionQueue } from "../injection-queue.js";
 
@@ -63,6 +63,23 @@ function contextString(
   return typeof value === "string" ? value : undefined;
 }
 
+/**
+ * #562 F3: injected responses are recorded as SYNTHESIZED TRANSCRIPT FACTS
+ * (message.created + part.appended + message.finished), not as
+ * projection-only message/part rows. This seam writes into the same worker
+ * session whose own turns record facts via the worker-runner onFact sink;
+ * Session.resume replays the fact stream once one exists, so a
+ * projection-only write here would silently vanish from recovery.
+ * TranscriptStore.record commits each fact and its message/part projection
+ * in one storage transaction — one source of truth, and one more assistant
+ * writer off the projection-fallback removal condition (see
+ * packages/session/src/session/messages.ts resume()).
+ *
+ * The attemptId is derived from the injected messageId: injected responses
+ * arrive whole (no retries, no streaming), so one message = one attempt, and
+ * a duplicate drain of the same messageId rejects loudly in the fold
+ * (created-on-existing) instead of duplicating history.
+ */
 function persistResponse(
   sessionId: string,
   agentName: string,
@@ -72,7 +89,7 @@ function persistResponse(
     id: response.messageId,
     sessionID: sessionId,
     role: "assistant",
-    time: { created: response.timestamp, completed: response.timestamp },
+    time: { created: response.timestamp },
     parentID: "",
     modelID: "",
     providerID: "",
@@ -81,12 +98,32 @@ function persistResponse(
     cost: 0,
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
   };
-  Session.addMessage(sessionId, message);
-  Session.addPart(response.messageId, {
-    id: crypto.randomUUID(),
-    sessionID: sessionId,
-    messageID: response.messageId,
-    type: "text",
-    text: response.output,
+  const attemptId = `${response.messageId}#inject`;
+  // One injected response = one all-or-nothing unit: the outer transaction
+  // makes the three per-fact transactions degrade to savepoints, so a
+  // failure never strands a created-but-unfinished injected message.
+  Storage.get().transaction(() => {
+    TranscriptStore.record(sessionId, { type: "message.created", attemptId, message });
+    TranscriptStore.record(sessionId, {
+      type: "part.appended",
+      attemptId,
+      messageId: response.messageId,
+      part: {
+        id: `${response.messageId}-text`,
+        sessionID: sessionId,
+        messageID: response.messageId,
+        type: "text",
+        text: response.output,
+        time: { start: response.timestamp },
+      },
+    });
+    TranscriptStore.record(sessionId, {
+      type: "message.finished",
+      attemptId,
+      messageId: response.messageId,
+      at: response.timestamp,
+      finish: "stop",
+      usage: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    });
   });
 }

--- a/packages/openomni/src/resident/runtime-agent-config.ts
+++ b/packages/openomni/src/resident/runtime-agent-config.ts
@@ -7,6 +7,25 @@ type RuntimeAgentDef = Ingress.AgentDef & {
   readonly providerOptions?: Record<string, unknown>;
 };
 
+/**
+ * #562 F2: the resident direct path runs WITHOUT a transcript fact sink ON
+ * PURPOSE — not for layering reasons (this package already reaches
+ * TranscriptStore, and ResidentRuntimeOptions.runAgent is injectable from
+ * the server composition), but because the resident path's durable
+ * assistant write is SessionBridge.storeDirectResult at the ingress handler
+ * (ingress/handlers.ts handleResident): it persists the POST-writeback
+ * output (commitWriteback policies may transform it) under its own message
+ * id, wrapped in the ingress audit envelope. Wiring a raw-stream sink here
+ * would (1) double-persist every resident turn — the streamed message id
+ * via facts plus the writeback message id via projection, with diverging
+ * raw-vs-committed text — and (2) give resident sessions their first
+ * transcript facts, flipping Session.resume off the projection fallback and
+ * silently dropping all pre-existing projection-only resident history.
+ * Recording facts for residents therefore rides a redesign of the writeback
+ * seam (record the committed writeback as the fact), not a sink here.
+ * Resident sessions stay all-projection, so resume's fallback covers them
+ * losslessly — see the writer census in Session.resume.
+ */
 export function defaultRunAgent(config: ChatAgentConfig, input: ChatAgentInput) {
   return ChatAgent.create(config).run(input);
 }

--- a/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
+++ b/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { PolicyEngine, type PolicyEngineInstance } from "@openomni/agent";
-import { Session, Storage } from "@openomni/session";
+import { Session, Storage, TranscriptStore } from "@openomni/session";
+import type { Message, Transcript } from "@openomni/protocol";
 import { InjectionQueue } from "../../src/execution-runtime/injection-queue.js";
 import { createInjectionQueueDrainPolicy } from "../../src/execution-runtime/middleware/injection-queue-policy.js";
 import { buildWorkerMiddleware } from "../../src/execution-runtime/middleware.js";
@@ -31,6 +32,87 @@ async function dispatchTurnFinish(
   const engine = PolicyEngine.create({ audit: false });
   engine.register(createInjectionQueueDrainPolicy(queue));
   return engine.dispatchPoint("run.turn.post", baseContext(runId, sessionId));
+}
+
+function assistantInfo(sessionID: string, messageID: string): Message.AssistantMessage {
+  return {
+    id: messageID,
+    sessionID,
+    role: "assistant",
+    time: { created: 1_000 },
+    parentID: "user-1",
+    modelID: "test-model",
+    providerID: "test",
+    agent: "worker",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  };
+}
+
+/** One complete tool-bearing worker turn recorded as transcript facts. */
+function recordToolTurn(sessionID: string, messageID: string): void {
+  const attemptId = `${messageID}#1`;
+  const facts: Transcript.Fact[] = [
+    { type: "message.created", attemptId, message: assistantInfo(sessionID, messageID) },
+    {
+      type: "part.appended",
+      attemptId,
+      messageId: messageID,
+      part: {
+        id: `${messageID}-text`,
+        sessionID,
+        messageID,
+        type: "text",
+        text: "",
+        time: { start: 1_010 },
+      },
+    },
+    {
+      type: "part.advanced",
+      attemptId,
+      messageId: messageID,
+      partId: `${messageID}-text`,
+      transition: { to: "completed", at: 1_020, output: "worker turn output" },
+    },
+    {
+      type: "part.appended",
+      attemptId,
+      messageId: messageID,
+      part: {
+        id: `${messageID}-tool`,
+        sessionID,
+        messageID,
+        type: "tool",
+        callID: `${messageID}-call`,
+        tool: "bash",
+        state: { status: "pending", input: { command: "ls" } },
+      },
+    },
+    {
+      type: "part.advanced",
+      attemptId,
+      messageId: messageID,
+      partId: `${messageID}-tool`,
+      transition: { to: "running", at: 1_030 },
+    },
+    {
+      type: "part.advanced",
+      attemptId,
+      messageId: messageID,
+      partId: `${messageID}-tool`,
+      transition: { to: "completed", at: 1_040, output: "file-a", title: "bash" },
+    },
+    {
+      type: "message.finished",
+      attemptId,
+      messageId: messageID,
+      at: 1_050,
+      finish: "stop",
+      usage: { input: 12, output: 7, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+  ];
+  for (const fact of facts) TranscriptStore.record(sessionID, fact);
 }
 
 describe("createInjectionQueueDrainPolicy", () => {
@@ -108,6 +190,32 @@ describe("createInjectionQueueDrainPolicy", () => {
     ]);
   });
 
+  // #562 F3 red pin: injected responses land in the SAME worker session that
+  // records transcript facts. Resume replays the fact stream once one exists,
+  // so a projection-only injected write silently vanishes from recovery. The
+  // seam must record the injected response as synthesized facts.
+  it("resume keeps injected responses in a fact-bearing session, in recording order", async () => {
+    const session = Session.create({
+      title: "Resume Merge",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    recordToolTurn(session.id, "msg-turn");
+    const queue = InjectionQueue.create();
+    queue.enqueue("run-resume", {
+      messageId: "msg-injected",
+      output: "resident answer",
+      injectToHistory: true,
+      timestamp: 2_000,
+    });
+
+    await dispatchTurnFinish(queue, "run-resume", session.id);
+
+    const recovered = await Session.resume(session.id);
+    // Ordering rule: replay order is the session fact-stream seq (recording
+    // order) — the injected response drains after the turn that asked for it.
+    expect(recovered.map((entry) => entry.text)).toEqual(["worker turn output", "resident answer"]);
+  });
+
   it("still emits drained responses when history persistence fails", async () => {
     const queue = InjectionQueue.create();
     queue.enqueue("run-storage-failure", {
@@ -116,7 +224,7 @@ describe("createInjectionQueueDrainPolicy", () => {
       injectToHistory: true,
       timestamp: 4,
     });
-    const addMessageSpy = spyOn(Session, "addMessage").mockImplementation(() => {
+    const recordSpy = spyOn(TranscriptStore, "record").mockImplementation(() => {
       throw new Error("storage unavailable");
     });
 
@@ -124,7 +232,7 @@ describe("createInjectionQueueDrainPolicy", () => {
     try {
       decision = await dispatchTurnFinish(queue, "run-storage-failure", "session-storage-failure");
     } finally {
-      addMessageSpy.mockRestore();
+      recordSpy.mockRestore();
     }
 
     expect(decision.effects).toEqual([

--- a/packages/session/migration/0015_transcript_fact/migration.sql
+++ b/packages/session/migration/0015_transcript_fact/migration.sql
@@ -13,6 +13,12 @@
 -- The composite PK (session_id, seq) is the backstop against seq reuse; the
 -- table carries no UPDATE path by design — later lifecycle steps are NEW
 -- part.advanced facts, never rewrites of stored rows.
+--
+-- #562 F5 — cascade intent: transcript facts deliberately carry no FK and
+-- no ON DELETE CASCADE. The record outlives its projection ("기록은 남는다"):
+-- deleting a session cascades the message/part read-model rows away
+-- (0001 FKs plus explicit lifecycle deletes), but the recorded fact stream
+-- persists — facts persist, projection cascades.
 
 CREATE TABLE IF NOT EXISTS transcript_fact (
   session_id TEXT NOT NULL,

--- a/packages/session/src/session/messages.ts
+++ b/packages/session/src/session/messages.ts
@@ -148,13 +148,33 @@ export function getParts(messageID: string): Message.Part[] {
 export async function resume(id: string): Promise<RecoveredMessage[]> {
   // #547 C3: resume replays the persisted Transcript.Fact stream through the
   // fold — the message/part tables are read-model projections of it, never
-  // the record. Sessions with an empty fact stream (history recorded before
-  // the transcript record family, or projection-only writers like ingress)
-  // fall back to the projection read. The projection fallback survives until
-  // (a) all pre-0015 sessions expire/archive AND (b) every assistant writer
-  // records facts (injection-queue persistResponse is projection-only today —
-  // see follow-up issue). Mixed-source sessions: facts win, projection-only
-  // assistant rows are NOT merged yet.
+  // the record. Replay order is the session fact-stream seq (recording
+  // order): messages appear in first message.created order, so an injected
+  // response sorts after the turn that drained it. Sessions with an empty
+  // fact stream (history recorded before the transcript record family, or
+  // projection-only writers) fall back to the projection read.
+  //
+  // Projection fallback removal condition (#562): the fallback dies when
+  // (a) all pre-0015 sessions are expired/archived AND (b) every assistant
+  // writer records facts. Writer census as of #562:
+  //   - worker turns: facts (worker-runner onFact sink);
+  //   - injected responses: facts (injection-queue persistResponse
+  //     synthesizes message.created/part.appended/message.finished — #562);
+  //   - resident direct runs: projection-only via
+  //     SessionBridge.storeDirectResult (post-writeback output, own message
+  //     id — see defaultRunAgent in resident/runtime-agent-config.ts);
+  //   - ingress writeback of worker output (handlers.ts storeDirectResult
+  //     calls): projection-only, but it DUPLICATES the worker's final
+  //     fact-recorded turn (post-writeback-policy text), so dropping it from
+  //     replay loses no substance;
+  //   - child-agent streams: record nothing (no sink, no session writes) —
+  //     bounded, because child output reaches the parent as tool results,
+  //     which the parent's fact-recorded turns carry.
+  // Mixed-source sessions: facts win, projection-only assistant rows are
+  // NOT merged — every fact-recording session must therefore keep all its
+  // NON-duplicate assistant writers on the fact path (true for worker
+  // sessions since #562; resident sessions record no facts, so they always
+  // fall back).
   const replayed = TranscriptStore.replay(id);
   const source = replayed.length > 0 ? replayed : await hydrateMessages(getMessages(id));
 

--- a/packages/session/src/session/transcript.ts
+++ b/packages/session/src/session/transcript.ts
@@ -100,6 +100,35 @@ function maintainProjection(
   }
 }
 
+/**
+ * #562 F7: attemptId-keyed in-memory fold-state cache for the record path.
+ * Without it every record refolds the attempt's whole persisted stream
+ * inside BEGIN IMMEDIATE — O(n²) JSON.parse + fold per attempt. With it,
+ * one fact folds onto the cached state in O(1); the stored-fact COUNT
+ * (index-only) is the continuity check.
+ *
+ * Correctness envelope:
+ *   - the cache is written ONLY after the storage transaction committed, so
+ *     it always equals the fold of the attempt's durable facts;
+ *   - continuity check: cached.factCount must equal the stored count read
+ *     inside the same transaction — any divergence (process restart with a
+ *     different DB, an outer transaction that rolled a committed savepoint
+ *     back, a concurrent writer) falls back to the full refold. Restart
+ *     safety is preserved on top of that: the llm processor issues fresh
+ *     attemptIds after a restart, so a rebooted process never even hits a
+ *     stale key;
+ *   - message.finished evicts (the attempt is terminal — the fold rejects
+ *     any later fact), and the cache is FIFO-bounded as a leak backstop for
+ *     attempts that never finish.
+ */
+type FoldCacheEntry = { state: Message.WithParts; factCount: number };
+const foldStateCache = new Map<string, FoldCacheEntry>();
+const FOLD_CACHE_LIMIT = 256;
+
+function foldCacheKey(sessionID: string, attemptId: string): string {
+  return `${sessionID}\u0000${attemptId}`;
+}
+
 export namespace TranscriptStore {
   /**
    * Pure fold driver over an ordered fact stream. State is keyed by
@@ -149,14 +178,31 @@ export namespace TranscriptStore {
     }
     const adapter = Storage.get();
     const facts = requireFacts(adapter);
-    return adapter.transaction(() => {
-      const stream = facts.listByAttempt(sessionID, parsed.attemptId).map(parseRow);
-      const projected = projectFrom([...stream, parsed]);
-      const state = projected.at(-1);
-      if (state === undefined) {
-        // Unreachable: projectFrom either threw or produced this attempt's
-        // message state — kept as the explosive backstop.
-        throw new TranscriptRecordingError("unknown_message", parsed.type);
+    const cacheKey = foldCacheKey(sessionID, parsed.attemptId);
+    const committed = adapter.transaction(() => {
+      // #562 F7: O(1) hot path — fold the one new fact onto the cached
+      // attempt state when the stored-fact count confirms continuity;
+      // anything else refolds the attempt's persisted stream (cold start,
+      // restart, rolled-back outer transaction, foreign writer).
+      const storedCount = facts.countByAttempt(sessionID, parsed.attemptId);
+      const cached = foldStateCache.get(cacheKey);
+      let state: Message.WithParts;
+      if (cached !== undefined && cached.factCount === storedCount) {
+        const outcome = Transcript.fold(cached.state, parsed);
+        if ("rejected" in outcome) {
+          throw new TranscriptRecordingError(outcome.reason, parsed.type);
+        }
+        state = outcome.state;
+      } else {
+        const stream = facts.listByAttempt(sessionID, parsed.attemptId).map(parseRow);
+        const projected = projectFrom([...stream, parsed]);
+        const refolded = projected.at(-1);
+        if (refolded === undefined) {
+          // Unreachable: projectFrom either threw or produced this attempt's
+          // message state — kept as the explosive backstop.
+          throw new TranscriptRecordingError("unknown_message", parsed.type);
+        }
+        state = refolded;
       }
       facts.append({
         sessionID,
@@ -167,8 +213,20 @@ export namespace TranscriptStore {
         timeCreated: Date.now(),
       });
       maintainProjection(adapter, sessionID, parsed, state);
-      return state;
+      return { state, factCount: storedCount + 1 };
     });
+    // Cache write only AFTER the transaction returned (committed, or — under
+    // an outer transaction — reached a savepoint whose later rollback the
+    // count continuity check catches on the next record).
+    foldStateCache.delete(cacheKey);
+    if (parsed.type !== "message.finished") {
+      foldStateCache.set(cacheKey, committed);
+      if (foldStateCache.size > FOLD_CACHE_LIMIT) {
+        const oldest = foldStateCache.keys().next().value;
+        if (oldest !== undefined) foldStateCache.delete(oldest);
+      }
+    }
+    return committed.state;
   }
 
   /**

--- a/packages/session/src/storage/sqlite-transcript-fact-adapter.ts
+++ b/packages/session/src/storage/sqlite-transcript-fact-adapter.ts
@@ -47,5 +47,17 @@ export function createSqliteTranscriptFactAdapter(
            WHERE session_id = ? AND attempt_id = ? ORDER BY seq ASC`,
         )
         .all(sessionID, attemptID) as Storage.TranscriptFactRow[],
+
+    // #562 F7: continuity check for the record path's fold-state cache — a
+    // covering-index count (idx_transcript_fact_attempt), no row payloads.
+    countByAttempt: (sessionID, attemptID): number => {
+      const row = db
+        .query(
+          `SELECT COUNT(*) AS count FROM transcript_fact
+           WHERE session_id = ? AND attempt_id = ?`,
+        )
+        .get(sessionID, attemptID) as { count: number };
+      return row.count;
+    },
   };
 }

--- a/packages/session/src/storage/storage.ts
+++ b/packages/session/src/storage/storage.ts
@@ -66,6 +66,12 @@ export namespace Storage {
       }): number;
       list(sessionID: string): TranscriptFactRow[];
       listByAttempt(sessionID: string, attemptID: string): TranscriptFactRow[];
+      /**
+       * #562 F7: stored-fact count for one attempt — the record path's
+       * continuity check for its in-memory fold-state cache (an index count,
+       * never a row read). Still read-only surface: no update, no delete.
+       */
+      countByAttempt(sessionID: string, attemptID: string): number;
     };
 
     // Optional here for test fakes only — SurfaceKey operations fail closed

--- a/packages/session/test/session/transcript-store.test.ts
+++ b/packages/session/test/session/transcript-store.test.ts
@@ -244,6 +244,74 @@ describe("TranscriptStore resume-by-replay (pin 1)", () => {
   });
 });
 
+describe("TranscriptStore record-path fold cache (#562 F7)", () => {
+  test("kill/reopen mid-attempt: recording continues and replay matches the projection", async () => {
+    const session = createSession();
+    const facts = toolTurnFacts(session.id, "msg-cache", "msg-cache#1");
+
+    for (const fact of facts.slice(0, 3)) TranscriptStore.record(session.id, fact);
+    reopenStorage();
+    for (const fact of facts.slice(3)) TranscriptStore.record(session.id, fact);
+
+    const replayed = TranscriptStore.replay(session.id);
+    const projection = await Session.hydrateMessages(Session.getMessages(session.id));
+    expect(JSON.stringify(replayed)).toBe(JSON.stringify(projection));
+    const [message] = replayed;
+    expect(message?.info.role === "assistant" ? message.info.finish : undefined).toBe("stop");
+  });
+
+  test("outer-transaction rollback: count continuity refolds instead of trusting the cache", async () => {
+    const session = createSession();
+    const facts = toolTurnFacts(session.id, "msg-rollback", "msg-rollback#1");
+    const [created, appended, ...rest] = facts;
+    if (!created || !appended) throw new Error("fixture shape");
+    TranscriptStore.record(session.id, created);
+
+    // The savepoint commits inside record(), the cache advances, then the
+    // OUTER transaction rolls everything back — cache and disk now disagree.
+    const adapter = Storage.getAdapter();
+    expect(() =>
+      adapter.transaction(() => {
+        TranscriptStore.record(session.id, appended);
+        throw new Error("outer rollback");
+      }),
+    ).toThrow("outer rollback");
+    expect(Storage.getAdapter().transcriptFact?.list(session.id)).toHaveLength(1);
+
+    // Re-recording the same fact must refold from the stored stream (count
+    // mismatch), not double-apply the cached state.
+    for (const fact of [appended, ...rest]) TranscriptStore.record(session.id, fact);
+
+    const replayed = TranscriptStore.replay(session.id);
+    const projection = await Session.hydrateMessages(Session.getMessages(session.id));
+    expect(JSON.stringify(replayed)).toBe(JSON.stringify(projection));
+    expect(replayed[0]?.parts.map((part) => part.id)).toEqual([
+      "msg-rollback-text",
+      "msg-rollback-tool",
+    ]);
+  });
+
+  test("cached-path fold rejection stays loud and persists nothing", () => {
+    const session = createSession();
+    TranscriptStore.record(session.id, {
+      type: "message.created",
+      attemptId: "msg-dup#1",
+      message: assistantInfo(session.id, "msg-dup"),
+    });
+
+    // Second message.created on the same (now cached) attempt: the O(1)
+    // cached fold must escalate exactly like the refold path.
+    expect(() =>
+      TranscriptStore.record(session.id, {
+        type: "message.created",
+        attemptId: "msg-dup#1",
+        message: assistantInfo(session.id, "msg-dup"),
+      }),
+    ).toThrow(TranscriptRecordingError);
+    expect(Storage.getAdapter().transcriptFact?.list(session.id)).toHaveLength(1);
+  });
+});
+
 describe("TranscriptStore recording defects (pin 2)", () => {
   test("out-of-order fact write escalates to a loud throw and persists nothing", () => {
     const session = createSession();
@@ -347,6 +415,12 @@ describe("TranscriptStore append-only fact rows (pin 3)", () => {
   test("the fact sub-adapter exposes no update or delete surface", () => {
     const facts = Storage.getAdapter().transcriptFact;
     expect(facts).toBeDefined();
-    expect(Object.keys(facts ?? {}).sort()).toEqual(["append", "list", "listByAttempt"]);
+    // countByAttempt (#562 F7) is read-only — still no update/delete surface.
+    expect(Object.keys(facts ?? {}).sort()).toEqual([
+      "append",
+      "countByAttempt",
+      "list",
+      "listByAttempt",
+    ]);
   });
 });


### PR DESCRIPTION
Closes #562 (F1 rides #493 — see disposition below).

## The defect (F3)

`Session.resume` is all-or-nothing per session (`replayed.length > 0 ? replayed : projection`), while injection-queue `persistResponse` wrote `role:"assistant"` rows projection-only into the SAME worker session. Once a session had one transcript fact, resume replayed facts and silently dropped every injected assistant response.

## Choice: (a) synthesized facts at the seam, not (b) resume merge

The write path cleanly reaches `TranscriptStore` (`@openomni/openomni` already depends on `@openomni/session`), so `persistResponse` now records `message.created` + `part.appended(text)` + `message.finished` under an attemptId derived from the injected messageId, all three wrapped in one outer transaction (savepoint degradation) so a failure never strands a created-but-unfinished message. One source of truth, and one more assistant writer off the projection-fallback removal condition. A resume-side merge (b) would have permanently blurred record vs read-model and re-opened dedup/ordering questions for every future writer.

**Ordering rule:** replay order is the session fact-stream `seq` (recording order); messages appear in first-`message.created` order, so an injected response sorts after the turn that drained it.

**Red evidence:** new pin "resume keeps injected responses in a fact-bearing session, in recording order" fails on main (`recovered.map(text)` = `["worker turn output"]`, expected `["worker turn output", "resident answer"]`) and is green here.

**Fallback removal condition** documented in `Session.resume`: projection fallback dies when (a) all pre-0015 sessions are expired/archived AND (b) every assistant writer records facts — with a full writer census.

## Checklist disposition vs #562

- [x] **F3 (main)** — injected responses recorded as synthesized facts; red-first pin; removal condition documented.
- [x] **F2** — explicitly scoped, not wired. Layering is NOT the blocker (ResidentRuntimeOptions.runAgent is injectable and the package reaches TranscriptStore); the blocker is semantic: the resident direct path's durable assistant write is the post-writeback `SessionBridge.storeDirectResult` (own message id, `commitWriteback`-transformed text, audit-enveloped). A raw-stream sink would double-persist every resident turn AND flip resident sessions off the lossless projection fallback, dropping their pre-existing history. Fact recording for residents rides a writeback-seam redesign; documented at `defaultRunAgent`. Child-agent runs record nothing and are bounded (child output reaches the parent as fact-recorded tool results); noted in the census.
- [x] **F5** — migration 0015 header now states the decided intent: transcript facts deliberately carry no FK/CASCADE; the record outlives its projection ("기록은 남는다") — facts persist, projection cascades. Comment-only; drift gate re-applies the chain (green).
- [x] **F7** — record-path full refold replaced by an attemptId-keyed in-memory fold-state cache with a stored-fact-count continuity check (index-only `countByAttempt`); refold only on count mismatch (cold start, restart, rolled-back outer savepoint, foreign writer). Cache written only after the transaction returns; `message.finished` evicts; FIFO-bounded. Restart safe: the processor issues fresh attemptIds. **Measurement** (one attempt, disk db): 150 facts 68 ms → 29 ms; 500 facts 497 ms → 102 ms (quadratic term gone; residual is per-fact fsync).
- [ ] **F1** — not here by design: per-session seq-range digest rides the #493 JSONL export (or #226 offline verification).

## Gates

Baseline suites re-green: `bun test packages/session packages/openomni apps/server script/conformance` — 2182 pass / 0 fail (baseline 2178; +4 new tests: 1 injection-resume pin, 3 fold-cache pins: kill/reopen mid-attempt, outer-rollback continuity refold, cached-path loud rejection). check-types, build, lint, check-deps, check-dead-exports (24 known, none new), conformance, schema-drift all green. No workflow/CI-job changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped injected assistant responses on resume by recording them as synthesized transcript facts in worker sessions, so recovery replays them in order. Also adds a fast fold-state cache to `TranscriptStore.record`; resident direct runs stay projection-only by design. Aligns with #562.

- **Bug Fixes**
  - Injected responses are persisted as transcript facts (`message.created` → `part.appended` → `message.finished`) via `TranscriptStore.record`, using attemptId `<messageId>#inject`.
  - Wrapped in one transaction; `Session.resume` now replays them in recording order instead of dropping them. New tests pin recovery behavior.
  - Resident direct runs remain sinkless and child-agent streams record nothing; projection fallback rules documented in `Session.resume`.

- **Performance**
  - Added attemptId-keyed fold-state cache with a stored-fact continuity check (`countByAttempt`) to avoid O(n²) refolds; evicts on `message.finished` and is FIFO-bounded.
  - SQLite adapter now exposes `countByAttempt`. Measured improvements: 150 facts 68→29 ms; 500 facts 497→102 ms.

<sup>Written for commit d1f9f5b0c39b12889a2f513a76c9f2a4c65179dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Injected responses are now preserved in transcript history and replayed in the correct order.
  * Transcript recording now supports faster processing through safe in-memory state reuse.
  * Transcript history remains available even when session projection data is removed.

* **Bug Fixes**
  * Improved handling of transcript persistence failures, transaction rollbacks, and duplicate records.
  * Added safeguards to maintain reliable message delivery and queue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->