### PR TITLE
fix(llm): typed retry reasons with exhaustive dispatch

### DIFF
--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -184,8 +184,8 @@ export namespace Processor {
               const apiError = coerceApiError(e);
               const decision = Retry.decide(attempt + 1, apiError ?? e);
 
-              if (!decision.retryable || ++attempt > retryAttemptLimit) {
-                if (!decision.retryable && decision.reason !== "non_retryable" && trace) {
+              if (!decision.retry || ++attempt > retryAttemptLimit) {
+                if (!decision.retry && decision.reason !== "non_retryable" && trace) {
                   // A retryable error declined for another reason (e.g. the
                   // server-directed wait exceeded the cap) must say why.
                   Bus.publish(Operational.Error, {
@@ -194,7 +194,10 @@ export namespace Processor {
                     sessionId: trace.sessionId,
                     component: "llm.retry",
                     msg: "retry declined",
-                    error: decision.reason,
+                    error:
+                      decision.detail === undefined
+                        ? decision.reason
+                        : `${decision.reason}: ${decision.detail}`,
                   });
                 }
                 const aborted = e instanceof DOMException && e.name === "AbortError";
@@ -223,7 +226,7 @@ export namespace Processor {
                   time: Date.now(),
                 });
 
-                if (retryReason === "Too Many Requests" || retryReason === "Rate Limited") {
+                if (publishesRateLimited(retryReason)) {
                   Bus.publish(LlmCall.RateLimited, {
                     traceId: trace.traceId,
                     sessionId: trace.sessionId,
@@ -238,7 +241,7 @@ export namespace Processor {
               publishStatus(sink, sessionID, {
                 type: "retry",
                 attempt,
-                message: String(retryReason),
+                message: retryReason,
                 next: Date.now() + delayMs,
               });
 
@@ -250,6 +253,22 @@ export namespace Processor {
         }
       },
     };
+  }
+
+  /**
+   * Exhaustive over Retry.RetryableReason — no default, so a new reason
+   * member fails to compile here instead of silently skipping the
+   * RateLimited publish (the exact hazard the old prose string-match had).
+   */
+  function publishesRateLimited(reason: Retry.RetryableReason): boolean {
+    switch (reason) {
+      case "rate_limit":
+        return true;
+      case "overloaded":
+      case "server_error":
+        return false;
+    }
+    return reason satisfies never;
   }
 
   function publishInfo(

--- a/packages/llm/src/retry/index.ts
+++ b/packages/llm/src/retry/index.ts
@@ -35,23 +35,33 @@ export namespace Retry {
    */
   export const RETRY_HEADER_DELAY_CAP = 60_000;
 
+  /**
+   * The retry vocabulary (#532 candidate 3). Every member has a producing
+   * branch in classify() and a consuming case in the processor's typed
+   * switch — reasons are branched on as literals, never as prose. Human
+   * prose lives only in Decision.detail.
+   */
+  export type Reason = "rate_limit" | "overloaded" | "server_error" | "non_retryable";
+  export type RetryableReason = Exclude<Reason, "non_retryable">;
+
   export type Decision =
     | {
-        readonly retryable: true;
-        readonly reason: string;
+        readonly retry: true;
+        readonly reason: RetryableReason;
         readonly delayMs: number;
-        readonly source: "header" | "backoff";
+        /** An inferred ratelimit reset exceeded the cap and was demoted to backoff. */
+        readonly retryAfterOverCap?: boolean;
       }
-    | { readonly retryable: false; readonly reason: string };
+    | { readonly retry: false; readonly reason: Reason; readonly detail?: string };
 
   /**
    * Typed retry decision (#532 candidate 3): classification + delay in one
    * call, failing fast when the server asks for a wait above the cap.
    */
   export function decide(attempt: number, error: unknown): Decision {
-    const reason = isRetryable(error);
-    if (reason === undefined) {
-      return { retryable: false, reason: "non_retryable" };
+    const reason = classify(error);
+    if (reason === "non_retryable") {
+      return { retry: false, reason };
     }
     const apiError = APIError.isInstance(error) ? error : undefined;
     const header = headerDelay(apiError);
@@ -62,32 +72,23 @@ export namespace Retry {
         // rather than killing the run.
         if (header.directive) {
           return {
-            retryable: false,
-            reason: `${reason}: server asked to wait ${header.ms}ms, above the ${RETRY_HEADER_DELAY_CAP}ms cap`,
+            retry: false,
+            reason,
+            detail: `server asked to wait ${header.ms}ms, above the ${RETRY_HEADER_DELAY_CAP}ms cap`,
           };
         }
-        return { retryable: true, reason, delayMs: backoffDelayMs(attempt), source: "backoff" };
+        return { retry: true, reason, delayMs: backoffDelayMs(attempt), retryAfterOverCap: true };
       }
-      return { retryable: true, reason, delayMs: Math.max(0, header.ms), source: "header" };
+      return { retry: true, reason, delayMs: Math.max(0, header.ms) };
     }
-    return { retryable: true, reason, delayMs: backoffDelayMs(attempt), source: "backoff" };
+    return { retry: true, reason, delayMs: backoffDelayMs(attempt) };
   }
 
-  export function delay(
-    attempt: number,
-    error?: InstanceType<typeof APIError>,
-    initialDelay?: number,
-  ): number {
-    const header = headerDelay(error);
-    if (header !== undefined) {
-      return header.ms;
-    }
-    return backoffDelayMs(attempt, initialDelay);
-  }
-
-  function backoffDelayMs(attempt: number, initialDelay?: number): number {
-    const baseDelay = initialDelay ?? RETRY_INITIAL_DELAY;
-    return Math.min(baseDelay * RETRY_BACKOFF_FACTOR ** (attempt - 1), RETRY_MAX_DELAY_NO_HEADERS);
+  function backoffDelayMs(attempt: number): number {
+    return Math.min(
+      RETRY_INITIAL_DELAY * RETRY_BACKOFF_FACTOR ** (attempt - 1),
+      RETRY_MAX_DELAY_NO_HEADERS,
+    );
   }
 
   /** directive: an explicit server instruction (retry-after) vs an inferred
@@ -155,13 +156,13 @@ export namespace Retry {
     return undefined;
   }
 
-  export function isRetryable(error: unknown): string | undefined {
+  function classify(error: unknown): Reason {
     if (!APIError.isInstance(error)) {
-      return undefined;
+      return "non_retryable";
     }
 
     if (!error.data.isRetryable) {
-      return undefined;
+      return "non_retryable";
     }
 
     const sniffed =
@@ -170,20 +171,21 @@ export namespace Retry {
       return sniffed;
     }
 
+    // Status outranks a payload the sniffer found no specific signal in: an
+    // Anthropic 429 body ({error:{type:"rate_limit_error"}}) must classify as
+    // a rate limit, not fall into the generic server-error bucket.
     const status = error.data.statusCode;
     if (status === 429) {
-      return "Rate Limited";
-    }
-    if (status !== undefined && status >= 500) {
-      return "Provider Server Error";
+      return "rate_limit";
     }
 
-    // The provider marked this retryable (408/409, x-should-retry, …) even
-    // though the payload carries no recognizable detail.
-    return "Provider Error";
+    // 5xx, plus the residue the provider marked retryable (408/409,
+    // x-should-retry, network failures) without a recognizable class — no
+    // consumer distinguishes these, so they share the server_error bucket.
+    return "server_error";
   }
 
-  function classifyErrorPayload(payload: string | undefined): string | undefined {
+  function classifyErrorPayload(payload: string | undefined): RetryableReason | undefined {
     if (!payload) return undefined;
 
     let json: unknown;
@@ -203,29 +205,31 @@ export namespace Retry {
       error?: { type?: unknown; code?: unknown; message?: unknown };
     };
     const code = typeof body.code === "string" ? body.code : "";
+    const errorType = typeof body.error?.type === "string" ? body.error.type : "";
     const errorCode = typeof body.error?.code === "string" ? body.error.code : "";
     const errorMessage = typeof body.error?.message === "string" ? body.error.message : "";
 
-    if (body.type === "error" && body.error?.type === "too_many_requests") {
-      return "Too Many Requests";
+    if (
+      body.type === "error" &&
+      (errorType === "too_many_requests" ||
+        errorType.includes("rate_limit") ||
+        errorCode.includes("rate_limit"))
+    ) {
+      return "rate_limit";
     }
 
     if (code.includes("exhausted") || code.includes("unavailable")) {
-      return "Provider is overloaded";
-    }
-
-    if (body.type === "error" && errorCode.includes("rate_limit")) {
-      return "Rate Limited";
+      return "overloaded";
     }
 
     if (
       errorMessage.includes("no_kv_space") ||
-      (body.type === "error" && body.error?.type === "server_error") ||
-      !!body.error
+      (body.type === "error" && errorType === "server_error")
     ) {
-      return "Provider Server Error";
+      return "server_error";
     }
 
+    // A generic error body carries no class of its own — defer to status.
     return undefined;
   }
 }

--- a/packages/llm/test/processor/processor.test.ts
+++ b/packages/llm/test/processor/processor.test.ts
@@ -694,7 +694,9 @@ describe("Processor", () => {
       expect(retries).toHaveLength(1);
       expect(retries[0]).toMatchObject({
         runId: "run-processor-retry",
-        reason: "Too Many Requests",
+        // The wire value is the typed Retry.Reason literal — a subset of the
+        // protocol's z.string(), so no schema change.
+        reason: "rate_limit",
       });
       expect(retries[0]?.backoffMs).toBeGreaterThan(0);
       expect(rateLimits).toHaveLength(1);
@@ -703,6 +705,54 @@ describe("Processor", () => {
         provider: "anthropic",
         retryAfterMs: retries[0]?.backoffMs,
       });
+    });
+
+    test("publishes RateLimited for a real Anthropic 429 rate_limit_error body", async () => {
+      // Pin (#532-3): Anthropic sends {type:"error",error:{type:"rate_limit_error"}}
+      // with status 429. Under prose classification the generic body.error
+      // sniff outranked the 429 status ("Provider Server Error"), so the
+      // string-matched RateLimited publish silently skipped a genuine rate
+      // limit. The typed reason switch must catch it.
+      let attemptCount = 0;
+      const rateLimits: Array<{ provider: string; retryAfterMs: number }> = [];
+      const unsubRateLimit = Bus.subscribe(LlmCall.RateLimited, (event) => {
+        rateLimits.push(event);
+      });
+
+      const processor = createProcessor({
+        trace: {
+          traceId: "trace-processor-429",
+          sessionId: "session-456",
+          provider: "anthropic",
+        },
+        createStream: async () => ({
+          fullStream: (async function* () {
+            attemptCount++;
+            if (attemptCount === 1) {
+              throw new APIError({
+                message: JSON.stringify({
+                  type: "error",
+                  error: {
+                    type: "rate_limit_error",
+                    message: "Number of request tokens has exceeded your per-minute rate limit",
+                  },
+                }),
+                statusCode: 429,
+                isRetryable: true,
+                responseHeaders: { "retry-after-ms": "1" },
+              });
+            }
+            yield { type: "finish" };
+          })(),
+        }),
+      });
+
+      await processor.process({ system: "" });
+      unsubRateLimit();
+
+      expect(attemptCount).toBe(2);
+      expect(rateLimits).toHaveLength(1);
+      expect(rateLimits[0]).toMatchObject({ provider: "anthropic", retryAfterMs: 1 });
     });
 
     test("throws original error instance for non-retryable errors and settles cleanly", async () => {

--- a/packages/llm/test/retry/retry.test.ts
+++ b/packages/llm/test/retry/retry.test.ts
@@ -84,92 +84,55 @@ describe("Retry", () => {
     });
   });
 
-  describe("delay(attempt, error?)", () => {
-    test("exponential backoff without error", () => {
-      const delay1 = Retry.delay(1);
-      expect(delay1).toBe(2000); // 2000 * 2^0
+  describe("decide(attempt, error) delay computation", () => {
+    function retryableError(headers?: Record<string, string>): InstanceType<typeof APIError> {
+      return new APIError({
+        message: "Rate limited",
+        isRetryable: true,
+        ...(headers && { responseHeaders: headers }),
+      });
+    }
 
-      const delay2 = Retry.delay(2);
-      expect(delay2).toBe(4000); // 2000 * 2^1
+    function delayOf(attempt: number, error: unknown): number {
+      const decision = Retry.decide(attempt, error);
+      if (!decision.retry) throw new Error(`expected a retry decision, got ${decision.reason}`);
+      return decision.delayMs;
+    }
 
-      const delay3 = Retry.delay(3);
-      expect(delay3).toBe(8000); // 2000 * 2^2
-
-      const delay4 = Retry.delay(4);
-      expect(delay4).toBe(16000); // 2000 * 2^3
+    test("exponential backoff without headers", () => {
+      expect(delayOf(1, retryableError())).toBe(2000); // 2000 * 2^0
+      expect(delayOf(2, retryableError())).toBe(4000); // 2000 * 2^1
+      expect(delayOf(3, retryableError())).toBe(8000); // 2000 * 2^2
+      expect(delayOf(4, retryableError())).toBe(16000); // 2000 * 2^3
     });
 
     test("caps exponential backoff at RETRY_MAX_DELAY_NO_HEADERS", () => {
-      // Calculate attempt that would exceed max
-      const delay = Retry.delay(20);
-      expect(delay).toBeLessThanOrEqual(Retry.RETRY_MAX_DELAY_NO_HEADERS);
+      expect(delayOf(20, retryableError())).toBeLessThanOrEqual(Retry.RETRY_MAX_DELAY_NO_HEADERS);
     });
 
     test("uses Retry-After-Ms header if present", () => {
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        responseHeaders: {
-          "retry-after-ms": "5000",
-        },
-      });
-
-      const delay = Retry.delay(1, error);
-      expect(delay).toBe(5000);
+      expect(delayOf(1, retryableError({ "retry-after-ms": "5000" }))).toBe(5000);
     });
 
     test("uses Retry-After header (seconds) if Retry-After-Ms not present", () => {
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        responseHeaders: {
-          "retry-after": "10",
-        },
-      });
-
-      const delay = Retry.delay(1, error);
-      expect(delay).toBe(10000); // 10 seconds converted to ms
+      expect(delayOf(1, retryableError({ "retry-after": "10" }))).toBe(10000);
     });
 
     test("parses Retry-After as HTTP date if not a number", () => {
       const futureDate = new Date(Date.now() + 5000).toUTCString();
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        responseHeaders: {
-          "retry-after": futureDate,
-        },
-      });
-
-      const delay = Retry.delay(1, error);
-      expect(delay).toBeGreaterThan(4000);
-      expect(delay).toBeLessThanOrEqual(5000);
+      const delayMs = delayOf(1, retryableError({ "retry-after": futureDate }));
+      expect(delayMs).toBeGreaterThan(4000);
+      expect(delayMs).toBeLessThanOrEqual(5000);
     });
 
     test("falls back to exponential backoff if Retry-After is invalid", () => {
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        responseHeaders: {
-          "retry-after": "invalid",
-        },
-      });
-
-      const delay = Retry.delay(2, error);
-      expect(delay).toBe(4000); // 2000 * 2^1
+      expect(delayOf(2, retryableError({ "retry-after": "invalid" }))).toBe(4000);
     });
 
     test("caps the fallback backoff even when headers are present", () => {
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        responseHeaders: {
-          "retry-after": "invalid",
-        },
-      });
-
-      const delay = Retry.delay(20, error);
-      expect(delay).toBe(Retry.RETRY_MAX_DELAY_NO_HEADERS);
+      expect(delayOf(20, retryableError({ "retry-after": "invalid" }))).toBe(
+        Retry.RETRY_MAX_DELAY_NO_HEADERS,
+      );
     });
 
     test("does not throw when error payload code fields are not strings", () => {
@@ -181,51 +144,50 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      expect(Retry.isRetryable(error)).toBe("Provider Server Error");
+      expect(Retry.decide(1, error)).toMatchObject({ retry: true, reason: "server_error" });
     });
 
     test("prioritizes Retry-After-Ms over Retry-After", () => {
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        responseHeaders: {
-          "retry-after-ms": "3000",
-          "retry-after": "10",
-        },
-      });
-
-      const delay = Retry.delay(1, error);
-      expect(delay).toBe(3000);
+      expect(delayOf(1, retryableError({ "retry-after-ms": "3000", "retry-after": "10" }))).toBe(
+        3000,
+      );
     });
 
     test("handles missing headers gracefully", () => {
-      const error = new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-      });
+      expect(delayOf(2, retryableError())).toBe(4000);
+    });
 
-      const delay = Retry.delay(2, error);
-      expect(delay).toBe(4000); // Falls back to exponential backoff
+    test("does not expose the removed delay dual path", async () => {
+      // decide() is the single retry decision surface; the standalone
+      // uncapped delay() had no src consumer and is gone.
+      const retrySource = await Bun.file(
+        new URL("../../src/retry/index.ts", import.meta.url),
+      ).text();
+      expect(Object.hasOwn(Retry, "delay")).toBe(false);
+      expect(retrySource).not.toMatch(/\bexport function delay\b/);
     });
   });
 
-  describe("isRetryable(error)", () => {
-    test("returns undefined if error is not APIError", () => {
-      const error = new Error("Retry failed");
+  describe("decide(attempt, error) reason classification", () => {
+    function reasonOf(error: unknown): Retry.Reason {
+      return Retry.decide(1, error).reason;
+    }
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBeUndefined();
+    test("classifies non-APIError as non_retryable", () => {
+      expect(Retry.decide(1, new Error("Retry failed"))).toEqual({
+        retry: false,
+        reason: "non_retryable",
+      });
     });
 
-    test("returns undefined if APIError.isRetryable is false", () => {
+    test("classifies APIError with isRetryable false as non_retryable", () => {
       const error = new APIError({
         message: "Not found",
         statusCode: 404,
         isRetryable: false,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBeUndefined();
+      expect(reasonOf(error)).toBe("non_retryable");
     });
 
     test("falls back to status classification when message is not JSON", () => {
@@ -235,7 +197,7 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      expect(Retry.isRetryable(error)).toBe("Provider Server Error");
+      expect(reasonOf(error)).toBe("server_error");
     });
 
     test("classifies 429 by status when payload is opaque", () => {
@@ -245,7 +207,23 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      expect(Retry.isRetryable(error)).toBe("Rate Limited");
+      expect(reasonOf(error)).toBe("rate_limit");
+    });
+
+    test("classifies 429 by status when the JSON body has no specific signal", () => {
+      // The prose classifier let the generic body.error sniff outrank the 429
+      // status ("Provider Server Error"), so real Anthropic rate limits
+      // ({error:{type:"rate_limit_error"}}) skipped the RateLimited path.
+      const error = new APIError({
+        message: JSON.stringify({
+          type: "error",
+          error: { message: "request tokens exceeded your per-minute rate limit" },
+        }),
+        statusCode: 429,
+        isRetryable: true,
+      });
+
+      expect(reasonOf(error)).toBe("rate_limit");
     });
 
     test("classifies from responseBody when message is opaque", () => {
@@ -258,7 +236,7 @@ describe("Retry", () => {
         }),
       });
 
-      expect(Retry.isRetryable(error)).toBe("Too Many Requests");
+      expect(reasonOf(error)).toBe("rate_limit");
     });
 
     test("detects too_many_requests in JSON response", () => {
@@ -270,11 +248,10 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBe("Too Many Requests");
+      expect(reasonOf(error)).toBe("rate_limit");
     });
 
-    test("detects rate_limit in JSON response", () => {
+    test("detects rate_limit in JSON error code", () => {
       const error = new APIError({
         message: JSON.stringify({
           type: "error",
@@ -283,8 +260,19 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBe("Rate Limited");
+      expect(reasonOf(error)).toBe("rate_limit");
+    });
+
+    test("detects rate_limit in JSON error type (Anthropic rate_limit_error)", () => {
+      const error = new APIError({
+        message: JSON.stringify({
+          type: "error",
+          error: { type: "rate_limit_error", message: "rate limited" },
+        }),
+        isRetryable: true,
+      });
+
+      expect(reasonOf(error)).toBe("rate_limit");
     });
 
     test("detects server_error in JSON response", () => {
@@ -296,8 +284,7 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBe("Provider Server Error");
+      expect(reasonOf(error)).toBe("server_error");
     });
 
     test("detects exhausted in error code", () => {
@@ -308,8 +295,7 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBe("Provider is overloaded");
+      expect(reasonOf(error)).toBe("overloaded");
     });
 
     test("detects unavailable in error code", () => {
@@ -320,8 +306,7 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBe("Provider is overloaded");
+      expect(reasonOf(error)).toBe("overloaded");
     });
 
     test("detects no_kv_space in error message", () => {
@@ -332,8 +317,7 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      const result = Retry.isRetryable(error);
-      expect(result).toBe("Provider Server Error");
+      expect(reasonOf(error)).toBe("server_error");
     });
 
     test("trusts the provider retryable flag when payload and status are opaque", () => {
@@ -348,8 +332,12 @@ describe("Retry", () => {
         isRetryable: true,
       });
 
-      expect(Retry.isRetryable(plainText)).toBe("Provider Error");
-      expect(Retry.isRetryable(invalidJson)).toBe("Provider Error");
+      expect(Retry.decide(1, plainText)).toMatchObject({ retry: true, reason: "server_error" });
+      expect(Retry.decide(1, invalidJson)).toMatchObject({ retry: true, reason: "server_error" });
+    });
+
+    test("does not expose the folded-away prose classifier", () => {
+      expect(Object.hasOwn(Retry, "isRetryable")).toBe(false);
     });
   });
 
@@ -365,7 +353,7 @@ describe("Retry", () => {
   });
 });
 
-describe("Retry.delay ratelimit-reset parsing (#532 candidate 3)", () => {
+describe("Retry.decide ratelimit-reset parsing (#532 candidate 3)", () => {
   function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
     return new APIError({
       name: "APIError",
@@ -376,25 +364,36 @@ describe("Retry.delay ratelimit-reset parsing (#532 candidate 3)", () => {
     });
   }
 
+  function delayOf(headers: Record<string, string>): number {
+    const decision = Retry.decide(1, apiError(headers));
+    if (!decision.retry) throw new Error(`expected a retry decision, got ${decision.reason}`);
+    return decision.delayMs;
+  }
+
   test("x-ratelimit-reset-requests duration is used when retry-after is absent", () => {
-    expect(Retry.delay(1, apiError({ "x-ratelimit-reset-requests": "3s" }))).toBe(3000);
+    expect(delayOf({ "x-ratelimit-reset-requests": "3s" })).toBe(3000);
   });
 
   test("x-ratelimit-reset duration with compound units parses", () => {
-    expect(Retry.delay(1, apiError({ "x-ratelimit-reset-tokens": "1m30s" }))).toBe(90_000);
+    // 1m30s parses to 90s — above the header cap, so the inferred reset
+    // demotes to backoff with the over-cap flag proving the parse happened.
+    expect(Retry.decide(1, apiError({ "x-ratelimit-reset-tokens": "1m30s" }))).toEqual({
+      retry: true,
+      reason: "rate_limit",
+      delayMs: Retry.RETRY_INITIAL_DELAY,
+      retryAfterOverCap: true,
+    });
   });
 
   test("anthropic-ratelimit reset timestamp is used when retry-after is absent", () => {
     const resetAt = new Date(Date.now() + 5000).toISOString();
-    const ms = Retry.delay(1, apiError({ "anthropic-ratelimit-requests-reset": resetAt }));
+    const ms = delayOf({ "anthropic-ratelimit-requests-reset": resetAt });
     expect(ms).toBeGreaterThan(3500);
     expect(ms).toBeLessThanOrEqual(5100);
   });
 
   test("retry-after still wins over ratelimit resets", () => {
-    expect(
-      Retry.delay(1, apiError({ "retry-after": "2", "x-ratelimit-reset-requests": "9s" })),
-    ).toBe(2000);
+    expect(delayOf({ "retry-after": "2", "x-ratelimit-reset-requests": "9s" })).toBe(2000);
   });
 });
 
@@ -411,36 +410,36 @@ describe("Retry.decide (#532 candidate 3)", () => {
 
   test("non-retryable errors decide against retry", () => {
     const decision = Retry.decide(1, new Error("plain"));
-    expect(decision.retryable).toBe(false);
+    expect(decision.retry).toBe(false);
   });
 
   test("header delay within the cap is honored", () => {
     const decision = Retry.decide(1, apiError({ "retry-after": "45" }));
     expect(decision).toEqual({
-      retryable: true,
-      reason: "Rate Limited",
+      retry: true,
+      reason: "rate_limit",
       delayMs: 45_000,
-      source: "header",
     });
   });
 
   test("header delay above the cap fails fast instead of silently stalling", () => {
     const decision = Retry.decide(1, apiError({ "retry-after": "3600" }));
-    expect(decision.retryable).toBe(false);
-    if (!decision.retryable) {
-      expect(decision.reason).toContain("3600000");
+    expect(decision.retry).toBe(false);
+    if (!decision.retry) {
+      // The typed reason stays a branchable literal; prose lives in detail.
+      expect(decision.reason).toBe("rate_limit");
+      expect(decision.detail).toContain("3600000");
     }
   });
 
   test("headless retry keeps the exponential backoff and its 30s cap", () => {
     expect(Retry.decide(1, apiError())).toEqual({
-      retryable: true,
-      reason: "Rate Limited",
+      retry: true,
+      reason: "rate_limit",
       delayMs: Retry.RETRY_INITIAL_DELAY,
-      source: "backoff",
     });
     const late = Retry.decide(10, apiError());
-    if (late.retryable) {
+    if (late.retry) {
       expect(late.delayMs).toBe(Retry.RETRY_MAX_DELAY_NO_HEADERS);
     }
   });
@@ -460,20 +459,19 @@ describe("Retry.decide cap semantics for inferred resets", () => {
   test("an out-of-range ratelimit reset demotes to backoff instead of failing", () => {
     const decision = Retry.decide(1, apiError({ "x-ratelimit-reset-requests": "30m" }));
     expect(decision).toEqual({
-      retryable: true,
-      reason: "Rate Limited",
+      retry: true,
+      reason: "rate_limit",
       delayMs: Retry.RETRY_INITIAL_DELAY,
-      source: "backoff",
+      retryAfterOverCap: true,
     });
   });
 
   test("bare numbers in reset headers are never parsed as years", () => {
     const decision = Retry.decide(1, apiError({ "x-ratelimit-reset-requests": "2027" }));
     expect(decision).toEqual({
-      retryable: true,
-      reason: "Rate Limited",
+      retry: true,
+      reason: "rate_limit",
       delayMs: Retry.RETRY_INITIAL_DELAY,
-      source: "backoff",
     });
   });
 });


### PR DESCRIPTION
Realizes the substance of #532-3 (PR #544 shipped the name; the quality audit found prose-string branching remained) — and the red-first pin exposed a real production bug.

## The bug the pin proved

A genuine Anthropic 429 with `{error:{type:"rate_limit_error"}}` was classified as "Provider Server Error" — the generic `!!body.error` sniff outranked the status check — so the `LlmCall.RateLimited` event **never fired for real Anthropic rate limits**. Red before (`21 pass / 1 fail`), green after via status-outranks-sniff classification.

## What

- `Retry.Reason` = `"rate_limit" | "overloaded" | "server_error" | "non_retryable"` — every member has a real producer branch AND a consumer; no invented members (408/409/network residue folds into server_error because no consumer distinguishes them).
- `Retry.Decision` is a discriminated shape (`{retry:false, reason, detail?} | {retry:true, reason, delayMs, retryAfterOverCap?}`) — prose lives only in `detail`, never branched on. Consumer dispatch is an exhaustive switch with a `satisfies never` tail: a new member fails compile, a typo cannot silently kill the branch.
- Dead dual paths deleted: `Retry.delay` (zero src consumers, uncapped) and the `isRetryable` export (folded private).
- Wire compatibility: `RetryDecided.reason` stays `z.string()` in protocol; values are now the typed literals (subset — no protocol change).

## Verification

llm 250 pass / 0 fail (agent suite green, its separate Retry module untouched); prose literals in src: 0; check-types, build, lint, check-deps, dead-exports (21/0 new) green. One atomic commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed retry reasons with exhaustive handling fix misclassification of Anthropic 429s, so real rate limits are detected and `LlmCall.RateLimited` fires correctly.

- **Bug Fixes**
  - Classifies Anthropic 429 `{error:{type:"rate_limit_error"}}` as `rate_limit` (status outranks generic payload), restoring `LlmCall.RateLimited`.
  - Declined retries now include `reason:detail`; `Retry-After` headers are honored, and over-cap inferred resets fail fast or demote to backoff.

- **Refactors**
  - Adds `Retry.Reason` literals (`rate_limit | overloaded | server_error | non_retryable`) and a `Retry.Decision` discriminated union with `retry`, `detail?`, and `retryAfterOverCap?`.
  - Replaces prose-based branching with an exhaustive switch; removes `Retry.delay` and `Retry.isRetryable` in favor of `Retry.decide()`. Protocol remains `z.string()`; values are now the typed literals. Linked to Linear #532.

<sup>Written for commit 3fbe85ce0fe745744be16c203b1188c6ebbfa973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic retry behavior for temporary failures and rate limits.
  - Added broader recognition of provider rate-limit responses, including Anthropic 429 errors.
  - Prevented inferred rate-limit reset values from causing premature failures.
  - Standardized retry reasons and included clearer retry details in error reporting.

- **Reliability**
  - Rate-limit events now report more accurate provider information and wait times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->