### PR TITLE
refactor(protocol): drop dead ingress/message/actor members (#497)

### DIFF
--- a/packages/protocol/src/actor/index.ts
+++ b/packages/protocol/src/actor/index.ts
@@ -1,14 +1,7 @@
 import { z } from "zod";
 
 export namespace Actor {
-  export const Kind = z.enum([
-    "human",
-    "ai_agent",
-    "service",
-    "resident",
-    "internal_worker",
-    "system",
-  ]);
+  const Kind = z.enum(["human", "ai_agent", "service", "resident", "internal_worker", "system"]);
   export type Kind = z.infer<typeof Kind>;
 
   export const TrustTier = z.enum([

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -90,17 +90,14 @@ const MetaSchemaImpl = z
 export namespace Ingress {
   export const ActorSchema = ActorSchemaImpl;
   export type Actor = z.infer<typeof ActorSchema>;
-  export type ActorMetadata = Actor;
 
   export const TargetSchema = TargetSchemaImpl;
   export type Target = z.infer<typeof TargetSchema>;
 
   export const MetaSchema = MetaSchemaImpl;
   export type Meta = z.infer<typeof MetaSchema>;
-  export type EventMetadata = Meta;
 
-  export const ActivationMetadataSchema = ActivationMetadataSchemaImpl;
-  export type ActivationMetadata = z.infer<typeof ActivationMetadataSchema>;
+  export type ActivationMetadata = z.infer<typeof ActivationMetadataSchemaImpl>;
 
   export const AgentDefSchema = z
     .object({
@@ -154,12 +151,10 @@ export namespace Ingress {
     DirectEventSchema,
     InternalEventSchema,
   ]);
-  export const ExternalInboundEventSchema = DirectEventSchema;
   export type InboundEvent = DirectEvent | InternalEvent;
-  export type ExternalInboundEvent = DirectEvent;
   export type ResolvedInboundEvent = DirectEvent | (InternalEvent & { agent: AgentDef });
 
-  export type DirectResult = {
+  type DirectResult = {
     output: string;
     finishReason: string;
   };

--- a/packages/protocol/src/message/index.ts
+++ b/packages/protocol/src/message/index.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { APIError } from "../error/index.js";
 import { Token } from "../token/index.js";
 import { Tool } from "../tool/index.js";
 
@@ -59,16 +58,6 @@ export namespace Message {
   });
   export type StepFinishPart = z.infer<typeof StepFinishPart>;
 
-  export const RetryPart = PartBase.extend({
-    type: z.literal("retry"),
-    attempt: z.number(),
-    error: APIError.Schema,
-    time: z.object({
-      created: z.number(),
-    }),
-  });
-  export type RetryPart = z.infer<typeof RetryPart>;
-
   export const ToolPart = PartBase.extend({
     type: z.literal("tool"),
     callID: z.string(),
@@ -82,7 +71,6 @@ export namespace Message {
     ReasoningPart,
     StepStartPart,
     StepFinishPart,
-    RetryPart,
     ToolPart,
   ]);
   export type Part = z.infer<typeof Part>;

--- a/packages/protocol/src/transcript/fold.ts
+++ b/packages/protocol/src/transcript/fold.ts
@@ -142,7 +142,6 @@ function isAppendableInitialState(part: Message.Part): boolean {
       return part.time?.end === undefined;
     case "step-start":
     case "step-finish":
-    case "retry":
       return true;
   }
 }
@@ -160,7 +159,6 @@ function advancePart(
       return advanceTextLikePart(part, transition);
     case "step-start":
     case "step-finish":
-    case "retry":
       // Punctual parts: appended whole, never advanced.
       return undefined;
   }

--- a/packages/protocol/test/ingress-internal.test.ts
+++ b/packages/protocol/test/ingress-internal.test.ts
@@ -49,7 +49,7 @@ describe("InternalEventSchema", () => {
 
   test("external inbound schema rejects internal events", () => {
     expectParseFailure(() =>
-      Ingress.ExternalInboundEventSchema.parse({
+      Ingress.DirectEventSchema.parse({
         id: "t3",
         surface: "cron",
         mode: "internal",

--- a/packages/protocol/test/message.test.ts
+++ b/packages/protocol/test/message.test.ts
@@ -150,41 +150,6 @@ describe("Message.StepFinishPart", () => {
   });
 });
 
-describe("Message.RetryPart", () => {
-  test("parses valid retry part with serialized APIError", () => {
-    const part = Message.RetryPart.parse({
-      ...base,
-      type: "retry",
-      attempt: 2,
-      error: {
-        name: "APIError",
-        data: { message: "rate limited", isRetryable: true },
-      },
-      time: { created: 1000 },
-    });
-
-    expect(part.type).toBe("retry");
-    expect(part.attempt).toBe(2);
-    expect(part.error.name).toBe("APIError");
-    expect(part.error.data.isRetryable).toBe(true);
-    expect(part.time.created).toBe(1000);
-  });
-
-  test("rejects missing attempt", () => {
-    expect(() =>
-      Message.RetryPart.parse({
-        ...base,
-        type: "retry",
-        error: {
-          name: "APIError",
-          data: { message: "fail", isRetryable: false },
-        },
-        time: { created: 1000 },
-      }),
-    ).toThrow();
-  });
-});
-
 describe("Message.ToolPart", () => {
   const toolBase = {
     ...base,

--- a/script/conformance/schema-snapshot.json
+++ b/script/conformance/schema-snapshot.json
@@ -314,13 +314,6 @@
     "status",
     "usage"
   ],
-  "Ingress.ActivationMetadataSchema": [
-    "activationId",
-    "durableSessionId",
-    "lifecycle",
-    "runId",
-    "trigger"
-  ],
   "Ingress.ActorSchema": [
     "actorId",
     "endpoint",
@@ -346,19 +339,6 @@
     "tools"
   ],
   "Ingress.DirectEventSchema": [
-    "agent",
-    "channel",
-    "id",
-    "meta",
-    "mode",
-    "payload",
-    "runtime",
-    "surface",
-    "target",
-    "userId",
-    "workspace"
-  ],
-  "Ingress.ExternalInboundEventSchema": [
     "agent",
     "channel",
     "id",
@@ -533,15 +513,6 @@
     "type"
   ],
   "Message.Part#4": [
-    "attempt",
-    "error",
-    "id",
-    "messageID",
-    "sessionID",
-    "time",
-    "type"
-  ],
-  "Message.Part#5": [
     "callID",
     "id",
     "messageID",
@@ -556,15 +527,6 @@
     "metadata",
     "sessionID",
     "text",
-    "time",
-    "type"
-  ],
-  "Message.RetryPart": [
-    "attempt",
-    "error",
-    "id",
-    "messageID",
-    "sessionID",
     "time",
     "type"
   ],


### PR DESCRIPTION
Kill-batch increment of #497 (protocol dead-surface concept diet). Removes
proven-dead members of the `ingress`, `message`, and `actor` protocol
namespaces. Every claim was fresh-grepped before cutting; symbols that
turned out to have live consumers were preserved and are reported below.

## Deleted
- **`Message.RetryPart`** — the `type:"retry"` part schema, its `type RetryPart`,
  and its member in the `Part` discriminatedUnion. Never produced (the only
  `type:"retry"` literals were the schema def + its own test), so never
  persisted → fail-closed-safe. Also removed the two exhaustive `case "retry":`
  arms in `transcript/fold.ts` (switches remain exhaustive over the surviving
  part types), the `Message.RetryPart` describe block in `message.test.ts`, and
  the now-orphaned `APIError` import in `message/index.ts`. `StepStartPart` /
  `StepFinishPart` are untouched (still produced by llm `stream-events.ts`).
- **`Ingress.ActorMetadata`, `Ingress.EventMetadata`** — zero-consumer type
  aliases (`= Actor` / `= Meta`).
- **`Ingress.ExternalInboundEventSchema`** (a pure `= DirectEventSchema` alias)
  and its paired type **`Ingress.ExternalInboundEvent`**. The one consumer, a
  trust-boundary test asserting internal-mode rejection, was repointed to the
  byte-identical `DirectEventSchema` (zero coverage loss, still asserts
  rejection).
- **`Ingress.ActivationMetadataSchema`** — the exported alias of the retained
  module-local `ActivationMetadataSchemaImpl` (used for runtime validation).
  The `ActivationMetadata` type was repointed to the Impl.

## Unexported
- **`Actor.Kind`** (const) — no cross-package/barrel value-consumer; `type Kind`
  export retained.
- **`Ingress.DirectResult`** (type) — referenced intra-namespace only.

## Preserved — fresh grep found live consumers (reported, not cut)
- **`Actor.BlacklistKind`** — the *type* is consumed cross-package by
  `packages/openomni/src/ingress/resolve-route.ts:74` (`readonly kind: Actor.BlacklistKind`).
- **`Ingress.InboundEventSchema`** — value-parsed (`.parse()`) by cross-package
  `packages/openomni/test/ingress/target.test.ts` and by protocol tests; it is
  the sole mode-discriminating validator (only schema that rejects `mode:"auto"`),
  with no repoint target.
- **`Ingress.InternalEventSchema`** (+ exported `InternalEvent` type) — a
  dedicated `describe("InternalEventSchema")` block in
  `packages/protocol/test/ingress-internal.test.ts` parses it directly
  (valid/invalid/trigger-metadata cases); no equivalent to repoint to, so
  unexporting would break tests / lose coverage.

## schema-snapshot.json
Surgically hand-edited (never `--update`). Removed exactly the keys that
vanished from the rebuilt snapshot: `Message.RetryPart`,
`Ingress.ExternalInboundEventSchema`, `Ingress.ActivationMetadataSchema`.
Because removing `RetryPart` reindexes the `Part` union, `Message.Part#5`
(ToolPart) collapses into `Message.Part#4` and `Part#5` is dropped. Every
other entry is byte-identical.

## Gates (all green)
`bun run build`, `check-types` (13/13), `biome check`, `check-deps.ts`,
`check-dead-exports.ts` (none new), `lint-tools.ts` (schema snapshot + vocab
pass), protocol test suite (487 pass / 0 fail) plus the cross-package
`target.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unused protocol exports from `ingress`, `message`, and `actor` to reduce the public surface without changing runtime behavior.

- Delete `Message.RetryPart`; remove its switch arms in `transcript/fold.ts` and related tests.
- Remove `Ingress.ActorMetadata` and `Ingress.EventMetadata` aliases.
- Stop exporting `Ingress.ExternalInboundEventSchema` and `ExternalInboundEvent`; use `Ingress.DirectEventSchema` and `DirectEvent` instead.
- Stop exporting `Ingress.ActivationMetadataSchema`; keep `ActivationMetadata` (type) inferred from the internal schema.
- Unexport the `Actor.Kind` value and the `Ingress.DirectResult` type; keep the `type Actor.Kind`.
- Update `schema-snapshot.json` to drop deleted keys and reindex the `Message.Part` union (ToolPart is now `Part#4`).

<sup>Written for commit 54c8f88cb0faacfefc8204226bcad297bc2c5f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

