### PR TITLE
chore: break the two value-import cycles, add cycle ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
         run: |
           bun run script/check-coverage-ratchet.ts --self-test
           bun run script/check-dead-exports.ts --self-test
+          bun run script/check-import-cycles.ts --self-test
       - run: bun run script/check-dead-exports.ts
+      - run: bun run script/check-import-cycles.ts
       - run: bun run script/check-ledger-schema-drift.ts
       - run: bun run script/report-source-metrics.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/packages/llm/src/provider/index.ts
+++ b/packages/llm/src/provider/index.ts
@@ -3,7 +3,6 @@ import { Model as ProtocolModel } from "@openomni/protocol";
 import { ProviderError } from "../error";
 import { ModelsDev } from "../model";
 import { Auth } from "../auth/storage";
-import { fromModelsDevProvider } from "./sdk";
 import { enrichWithCatalog, fetchProxyModels } from "./proxy-models";
 
 export namespace Provider {
@@ -147,6 +146,27 @@ export namespace Provider {
       },
       release_date: model.release_date ?? "",
       variants: model.variants ?? {},
+    };
+  }
+
+  function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
+    const models: Record<string, Model> = {};
+
+    if (provider.models) {
+      for (const [id, rawModel] of Object.entries(provider.models)) {
+        const isValid = typeof rawModel === "object" && rawModel !== null;
+        if (!isValid) continue;
+
+        models[id] = fromModelsDevModel(provider, rawModel as ModelsDev.Model);
+      }
+    }
+
+    return {
+      id: provider.id,
+      name: provider.name,
+      env: provider.env ?? [],
+      npm: provider.npm,
+      models,
     };
   }
 

--- a/packages/llm/src/provider/sdk.ts
+++ b/packages/llm/src/provider/sdk.ts
@@ -2,8 +2,7 @@ import { createAnthropic, type AnthropicProvider } from "@ai-sdk/anthropic";
 import { createOpenAI, type OpenAIProvider } from "@ai-sdk/openai";
 import type { LanguageModel } from "ai";
 import type { Auth } from "../auth/storage";
-import { Provider } from "./index";
-import type { ModelsDev } from "../model";
+import type { Provider } from "./index";
 
 type SdkOptions = {
   apiKey?: string;
@@ -163,25 +162,4 @@ function resolveLanguageModel(
 
 function isOpenAIProvider(sdk: ProviderSDK): sdk is OpenAIProvider {
   return "responses" in sdk;
-}
-
-export function fromModelsDevProvider(provider: ModelsDev.Provider): Provider.Info {
-  const models: Record<string, Provider.Model> = {};
-
-  if (provider.models) {
-    for (const [id, rawModel] of Object.entries(provider.models)) {
-      const isValid = typeof rawModel === "object" && rawModel !== null;
-      if (!isValid) continue;
-
-      models[id] = Provider.fromModelsDevModel(provider, rawModel as ModelsDev.Model);
-    }
-  }
-
-  return {
-    id: provider.id,
-    name: provider.name,
-    env: provider.env ?? [],
-    npm: provider.npm,
-    models,
-  };
 }

--- a/packages/openomni/src/ledger/stakes-constants.ts
+++ b/packages/openomni/src/ledger/stakes-constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Dependency-free leaf shared by stakes-contract.ts and stakes-reference.ts.
+ *
+ * These values used to live in stakes-contract.ts, which made contract ↔
+ * reference a two-way value-import cycle — safe only because the back
+ * references sat inside superRefine closures while createStakesSchemas() runs
+ * at contract module init. Keeping them in a leaf with no ledger imports
+ * makes the remaining contract → reference edge one-way by construction.
+ */
+import { createHash } from "node:crypto";
+
+export const STAKES_POLICY_VERSION = "stakes-policy-v1";
+export const STAKES_THETA = 1_000;
+
+export type StakesHashValue = null | boolean | number | string | readonly StakesHashValue[];
+
+export function hashStakesValue(value: StakesHashValue): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+}

--- a/packages/openomni/src/ledger/stakes-contract.ts
+++ b/packages/openomni/src/ledger/stakes-contract.ts
@@ -1,22 +1,16 @@
-import { createHash } from "node:crypto";
 import { z } from "zod";
 import { snapshotFirstJsonSchema } from "../evidence/verifier-conformance-canonical.js";
+import { STAKES_POLICY_VERSION, STAKES_THETA } from "./stakes-constants.js";
 import {
   expectedStakesComparison,
   expectedStakesReference,
   expectedWindowRef,
 } from "./stakes-reference.js";
 
-export const STAKES_POLICY_VERSION = "stakes-policy-v1";
-export const STAKES_THETA = 1_000;
+export { STAKES_POLICY_VERSION, STAKES_THETA, hashStakesValue } from "./stakes-constants.js";
+
 export const STAKES_EPSILON = 1;
 export const STAKES_AMOUNT_DENOMINATION = "owner_base_budget_micro_unit";
-
-export type StakesHashValue = null | boolean | number | string | readonly StakesHashValue[];
-
-export function hashStakesValue(value: StakesHashValue): string {
-  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
-}
 
 export function createStakesSchemaPrimitives() {
   return {

--- a/packages/openomni/src/ledger/stakes-reference.ts
+++ b/packages/openomni/src/ledger/stakes-reference.ts
@@ -1,4 +1,4 @@
-import { STAKES_POLICY_VERSION, STAKES_THETA, hashStakesValue } from "./stakes-contract.js";
+import { STAKES_POLICY_VERSION, STAKES_THETA, hashStakesValue } from "./stakes-constants.js";
 
 type WindowIdentity = Readonly<{
   ownerKey: string;

--- a/script/check-import-cycles.ts
+++ b/script/check-import-cycles.ts
@@ -1,0 +1,198 @@
+/**
+ * Import-cycle ratchet. Baseline: 0 value-import cycles.
+ *
+ * Builds the eager value-import graph over every src file in packages/* and
+ * apps/* — static `import`/`export … from` statements, following relative
+ * specifiers and workspace package names — and fails when a cycle exists.
+ * Type-only edges (`import type`, `export type … from`, clauses whose named
+ * specifiers are all `type`-prefixed) are skipped: they are erased at runtime
+ * and cannot cause TDZ/partial-init hazards. Lazy `await import()` edges are
+ * skipped for the same reason.
+ *
+ * Modes:
+ *   bun run script/check-import-cycles.ts             check the tree
+ *   bun run script/check-import-cycles.ts --self-test discrimination bench on
+ *                                                     synthetic graphs only
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+const root = join(import.meta.dir, "..");
+
+function listSourceFiles(): string[] {
+  const glob = new Bun.Glob("{packages,apps}/*/src/**/*.{ts,tsx}");
+  return [...glob.scanSync({ cwd: root, absolute: true })].sort();
+}
+
+function workspaceEntryPoints(): Map<string, string> {
+  const entries = new Map<string, string>();
+  for (const manifestPath of new Bun.Glob("{packages,apps}/*/package.json").scanSync({
+    cwd: root,
+    absolute: true,
+  })) {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      name?: string;
+      main?: string;
+    };
+    if (manifest.name && manifest.main) {
+      entries.set(manifest.name, resolve(dirname(manifestPath), manifest.main));
+    }
+  }
+  return entries;
+}
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+/** Static value-import specifiers of one module (type-only edges excluded). */
+export function valueImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const stripped = stripComments(source);
+  const statement =
+    /\b(import|export)\s+(type\s+)?([^"'`;]*?)\bfrom\s*["']([^"']+)["']|\bimport\s*["']([^"']+)["']/g;
+  for (const match of stripped.matchAll(statement)) {
+    const [, , typeKeyword, clause, fromSpecifier, bareSpecifier] = match;
+    if (bareSpecifier !== undefined) {
+      specifiers.push(bareSpecifier); // side-effect import — always a value edge
+      continue;
+    }
+    if (typeKeyword) continue;
+    const braceStart = clause?.indexOf("{") ?? -1;
+    if (braceStart >= 0 && clause) {
+      const named = clause.slice(braceStart + 1, clause.indexOf("}"));
+      const namedAllTypes = named
+        .split(",")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0)
+        .every((item) => item.startsWith("type "));
+      // `{ type A } from` alone is erased; a default binding beside the
+      // braces (`Foo, { type A }`) keeps the edge.
+      const hasBindingBeforeBraces = clause.slice(0, braceStart).trim().length > 0;
+      if (namedAllTypes && !hasBindingBeforeBraces) continue;
+    }
+    specifiers.push(fromSpecifier as string);
+  }
+  return specifiers;
+}
+
+function resolveSpecifier(
+  fromFile: string,
+  specifier: string,
+  workspaces: Map<string, string>,
+): string | undefined {
+  let base: string | undefined;
+  if (specifier.startsWith(".")) {
+    base = resolve(dirname(fromFile), specifier);
+  } else if (workspaces.has(specifier)) {
+    base = workspaces.get(specifier);
+  } else {
+    return undefined; // external dependency — out of scope
+  }
+  if (base === undefined) return undefined;
+  const candidates = [
+    base,
+    base.replace(/\.js$/, ".ts"),
+    base.replace(/\.js$/, ".tsx"),
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+  ];
+  return candidates.find((candidate) => /\.tsx?$/.test(candidate) && existsSync(candidate));
+}
+
+export function findCycles(graph: Map<string, readonly string[]>): string[][] {
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  const stack: string[] = [];
+  const cycles: string[][] = [];
+  const seen = new Set<string>();
+
+  function visit(node: string): void {
+    color.set(node, GRAY);
+    stack.push(node);
+    for (const next of graph.get(node) ?? []) {
+      const state = color.get(next) ?? WHITE;
+      if (state === GRAY) {
+        const cycle = stack.slice(stack.indexOf(next));
+        const key = [...cycle].sort().join(" -> ");
+        if (!seen.has(key)) {
+          seen.add(key);
+          cycles.push([...cycle, next]);
+        }
+      } else if (state === WHITE) {
+        visit(next);
+      }
+    }
+    stack.pop();
+    color.set(node, BLACK);
+  }
+
+  for (const node of [...graph.keys()].sort()) {
+    if ((color.get(node) ?? WHITE) === WHITE) visit(node);
+  }
+  return cycles;
+}
+
+function buildGraph(): Map<string, readonly string[]> {
+  const files = listSourceFiles();
+  const inScope = new Set(files);
+  const workspaces = workspaceEntryPoints();
+  const graph = new Map<string, readonly string[]>();
+  for (const file of files) {
+    const edges = new Set<string>();
+    for (const specifier of valueImportSpecifiers(readFileSync(file, "utf8"))) {
+      const resolved = resolveSpecifier(file, specifier, workspaces);
+      if (resolved && resolved !== file && inScope.has(resolved)) edges.add(resolved);
+    }
+    graph.set(file, [...edges].sort());
+  }
+  return graph;
+}
+
+function selfTest(): void {
+  const cyclic = new Map<string, readonly string[]>([
+    ["a.ts", ["b.ts"]],
+    ["b.ts", ["c.ts", "a.ts"]],
+    ["c.ts", []],
+  ]);
+  const acyclic = new Map<string, readonly string[]>([
+    ["a.ts", ["b.ts", "c.ts"]],
+    ["b.ts", ["c.ts"]],
+    ["c.ts", []],
+  ]);
+  const typeOnly = valueImportSpecifiers(
+    'import type { A } from "./a.js";\nexport type { B } from "./b.js";\nimport { type C } from "./c.js";\nimport { type D, e } from "./e.js";\nimport "./side-effect.js";\nimport { f } from "./f.js";',
+  );
+  const failures: string[] = [];
+  if (findCycles(cyclic).length !== 1) failures.push("planted cycle not detected");
+  if (findCycles(acyclic).length !== 0) failures.push("false positive on acyclic graph");
+  if (typeOnly.join(",") !== "./e.js,./side-effect.js,./f.js") {
+    failures.push(`value-edge extraction wrong: [${typeOnly.join(", ")}]`);
+  }
+  if (failures.length > 0) {
+    for (const failure of failures) console.error(`SELF-TEST FAIL: ${failure}`);
+    process.exit(1);
+  }
+  console.log("OK: import-cycle self-test — planted cycle red, acyclic green, type edges erased");
+}
+
+if (process.argv.includes("--self-test")) {
+  selfTest();
+} else {
+  const graph = buildGraph();
+  const cycles = findCycles(graph);
+  if (cycles.length > 0) {
+    for (const cycle of cycles) {
+      console.error(`CYCLE: ${cycle.map((file) => relative(root, file)).join("\n    -> ")}`);
+    }
+    console.error(
+      `\n${cycles.length} value-import cycle(s) found — baseline is 0. Break the cycle (extract a shared leaf module) instead of adding to it.`,
+    );
+    process.exit(1);
+  }
+  console.log(`OK: import-cycle check — ${graph.size} modules, 0 value-import cycles`);
+}


### PR DESCRIPTION
The only two findings that survived the 15-agent adversarial slop hunt (7 dimensions, repo-wide): latent import-order hazards, both fixed + a ratchet so the class stays dead.

## What

- **stakes cycle** (openomni/ledger): contract↔reference two-way value imports — one refactor away from a TDZ crash (`createStakesSchemas()` runs at module init). The three genuinely shared leaves (`STAKES_POLICY_VERSION`, `STAKES_THETA`, `hashStakesValue`) extracted to dependency-free `stakes-constants.ts`; contract re-exports them so every existing importer is untouched. Only contract→reference remains.
- **llm provider cycle**: sdk.ts's value import of the barrel eliminated — `fromModelsDevModel` joins the Provider namespace as the single shared symbol, sdk's import is now type-only. Zero package-surface change.
- **`script/check-import-cycles.ts`**: hand-rolled DFS over src imports (no new deps — madge isn't in the tree), type-only edges erased, `--self-test` proves discrimination on planted graphs. Red on the pre-fix tree (exactly the two cycles), green after; wired into the CI Quality job. Baseline: **0 cycles / 503 modules**.

## Verification

openomni 1,063 / llm 250 — 0 fail (= baselines); build, check-types, lint, check-deps, dead-exports (18/0 new), cycle check + self-test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaks two value-import cycles (stakes contract/reference and LLM provider index/sdk) to remove TDZ risk, and adds a CI import-cycle ratchet to prevent regressions. No public API changes.

- Refactors
  - Extract shared stakes constants and hash to `stakes-constants.ts`; re-export from `stakes-contract.ts`; breaks contract↔reference cycle.
  - Move `fromModelsDevProvider` into the `Provider` namespace in `provider/index.ts`; `sdk.ts` now type-only imports `Provider`; breaks index↔sdk cycle.

- New Features
  - Add `script/check-import-cycles.ts` (DFS over static value imports; skips `import type` and dynamic imports), wired into the CI Quality job with `--self-test` and a normal run. Baseline: 0 cycles.

<sup>Written for commit a6e899790bb44b9816c8a2408972dcd7ba22d5ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

