### PR TITLE
feat(openomni): #493 hash-addressed sidecar store (I3)

### DIFF
--- a/packages/openomni/src/projection/sidecar-store.test.ts
+++ b/packages/openomni/src/projection/sidecar-store.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFilesystemSidecarStore,
+  createInMemorySidecarStore,
+  type SidecarDigest,
+  digestOf,
+  type SidecarStore,
+  SidecarDigestError,
+  SidecarIntegrityError,
+  SidecarNotFoundError,
+} from "./sidecar-store.js";
+
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "sidecar-store-test-"));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const backends: { name: string; make: () => SidecarStore }[] = [
+  { name: "in-memory", make: () => createInMemorySidecarStore() },
+  { name: "filesystem", make: () => createFilesystemSidecarStore(mkdtempSync(join(root, "fs-"))) },
+];
+
+describe("digestOf", () => {
+  it("uses the repo sha256:<hex> convention", () => {
+    // sha256 of empty input.
+    expect(String(digestOf(new Uint8Array()))).toBe(
+      "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("is deterministic: same content -> same digest", () => {
+    expect(digestOf("hello world")).toBe(digestOf("hello world"));
+  });
+
+  it("distinguishes different content", () => {
+    expect(digestOf("hello")).not.toBe(digestOf("world"));
+  });
+
+  it("treats a string and its UTF-8 bytes as equivalent", () => {
+    const bytes = new TextEncoder().encode("héllo");
+    expect(digestOf("héllo")).toBe(digestOf(bytes));
+  });
+});
+
+for (const { name, make } of backends) {
+  describe(`SidecarStore (${name})`, () => {
+    it("roundtrips bytes: put then get returns identical content", () => {
+      const store = make();
+      const bytes = new TextEncoder().encode("prompt: do the thing");
+      const digest = store.put(bytes);
+      expect(store.get(digest)).toEqual(bytes);
+    });
+
+    it("roundtrips text via getText", () => {
+      const store = make();
+      const digest = store.put("observation body");
+      expect(store.getText(digest)).toBe("observation body");
+    });
+
+    it("is idempotent: putting the same bytes twice yields the same digest, no error", () => {
+      const store = make();
+      const first = store.put("same bytes");
+      const second = store.put("same bytes");
+      expect(second).toBe(first);
+      expect(store.has(first)).toBe(true);
+      expect(store.getText(first)).toBe("same bytes");
+    });
+
+    it("treats string and its UTF-8 bytes as the same blob", () => {
+      const store = make();
+      const fromString = store.put("hello");
+      const fromBytes = store.put(new TextEncoder().encode("hello"));
+      expect(fromBytes).toBe(fromString);
+    });
+
+    it("has() is false for absent digests", () => {
+      const store = make();
+      expect(store.has(digestOf("never stored"))).toBe(false);
+    });
+
+    it("get() on an unknown digest throws SidecarNotFoundError carrying the digest", () => {
+      const store = make();
+      const missing = digestOf("missing");
+      let caught: unknown;
+      try {
+        store.get(missing);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(SidecarNotFoundError);
+      expect((caught as SidecarNotFoundError).digest).toBe(missing);
+    });
+
+    it("getText() on an unknown digest throws SidecarNotFoundError", () => {
+      const store = make();
+      expect(() => store.getText(digestOf("missing"))).toThrow(SidecarNotFoundError);
+    });
+  });
+}
+
+describe("copy semantics", () => {
+  for (const { name, make } of backends) {
+    it(`${name}: mutating the input after put does not corrupt the store`, () => {
+      const store = make();
+      const bytes = new TextEncoder().encode("caller-owned bytes");
+      const digest = store.put(bytes);
+      bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+      expect(store.getText(digest)).toBe("caller-owned bytes");
+    });
+
+    it(`${name}: mutating a returned buffer does not corrupt the store`, () => {
+      const store = make();
+      const digest = store.put("trusted bytes");
+      const returned = store.get(digest);
+      returned[0] = (returned[0] ?? 0) ^ 0xff;
+      expect(store.getText(digest)).toBe("trusted bytes");
+    });
+  }
+});
+
+describe("integrity enforcement", () => {
+  it("filesystem: overwriting the blob file makes get throw SidecarIntegrityError", () => {
+    const dir = mkdtempSync(join(root, "fs-tamper-"));
+    const store = createFilesystemSidecarStore(dir);
+    const digest = store.put("trusted bytes");
+    const hex = digest.slice("sha256:".length);
+    const path = join(dir, hex.slice(0, 2), hex.slice(2));
+    writeFileSync(path, "tampered bytes");
+    let caught: unknown;
+    try {
+      store.get(digest);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SidecarIntegrityError);
+    const integrity = caught as SidecarIntegrityError;
+    expect(integrity.expected).toBe(digest);
+    expect(String(integrity.actual)).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(integrity.actual).not.toBe(digest);
+  });
+
+  it("filesystem: put over a torn or corrupt existing blob repairs it", () => {
+    const dir = mkdtempSync(join(root, "fs-torn-"));
+    const store = createFilesystemSidecarStore(dir);
+    const digest = digestOf("replay-critical bytes");
+    const hex = digest.slice("sha256:".length);
+    const path = join(dir, hex.slice(0, 2), hex.slice(2));
+    // Simulate a crash mid-write: a partial file already sits at the address.
+    mkdirSync(join(dir, hex.slice(0, 2)), { recursive: true });
+    writeFileSync(path, "replay-crit");
+    expect(store.put("replay-critical bytes")).toBe(digest);
+    expect(store.getText(digest)).toBe("replay-critical bytes");
+  });
+});
+
+describe("malformed digest rejection (path-traversal hardening)", () => {
+  const malformed: string[] = [
+    "sha256:../../../etc/passwd",
+    "sha256:../",
+    "not-a-digest",
+    // uppercase hex is not canonical.
+    `sha256:${"A".repeat(64)}`,
+    // 63 hex chars (too short).
+    `sha256:${"a".repeat(63)}`,
+    // 65 hex chars (too long).
+    `sha256:${"a".repeat(65)}`,
+    // right shape but missing the sha256: prefix.
+    "a".repeat(64),
+  ];
+
+  for (const { name, make } of backends) {
+    describe(name, () => {
+      for (const value of malformed) {
+        it(`get() rejects ${JSON.stringify(value)} with SidecarDigestError`, () => {
+          const store = make();
+          const bad = value as SidecarDigest;
+          let caught: unknown;
+          try {
+            store.get(bad);
+          } catch (error) {
+            caught = error;
+          }
+          expect(caught).toBeInstanceOf(SidecarDigestError);
+          expect((caught as SidecarDigestError).value).toBe(value);
+        });
+
+        it(`has() rejects ${JSON.stringify(value)} with SidecarDigestError`, () => {
+          const store = make();
+          const bad = value as SidecarDigest;
+          expect(() => store.has(bad)).toThrow(SidecarDigestError);
+        });
+      }
+
+      it("rejects malformed digests before any well-formed put, and the happy path still round-trips", () => {
+        const store = make();
+        const digest = store.put("legit payload");
+        expect(store.getText(digest)).toBe("legit payload");
+      });
+    });
+  }
+
+  it("filesystem: a traversal digest never reads outside rootDir", () => {
+    const dir = mkdtempSync(join(root, "fs-traversal-"));
+    const store = createFilesystemSidecarStore(dir);
+    const attack = "sha256:../../../../../../etc/passwd" as SidecarDigest;
+    // No filesystem access happens: it throws on the malformed address first.
+    expect(() => store.get(attack)).toThrow(SidecarDigestError);
+    expect(() => store.has(attack)).toThrow(SidecarDigestError);
+  });
+
+  it("digestOf output is always well-formed and passes the guard", () => {
+    const store = createInMemorySidecarStore();
+    const digest = store.put("well-formed by construction");
+    expect(String(digest)).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(store.has(digest)).toBe(true);
+  });
+});
+
+describe("filesystem sharding", () => {
+  it("lands a stored digest at <rootDir>/<2>/<rest>", () => {
+    const dir = mkdtempSync(join(root, "fs-shard-"));
+    const store = createFilesystemSidecarStore(dir);
+    const digest = store.put("shard me");
+    const hex = digest.slice("sha256:".length);
+    const expectedPath = join(dir, hex.slice(0, 2), hex.slice(2));
+    expect(Bun.file(expectedPath).size).toBeGreaterThan(0);
+  });
+});

--- a/packages/openomni/src/projection/sidecar-store.ts
+++ b/packages/openomni/src/projection/sidecar-store.ts
@@ -1,0 +1,261 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Content-addressed sidecar store for prompt text and observation bodies.
+ *
+ * The #493 flat-event projection references blobs by digest (`prompt_hash`,
+ * `observation_hash`); the zero-live replay engine re-reads the exact recorded
+ * bytes from this store. A blob is addressed solely by the digest of its
+ * content, so identical content is stored once.
+ *
+ * BOUNDARY — RAW BYTES, NO REDACTION: this layer holds prompts and
+ * observations verbatim because exact-byte replay requires the original bytes.
+ * Redaction is deliberately NOT this layer's responsibility; a later export
+ * increment (I6) redacts on export. Do not assume anything read back here has
+ * been sanitized.
+ *
+ * Reads are integrity-bound: `get` recomputes the digest of the stored bytes
+ * and fails loud on any mismatch rather than returning tampered content.
+ */
+
+/**
+ * A content digest in the repo's canonical form:
+ * `sha256:${createHash("sha256").update(bytes).digest("hex")}`.
+ */
+export type SidecarDigest = string & { readonly __brand: "SidecarDigest" };
+
+/**
+ * Thrown when a supplied digest is not a well-formed address —
+ * `sha256:` followed by exactly 64 lowercase hex chars. A malformed address is
+ * a caller bug (or hostile input), distinct from an absent blob; it is
+ * rejected before any path construction or map lookup so an attacker cannot
+ * traverse out of the store root via a crafted digest.
+ */
+export class SidecarDigestError extends Error {
+  readonly value: string;
+  constructor(value: string) {
+    super(`malformed sidecar digest: ${value}`);
+    this.name = "SidecarDigestError";
+    this.value = value;
+  }
+}
+
+/** Thrown when a requested digest is not present in the store. */
+export class SidecarNotFoundError extends Error {
+  readonly digest: SidecarDigest;
+  constructor(digest: SidecarDigest) {
+    super(`sidecar blob not found: ${digest}`);
+    this.name = "SidecarNotFoundError";
+    this.digest = digest;
+  }
+}
+
+/**
+ * Thrown when stored bytes do not hash to the digest they are addressed by —
+ * i.e. the blob was tampered with or corrupted at rest.
+ */
+export class SidecarIntegrityError extends Error {
+  readonly expected: SidecarDigest;
+  readonly actual: SidecarDigest;
+  constructor(expected: SidecarDigest, actual: SidecarDigest) {
+    super(`sidecar integrity check failed: expected ${expected}, got ${actual}`);
+    this.name = "SidecarIntegrityError";
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+/** Content-addressed blob store with integrity-bound reads. */
+export type SidecarStore = {
+  /**
+   * Content-addressed write. Writing identical bytes twice is idempotent and
+   * returns the same digest without duplication or error.
+   */
+  put(bytes: Uint8Array | string): SidecarDigest;
+  /**
+   * Integrity-bound read. Recomputes the digest of the stored bytes and throws
+   * `SidecarIntegrityError` on mismatch, `SidecarNotFoundError` if absent.
+   */
+  get(digest: SidecarDigest): Uint8Array;
+  /** UTF-8 decodes the bytes returned by `get`. */
+  getText(digest: SidecarDigest): string;
+  /** Whether a blob is present for `digest` (does not verify integrity). */
+  has(digest: SidecarDigest): boolean;
+};
+
+function toBytes(bytes: Uint8Array | string): Uint8Array {
+  return typeof bytes === "string" ? new TextEncoder().encode(bytes) : bytes;
+}
+
+/**
+ * Pure content digest. Same content always yields the same digest — no
+ * timestamps, no randomness. Strings are normalized to UTF-8 bytes first.
+ */
+export function digestOf(bytes: Uint8Array | string): SidecarDigest {
+  const hex = createHash("sha256").update(toBytes(bytes)).digest("hex");
+  return `sha256:${hex}` as SidecarDigest;
+}
+
+/** Canonical address shape: `sha256:` + exactly 64 lowercase hex chars. */
+const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+/**
+ * Assert `digest` is a well-formed address before it is used to build a
+ * filesystem path or look up a blob. Rejects externally-supplied garbage (e.g.
+ * a path-traversal payload cast to `SidecarDigest`) fail-loud, so no backend
+ * ever touches disk or the map with an untrusted address. Digests produced by
+ * `digestOf`/`put` are well-formed by construction and always pass.
+ */
+function assertWellFormedDigest(digest: SidecarDigest): void {
+  if (!DIGEST_PATTERN.test(digest)) {
+    throw new SidecarDigestError(digest);
+  }
+}
+
+/**
+ * Strip the `sha256:` prefix, returning the bare hex digest. Callers validate
+ * the address first (`assertWellFormedDigest`), so the prefix is always
+ * present.
+ */
+function toHex(digest: SidecarDigest): string {
+  return digest.slice("sha256:".length);
+}
+
+/** Recompute the digest and fail loud if it does not match the address. */
+function verify(digest: SidecarDigest, stored: Uint8Array): Uint8Array {
+  const actual = digestOf(stored);
+  if (actual !== digest) {
+    throw new SidecarIntegrityError(digest, actual);
+  }
+  return stored;
+}
+
+/**
+ * Filesystem-backed store. Blobs are laid out git-style as
+ * `<rootDir>/<first 2 hex chars>/<rest of hex>` (the `sha256:` prefix is
+ * stripped for the path). Directories are created lazily on write. This is the
+ * production / archive-adjacent backend.
+ */
+export function createFilesystemSidecarStore(rootDir: string): SidecarStore {
+  function pathFor(digest: SidecarDigest): string {
+    // Defense-in-depth: never construct a path from an unvalidated address.
+    assertWellFormedDigest(digest);
+    const hex = toHex(digest);
+    return join(rootDir, hex.slice(0, 2), hex.slice(2));
+  }
+
+  /**
+   * Atomically publish `content` at `path`: write to a same-directory temp
+   * file, fsync it, rename over the target (atomic on POSIX), then fsync the
+   * directory so the rename itself is durable. Readers never observe a
+   * partial blob and a crash never leaves a torn file at the address.
+   */
+  function publish(path: string, content: Uint8Array): void {
+    const dir = dirname(path);
+    mkdirSync(dir, { recursive: true });
+    const tmp = join(dir, `.tmp-${randomBytes(8).toString("hex")}`);
+    try {
+      writeFileSync(tmp, content);
+      const fd = openSync(tmp, "r");
+      try {
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+      renameSync(tmp, path);
+    } catch (error) {
+      rmSync(tmp, { force: true });
+      throw error;
+    }
+    const dirFd = openSync(dir, "r");
+    try {
+      fsyncSync(dirFd);
+    } finally {
+      closeSync(dirFd);
+    }
+  }
+
+  return {
+    put(bytes: Uint8Array | string): SidecarDigest {
+      const content = toBytes(bytes);
+      const digest = digestOf(content);
+      const path = pathFor(digest);
+      // Content-addressed: identical content maps to the same path. An
+      // existing file is only trusted after verifying it actually hashes to
+      // the address — a torn or tampered blob is repaired by republishing.
+      if (existsSync(path)) {
+        try {
+          verify(digest, new Uint8Array(readFileSync(path)));
+          return digest;
+        } catch {
+          // Fall through to republish the correct bytes.
+        }
+      }
+      publish(path, content);
+      return digest;
+    },
+    get(digest: SidecarDigest): Uint8Array {
+      const path = pathFor(digest);
+      if (!existsSync(path)) {
+        throw new SidecarNotFoundError(digest);
+      }
+      return verify(digest, new Uint8Array(readFileSync(path)));
+    },
+    getText(digest: SidecarDigest): string {
+      return new TextDecoder().decode(this.get(digest));
+    },
+    has(digest: SidecarDigest): boolean {
+      return existsSync(pathFor(digest));
+    },
+  };
+}
+
+/**
+ * In-memory, Map-backed store for tests and fixtures. Semantics are identical
+ * to the filesystem backend: bytes are copied at both boundaries (`put`
+ * stores a copy, `get` returns a copy), so caller-side mutation of an input
+ * or a returned buffer never corrupts the store, and stored bytes are
+ * re-hashed on `get` (defense in depth, same as the filesystem read path).
+ */
+export function createInMemorySidecarStore(): SidecarStore {
+  const blobs = new Map<SidecarDigest, Uint8Array>();
+
+  return {
+    put(bytes: Uint8Array | string): SidecarDigest {
+      const content = toBytes(bytes);
+      const digest = digestOf(content);
+      if (!blobs.has(digest)) {
+        blobs.set(digest, content.slice());
+      }
+      return digest;
+    },
+    get(digest: SidecarDigest): Uint8Array {
+      // Reject malformed addresses before touching the map.
+      assertWellFormedDigest(digest);
+      const stored = blobs.get(digest);
+      if (stored === undefined) {
+        throw new SidecarNotFoundError(digest);
+      }
+      return verify(digest, stored).slice();
+    },
+    getText(digest: SidecarDigest): string {
+      return new TextDecoder().decode(this.get(digest));
+    },
+    has(digest: SidecarDigest): boolean {
+      assertWellFormedDigest(digest);
+      return blobs.has(digest);
+    },
+  };
+}


### PR DESCRIPTION
## #493 I3 — hash-addressed sidecar store (rebased 2026-08-23)

Content-addressed blob store (`sha256:<hex>` → bytes) for large payloads referenced from projections/exports. Two backends behind one `SidecarStore` interface: sharded filesystem (`ab/cdef...`) and in-memory (tests/fixtures). Integrity is verified on every read; malformed addresses, missing blobs, and hash mismatches are typed errors (`SidecarDigestError`, `SidecarNotFoundError`, `SidecarIntegrityError`) carrying branchable fields.

### Rebase deltas vs the original 08-12 commit
- `projection/index.ts` barrel change dropped — main deleted the whole `projection/` dir (I1 flat-event spine) as proven-dead in #744, so this module now lands self-contained with no barrel export.
- **Atomic, self-healing filesystem writes**: `put` publishes via same-dir temp file + fsync + rename + dir fsync; an existing blob is verified against its address and a torn/corrupt file is repaired by republishing (was: `existsSync` + bare `writeFileSync`, trusted-if-exists).
- **Copy semantics on the memory backend**: `put` stores a copy, `get` returns a copy — backend semantics now genuinely identical; caller-side mutation cannot corrupt the store.
- `toHex` unreachable prefix fallback removed (rule 6).
- Tests: aliasing-based tamper test replaced with copy-semantics tests on both backends + a torn-blob repair test; error assertions now pin typed fields (`value`, `digest`, `expected`/`actual`).

### Adversarial review (independent deep agent, 2026-08-23)
All three MAJOR code findings above are fixed in this commit. Two findings remain **open by design** and are deferred to the slice that lands the first consumer:
1. **No production consumer yet** — same shape #744 deleted; merging this standalone is an explicit Owner call against the "engine without a consumer" law, justified only as the base increment of the actively-resumed #493 campaign. The dead-export ratchet is blind to this module (colocated src test is a knip entry point), so the green gate does not vouch for reachability.
2. **Digest-convention ownership** — this module owns another `sha256:<hex>` spelling; extraction of a single byte-digest owner is deferred to consumer-landing to avoid growing protocol surface ahead of use.

### Gates (local, on rebased head)
build / check-types / check-deps / lint:tools / dead-export ratchet: green. Full suite 3820 pass, 0 fail. openomni package: 1020 pass / 0 fail. Coverage ratchet: openomni passes; sole violation is `apps/server` −0.81pp, reproduced identically on origin/main (pre-existing, tracked separately).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content-addressed storage for binary and text sidecar data.
  * Added in-memory and filesystem-backed storage options.
  * Added SHA-256 digest generation and integrity verification.
  * Added support for checking, retrieving, and decoding stored content.
  * Added safeguards against invalid addresses, missing data, tampering, and path traversal.

* **Tests**
  * Added comprehensive coverage for storage behavior, data integrity, filesystem recovery, and sharding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->