### PR TITLE
refactor(protocol,server): channels band seam precursors

### DIFF
--- a/apps/server/src/bootstrap/channels.ts
+++ b/apps/server/src/bootstrap/channels.ts
@@ -1,5 +1,7 @@
 import type { Adapter } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import { DiscordAdapter, GitHubAdapter, TelegramAdapter, WebSocketHandler } from "../channel";
+import type { PublishPort } from "../channel/types";
 import type { ServerConfig } from "../config";
 import type { ChannelDeliveryRoute } from "./messaging";
 
@@ -30,20 +32,28 @@ export function createChannelAdapters(
   const deliveryRoutes = new Map<string, ChannelDeliveryRoute>();
   let wsHandler: WebSocketHandler | undefined;
   let githubWebhookHandler: ((req: Request) => Promise<Response>) | undefined;
+  // Composition-root binding: channel adapters observe through an injected
+  // publish port; today it is the session Bus (same seam as the execution
+  // coordinator's events.publish, #462 §2).
+  const publish: PublishPort = Bus.publish;
 
   if (routingHandler) {
-    wsHandler = new WebSocketHandler(routingHandler, { token: config.server.wsToken });
+    wsHandler = new WebSocketHandler(routingHandler, publish, { token: config.server.wsToken });
   }
 
   if (config.telegram.token && routingHandler) {
-    const telegram = new TelegramAdapter(config.telegram.token, {
-      triggers: [
-        ...(config.telegram.allowedUsers.length > 0
-          ? [{ type: "sender" as const, allow: config.telegram.allowedUsers }]
-          : []),
-      ],
-      deliveryPolicy: "final",
-    });
+    const telegram = new TelegramAdapter(
+      config.telegram.token,
+      {
+        triggers: [
+          ...(config.telegram.allowedUsers.length > 0
+            ? [{ type: "sender" as const, allow: config.telegram.allowedUsers }]
+            : []),
+        ],
+        deliveryPolicy: "final",
+      },
+      publish,
+    );
     telegram.onMessage(routingHandler);
     channels.push(telegram);
     deliveryRoutes.set(telegram.id, (externalId, body) => telegram.deliver(externalId, body));
@@ -61,6 +71,7 @@ export function createChannelAdapters(
         ],
         deliveryPolicy: "final",
       },
+      publish,
       config.github.token,
       config.github.botUsername,
     );
@@ -70,15 +81,19 @@ export function createChannelAdapters(
   }
 
   if (config.discord.token && routingHandler) {
-    const discord = new DiscordAdapter(config.discord.token, {
-      triggers: [
-        { type: "mention" },
-        ...(config.discord.allowedUsers.length > 0
-          ? [{ type: "sender" as const, allow: config.discord.allowedUsers }]
-          : []),
-      ],
-      deliveryPolicy: "final",
-    });
+    const discord = new DiscordAdapter(
+      config.discord.token,
+      {
+        triggers: [
+          { type: "mention" },
+          ...(config.discord.allowedUsers.length > 0
+            ? [{ type: "sender" as const, allow: config.discord.allowedUsers }]
+            : []),
+        ],
+        deliveryPolicy: "final",
+      },
+      publish,
+    );
     discord.onMessage(routingHandler);
     channels.push(discord);
     deliveryRoutes.set(discord.id, (externalId, body) => discord.deliver(externalId, body));

--- a/apps/server/src/channel/authn/websocket.ts
+++ b/apps/server/src/channel/authn/websocket.ts
@@ -1,12 +1,13 @@
 import { Operational } from "@openomni/protocol";
 import type { Policy } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { WebSocketToken } from "./definitions";
 import { evaluateChannelPermission, recordDecision } from "./decision";
 import type { ChannelAuthnDecisionObserver, WebSocketAuthResult } from "./types";
+import type { PublishPort } from "../types";
 
 interface WebSocketAuthState {
   readonly request: Request;
+  readonly publish: PublishPort;
   readonly token?: string;
   headers?: Record<string, string>;
   response?: Response;
@@ -44,7 +45,7 @@ function evaluateWebSocketToken(state: WebSocketAuthState): Policy.PolicyDecisio
   const subprotocolAuth = readSubprotocolAuth(state.request);
   const provided = subprotocolAuth?.token ?? url.searchParams.get("token");
   if (provided !== state.token) {
-    Bus.publish(Operational.Warn, {
+    state.publish(Operational.Warn, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -73,7 +74,7 @@ function evaluateWebSocketToken(state: WebSocketAuthState): Policy.PolicyDecisio
     });
   }
 
-  Bus.publish(Operational.Warn, {
+  state.publish(Operational.Warn, {
     traceId: crypto.randomUUID(),
     time: Date.now(),
     component: "server",
@@ -91,12 +92,14 @@ function evaluateWebSocketToken(state: WebSocketAuthState): Policy.PolicyDecisio
 
 export function authenticateWebSocketUpgrade(input: {
   readonly request: Request;
+  readonly publish: PublishPort;
   readonly token?: string;
   readonly onDecision?: ChannelAuthnDecisionObserver;
 }): WebSocketAuthResult {
   const startedAt = Date.now();
   const state: WebSocketAuthState = {
     request: input.request,
+    publish: input.publish,
     ...(input.token !== undefined ? { token: input.token } : {}),
   };
   const verdict = evaluateWebSocketToken(state);

--- a/apps/server/src/channel/discord/client.ts
+++ b/apps/server/src/channel/discord/client.ts
@@ -1,12 +1,14 @@
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { fetchWithRetry } from "../../shared/fetch-retry";
-import type { ChannelClient } from "../types";
+import type { ChannelClient, PublishPort } from "../types";
 
 const BASE_URL = "https://discord.com/api/v10";
 
 export class DiscordClient implements ChannelClient {
-  constructor(private readonly token: string) {}
+  constructor(
+    private readonly token: string,
+    private readonly publish: PublishPort,
+  ) {}
 
   async send(channelId: string, text: string): Promise<string | undefined> {
     const message = (await this.api(`/channels/${channelId}/messages`, { content: text })) as {
@@ -20,7 +22,7 @@ export class DiscordClient implements ChannelClient {
       method: "POST",
       headers: { Authorization: `Bot ${this.token}` },
     }).catch((e) =>
-      Bus.publish(Operational.Warn, {
+      this.publish(Operational.Warn, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",

--- a/apps/server/src/channel/discord/gateway.ts
+++ b/apps/server/src/channel/discord/gateway.ts
@@ -1,6 +1,6 @@
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { sleep } from "../../shared/sleep";
+import type { PublishPort } from "../types";
 import { GatewayOp, Intents, type DiscordUser, type GatewayPayload } from "./types";
 
 export interface GatewayCallbacks {
@@ -31,6 +31,7 @@ export class DiscordGateway {
     private readonly token: string,
     private readonly fetchGatewayUrl: () => Promise<string>,
     private readonly callbacks: GatewayCallbacks,
+    private readonly publish: PublishPort,
   ) {}
 
   async start(): Promise<void> {
@@ -73,7 +74,7 @@ export class DiscordGateway {
         }
         if (FATAL_CLOSE_CODES.has(event.code)) {
           this.running = false;
-          Bus.publish(Operational.Error, {
+          this.publish(Operational.Error, {
             traceId: crypto.randomUUID(),
             time: Date.now(),
             component: "server",
@@ -85,7 +86,7 @@ export class DiscordGateway {
         if (this.running) {
           this.reconnectAttempt++;
           const backoffMs = calculateBackoff(this.reconnectAttempt);
-          Bus.publish(Operational.Warn, {
+          this.publish(Operational.Warn, {
             traceId: crypto.randomUUID(),
             time: Date.now(),
             component: "server",
@@ -98,7 +99,7 @@ export class DiscordGateway {
           await sleep(backoffMs);
           if (this.running)
             this.reconnect().catch((err) =>
-              Bus.publish(Operational.Error, {
+              this.publish(Operational.Error, {
                 traceId: crypto.randomUUID(),
                 time: Date.now(),
                 component: "server",
@@ -110,7 +111,7 @@ export class DiscordGateway {
       });
 
       ws.addEventListener("error", (err) =>
-        Bus.publish(Operational.Error, {
+        this.publish(Operational.Error, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",
@@ -157,7 +158,7 @@ export class DiscordGateway {
         this.heartbeatAckReceived = true;
         return false;
       case GatewayOp.RECONNECT:
-        Bus.publish(Operational.Info, {
+        this.publish(Operational.Info, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",
@@ -167,7 +168,7 @@ export class DiscordGateway {
         return false;
       case GatewayOp.INVALID_SESSION: {
         const resumable = payload.d as boolean;
-        Bus.publish(Operational.Warn, {
+        this.publish(Operational.Warn, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",
@@ -199,7 +200,7 @@ export class DiscordGateway {
     }
     if (event === "RESUMED") {
       this.reconnectAttempt = 0;
-      Bus.publish(Operational.Info, {
+      this.publish(Operational.Info, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",
@@ -210,7 +211,7 @@ export class DiscordGateway {
     try {
       this.callbacks.onDispatch(event, data);
     } catch (err) {
-      Bus.publish(Operational.Error, {
+      this.publish(Operational.Error, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",

--- a/apps/server/src/channel/discord/normalizer.ts
+++ b/apps/server/src/channel/discord/normalizer.ts
@@ -1,5 +1,4 @@
-import type { Adapter } from "@openomni/protocol";
-import { SurfaceKey } from "@openomni/session";
+import { Adapter } from "@openomni/protocol";
 import { normalizeContent } from "../../shared/trigger";
 import type { InboundNormalizer } from "../types";
 import type { DiscordMessage } from "./types";
@@ -26,7 +25,7 @@ export class DiscordNormalizer implements InboundNormalizer<DiscordMessage> {
     content = normalizeContent(content, this.ctx.triggers);
     if (!content) return null;
 
-    const surfaceKey = SurfaceKey.fromChannel({
+    const surfaceKey = Adapter.SurfaceKey.fromChannel({
       surface: "discord",
       namespace: this.ctx.botId,
       kind: isDM ? "dm" : "channel",

--- a/apps/server/src/channel/discord/surface.ts
+++ b/apps/server/src/channel/discord/surface.ts
@@ -1,6 +1,5 @@
-import type { Adapter } from "@openomni/protocol";
-import { Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus, SurfaceKey } from "@openomni/session";
+import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import { Dedupe } from "../../shared/dedupe";
 import { DiscordClient } from "./client";
 import { DiscordGateway } from "./gateway";
@@ -78,7 +77,7 @@ export class DiscordAdapter implements Adapter.Surface {
   }
 
   async send(surfaceKey: string, message: Adapter.OutboundMessage): Promise<void> {
-    const parsed = SurfaceKey.parse(surfaceKey);
+    const parsed = Adapter.SurfaceKey.parse(surfaceKey);
     if (!parsed.id) {
       throw new Error(`[discord] surface key missing id: ${surfaceKey}`);
     }

--- a/apps/server/src/channel/discord/surface.ts
+++ b/apps/server/src/channel/discord/surface.ts
@@ -1,10 +1,10 @@
 import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { Dedupe } from "../../shared/dedupe";
 import { DiscordClient } from "./client";
 import { DiscordGateway } from "./gateway";
 import { DiscordNormalizer } from "./normalizer";
 import type { DiscordMessage } from "./types";
+import type { PublishPort } from "../types";
 import { ChannelAuthnMiddleware, type ChannelAuthnDecisionObserver } from "../channel-authn";
 
 export interface DiscordAuthOptions {
@@ -30,29 +30,35 @@ export class DiscordAdapter implements Adapter.Surface {
   constructor(
     token: string,
     readonly config: Adapter.Config,
+    private readonly publish: PublishPort,
     private readonly authOptions: DiscordAuthOptions = {},
   ) {
-    this.client = new DiscordClient(token);
-    this.gateway = new DiscordGateway(token, () => this.client.fetchGatewayUrl(), {
-      onReady: ({ botId, botUsername }) => {
-        this.botId = botId;
-        this.normalizer = new DiscordNormalizer({
-          botId,
-          triggers: this.config.triggers,
-        });
-        Bus.publish(Operational.Info, {
-          traceId: crypto.randomUUID(),
-          time: Date.now(),
-          component: "server",
-          msg: "discord bot started",
-          context: { username: botUsername, botId },
-        });
+    this.client = new DiscordClient(token, publish);
+    this.gateway = new DiscordGateway(
+      token,
+      () => this.client.fetchGatewayUrl(),
+      {
+        onReady: ({ botId, botUsername }) => {
+          this.botId = botId;
+          this.normalizer = new DiscordNormalizer({
+            botId,
+            triggers: this.config.triggers,
+          });
+          this.publish(Operational.Info, {
+            traceId: crypto.randomUUID(),
+            time: Date.now(),
+            component: "server",
+            msg: "discord bot started",
+            context: { username: botUsername, botId },
+          });
+        },
+        onDispatch: (event, data) => {
+          if (event !== "MESSAGE_CREATE") return;
+          this.handleMessageCreate(data as DiscordMessage);
+        },
       },
-      onDispatch: (event, data) => {
-        if (event !== "MESSAGE_CREATE") return;
-        this.handleMessageCreate(data as DiscordMessage);
-      },
-    });
+      publish,
+    );
   }
 
   onMessage(handler: Adapter.MessageHandler): void {
@@ -68,7 +74,7 @@ export class DiscordAdapter implements Adapter.Surface {
 
   stop(): void {
     this.gateway.stop();
-    Bus.publish(Operational.Info, {
+    this.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -128,7 +134,7 @@ export class DiscordAdapter implements Adapter.Surface {
     if (!inbound) return;
 
     this.handleIncoming(inbound, message.channel_id).catch((err) => {
-      Bus.publish(Operational.Error, {
+      this.publish(Operational.Error, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",
@@ -139,7 +145,7 @@ export class DiscordAdapter implements Adapter.Surface {
   }
 
   private async handleIncoming(inbound: Adapter.InboundMessage, channelId: string): Promise<void> {
-    Bus.publish(Operational.Debug, {
+    this.publish(Operational.Debug, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -159,7 +165,7 @@ export class DiscordAdapter implements Adapter.Surface {
       const outbound = await handler(inbound);
       if (outbound) await sendDiscordMessage(this.client, channelId, outbound);
     } catch (err) {
-      Bus.publish(Operational.Error, {
+      this.publish(Operational.Error, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",

--- a/apps/server/src/channel/github/client.ts
+++ b/apps/server/src/channel/github/client.ts
@@ -1,9 +1,12 @@
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { fetchWithRetry } from "../../shared/fetch-retry";
+import type { PublishPort } from "../types";
 
 export class GitHubClient {
-  constructor(private readonly token?: string) {}
+  constructor(
+    private readonly publish: PublishPort,
+    private readonly token?: string,
+  ) {}
 
   async postComment(repo: string, issueNumber: number, body: string): Promise<void> {
     if (!this.token) return;
@@ -29,7 +32,7 @@ export class GitHubClient {
       throw new Error(`GitHub API failed (${response.status}): ${text}`);
     }
 
-    Bus.publish(Operational.Debug, {
+    this.publish(Operational.Debug, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",

--- a/apps/server/src/channel/github/normalizer.ts
+++ b/apps/server/src/channel/github/normalizer.ts
@@ -1,5 +1,4 @@
-import type { Adapter } from "@openomni/protocol";
-import { SurfaceKey } from "@openomni/session";
+import { Adapter } from "@openomni/protocol";
 import { normalizeContent } from "../../shared/trigger";
 import type { GitHubEventContent } from "./types";
 
@@ -16,7 +15,7 @@ export class GitHubNormalizer {
     eventKey: string,
     deliveryId?: string,
   ): Adapter.InboundMessage | null {
-    const surfaceKey = SurfaceKey.fromChannel({
+    const surfaceKey = Adapter.SurfaceKey.fromChannel({
       surface: "github",
       namespace: content.repo,
       kind: "channel",

--- a/apps/server/src/channel/github/surface.ts
+++ b/apps/server/src/channel/github/surface.ts
@@ -1,9 +1,9 @@
 import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { Dedupe } from "../../shared/dedupe";
 import { GitHubClient } from "./client";
 import { GitHubNormalizer } from "./normalizer";
 import type { GitHubEventContent, GitHubIssueCommentPayload, GitHubIssuesPayload } from "./types";
+import type { PublishPort } from "../types";
 import { ChannelAuthnMiddleware, type ChannelAuthnDecisionObserver } from "../channel-authn";
 
 export interface GitHubAuthOptions {
@@ -27,11 +27,12 @@ export class GitHubAdapter implements Adapter.Surface {
   constructor(
     private readonly secret: string,
     readonly config: Adapter.Config,
+    private readonly publish: PublishPort,
     githubToken?: string,
     private readonly botUsername?: string,
     private readonly authOptions: GitHubAuthOptions = {},
   ) {
-    this.client = new GitHubClient(githubToken);
+    this.client = new GitHubClient(publish, githubToken);
     this.normalizer = new GitHubNormalizer({
       botUsername,
       triggers: config.triggers,
@@ -46,7 +47,7 @@ export class GitHubAdapter implements Adapter.Surface {
     if (!this.handler) {
       throw new Error("[github] No message handler registered. Call onMessage() before start().");
     }
-    Bus.publish(Operational.Info, {
+    this.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -65,7 +66,7 @@ export class GitHubAdapter implements Adapter.Surface {
     const issueNumber = Number.parseInt(issueId ?? "", 10);
 
     if (Number.isNaN(issueNumber)) {
-      Bus.publish(Operational.Error, {
+      this.publish(Operational.Error, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",
@@ -102,7 +103,7 @@ export class GitHubAdapter implements Adapter.Surface {
 
     const payload = JSON.parse(body) as Record<string, unknown>;
     const eventKey = `${event}.${payload.action}`;
-    Bus.publish(Operational.Info, {
+    this.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -133,7 +134,7 @@ export class GitHubAdapter implements Adapter.Surface {
     const inbound = this.normalizer.normalize(content, eventKey, deliveryId ?? undefined);
     if (!inbound) return new Response("Filtered", { status: 200 });
 
-    Bus.publish(Operational.Debug, {
+    this.publish(Operational.Debug, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -151,7 +152,7 @@ export class GitHubAdapter implements Adapter.Surface {
         await this.client.postComment(content.repo, content.issueNumber, outbound.text);
       }
     } catch (err) {
-      Bus.publish(Operational.Error, {
+      this.publish(Operational.Error, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",

--- a/apps/server/src/channel/github/surface.ts
+++ b/apps/server/src/channel/github/surface.ts
@@ -1,6 +1,5 @@
-import type { Adapter } from "@openomni/protocol";
-import { Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus, SurfaceKey } from "@openomni/session";
+import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import { Dedupe } from "../../shared/dedupe";
 import { GitHubClient } from "./client";
 import { GitHubNormalizer } from "./normalizer";
@@ -60,7 +59,7 @@ export class GitHubAdapter implements Adapter.Surface {
   }
 
   async send(surfaceKey: string, message: Adapter.OutboundMessage): Promise<void> {
-    const parsed = SurfaceKey.parse(surfaceKey);
+    const parsed = Adapter.SurfaceKey.parse(surfaceKey);
     const repo = parsed.namespace;
     const [, issueId] = (parsed.id ?? "").split("-");
     const issueNumber = Number.parseInt(issueId ?? "", 10);

--- a/apps/server/src/channel/telegram/client.ts
+++ b/apps/server/src/channel/telegram/client.ts
@@ -1,13 +1,15 @@
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { fetchWithRetry } from "../../shared/fetch-retry";
-import type { ChannelClient } from "../types";
+import type { ChannelClient, PublishPort } from "../types";
 import type { TelegramResponse, TelegramUser } from "./types";
 
 export class TelegramClient implements ChannelClient {
   private readonly baseUrl: string;
 
-  constructor(token: string) {
+  constructor(
+    token: string,
+    private readonly publish: PublishPort,
+  ) {
     this.baseUrl = `https://api.telegram.org/bot${token}`;
   }
 
@@ -23,7 +25,7 @@ export class TelegramClient implements ChannelClient {
 
   async sendTyping(channelId: string): Promise<void> {
     await this.api("sendChatAction", { chat_id: channelId, action: "typing" }).catch((e) =>
-      Bus.publish(Operational.Warn, {
+      this.publish(Operational.Warn, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",

--- a/apps/server/src/channel/telegram/normalizer.ts
+++ b/apps/server/src/channel/telegram/normalizer.ts
@@ -1,5 +1,4 @@
-import type { Adapter } from "@openomni/protocol";
-import { SurfaceKey } from "@openomni/session";
+import { Adapter } from "@openomni/protocol";
 import { normalizeContent } from "../../shared/trigger";
 import type { InboundNormalizer } from "../types";
 import type { TelegramMessage } from "./types";
@@ -24,7 +23,7 @@ export class TelegramNormalizer implements InboundNormalizer<TelegramMessage> {
     const content = normalizeContent(text, this.ctx.triggers, this.ctx.botUsername);
     if (!content) return null;
 
-    const surfaceKey = SurfaceKey.fromChannel({
+    const surfaceKey = Adapter.SurfaceKey.fromChannel({
       surface: "telegram",
       namespace: this.ctx.botId,
       kind: "chat",

--- a/apps/server/src/channel/telegram/poller.ts
+++ b/apps/server/src/channel/telegram/poller.ts
@@ -1,6 +1,6 @@
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { sleep } from "../../shared/sleep";
+import type { PublishPort } from "../types";
 import type { TelegramClient } from "./client";
 import type { TelegramMessage, TelegramUpdate } from "./types";
 
@@ -16,6 +16,7 @@ export class TelegramPoller {
   constructor(
     private readonly client: TelegramClient,
     private readonly callbacks: PollerCallbacks,
+    private readonly publish: PublishPort,
   ) {}
 
   start(): void {
@@ -45,7 +46,7 @@ export class TelegramPoller {
         }
       } catch (err) {
         if (!this.running) break;
-        Bus.publish(Operational.Warn, {
+        this.publish(Operational.Warn, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",

--- a/apps/server/src/channel/telegram/surface.ts
+++ b/apps/server/src/channel/telegram/surface.ts
@@ -1,5 +1,4 @@
-import type { Adapter } from "@openomni/protocol";
-import { Operational, PolicyDecision } from "@openomni/protocol";
+import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { Dedupe } from "../../shared/dedupe";
 import { splitText } from "../../shared/chunk-text";
@@ -95,8 +94,7 @@ export class TelegramAdapter implements Adapter.Surface {
   }
 
   async send(surfaceKey: string, message: Adapter.OutboundMessage): Promise<void> {
-    const { SurfaceKey } = await import("@openomni/session");
-    const parsed = SurfaceKey.parse(surfaceKey);
+    const parsed = Adapter.SurfaceKey.parse(surfaceKey);
     const chatId = parsed.id ?? "";
     await this.sendOutbound(chatId, message);
   }

--- a/apps/server/src/channel/telegram/surface.ts
+++ b/apps/server/src/channel/telegram/surface.ts
@@ -1,11 +1,11 @@
 import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { Dedupe } from "../../shared/dedupe";
 import { splitText } from "../../shared/chunk-text";
 import { TelegramClient } from "./client";
 import { TelegramNormalizer } from "./normalizer";
 import { TelegramPoller } from "./poller";
 import type { TelegramMessage } from "./types";
+import type { PublishPort } from "../types";
 import { ChannelAuthnMiddleware, type ChannelAuthnDecisionObserver } from "../channel-authn";
 
 const TELEGRAM_MESSAGE_LIMIT = 4096;
@@ -33,9 +33,10 @@ export class TelegramAdapter implements Adapter.Surface {
   constructor(
     token: string,
     readonly config: Adapter.Config,
+    private readonly publish: PublishPort,
     private readonly authOptions: TelegramAuthOptions = {},
   ) {
-    this.client = new TelegramClient(token);
+    this.client = new TelegramClient(token, publish);
   }
 
   onMessage(handler: Adapter.MessageHandler): void {
@@ -51,7 +52,7 @@ export class TelegramAdapter implements Adapter.Surface {
     const botId = String(me.id);
     const botUsername = me.username ?? "";
     this.botUsername = botUsername;
-    Bus.publish(Operational.Info, {
+    this.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -65,27 +66,31 @@ export class TelegramAdapter implements Adapter.Surface {
       triggers: this.config.triggers,
     });
 
-    this.poller = new TelegramPoller(this.client, {
-      onMessage: (message) => {
-        if (this.dedupe.isDuplicate(String(message.message_id))) return;
-        this.handleMessage(message).catch((err) => {
-          Bus.publish(Operational.Error, {
-            traceId: crypto.randomUUID(),
-            time: Date.now(),
-            component: "server",
-            msg: "telegram message handling failed",
-            context: { err: String(err) },
+    this.poller = new TelegramPoller(
+      this.client,
+      {
+        onMessage: (message) => {
+          if (this.dedupe.isDuplicate(String(message.message_id))) return;
+          this.handleMessage(message).catch((err) => {
+            this.publish(Operational.Error, {
+              traceId: crypto.randomUUID(),
+              time: Date.now(),
+              component: "server",
+              msg: "telegram message handling failed",
+              context: { err: String(err) },
+            });
           });
-        });
+        },
       },
-    });
+      this.publish,
+    );
 
     this.poller.start();
   }
 
   stop(): void {
     this.poller?.stop();
-    Bus.publish(Operational.Info, {
+    this.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -135,7 +140,7 @@ export class TelegramAdapter implements Adapter.Surface {
     const inbound = this.normalizer.normalize(message);
     if (!inbound) return;
 
-    Bus.publish(Operational.Debug, {
+    this.publish(Operational.Debug, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
       component: "server",
@@ -152,7 +157,7 @@ export class TelegramAdapter implements Adapter.Surface {
       const outbound = await this.getHandler()(inbound);
       if (outbound) await this.sendOutbound(chatId, outbound);
     } catch (err) {
-      Bus.publish(Operational.Error, {
+      this.publish(Operational.Error, {
         traceId: crypto.randomUUID(),
         time: Date.now(),
         component: "server",

--- a/apps/server/src/channel/types.ts
+++ b/apps/server/src/channel/types.ts
@@ -1,4 +1,13 @@
-import type { Adapter } from "@openomni/protocol";
+import type { Adapter, BusEvent } from "@openomni/protocol";
+
+/**
+ * Observation port: channel code reports Operational telemetry through this
+ * injected function instead of importing the session Bus directly (precedent:
+ * the execution coordinator's `events.publish` injection). The composition
+ * root (bootstrap/channels.ts) binds it to Bus.publish; tests bind a
+ * collector or noop. #499 promotes this to the Channel protocol contract.
+ */
+export type PublishPort = BusEvent.Sink["publish"];
 
 /**
  * Platform API calls: send messages, typing indicators, authentication, rate limiting.

--- a/apps/server/src/channel/websocket.ts
+++ b/apps/server/src/channel/websocket.ts
@@ -1,7 +1,7 @@
 import type { Adapter } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import { ChannelAuthnMiddleware, type ChannelAuthnDecisionObserver } from "./channel-authn";
+import type { PublishPort } from "./types";
 
 export interface WebSocketConfig {
   token?: string;
@@ -21,6 +21,7 @@ interface WebSocketUpgradeOptions {
 export class WebSocketHandler {
   constructor(
     private readonly handler: Adapter.MessageHandler,
+    private readonly publish: PublishPort,
     private readonly config: WebSocketConfig = {},
   ) {}
 
@@ -29,7 +30,7 @@ export class WebSocketHandler {
     return {
       message(ws: { data: WsConnectionData; send(msg: string): void }, data: string | Buffer) {
         const raw = typeof data === "string" ? data : new TextDecoder().decode(data);
-        Bus.publish(Operational.Debug, {
+        self.publish(Operational.Debug, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",
@@ -43,7 +44,7 @@ export class WebSocketHandler {
           surfaceKey: ws.data.surfaceKey,
           authenticated: ws.data.authenticated,
         };
-        Bus.publish(Operational.Info, {
+        self.publish(Operational.Info, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",
@@ -52,7 +53,7 @@ export class WebSocketHandler {
         });
       },
       close(ws: { data: WsConnectionData }) {
-        Bus.publish(Operational.Info, {
+        self.publish(Operational.Info, {
           traceId: crypto.randomUUID(),
           time: Date.now(),
           component: "server",
@@ -69,6 +70,7 @@ export class WebSocketHandler {
   ): Response | undefined {
     const auth = ChannelAuthnMiddleware.authenticateWebSocketUpgrade({
       request: req,
+      publish: this.publish,
       ...(this.config.token !== undefined ? { token: this.config.token } : {}),
       ...(this.config.onAuthDecision !== undefined
         ? { onDecision: this.config.onAuthDecision }

--- a/apps/server/src/handler/conversation.ts
+++ b/apps/server/src/handler/conversation.ts
@@ -1,8 +1,8 @@
 // server → openomni → agent → llm (direct agent imports forbidden)
 import type { IngressEngine } from "@openomni/openomni";
-import type { Adapter, Ingress } from "@openomni/protocol";
-import { Operational, WorkItem } from "@openomni/protocol";
-import { Bus, hasRetryExhaustionBlocker, SurfaceKey, WorkItemStore } from "@openomni/session";
+import type { Ingress } from "@openomni/protocol";
+import { Adapter, Operational, WorkItem } from "@openomni/protocol";
+import { Bus, hasRetryExhaustionBlocker, WorkItemStore } from "@openomni/session";
 import { resolveRuntimeModel } from "../agents/model-resolution";
 import { buildInboundEvent, type BridgeDeps } from "../ingress/bridge";
 
@@ -41,7 +41,7 @@ function normalizeCommand(text: string): string {
 }
 
 function canReadTaskLedger(message: Adapter.InboundMessage): boolean {
-  const surface = SurfaceKey.parse(message.surfaceKey).surface;
+  const surface = Adapter.SurfaceKey.parse(message.surfaceKey).surface;
   if (surface !== "ws") return false;
   if (!isWebSocketRaw(message.raw)) return false;
   return message.raw.websocket.authenticated === true;

--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -1,5 +1,4 @@
-import type { Adapter, Dispatch, Ingress } from "@openomni/protocol";
-import { SurfaceKey } from "@openomni/session";
+import { Adapter, type Dispatch, type Ingress } from "@openomni/protocol";
 import type { NativeTool } from "@openomni/openomni";
 import {
   buildToolCatalog,
@@ -100,7 +99,7 @@ function rawCorrelationToken(raw: unknown): string | undefined {
 
 function scopedCorrelation(
   message: Adapter.InboundMessage,
-  descriptor: ReturnType<typeof SurfaceKey.parse>,
+  descriptor: ReturnType<typeof Adapter.SurfaceKey.parse>,
 ) {
   return {
     endpointId: descriptor.namespace || descriptor.surface,
@@ -110,7 +109,7 @@ function scopedCorrelation(
 
 function actorMessageCorrelation(
   message: Adapter.InboundMessage,
-  descriptor: ReturnType<typeof SurfaceKey.parse>,
+  descriptor: ReturnType<typeof Adapter.SurfaceKey.parse>,
   threadId: string | undefined,
 ): Dispatch.Correlation {
   const token = rawCorrelationToken(message.raw);
@@ -125,7 +124,7 @@ function actorMessageCorrelation(
 
 function createBaseEvent(
   message: Adapter.InboundMessage,
-  descriptor: ReturnType<typeof SurfaceKey.parse>,
+  descriptor: ReturnType<typeof Adapter.SurfaceKey.parse>,
   threadId: string | undefined,
 ): Omit<Ingress.DirectEvent, "mode" | "agent"> {
   return {
@@ -155,7 +154,7 @@ export function buildInboundEvent(
   message: Adapter.InboundMessage,
   deps: BridgeDeps,
 ): Ingress.DirectEvent {
-  const descriptor = SurfaceKey.parse(message.surfaceKey);
+  const descriptor = Adapter.SurfaceKey.parse(message.surfaceKey);
   const threadId = message.threadId ?? descriptor.threadId;
   const base = createBaseEvent(message, descriptor, threadId);
   const agent = buildResidentAgentDef(deps);

--- a/apps/server/test/channel-band-boundary.test.ts
+++ b/apps/server/test/channel-band-boundary.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+/**
+ * Channels band-extraction readiness gate (#499 precursor).
+ *
+ * The future channels band depends on exactly @openomni/protocol: channel
+ * code observes through the injected publish port (channel/types.ts) and
+ * speaks the Adapter.SurfaceKey codec. This static scan pins that seam —
+ * every import in apps/server/src/channel/** must be @openomni/protocol,
+ * a node builtin, or relative. When the band MOVE lands (post-#499) this
+ * gate travels with it as the package's import contract.
+ */
+
+const CHANNEL_ROOT = fileURLToPath(new URL("../src/channel", import.meta.url));
+const ALLOWED_PACKAGE = "@openomni/protocol";
+
+type ScannedSource = Readonly<{ path: string; text: string }>;
+
+function channelSources(): readonly ScannedSource[] {
+  return readdirSync(CHANNEL_ROOT, { recursive: true })
+    .map(String)
+    .filter((entry) => entry.endsWith(".ts"))
+    .map((entry) => {
+      const path = join(CHANNEL_ROOT, entry);
+      return { path: join("src/channel", entry), text: readFileSyncText(path) };
+    });
+}
+
+function readFileSyncText(path: string): string {
+  return ts.sys.readFile(path) ?? "";
+}
+
+function collectModuleSpecifiers(source: ts.SourceFile): readonly string[] {
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    }
+    if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    ) {
+      specifiers.push(node.moduleReference.expression.text);
+    }
+    if (ts.isCallExpression(node)) {
+      const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+      const isRequire = ts.isIdentifier(node.expression) && node.expression.text === "require";
+      if (isDynamicImport || isRequire) {
+        const argument = node.arguments[0];
+        if (argument !== undefined && ts.isStringLiteralLike(argument)) {
+          specifiers.push(argument.text);
+        } else {
+          // A non-literal dynamic import cannot be verified statically —
+          // treat it as a violation (the telegram surface used exactly this
+          // shape to smuggle a session import past a plain-text scan).
+          specifiers.push("<non-literal dynamic import>");
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return specifiers;
+}
+
+function isAllowedSpecifier(specifier: string): boolean {
+  if (specifier === ALLOWED_PACKAGE) return true;
+  if (specifier.startsWith(`${ALLOWED_PACKAGE}/`)) return true;
+  if (specifier.startsWith("./") || specifier.startsWith("../")) return true;
+  if (specifier.startsWith("node:")) return true;
+  return false;
+}
+
+function detectBandViolations(sources: readonly ScannedSource[]): readonly string[] {
+  const violations: string[] = [];
+  for (const { path, text } of sources) {
+    const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    for (const specifier of collectModuleSpecifiers(source)) {
+      if (!isAllowedSpecifier(specifier)) {
+        violations.push(`${path}: imports ${specifier}`);
+      }
+    }
+  }
+  return violations;
+}
+
+describe("channels band import boundary", () => {
+  it("scans the real channel tree, not an empty directory", () => {
+    expect(channelSources().length).toBeGreaterThan(10);
+  });
+
+  it("keeps channel/* on the band contract: protocol, node builtins, relative only", () => {
+    expect(detectBandViolations(channelSources())).toEqual([]);
+  });
+
+  const violationFixtures = [
+    [
+      "named session import",
+      'import { Bus } from "@openomni/session";',
+      "imports @openomni/session",
+    ],
+    [
+      "type-only session import",
+      'import type { SurfaceKey } from "@openomni/session";',
+      "imports @openomni/session",
+    ],
+    [
+      "namespace session import",
+      'import * as Session from "@openomni/session";',
+      "imports @openomni/session",
+    ],
+    [
+      "session re-export",
+      'export { SurfaceKey } from "@openomni/session";',
+      "imports @openomni/session",
+    ],
+    [
+      "dynamic session import",
+      'const { SurfaceKey } = await import("@openomni/session");',
+      "imports @openomni/session",
+    ],
+    [
+      "require of the kernel",
+      'const oo = require("@openomni/openomni");',
+      "imports @openomni/openomni",
+    ],
+    [
+      "import-equals require",
+      'import session = require("@openomni/session");',
+      "imports @openomni/session",
+    ],
+    ["arbitrary npm package", 'import { z } from "zod";', "imports zod"],
+    [
+      "non-literal dynamic import",
+      "const mod = await import(moduleName);",
+      "imports <non-literal dynamic import>",
+    ],
+  ] as const;
+
+  for (const [name, text, violation] of violationFixtures) {
+    it(`detects ${name}`, () => {
+      const path = "src/channel/synthetic.ts";
+      expect(detectBandViolations([{ path, text }])).toContain(`${path}: ${violation}`);
+    });
+  }
+
+  it("allows protocol, node builtin, and relative imports", () => {
+    const text = [
+      'import { Adapter, Operational } from "@openomni/protocol";',
+      'import { timingSafeEqual } from "node:crypto";',
+      'import type { PublishPort } from "../types";',
+      'import { GatewayOp } from "./types";',
+      'export * from "./surface.js";',
+    ].join("\n");
+    expect(detectBandViolations([{ path: "src/channel/synthetic.ts", text }])).toEqual([]);
+  });
+});

--- a/apps/server/test/channel/discord-gateway.test.ts
+++ b/apps/server/test/channel/discord-gateway.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it } from "bun:test";
 import type { ServerWebSocket } from "bun";
 import { DiscordGateway } from "../../src/channel/discord/gateway";
 import { GatewayOp } from "../../src/channel/discord/types";
+import type { PublishPort } from "../../src/channel/types";
+
+const noopPublish: PublishPort = () => undefined;
 
 /**
  * #520 state-machine pins over a real WebSocket against a scripted fake
@@ -130,10 +133,15 @@ describe("discord gateway state machine (#520)", () => {
       onIdentify: (ws) => sendReady(ws, local.url, "sess-1"),
     });
     fake = local;
-    gateway = new DiscordGateway("test-token", () => Promise.resolve(local.url), {
-      onDispatch: () => undefined,
-      onReady: () => undefined,
-    });
+    gateway = new DiscordGateway(
+      "test-token",
+      () => Promise.resolve(local.url),
+      {
+        onDispatch: () => undefined,
+        onReady: () => undefined,
+      },
+      noopPublish,
+    );
 
     await gateway.start();
     const identify = await local.waitFor((p) => p.op === GatewayOp.IDENTIFY);
@@ -156,10 +164,15 @@ describe("discord gateway state machine (#520)", () => {
       onIdentify: (ws) => sendReady(ws, local.url, "sess-2"),
     });
     fake = local;
-    gateway = new DiscordGateway("test-token", () => Promise.resolve(local.url), {
-      onDispatch: () => undefined,
-      onReady: () => undefined,
-    });
+    gateway = new DiscordGateway(
+      "test-token",
+      () => Promise.resolve(local.url),
+      {
+        onDispatch: () => undefined,
+        onReady: () => undefined,
+      },
+      noopPublish,
+    );
 
     await gateway.start();
     const closeCode = await local.waitForClose();
@@ -188,10 +201,15 @@ describe("discord gateway state machine (#520)", () => {
       },
     });
     fake = local;
-    gateway = new DiscordGateway("test-token", () => Promise.resolve(local.url), {
-      onDispatch: () => undefined,
-      onReady: () => undefined,
-    });
+    gateway = new DiscordGateway(
+      "test-token",
+      () => Promise.resolve(local.url),
+      {
+        onDispatch: () => undefined,
+        onReady: () => undefined,
+      },
+      noopPublish,
+    );
 
     await gateway.start();
     // Reconnect backoff for attempt 1 is 2s + up to 1s jitter.
@@ -222,10 +240,15 @@ describe("discord gateway state machine (#520)", () => {
       },
     });
     fake = local;
-    gateway = new DiscordGateway("test-token", () => Promise.resolve(local.url), {
-      onDispatch: () => undefined,
-      onReady: () => undefined,
-    });
+    gateway = new DiscordGateway(
+      "test-token",
+      () => Promise.resolve(local.url),
+      {
+        onDispatch: () => undefined,
+        onReady: () => undefined,
+      },
+      noopPublish,
+    );
 
     await gateway.start();
     const deadline = Date.now() + 8000;

--- a/apps/server/test/channel/github-authn.test.ts
+++ b/apps/server/test/channel/github-authn.test.ts
@@ -146,7 +146,7 @@ function createAdapter(
   decisions: ChannelAuthnDecision[],
   adapterConfig: Adapter.Config = config,
 ): GitHubAdapter {
-  return new GitHubAdapter(secret, adapterConfig, undefined, undefined, {
+  return new GitHubAdapter(secret, adapterConfig, () => undefined, undefined, undefined, {
     onDecision: (decision) => {
       decisions.push(decision);
     },

--- a/apps/server/test/channel/websocket.test.ts
+++ b/apps/server/test/channel/websocket.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from "bun:test";
 import type { Adapter } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/session";
 import type { ChannelAuthnDecisionObserver } from "../../src/channel/authn/types";
+import type { PublishPort } from "../../src/channel/types";
 import { WebSocketHandler } from "../../src/channel/websocket";
 
 type ChannelAuthnDecision = Parameters<ChannelAuthnDecisionObserver>[0];
 
-function createHandler(decisions: ChannelAuthnDecision[] = []): WebSocketHandler {
+const noopPublish: PublishPort = () => undefined;
+
+function createHandler(
+  decisions: ChannelAuthnDecision[] = [],
+  publish: PublishPort = noopPublish,
+): WebSocketHandler {
   const handler: Adapter.MessageHandler = async () => ({ text: "ok" });
-  return new WebSocketHandler(handler, {
+  return new WebSocketHandler(handler, publish, {
     token: "secret-token",
     onAuthDecision: (decision) => {
       decisions.push(decision);
@@ -61,9 +66,13 @@ describe("WebSocketHandler authentication", () => {
   });
 
   it("keeps query token fallback and publishes a deprecation warning", () => {
-    const events: unknown[] = [];
-    const unsub = Bus.subscribe(Operational.Warn, (data) => events.push(data));
-    const handler = createHandler();
+    const warnings: string[] = [];
+    const collector: PublishPort = (event, data) => {
+      if (event.name === Operational.Warn.name) {
+        warnings.push((data as { msg: string }).msg);
+      }
+    };
+    const handler = createHandler([], collector);
     const upgrade = createUpgradeServer();
     const req = new Request("http://localhost/ws?token=secret-token");
 
@@ -72,11 +81,11 @@ describe("WebSocketHandler authentication", () => {
     expect(res).toBeUndefined();
     expect(upgrade.options?.headers).toBeUndefined();
     expect((upgrade.options?.data as { authenticated: boolean }).authenticated).toBe(true);
-    unsub();
+    expect(warnings).toEqual(["websocket query token auth is deprecated"]);
   });
 
   it("marks websocket connections unauthenticated when token auth is not configured", () => {
-    const handler = new WebSocketHandler(async () => ({ text: "ok" }));
+    const handler = new WebSocketHandler(async () => ({ text: "ok" }), noopPublish);
     const upgrade = createUpgradeServer();
     const req = new Request("http://localhost/ws");
 
@@ -87,7 +96,9 @@ describe("WebSocketHandler authentication", () => {
   });
 
   it("marks websocket connections unauthenticated when token auth is configured as empty", () => {
-    const handler = new WebSocketHandler(async () => ({ text: "ok" }), { token: "" });
+    const handler = new WebSocketHandler(async () => ({ text: "ok" }), noopPublish, {
+      token: "",
+    });
     const upgrade = createUpgradeServer();
     const req = new Request("http://localhost/ws");
 
@@ -102,7 +113,7 @@ describe("WebSocketHandler authentication", () => {
     const handler = new WebSocketHandler(async (inbound) => {
       message = inbound;
       return { text: "ok" };
-    });
+    }, noopPublish);
     const sent: string[] = [];
     const ws = {
       data: { surfaceKey: "ws:test", authenticated: true },

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -1,4 +1,5 @@
 import {
+  Adapter,
   type Ingress,
   IngressEvent,
   type TraceContext as TraceContextProtocol,
@@ -36,7 +37,7 @@ export namespace IngressSessionResolver {
     if (target && target.kind !== "resident") {
       parts.push("target", targetKey(target));
     }
-    return SurfaceKey.create(parts);
+    return Adapter.SurfaceKey.create(parts);
   }
 
   export function resolve(

--- a/packages/protocol/src/adapter/index.ts
+++ b/packages/protocol/src/adapter/index.ts
@@ -114,4 +114,117 @@ export namespace Adapter {
     registerCommands?(commands: Command[]): Promise<void>;
     onCommand?(handler: CommandHandler): void;
   }
+
+  /**
+   * Pure string codec for surface keys — the wire vocabulary channel
+   * adapters and routing share. Moved here from @openomni/session (#499
+   * precursor): the codec is adapter vocabulary; storage semantics
+   * (register/claim/lookup) stay in the session surface-key store, which
+   * imports this codec for format validation.
+   *
+   * Key format: `<surface-type>:<surface-specific-path>`
+   *
+   * Channel/peer kind encoding:
+   *   - DM:      slack:workspaceA:dm:U123
+   *   - Group:   slack:workspaceA:group:C123
+   *   - Thread:  slack:workspaceA:group:C123:thread:171000
+   *   - Channel: slack:workspaceA:channel:C123
+   *   - TUI:     tui:/Users/ino/Develop/OpenOmni
+   *   - Chat:    telegram:botId:chat:chatId
+   */
+  export namespace SurfaceKey {
+    export type ChannelKind = "dm" | "group" | "channel" | "thread" | "chat";
+
+    export interface ParsedKey {
+      readonly surface: string;
+      readonly namespace: string;
+      readonly kind: ChannelKind | undefined;
+      readonly id: string | undefined;
+      readonly threadId: string | undefined;
+    }
+
+    export interface ChannelDescriptor {
+      /** Surface type (e.g., "slack", "telegram", "tui") */
+      surface: string;
+      /** Namespace/workspace/bot identifier */
+      namespace: string;
+      kind: ChannelKind;
+      id: string;
+      /** Optional thread identifier (creates a sub-key under the channel) */
+      threadId?: string;
+    }
+
+    /**
+     * Assert the surfaceKey wire-format invariant. The single validation
+     * authority: `create` and the session store's register/claim call this.
+     * @returns the key unchanged when well-formed
+     */
+    export function assertWellFormed(key: string): string {
+      if (!key.includes(":")) {
+        throw new Error(
+          `Invalid surfaceKey format: "${key}". Must include surface type prefix (e.g., "slack:...")`,
+        );
+      }
+      return key;
+    }
+
+    /**
+     * Create a surfaceKey from parts.
+     * @param parts - Array of strings to join with colons
+     * @returns Formatted surfaceKey
+     * @throws Error if parts is empty or validation fails
+     */
+    export function create(parts: string[]): string {
+      if (parts.length === 0) {
+        throw new Error("SurfaceKey parts cannot be empty");
+      }
+
+      return assertWellFormed(parts.join(":"));
+    }
+
+    const KNOWN_KINDS: ReadonlySet<string> = new Set<ChannelKind>([
+      "dm",
+      "group",
+      "channel",
+      "thread",
+      "chat",
+    ]);
+
+    export function fromChannel(descriptor: ChannelDescriptor): string {
+      const parts = [descriptor.surface, descriptor.namespace, descriptor.kind, descriptor.id];
+      if (descriptor.threadId) {
+        parts.push("thread", descriptor.threadId);
+      }
+      return create(parts);
+    }
+
+    export function parse(key: string): ParsedKey {
+      const segments = key.split(":");
+      const surface = segments[0] ?? "";
+      const namespace = segments[1] ?? "";
+
+      let kind: ChannelKind | undefined;
+      let id: string | undefined;
+      let threadId: string | undefined;
+
+      for (let i = 2; i < segments.length; i++) {
+        const seg = segments[i];
+        if (seg == null) {
+          continue;
+        }
+        if (KNOWN_KINDS.has(seg)) {
+          if (seg === "thread") {
+            threadId = segments[i + 1];
+            i++;
+          } else {
+            kind = seg as ChannelKind;
+            id = segments[i + 1];
+            i++;
+          }
+        }
+      }
+
+      return { surface, namespace, kind, id, threadId };
+    }
+  }
 }

--- a/packages/protocol/test/adapter-surface-key.test.ts
+++ b/packages/protocol/test/adapter-surface-key.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import { Adapter } from "../src/adapter/index.js";
+
+const SurfaceKey = Adapter.SurfaceKey;
+
+describe("Adapter.SurfaceKey codec", () => {
+  describe("create", () => {
+    test("creates a valid surfaceKey from parts", () => {
+      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123"]);
+      expect(key).toBe("slack:workspaceA:channel:C123");
+    });
+
+    test("creates a surfaceKey with single part and colon", () => {
+      const key = SurfaceKey.create(["tui", "/Users/ino/Develop/OpenOmni"]);
+      expect(key).toBe("tui:/Users/ino/Develop/OpenOmni");
+    });
+
+    test("throws error on empty parts", () => {
+      expect(() => SurfaceKey.create([])).toThrow("SurfaceKey parts cannot be empty");
+    });
+
+    test("throws error if format validation fails (no colon)", () => {
+      expect(() => SurfaceKey.create(["singlepart"])).toThrow(/Invalid surfaceKey format/);
+    });
+
+    test("creates complex keys with multiple colons", () => {
+      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123", "thread", "171000"]);
+      expect(key).toBe("slack:workspaceA:channel:C123:thread:171000");
+    });
+  });
+
+  describe("assertWellFormed", () => {
+    test("returns a well-formed key unchanged", () => {
+      expect(SurfaceKey.assertWellFormed("slack:workspaceA")).toBe("slack:workspaceA");
+    });
+
+    test("throws on a key without a surface prefix", () => {
+      expect(() => SurfaceKey.assertWellFormed("invalid")).toThrow(/Invalid surfaceKey format/);
+    });
+  });
+
+  describe("fromChannel", () => {
+    test("creates a DM key", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "dm",
+        id: "U123",
+      });
+      expect(key).toBe("slack:workspaceA:dm:U123");
+    });
+
+    test("creates a group key", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "group",
+        id: "C456",
+      });
+      expect(key).toBe("slack:workspaceA:group:C456");
+    });
+
+    test("creates a thread key under a group", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "group",
+        id: "C456",
+        threadId: "171000",
+      });
+      expect(key).toBe("slack:workspaceA:group:C456:thread:171000");
+    });
+
+    test("creates a channel key (backward compat kind)", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "workspaceA",
+        kind: "channel",
+        id: "C789",
+      });
+      expect(key).toBe("slack:workspaceA:channel:C789");
+    });
+
+    test("creates a telegram chat key", () => {
+      const key = SurfaceKey.fromChannel({
+        surface: "telegram",
+        namespace: "bot123",
+        kind: "chat",
+        id: "chat456",
+      });
+      expect(key).toBe("telegram:bot123:chat:chat456");
+    });
+  });
+
+  describe("parse", () => {
+    test("parses a DM key", () => {
+      const parsed = SurfaceKey.parse("slack:workspaceA:dm:U123");
+      expect(parsed.surface).toBe("slack");
+      expect(parsed.namespace).toBe("workspaceA");
+      expect(parsed.kind).toBe("dm");
+      expect(parsed.id).toBe("U123");
+      expect(parsed.threadId).toBeUndefined();
+    });
+
+    test("parses a group key", () => {
+      const parsed = SurfaceKey.parse("slack:workspaceA:group:C456");
+      expect(parsed.kind).toBe("group");
+      expect(parsed.id).toBe("C456");
+    });
+
+    test("parses a thread key", () => {
+      const parsed = SurfaceKey.parse("slack:workspaceA:group:C456:thread:171000");
+      expect(parsed.kind).toBe("group");
+      expect(parsed.id).toBe("C456");
+      expect(parsed.threadId).toBe("171000");
+    });
+
+    test("parses a chat key", () => {
+      const parsed = SurfaceKey.parse("telegram:bot123:chat:chat456");
+      expect(parsed.kind).toBe("chat");
+      expect(parsed.id).toBe("chat456");
+    });
+
+    test("parses a legacy key without known kind", () => {
+      const parsed = SurfaceKey.parse("tui:/Users/ino/Develop/OpenOmni");
+      expect(parsed.surface).toBe("tui");
+      expect(parsed.namespace).toBe("/Users/ino/Develop/OpenOmni");
+      expect(parsed.kind).toBeUndefined();
+      expect(parsed.id).toBeUndefined();
+    });
+
+    test("parse handles legacy keys gracefully", () => {
+      const parsed = SurfaceKey.parse("myservice:some-id");
+      expect(parsed.surface).toBe("myservice");
+      expect(parsed.namespace).toBe("some-id");
+      expect(parsed.kind).toBeUndefined();
+    });
+  });
+
+  describe("DM vs group vs thread distinction", () => {
+    test("produces distinct keys for DM and group in same workspace", () => {
+      const dmKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "dm",
+        id: "U001",
+      });
+      const groupKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+      });
+      expect(dmKey).not.toBe(groupKey);
+      expect(dmKey).toContain(":dm:");
+      expect(groupKey).toContain(":group:");
+    });
+
+    test("produces distinct keys for group and thread in same channel", () => {
+      const groupKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+      });
+      const threadKey = SurfaceKey.fromChannel({
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+        threadId: "171000",
+      });
+      expect(groupKey).not.toBe(threadKey);
+      expect(threadKey).toContain(":thread:");
+      expect(groupKey).not.toContain(":thread:");
+    });
+
+    test("roundtrips fromChannel → parse correctly", () => {
+      const descriptor: Adapter.SurfaceKey.ChannelDescriptor = {
+        surface: "slack",
+        namespace: "ws1",
+        kind: "group",
+        id: "C001",
+        threadId: "171000",
+      };
+      const key = SurfaceKey.fromChannel(descriptor);
+      const parsed = SurfaceKey.parse(key);
+
+      expect(parsed.surface).toBe(descriptor.surface);
+      expect(parsed.namespace).toBe(descriptor.namespace);
+      expect(parsed.kind).toBe(descriptor.kind);
+      expect(parsed.id).toBe(descriptor.id);
+      expect(parsed.threadId).toBe(descriptor.threadId);
+    });
+  });
+});

--- a/packages/session/src/surface-key/index.ts
+++ b/packages/session/src/surface-key/index.ts
@@ -1,120 +1,21 @@
 /**
- * SurfaceKey index: N:1 mapping from surface-specific keys to session IDs.
+ * SurfaceKey store: N:1 mapping from surface-specific keys to session IDs.
  * Provides bidirectional lookup for routing events to sessions.
  *
- * Key format: `<surface-type>:<surface-specific-path>`
- *
- * Channel/peer kind encoding:
- *   - DM:      slack:workspaceA:dm:U123
- *   - Group:   slack:workspaceA:group:C123
- *   - Thread:  slack:workspaceA:group:C123:thread:171000
- *   - Channel: slack:workspaceA:channel:C123
- *   - TUI:     tui:/Users/ino/Develop/OpenOmni
- *   - Chat:    telegram:botId:chat:chatId
- *
- * The `ChannelKind` type defines recognized channel/peer kinds.
- * Use `SurfaceKey.fromChannel()` for structured creation with explicit kind.
+ * Storage semantics only — the pure string codec (parse/fromChannel/create
+ * and the key-format documentation) lives in the protocol adapter domain
+ * (`Adapter.SurfaceKey`, #499 precursor); this store imports it for format
+ * validation.
  *
  * Storage: uses Storage.Adapter.surfaceKey (SQLite); a missing sub-adapter
  * fails closed — routing must never fabricate ownership answers (#522).
  */
 
+import { Adapter } from "@openomni/protocol";
 import { requireSubAdapter } from "../storage/timestamped-store";
 import { Storage } from "../storage/storage";
 
-type ChannelKind = "dm" | "group" | "channel" | "thread" | "chat";
-
-interface ParsedKey {
-  readonly surface: string;
-  readonly namespace: string;
-  readonly kind: ChannelKind | undefined;
-  readonly id: string | undefined;
-  readonly threadId: string | undefined;
-}
-
 export namespace SurfaceKey {
-  export interface ChannelDescriptor {
-    /** Surface type (e.g., "slack", "telegram", "tui") */
-    surface: string;
-    /** Namespace/workspace/bot identifier */
-    namespace: string;
-    kind: ChannelKind;
-    id: string;
-    /** Optional thread identifier (creates a sub-key under the channel) */
-    threadId?: string;
-  }
-
-  function validateFormat(key: string): boolean {
-    return key.includes(":");
-  }
-
-  /**
-   * Create a surfaceKey from parts.
-   * @param parts - Array of strings to join with colons
-   * @returns Formatted surfaceKey
-   * @throws Error if parts is empty or validation fails
-   */
-  export function create(parts: string[]): string {
-    if (parts.length === 0) {
-      throw new Error("SurfaceKey parts cannot be empty");
-    }
-
-    const key = parts.join(":");
-
-    if (!validateFormat(key)) {
-      throw new Error(
-        `Invalid surfaceKey format: "${key}". Must include surface type prefix (e.g., "slack:...")`,
-      );
-    }
-
-    return key;
-  }
-
-  const KNOWN_KINDS: ReadonlySet<string> = new Set<ChannelKind>([
-    "dm",
-    "group",
-    "channel",
-    "thread",
-    "chat",
-  ]);
-
-  export function fromChannel(descriptor: ChannelDescriptor): string {
-    const parts = [descriptor.surface, descriptor.namespace, descriptor.kind, descriptor.id];
-    if (descriptor.threadId) {
-      parts.push("thread", descriptor.threadId);
-    }
-    return create(parts);
-  }
-
-  export function parse(key: string): ParsedKey {
-    const segments = key.split(":");
-    const surface = segments[0] ?? "";
-    const namespace = segments[1] ?? "";
-
-    let kind: ChannelKind | undefined;
-    let id: string | undefined;
-    let threadId: string | undefined;
-
-    for (let i = 2; i < segments.length; i++) {
-      const seg = segments[i];
-      if (seg == null) {
-        continue;
-      }
-      if (KNOWN_KINDS.has(seg)) {
-        if (seg === "thread") {
-          threadId = segments[i + 1];
-          i++;
-        } else {
-          kind = seg as ChannelKind;
-          id = segments[i + 1];
-          i++;
-        }
-      }
-    }
-
-    return { surface, namespace, kind, id, threadId };
-  }
-
   function subAdapter(): NonNullable<Storage.Adapter["surfaceKey"]> {
     return requireSubAdapter(
       Storage.get().surfaceKey,
@@ -133,12 +34,7 @@ export namespace SurfaceKey {
    * @param sessionId - The session ID
    */
   export function register(key: string, sessionId: string): void {
-    if (!validateFormat(key)) {
-      throw new Error(
-        `Invalid surfaceKey format: "${key}". Must include surface type prefix (e.g., "slack:...")`,
-      );
-    }
-
+    Adapter.SurfaceKey.assertWellFormed(key);
     subAdapter().register(key, sessionId);
   }
 
@@ -149,12 +45,7 @@ export namespace SurfaceKey {
    * Returns the session ID that owns the key after the claim attempt.
    */
   export function claim(key: string, sessionId: string, expectedSessionId?: string): string {
-    if (!validateFormat(key)) {
-      throw new Error(
-        `Invalid surfaceKey format: "${key}". Must include surface type prefix (e.g., "slack:...")`,
-      );
-    }
-
+    Adapter.SurfaceKey.assertWellFormed(key);
     return subAdapter().claim(key, sessionId, expectedSessionId);
   }
 

--- a/packages/session/test/surface-key.test.ts
+++ b/packages/session/test/surface-key.test.ts
@@ -1,7 +1,12 @@
 import { describe, test, expect, beforeEach } from "bun:test";
+import { Adapter } from "@openomni/protocol";
 import { SurfaceKey } from "../src/surface-key";
 import { Storage } from "../src/storage/storage";
 import "../src/storage/initialize";
+
+// The pure string codec (create/fromChannel/parse) lives in the protocol
+// adapter domain — see packages/protocol/test/adapter-surface-key.test.ts.
+// This suite covers the storage semantics: register/claim/lookup.
 
 function seedSession(id: string): void {
   Storage.getAdapter().session.set(id, {
@@ -17,31 +22,6 @@ describe("SurfaceKey", () => {
   beforeEach(() => {
     Storage.reset();
     Storage.initialize({ dbPath: ":memory:" });
-  });
-
-  describe("create", () => {
-    test("creates a valid surfaceKey from parts", () => {
-      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123"]);
-      expect(key).toBe("slack:workspaceA:channel:C123");
-    });
-
-    test("creates a surfaceKey with single part and colon", () => {
-      const key = SurfaceKey.create(["tui", "/Users/ino/Develop/OpenOmni"]);
-      expect(key).toBe("tui:/Users/ino/Develop/OpenOmni");
-    });
-
-    test("throws error on empty parts", () => {
-      expect(() => SurfaceKey.create([])).toThrow("SurfaceKey parts cannot be empty");
-    });
-
-    test("throws error if format validation fails (no colon)", () => {
-      expect(() => SurfaceKey.create(["singlepart"])).toThrow(/Invalid surfaceKey format/);
-    });
-
-    test("creates complex keys with multiple colons", () => {
-      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123", "thread", "171000"]);
-      expect(key).toBe("slack:workspaceA:channel:C123:thread:171000");
-    });
   });
 
   describe("register and lookup", () => {
@@ -62,6 +42,10 @@ describe("SurfaceKey", () => {
       expect(() => SurfaceKey.register("invalid", "session-123")).toThrow(
         /Invalid surfaceKey format/,
       );
+    });
+
+    test("throws error on invalid format during claim", () => {
+      expect(() => SurfaceKey.claim("invalid", "session-123")).toThrow(/Invalid surfaceKey format/);
     });
 
     test("overwrites previous mapping for same key", () => {
@@ -226,143 +210,15 @@ describe("SurfaceKey", () => {
     });
   });
 
-  describe("fromChannel", () => {
-    test("creates a DM key", () => {
-      const key = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "workspaceA",
-        kind: "dm",
-        id: "U123",
-      });
-      expect(key).toBe("slack:workspaceA:dm:U123");
-    });
-
-    test("creates a group key", () => {
-      const key = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "workspaceA",
-        kind: "group",
-        id: "C456",
-      });
-      expect(key).toBe("slack:workspaceA:group:C456");
-    });
-
-    test("creates a thread key under a group", () => {
-      const key = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "workspaceA",
-        kind: "group",
-        id: "C456",
-        threadId: "171000",
-      });
-      expect(key).toBe("slack:workspaceA:group:C456:thread:171000");
-    });
-
-    test("creates a channel key (backward compat kind)", () => {
-      const key = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "workspaceA",
-        kind: "channel",
-        id: "C789",
-      });
-      expect(key).toBe("slack:workspaceA:channel:C789");
-    });
-
-    test("creates a telegram chat key", () => {
-      const key = SurfaceKey.fromChannel({
-        surface: "telegram",
-        namespace: "bot123",
-        kind: "chat",
-        id: "chat456",
-      });
-      expect(key).toBe("telegram:bot123:chat:chat456");
-    });
-  });
-
-  describe("parse", () => {
-    test("parses a DM key", () => {
-      const parsed = SurfaceKey.parse("slack:workspaceA:dm:U123");
-      expect(parsed.surface).toBe("slack");
-      expect(parsed.namespace).toBe("workspaceA");
-      expect(parsed.kind).toBe("dm");
-      expect(parsed.id).toBe("U123");
-      expect(parsed.threadId).toBeUndefined();
-    });
-
-    test("parses a group key", () => {
-      const parsed = SurfaceKey.parse("slack:workspaceA:group:C456");
-      expect(parsed.kind).toBe("group");
-      expect(parsed.id).toBe("C456");
-    });
-
-    test("parses a thread key", () => {
-      const parsed = SurfaceKey.parse("slack:workspaceA:group:C456:thread:171000");
-      expect(parsed.kind).toBe("group");
-      expect(parsed.id).toBe("C456");
-      expect(parsed.threadId).toBe("171000");
-    });
-
-    test("parses a chat key", () => {
-      const parsed = SurfaceKey.parse("telegram:bot123:chat:chat456");
-      expect(parsed.kind).toBe("chat");
-      expect(parsed.id).toBe("chat456");
-    });
-
-    test("parses a legacy key without known kind", () => {
-      const parsed = SurfaceKey.parse("tui:/Users/ino/Develop/OpenOmni");
-      expect(parsed.surface).toBe("tui");
-      expect(parsed.namespace).toBe("/Users/ino/Develop/OpenOmni");
-      expect(parsed.kind).toBeUndefined();
-      expect(parsed.id).toBeUndefined();
-    });
-  });
-
-  describe("DM vs group vs thread distinction", () => {
-    test("produces distinct keys for DM and group in same workspace", () => {
-      const dmKey = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "ws1",
-        kind: "dm",
-        id: "U001",
-      });
-      const groupKey = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "ws1",
-        kind: "group",
-        id: "C001",
-      });
-      expect(dmKey).not.toBe(groupKey);
-      expect(dmKey).toContain(":dm:");
-      expect(groupKey).toContain(":group:");
-    });
-
-    test("produces distinct keys for group and thread in same channel", () => {
-      const groupKey = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "ws1",
-        kind: "group",
-        id: "C001",
-      });
-      const threadKey = SurfaceKey.fromChannel({
-        surface: "slack",
-        namespace: "ws1",
-        kind: "group",
-        id: "C001",
-        threadId: "171000",
-      });
-      expect(groupKey).not.toBe(threadKey);
-      expect(threadKey).toContain(":thread:");
-      expect(groupKey).not.toContain(":thread:");
-    });
-
+  describe("codec-built keys route independently", () => {
     test("routes DM and group to different sessions", () => {
-      const dmKey = SurfaceKey.fromChannel({
+      const dmKey = Adapter.SurfaceKey.fromChannel({
         surface: "slack",
         namespace: "ws1",
         kind: "dm",
         id: "U001",
       });
-      const groupKey = SurfaceKey.fromChannel({
+      const groupKey = Adapter.SurfaceKey.fromChannel({
         surface: "slack",
         namespace: "ws1",
         kind: "group",
@@ -379,13 +235,13 @@ describe("SurfaceKey", () => {
     });
 
     test("routes thread separately from parent channel", () => {
-      const channelKey = SurfaceKey.fromChannel({
+      const channelKey = Adapter.SurfaceKey.fromChannel({
         surface: "slack",
         namespace: "ws1",
         kind: "group",
         id: "C001",
       });
-      const threadKey = SurfaceKey.fromChannel({
+      const threadKey = Adapter.SurfaceKey.fromChannel({
         surface: "slack",
         namespace: "ws1",
         kind: "group",
@@ -402,43 +258,11 @@ describe("SurfaceKey", () => {
       expect(SurfaceKey.lookup(threadKey)).toBe("session-thread");
     });
 
-    test("roundtrips fromChannel → parse correctly", () => {
-      const descriptor: SurfaceKey.ChannelDescriptor = {
-        surface: "slack",
-        namespace: "ws1",
-        kind: "group",
-        id: "C001",
-        threadId: "171000",
-      };
-      const key = SurfaceKey.fromChannel(descriptor);
-      const parsed = SurfaceKey.parse(key);
-
-      expect(parsed.surface).toBe(descriptor.surface);
-      expect(parsed.namespace).toBe(descriptor.namespace);
-      expect(parsed.kind).toBe(descriptor.kind);
-      expect(parsed.id).toBe(descriptor.id);
-      expect(parsed.threadId).toBe(descriptor.threadId);
-    });
-  });
-
-  describe("backward compatibility", () => {
-    test("existing create() API still works unchanged", () => {
-      const key = SurfaceKey.create(["slack", "workspaceA", "channel", "C123"]);
-      expect(key).toBe("slack:workspaceA:channel:C123");
-    });
-
     test("existing keys without explicit kind still register/lookup", () => {
       const legacyKey = "tui:/Users/ino/Develop/OpenOmni";
       seedSession("session-tui");
       SurfaceKey.register(legacyKey, "session-tui");
       expect(SurfaceKey.lookup(legacyKey)).toBe("session-tui");
-    });
-
-    test("parse handles legacy keys gracefully", () => {
-      const parsed = SurfaceKey.parse("myservice:some-id");
-      expect(parsed.surface).toBe("myservice");
-      expect(parsed.namespace).toBe("some-id");
-      expect(parsed.kind).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Corpus-approved seam precursors for the future `@openomni/channels` band extraction (C7/#551 — the MOVE itself stays post-#499; approved ordering note A3 allows these seams early, and they also clear the channel portion of #503's bootstrap-only boundary).

## What

- **SurfaceKey string codec → protocol** (`Adapter.SurfaceKey` — nested in the existing Adapter namespace, no new top-level noun; #499 carries it into the converged Channel namespace). Session keeps everything storage-shaped (register/claim/lookup + the #522 fail-closed guard) and imports the single validation authority (`assertWellFormed`). The telegram dynamic import dies.
- **Publish observation port**: channel adapters receive an injected `PublishPort` (= the protocol's existing `BusEvent.Sink["publish"]` — no new vocabulary) instead of importing Bus; bound once in bootstrap (coordinator precedent).
- **Band boundary gate**: `channel-band-boundary.test.ts` — AST scan allowing only `@openomni/protocol` + `node:` + relative imports under src/channel, with a >10-file floor against vacuous passes and non-literal-dynamic-import detection.

## Proof

- `rg "@openomni/session" apps/server/src/channel` → **zero matches** (the band's dependency whitelist is now real, not aspirational).
- Boundary gate red proven live (synthetic session import → typed violation), 9 in-test fixtures pin each detection path.
- Suites 1,650 pass / 0 fail (discord gateway state machine, telegram/github/websocket, session store semantics + new claim-format pin, codec tests relocated to protocol); check-types, build, lint, check-deps, dead-export ratchet (24/0 new) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the channels band extraction by moving the surface key codec to `@openomni/protocol` and injecting a `publish` port into channel adapters, removing direct `@openomni/session` imports. Adds an import-boundary test to lock the contract ahead of the move (supports #499 and clears the channel side of #503; aligns with C7/#551).

- **Refactors**
  - Moved SurfaceKey string codec to `Adapter.SurfaceKey` in `@openomni/protocol` (create/fromChannel/parse + `assertWellFormed`); session keeps only register/claim/lookup and validates via the protocol codec. Updated all call-sites; removed the Telegram dynamic import.
  - Introduced `PublishPort` (alias of `BusEvent.Sink["publish"]`) and injected it into channel adapters and websocket auth; `bootstrap/channels.ts` binds it to `Bus.publish`. Channel code now publishes Operational events via the port and no longer imports `@openomni/session`.
  - Added `channel-band-boundary.test.ts` to enforce that `apps/server/src/channel/**` imports only `@openomni/protocol`, `node:` modules, or relative paths; covers static/dynamic imports and require(), with fixtures proving violations.
  - Moved codec tests to `packages/protocol`; session tests focus on store semantics and add a format guard.

<sup>Written for commit 71ed7c78d004587fdddd62d1842dc485b44a78b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared surface-key handling across channel integrations, including support for direct messages, groups, threads, and structured parsing.
  * Added validation and round-trip conversion for channel surface keys.

* **Bug Fixes**
  * Improved consistency of operational event and warning reporting across WebSocket, Telegram, GitHub, and Discord channels.
  * Preserved compatibility with legacy surface-key formats.

* **Tests**
  * Expanded coverage for surface-key behavior, WebSocket authentication warnings, channel event reporting, and import boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->