### PR TITLE
refactor(coordinator): narrow public surface to the driver shape

### DIFF
--- a/apps/server/test/execution/worker-full-stack.test.ts
+++ b/apps/server/test/execution/worker-full-stack.test.ts
@@ -32,7 +32,6 @@ const mockWorkerManagerFactory: WorkerManagerFactory = (_config, ports) => {
       mockPoolDispatch(task.sessionId, runId, task),
     send: async () => ({ sent: true }),
     cancel: async () => ({ cancelled: true }),
-    killWorker: () => undefined,
     stats: () => ({
       workers: 1,
       active: 0,

--- a/packages/coordinator/src/index.ts
+++ b/packages/coordinator/src/index.ts
@@ -1,13 +1,15 @@
+// Public surface (#553 C9): the Execution.Driver-shaped delivery core —
+// deliver/cancel/send/stats/waitUntilReady/shutdown — plus its parameter and
+// result types. Pool construction knobs (`WorkerManagerConfig`/`WorkerPorts`)
+// are factory-private; worker-supervision never leaves the package.
 export { createWorkerManager } from "./worker-manager";
 export type {
+  DeliverTask,
   InboundWaitParams,
   InboundWaitResult,
-  ToolCallCancelParams,
   ToolCallContext,
   ToolCallParams,
   ToolCallResult,
   WorkerManager,
-  WorkerManagerConfig,
   WorkerManagerStats,
-  WorkerPorts,
 } from "./worker-manager";

--- a/packages/coordinator/src/worker-manager/index.ts
+++ b/packages/coordinator/src/worker-manager/index.ts
@@ -1,14 +1,12 @@
-export {
-  createWorkerManager,
-  type DeliverTask,
-  type WorkerManager,
-  type WorkerManagerConfig,
-  type WorkerManagerStats,
-  type WorkerPorts,
-  type ToolCallCancelParams,
-  type ToolCallContext,
-  type ToolCallParams,
-  type ToolCallResult,
-  type InboundWaitParams,
-  type InboundWaitResult,
-} from "./worker-pool";
+export { createWorkerManager, killWorkerForTest } from "./worker-pool";
+export type {
+  DeliverTask,
+  InboundWaitParams,
+  InboundWaitResult,
+  ToolCallContext,
+  ToolCallParams,
+  ToolCallResult,
+  WorkerManager,
+  WorkerManagerStats,
+  WorkerPorts,
+} from "./worker-manager-types";

--- a/packages/coordinator/src/worker-manager/worker-manager-types.ts
+++ b/packages/coordinator/src/worker-manager/worker-manager-types.ts
@@ -2,7 +2,6 @@ import type { BusEvent, TraceContext, WorkerBootstrap } from "@openomni/protocol
 import type {
   InboundWaitParams,
   InboundWaitResult,
-  ToolCallCancelParams,
   ToolCallContext as SupervisorToolCallContext,
   ToolCallParams,
   ToolCallResult,
@@ -15,13 +14,19 @@ export const DEFAULT_IDLE_SHUTDOWN_MS = 600_000;
 export const DEFAULT_SLOT_WAIT_TIMEOUT_MS = 30_000;
 export const DEFAULT_MAX_QUEUED_DELIVERIES = 100;
 
-export type { ToolCallCancelParams, ToolCallParams, ToolCallResult };
+export type { ToolCallParams, ToolCallResult };
 export type { InboundWaitParams, InboundWaitResult };
 
 export type ToolCallContext = SupervisorToolCallContext & {
   readonly traceContext?: TraceContext.Type;
 };
 
+/**
+ * Factory-private pool construction config (#553 C9): not exported from the
+ * package barrel. External callers pass an object literal to
+ * `createWorkerManager`; `slotWaitTimeoutMs`/`maxQueuedDeliveries` are
+ * pool-internal knobs exercised only by the coordinator's own tests.
+ */
 export type WorkerManagerConfig = {
   workerScript: string;
   socketDir?: string;
@@ -38,6 +43,8 @@ export type WorkerManagerConfig = {
  * through here — the ledger event edge via `events`, tool execution via
  * `toolRelay` (the dispatcher, ring 4), and the resident question bridge
  * via `inboundWait`. Tests bind a collector sink instead of the Bus.
+ * Factory-private (#553 C9): callers pass a literal; only the port
+ * param/result types are public.
  */
 export type WorkerPorts = {
   events: BusEvent.Sink;
@@ -64,6 +71,8 @@ export type DeliverTask = { sessionId: string } & Record<string, unknown>;
 /**
  * Ring-2 process driver surface (#462 §1): one verb, no judgment.
  * Implements the command face of `Execution.Driver` in protocol.
+ * Exactly the six driver-shaped methods (#553 C9); the test-only chaos
+ * hook lives on the pool class behind `killWorkerForTest`.
  */
 export type WorkerManager = {
   deliver(runId: string, task: DeliverTask): Promise<unknown>;
@@ -71,7 +80,6 @@ export type WorkerManager = {
   send(sessionId: string, message: string, runId?: string): Promise<unknown>;
   stats(): WorkerManagerStats;
   waitUntilReady(timeoutMs?: number): Promise<void>;
-  killWorker(index: number): void;
   shutdown(): Promise<void>;
 };
 

--- a/packages/coordinator/src/worker-manager/worker-pool.ts
+++ b/packages/coordinator/src/worker-manager/worker-pool.ts
@@ -28,25 +28,24 @@ import {
   type WorkerSlot,
 } from "./worker-manager-types";
 
-export type {
-  DeliverTask,
-  InboundWaitParams,
-  InboundWaitResult,
-  ToolCallCancelParams,
-  ToolCallContext,
-  ToolCallParams,
-  ToolCallResult,
-  WorkerManager,
-  WorkerManagerConfig,
-  WorkerManagerStats,
-  WorkerPorts,
-} from "./worker-manager-types";
-
 export function createWorkerManager(
   config: WorkerManagerConfig,
   ports: WorkerPorts,
 ): WorkerManager {
   return new WorkerPool(config, ports);
+}
+
+/**
+ * Test-only chaos hook (#553 C9): `killWorker` is not part of the public
+ * driver shape, so the coordinator's own crash-recovery test reaches the
+ * pool internals through this function instead. Exported from the internal
+ * worker-manager barrel only — never from the package barrel.
+ */
+export function killWorkerForTest(manager: WorkerManager, index: number): void {
+  if (!(manager instanceof WorkerPool)) {
+    throw new Error("killWorkerForTest requires a coordinator WorkerPool instance");
+  }
+  manager.killWorker(index);
 }
 
 // One pool module, one concept (#462 §3): the slot state machine

--- a/packages/coordinator/src/worker-supervision/supervisor.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor.ts
@@ -27,7 +27,6 @@ const WORKER_CONNECT_TIMEOUT_MS = 10_000;
 export type {
   InboundWaitParams,
   InboundWaitResult,
-  ToolCallCancelParams,
   ToolCallContext,
   ToolCallParams,
   ToolCallResult,

--- a/packages/coordinator/test/worker-manager/crash.test.ts
+++ b/packages/coordinator/test/worker-manager/crash.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import { createWorkerManager, type WorkerManager } from "../../src/worker-manager";
+import {
+  createWorkerManager,
+  killWorkerForTest,
+  type WorkerManager,
+} from "../../src/worker-manager";
 import { collectorPorts } from "../harness/ports";
 
 const WORKER_ENTRY = fileURLToPath(new URL("../harness/worker-fixture.ts", import.meta.url));
@@ -32,7 +36,7 @@ describe("worker manager crash recovery", () => {
     });
 
     await new Promise<void>((r) => setTimeout(r, 50));
-    manager.killWorker(0);
+    killWorkerForTest(manager, 0);
 
     let errorMessage: string | undefined;
     try {

--- a/packages/coordinator/test/worker-supervision/facade-removal.test.ts
+++ b/packages/coordinator/test/worker-supervision/facade-removal.test.ts
@@ -9,5 +9,9 @@ describe("worker supervision public facade removal", () => {
     expect("createSessionRouting" in coordinator).toBe(false);
     expect("SessionRouting" in coordinator).toBe(false);
     expect("createWorkerManager" in coordinator).toBe(true);
+
+    // #553 C9: the delivery factory is the only runtime export — the rest of
+    // the public surface is types (driver shape + its parameter/result types).
+    expect(Object.keys(coordinator).sort()).toEqual(["createWorkerManager"]);
   });
 });

--- a/script/conformance/knip-baseline.json
+++ b/script/conformance/knip-baseline.json
@@ -16,8 +16,6 @@
     "exports packages/session/src/bus-persistence/event-query.ts toEventRecord",
     "exports packages/session/src/storage/sqlite-part-adapter.ts getPartStartTime",
     "files packages/openomni/test/dispatch/policy-registration.contract-test.ts",
-    "types packages/coordinator/src/worker-manager/index.ts DeliverTask",
-    "types packages/coordinator/src/worker-manager/worker-pool.ts DeliverTask",
     "types packages/openomni/src/execution-runtime/child-agent/types.ts ChildStatus",
     "types packages/openomni/src/execution-runtime/child-agent/types.ts DelegationPolicyPointId",
     "types packages/openomni/src/ingress/audit-envelope.ts IngressAuditEvent"


### PR DESCRIPTION
Closes #553 (leaf C9, unblocked by #496). The J11 narrowing: coordinator's public barrel is now exactly the Execution.Driver-shaped delivery core.

## What

- Runtime export = `createWorkerManager` alone (pinned); `WorkerManager` = the six driver methods (deliver/cancel/send/stats/waitUntilReady/shutdown) — `killWorker` removed from the contract (crash tests use an internal instanceof-guarded seam, never package-exported).
- `WorkerManagerConfig`/`WorkerPorts` pool knobs folded factory-private; `ToolCallCancelParams` dead re-export chain removed end-to-end; `DeliverTask` (deliver's actual parameter type) properly surfaced.
- All 6 external consumer sites compile unchanged; zero `as` bridges, zero wrappers; worker-supervision verified still private.

## Verification

Suites 1,775 pass / 1 pre-existing skip / 0 fail (= baseline); check-types 13/13, build, lint, check-deps (ring = protocol+ipc unchanged) green; dead-export ratchet **21 → 19** (two grandfathered entries resolved by the narrowing — sanctioned shrink via --update, diff is exactly those removals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the coordinator public API to the driver shape. Only `createWorkerManager` is exported at runtime; the public types are the six-method `WorkerManager` and its param/result types. `killWorker` is internal via a test-only helper. Addresses Linear #553.

- **Refactors**
  - Package barrel exports only `createWorkerManager`; driver has exactly six methods.
  - Public types limited to `WorkerManager`, `WorkerManagerStats`, `DeliverTask`, `ToolCall*`, and `InboundWait*`.
  - `WorkerManagerConfig` and `WorkerPorts` are factory-private; callers pass literals.
  - `killWorker` removed; added `killWorkerForTest` on the internal worker-manager barrel.
  - Removed `ToolCallCancelParams` and stopped re-exporting types from `worker-pool`, resolving two dead-export entries.

- **Migration**
  - Stop importing `WorkerManagerConfig`/`WorkerPorts`; pass object literals to `createWorkerManager`.
  - Do not use `killWorker`; tests can call `killWorkerForTest` from the internal worker-manager barrel.
  - Remove any imports of `ToolCallCancelParams`.

<sup>Written for commit 5dd8a5da77ab1c9e0f877da6e3489fdee9aa6666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

