### PR TITLE
fix(coordinator,ipc,protocol): worker-delivery and transport correctness

### DIFF
--- a/apps/server/src/execution/worker-runner-ipc.ts
+++ b/apps/server/src/execution/worker-runner-ipc.ts
@@ -96,11 +96,12 @@ export function createWorkerDispatchRuntime(options: {
 export function createMcpProxyProvider(options: {
   readonly toolCatalog: WorkerBootstrap.RuntimeToolCatalogEntry[];
   readonly server: WorkerRunIpcServer;
+  readonly ipcAuthToken: string;
   readonly runId: string;
   readonly sessionId: string;
   readonly workspaceRoot?: string;
 }): { listTools(): NativeTool[] } {
-  const { toolCatalog, server, runId, sessionId, workspaceRoot } = options;
+  const { toolCatalog, server, ipcAuthToken, runId, sessionId, workspaceRoot } = options;
   const callTool = async (
     toolName: string,
     toolArgs: Record<string, unknown>,
@@ -128,6 +129,7 @@ export function createMcpProxyProvider(options: {
           server.call(
             "worker.tool_call",
             {
+              authToken: ipcAuthToken,
               runId,
               sessionId,
               callId,

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -86,6 +86,7 @@ export namespace WorkerRunner {
         const mcpProxyProvider = createMcpProxyProvider({
           toolCatalog: bootstrap?.toolCatalog ?? [],
           server,
+          ipcAuthToken,
           runId,
           sessionId,
           ...(workspaceRoot ? { workspaceRoot } : {}),

--- a/apps/server/test/execution/mcp-proxy-provider.test.ts
+++ b/apps/server/test/execution/mcp-proxy-provider.test.ts
@@ -55,6 +55,7 @@ function makeProvider(
   const provider = createMcpProxyProvider({
     toolCatalog: entries,
     server,
+    ipcAuthToken: "test-ipc-token",
     runId: "run-1",
     sessionId: "session-1",
   });
@@ -99,6 +100,7 @@ describe("createMcpProxyProvider", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.method).toBe("worker.tool_call");
     expect(calls[0]?.params).toMatchObject({
+      authToken: "test-ipc-token",
       tool: "filesystem.read_file",
       input: { path: "/tmp/test.txt" },
       runId: "run-1",

--- a/packages/coordinator/src/worker-manager/worker-pool.ts
+++ b/packages/coordinator/src/worker-manager/worker-pool.ts
@@ -348,6 +348,14 @@ class WorkerPool implements WorkerManager, Execution.Driver {
   private ensureSupervisor(slot: WorkerSlot): WorkerSupervisor {
     if (slot.supervisor?.isActive() === true) return slot.supervisor;
 
+    // A non-active supervisor still occupying the slot is one that crashed and
+    // is sitting in restart backoff with its restart timer armed. Replacing it
+    // without disposing first orphans that timer — it keeps re-spawning forever
+    // and double-spawns on the slot's single socket path. dispose() flips
+    // `stopping` (which neutralizes the pending restart) and kills any lingering
+    // process, so exactly one supervisor owns the slot after this point.
+    slot.supervisor?.dispose();
+
     slot.supervisor = new WorkerSupervisor({
       id: slot.id,
       script: this.workerScript,

--- a/packages/coordinator/src/worker-supervision/supervisor-requests.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor-requests.ts
@@ -1,10 +1,11 @@
+import { Ipc } from "@openomni/protocol";
 import type {
   ActiveRequest,
   InboundWaitHandler,
   InboundWaitResult,
   ToolCallCancelParams,
   ToolCallHandler,
-  ToolCallParams,
+  ToolCallResult,
 } from "./supervisor-types.js";
 
 type RequestContext = {
@@ -81,7 +82,23 @@ function handleToolCall(
     respond(null);
     return;
   }
-  const p = params as ToolCallParams;
+  // Parse-don't-cast at the boundary (#QB1 BUG2): tool execution is the most
+  // dangerous worker verb, so a malformed frame must never throw across the
+  // handler (that TypeError crashed the coordinator). safeParse + a typed
+  // error frame keep the handler total.
+  const parsed = Ipc.Methods["worker.tool_call"].params.safeParse(params);
+  if (!parsed.success) {
+    respond(toolCallError(params, "invalid worker.tool_call params"));
+    return;
+  }
+  const p = parsed.data;
+  // Authenticate like every other worker→coordinator verb (see handleInboundWait
+  // and worker-bootstrap-handler): the env-injected token proves the request
+  // came from the worker this supervisor spawned.
+  if (p.authToken !== context.authToken) {
+    respond(toolCallError(p, "unauthorized worker request"));
+    return;
+  }
   const controller = new AbortController();
   const active: ActiveRequest = {
     runId: p.runId,
@@ -93,7 +110,17 @@ function handleToolCall(
   };
   context.activeToolCalls.set(p.callId, active);
   context
-    .toolCallHandler(p, { signal: controller.signal })
+    .toolCallHandler(
+      {
+        runId: p.runId,
+        sessionId: p.sessionId,
+        callId: p.callId,
+        tool: p.tool,
+        input: p.input,
+        ...(typeof p.workspaceRoot === "string" ? { workspaceRoot: p.workspaceRoot } : {}),
+      },
+      { signal: controller.signal },
+    )
     .then((result) => respondAndForget(context.activeToolCalls, p.callId, active, result))
     .catch((err) =>
       respondAndForget(context.activeToolCalls, p.callId, active, {
@@ -196,6 +223,15 @@ function handleInboundWait(
     .finally(() => {
       context.activeInboundWaitCalls.delete(callId);
     });
+}
+
+/** Typed rejection frame for a tool call — a Tool.Result the sender can parse. */
+function toolCallError(
+  source: Record<string, unknown> | undefined,
+  message: string,
+): ToolCallResult {
+  const callId = typeof source?.callId === "string" ? source.callId : "invalid";
+  return { id: callId, toolCallId: callId, output: message, isError: true, settlement: "unknown" };
 }
 
 function respondAndForget(

--- a/packages/coordinator/test/harness/worker-fixture.ts
+++ b/packages/coordinator/test/harness/worker-fixture.ts
@@ -76,6 +76,7 @@ const server = createIpcServer(socketPath, (method, params, respond, _notify, co
             toolCallSettlements.set(toolCallId, resolve);
           });
           toolRelayResult = await server.call("worker.tool_call", {
+            authToken: ipcAuthToken,
             runId: relayRunId,
             sessionId: "spoofed-session",
             callId: toolCallId,

--- a/packages/coordinator/test/worker-manager/ensure-supervisor.test.ts
+++ b/packages/coordinator/test/worker-manager/ensure-supervisor.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createWorkerManager, type WorkerManager } from "../../src/worker-manager";
+import { collectorPorts } from "../harness/ports";
+
+const WORKER_ENTRY = fileURLToPath(new URL("../harness/worker-fixture.ts", import.meta.url));
+const socketDir = `/tmp/omo-ensure-${process.pid}`;
+
+// White-box pool access (same seam the crash test reaches through
+// `killWorkerForTest`): `ensureSupervisor` is private and constructs a real
+// supervisor, so we drive it directly with an injected slot.
+type FakeSupervisor = { isActive: () => boolean; dispose: () => void };
+type PoolInternals = {
+  ensureSupervisor(slot: unknown): FakeSupervisor;
+  slots: Map<number, unknown>;
+};
+
+describe("ensureSupervisor replacement safety (#QB1)", () => {
+  const created: WorkerManager[] = [];
+
+  afterEach(async () => {
+    for (const m of created.splice(0)) await m.shutdown();
+  });
+
+  test("disposes the existing inactive supervisor before replacing it", () => {
+    fs.mkdirSync(socketDir, { recursive: true });
+    const manager = createWorkerManager(
+      { maxActiveWorkers: 1, workerScript: WORKER_ENTRY, socketDir },
+      collectorPorts(),
+    );
+    created.push(manager);
+    const pool = manager as unknown as PoolInternals;
+
+    let disposeCalls = 0;
+    // A supervisor that crashed and is sitting in restart backoff: inactive,
+    // but its internal restart timer is still armed. Replacing it without
+    // disposing orphans that timer (it re-spawns forever) and double-spawns
+    // on the slot's single socket path.
+    const staleSupervisor = {
+      isActive: () => false,
+      dispose: () => {
+        disposeCalls += 1;
+      },
+    };
+    const slot = {
+      id: 0,
+      ownerSessionId: "s",
+      supervisor: staleSupervisor,
+      load: 1,
+      reserved: false,
+      idleTimer: null,
+    };
+    pool.slots.set(0, slot);
+
+    const next = pool.ensureSupervisor(slot);
+    try {
+      expect(disposeCalls).toBe(1);
+      expect(slot.supervisor).toBe(next);
+      expect(slot.supervisor).not.toBe(staleSupervisor);
+    } finally {
+      // Kill the real supervisor `ensureSupervisor` spawned.
+      next.dispose();
+    }
+  });
+});

--- a/packages/coordinator/test/worker-supervision/tool-call-boundary.test.ts
+++ b/packages/coordinator/test/worker-supervision/tool-call-boundary.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "bun:test";
+import { handleWorkerRequest } from "../../src/worker-supervision/supervisor-requests";
+import type { ToolCallResult } from "../../src/worker-supervision/supervisor-types";
+
+const AUTH = "right-token";
+
+function makeCtx(over: Record<string, unknown> = {}) {
+  let handlerCalls = 0;
+  const ctx = {
+    authToken: AUTH,
+    workerId: 7,
+    activeToolCalls: new Map(),
+    activeInboundWaitCalls: new Map(),
+    toolCallHandler: async (): Promise<ToolCallResult> => {
+      handlerCalls += 1;
+      return { id: "c", toolCallId: "c", output: "ok" };
+    },
+    notifyToolCallSettled: async () => undefined,
+    ...over,
+  };
+  return { ctx, handlerCalls: () => handlerCalls };
+}
+
+const wellFormed = {
+  authToken: AUTH,
+  runId: "r",
+  sessionId: "s",
+  callId: "c",
+  tool: "fixture.tool",
+  input: {},
+};
+
+describe("worker.tool_call boundary (#QB1 BUG2)", () => {
+  test("malformed params → typed error frame, never throws across the handler", async () => {
+    const { ctx, handlerCalls } = makeCtx();
+    let result: unknown;
+    // Today `params as ToolCallParams` on undefined throws a TypeError that
+    // escapes the handler and crashes the coordinator.
+    expect(() =>
+      handleWorkerRequest(
+        "worker.tool_call",
+        undefined,
+        (r) => {
+          result = r;
+        },
+        ctx as never,
+      ),
+    ).not.toThrow();
+    await Bun.sleep(5);
+    expect(handlerCalls()).toBe(0);
+    expect(result).toMatchObject({ isError: true });
+  });
+
+  test("wrong authToken → unauthorized rejection, handler not invoked", async () => {
+    const { ctx, handlerCalls } = makeCtx();
+    let result: unknown;
+    handleWorkerRequest(
+      "worker.tool_call",
+      { ...wellFormed, authToken: "WRONG" },
+      (r) => {
+        result = r;
+      },
+      ctx as never,
+    );
+    await Bun.sleep(5);
+    expect(handlerCalls()).toBe(0);
+    expect(result).toMatchObject({ isError: true });
+  });
+
+  test("well-formed + correct authToken → handler runs, result relayed", async () => {
+    const { ctx, handlerCalls } = makeCtx();
+    let result: unknown;
+    handleWorkerRequest(
+      "worker.tool_call",
+      { ...wellFormed },
+      (r) => {
+        result = r;
+      },
+      ctx as never,
+    );
+    await Bun.sleep(5);
+    expect(handlerCalls()).toBe(1);
+    expect(result).toMatchObject({ id: "c", output: "ok" });
+  });
+});

--- a/packages/ipc/src/client.ts
+++ b/packages/ipc/src/client.ts
@@ -97,7 +97,22 @@ export function connectIpcClient(
             const respond = (result: unknown) => {
               socket.write(encode(Ipc.createResponse(request.data.id, result)));
             };
-            opts.onRequest(request.data.method, request.data.params, respond);
+            // A throwing handler must never escape the socket 'data' listener —
+            // that tears down the connection (and can crash the process). Turn
+            // it into a typed error response instead, mirroring the server side.
+            try {
+              opts.onRequest(request.data.method, request.data.params, respond);
+            } catch (err) {
+              socket.write(
+                encode(
+                  Ipc.createErrorResponse(
+                    request.data.id,
+                    1000,
+                    err instanceof Error ? err.message : String(err),
+                  ),
+                ),
+              );
+            }
           }
           continue;
         }

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -75,6 +75,10 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
   function removeConnection(id: string, reason: string): void {
     connections.delete(id);
     if (id === activeConnectionId) {
+      // Clear the pin: leaving it set to a now-dead connection wedges
+      // getActiveSocket() (it resolves the stale id, finds nothing, and never
+      // falls through to a surviving connection), so no next connection binds.
+      activeConnectionId = undefined;
       failAllPending(new IpcConnectionError(reason));
       return;
     }

--- a/packages/ipc/test/transport-resilience.test.ts
+++ b/packages/ipc/test/transport-resilience.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { connectIpcClient } from "../src/client";
+import { createIpcServer } from "../src/server";
+
+function tmpSocketPath(label: string): string {
+  return path.join(os.tmpdir(), `omo-ipc-resil-${label}-${process.pid}.sock`);
+}
+
+describe("IPC transport resilience (#QB1)", () => {
+  const servers: ReturnType<typeof createIpcServer>[] = [];
+  const clients: Awaited<ReturnType<typeof connectIpcClient>>[] = [];
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    for (const s of servers.splice(0)) s.close();
+    await Bun.sleep(10);
+  });
+
+  test("throwing onRequest handler → typed error frame, not a process crash", async () => {
+    const socketPath = tmpSocketPath("throw");
+    const srv = createIpcServer(socketPath, () => undefined);
+    servers.push(srv);
+
+    const client = await connectIpcClient(socketPath, {
+      onRequest(method, _params, respond) {
+        if (method === "boom") throw new TypeError("handler blew up");
+        respond({ ok: method });
+      },
+    });
+    clients.push(client);
+
+    // Today the throw escapes the socket 'data' listener and crashes the
+    // process; fixed, it comes back as a typed error response.
+    await expect(srv.call("boom", { x: 1 })).rejects.toThrow("handler blew up");
+
+    // Process + socket survived: a normal request still round-trips.
+    expect(await srv.call("ok")).toEqual({ ok: "ok" });
+  });
+
+  test("removing the active connection lets the next connection bind", async () => {
+    const socketPath = tmpSocketPath("active");
+    const srv = createIpcServer(socketPath, () => undefined);
+    servers.push(srv);
+
+    const c1 = await connectIpcClient(socketPath, {
+      onRequest: (_m, _p, respond) => respond({ from: "c1" }),
+    });
+    clients.push(c1);
+    await Bun.sleep(20);
+    srv.useConnection("conn-1");
+
+    const c2 = await connectIpcClient(socketPath, {
+      onRequest: (_m, _p, respond) => respond({ from: "c2" }),
+    });
+    clients.push(c2);
+    await Bun.sleep(20);
+
+    // Active connection routes to c1.
+    expect(await srv.call("ping")).toEqual({ from: "c1" });
+
+    // Drop the active connection.
+    c1.close();
+    await Bun.sleep(40);
+
+    // Fixed: activeConnectionId is cleared, so the surviving connection binds.
+    // Today it stays pinned to the dead conn-1 and this call finds no socket.
+    expect(await srv.call("ping")).toEqual({ from: "c2" });
+  });
+});

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -107,6 +107,7 @@ const methods = {
   },
   "worker.tool_call": {
     params: z.object({
+      authToken: z.string(),
       runId: z.string(),
       sessionId: z.string(),
       callId: z.string(),

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -222,6 +222,20 @@ describe("Ipc.Methods param schemas", () => {
     ).toBe(true);
   });
 
+  test("worker.tool_call requires an auth token like other worker verbs", () => {
+    const base = {
+      runId: "run-1",
+      sessionId: "session-1",
+      callId: "call-1",
+      tool: "fs.read",
+      input: { path: "/tmp/x" },
+    };
+    expect(
+      Ipc.Methods["worker.tool_call"].params.safeParse({ authToken: "t", ...base }).success,
+    ).toBe(true);
+    expect(Ipc.Methods["worker.tool_call"].params.safeParse(base).success).toBe(false);
+  });
+
   test("worker.inbound_wait_cancel params valid", () => {
     expect(
       Ipc.Methods["worker.inbound_wait_cancel"].params.safeParse({


### PR DESCRIPTION
Three Tier-0 correctness bugs in the coordinator/ipc worker-delivery+transport path, surfaced by the package quality audit. All red-first.

## BUG 1 — supervisor double-spawn / orphan timer (coordinator)
`ensureSupervisor` (`worker-pool.ts`) replaced an inactive `slot.supervisor` without teardown — a same-session re-deliver during the 1–30s restart backoff double-spawned on the slot's single socket path and orphaned a supervisor whose restart timer re-armed forever. Fix: `dispose()` the old one first (sets `stopping`, so the armed `setTimeout` callback's `if(!stopping)` re-check no-ops, and the exit-handler re-arm is blocked). Replace only happens on inactive (active returns early — no live-worker teardown).

## BUG 2 — unvalidated/unauthenticated tool_call (coordinator + protocol)
`handleToolCall` did `params as ToolCallParams` with no auth — a malformed `worker.tool_call` threw an uncaught TypeError (coordinator crash) on the most dangerous verb, and a forged frame still executed. Fix: `safeParse` the canonical zod schema + verify the env-injected `authToken` (the precedent from the other authenticated verbs); malformed/forged → typed `Tool.Result` error frame, never a throw. Added `authToken` to the `worker.tool_call` protocol schema (the only worker verb missing it) and threaded it through the sole producer (mcp-proxy sender).

## BUG 3 — transport crash + connection wedge (ipc)
Client `onRequest` wasn't wrapped (a throwing handler tore down the connection) and `removeConnection` never cleared `activeConnectionId` on the active-removed branch (later connections couldn't bind). Fix: wrap onRequest dispatch → correlated typed error response (same requestId, caller rejects instead of hanging); clear `activeConnectionId` on active-removed so the next connection binds.

BUG 2 and 3 compose as defense-in-depth: the ipc catch (3) contains the crash class, the verb-level parse+auth (2) is the primary control that rejects forged calls before any execution.

## Verification

coordinator 44 / ipc 30 / server 461 — 0 fail (all red-first pins verified failing on base); check-types, build, lint, check-deps, dead-exports (18/0), import-cycles (0) green; coverage rose on all four touched packages. Adversarial review: **MERGE-SAFE** (dispose timer-neutralization verified, authToken producer sweep clean, wedge handoff correct; one MINOR — non-constant-time token compare, consistent with every other worker verb — accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three critical correctness issues across coordinator, protocol, and IPC to stop crashes, double-spawns, and wedged connections. Tool calls are now validated and authenticated, and IPC survives handler errors and connection turnover.

- **Bug Fixes**
  - Coordinator: dispose inactive supervisors before replacement to avoid orphaned restart timers and double-spawns.
  - Protocol/Coordinator: validate `worker.tool_call` params with schema and require `authToken`; reject malformed/forged calls with a typed error instead of throwing.
  - IPC: guard client `onRequest` to return typed errors on throw, and clear `activeConnectionId` when removing the active connection so the next client can bind.

- **Migration**
  - `worker.tool_call` now requires `authToken` in params. Update any custom senders to include the token (the built-in MCP proxy now threads it through).

<sup>Written for commit 5ab1628c094a542e83fb77c511cf0bfb339d5689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

