### PR TITLE
feat(openomni): flat-event projection spine + verdict mapper (#493)

### DIFF
--- a/packages/openomni/package.json
+++ b/packages/openomni/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./ledger": "./src/ledger/index.ts",
-    "./messaging": "./src/messaging/index.ts"
+    "./messaging": "./src/messaging/index.ts",
+    "./projection": "./src/projection/index.ts"
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",

--- a/packages/openomni/src/projection/flat-event.ts
+++ b/packages/openomni/src/projection/flat-event.ts
@@ -1,0 +1,321 @@
+import { WorkItem } from "@openomni/protocol";
+import { z } from "zod";
+
+/**
+ * #493 I1 — the deterministic flat-event PROJECTION SPINE.
+ *
+ * A `FlatEvent` is one denormalized, replay-shaped row: a single per-step
+ * fact bundle flattened onto a fixed 30-column schema so projections, export
+ * (JSONL), and deterministic replay all read the SAME row shape. This module
+ * owns three PURE pieces and nothing else — no I/O, no clock, no LLM:
+ *
+ *   1. the `FlatEvent` zod schema (30 fields, fixed order);
+ *   2. `mapVerdict` — a pure map from the verifier registry status vocabulary
+ *      onto `ok | warn | error`, throw-on-unknown (fail loud);
+ *   3. `foldToFlatEvents` — maps an assembled, fully-populated intermediate
+ *      `ProjectionInput` into a deterministically ordered `FlatEvent[]`.
+ *
+ * AUTHORITY SOURCE — NOT bus_event. Every authoritative field is assembled
+ * from the WorkItem attempt ledger facts (`work_item.attempt_allocated`, the
+ * immutable Attempt identity — packages/session/src/work-item/facts.ts) plus
+ * the append-only `transcript_fact` rows (migration 0015). It is NEVER read
+ * from `bus_event`, which is telemetry-tier, lossy, and destroys raw bodies
+ * via `redactForPersistence`. `ProjectionInput` is the already-assembled
+ * intermediate; this fold is a pure function over it.
+ *
+ * LATER-INCREMENT INPUTS — carried through, never invented. Five columns are
+ * produced by runtime writers that land in later increments and are simply
+ * carried through from `ProjectionInput`:
+ *
+ *   - `prompt_hash`, `observation_hash`  → I3 evidence/prompt sidecars;
+ *   - `cache_key`, `replay_key`, `nondeterminism_manifest_hash`
+ *                                        → I2 replay-identity writers.
+ *
+ * This fold maps whatever the input provides for those five; it does NOT
+ * fabricate them (a step with no sidecar carries `null`). Likewise, PRODUCTION
+ * fingerprint richness — the `absent-but-listed` spawn-site inputs behind
+ * `content_fingerprint` / `environment_fingerprint` (protocol
+ * `ContentFingerprintInputs` / `EnvironmentFingerprintInputs`) — is upstream
+ * #510 phase-D scope and is NOT papered over here: this fold emits the SCALAR
+ * `.digest` the attempt already recorded, whatever its input coverage.
+ */
+
+// ---------------------------------------------------------------------------
+// scalar building blocks
+// ---------------------------------------------------------------------------
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.null(),
+    z.boolean(),
+    z.number().finite(),
+    z.string(),
+    z.array(JsonValue),
+    z.record(z.string(), JsonValue),
+  ]),
+);
+
+/** Denormalized outcome of one step. Distinct from the verifier status. */
+export const Verdict = z.enum(["ok", "warn", "error"]);
+export type Verdict = z.infer<typeof Verdict>;
+
+/**
+ * The verifier registry status vocabulary (single source of truth:
+ * `VerifierRegistry.ResultStatus`, packages/openomni/src/evidence/
+ * verifier-registry-contract.ts, mirrored by protocol `ResultValue`). A step
+ * with no verification carries `null` (see `ProjectionStep.verifierStatus`).
+ */
+export const VerifierStatus = z.enum(["verified", "refuted", "inconclusive", "asserted"]);
+export type VerifierStatus = z.infer<typeof VerifierStatus>;
+
+// ---------------------------------------------------------------------------
+// verdict mapper — PURE, throw-on-unknown
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a recorded verifier status onto the flat-event verdict. PURE — a total
+ * function over the recorded status string; it NEVER calls an LLM or reads any
+ * ambient state. Mirrors the throw-on-unknown discipline of
+ * `projectCompletionOrigin` (dispatch/handlers/completion-origin-projector via
+ * work-item): an unrecognized status is a corrupt/foreign fact and fails loud
+ * rather than defaulting.
+ *
+ * Mapping (documented):
+ *   - `verified`     → `ok`    — the predicate was executed and held;
+ *   - `asserted`     → `ok`    — an asserted-only kind (reasoning/subjective/
+ *                                creative/opinion/prediction/normative/…) that
+ *                                the registry admits WITHOUT refutation — it is
+ *                                a recorded claim, not a failure, so `ok`;
+ *   - `inconclusive` → `warn`  — evidence was neither confirmed nor refuted;
+ *   - `refuted`      → `error` — the predicate was executed and FAILED.
+ */
+export function mapVerdict(status: string): Verdict {
+  switch (status) {
+    case "verified":
+    case "asserted":
+      return "ok";
+    case "inconclusive":
+      return "warn";
+    case "refuted":
+      return "error";
+    default:
+      throw new Error(`unknown verifier status: ${status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// loop_key — deterministic per-iteration correlation key
+// ---------------------------------------------------------------------------
+
+/**
+ * `loop_key` correlates the iterations of ONE retry/re-plan loop over the same
+ * WorkItem. It is a PURE function of recorded facts: the canonical digest of
+ * `(work_item_id, content_fingerprint.digest)`. Two attempts of the same
+ * WorkItem whose content fingerprint digest is IDENTICAL (same task input,
+ * handler, model, upstream, dependency-lock — a bare retry over identical work
+ * content) share a loop_key; a different plan/content produces a different
+ * content digest and therefore STARTS A NEW loop. `work_item_id` scopes the
+ * key so identical content under different WorkItems never collides.
+ */
+export function deriveLoopKey(workItemId: string, contentDigest: string): string {
+  return WorkItem.canonicalDigest({ workItemId, contentDigest });
+}
+
+// ---------------------------------------------------------------------------
+// FlatEvent — the fixed 30-column projection row
+// ---------------------------------------------------------------------------
+
+const nonEmpty = z.string().min(1);
+const nullableString = z.string().nullable();
+
+/**
+ * The flat-event row. EXACTLY 30 fields, in the order below (the JSONL column
+ * order — do not reorder). `.strict()` rejects any extra column.
+ */
+export const FlatEvent = z
+  .object({
+    // -- identity (WorkItem owner stream + Attempt ledger facts) --
+    owner_key: nonEmpty, // work-item owner stream id `work:<hash>`
+    work_item_id: nonEmpty, // WorkItem.Info.hash
+    attempt_id: nonEmpty, // Attempt.attemptId
+    attempt_seq: z.number().int().positive(), // Attempt.attemptSeq
+    retry_of: z.string().min(1).nullable(), // Attempt.retryOf
+    reused_from_attempt_id: z.string().min(1).nullable(), // Attempt.reusedFromAttemptId
+    // -- step position (transcript_fact) --
+    step: z.number().int().nonnegative(), // transcript step ordinal
+    parent_step: z.number().int().nonnegative().nullable(),
+    agent: nullableString, // executing agent/session identity
+    op: nonEmpty, // transcript fact / operation type
+    thought: nullableString,
+    action: nullableString,
+    action_args: JsonValue.nullable(),
+    observation_hash: nullableString, // I3 sidecar — carried through
+    // -- model call telemetry (recorded, not bus) --
+    model: nullableString,
+    in_tokens: z.number().int().nonnegative().nullable(),
+    out_tokens: z.number().int().nonnegative().nullable(),
+    finish_reason: nullableString,
+    // -- verification outcome --
+    verdict: Verdict.nullable(), // mapVerdict(status) or null
+    checked_predicate: nullableString, // VerificationResult.checkedPredicate
+    error_type: nullableString,
+    // -- loop / plan correlation --
+    loop_key: nonEmpty, // deriveLoopKey(work_item_id, content digest)
+    plan_divergence: nullableString,
+    state_hash: nullableString,
+    prompt_hash: nullableString, // I3 sidecar — carried through
+    // -- attempt fingerprints (SCALAR digests) --
+    content_fingerprint: nonEmpty, // Attempt.contentFingerprint.digest
+    environment_fingerprint: nonEmpty, // Attempt.environmentFingerprint.digest
+    // -- replay identity (I2 writers) — carried through --
+    cache_key: nullableString,
+    replay_key: nullableString,
+    nondeterminism_manifest_hash: nullableString,
+  })
+  .strict();
+export type FlatEvent = z.infer<typeof FlatEvent>;
+
+/** The 30 field names, in order — exported so export/replay share one list. */
+export const FLAT_EVENT_FIELDS = Object.keys(FlatEvent.shape) as (keyof FlatEvent)[];
+
+// ---------------------------------------------------------------------------
+// ProjectionInput — the assembled intermediate this fold consumes
+// ---------------------------------------------------------------------------
+
+/**
+ * The immutable recorded-order key for one step. Because `ledger_event` has NO
+ * global append-ordinal column (its PK is `(stream_id, seq)` only — migration
+ * 0013), a total order is imposed by `(timeCreated ASC, streamId ASC, seq
+ * ASC)` over RECORDED archive values. This is deterministic precisely because
+ * every value is the value the row was PERSISTED with (the archive stores
+ * recorded time, never a live clock): the same archived rows always sort the
+ * same way, on any machine, at any time. `timeCreated`/`streamId`/`seq` come
+ * straight off the immutable row — the fold NEVER reads `Date.now()`.
+ */
+export const StepOrder = z
+  .object({
+    timeCreated: z.number().int(),
+    streamId: z.string().min(1),
+    seq: z.number().int().nonnegative(),
+  })
+  .strict();
+export type StepOrder = z.infer<typeof StepOrder>;
+
+/**
+ * One assembled per-step fact bundle. The assembler (later increments) reads
+ * the attempt ledger + transcript facts and populates this; the fold below is
+ * a pure map from it. The full `WorkItem.Attempt` identity rides along so the
+ * fold — not the caller — owns extracting the SCALAR fingerprint digests and
+ * deriving `loop_key`, keeping those decisions in one pure place.
+ */
+export const ProjectionStep = z
+  .object({
+    order: StepOrder,
+    ownerKey: nonEmpty,
+    workItemId: nonEmpty,
+    attempt: WorkItem.Attempt,
+    step: z.number().int().nonnegative(),
+    parentStep: z.number().int().nonnegative().nullable(),
+    agent: nullableString,
+    op: nonEmpty,
+    thought: nullableString,
+    action: nullableString,
+    actionArgs: JsonValue.nullable(),
+    observationHash: nullableString,
+    model: nullableString,
+    inTokens: z.number().int().nonnegative().nullable(),
+    outTokens: z.number().int().nonnegative().nullable(),
+    finishReason: nullableString,
+    /** Recorded verifier status; `null` for a non-verification step. */
+    verifierStatus: VerifierStatus.nullable(),
+    checkedPredicate: nullableString,
+    errorType: nullableString,
+    planDivergence: nullableString,
+    stateHash: nullableString,
+    promptHash: nullableString,
+    cacheKey: nullableString,
+    replayKey: nullableString,
+    nondeterminismManifestHash: nullableString,
+  })
+  .strict();
+export type ProjectionStep = z.infer<typeof ProjectionStep>;
+
+/** The full assembled projection input: the per-step bundles to flatten. */
+export const ProjectionInput = z.object({ steps: z.array(ProjectionStep) }).strict();
+export type ProjectionInput = z.infer<typeof ProjectionInput>;
+
+// ---------------------------------------------------------------------------
+// foldToFlatEvents — the pure projection
+// ---------------------------------------------------------------------------
+
+function compareStepOrder(a: StepOrder, b: StepOrder): number {
+  if (a.timeCreated !== b.timeCreated) return a.timeCreated - b.timeCreated;
+  if (a.streamId !== b.streamId) return a.streamId < b.streamId ? -1 : 1;
+  return a.seq - b.seq;
+}
+
+/**
+ * Folds an assembled `ProjectionInput` into a deterministically ordered
+ * `FlatEvent[]`. PURE: same input → byte-identical output every time, on any
+ * machine. The fold — not the caller — imposes the global order (see
+ * `StepOrder`) by sorting on the recorded key, so input list order is
+ * irrelevant to the result. A non-total order (two bundles sharing the exact
+ * `(timeCreated, streamId, seq)` tuple) is a corrupt assembly and fails loud
+ * rather than producing an ambiguous projection.
+ */
+export function foldToFlatEvents(input: ProjectionInput): FlatEvent[] {
+  const parsed = ProjectionInput.parse(input);
+  const ordered = [...parsed.steps].sort((a, b) => compareStepOrder(a.order, b.order));
+
+  for (let i = 1; i < ordered.length; i += 1) {
+    const previous = ordered[i - 1];
+    const current = ordered[i];
+    if (
+      previous !== undefined &&
+      current !== undefined &&
+      compareStepOrder(previous.order, current.order) === 0
+    ) {
+      throw new Error(
+        `non-total projection order: duplicate (timeCreated,streamId,seq) at ${current.order.streamId}#${current.order.seq}`,
+      );
+    }
+  }
+
+  return ordered.map((bundle) => {
+    const attempt = bundle.attempt;
+    const row: FlatEvent = {
+      owner_key: bundle.ownerKey,
+      work_item_id: bundle.workItemId,
+      attempt_id: attempt.attemptId,
+      attempt_seq: attempt.attemptSeq,
+      retry_of: attempt.retryOf,
+      reused_from_attempt_id: attempt.reusedFromAttemptId,
+      step: bundle.step,
+      parent_step: bundle.parentStep,
+      agent: bundle.agent,
+      op: bundle.op,
+      thought: bundle.thought,
+      action: bundle.action,
+      action_args: bundle.actionArgs,
+      observation_hash: bundle.observationHash,
+      model: bundle.model,
+      in_tokens: bundle.inTokens,
+      out_tokens: bundle.outTokens,
+      finish_reason: bundle.finishReason,
+      verdict: bundle.verifierStatus === null ? null : mapVerdict(bundle.verifierStatus),
+      checked_predicate: bundle.checkedPredicate,
+      error_type: bundle.errorType,
+      loop_key: deriveLoopKey(bundle.workItemId, attempt.contentFingerprint.digest),
+      plan_divergence: bundle.planDivergence,
+      state_hash: bundle.stateHash,
+      prompt_hash: bundle.promptHash,
+      content_fingerprint: attempt.contentFingerprint.digest,
+      environment_fingerprint: attempt.environmentFingerprint.digest,
+      cache_key: bundle.cacheKey,
+      replay_key: bundle.replayKey,
+      nondeterminism_manifest_hash: bundle.nondeterminismManifestHash,
+    };
+    return FlatEvent.parse(row);
+  });
+}

--- a/packages/openomni/src/projection/index.ts
+++ b/packages/openomni/src/projection/index.ts
@@ -1,0 +1,13 @@
+// #493 I1 — deterministic flat-event projection spine.
+export {
+  deriveLoopKey,
+  FLAT_EVENT_FIELDS,
+  FlatEvent,
+  foldToFlatEvents,
+  mapVerdict,
+  ProjectionInput,
+  ProjectionStep,
+  StepOrder,
+  Verdict,
+  VerifierStatus,
+} from "./flat-event.js";

--- a/packages/openomni/test/projection/flat-event.test.ts
+++ b/packages/openomni/test/projection/flat-event.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test } from "bun:test";
+import { WorkItem } from "@openomni/protocol";
+import {
+  deriveLoopKey,
+  FLAT_EVENT_FIELDS,
+  FlatEvent,
+  foldToFlatEvents,
+  mapVerdict,
+  type ProjectionInput,
+  type ProjectionStep,
+} from "@openomni/openomni/projection";
+
+// ---------------------------------------------------------------------------
+// fixture builders — every field is supplied so the schema + mapping + order
+// + verdict are fully proven now (later-increment writers do not exist yet).
+// ---------------------------------------------------------------------------
+
+function contentFingerprint(workInput: string): WorkItem.ContentFingerprint {
+  return WorkItem.contentFingerprintOf({
+    workInput,
+    handlerKind: "worker",
+    handlerCodeRef: { absent: true, reason: "test fixture" },
+    model: {
+      provider: "anthropic",
+      id: "claude-fable-5",
+      parameters: { absent: true, reason: "test fixture" },
+    },
+    upstreamFingerprints: { absent: true, reason: "test fixture" },
+    dependencyLock: { absent: true, reason: "test fixture" },
+  });
+}
+
+function environmentFingerprint(): WorkItem.EnvironmentFingerprint {
+  return WorkItem.environmentFingerprintOf({
+    os: "darwin",
+    arch: "arm64",
+    bunVersion: "1.2.0",
+    workspaceRoot: { absent: true, reason: "test fixture" },
+    schemaVersions: { protocol: 1 },
+    policy: { absent: true, reason: "test fixture" },
+    toolVersions: { absent: true, reason: "test fixture" },
+    verifierVersions: { absent: true, reason: "test fixture" },
+    providerParameters: { absent: true, reason: "test fixture" },
+    configRef: { absent: true, reason: "test fixture" },
+  });
+}
+
+function attempt(
+  overrides: Partial<WorkItem.Attempt> & { workInput?: string } = {},
+): WorkItem.Attempt {
+  const { workInput, ...rest } = overrides;
+  return WorkItem.Attempt.parse({
+    attemptId: "attempt_a",
+    attemptSeq: 1,
+    retryOf: null,
+    reusedFromAttemptId: null,
+    contentFingerprint: contentFingerprint(workInput ?? "ship the widget"),
+    environmentFingerprint: environmentFingerprint(),
+    ...rest,
+  });
+}
+
+function step(overrides: Partial<ProjectionStep> = {}): ProjectionStep {
+  return {
+    order: { timeCreated: 1_000, streamId: "work:abc", seq: 1 },
+    ownerKey: "work:abc",
+    workItemId: "abc",
+    attempt: attempt(),
+    step: 0,
+    parentStep: null,
+    agent: "session-1",
+    op: "part.advanced",
+    thought: "let me try",
+    action: "bash",
+    actionArgs: { cmd: "ls" },
+    observationHash: "sha256:obs",
+    model: "claude-fable-5",
+    inTokens: 10,
+    outTokens: 20,
+    finishReason: "stop",
+    verifierStatus: "verified",
+    checkedPredicate: "output === expected",
+    errorType: null,
+    planDivergence: null,
+    stateHash: "sha256:state",
+    promptHash: "sha256:prompt",
+    cacheKey: "sha256:cache",
+    replayKey: "sha256:replay",
+    nondeterminismManifestHash: "sha256:manifest",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// schema shape — exactly 30 fields, in order
+// ---------------------------------------------------------------------------
+
+const EXPECTED_FIELDS = [
+  "owner_key",
+  "work_item_id",
+  "attempt_id",
+  "attempt_seq",
+  "retry_of",
+  "reused_from_attempt_id",
+  "step",
+  "parent_step",
+  "agent",
+  "op",
+  "thought",
+  "action",
+  "action_args",
+  "observation_hash",
+  "model",
+  "in_tokens",
+  "out_tokens",
+  "finish_reason",
+  "verdict",
+  "checked_predicate",
+  "error_type",
+  "loop_key",
+  "plan_divergence",
+  "state_hash",
+  "prompt_hash",
+  "content_fingerprint",
+  "environment_fingerprint",
+  "cache_key",
+  "replay_key",
+  "nondeterminism_manifest_hash",
+] as const;
+
+describe("FlatEvent schema", () => {
+  test("has exactly the 30 fields in the mandated order", () => {
+    expect(FLAT_EVENT_FIELDS).toEqual([...EXPECTED_FIELDS]);
+    expect(FLAT_EVENT_FIELDS).toHaveLength(30);
+  });
+
+  test("a folded row carries all 30 fields and round-trips the schema", () => {
+    const [row] = foldToFlatEvents({ steps: [step()] });
+    expect(row).toBeDefined();
+    expect(Object.keys(row as FlatEvent)).toEqual([...EXPECTED_FIELDS]);
+    expect(() => FlatEvent.parse(row)).not.toThrow();
+  });
+
+  test("rejects an unknown column (strict)", () => {
+    const [row] = foldToFlatEvents({ steps: [step()] });
+    expect(() => FlatEvent.parse({ ...(row as FlatEvent), extra: true })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verdict mapping — exhaustive incl. throw-on-unknown
+// ---------------------------------------------------------------------------
+
+describe("mapVerdict", () => {
+  test("maps the full verifier status vocabulary", () => {
+    expect(mapVerdict("verified")).toBe("ok");
+    expect(mapVerdict("asserted")).toBe("ok");
+    expect(mapVerdict("inconclusive")).toBe("warn");
+    expect(mapVerdict("refuted")).toBe("error");
+  });
+
+  test("throws on an unknown status (fail loud)", () => {
+    expect(() => mapVerdict("bogus")).toThrow("unknown verifier status: bogus");
+    expect(() => mapVerdict("")).toThrow();
+  });
+
+  test("a null verifier status projects a null verdict", () => {
+    const [row] = foldToFlatEvents({ steps: [step({ verifierStatus: null })] });
+    expect(row?.verdict).toBeNull();
+  });
+
+  test("verifier statuses flow through the fold", () => {
+    for (const [status, verdict] of [
+      ["verified", "ok"],
+      ["asserted", "ok"],
+      ["inconclusive", "warn"],
+      ["refuted", "error"],
+    ] as const) {
+      const [row] = foldToFlatEvents({ steps: [step({ verifierStatus: status })] });
+      expect(row?.verdict).toBe(verdict);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// field provenance — scalar fingerprints, carried-through inputs
+// ---------------------------------------------------------------------------
+
+describe("field provenance", () => {
+  test("fingerprints are the SCALAR .digest strings", () => {
+    const a = attempt();
+    const [row] = foldToFlatEvents({ steps: [step({ attempt: a })] });
+    expect(row?.content_fingerprint).toBe(a.contentFingerprint.digest);
+    expect(row?.environment_fingerprint).toBe(a.environmentFingerprint.digest);
+    // NOT the structured object.
+    expect(typeof row?.content_fingerprint).toBe("string");
+    expect(row?.content_fingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  test("attempt identity maps from the Attempt ledger fact", () => {
+    const a = attempt({
+      attemptId: "attempt_b",
+      attemptSeq: 2,
+      retryOf: "attempt_a",
+      reusedFromAttemptId: "attempt_a",
+    });
+    const [row] = foldToFlatEvents({ steps: [step({ attempt: a })] });
+    expect(row?.attempt_id).toBe("attempt_b");
+    expect(row?.attempt_seq).toBe(2);
+    expect(row?.retry_of).toBe("attempt_a");
+    expect(row?.reused_from_attempt_id).toBe("attempt_a");
+  });
+
+  test("the 5 later-increment fields are carried through, not invented", () => {
+    const [carried] = foldToFlatEvents({ steps: [step()] });
+    expect(carried?.prompt_hash).toBe("sha256:prompt");
+    expect(carried?.observation_hash).toBe("sha256:obs");
+    expect(carried?.cache_key).toBe("sha256:cache");
+    expect(carried?.replay_key).toBe("sha256:replay");
+    expect(carried?.nondeterminism_manifest_hash).toBe("sha256:manifest");
+
+    const [absent] = foldToFlatEvents({
+      steps: [
+        step({
+          promptHash: null,
+          observationHash: null,
+          cacheKey: null,
+          replayKey: null,
+          nondeterminismManifestHash: null,
+        }),
+      ],
+    });
+    expect(absent?.prompt_hash).toBeNull();
+    expect(absent?.observation_hash).toBeNull();
+    expect(absent?.cache_key).toBeNull();
+    expect(absent?.replay_key).toBeNull();
+    expect(absent?.nondeterminism_manifest_hash).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loop_key — deterministic, pure over recorded facts
+// ---------------------------------------------------------------------------
+
+describe("loop_key", () => {
+  test("is the canonical digest of (work_item_id, content digest)", () => {
+    const a = attempt();
+    const [row] = foldToFlatEvents({ steps: [step({ attempt: a })] });
+    expect(row?.loop_key).toBe(deriveLoopKey("abc", a.contentFingerprint.digest));
+  });
+
+  test("identical work content across attempts shares a loop_key", () => {
+    const first = attempt({ attemptId: "attempt_a", attemptSeq: 1, workInput: "same task" });
+    const retry = attempt({
+      attemptId: "attempt_b",
+      attemptSeq: 2,
+      retryOf: "attempt_a",
+      workInput: "same task",
+    });
+    const [a] = foldToFlatEvents({ steps: [step({ attempt: first })] });
+    const [b] = foldToFlatEvents({ steps: [step({ attempt: retry })] });
+    expect(a?.loop_key).toBe(b?.loop_key ?? "");
+  });
+
+  test("a different plan/content starts a new loop", () => {
+    const first = attempt({ workInput: "plan A" });
+    const replan = attempt({
+      attemptId: "attempt_b",
+      attemptSeq: 2,
+      retryOf: "attempt_a",
+      workInput: "plan B",
+    });
+    const [a] = foldToFlatEvents({ steps: [step({ attempt: first })] });
+    const [b] = foldToFlatEvents({ steps: [step({ attempt: replan })] });
+    expect(a?.loop_key).not.toBe(b?.loop_key);
+  });
+
+  test("different WorkItems never collide on identical content", () => {
+    const shared = attempt({ workInput: "identical" });
+    const [a] = foldToFlatEvents({ steps: [step({ workItemId: "wi-1", attempt: shared })] });
+    const [b] = foldToFlatEvents({ steps: [step({ workItemId: "wi-2", attempt: shared })] });
+    expect(a?.loop_key).not.toBe(b?.loop_key);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deterministic global order + byte-identical output
+// ---------------------------------------------------------------------------
+
+describe("foldToFlatEvents determinism", () => {
+  const s1 = step({
+    order: { timeCreated: 1_000, streamId: "work:abc", seq: 1 },
+    step: 0,
+    op: "attempt.started",
+  });
+  const s2 = step({
+    order: { timeCreated: 1_000, streamId: "work:abc", seq: 2 },
+    step: 1,
+    op: "part.advanced",
+  });
+  const s3 = step({
+    order: { timeCreated: 2_000, streamId: "work:abc", seq: 1 },
+    step: 2,
+    op: "attempt.finished",
+  });
+  // Same recorded time, different stream — tie-broken by streamId ASC.
+  const s4 = step({
+    order: { timeCreated: 1_000, streamId: "work:aaa", seq: 9 },
+    step: 3,
+    op: "part.advanced",
+  });
+
+  test("orders by (timeCreated ASC, streamId ASC, seq ASC) regardless of input order", () => {
+    const shuffled: ProjectionInput = { steps: [s3, s1, s4, s2] };
+    const rows = foldToFlatEvents(shuffled);
+    expect(rows.map((r) => r.op)).toEqual([
+      "part.advanced", // work:aaa @1000 seq9
+      "attempt.started", // work:abc @1000 seq1
+      "part.advanced", // work:abc @1000 seq2
+      "attempt.finished", // work:abc @2000 seq1
+    ]);
+  });
+
+  test("same input yields byte-identical FlatEvent[] twice", () => {
+    const input: ProjectionInput = { steps: [s3, s1, s4, s2] };
+    const first = JSON.stringify(foldToFlatEvents(input));
+    const second = JSON.stringify(foldToFlatEvents(input));
+    expect(first).toBe(second);
+  });
+
+  test("input list order does not change the output", () => {
+    const a = JSON.stringify(foldToFlatEvents({ steps: [s1, s2, s3, s4] }));
+    const b = JSON.stringify(foldToFlatEvents({ steps: [s4, s3, s2, s1] }));
+    expect(a).toBe(b);
+  });
+
+  test("a non-total order (duplicate order tuple) fails loud", () => {
+    const dup = step({ order: { timeCreated: 1_000, streamId: "work:abc", seq: 1 }, step: 7 });
+    expect(() => foldToFlatEvents({ steps: [s1, dup] })).toThrow("non-total projection order");
+  });
+
+  test("an empty input folds to an empty projection", () => {
+    expect(foldToFlatEvents({ steps: [] })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Increment I1 of #493 — deterministic flat-event PROJECTION SPINE

Delivers ONLY the projection spine (later increments build export/replay on top).

### What landed
- **`FlatEvent`** zod schema — exactly the mandated 30 columns, fixed order, `.strict()`.
- **`mapVerdict`** — PURE map from the verifier registry status vocabulary (`verified|refuted|inconclusive|asserted`) onto `ok|warn|error`, **throw-on-unknown** (mirrors `projectCompletionOrigin` fail-loud). Never calls an LLM.
- **`foldToFlatEvents(input)`** — pure map from an assembled `ProjectionInput` (per-step fact bundles) into a deterministically ordered `FlatEvent[]`.

### Hard decisions implemented
- **Authority source = Attempt ledger fact + `transcript_fact`, NOT `bus_event`.** `ProjectionInput` is assembled from those; the fold is pure over it.
- **Scalar fingerprints** — `content_fingerprint`/`environment_fingerprint` emit `attempt.*Fingerprint.digest`, not the structured objects.
- **Global order** — `ledger_event` has no global ordinal column (migration 0013 PK is `(stream_id, seq)`), so the fold sorts by `(timeCreated ASC, streamId ASC, seq ASC)` over immutable recorded rows; deterministic because the archive stores recorded values, never a live clock. Fails loud on a non-total order.
- **`loop_key`** = `canonicalDigest(work_item_id, content_fingerprint.digest)` — identical work content across attempts shares a loop; different plan/content starts a new one.
- **5 later-increment columns carried through, never faked** — `prompt_hash`/`observation_hash` (I3), `cache_key`/`replay_key`/`nondeterminism_manifest_hash` (I2). Fixtures supply all 30 fields so schema+mapping+ordering+verdict are proven now.

### Placement
`packages/openomni/src/projection/` (openomni may import protocol/session; no protocol widening → no schema-snapshot churn). `check-deps` confirms no cycle.

### Gates (all pass)
`bun run build`, `bun run check-types`, `bunx biome check packages apps script`, `bun run script/check-deps.ts`, `bun test packages/openomni/test/projection/flat-event.test.ts` (19 pass), `git diff --check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a deterministic flat-event projection spine for #493 to enable a single strict 30-column row shape and reproducible ordering for export/replay. Previously there was no flat-event projection; now `FlatEvent`, `mapVerdict`, and `foldToFlatEvents` provide a pure, fail-loud projection over recorded facts.

- `FlatEvent` schema: exactly 30 fixed-order columns, `.strict()`; carries through nullable later-increment fields (`prompt_hash`, `observation_hash`, `cache_key`, `replay_key`, `nondeterminism_manifest_hash`) without inventing values.
- Deterministic order: sorts by `(timeCreated ASC, streamId ASC, seq ASC)` from recorded archive values; throws on duplicate tuples to avoid ambiguous projection.
- `mapVerdict`: `verified|asserted|inconclusive|refuted` → `ok|ok|warn|error`; unknown statuses throw; `null` status yields `null` verdict.
- Authority: folds only attempt ledger facts and `transcript_fact`; never reads `bus_event`. Fingerprints emit the scalar `.digest` values.
- `loop_key`: `canonicalDigest(work_item_id, content_fingerprint.digest)`; identical content across attempts shares a key; different content starts a new loop.
- Exposes `./projection` from `packages/openomni` and adds tests in `packages/openomni/test/projection/flat-event.test.ts`. No DB or protocol changes; no migrations required.

<sup>Written for commit f47cb161b24fc2b1a12dc68867f4418bca3a4c79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a flat-event projection API for converting validated workflow steps into consistently structured event records.
  * Added deterministic event ordering, loop-key generation, verdict mapping, and preservation of fingerprint and attempt details.
  * Exposed the projection functionality through the package’s public exports.

* **Bug Fixes**
  * Added validation that rejects unknown verifier statuses and duplicate ordering keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->