### PR TITLE
fix(session,protocol,llm): pure TTL reads, dead sink hook, ghost parts

### DIFF
--- a/apps/server/src/bootstrap/recovery.ts
+++ b/apps/server/src/bootstrap/recovery.ts
@@ -5,7 +5,7 @@ import {
   type DefaultDispatchRuntime,
   type EffectReconciler,
 } from "@openomni/openomni";
-import { Bus, Storage } from "@openomni/session";
+import { Bus, Session, Storage } from "@openomni/session";
 import { recoverInterruptedMessages, type RecoveryItem } from "../recovery";
 
 async function processRetryQueue(
@@ -221,6 +221,18 @@ export async function runRecovery(input: BootstrapRecoveryInput): Promise<void> 
         time: Date.now(),
         component: "server",
         msg: `recovery expired ${expiredWaits.length} wait(s)`,
+      });
+    }
+    // Session TTL expiry: reads (Session.get/list) only filter expired rows;
+    // this sweep is the one deliberate deletion point (same seam as the wait
+    // sweep above — boot-time only until a periodic scheduler exists).
+    const expiredSessions = Session.sweepExpired();
+    if (expiredSessions.length > 0) {
+      Bus.publish(Operational.Info, {
+        traceId: id,
+        time: Date.now(),
+        component: "server",
+        msg: `recovery removed ${expiredSessions.length} expired session(s)`,
       });
     }
 

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -183,7 +183,6 @@ export namespace WorkerRunner {
             onMessage: () => undefined,
             onToolCall: () => undefined,
             onToolResult: () => undefined,
-            onSnapshot: () => undefined,
             // #547 C3: the wiring point for WORKER sessions where the
             // transcript fact stream meets durable recording —
             // TranscriptStore.record commits the fact and its message/part

--- a/packages/agent/src/core/execution/turn-prepare.ts
+++ b/packages/agent/src/core/execution/turn-prepare.ts
@@ -284,7 +284,6 @@ function createTrackingSink(
       turnToolResults.push({ toolCallId: result.toolCallId, result });
       sink?.onToolResult(result);
     },
-    onSnapshot: sink?.onSnapshot ?? (() => undefined),
     // #547 C3: the fact stream passes through untouched — the transcript
     // record family subscribes to facts, not boundary snapshots.
     onFact: (fact) => sink?.onFact?.(fact),

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -52,7 +52,6 @@ function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtifacts {
       onMessage: () => undefined,
       onToolCall: () => undefined,
       onToolResult: () => undefined,
-      onSnapshot: () => undefined,
     },
     turnAssistant: {},
     turnUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },

--- a/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
+++ b/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
@@ -43,7 +43,6 @@ export function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtif
       onMessage: () => undefined,
       onToolCall: () => undefined,
       onToolResult: () => undefined,
-      onSnapshot: () => undefined,
     },
     turnAssistant: {},
     turnUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },

--- a/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
@@ -25,7 +25,6 @@ function makeTurnArtifacts(): TurnArtifacts {
       onMessage: () => undefined,
       onToolCall: () => undefined,
       onToolResult: () => undefined,
-      onSnapshot: () => undefined,
     },
     turnAssistant: {},
     turnUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },

--- a/packages/agent/test/core/tool-permission-integration.test.ts
+++ b/packages/agent/test/core/tool-permission-integration.test.ts
@@ -141,7 +141,6 @@ describe("tool permission integration via toolExecutor", () => {
         onToolResult: (result) => {
           observedToolResult = result;
         },
-        onSnapshot: () => undefined,
       },
     );
 
@@ -199,7 +198,6 @@ describe("tool permission integration via toolExecutor", () => {
         onToolResult: (result) => {
           observedToolResult = result;
         },
-        onSnapshot: () => undefined,
       },
     );
 
@@ -257,7 +255,6 @@ describe("tool permission integration via toolExecutor", () => {
         onToolResult: (result) => {
           observedToolResult = result;
         },
-        onSnapshot: () => undefined,
       },
     );
 
@@ -314,7 +311,6 @@ describe("tool permission integration via toolExecutor", () => {
         onToolResult: (result) => {
           observedToolResult = result;
         },
-        onSnapshot: () => undefined,
       },
     );
 
@@ -371,7 +367,6 @@ describe("tool permission integration via toolExecutor", () => {
         onToolResult: (result) => {
           observedToolResult = result;
         },
-        onSnapshot: () => undefined,
       },
     );
 

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -3,7 +3,6 @@ import {
   Operational,
   Transcript,
   type Message,
-  type Run,
   type Sink,
   type Tool,
 } from "@openomni/protocol";
@@ -103,7 +102,7 @@ export namespace Processor {
       },
 
       async process(streamInput: StreamInput): Promise<void> {
-        publishStatus(sink, sessionID, { type: "busy" });
+        publishStatus(sessionID, trace?.traceId, "busy");
         let attempt = 0;
         let attemptSeq = 0;
 
@@ -238,18 +237,13 @@ export namespace Processor {
                 }
               }
 
-              publishStatus(sink, sessionID, {
-                type: "retry",
-                attempt,
-                message: retryReason,
-                next: Date.now() + delayMs,
-              });
+              publishStatus(sessionID, trace?.traceId, "retry");
 
               await Retry.sleep(delayMs, abort);
             }
           }
         } finally {
-          publishStatus(sink, sessionID, { type: "idle" });
+          publishStatus(sessionID, trace?.traceId, "idle");
         }
       },
     };
@@ -324,11 +318,6 @@ export namespace Processor {
           isError: result.isError,
         });
       },
-
-      onSnapshot(snapshot: Run.Snapshot) {
-        sink.onSnapshot(snapshot);
-        publish("sink.snapshot", { stateType: String(snapshot.state.type ?? "unknown") });
-      },
     };
   }
 
@@ -337,17 +326,17 @@ export namespace Processor {
       onMessage: () => void 0,
       onToolCall: () => void 0,
       onToolResult: () => void 0,
-      onSnapshot: () => void 0,
     };
   }
 
-  function publishStatus(sink: Sink, sessionID: string, state: Record<string, unknown>): void {
-    sink.onSnapshot({
-      id: crypto.randomUUID(),
-      sessionID,
-      timestamp: Date.now(),
-      state,
-    });
+  /**
+   * Run-status telemetry (busy / retry / idle). This used to ride
+   * Sink.onSnapshot, but every production consumer was a no-op, so the sink
+   * hop was removed; the operational publish — the only observable effect it
+   * ever had — stays, under the same msg name for log continuity.
+   */
+  function publishStatus(sessionID: string, traceId: string | undefined, stateType: string): void {
+    publishInfo(sessionID, traceId, "sink.snapshot", { stateType });
   }
 
   function summarizeRecord(input: Record<string, unknown>): string {

--- a/packages/llm/test/processor/emission-measurement.test.ts
+++ b/packages/llm/test/processor/emission-measurement.test.ts
@@ -82,7 +82,6 @@ describe("Processor emission measurement (#545 T2)", () => {
       },
       onToolCall: () => undefined,
       onToolResult: () => undefined,
-      onSnapshot: () => undefined,
     };
 
     const processor = Processor.create({

--- a/packages/llm/test/processor/fold-emission.test.ts
+++ b/packages/llm/test/processor/fold-emission.test.ts
@@ -49,7 +49,6 @@ function capture(): Capture {
       onMessage: (message) => messages.push(message),
       onToolCall: () => undefined,
       onToolResult: (result) => toolResults.push(result),
-      onSnapshot: () => undefined,
       onFact: (fact) => facts.push(fact),
     },
     messages,

--- a/packages/llm/test/processor/processor.test.ts
+++ b/packages/llm/test/processor/processor.test.ts
@@ -1,12 +1,5 @@
 import { afterEach, describe, expect, test, beforeEach } from "bun:test";
-import {
-  LlmCall,
-  Operational,
-  type Message,
-  type Run,
-  type Sink,
-  type Tool,
-} from "@openomni/protocol";
+import { LlmCall, Operational, type Message, type Sink, type Tool } from "@openomni/protocol";
 import { Bus, Storage } from "@openomni/session";
 import { Processor } from "../../src/processor";
 import { APIError } from "../../src/error";
@@ -91,7 +84,6 @@ type PartsCapture = {
   sink: Sink;
   messages: Message.WithParts[];
   finalParts: () => Message.Part[];
-  snapshotStates: string[];
   toolCalls: Tool.Call[];
   toolResults: Tool.Result[];
   /** Text of the first text part, captured at each onMessage callback. */
@@ -100,7 +92,6 @@ type PartsCapture = {
 
 function capturingSink(): PartsCapture {
   const messages: Message.WithParts[] = [];
-  const snapshotStates: string[] = [];
   const toolCalls: Tool.Call[] = [];
   const toolResults: Tool.Result[] = [];
   const textTimeline: Array<string | undefined> = [];
@@ -120,17 +111,27 @@ function capturingSink(): PartsCapture {
       onToolResult(result) {
         toolResults.push(result);
       },
-      onSnapshot(snapshot: Run.Snapshot) {
-        snapshotStates.push(String(snapshot.state.type));
-      },
     },
     messages,
     finalParts: () => messages.at(-1)?.parts ?? [],
-    snapshotStates,
     toolCalls,
     toolResults,
     textTimeline,
   };
+}
+
+/**
+ * Run-status telemetry (busy/retry/idle) is published on the Operational bus
+ * as "sink.snapshot" (the Sink.onSnapshot hop was removed — no consumer).
+ */
+function captureStatusStates(): { states: string[]; unsub: () => void } {
+  const states: string[] = [];
+  const unsub = Bus.subscribe(Operational.Info, (data) => {
+    if (data.component === "llm.processor" && data.msg === "sink.snapshot") {
+      states.push(String((data.context as Record<string, unknown> | undefined)?.stateType));
+    }
+  });
+  return { states, unsub };
 }
 
 describe("Processor", () => {
@@ -453,13 +454,15 @@ describe("Processor", () => {
       });
     });
 
-    test("publishes exactly one busy and one idle snapshot on success", async () => {
-      const capture = capturingSink();
-      const processor = createProcessor({ sink: capture.sink });
+    test("publishes exactly one busy and one idle status on success", async () => {
+      const { states, unsub } = captureStatusStates();
+      const processor = createProcessor();
 
       await processor.process({ system: "" });
+      await new Promise((resolve) => queueMicrotask(resolve));
+      unsub();
 
-      expect(capture.snapshotStates).toEqual(["busy", "idle"]);
+      expect(states).toEqual(["busy", "idle"]);
     });
 
     test("projects sink callbacks to Bus events", async () => {
@@ -473,7 +476,6 @@ describe("Processor", () => {
       const sinkEvents: string[] = [];
       const toolCalls: Tool.Call[] = [];
       const toolResults: Tool.Result[] = [];
-      const snapshots: Run.Snapshot[] = [];
       const messages: Message.WithParts[] = [];
 
       configureSession("session-456");
@@ -490,10 +492,6 @@ describe("Processor", () => {
         onToolResult(result) {
           sinkEvents.push("toolResult");
           toolResults.push(result);
-        },
-        onSnapshot(snapshot) {
-          sinkEvents.push(`snapshot:${String(snapshot.state.type)}`);
-          snapshots.push(snapshot);
         },
       };
 
@@ -516,13 +514,10 @@ describe("Processor", () => {
       expect(sinkEvents).toContain("message");
       expect(sinkEvents).toContain("toolCall");
       expect(sinkEvents).toContain("toolResult");
-      expect(sinkEvents).toContain("snapshot:busy");
-      expect(sinkEvents).toContain("snapshot:idle");
       expect(messages.length).toBeGreaterThan(0);
       expect(toolCalls).toEqual([{ id: "call-1", tool: "lookup", input: { q: "x" } }]);
       expect(toolResults).toHaveLength(1);
       expect(toolResults[0]?.toolCallId).toBe("call-1");
-      expect(snapshots.map((snapshot) => snapshot.state.type)).toEqual(["busy", "idle"]);
 
       expect(busEvents.every((event) => event.component === "llm.processor")).toBe(true);
       expect(busEvents.every((event) => event.sessionId === "session-456")).toBe(true);
@@ -601,7 +596,6 @@ describe("Processor", () => {
         onMessage: (message) => snapshots.push(message),
         onToolCall: () => undefined,
         onToolResult: () => undefined,
-        onSnapshot: () => undefined,
       };
 
       const processor = createProcessor({
@@ -757,6 +751,7 @@ describe("Processor", () => {
 
     test("throws original error instance for non-retryable errors and settles cleanly", async () => {
       const capture = capturingSink();
+      const { states, unsub } = captureStatusStates();
       const errorInstance = new APIError({
         message: "Specific error",
         statusCode: 500,
@@ -781,7 +776,9 @@ describe("Processor", () => {
       }
 
       // Exactly one idle transition, and the pending tool is closed out once.
-      expect(capture.snapshotStates).toEqual(["busy", "idle"]);
+      await new Promise((resolve) => queueMicrotask(resolve));
+      unsub();
+      expect(states).toEqual(["busy", "idle"]);
       expect(capture.toolResults).toHaveLength(1);
       expect(capture.toolResults[0]).toMatchObject({
         toolCallId: "call-1",

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -109,7 +109,6 @@ describe("Processor retry header-delay cap (#532 candidate 3)", () => {
         onMessage: () => undefined,
         onToolCall: () => undefined,
         onToolResult: () => undefined,
-        onSnapshot: () => undefined,
       },
       createStream: async () => ({
         fullStream: (async function* () {

--- a/packages/llm/test/processor/tool-result.test.ts
+++ b/packages/llm/test/processor/tool-result.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { Message, Run, Sink, Tool } from "@openomni/protocol";
+import type { Message, Sink, Tool } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { Processor } from "../../src/processor";
 import type { Provider } from "../../src/provider";
@@ -40,13 +40,11 @@ describe("Processor tool result projection", () => {
   test("projects AI SDK tool-call and tool-result stream parts once", async () => {
     const toolCalls: Tool.Call[] = [];
     const toolResults: Tool.Result[] = [];
-    const snapshots: Run.Snapshot[] = [];
     const messages: Message.WithParts[] = [];
     const sink: Sink = {
       onMessage: (message) => messages.push(message),
       onToolCall: (call) => toolCalls.push(call),
       onToolResult: (result) => toolResults.push(result),
-      onSnapshot: (snapshot) => snapshots.push(snapshot),
     };
 
     const processor = Processor.create({
@@ -84,7 +82,6 @@ describe("Processor tool result projection", () => {
       toolCallId: "call-weather",
       output: "sunny",
     });
-    expect(snapshots.length).toBeGreaterThan(0);
     const toolPart = messages.at(-1)?.parts.find((part) => part.type === "tool");
     expect(toolPart).toMatchObject({
       callID: "call-weather",
@@ -112,7 +109,6 @@ describe("Processor tool result projection", () => {
       onMessage: (message) => messages.push(message),
       onToolCall: (call) => toolCalls.push(call),
       onToolResult: (result) => toolResults.push(result),
-      onSnapshot: () => undefined,
     };
 
     const processor = Processor.create({
@@ -154,7 +150,6 @@ describe("Processor tool result projection", () => {
       onMessage: (message) => messages.push(message),
       onToolCall: () => undefined,
       onToolResult: (result) => toolResults.push(result),
-      onSnapshot: () => undefined,
     };
 
     const processor = Processor.create({
@@ -202,7 +197,6 @@ describe("Processor tool result projection", () => {
       onMessage: (message) => messages.push(message),
       onToolCall: () => undefined,
       onToolResult: () => undefined,
-      onSnapshot: () => undefined,
     };
 
     const processor = Processor.create({
@@ -249,7 +243,6 @@ describe("Processor tool output normalization", () => {
       onMessage: (message) => messages.push(message),
       onToolCall: () => undefined,
       onToolResult: (result) => toolResults.push(result),
-      onSnapshot: () => undefined,
     };
 
     const processor = Processor.create({
@@ -295,7 +288,6 @@ describe("Processor tool error normalization", () => {
       onMessage: () => undefined,
       onToolCall: () => undefined,
       onToolResult: (result) => toolResults.push(result),
-      onSnapshot: () => undefined,
     };
 
     const processor = Processor.create({
@@ -344,7 +336,6 @@ describe("Processor abort settlement grace (#532 candidate 2)", () => {
       onMessage: (message) => messages.push(message),
       onToolCall: () => undefined,
       onToolResult: () => undefined,
-      onSnapshot: () => undefined,
     };
   }
 

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -41,7 +41,6 @@ describe("run() streamText arguments", () => {
     onMessage: () => undefined,
     onToolCall: () => undefined,
     onToolResult: () => undefined,
-    onSnapshot: () => undefined,
   };
 
   beforeEach(() => {

--- a/packages/llm/test/run-tool-execution.test.ts
+++ b/packages/llm/test/run-tool-execution.test.ts
@@ -48,7 +48,6 @@ describe("run() tool execution ownership", () => {
     onToolResult: (result) => {
       capturedToolResults.push(result);
     },
-    onSnapshot: () => undefined,
   };
 
   beforeAll(async () => {

--- a/packages/llm/test/run-tool-schema.test.ts
+++ b/packages/llm/test/run-tool-schema.test.ts
@@ -42,7 +42,6 @@ describe("run() with model - tool schema conversion", () => {
     onMessage: () => undefined,
     onToolCall: () => undefined,
     onToolResult: () => undefined,
-    onSnapshot: () => undefined,
   };
 
   test("maps Tool.Spec inputSchema to raw function tools via jsonSchema", async () => {

--- a/packages/llm/test/run.test.ts
+++ b/packages/llm/test/run.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { LlmCall, type Message, type Run, type Sink, type Tool } from "@openomni/protocol";
+import { LlmCall, type Message, type Sink, type Tool } from "@openomni/protocol";
 import { Bus } from "@openomni/session";
 import { Auth } from "../src/auth";
 import type { Provider } from "../src/provider";
@@ -52,7 +52,6 @@ describe("run", () => {
   let capturedMessages: Message.WithParts[];
   let capturedToolCalls: Tool.Call[];
   let capturedToolResults: Tool.Result[];
-  let capturedSnapshots: Run.Snapshot[];
 
   beforeAll(async () => {
     ({ run } = await import("../src/run"));
@@ -64,7 +63,6 @@ describe("run", () => {
     capturedMessages = [];
     capturedToolCalls = [];
     capturedToolResults = [];
-    capturedSnapshots = [];
     aiCapture.__openomniAiStreamArgs = undefined;
 
     mockSink = {
@@ -76,9 +74,6 @@ describe("run", () => {
       },
       onToolResult: (result: Tool.Result) => {
         capturedToolResults.push(result);
-      },
-      onSnapshot: (snapshot: Run.Snapshot) => {
-        capturedSnapshots.push(snapshot);
       },
     };
   });
@@ -230,7 +225,7 @@ describe("run", () => {
 
     await run(input, mockSink);
 
-    expect(capturedSnapshots.length).toBeGreaterThan(0);
+    expect(capturedMessages.length).toBeGreaterThan(0);
     expect(capturedToolCalls.length).toBe(0);
   });
 

--- a/packages/protocol/src/message/index.ts
+++ b/packages/protocol/src/message/index.ts
@@ -77,18 +77,6 @@ export namespace Message {
   });
   export type ToolPart = z.infer<typeof ToolPart>;
 
-  export const SnapshotPart = PartBase.extend({
-    type: z.literal("snapshot"),
-    snapshot: z.string(),
-  });
-  export type SnapshotPart = z.infer<typeof SnapshotPart>;
-
-  export const CompactionPart = PartBase.extend({
-    type: z.literal("compaction"),
-    auto: z.boolean(),
-  });
-  export type CompactionPart = z.infer<typeof CompactionPart>;
-
   export const Part = z.discriminatedUnion("type", [
     TextPart,
     ReasoningPart,
@@ -96,8 +84,6 @@ export namespace Message {
     StepFinishPart,
     RetryPart,
     ToolPart,
-    SnapshotPart,
-    CompactionPart,
   ]);
   export type Part = z.infer<typeof Part>;
 

--- a/packages/protocol/src/run/index.ts
+++ b/packages/protocol/src/run/index.ts
@@ -1,14 +1,6 @@
 import { z } from "zod";
 
 export namespace Run {
-  export const Snapshot = z.object({
-    id: z.string(),
-    sessionID: z.string(),
-    timestamp: z.number(),
-    state: z.record(z.string(), z.unknown()),
-  });
-  export type Snapshot = z.infer<typeof Snapshot>;
-
   export const Outcome = z.discriminatedUnion("type", [
     z.object({ type: z.literal("stop") }),
     z.object({ type: z.literal("continue") }),

--- a/packages/protocol/src/sink/index.ts
+++ b/packages/protocol/src/sink/index.ts
@@ -1,13 +1,21 @@
 import type { Message } from "../message/index.js";
 import type { Tool } from "../tool/index.js";
-import type { Run } from "../run/index.js";
 import type { Transcript } from "../transcript/index.js";
 
 export interface Sink {
   onMessage: (message: Message.WithParts) => void;
+  /**
+   * Executor-boundary tool events. These are NOT redundant with onFact:
+   * every onToolResult pairs with a preceding onToolCall (the llm processor
+   * emits no callback for an unmatched tool-result, #532-6, and settles
+   * interruptions as error results), while the fact stream records those
+   * anomalies as raw part lifecycle. The agent's trackingSink builds its
+   * public tool_call_start/tool_call_complete AgentEvents from these
+   * correlated pairs; deriving them from facts would change the anomaly-path
+   * event stream.
+   */
   onToolCall: (call: Tool.Call) => void;
   onToolResult: (result: Tool.Result) => void;
-  onSnapshot: (snapshot: Run.Snapshot) => void;
   /**
    * Transcript fact stream (#545 T2): every fact the llm processor folds is
    * also offered here, in fold order. Optional because most sinks only want

--- a/packages/protocol/src/transcript/fold.ts
+++ b/packages/protocol/src/transcript/fold.ts
@@ -143,8 +143,6 @@ function isAppendableInitialState(part: Message.Part): boolean {
     case "step-start":
     case "step-finish":
     case "retry":
-    case "snapshot":
-    case "compaction":
       return true;
   }
 }
@@ -163,8 +161,6 @@ function advancePart(
     case "step-start":
     case "step-finish":
     case "retry":
-    case "snapshot":
-    case "compaction":
       // Punctual parts: appended whole, never advanced.
       return undefined;
   }

--- a/packages/protocol/test/message.test.ts
+++ b/packages/protocol/test/message.test.ts
@@ -263,40 +263,6 @@ describe("Message.ToolPart", () => {
   });
 });
 
-describe("Message.SnapshotPart", () => {
-  test("parses valid snapshot part", () => {
-    const part = Message.SnapshotPart.parse({
-      ...base,
-      type: "snapshot",
-      snapshot: '{"ctx":"data"}',
-    });
-
-    expect(part.type).toBe("snapshot");
-    expect(part.snapshot).toBe('{"ctx":"data"}');
-  });
-
-  test("rejects missing snapshot", () => {
-    expect(() => Message.SnapshotPart.parse({ ...base, type: "snapshot" })).toThrow();
-  });
-});
-
-describe("Message.CompactionPart", () => {
-  test("parses valid compaction part", () => {
-    const part = Message.CompactionPart.parse({
-      ...base,
-      type: "compaction",
-      auto: true,
-    });
-
-    expect(part.type).toBe("compaction");
-    expect(part.auto).toBe(true);
-  });
-
-  test("rejects missing auto", () => {
-    expect(() => Message.CompactionPart.parse({ ...base, type: "compaction" })).toThrow();
-  });
-});
-
 describe("Message.Part", () => {
   test("rejects unknown type literal", () => {
     expect(() => Message.Part.parse({ ...base, type: "unknown" })).toThrow();

--- a/packages/protocol/test/run.test.ts
+++ b/packages/protocol/test/run.test.ts
@@ -50,42 +50,6 @@ describe("Run.Outcome", () => {
   });
 });
 
-describe("Run.Snapshot", () => {
-  test("parses a valid snapshot", () => {
-    const snapshot = Run.Snapshot.parse({
-      id: "run-1",
-      sessionID: "session-1",
-      timestamp: 123,
-      state: { step: 1, active: true },
-    });
-
-    expect(snapshot.id).toBe("run-1");
-    expect(snapshot.sessionID).toBe("session-1");
-    expect(snapshot.timestamp).toBe(123);
-    expect(snapshot.state).toEqual({ step: 1, active: true });
-  });
-
-  test("rejects missing id", () => {
-    expect(() =>
-      Run.Snapshot.parse({
-        sessionID: "session-1",
-        timestamp: 123,
-        state: {},
-      }),
-    ).toThrow();
-  });
-
-  test("rejects missing sessionID", () => {
-    expect(() =>
-      Run.Snapshot.parse({
-        id: "run-1",
-        timestamp: 123,
-        state: {},
-      }),
-    ).toThrow();
-  });
-});
-
 describe("Run.RetryPolicy", () => {
   test("parses a valid retry policy with retryOn", () => {
     const policy = Run.RetryPolicy.parse({

--- a/packages/session/src/session/index.ts
+++ b/packages/session/src/session/index.ts
@@ -18,6 +18,7 @@ export namespace Session {
   export const updateWorkerMeta = Lifecycle.updateWorkerMeta;
   export const update = Lifecycle.update;
   export const remove = Lifecycle.remove;
+  export const sweepExpired = Lifecycle.sweepExpired;
   export const addMessage = Messages.addMessage;
   export const updateMessageStatus = Messages.updateMessageStatus;
   export const getMessages = Messages.getMessages;

--- a/packages/session/src/session/lifecycle.ts
+++ b/packages/session/src/session/lifecycle.ts
@@ -69,29 +69,45 @@ export function createChild(input: CreateChildInput): SessionInfo {
   return child;
 }
 
+function isExpired(session: SessionInfo, now: number): boolean {
+  return session.expiresAt !== undefined && now > session.expiresAt;
+}
+
 export function get(id: string): SessionInfo | undefined {
   const session = Storage.getAdapter().session.get(id);
   if (!session) return undefined;
-
-  if (session.expiresAt !== undefined && Date.now() > session.expiresAt) {
-    remove(id);
-    return undefined;
-  }
-
+  // Reads are pure: an expired session is invisible but NOT deleted here —
+  // a get() that writes turns every read into a mutation (delete-during-get
+  // races, list() corrupting its own iteration). Physical deletion is
+  // sweepExpired()'s job, invoked from a deliberate caller.
+  if (isExpired(session, Date.now())) return undefined;
   return session;
 }
 
 export function list(): SessionInfo[] {
-  const sessions = Storage.getAdapter().session.list();
   const now = Date.now();
+  // Pure read: expired sessions are filtered out, never removed mid-filter.
+  return Storage.getAdapter()
+    .session.list()
+    .filter((session) => !isExpired(session, now));
+}
 
-  return sessions.filter((session) => {
-    if (session.expiresAt !== undefined && now > session.expiresAt) {
-      remove(session.id);
-      return false;
-    }
-    return true;
-  });
+/**
+ * Explicit expiry sweep: physically removes every expired session (message/
+ * part cascade included, via remove()). Reads (get/list) only FILTER expired
+ * rows; this is the single place expiry causes a write. Invoked from the boot
+ * recovery sweep (apps/server/src/bootstrap/recovery.ts) alongside
+ * WaitService.sweepExpired; there is no periodic scheduler yet, so long-lived
+ * processes re-sweep only on restart.
+ */
+export function sweepExpired(now = Date.now()): SessionInfo[] {
+  const expired = Storage.getAdapter()
+    .session.list()
+    .filter((session) => isExpired(session, now));
+  for (const session of expired) {
+    remove(session.id);
+  }
+  return expired;
 }
 
 export function listChildren(parentSessionId: string): SessionInfo[] {

--- a/packages/session/test/ttl.test.ts
+++ b/packages/session/test/ttl.test.ts
@@ -2,8 +2,14 @@
 
 import { describe, expect, test, beforeEach } from "bun:test";
 import { Session } from "../src/session";
+import { Bus } from "../src/bus";
 import { Storage } from "../src/storage/storage";
 import "../src/storage/initialize";
+
+/** Bus delivery is microtask-queued; flush before asserting on received events. */
+function flushBus(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe("Session TTL", () => {
   beforeEach(() => {
@@ -50,18 +56,29 @@ describe("Session TTL", () => {
       expect(retrieved?.id).toBe(session.id);
     });
 
-    test("should return undefined and remove session when expired", () => {
+    test("should return undefined for an expired session WITHOUT deleting it", async () => {
+      // Reads are pure: expiry filtering never writes. Deletion is the
+      // explicit sweep's job (sweepExpired below).
       const session = Session.create({
         title: "Test Session",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -1000,
       });
 
+      const deleted: string[] = [];
+      const unsub = Bus.subscribe(Session.Event.Deleted, (data) => {
+        deleted.push(data.id);
+      });
+
       const retrieved = Session.get(session.id);
       expect(retrieved).toBeUndefined();
 
-      const checkAgain = Storage.getAdapter().session.get(session.id);
-      expect(checkAgain).toBeUndefined();
+      // The row survives the read; no delete event fired.
+      const stillStored = Storage.getAdapter().session.get(session.id);
+      expect(stillStored).toBeDefined();
+      await flushBus();
+      expect(deleted).toEqual([]);
+      unsub();
     });
 
     test("should return session without expiresAt normally", () => {
@@ -95,7 +112,7 @@ describe("Session TTL", () => {
       expect(sessions.find((s) => s.id === session2.id)).toBeDefined();
     });
 
-    test("should exclude expired sessions and remove them", () => {
+    test("should exclude expired sessions WITHOUT deleting them", async () => {
       const expiredSession = Session.create({
         title: "Expired Session",
         model: { providerID: "test", modelID: "test-model" },
@@ -108,15 +125,24 @@ describe("Session TTL", () => {
         ttlMs: 5000,
       });
 
+      const deleted: string[] = [];
+      const unsub = Bus.subscribe(Session.Event.Deleted, (data) => {
+        deleted.push(data.id);
+      });
+
       const sessions = Session.list();
       expect(sessions.length).toBe(1);
       expect(sessions[0].id).toBe(activeSession.id);
 
-      const checkExpired = Storage.getAdapter().session.get(expiredSession.id);
-      expect(checkExpired).toBeUndefined();
+      // list() is a pure read: the expired row survives until the sweep.
+      const stillStored = Storage.getAdapter().session.get(expiredSession.id);
+      expect(stillStored).toBeDefined();
+      await flushBus();
+      expect(deleted).toEqual([]);
+      unsub();
     });
 
-    test("should handle mixed sessions correctly", () => {
+    test("should handle mixed sessions correctly and stay stable across repeated reads", () => {
       const expired1 = Session.create({
         title: "Expired 1",
         model: { providerID: "test", modelID: "test-model" },
@@ -140,30 +166,66 @@ describe("Session TTL", () => {
         ttlMs: -2000,
       });
 
-      const sessions = Session.list();
-      expect(sessions.length).toBe(2);
-      expect(sessions.find((s) => s.id === active1.id)).toBeDefined();
-      expect(sessions.find((s) => s.id === noExpiry.id)).toBeDefined();
-      expect(sessions.find((s) => s.id === expired1.id)).toBeUndefined();
-      expect(sessions.find((s) => s.id === expired2.id)).toBeUndefined();
+      // Interleaved reads during expiry must not corrupt each other: a get()
+      // issued mid-listing (formerly a delete-while-iterating hazard) leaves
+      // every row intact, and a second list() sees the identical view.
+      const first = Session.list();
+      Session.get(expired1.id);
+      const second = Session.list();
+
+      for (const sessions of [first, second]) {
+        expect(sessions.length).toBe(2);
+        expect(sessions.find((s) => s.id === active1.id)).toBeDefined();
+        expect(sessions.find((s) => s.id === noExpiry.id)).toBeDefined();
+        expect(sessions.find((s) => s.id === expired1.id)).toBeUndefined();
+        expect(sessions.find((s) => s.id === expired2.id)).toBeUndefined();
+      }
+      expect(Storage.getAdapter().session.list().length).toBe(4);
     });
   });
 
-  describe("lazy deletion", () => {
-    test("should not auto-delete expired sessions until accessed", () => {
-      const session = Session.create({
-        title: "Test Session",
+  describe("sweepExpired", () => {
+    test("removes expired sessions and leaves the rest untouched", async () => {
+      const expired = Session.create({
+        title: "Expired",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -1000,
       });
+      const active = Session.create({
+        title: "Active",
+        model: { providerID: "test", modelID: "test-model" },
+        ttlMs: 5000,
+      });
+      const noExpiry = Session.create({
+        title: "No Expiry",
+        model: { providerID: "test", modelID: "test-model" },
+      });
 
-      const directCheck = Storage.getAdapter().session.get(session.id);
-      expect(directCheck).toBeDefined();
+      const deleted: string[] = [];
+      const unsub = Bus.subscribe(Session.Event.Deleted, (data) => {
+        deleted.push(data.id);
+      });
 
-      Session.get(session.id);
+      const swept = Session.sweepExpired();
 
-      const afterGet = Storage.getAdapter().session.get(session.id);
-      expect(afterGet).toBeUndefined();
+      expect(swept.map((s) => s.id)).toEqual([expired.id]);
+      await flushBus();
+      expect(deleted).toEqual([expired.id]);
+      expect(Storage.getAdapter().session.get(expired.id)).toBeUndefined();
+      expect(Storage.getAdapter().session.get(active.id)).toBeDefined();
+      expect(Storage.getAdapter().session.get(noExpiry.id)).toBeDefined();
+      unsub();
+    });
+
+    test("is a no-op when nothing is expired", () => {
+      Session.create({
+        title: "Active",
+        model: { providerID: "test", modelID: "test-model" },
+        ttlMs: 5000,
+      });
+
+      expect(Session.sweepExpired()).toEqual([]);
+      expect(Storage.getAdapter().session.list().length).toBe(1);
     });
   });
 });

--- a/script/conformance/schema-snapshot.json
+++ b/script/conformance/schema-snapshot.json
@@ -509,7 +509,6 @@
     "time",
     "tokens"
   ],
-  "Message.CompactionPart": ["auto", "id", "messageID", "sessionID", "type"],
   "Message.Info#0": [
     "agent",
     "id",
@@ -581,8 +580,6 @@
     "tool",
     "type"
   ],
-  "Message.Part#6": ["id", "messageID", "sessionID", "snapshot", "type"],
-  "Message.Part#7": ["auto", "id", "messageID", "sessionID", "type"],
   "Message.ReasoningPart": [
     "id",
     "messageID",
@@ -601,7 +598,6 @@
     "time",
     "type"
   ],
-  "Message.SnapshotPart": ["id", "messageID", "sessionID", "snapshot", "type"],
   "Message.StepFinishPart": [
     "cost",
     "id",

--- a/script/conformance/schema-snapshot.json
+++ b/script/conformance/schema-snapshot.json
@@ -738,7 +738,6 @@
   "Run.Outcome#3": ["type"],
   "Run.Outcome#4": ["error", "type"],
   "Run.RetryPolicy": ["backoffMs", "maxAttempts", "retryOn"],
-  "Run.Snapshot": ["id", "sessionID", "state", "timestamp"],
   "RuntimeResource.ActorDescriptor": [
     "actorId",
     "actorType",


### PR DESCRIPTION
Confirmed-slop batch W1 from the quality audit (net −46 LOC).

## What

- **TTL read-during-get delete (real defect, red-first)**: `Session.get()/list()` no longer delete expired rows mid-read (the read-causes-write class; list even deleted while iterating). Reads are pure filters; deletion moved to `Session.sweepExpired()`, wired at the existing boot-recovery sweep seam alongside `WaitService.sweepExpired()` — no scheduler invented. 5 red-first pins. Follow-up noted (review MINOR): a periodic sweep + guarding the pre-existing expired-session write bypass (update/addMessage read the adapter directly) — latent today, zero production ttlMs setters.
- **`Sink.onSnapshot` removed (dead)**: every terminal consumer was `() => undefined`; the only observable effect (busy/retry/idle `sink.snapshot` telemetry) is preserved via direct publish — review verified field/timing identity. Orphaned `Run.Snapshot` removed with it. `onToolCall`/`onToolResult` **kept with an accurate interface comment**: they carry the executor-boundary correlation guarantee and the anomaly-path AgentEvent semantics genuinely differ from a fact-derived stream (unmatched results emit facts but deliberately no callback — review reproduced the divergence).
- **Ghost part types deleted**: `SnapshotPart`/`CompactionPart` — zero producers in the entire repo HISTORY (verified back to inception), zero consumers; fold dead-cases removed cleanly; a hypothetical stored ghost row still lands on a typed fold rejection, not a crash (review-constructed).

Schema-snapshot updated surgically (exactly the five removed entries — union index stability verified by lint-tools); this diff is the Owner sign-off surface.

## Verification

Suites session 438 / protocol 645 / llm 250 / agent 384 / server 460 — 0 fail; conformance 39/39; check-types, build, lint, check-deps, dead-exports (18 known/0 new), schema-drift, lint-tools green; coverage within tolerance on all packages. Adversarial review: **MERGE-SAFE** (all 5 attacks passed; 1 MINOR follow-up recorded above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session TTL reads pure and safe, and remove unused snapshot plumbing. Run status telemetry stays the same via `Operational.Info`, and unused protocol parts are deleted.

- **Bug Fixes**
  - `@openomni/session`: `Session.get()`/`Session.list()` no longer delete expired sessions during reads. They only filter them. Physical deletion moved to `Session.sweepExpired()`, invoked during server boot recovery next to `WaitService.sweepExpired()`.
  - Prevents read-causes-write and delete-while-iterating races in TTL handling.

- **Refactors**
  - `@openomni/protocol`/`@openomni/llm`/`@openomni/agent`: removed `Sink.onSnapshot` and `Run.Snapshot`. Busy/retry/idle status is now published directly as `Operational.Info` with msg `"sink.snapshot"` from the processor. If you used `onSnapshot`, subscribe to `Operational.Info` instead.
  - Kept `onToolCall`/`onToolResult` and documented that they are not redundant with facts (they preserve executor-boundary correlation).
  - Deleted ghost types `Message.SnapshotPart` and `Message.CompactionPart` and their fold cases. Schema snapshot trimmed accordingly.

<sup>Written for commit 05334d474c67e1f00e8f13d8e4f2332d9863674d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit cleanup for expired sessions, with operational reporting when sessions are removed.
  - Session reads now consistently ignore expired sessions without deleting them automatically.

- **Improvements**
  - Stream status telemetry now reports busy, retry, and idle states more directly.
  - Simplified event handling by removing obsolete snapshot notifications.

- **Breaking Changes**
  - Removed snapshot and compaction message types from the supported protocol.
  - Snapshot callbacks are no longer available in event sinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->