### PR TITLE
refactor(protocol): unexport orphaned policy permission surface (#497)

### DIFF
--- a/packages/protocol/src/policy/permission.ts
+++ b/packages/protocol/src/policy/permission.ts
@@ -8,13 +8,9 @@ export namespace PolicyPermission {
   // Label source enumeration: where a label originates from
   // Labels use source.category naming convention to prevent namespace collisions
   // Examples: tool.filesystem, actor.owner, surface.github, risk.tier-2, capability.write
-  export const Label = {
+  const Label = {
     Source: z.enum(["system", "tool_metadata", "agent_profile", "policy_rule", "operator"]),
   } as const;
-
-  export type Label = {
-    Source: z.infer<typeof Label.Source>;
-  };
 
   // Label entry: a labeled value with its source for audit and policy evaluation
   export const LabelEntry = z.object({
@@ -23,8 +19,8 @@ export namespace PolicyPermission {
   });
   export type LabelEntry = z.infer<typeof LabelEntry>;
 
-  export const PermissionDecision = z.enum(["allow", "deny", "require_approval"]);
-  export type PermissionDecision = z.infer<typeof PermissionDecision>;
+  const PermissionDecision = z.enum(["allow", "deny", "require_approval"]);
+  type PermissionDecision = z.infer<typeof PermissionDecision>;
 
   export const InputRule = z.object({
     toolPattern: z.string(),


### PR DESCRIPTION
## #497 batch-#15b — complete the narrowing #599 left half-done

PR #599 deleted the `Policy.Label` / `Policy.PermissionDecision` re-export aliases from `policy/index.ts`. Those aliases were the only external consumers of the underlying `PolicyPermission.Label` and `PolicyPermission.PermissionDecision`, so both became unused exports and the `Quality` gate (`bun run script/check-dead-exports.ts`) went **red on main** with exactly two violations:

```
VIOLATION [dead-exports] namespaceMembers packages/protocol/src/policy/permission.ts Label
VIOLATION [dead-exports] namespaceMembers packages/protocol/src/policy/permission.ts PermissionDecision
```

This finishes the narrowing by **unexporting** both — neither can be deleted, both are referenced bare inside their own namespace.

### Change (`packages/protocol/src/policy/permission.ts`, +3/-7)
- `export const Label` → `const Label` — still feeds `LabelEntry.source` via `Label.Source`.
- **DELETE** `export type Label` — no internal reference (biome `noUnusedVariables` flags it; it existed only for the now-deleted `Policy.Label` re-export).
- `export const PermissionDecision` → `const PermissionDecision` — still feeds `InputRule.action`, `EvaluationResult.decision`, and `verdict()` as a zod value.
- `export type PermissionDecision` → `type PermissionDecision` — kept + unexported; still referenced as the `verdict(decision:)` param type annotation.

No `schema-snapshot.json` change (both are enum / plain-object — no `.shape`, no snapshot key). No `knip-baseline.json` `--update`.

### Gates (all green)
1. `bun run build` — 5/5 successful
2. `bunx biome check packages apps script` — 968 files, no fixes
3. `bun run script/check-dead-exports.ts` — **`OK: dead-export ratchet — 18 known issues, none new`** (the gate this batch fixes)
4. `bun run script/lint-tools.ts` — `OK: conformance lint … schema snapshot`
5. `bun test packages/protocol/test/policy.test.ts packages/protocol/test/policy/module-surface.test.ts` — 56 pass, 0 fail
6. `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unexports orphaned `PolicyPermission` permission surface to restore the dead-exports gate and complete #497’s narrowing. Previously #599 removed `Policy.Label` and `Policy.PermissionDecision` re-exports; the underlying `PolicyPermission.Label` and `PolicyPermission.PermissionDecision` stayed exported but unused. Now they are internal only. Supported entrypoints have no behavior change; direct imports of these members no longer compile.

- In `packages/protocol/src/policy/permission.ts`: make `Label` and `PermissionDecision` `const` internal; delete the unused exported `type Label`; keep but unexport `type PermissionDecision`.
- Internal use remains: `Label.Source` feeds `LabelEntry`; `PermissionDecision` feeds `InputRule.action`, `EvaluationResult.decision`, and `verdict()`.
- No schema snapshot churn. Dead-exports ratchet back to green; build/lint/tests pass.
- No migration for consumers of `policy/index.ts`. If you imported `PolicyPermission.Label` or `PolicyPermission.PermissionDecision` directly, remove those imports.

<sup>Written for commit dc0c0b347fd9412ed1e4901a2db5ac352f5fe4ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

