### PR TITLE
refactor(protocol): unexport variant schemas, drop dead aliases (#497)

### DIFF
--- a/packages/protocol/src/communication/index.ts
+++ b/packages/protocol/src/communication/index.ts
@@ -1,12 +1,8 @@
-import { Envelope as EnvelopeSchema } from "./envelope.js";
 import * as PendingAskSchema from "./pending-ask.js";
 import * as PendingInteractionSchema from "./pending-interaction.js";
 import * as WorkerGrantSchema from "./worker-grant.js";
 
 export namespace Communication {
-  export const Envelope = EnvelopeSchema;
-  export type Envelope = EnvelopeSchema;
-
   export namespace PendingAsk {
     export const Status = PendingAskSchema.Status;
     export type Status = PendingAskSchema.Status;

--- a/packages/protocol/src/mcp/index.ts
+++ b/packages/protocol/src/mcp/index.ts
@@ -9,24 +9,21 @@ export namespace McpConfig {
     retries: z.number().int().nonnegative().optional(),
   });
 
-  export const StdioServerConfig = BaseServerConfig.extend({
+  const StdioServerConfig = BaseServerConfig.extend({
     transport: z.literal("stdio"),
     command: z.string().min(1),
     args: z.string().array().optional(),
   });
-  export type StdioServerConfig = z.infer<typeof StdioServerConfig>;
 
-  export const SseServerConfig = BaseServerConfig.extend({
+  const SseServerConfig = BaseServerConfig.extend({
     transport: z.literal("sse"),
     url: z.string().url(),
   });
-  export type SseServerConfig = z.infer<typeof SseServerConfig>;
 
-  export const StreamableHttpServerConfig = BaseServerConfig.extend({
+  const StreamableHttpServerConfig = BaseServerConfig.extend({
     transport: z.literal("streamable-http"),
     url: z.string().url(),
   });
-  export type StreamableHttpServerConfig = z.infer<typeof StreamableHttpServerConfig>;
 
   export const ServerConfig = z.discriminatedUnion("transport", [
     StdioServerConfig,
@@ -36,5 +33,4 @@ export namespace McpConfig {
   export type ServerConfig = z.infer<typeof ServerConfig>;
 }
 
-export const McpServerConfig = McpConfig.ServerConfig;
 export type McpServerConfig = McpConfig.ServerConfig;

--- a/packages/protocol/src/model/index.ts
+++ b/packages/protocol/src/model/index.ts
@@ -9,8 +9,4 @@ export namespace Model {
     id: z.string(),
   });
   export type Ref = z.infer<typeof Ref>;
-
-  export function isRef(value: unknown): value is Ref {
-    return Ref.safeParse(value).success;
-  }
 }

--- a/packages/protocol/src/tool/index.ts
+++ b/packages/protocol/src/tool/index.ts
@@ -30,22 +30,20 @@ export namespace Tool {
   });
   export type Config = z.infer<typeof Config>;
 
-  export const StatePending = z.object({
+  const StatePending = z.object({
     status: z.literal("pending"),
     input: z.record(z.string(), z.unknown()),
   });
-  export type StatePending = z.infer<typeof StatePending>;
 
-  export const StateRunning = z.object({
+  const StateRunning = z.object({
     status: z.literal("running"),
     input: z.record(z.string(), z.unknown()),
     time: z.object({
       start: z.number(),
     }),
   });
-  export type StateRunning = z.infer<typeof StateRunning>;
 
-  export const StateCompleted = z.object({
+  const StateCompleted = z.object({
     status: z.literal("completed"),
     input: z.record(z.string(), z.unknown()),
     output: z.string(),
@@ -56,9 +54,8 @@ export namespace Tool {
       end: z.number(),
     }),
   });
-  export type StateCompleted = z.infer<typeof StateCompleted>;
 
-  export const StateError = z.object({
+  const StateError = z.object({
     status: z.literal("error"),
     input: z.record(z.string(), z.unknown()),
     error: z.string(),
@@ -67,7 +64,6 @@ export namespace Tool {
       end: z.number(),
     }),
   });
-  export type StateError = z.infer<typeof StateError>;
 
   export const State = z.discriminatedUnion("status", [
     StatePending,

--- a/packages/protocol/test/agent.test.ts
+++ b/packages/protocol/test/agent.test.ts
@@ -170,10 +170,6 @@ describe("acceptance (documents current behavior)", () => {
       provider: "openai",
       id: "gpt-4o",
     }));
-  it("recognizes model refs with the shared guard", () => {
-    expect(Model.isRef({ provider: "openai", id: "gpt-4o" })).toBe(true);
-    expect(Model.isRef({ providerID: "openai", id: "gpt-4o" })).toBe(false);
-  });
   it("exposes shared model status values", () => {
     for (const status of ["alpha", "beta", "deprecated", "active"] as const) {
       expect(Model.Status.parse(status)).toBe(status);

--- a/packages/protocol/test/communication/schema.test.ts
+++ b/packages/protocol/test/communication/schema.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { Communication, Dispatch } from "../../src/index.js";
+import { Envelope } from "../../src/communication/envelope.js";
 
 describe("Communication protocol schemas", () => {
   test("Envelope accepts normalized adapter/delivery fields", () => {
-    const parsed = Communication.Envelope.parse({
+    const parsed = Envelope.parse({
       id: "env-1",
       direction: "inbound",
       surface: "discord",

--- a/packages/protocol/test/mcp.test.ts
+++ b/packages/protocol/test/mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { McpConfig, McpServerConfig, Mcp } from "../src/index.js";
+import { McpConfig, Mcp } from "../src/index.js";
 
 describe("McpConfig.ServerConfig", () => {
   test("parses stdio server config", () => {
@@ -18,7 +18,7 @@ describe("McpConfig.ServerConfig", () => {
   });
 
   test("parses http-style server config with headers", () => {
-    const config = McpServerConfig.parse({
+    const config = McpConfig.ServerConfig.parse({
       name: "remote",
       transport: "streamable-http",
       url: "https://example.com/mcp",

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -34,7 +34,7 @@ describe("Tool shared contracts", () => {
 
 describe("Tool.StatePending", () => {
   test("parses valid pending state with empty input", () => {
-    const state = Tool.StatePending.parse({
+    const state = Tool.State.parse({
       status: "pending",
       input: {},
     });
@@ -44,16 +44,16 @@ describe("Tool.StatePending", () => {
   });
 
   test("rejects missing input", () => {
-    expect(() => Tool.StatePending.parse({ status: "pending" })).toThrow();
+    expect(() => Tool.State.parse({ status: "pending" })).toThrow();
   });
 
   test("rejects missing status", () => {
-    expect(() => Tool.StatePending.parse({ input: {} })).toThrow();
+    expect(() => Tool.State.parse({ input: {} })).toThrow();
   });
 
   test("rejects wrong status", () => {
     expect(() =>
-      Tool.StatePending.parse({
+      Tool.State.parse({
         status: "running",
         input: {},
       }),
@@ -63,7 +63,7 @@ describe("Tool.StatePending", () => {
 
 describe("Tool.StateRunning", () => {
   test("parses valid running state with negative start time", () => {
-    const state = Tool.StateRunning.parse({
+    const state = Tool.State.parse({
       status: "running",
       input: { task: "demo" },
       time: { start: -5 },
@@ -75,7 +75,7 @@ describe("Tool.StateRunning", () => {
 
   test("rejects missing time", () => {
     expect(() =>
-      Tool.StateRunning.parse({
+      Tool.State.parse({
         status: "running",
         input: {},
       }),
@@ -84,7 +84,7 @@ describe("Tool.StateRunning", () => {
 
   test("rejects missing input", () => {
     expect(() =>
-      Tool.StateRunning.parse({
+      Tool.State.parse({
         status: "running",
         time: { start: 1 },
       }),
@@ -94,7 +94,7 @@ describe("Tool.StateRunning", () => {
 
 describe("Tool.StateCompleted", () => {
   test("parses valid completed state with time.end set to 0", () => {
-    const state = Tool.StateCompleted.parse({
+    const state = Tool.State.parse({
       status: "completed",
       input: { task: "demo" },
       output: "done",
@@ -110,7 +110,7 @@ describe("Tool.StateCompleted", () => {
 
   test("rejects missing output", () => {
     expect(() =>
-      Tool.StateCompleted.parse({
+      Tool.State.parse({
         status: "completed",
         input: {},
         title: "Demo Task",
@@ -122,7 +122,7 @@ describe("Tool.StateCompleted", () => {
 
   test("rejects missing title", () => {
     expect(() =>
-      Tool.StateCompleted.parse({
+      Tool.State.parse({
         status: "completed",
         input: {},
         output: "done",
@@ -134,7 +134,7 @@ describe("Tool.StateCompleted", () => {
 
   test("rejects missing time", () => {
     expect(() =>
-      Tool.StateCompleted.parse({
+      Tool.State.parse({
         status: "completed",
         input: {},
         output: "done",
@@ -147,7 +147,7 @@ describe("Tool.StateCompleted", () => {
 
 describe("Tool.StateError", () => {
   test("parses valid error state", () => {
-    const state = Tool.StateError.parse({
+    const state = Tool.State.parse({
       status: "error",
       input: { task: "demo" },
       error: "failed",
@@ -160,7 +160,7 @@ describe("Tool.StateError", () => {
 
   test("rejects missing error", () => {
     expect(() =>
-      Tool.StateError.parse({
+      Tool.State.parse({
         status: "error",
         input: {},
         time: { start: 1, end: 2 },
@@ -170,7 +170,7 @@ describe("Tool.StateError", () => {
 
   test("rejects missing time", () => {
     expect(() =>
-      Tool.StateError.parse({
+      Tool.State.parse({
         status: "error",
         input: {},
         error: "failed",

--- a/script/conformance/schema-snapshot.json
+++ b/script/conformance/schema-snapshot.json
@@ -182,21 +182,6 @@
     "version"
   ],
   "Artifact.Part": ["artifactId", "meta", "type"],
-  "Communication.Envelope": [
-    "actorId",
-    "channelId",
-    "correlationToken",
-    "direction",
-    "endpointId",
-    "externalMessageId",
-    "id",
-    "payload",
-    "receivedAt",
-    "replyToMessageId",
-    "sentAt",
-    "surface",
-    "threadId"
-  ],
   "CronJob.Info": [
     "agentName",
     "createdAt",
@@ -433,31 +418,6 @@
     "url"
   ],
   "McpConfig.ServerConfig#2": [
-    "headers",
-    "name",
-    "retries",
-    "timeout",
-    "transport",
-    "url"
-  ],
-  "McpConfig.SseServerConfig": [
-    "headers",
-    "name",
-    "retries",
-    "timeout",
-    "transport",
-    "url"
-  ],
-  "McpConfig.StdioServerConfig": [
-    "args",
-    "command",
-    "headers",
-    "name",
-    "retries",
-    "timeout",
-    "transport"
-  ],
-  "McpConfig.StreamableHttpServerConfig": [
     "headers",
     "name",
     "retries",
@@ -789,17 +749,6 @@
   "Tool.State#1": ["input", "status", "time"],
   "Tool.State#2": ["input", "metadata", "output", "status", "time", "title"],
   "Tool.State#3": ["error", "input", "status", "time"],
-  "Tool.StateCompleted": [
-    "input",
-    "metadata",
-    "output",
-    "status",
-    "time",
-    "title"
-  ],
-  "Tool.StateError": ["error", "input", "status", "time"],
-  "Tool.StatePending": ["input", "status"],
-  "Tool.StateRunning": ["input", "status", "time"],
   "ToolSelection.Selection": ["all", "allow", "categories", "deny"],
   "TraceContext.Schema": [
     "agentName",


### PR DESCRIPTION
## #497 batch-2 — protocol dead-surface kill

Removes dead exported members from the `@openomni/protocol` public surface. No behavior change: every union that referenced these members still builds and stays exported.

### 7 unexports (member `const` kept namespace-internal, feeding its union; unused variant `type` aliases dropped so biome `noUnusedVariables` stays green)
- `Tool.StatePending`
- `Tool.StateRunning`
- `Tool.StateCompleted`
- `Tool.StateError`
  → `Tool.State` discriminated union stays exported.
- `McpConfig.StdioServerConfig`
- `McpConfig.SseServerConfig`
- `McpConfig.StreamableHttpServerConfig`
  → `McpConfig.ServerConfig` discriminated union stays exported.

### 3 deletes
- `Communication.Envelope` alias (`const` + `type`) and its now-unused `import` — the `Communication` namespace keeps `PendingAsk` / `PendingInteraction` / `WorkerGrant`.
- `Model.isRef` type guard (`export function isRef`).
- `McpServerConfig` **value** const only — `export type McpServerConfig = McpConfig.ServerConfig` is kept (pervasive `import type` across agent/server depends on it).

### 4 test repoints (coverage-preserving)
- `test/tool.test.ts`: every `Tool.State*.parse(...)` → `Tool.State.parse(...)` (discriminated union routes each valid variant to the same schema; negative cases are `.toThrow()`).
- `test/mcp.test.ts`: dropped the `McpServerConfig` value import; `McpServerConfig.parse(...)` → `McpConfig.ServerConfig.parse(...)`.
- `test/communication/schema.test.ts`: import the underlying `Envelope` from `../../src/communication/envelope.js`; `Communication.Envelope.parse(...)` → `Envelope.parse(...)`.
- `test/agent.test.ts`: removed the `Model.isRef` guard assertions block (its only two assertions exercised the deleted guard).

### schema-snapshot.json
Surgically removed exactly the 8 keys that vanish from the exported-zod enumeration; every other byte unchanged. Union keys (`Tool.State#0..#3`, `McpConfig.ServerConfig#0..#2`) are byte-identical.
- `Communication.Envelope`
- `McpConfig.SseServerConfig`
- `McpConfig.StdioServerConfig`
- `McpConfig.StreamableHttpServerConfig`
- `Tool.StateCompleted`
- `Tool.StateError`
- `Tool.StatePending`
- `Tool.StateRunning`

(The `McpServerConfig` value produced no standalone snapshot key — a bare top-level union yields no schema-member key — so its removal changes nothing in the snapshot; conformance confirms.)

### Gates
- `bun run build` → 5 successful, clean
- `bun run script/lint-tools.ts` (schema-snapshot conformance) → OK
- `bunx biome check packages apps script` → clean (964 files)
- `bun test --timeout 15000` on the 4 touched protocol tests → 66 pass, 0 fail
- `git diff --check` → clean

Refs #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes variant schemas internal and removes dead aliases in `@openomni/protocol` without changing behavior. The per-variant schemas `Tool.State{Pending,Running,Completed,Error}` and `McpConfig.{Stdio,Sse,StreamableHttp}ServerConfig` are now internal; `Tool.State` and `McpConfig.ServerConfig` remain exported. Also removes the `Communication.Envelope` alias, `Model.isRef`, and the `McpServerConfig` value; the `export type McpServerConfig = McpConfig.ServerConfig` stays. The schema snapshot drops 8 keys; union entries are unchanged.

**Migration**
- Replace `Tool.State*`.parse(...) with `Tool.State`.parse(...).
- Replace `McpConfig.{Stdio,Sse,StreamableHttp}ServerConfig.parse(...)` and `McpServerConfig.parse(...)` with `McpConfig.ServerConfig.parse(...)`.
- If you used `Communication.Envelope`, import `Envelope` from `communication/envelope` and call `Envelope.parse(...)`.
- Replace `Model.isRef(value)` with `Model.Ref.safeParse(value).success`.

<sup>Written for commit 8a593e0fcc2254f660310dab5ef620820c99071e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

