### PR TITLE
refactor(openomni): wire dispatch action constants (#497)

### DIFF
--- a/packages/openomni/src/dispatch/handlers/schedule.ts
+++ b/packages/openomni/src/dispatch/handlers/schedule.ts
@@ -1,4 +1,4 @@
-import { CronJob, type Dispatch } from "@openomni/protocol";
+import { CronJob, Dispatch } from "@openomni/protocol";
 import type { DispatchSchedulerOwner } from "../owners.js";
 import type { DispatchHandler } from "../registry.js";
 import { extractText } from "../../ingress/handlers.js";
@@ -42,9 +42,12 @@ function scheduleTarget(command: Dispatch.Command): CronJob.Target {
 
 export function createScheduleDispatchHandlers(
   options: ScheduleDispatchHandlerOptions = {},
-): Record<"schedule.create" | "schedule.cancel", DispatchHandler> {
+): Record<
+  typeof Dispatch.Actions.ScheduleCreate | typeof Dispatch.Actions.ScheduleCancel,
+  DispatchHandler
+> {
   return {
-    "schedule.create"(command) {
+    [Dispatch.Actions.ScheduleCreate](command) {
       const scheduler = requireScheduler(options.scheduler);
       const schedule = scheduleFromPayload(command);
       if (!schedule) throw new Error("schedule.create requires payload.schedule");
@@ -67,7 +70,7 @@ export function createScheduleDispatchHandlers(
       return { output: { scheduled: true, jobId, messageId: jobId } };
     },
 
-    "schedule.cancel"(command) {
+    [Dispatch.Actions.ScheduleCancel](command) {
       const scheduler = requireScheduler(options.scheduler);
       const jobId = command.target.id ?? command.target.name;
       if (!jobId) throw new Error("schedule.cancel requires target.id");

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -1,4 +1,4 @@
-import { Execution, type Dispatch, type Model, type WorkItem } from "@openomni/protocol";
+import { Dispatch, Execution, type Model, type WorkItem } from "@openomni/protocol";
 import { WorkItemAttemptRun, WorkItemStore } from "@openomni/session";
 import { z } from "zod";
 import { VerifierRegistry } from "../../evidence/verifier-registry.js";
@@ -155,11 +155,11 @@ function assertWorkerCompletionWorkItemAuthority(
 export function createWorkerDispatchHandlers(
   options: WorkerDispatchHandlerOptions = {},
 ): Record<
-  | "worker.spawn"
-  | "worker.complete"
-  | "worker.send"
-  | "worker.resume"
-  | "worker.cancel"
+  | typeof Dispatch.Actions.WorkerSpawn
+  | typeof Dispatch.Actions.WorkerComplete
+  | typeof Dispatch.Actions.WorkerSend
+  | typeof Dispatch.Actions.WorkerResume
+  | typeof Dispatch.Actions.WorkerCancel
   | "actor.reply",
   DispatchHandler
 > {
@@ -167,7 +167,7 @@ export function createWorkerDispatchHandlers(
   const policyResolver = options.policyResolver ?? PolicyResolver.create();
   const verifierRegistry = options.verifierRegistry ?? VerifierRegistry.create();
   return {
-    async "worker.spawn"(command) {
+    async [Dispatch.Actions.WorkerSpawn](command) {
       const payload = parseWorkerSpawnPayload(command.payload);
       if (isConnectorEndpointTarget(command.target)) {
         return handleConnectorEndpointWorkerSpawn(command, model, payload, {
@@ -247,7 +247,7 @@ export function createWorkerDispatchHandlers(
       };
     },
 
-    async "worker.complete"(command) {
+    async [Dispatch.Actions.WorkerComplete](command) {
       const payload = parseWorkerCompletePayload(command.payload);
       assertWorkerCompletionActorAuthority(command, payload);
       const workItem = resolveCompletedWorkItem(command, payload);
@@ -302,7 +302,7 @@ export function createWorkerDispatchHandlers(
       };
     },
 
-    async "worker.send"(command) {
+    async [Dispatch.Actions.WorkerSend](command) {
       const coordinator = requireCoordinator(options.coordinator);
       if (!coordinator.deliverMessage) {
         throw new Error("dispatch worker.send requires coordinator.deliverMessage owner");
@@ -317,7 +317,7 @@ export function createWorkerDispatchHandlers(
       return { output: { delivered: true, sessionId, runId: targetRunId(command), result } };
     },
 
-    async "worker.resume"(command) {
+    async [Dispatch.Actions.WorkerResume](command) {
       const coordinator = requireCoordinator(options.coordinator);
       if (!coordinator.deliverMessage) {
         throw new Error("dispatch worker.resume requires coordinator.deliverMessage owner");
@@ -332,7 +332,7 @@ export function createWorkerDispatchHandlers(
       return { output: { resumed: true, sessionId, runId: targetRunId(command), result } };
     },
 
-    async "worker.cancel"(command) {
+    async [Dispatch.Actions.WorkerCancel](command) {
       const coordinator = requireCoordinator(options.coordinator);
       if (!coordinator.cancelRun) {
         throw new Error("dispatch worker.cancel requires coordinator.cancelRun owner");


### PR DESCRIPTION
## What

Pure wiring for #497. The `Dispatch.Actions` constants are the canonical action identifiers, but the worker/schedule dispatch-handler records hard-coded the same raw string literals as object keys. This wires them via computed keys and `typeof` return-type unions, matching the `device.ts` reference idiom (`[Dispatch.Actions.DeviceCommand]: ...`).

Handler keys now reference the constants (#497):
- `Dispatch.Actions.WorkerSpawn`
- `Dispatch.Actions.WorkerComplete` (wired alongside for coherence — already-live)
- `Dispatch.Actions.WorkerSend`
- `Dispatch.Actions.WorkerResume`
- `Dispatch.Actions.WorkerCancel`
- `Dispatch.Actions.ScheduleCreate`
- `Dispatch.Actions.ScheduleCancel`

## Guarantees

- **No deletions, no behavior change.** Computed keys resolve to the identical string values (`"worker.spawn"`, `"schedule.create"`, …), so `registerBuiltInDispatchHandlers` (which spreads these records and registers by `Object.entries` key) produces unchanged runtime registry keys.
- **No error-message strings touched.** User-facing strings that merely mention `worker.spawn` / `schedule.create` (e.g. `throw new Error("schedule.create requires payload.schedule")`) are untouched — only the handler-object KEYS and their return-type unions changed.
- `Dispatch` switched from a `type`-only import to a value import in both files (`worker.ts`, `schedule.ts`) so `Dispatch.Actions.*` is available at runtime.
- `"actor.reply"` in the worker return-type union is retained as-is (out of scope for this leaf; dropping it would break compilation since the record still returns that handler).

## Gates (all green)

- `bun run build` — 5/5
- `bun run check-types` — 13/13
- `bunx biome check packages apps script` — clean
- `bun run script/check-deps.ts` — OK
- `bun test --timeout 15000` on dispatch + cron-job-runner + dispatch-tool suites — 200 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires worker and schedule dispatch handler keys to Dispatch.Actions constants to canonicalize action identifiers and tighten typing. Runtime behavior and registry keys are unchanged.

- Replaces string-literal keys with computed keys for WorkerSpawn, WorkerComplete, WorkerSend, WorkerResume, WorkerCancel, ScheduleCreate, and ScheduleCancel in packages/openomni/src/dispatch/handlers/worker.ts and .../schedule.ts, matching the device.ts pattern and addressing #497.
- Updates record return-type unions to use typeof Dispatch.Actions.*; retains "actor.reply".
- Switches Dispatch to a value import from `@openomni/protocol`; no other strings change.
- No migration required; callers use the same action strings and see identical error messages.

<sup>Written for commit c18351534aeec3c9364d7fe77fbd956ecad36997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

