### PR TITLE
fix(openomni,session): cron single-backing, fail-closed corrupt-row reads

### DIFF
--- a/packages/openomni/src/execution-runtime/cron-job-registry.ts
+++ b/packages/openomni/src/execution-runtime/cron-job-registry.ts
@@ -1,17 +1,25 @@
-import { CronJob } from "@openomni/protocol";
+import { CronJob, type Storage as ProtocolStorage } from "@openomni/protocol";
 import { Bus, Storage } from "@openomni/session";
 
-const jobs = new Map<string, CronJob.Info>();
-
-function adapter() {
-  if (Storage.getInitializedDbPath() === null) return undefined;
-  return Storage.get().cronJob;
+// #522/#547: a cron job is durable by definition — a scheduled job that does
+// not survive process restart is not a cron job. Storage is therefore the
+// single canonical source; there is no volatile module-level Map to strand
+// jobs registered before init or to leave rows behind on clear(). Every
+// read/write/clear goes through the one backing, which fails closed
+// (Storage.get() throws) when used before Storage.initialize() — a loud
+// boot-order bug, never a silent in-memory fallback. Both consumers run after
+// init (CronJobRunner.start at bootstrap; dispatch schedule handlers at
+// runtime), and CronJobRunner.tick already treats a throw here as a logged
+// Operational.Error rather than a crash.
+function cronJobs(): ProtocolStorage.CronJobSubAdapter {
+  const adapter = Storage.get().cronJob;
+  if (!adapter) throw new Error("Storage adapter does not implement cronJob");
+  return adapter;
 }
 
 export namespace CronJobRegistry {
   export function register(job: CronJob.Info): string {
-    jobs.set(job.id, job);
-    adapter()?.set(job);
+    cronJobs().set(job);
     Bus.publish(CronJob.Events.CronJobScheduled, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
@@ -23,24 +31,19 @@ export namespace CronJobRegistry {
   }
 
   export function save(job: CronJob.Info): void {
-    jobs.set(job.id, job);
-    adapter()?.set(job);
+    cronJobs().set(job);
   }
 
   export function get(jobId: string): CronJob.Info | undefined {
-    const persisted = adapter();
-    return persisted ? persisted.get(jobId) : jobs.get(jobId);
+    return cronJobs().get(jobId);
   }
 
   export function list(): CronJob.Info[] {
-    const persisted = adapter()?.list();
-    return persisted ?? [...jobs.values()];
+    return cronJobs().list();
   }
 
   export function remove(jobId: string): boolean {
-    const deletedFromMemory = jobs.delete(jobId);
-    const deletedFromStorage = adapter()?.remove(jobId) ?? false;
-    const deleted = deletedFromMemory || deletedFromStorage;
+    const deleted = cronJobs().remove(jobId);
     if (deleted) {
       Bus.publish(CronJob.Events.CronJobCancelled, {
         traceId: crypto.randomUUID(),
@@ -52,6 +55,7 @@ export namespace CronJobRegistry {
   }
 
   export function clear(): void {
-    jobs.clear();
+    const adapter = cronJobs();
+    for (const job of adapter.list()) adapter.remove(job.id);
   }
 }

--- a/packages/openomni/test/dispatch/schedule-persistence.test.ts
+++ b/packages/openomni/test/dispatch/schedule-persistence.test.ts
@@ -45,12 +45,10 @@ describe("built-in schedule dispatch persistence", () => {
   const dbPaths = new Set<string>();
 
   beforeEach(() => {
-    CronJobRegistry.clear();
     Storage.reset();
   });
 
   afterEach(() => {
-    CronJobRegistry.clear();
     Storage.reset();
     for (const dbPath of dbPaths) removeSqliteFiles(dbPath);
     dbPaths.clear();
@@ -88,7 +86,6 @@ describe("built-in schedule dispatch persistence", () => {
     ]);
 
     Storage.reset();
-    CronJobRegistry.clear();
     Storage.initialize({ dbPath });
 
     expect(CronJobRegistry.list().map((reopenedJob) => reopenedJob.id)).toEqual([jobId]);
@@ -99,7 +96,6 @@ describe("built-in schedule dispatch persistence", () => {
 
     expect(cancelResult).toEqual({ output: { cancelled: true, jobId } });
     Storage.reset();
-    CronJobRegistry.clear();
     Storage.initialize({ dbPath });
     expect(CronJobRegistry.list()).toEqual([]);
   });

--- a/packages/openomni/test/execution-runtime/cron-job-registry.test.ts
+++ b/packages/openomni/test/execution-runtime/cron-job-registry.test.ts
@@ -27,7 +27,6 @@ describe("CronJobRegistry persistence", () => {
   let tmpDir = "";
 
   afterEach(() => {
-    CronJobRegistry.clear();
     Storage.reset();
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
     tmpDir = "";
@@ -41,21 +40,33 @@ describe("CronJobRegistry persistence", () => {
 
     CronJobRegistry.register(job);
     Storage.reset();
-    CronJobRegistry.clear();
     Storage.initialize({ dbPath: paths.dbPath });
 
     expect(CronJobRegistry.list()).toEqual([job]);
   });
 
-  test("registry falls back to process memory when storage is not initialized", () => {
+  test("register before initialize fails closed instead of stranding a volatile job", () => {
+    // #522/#547: cron is durable by definition. A job accepted into a volatile
+    // module-level Map before Storage.initialize() is stranded the moment
+    // get/list start reading storage. Registering before init is a loud
+    // boot-order bug, never a silent in-memory write.
     Storage.reset();
     const job = jobFixture();
 
-    CronJobRegistry.register(job);
-
+    expect(() => CronJobRegistry.register(job)).toThrow(/before initialize/);
     expect(Storage.getInitializedDbPath()).toBeNull();
-    expect(CronJobRegistry.list()).toEqual([job]);
-    expect(CronJobRegistry.remove(job.id)).toBe(true);
+  });
+
+  test("clear() empties the single canonical backing, not just process memory", () => {
+    const paths = tempDbPath();
+    tmpDir = paths.dir;
+    Storage.initialize({ dbPath: paths.dbPath });
+    CronJobRegistry.register(jobFixture("job-1"));
+    CronJobRegistry.register(jobFixture("job-2"));
+    expect(CronJobRegistry.list()).toHaveLength(2);
+
+    CronJobRegistry.clear();
+
     expect(CronJobRegistry.list()).toEqual([]);
   });
 
@@ -70,7 +81,6 @@ describe("CronJobRegistry persistence", () => {
     CronJobRegistry.register(second);
     expect(CronJobRegistry.remove("job-1")).toBe(true);
     Storage.reset();
-    CronJobRegistry.clear();
     Storage.initialize({ dbPath: paths.dbPath });
 
     expect(CronJobRegistry.list()).toEqual([second]);

--- a/packages/openomni/test/execution-runtime/cron-job-runner.test.ts
+++ b/packages/openomni/test/execution-runtime/cron-job-runner.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -56,9 +56,15 @@ function command(
 describe("CronJobRunner", () => {
   let tmpDir = "";
 
+  // Storage is the single canonical cron backing (fail-closed before init);
+  // give every test a live in-memory store. Reopen tests reset and reinitialize
+  // against a temp db to exercise durability.
+  beforeEach(() => {
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
   afterEach(() => {
     Bus.reset();
-    CronJobRegistry.clear();
     Storage.reset();
     if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
     tmpDir = "";
@@ -67,11 +73,11 @@ describe("CronJobRunner", () => {
   test("fires due persisted jobs and advances their next run", async () => {
     const paths = tempDbPath();
     tmpDir = paths.dir;
+    Storage.reset();
     Storage.initialize({ dbPath: paths.dbPath });
     CronJobRegistry.register(dueJob());
 
     Storage.reset();
-    CronJobRegistry.clear();
     Storage.initialize({ dbPath: paths.dbPath });
 
     const fired: CronJob.Info[] = [];
@@ -269,6 +275,7 @@ describe("CronJobRunner", () => {
   test("does not reinsert persisted jobs cancelled while firing", async () => {
     const paths = tempDbPath();
     tmpDir = paths.dir;
+    Storage.reset();
     Storage.initialize({ dbPath: paths.dbPath });
     const job = dueJob("job-persisted-cancel");
     CronJobRegistry.register(job);
@@ -303,6 +310,7 @@ describe("CronJobRunner", () => {
   test("fires a schedule.create job through CronAdapter after storage reopen", async () => {
     const paths = tempDbPath();
     tmpDir = paths.dir;
+    Storage.reset();
     Storage.initialize({ dbPath: paths.dbPath });
     const registry = new DispatchRegistry();
     registerBuiltInDispatchHandlers(registry);
@@ -318,7 +326,6 @@ describe("CronJobRunner", () => {
     if (!created) throw new Error("schedule.create did not persist a cron job");
 
     Storage.reset();
-    CronJobRegistry.clear();
     Storage.initialize({ dbPath: paths.dbPath });
 
     const received: Array<{ surface: string; mode: string; target?: string }> = [];

--- a/packages/session/src/storage/sqlite-message-adapter.ts
+++ b/packages/session/src/storage/sqlite-message-adapter.ts
@@ -1,6 +1,12 @@
 import type { Database } from "bun:sqlite";
-import type { Message } from "@openomni/protocol";
+import { Message } from "@openomni/protocol";
 import type { Storage } from "./storage";
+
+// Parse-don't-cast on read: a corrupt row is a loud typed defect, never a
+// silently-trusted value (matches the wait/blacklist precedent).
+function decodeMessage(data: string): Message.Info {
+  return Message.Info.parse(JSON.parse(data));
+}
 
 export function createSqliteMessageAdapter(db: Database): Storage.Adapter["message"] {
   return {
@@ -8,7 +14,7 @@ export function createSqliteMessageAdapter(db: Database): Storage.Adapter["messa
       const row = db
         .query("SELECT data FROM message WHERE id = ? AND session_id = ?")
         .get(messageID, sessionID) as { data: string } | null;
-      return row ? (JSON.parse(row.data) as Message.Info) : undefined;
+      return row ? decodeMessage(row.data) : undefined;
     },
 
     set: (sessionID: string, message: Message.Info): void => {
@@ -34,7 +40,7 @@ export function createSqliteMessageAdapter(db: Database): Storage.Adapter["messa
       const rows = db
         .query("SELECT data FROM message WHERE session_id = ? ORDER BY time_created ASC, rowid ASC")
         .all(sessionID) as Array<{ data: string }>;
-      return rows.map((r) => JSON.parse(r.data) as Message.Info);
+      return rows.map((r) => decodeMessage(r.data));
     },
 
     listPage: (
@@ -68,7 +74,7 @@ export function createSqliteMessageAdapter(db: Database): Storage.Adapter["messa
 
       const more = rows.length > options.limit;
       const page = more ? rows.slice(0, options.limit) : rows;
-      const items = page.map((r) => JSON.parse(r.data) as Message.Info).reverse();
+      const items = page.map((r) => decodeMessage(r.data)).reverse();
       const tail = page.at(-1);
 
       return {

--- a/packages/session/src/storage/sqlite-part-adapter.ts
+++ b/packages/session/src/storage/sqlite-part-adapter.ts
@@ -1,6 +1,12 @@
 import type { Database } from "bun:sqlite";
-import type { Message } from "@openomni/protocol";
+import { Message } from "@openomni/protocol";
 import type { Storage } from "./storage";
+
+// Parse-don't-cast on read: a corrupt row is a loud typed defect, never a
+// silently-trusted value (matches the wait/blacklist precedent).
+function decodePart(data: string): Message.Part {
+  return Message.Part.parse(JSON.parse(data));
+}
 
 export function createSqlitePartAdapter(db: Database): Storage.Adapter["part"] {
   return {
@@ -8,7 +14,7 @@ export function createSqlitePartAdapter(db: Database): Storage.Adapter["part"] {
       const row = db
         .query("SELECT data FROM part WHERE id = ? AND message_id = ?")
         .get(partID, messageID) as { data: string } | null;
-      return row ? (JSON.parse(row.data) as Message.Part) : undefined;
+      return row ? decodePart(row.data) : undefined;
     },
 
     set: (messageID: string, part: Message.Part): void => {
@@ -28,7 +34,7 @@ export function createSqlitePartAdapter(db: Database): Storage.Adapter["part"] {
       const rows = db
         .query("SELECT data FROM part WHERE message_id = ? ORDER BY rowid ASC")
         .all(messageID) as Array<{ data: string }>;
-      return rows.map((r) => JSON.parse(r.data) as Message.Part);
+      return rows.map((r) => decodePart(r.data));
     },
 
     listByMessageIDs: (messageIDs: string[]): Message.Part[] => {
@@ -38,7 +44,7 @@ export function createSqlitePartAdapter(db: Database): Storage.Adapter["part"] {
       const rows = db
         .prepare(`SELECT data FROM part WHERE message_id IN (${placeholders}) ORDER BY rowid ASC`)
         .all(...messageIDs) as Array<{ data: string }>;
-      return rows.map((r) => JSON.parse(r.data) as Message.Part);
+      return rows.map((r) => decodePart(r.data));
     },
 
     remove: (messageID: string, partID: string): boolean => {

--- a/packages/session/src/storage/sqlite-worker-grant-adapter.ts
+++ b/packages/session/src/storage/sqlite-worker-grant-adapter.ts
@@ -1,5 +1,12 @@
-import type { Communication, Storage as ProtocolStorage } from "@openomni/protocol";
+import { Communication, type Storage as ProtocolStorage } from "@openomni/protocol";
 import type { Database } from "bun:sqlite";
+
+// Parse-don't-cast on read (#authz fail-closed): a worker_grant row feeds an
+// authorization verdict, so a row that fails its schema is a loud recording/
+// corruption defect, never a silently-trusted value. Matches wait/blacklist.
+function decodeGrant(data: string): Communication.WorkerGrant.Record {
+  return Communication.WorkerGrant.Record.parse(JSON.parse(data));
+}
 
 export function createSqliteWorkerGrantAdapter(
   db: Database,
@@ -12,7 +19,7 @@ export function createSqliteWorkerGrantAdapter(
       const row = db.query("SELECT data FROM worker_grant WHERE id = ?").get(id) as {
         data: string;
       } | null;
-      return row ? (JSON.parse(row.data) as Communication.WorkerGrant.Record) : undefined;
+      return row ? decodeGrant(row.data) : undefined;
     },
     list(workerRunId) {
       const rows = workerRunId
@@ -24,7 +31,7 @@ export function createSqliteWorkerGrantAdapter(
         : (db.query("SELECT data FROM worker_grant ORDER BY time_created ASC").all() as Array<{
             data: string;
           }>);
-      return rows.map((row) => JSON.parse(row.data) as Communication.WorkerGrant.Record);
+      return rows.map((row) => decodeGrant(row.data));
     },
     set(record) {
       insertOrReplace(db, record, true);

--- a/packages/session/test/storage/read-validation.test.ts
+++ b/packages/session/test/storage/read-validation.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Message } from "@openomni/protocol";
+import { Database } from "bun:sqlite";
+import { Bus, Session, Storage, WorkerGrantStore } from "../../src/index";
+
+// A corrupt persisted row must fail closed on READ — parse-don't-cast, matching
+// the wait/blacklist precedent. worker_grant is authz-critical: an unvalidated
+// row was previously handed straight to WorkerGrantStore.evaluate. message/part
+// are the same class (blind `JSON.parse(...) as T`).
+
+function tempDbPath(): string {
+  return join(tmpdir(), `read-validation-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function removeSqliteFiles(path: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(`${path}${suffix}`);
+    } catch (_err) {
+      void _err;
+    }
+  }
+}
+
+/** Overwrite a row's JSON `data` column through a second connection. */
+function corruptRow(dbPath: string, table: string, id: string, data: string): void {
+  const raw = new Database(dbPath);
+  raw.query(`UPDATE ${table} SET data = ? WHERE id = ?`).run(data, id);
+  raw.close();
+}
+
+async function seedWorkerRun(runId: string): Promise<string> {
+  const session = Session.create({ title: runId, model: { providerID: "test", modelID: "test" } });
+  const adapter = Storage.getAdapter().workerRunState;
+  if (!adapter) throw new Error("workerRunState sub-adapter missing");
+  adapter.create(session.id, {
+    runId,
+    agentName: "worker",
+    status: "queued",
+    executorKind: "internal_chat_agent",
+    title: runId,
+    prompt: "test",
+  });
+  return session.id;
+}
+
+function userMessage(sessionID: string, id: string): Message.Info {
+  return {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "resident",
+    model: { providerID: "test", modelID: "test" },
+  };
+}
+
+function textPart(sessionID: string, messageID: string, id: string): Message.Part {
+  return { id, sessionID, messageID, type: "text", text: "hello" };
+}
+
+describe("sqlite adapters fail closed on corrupt rows", () => {
+  let dbPath = "";
+
+  beforeEach(() => {
+    Bus.reset();
+    Storage.reset();
+    dbPath = tempDbPath();
+    Storage.initialize({ dbPath });
+  });
+
+  afterEach(() => {
+    Storage.reset();
+    Bus.reset();
+    removeSqliteFiles(dbPath);
+    dbPath = "";
+  });
+
+  test("a corrupt worker_grant row rejects on read instead of reaching evaluate()", async () => {
+    await seedWorkerRun("run-corrupt");
+    WorkerGrantStore.create({
+      id: "grant-corrupt",
+      workerRunId: "run-corrupt",
+      allowedActions: ["worker.send"],
+    });
+
+    // Structurally-valid-looking but schema-invalid: missing id/workerRunId/
+    // version/timestamps. Before the fix this row parses to an object that
+    // evaluateRecord happily treats as an ACTIVE allow-all grant.
+    corruptRow(
+      dbPath,
+      "worker_grant",
+      "grant-corrupt",
+      JSON.stringify({ status: "active", allowedActions: ["worker.send"] }),
+    );
+
+    expect(() => WorkerGrantStore.get("grant-corrupt")).toThrow();
+    expect(() =>
+      WorkerGrantStore.evaluate({ workerRunId: "run-corrupt", action: "worker.send" }),
+    ).toThrow();
+  });
+
+  test("a corrupt message row rejects on read", () => {
+    const session = Session.create({
+      title: "s",
+      model: { providerID: "test", modelID: "test" },
+    });
+    Session.addMessage(session.id, userMessage(session.id, "msg-corrupt"));
+
+    corruptRow(dbPath, "message", "msg-corrupt", JSON.stringify({ role: "user" }));
+
+    expect(() => Session.getMessages(session.id)).toThrow();
+    expect(() => Storage.getAdapter().message.get(session.id, "msg-corrupt")).toThrow();
+  });
+
+  test("a corrupt part row rejects on read", () => {
+    const session = Session.create({
+      title: "s",
+      model: { providerID: "test", modelID: "test" },
+    });
+    Session.addMessage(session.id, userMessage(session.id, "msg-parts"));
+    Session.addPart("msg-parts", textPart(session.id, "msg-parts", "part-corrupt"));
+
+    corruptRow(dbPath, "part", "part-corrupt", JSON.stringify({ type: "text" }));
+
+    expect(() => Session.getParts("msg-parts")).toThrow();
+    expect(() => Storage.getAdapter().part.get("msg-parts", "part-corrupt")).toThrow();
+  });
+});


### PR DESCRIPTION
Two correctness bugs surfaced by the package quality audit (Tier-0, ship-quality — not aesthetics). Both red-first.

## BUG 4 — cron registry dual path (openomni)
`cron-job-registry.ts` wrote both a module Map AND storage, but `get`/`list` read storage only and `clear()` cleared only the Map — jobs registered before DB init were stranded/invisible, and `clear()` left storage rows. Collapsed to a single canonical backing: **storage-only, fail-closed before init** (a cron job is durable by definition; storage already zod-validates on read and fails closed post-#522; both production callers run post-init; `CronJobRunner.tick` already treats a throw as a logged Operational.Error). Red: register-before-init no longer strands; `clear()` then `list()` → empty from storage.

## BUG 5 — fail-open-on-corruption (session)
`worker_grant`/`message`/`part` adapters blind-cast `JSON.parse(row.data) as T` while `wait`/`blacklist` re-validate — a corrupt `worker_grant` row reached `evaluate()` unvalidated and fed an authorization verdict. Now parse-don't-cast via zod on read (matching the wait/blacklist precedent); a bad row is a loud typed error BEFORE `evaluate()`. Review confirmed the authz path fails **closed** (PolicyEngine catches → `fail-closed` deny, not a 500 — no DoS). Read-only scope; lifting the verdict out of session stays the separate P3 item.

## Verification

session 378 / openomni 891 / server 460 — 0 fail (+3 corruption pins, +1 cron, −1 obsolete); full gates (check-types, build, lint, check-deps, dead-exports 18/0, import-cycles 0, schema-drift) green. Adversarial review: **MERGE-SAFE** — swept the other 6 session stores (all already validate or hold no JSON blob); one out-of-scope sibling (`pending_interaction` blind-cast) filed as follow-up; upcast-on-read absence noted as a durable-store tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cron job persistence and hardens session reads against corrupt data. Cron registry is storage-only and fail-closed; session adapters validate on read so bad rows never reach auth.

- Bug Fixes
  - `openomni` cron registry
    - Removed in-memory Map; storage is the single source of truth.
    - All operations (`register/save/get/list/remove/clear`) use `Storage.cronJob`.
    - Using the registry before `Storage.initialize()` now throws (no silent fallback).
    - `clear()` now removes persisted jobs.
  - `session` sqlite adapters
    - Validate on read via zod for `worker_grant`, `message`, and `part`.
    - Corrupt rows throw; authorization fails closed (deny) instead of trusting bad data.
    - Added `read-validation.test.ts` to pin behavior.

<sup>Written for commit 35356b3db306a44c59f8923916e720555b53e2b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cron jobs now persist reliably across storage reinitialization and application restarts.
  * Clearing scheduled jobs removes all persisted entries.

* **Bug Fixes**
  * Invalid stored messages, message parts, and worker grants are now rejected instead of silently accepted.
  * Corrupt worker-grant data can no longer be evaluated.

* **Tests**
  * Added coverage for cron-job persistence, cancellation, clearing, and invalid stored data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->