### PR TITLE
fix(agent,session): eliminate cast launder, split budget query/command, sanctioned telemetry accessor

### DIFF
--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -33,10 +33,23 @@ export function effectiveBudgetThresholds(budget?: AgentProfile.BudgetThresholdI
   };
 }
 
-export function checkBudget(
-  state: BudgetState,
-  budget?: AgentBudget,
-): "ok" | "reassurance" | "warning" | "exceeded" {
+export type BudgetStatus = "ok" | "reassurance" | "warning" | "exceeded";
+
+type ExceededLimit = "wall time" | "turns" | "tool calls" | "tool wall time";
+
+interface BudgetEvaluation {
+  readonly status: BudgetStatus;
+  readonly elapsedMs: number;
+  readonly maxRatio: number;
+  readonly exceededLimit?: ExceededLimit;
+}
+
+/**
+ * Pure evaluator: the sole source of the 4-state budget verdict and the facts
+ * telemetry needs. No Bus emit, no mutation — see {@link checkBudget} (query)
+ * and {@link publishBudgetTelemetry} (command) for the split callers.
+ */
+function evaluateBudget(state: BudgetState, budget?: AgentBudget): BudgetEvaluation {
   const maxWallTimeMs = budget?.maxWallTimeMs ?? 5 * 60 * 1000;
   const maxTurns = budget?.maxTurns ?? 24;
   const maxToolCalls = budget?.maxToolCalls ?? 40;
@@ -44,81 +57,73 @@ export function checkBudget(
   const { warningThreshold: warningRatio, reassuranceThreshold: reassuranceRatio } =
     effectiveBudgetThresholds(budget);
 
-  const elapsed = Date.now() - state.startTime;
+  const elapsedMs = Date.now() - state.startTime;
 
-  if (maxWallTimeMs !== -1 && elapsed >= maxWallTimeMs) {
-    Bus.publish(Operational.Warn, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "agent.budget",
-      msg: "budget exceeded: wall time",
-      context: {
-        type: "exceeded",
-        turns: state.turns,
-        toolCalls: state.toolCalls,
-        wallTimeMs: elapsed,
-      },
-    });
-    return "exceeded";
-  }
-  if (maxTurns !== -1 && state.turns >= maxTurns) {
-    Bus.publish(Operational.Warn, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "agent.budget",
-      msg: "budget exceeded: turns",
-      context: {
-        type: "exceeded",
-        turns: state.turns,
-        toolCalls: state.toolCalls,
-        wallTimeMs: elapsed,
-      },
-    });
-    return "exceeded";
-  }
-  if (maxToolCalls !== -1 && state.toolCalls >= maxToolCalls) {
-    Bus.publish(Operational.Warn, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "agent.budget",
-      msg: "budget exceeded: tool calls",
-      context: {
-        type: "exceeded",
-        turns: state.turns,
-        toolCalls: state.toolCalls,
-        wallTimeMs: elapsed,
-      },
-    });
-    return "exceeded";
-  }
+  const exceeded = (exceededLimit: ExceededLimit): BudgetEvaluation => ({
+    status: "exceeded",
+    elapsedMs,
+    maxRatio: 1,
+    exceededLimit,
+  });
+
+  if (maxWallTimeMs !== -1 && elapsedMs >= maxWallTimeMs) return exceeded("wall time");
+  if (maxTurns !== -1 && state.turns >= maxTurns) return exceeded("turns");
+  if (maxToolCalls !== -1 && state.toolCalls >= maxToolCalls) return exceeded("tool calls");
   if (maxToolRuntimeMs !== -1 && state.toolRuntimeMs >= maxToolRuntimeMs) {
-    Bus.publish(Operational.Warn, {
-      traceId: crypto.randomUUID(),
-      time: Date.now(),
-      component: "agent.budget",
-      msg: "budget exceeded: tool wall time",
-      context: {
-        type: "exceeded",
-        turns: state.turns,
-        toolCalls: state.toolCalls,
-        wallTimeMs: elapsed,
-        toolRuntimeMs: state.toolRuntimeMs,
-      },
-    });
-    return "exceeded";
+    return exceeded("tool wall time");
   }
 
   const ratios: number[] = [];
-  if (maxWallTimeMs !== -1) ratios.push(elapsed / maxWallTimeMs);
+  if (maxWallTimeMs !== -1) ratios.push(elapsedMs / maxWallTimeMs);
   if (maxTurns !== -1) ratios.push(state.turns / maxTurns);
   if (maxToolCalls !== -1) ratios.push(state.toolCalls / maxToolCalls);
   if (maxToolRuntimeMs !== -1) ratios.push(state.toolRuntimeMs / maxToolRuntimeMs);
 
-  if (ratios.length === 0) return "ok";
+  if (ratios.length === 0) return { status: "ok", elapsedMs, maxRatio: 0 };
 
   const maxRatio = Math.max(...ratios);
+  if (maxRatio >= warningRatio) return { status: "warning", elapsedMs, maxRatio };
+  if (maxRatio >= reassuranceRatio) return { status: "reassurance", elapsedMs, maxRatio };
+  return { status: "ok", elapsedMs, maxRatio };
+}
 
-  if (maxRatio >= warningRatio) {
+/**
+ * Query (pure): the budget status. Emits nothing — callers that want the
+ * observability telemetry call {@link publishBudgetTelemetry}. This split
+ * lets the run.turn.pre budget builtins read the status as a predicate
+ * without each re-emitting the per-turn telemetry event (double-effect).
+ */
+export function checkBudget(state: BudgetState, budget?: AgentBudget): BudgetStatus {
+  return evaluateBudget(state, budget).status;
+}
+
+/**
+ * Command: emit the budget observability telemetry once and return the status
+ * for the caller to act on. Invoked from the per-turn lifecycle check so the
+ * event fires exactly once per turn, never once per policy that reads it.
+ */
+export function publishBudgetTelemetry(state: BudgetState, budget?: AgentBudget): BudgetStatus {
+  const evaluation = evaluateBudget(state, budget);
+
+  if (evaluation.status === "exceeded") {
+    Bus.publish(Operational.Warn, {
+      traceId: crypto.randomUUID(),
+      time: Date.now(),
+      component: "agent.budget",
+      msg: `budget exceeded: ${evaluation.exceededLimit}`,
+      context: {
+        type: "exceeded",
+        turns: state.turns,
+        toolCalls: state.toolCalls,
+        wallTimeMs: evaluation.elapsedMs,
+        ...(evaluation.exceededLimit === "tool wall time"
+          ? { toolRuntimeMs: state.toolRuntimeMs }
+          : {}),
+      },
+    });
+    return evaluation.status;
+  }
+  if (evaluation.status === "warning") {
     Bus.publish(Operational.Warn, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
@@ -127,12 +132,12 @@ export function checkBudget(
       context: {
         type: "warning",
         remaining: describeBudgetRemaining(state, budget),
-        ratio: maxRatio.toFixed(2),
+        ratio: evaluation.maxRatio.toFixed(2),
       },
     });
-    return "warning";
+    return evaluation.status;
   }
-  if (maxRatio >= reassuranceRatio) {
+  if (evaluation.status === "reassurance") {
     Bus.publish(Operational.Info, {
       traceId: crypto.randomUUID(),
       time: Date.now(),
@@ -141,12 +146,11 @@ export function checkBudget(
       context: {
         type: "reassurance",
         remaining: describeBudgetRemaining(state, budget),
-        ratio: maxRatio.toFixed(2),
+        ratio: evaluation.maxRatio.toFixed(2),
       },
     });
-    return "reassurance";
   }
-  return "ok";
+  return evaluation.status;
 }
 
 export function describeBudgetRemaining(state: BudgetState, budget?: AgentBudget): string {

--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -1,6 +1,6 @@
 import { PolicyDecision, type Run } from "@openomni/protocol";
 import { effectOf, PolicyEffectApplier } from "./policy-effects";
-import { checkBudget } from "../budget";
+import { publishBudgetTelemetry } from "../budget";
 import type { PolicyEngineInstance } from "../policy";
 import type { AgentEvent, ChatAgentConfig } from "../types";
 import {
@@ -46,7 +46,10 @@ export async function dispatchBudgetCheck(
   config: ChatAgentConfig,
   agentBase: AgentRunBase = agentBaseForState(state),
 ): Promise<AgentEvent | null> {
-  const budgetStatus = checkBudget(state.budgetState, config.budget);
+  // The single per-turn owner of budget telemetry: emit here (command) and act
+  // on the returned status. The run.turn.pre budget builtins read the status
+  // via the pure checkBudget query, so the event is not re-emitted per policy.
+  const budgetStatus = publishBudgetTelemetry(state.budgetState, config.budget);
   if (budgetStatus !== "exceeded") return null;
 
   const postRunDecision = await engine.dispatchPoint(

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -407,8 +407,11 @@ async function dispatchToolPost(
       ...input,
       ...(target.mcpServerId === undefined ? {} : { mcpServerId: target.mcpServerId }),
     };
-    // See dispatchToolPre: the single-field narrowing is confined to the one
-    // runtime-resolved boundary value; absence is denied by the point contract.
+    // Single-field narrowing as in dispatchToolPre. tool.mcp.post is a
+    // FAIL-OPEN post boundary (defaultFailPolicy "fail-open"), so an absent
+    // mcpServerId → context_missing → ALLOW, not deny. That is acceptable here:
+    // post is a post-hoc observation point, not an authorization gate — the
+    // gate already ran at the fail-closed tool.mcp.pre.
     return engine.dispatchPoint(
       "tool.mcp.post",
       mcpInput as typeof mcpInput & { mcpServerId: string },

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -365,10 +365,19 @@ async function dispatchToolPre(
     resourceDescriptor: target.descriptor,
   };
   if (target.kind === "mcp") {
-    return engine.dispatchPoint("tool.mcp.pre", {
+    const mcpInput = {
       ...input,
       ...(target.mcpServerId === undefined ? {} : { mcpServerId: target.mcpServerId }),
-    } as unknown as Policy.PolicyPointInputMap["tool.mcp.pre"] & PolicyContext);
+    };
+    // Invariant: an mcp target carries a string mcpServerId (resolved from the
+    // resource source or an `mcp.` label). When it is genuinely absent the
+    // engine's tool.mcp.pre point contract denies fail-closed (context_missing).
+    // Narrow ONLY that one boundary field — every other field is checked against
+    // the point input type exactly as the native branch below is.
+    return engine.dispatchPoint(
+      "tool.mcp.pre",
+      mcpInput as typeof mcpInput & { mcpServerId: string },
+    );
   }
   return engine.dispatchPoint("tool.native.pre", input);
 }
@@ -394,10 +403,16 @@ async function dispatchToolPost(
     resourceDescriptor: target.descriptor,
   };
   if (target.kind === "mcp") {
-    return engine.dispatchPoint("tool.mcp.post", {
+    const mcpInput = {
       ...input,
       ...(target.mcpServerId === undefined ? {} : { mcpServerId: target.mcpServerId }),
-    } as unknown as Policy.PolicyPointInputMap["tool.mcp.post"] & PolicyContext);
+    };
+    // See dispatchToolPre: the single-field narrowing is confined to the one
+    // runtime-resolved boundary value; absence is denied by the point contract.
+    return engine.dispatchPoint(
+      "tool.mcp.post",
+      mcpInput as typeof mcpInput & { mcpServerId: string },
+    );
   }
   return engine.dispatchPoint("tool.native.post", input);
 }

--- a/packages/agent/test/core/budget.test.ts
+++ b/packages/agent/test/core/budget.test.ts
@@ -1,10 +1,30 @@
 import { describe, expect, it } from "bun:test";
+import { Operational } from "@openomni/protocol";
+import { Bus } from "@openomni/session";
 import {
   checkBudget,
   describeBudgetRemaining,
   createBudgetState,
   effectiveBudgetThresholds,
+  publishBudgetTelemetry,
 } from "../../src/core/budget";
+
+async function countOperationalEmits(run: () => void): Promise<number> {
+  Bus.reset();
+  let count = 0;
+  const unsubWarn = Bus.subscribe(Operational.Warn, () => {
+    count += 1;
+  });
+  const unsubInfo = Bus.subscribe(Operational.Info, () => {
+    count += 1;
+  });
+  run();
+  // Bus delivers on a microtask; a macrotask turn flushes all pending handlers.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  unsubWarn();
+  unsubInfo();
+  return count;
+}
 
 describe("effectiveBudgetThresholds", () => {
   it("uses protocol-owned defaults and runtime-local resolution", () => {
@@ -71,6 +91,47 @@ describe("checkBudget 4-state", () => {
     expect(checkBudget(s, { maxTurns: 24, warningThreshold: 0.9, reassuranceThreshold: 0.7 })).toBe(
       "reassurance",
     );
+  });
+});
+
+describe("checkBudget is a pure query (query/command split)", () => {
+  it("emits no telemetry even called twice at the warning threshold", async () => {
+    const s = { ...createBudgetState(), turns: 20 };
+    const emits = await countOperationalEmits(() => {
+      checkBudget(s, { maxTurns: 24 });
+      checkBudget(s, { maxTurns: 24 });
+    });
+    expect(emits).toBe(0);
+  });
+
+  it("emits no telemetry at the exceeded threshold", async () => {
+    const s = { ...createBudgetState(), turns: 24 };
+    const emits = await countOperationalEmits(() => {
+      checkBudget(s, { maxTurns: 24 });
+    });
+    expect(emits).toBe(0);
+  });
+});
+
+describe("publishBudgetTelemetry is the command (emits once, returns status)", () => {
+  it("emits exactly one event per call at the warning threshold", async () => {
+    const s = { ...createBudgetState(), turns: 20 };
+    let status: string | undefined;
+    const emits = await countOperationalEmits(() => {
+      status = publishBudgetTelemetry(s, { maxTurns: 24 });
+    });
+    expect(status).toBe("warning");
+    expect(emits).toBe(1);
+  });
+
+  it("emits nothing below the reassurance threshold", async () => {
+    const s = { ...createBudgetState(), turns: 5 };
+    let status: string | undefined;
+    const emits = await countOperationalEmits(() => {
+      status = publishBudgetTelemetry(s, { maxTurns: 24 });
+    });
+    expect(status).toBe("ok");
+    expect(emits).toBe(0);
   });
 });
 

--- a/packages/agent/test/core/execution/tool-executor-verdicts.test.ts
+++ b/packages/agent/test/core/execution/tool-executor-verdicts.test.ts
@@ -441,6 +441,29 @@ describe("createToolExecutor effect application", () => {
     expect(capturedSources).toEqual(["mcp"]);
   });
 
+  it("denies a tool.mcp.pre with an absent mcpServerId (context_missing, fail-closed)", async () => {
+    // Pins the invariant the narrowed `& { mcpServerId: string }` cast in
+    // dispatchToolPre relies on: an mcp target with no resolvable server id
+    // (source.mcp label but no `mcp.<id>` label) omits mcpServerId, so the
+    // fail-closed tool.mcp.pre contract denies via context_missing BEFORE the
+    // tool runs — never a silent allow.
+    let invoked = 0;
+    const executor = createToolExecutor({
+      engine: PolicyEngine.create(),
+      getToolLabels: () => ["source.mcp"],
+      toolExecutor: async (call) => {
+        invoked += 1;
+        return { id: "r", toolCallId: call.id, output: "should not run" };
+      },
+    });
+
+    const result = await executor({ id: "mcp-no-server", tool: "fixture_read", input: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("[Denied:");
+    expect(invoked).toBe(0);
+  });
+
   describe("invoke.result run.abort propagation", () => {
     it("invoke.result deny with run.abort returns blocked result", async () => {
       let calls = 0;

--- a/packages/session/src/bus-persistence/database.ts
+++ b/packages/session/src/bus-persistence/database.ts
@@ -1,14 +1,12 @@
 import type { Database } from "bun:sqlite";
 import { Storage } from "../storage/storage.js";
-import type { PersistableAdapter } from "./types.js";
 
 // Telemetry writes AND reads ride the telemetry connection (#510 D1) —
 // bus_event traffic never contends with the FULL decision connection under
-// WAL. (merged from query-database.ts: the query-side accessor was the same
-// handle with the same fallback.)
+// WAL. The adapter's telemetryConnection() is the single sanctioned path to
+// the handle; no consumer casts past the adapter's private fields.
 export function getDatabase(): Database {
-  const adapter = Storage.getAdapter() as PersistableAdapter;
-  const db = adapter.telemetryDb ?? adapter.db;
+  const db = Storage.getAdapter().telemetryConnection?.();
   if (db === undefined) {
     throw new Error("BusPersistence requires a SQLite-backed storage adapter");
   }
@@ -16,6 +14,5 @@ export function getDatabase(): Database {
 }
 
 export function getOptionalDatabase(): Database | undefined {
-  const adapter = Storage.getAdapter() as PersistableAdapter;
-  return adapter.telemetryDb ?? adapter.db;
+  return Storage.getAdapter().telemetryConnection?.();
 }

--- a/packages/session/src/bus-persistence/types.ts
+++ b/packages/session/src/bus-persistence/types.ts
@@ -1,16 +1,4 @@
-import type { Database } from "bun:sqlite";
 import type { Bus } from "../bus/index.js";
-
-export interface PersistableAdapter {
-  readonly db?: Database;
-  /**
-   * #510 D1 durability split: the NORMAL/group-commit telemetry connection
-   * (same file, own connection). Telemetry writes prefer it so they can
-   * never join a decision-class transaction on `db`; absent (in-memory
-   * degradation or a foreign adapter) they fall back to `db`.
-   */
-  readonly telemetryDb?: Database;
-}
 
 export interface RuntimeState {
   readonly unsubscribe: () => void;

--- a/packages/session/src/storage/sqlite-storage.ts
+++ b/packages/session/src/storage/sqlite-storage.ts
@@ -111,6 +111,16 @@ export class SqliteStorageAdapter implements Storage.Adapter {
     this.appConnectorInstallation = createSqliteAppConnectorInstallationAdapter(this.db);
   }
 
+  /**
+   * #510 D1: the sanctioned accessor to the telemetry connection for
+   * bus-persistence — never exposes the private handle for casting. Always the
+   * telemetry connection (which IS `db` for `:memory:`), so it already encodes
+   * the "prefer telemetry, fall back to primary" resolution.
+   */
+  telemetryConnection(): Database {
+    return this.telemetryDb;
+  }
+
   clear(): void {
     clearSqliteStorage(this.db);
   }

--- a/packages/session/src/storage/storage.ts
+++ b/packages/session/src/storage/storage.ts
@@ -1,3 +1,4 @@
+import type { Database } from "bun:sqlite";
 import type { Message, Storage as ProtocolStorage, WorkItem } from "@openomni/protocol";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createWorkItemCompletionWriter } from "../work-item/completion-writer.js";
@@ -27,6 +28,15 @@ export namespace Storage {
 
   export interface Adapter {
     transaction<T>(operation: () => T): T;
+    /**
+     * #510 D1: the telemetry connection (NORMAL/group-commit) that
+     * bus-persistence reads and writes ride — the sanctioned accessor for the
+     * underlying SQLite handle so consumers never cast past `private` fields
+     * to reach it. Returns the primary connection when no split exists
+     * (`:memory:`). Absent on non-SQLite adapters; BusPersistence fails closed
+     * (getDatabase throws) or degrades to a no-op (getOptionalDatabase).
+     */
+    telemetryConnection?(): Database;
     session: {
       get(id: string): SessionInfo | undefined;
       set(id: string, info: SessionInfo): void;


### PR DESCRIPTION
Three A-blocking non-P3 defects from the package quality audit (agent A−→A, session surface cleanup).

## agent — cast launder eliminated
`tool-executor.ts` mcp dispatch used `as unknown as X & PolicyContext` on both branches — laundering the ENTIRE object through `unknown` (disabling all field checks) while falsely asserting presence. Narrowed to the one genuine boundary gap: `mcpInput as typeof mcpInput & { mcpServerId: string }` — TS now structurally checks every other field; only the runtime-resolved `mcpServerId` is asserted, and that's sound because `tool.mcp.pre` is fail-closed (absent id → context_missing → deny, now pinned by a new test). Native branch needs no cast (asymmetry is inherent to the schema, not a smell). Post-boundary comment corrected (post is fail-OPEN, not deny).

## agent — budget query/command split
`checkBudget` returned a status (query) while `Bus.publish`-ing telemetry (command) — called 3× per turn → up to 3 duplicate threshold events. Extracted pure `evaluateBudget`; `checkBudget` is now a pure query (builtins unchanged), telemetry relocated to one `publishBudgetTelemetry` call in the per-turn lifecycle owner → fires exactly once/turn. Review verified the surviving emit is byte-identical to the old duplicates (content depends on state, not caller). Red-first purity pins.

## session — sanctioned telemetry accessor
Replaced `getAdapter() as PersistableAdapter` reaching into `private readonly telemetryDb` with a first-class `telemetryConnection()` on the Storage.Adapter interface; deleted the `PersistableAdapter` interface (0 references repo-wide). Optional on the interface (test/bare adapters omit it; `getDatabase` fails closed, `getOptionalDatabase` guards — no prod fail-open since only SqliteStorageAdapter is used in production).

## Verification

agent 389 / session 442 — 0 fail; check-types 13/13, build, lint, check-deps, dead-exports (18/0), import-cycles 0, schema-drift green. Adversarial review: **MERGE-SAFE** (cast is the honest minimal escape, budget equivalence traced, accessor fail-open ruled out; the two MINORs it found — post-comment + missing deny pin — folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three audit blockers: safer MCP tool dispatch typing, a budget query/telemetry split to stop duplicate events, and a sanctioned telemetry DB accessor in session storage.

- **Bug Fixes**
  - Agent: Narrowed MCP dispatch cast to `mcpServerId` only; `tool.mcp.pre` denies missing id (test added); corrected note that `tool.mcp.post` is fail-open.
  - Agent: Split budget query/command. `checkBudget` is now pure; added `publishBudgetTelemetry` and call it once per turn from lifecycle so events fire once/turn with identical payloads; tests pin zero duplicates.
  - Session: Added `Storage.Adapter.telemetryConnection()` to expose the telemetry SQLite handle and removed private-field casts; deleted `PersistableAdapter`; bus persistence now uses the accessor and fails closed when unavailable.

<sup>Written for commit 623d2979c0e082da349ca33dcd97dddcfe25f22c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

