### PR TITLE
perf(policy): skip context materialization at unguarded points (#606)

### DIFF
--- a/packages/policy/src/engine/audit.ts
+++ b/packages/policy/src/engine/audit.ts
@@ -47,6 +47,16 @@ function resolveAuditPoint(ctx: Readonly<AuditDispatchContextGeneric<GenericPoli
   };
 }
 
+/**
+ * Whether anything will read an audit context. Not every engine binds one:
+ * the completion-admission engine is built as `PolicyEngine.create()` with no
+ * options (`packages/openomni/src/dispatch/setup.ts`), so building a
+ * correlation context for its dispatches is pure waste.
+ */
+export function auditIsConsumed(options: PolicyEngineConfig): boolean {
+  return options.audit !== false && options.auditEmit !== undefined;
+}
+
 export function publishPolicyEvent(
   options: PolicyEngineConfig,
   decision: Policy.PolicyDecision,

--- a/packages/policy/src/engine/context.ts
+++ b/packages/policy/src/engine/context.ts
@@ -10,9 +10,25 @@ type ImmutablePointSnapshot<TValue extends object> =
   | { readonly success: true; readonly value: Readonly<TValue> }
   | { readonly success: false };
 
+/**
+ * Copies a dispatch context into a frozen graph a policy cannot mutate.
+ *
+ * Only plain records, arrays, and primitives survive. Functions, symbols,
+ * cycles, proxies, and exotic objects (Date, Map, typed arrays) fail the
+ * snapshot, which the dispatcher reports as `policy.input_invalid`. The one
+ * exception is the caller's event emitter, carried through by reference.
+ *
+ * `added` is applied after the clone, so the engine's own fields — the point
+ * identity and the agent type that drove registration selection — are the ones
+ * a policy observes, never a context getter's second answer.
+ */
 export function immutablePointSnapshot<TCtx extends GenericPolicyContext>(
   value: Readonly<AuditDispatchContextGeneric<TCtx>>,
-  added: Readonly<{ readonly pointId: PolicyPointId; readonly timing: Policy.Timing }>,
+  added: Readonly<{
+    readonly pointId: PolicyPointId;
+    readonly timing: Policy.Timing;
+    readonly agentType?: string;
+  }>,
 ): ImmutablePointSnapshot<CanonicalAuditDispatchContextGeneric<TCtx>>;
 export function immutablePointSnapshot<TValue extends object, TAdded extends object>(
   value: TValue,
@@ -42,24 +58,45 @@ export function immutablePointSnapshot(
   }
 }
 
-function cloneRecord(record: Record<string, unknown>): Readonly<Record<string, unknown>> {
-  const clone: Record<string, unknown> = {};
+/**
+ * Correlation fields worth keeping on an audit record when the full context was
+ * never materialized. Each is captured independently so one unsafe field cannot
+ * suppress the rest.
+ */
+const AUDIT_CORRELATION_KEYS = [
+  "traceContext",
+  "sessionId",
+  "runId",
+  "resourceDescriptor",
+  "toolName",
+  "dispatchId",
+  "correlation",
+] as const;
 
-  for (const [key, value] of Object.entries(record)) {
-    clone[key] = cloneValue(value);
+/**
+ * Audit context for a dispatch that never built a full snapshot — either the
+ * snapshot failed, or the point carries no registration and materializing the
+ * context would be pure cost.
+ */
+export function auditCorrelationContext(
+  ctx: object,
+  pointId: PolicyPointId,
+  timing: Policy.Timing,
+): Readonly<
+  Record<string, unknown> & { readonly pointId: PolicyPointId; readonly timing: Policy.Timing }
+> {
+  const fields: Record<string, unknown> = {};
+  for (const key of AUDIT_CORRELATION_KEYS) {
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(ctx, key);
+      if (descriptor === undefined || !("value" in descriptor)) continue;
+      const captured = immutablePointSnapshot({ [key]: descriptor.value }, {});
+      if (captured.success) Object.assign(fields, captured.value);
+    } catch {
+      // Ignore unsafe getters and proxies; independently safe fields still land.
+    }
   }
-
-  return Object.freeze(clone);
-}
-
-function cloneArray(values: readonly unknown[]): readonly unknown[] {
-  return Object.freeze(values.map(cloneValue));
-}
-
-function cloneValue(value: unknown): unknown {
-  if (Array.isArray(value)) return cloneArray(value);
-  if (isPlainRecord(value)) return cloneRecord(value);
-  return value;
+  return Object.freeze({ ...fields, pointId, timing });
 }
 
 function freezePlainValue(

--- a/packages/policy/src/engine/context.ts
+++ b/packages/policy/src/engine/context.ts
@@ -13,10 +13,19 @@ type ImmutablePointSnapshot<TValue extends object> =
 /**
  * Copies a dispatch context into a frozen graph a policy cannot mutate.
  *
- * Only plain records, arrays, and primitives survive. Functions, symbols,
- * cycles, proxies, and exotic objects (Date, Map, typed arrays) fail the
- * snapshot, which the dispatcher reports as `policy.input_invalid`. The one
- * exception is the caller's event emitter, carried through by reference.
+ * Rejected, surfacing as `policy.input_invalid`: function and symbol values,
+ * cycles, nested proxies, and values `structuredClone` preserves but that are
+ * not plain records or arrays (Date, Map, Set, typed arrays, RegExp).
+ *
+ * Three shapes survive that the name "immutable snapshot" might suggest do not,
+ * all inherited from `structuredClone` and unchanged by #606:
+ *   - a *top-level* transparent proxy, flattened by the spread below before
+ *     `structuredClone` ever sees it (only nested proxies are rejected);
+ *   - symbol-keyed properties, silently dropped rather than rejected;
+ *   - a nested class instance, cloned into a plain record.
+ *
+ * The one deliberate exception is the caller's event emitter, carried through
+ * by reference.
  *
  * `added` is applied after the clone, so the engine's own fields — the point
  * identity and the agent type that drove registration selection — are the ones
@@ -77,6 +86,13 @@ const AUDIT_CORRELATION_KEYS = [
  * Audit context for a dispatch that never built a full snapshot — either the
  * snapshot failed, or the point carries no registration and materializing the
  * context would be pure cost.
+ *
+ * Values are read with `Reflect.get`, matching what the full snapshot's spread
+ * observes: an accessor-defined `traceContext` must reach the audit record, or
+ * `publishComposedDecision` drops the event for want of a trace id.
+ *
+ * One snapshot covers the whole set; a single unsafe field falls back to
+ * per-field capture so it cannot suppress the others.
  */
 export function auditCorrelationContext(
   ctx: object,
@@ -85,18 +101,28 @@ export function auditCorrelationContext(
 ): Readonly<
   Record<string, unknown> & { readonly pointId: PolicyPointId; readonly timing: Policy.Timing }
 > {
-  const fields: Record<string, unknown> = {};
+  const present: Record<string, unknown> = {};
   for (const key of AUDIT_CORRELATION_KEYS) {
     try {
-      const descriptor = Object.getOwnPropertyDescriptor(ctx, key);
-      if (descriptor === undefined || !("value" in descriptor)) continue;
-      const captured = immutablePointSnapshot({ [key]: descriptor.value }, {});
-      if (captured.success) Object.assign(fields, captured.value);
+      const value = Reflect.get(ctx, key);
+      if (value !== undefined) present[key] = value;
     } catch {
-      // Ignore unsafe getters and proxies; independently safe fields still land.
+      // A throwing accessor drops its own field, never the rest.
     }
   }
+
+  const combined = immutablePointSnapshot(present, {});
+  const fields = combined.success ? combined.value : capturePerField(present);
   return Object.freeze({ ...fields, pointId, timing });
+}
+
+function capturePerField(present: Readonly<Record<string, unknown>>): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(present)) {
+    const captured = immutablePointSnapshot({ [key]: value }, {});
+    if (captured.success) Object.assign(fields, captured.value);
+  }
+  return fields;
 }
 
 function freezePlainValue(

--- a/packages/policy/src/engine/context.ts
+++ b/packages/policy/src/engine/context.ts
@@ -87,9 +87,11 @@ const AUDIT_CORRELATION_KEYS = [
  * snapshot failed, or the point carries no registration and materializing the
  * context would be pure cost.
  *
- * Values are read with `Reflect.get`, matching what the full snapshot's spread
- * observes: an accessor-defined `traceContext` must reach the audit record, or
- * `publishComposedDecision` drops the event for want of a trace id.
+ * Values are read directly rather than through property descriptors, so an
+ * accessor-defined `traceContext` reaches the audit record instead of leaving
+ * `publishComposedDecision` to drop the event for want of a trace id. Unlike
+ * the full snapshot's spread, `Reflect.get` also observes non-enumerable and
+ * inherited properties, so this path can capture strictly more, never less.
  *
  * One snapshot covers the whole set; a single unsafe field falls back to
  * per-field capture so it cannot suppress the others.

--- a/packages/policy/src/engine/dispatch.ts
+++ b/packages/policy/src/engine/dispatch.ts
@@ -1,5 +1,5 @@
 import { Policy, PolicyDecision } from "@openomni/protocol";
-import { publishComposedDecision } from "./audit";
+import { auditIsConsumed, publishComposedDecision } from "./audit";
 import { auditCorrelationContext, immutablePointSnapshot } from "./context";
 import { COMPOSED_POLICY_ID, composeFinalPointDecision } from "./decisions";
 import {
@@ -38,8 +38,14 @@ export function createPolicyEngine<TCtx extends GenericPolicyContext>(
     ctx: object,
     timing: Policy.Timing,
   ): Policy.PolicyDecision {
-    const auditCtx = auditCorrelationContext(ctx, pointId, timing);
     const contractFailure = validatePointContract(pointId, ctx);
+    // Skipped when nothing reads it — the completion-admission engine binds
+    // neither `auditEmit` nor `onDecision`, and `work.complete.pre` is
+    // permanently unguarded, so this is its whole per-dispatch cost.
+    const auditCtx =
+      auditIsConsumed(options) || options.onDecision !== undefined
+        ? auditCorrelationContext(ctx, pointId, timing)
+        : Object.freeze({ pointId, timing });
     const decision =
       contractFailure === undefined
         ? PolicyDecision.allow({ policyId: COMPOSED_POLICY_ID })
@@ -163,16 +169,29 @@ function readAgentType(ctx: object): string | undefined {
   }
 }
 
+/**
+ * Total by construction. On the unguarded path this reads the caller's own
+ * object — `Reflect.get` for the required keys, and a `.passthrough()` schema
+ * that walks every key — so a hostile accessor would otherwise escape
+ * `dispatchPoint` as an exception rather than a verdict. Every caller awaits a
+ * decision; a throw would bypass fail-closed and fail-open alike.
+ */
 function validatePointContract(
   pointId: PolicyPointId,
   ctx: Readonly<object>,
 ): Policy.PolicyDecision | undefined {
   const contract = Policy.PolicyPoint.Registry[pointId];
-  if (contract.requiredContext.some((key) => Reflect.get(ctx, key) === undefined)) {
-    return pointContractDecision(pointId, "policy.context_missing");
-  }
-  if (!Policy.PolicyPoint.InputSchemas[pointId].safeParse(ctx).success) {
+  try {
+    if (contract.requiredContext.some((key) => Reflect.get(ctx, key) === undefined)) {
+      return pointContractDecision(pointId, "policy.context_missing");
+    }
+    if (!Policy.PolicyPoint.InputSchemas[pointId].safeParse(ctx).success) {
+      return pointContractDecision(pointId, "policy.input_invalid");
+    }
+    return undefined;
+  } catch {
+    // Matches the snapshot path, where the same throw is absorbed by
+    // `immutablePointSnapshot` and reported as an invalid input.
     return pointContractDecision(pointId, "policy.input_invalid");
   }
-  return undefined;
 }

--- a/packages/policy/src/engine/dispatch.ts
+++ b/packages/policy/src/engine/dispatch.ts
@@ -1,16 +1,16 @@
 import { Policy, PolicyDecision } from "@openomni/protocol";
-import { COMPOSED_POLICY_ID, composeFinalPointDecision } from "./decisions";
-import { timingForPolicyPoint } from "./points";
-import { createPolicyRegistrationStore } from "./registration";
-import { immutablePointSnapshot } from "./context";
 import { publishComposedDecision } from "./audit";
-import { publishMiddlewareDebug, publishMiddlewareError, recordDecision } from "./telemetry";
+import { auditCorrelationContext, immutablePointSnapshot } from "./context";
+import { COMPOSED_POLICY_ID, composeFinalPointDecision } from "./decisions";
 import {
   normalizePointDecision,
   pointContractDecision,
   pointMiddlewareErrorDecision,
   undeclaredEffectDecision,
 } from "./point-decisions";
+import { timingForPolicyPoint } from "./points";
+import { createPolicyRegistrationStore } from "./registration";
+import { publishMiddlewareDebug, publishMiddlewareError, recordDecision } from "./telemetry";
 import type {
   CanonicalPolicyRegistrationGeneric,
   DispatchPointContextGeneric,
@@ -20,20 +20,56 @@ import type {
   PolicyPointId,
 } from "./types";
 
+const CONTRACT_REGISTRATION = { name: "policy.point.contract" } as const;
+
 export function createPolicyEngine<TCtx extends GenericPolicyContext>(
   options: PolicyEngineConfig = {},
 ): PolicyEngineInstanceGeneric<TCtx> {
   const registrations = createPolicyRegistrationStore<TCtx>();
+
+  /**
+   * A point with no registration is unguarded: nothing will read the context,
+   * so it is never cloned or frozen. The point contract still runs, against the
+   * caller's object — snapshot-ability is a precondition for handing a context
+   * to a policy, and here no policy exists to hand it to.
+   */
+  function dispatchUnguardedPoint(
+    pointId: PolicyPointId,
+    ctx: object,
+    timing: Policy.Timing,
+  ): Policy.PolicyDecision {
+    const auditCtx = auditCorrelationContext(ctx, pointId, timing);
+    const contractFailure = validatePointContract(pointId, ctx);
+    const decision =
+      contractFailure === undefined
+        ? PolicyDecision.allow({ policyId: COMPOSED_POLICY_ID })
+        : composeFinalPointDecision(
+            [recordDecision(options, CONTRACT_REGISTRATION, auditCtx, contractFailure)],
+            pointId,
+          );
+    publishComposedDecision(options, timing, auditCtx, decision);
+    return decision;
+  }
 
   async function dispatchPoint<TPointId extends PolicyPointId>(
     pointId: TPointId,
     ctx: DispatchPointContextGeneric<TCtx, TPointId>,
   ): Promise<Policy.PolicyDecision> {
     const timing = timingForPolicyPoint(pointId);
-    const snapshot = immutablePointSnapshot(ctx, { pointId, timing });
+    // Selection reads the agent type once and pins it into the snapshot below,
+    // so a context getter cannot answer the selector and the policy differently.
+    const agentType = readAgentType(ctx);
+    const selected = registrations.selectPoint(pointId, agentType);
+    if (selected.length === 0) return dispatchUnguardedPoint(pointId, ctx, timing);
+
+    const snapshot = immutablePointSnapshot(ctx, {
+      pointId,
+      timing,
+      ...(agentType === undefined ? {} : { agentType }),
+    });
     const auditCtx = snapshot.success
       ? snapshot.value
-      : invalidPointAuditContext(ctx, pointId, timing);
+      : auditCorrelationContext(ctx, pointId, timing);
     const decisions: Policy.PolicyDecision[] = [];
 
     function composeAndPublish(): Policy.PolicyDecision {
@@ -46,7 +82,7 @@ export function createPolicyEngine<TCtx extends GenericPolicyContext>(
       decisions.push(
         recordDecision(
           options,
-          { name: "policy.point.contract" },
+          CONTRACT_REGISTRATION,
           auditCtx,
           pointContractDecision(pointId, "policy.input_invalid"),
         ),
@@ -57,17 +93,8 @@ export function createPolicyEngine<TCtx extends GenericPolicyContext>(
 
     const contractFailure = validatePointContract(pointId, fullCtx);
     if (contractFailure !== undefined) {
-      decisions.push(
-        recordDecision(options, { name: "policy.point.contract" }, fullCtx, contractFailure),
-      );
+      decisions.push(recordDecision(options, CONTRACT_REGISTRATION, fullCtx, contractFailure));
       return composeAndPublish();
-    }
-
-    const selected = registrations.selectPoint(pointId, fullCtx.agentType);
-    if (selected.length === 0) {
-      const decision = PolicyDecision.allow({ policyId: COMPOSED_POLICY_ID });
-      publishComposedDecision(options, timing, fullCtx, decision);
-      return decision;
     }
 
     for (const reg of selected) {
@@ -127,46 +154,24 @@ export function createPolicyEngine<TCtx extends GenericPolicyContext>(
   };
 }
 
-const SAFE_INVALID_CONTEXT_AUDIT_KEYS = [
-  "traceContext",
-  "sessionId",
-  "runId",
-  "resourceDescriptor",
-  "toolName",
-  "dispatchId",
-  "correlation",
-] as const;
-
-function invalidPointAuditContext(
-  ctx: object,
-  pointId: PolicyPointId,
-  timing: Policy.Timing,
-): Readonly<
-  Record<string, unknown> & { readonly pointId: PolicyPointId; readonly timing: Policy.Timing }
-> {
-  const safeFields: Record<string, unknown> = {};
-  for (const key of SAFE_INVALID_CONTEXT_AUDIT_KEYS) {
-    try {
-      const descriptor = Object.getOwnPropertyDescriptor(ctx, key);
-      if (descriptor === undefined || !("value" in descriptor)) continue;
-      const captured = immutablePointSnapshot({ [key]: descriptor.value }, {});
-      if (captured.success) Object.assign(safeFields, captured.value);
-    } catch {
-      // Ignore unsafe getters/proxies while retaining independently safe correlation fields.
-    }
+function readAgentType(ctx: object): string | undefined {
+  try {
+    const agentType = Reflect.get(ctx, "agentType");
+    return typeof agentType === "string" ? agentType : undefined;
+  } catch {
+    return undefined;
   }
-  return Object.freeze({ ...safeFields, pointId, timing });
 }
 
 function validatePointContract(
   pointId: PolicyPointId,
-  fullCtx: Readonly<object>,
+  ctx: Readonly<object>,
 ): Policy.PolicyDecision | undefined {
   const contract = Policy.PolicyPoint.Registry[pointId];
-  if (contract.requiredContext.some((key) => Reflect.get(fullCtx, key) === undefined)) {
+  if (contract.requiredContext.some((key) => Reflect.get(ctx, key) === undefined)) {
     return pointContractDecision(pointId, "policy.context_missing");
   }
-  if (!Policy.PolicyPoint.InputSchemas[pointId].safeParse(fullCtx).success) {
+  if (!Policy.PolicyPoint.InputSchemas[pointId].safeParse(ctx).success) {
     return pointContractDecision(pointId, "policy.input_invalid");
   }
   return undefined;

--- a/packages/policy/src/engine/registration.ts
+++ b/packages/policy/src/engine/registration.ts
@@ -70,10 +70,9 @@ export function createPolicyRegistrationStore<
             left.registration.priority - right.registration.priority || left.order - right.order,
         );
         entriesByPoint.set(pointId, entries);
-        selectionByPoint.set(
-          pointId,
-          entries.map((entry) => entry.registration),
-        );
+        // Frozen because it is shared with every dispatch at this point; TS
+        // `readonly` alone would let a caller mutate the store's own array.
+        selectionByPoint.set(pointId, Object.freeze(entries.map((entry) => entry.registration)));
         if (isAgentTypeScoped(prepared)) agentTypeScopedPoints.add(pointId);
       }
     },

--- a/packages/policy/src/engine/registration.ts
+++ b/packages/policy/src/engine/registration.ts
@@ -7,6 +7,8 @@ import type {
 
 export { PolicyRegistrationError } from "./registration-validation";
 
+const NO_REGISTRATIONS: readonly never[] = Object.freeze([]);
+
 function matchesScope<TCtx extends GenericPolicyContext>(
   registration: CanonicalPolicyRegistrationGeneric<TCtx>,
   agentType: string | undefined,
@@ -17,36 +19,72 @@ function matchesScope<TCtx extends GenericPolicyContext>(
   return allowed.includes(agentType);
 }
 
+function isAgentTypeScoped<TCtx extends GenericPolicyContext>(
+  registration: CanonicalPolicyRegistrationGeneric<TCtx>,
+): boolean {
+  return (registration.scope?.agentType?.length ?? 0) > 0;
+}
+
 export interface PolicyRegistrationStore<TCtx extends GenericPolicyContext> {
   register(registration: CanonicalPolicyRegistrationGeneric<TCtx>): void;
   selectPoint(
     pointId: PolicyPointId,
     agentType?: string,
-  ): CanonicalPolicyRegistrationGeneric<TCtx>[];
+  ): readonly CanonicalPolicyRegistrationGeneric<TCtx>[];
 }
 
+/**
+ * Registrations are fixed at composition time and selected on every dispatch,
+ * so ordering is computed once per point in `register()` instead of being
+ * re-derived per call. A point with no registration returns a shared frozen
+ * empty array — the signal the dispatcher uses to skip context materialization.
+ */
 export function createPolicyRegistrationStore<
   TCtx extends GenericPolicyContext,
 >(): PolicyRegistrationStore<TCtx> {
-  const pointRegistrations: CanonicalPolicyRegistrationGeneric<TCtx>[] = [];
+  interface Entry {
+    readonly registration: CanonicalPolicyRegistrationGeneric<TCtx>;
+    readonly order: number;
+  }
+
+  const entriesByPoint = new Map<PolicyPointId, Entry[]>();
+  const selectionByPoint = new Map<
+    PolicyPointId,
+    readonly CanonicalPolicyRegistrationGeneric<TCtx>[]
+  >();
+  const agentTypeScopedPoints = new Set<PolicyPointId>();
+  let registrationCount = 0;
 
   return {
     register(registration) {
-      pointRegistrations.push(prepareRegistrationBoundary<TCtx>(registration));
-    },
-    selectPoint(pointId, agentType) {
-      // Stable selection: ascending priority, registration order breaks ties.
-      return pointRegistrations
-        .map((registration, index) => ({ registration, index }))
-        .filter(
-          ({ registration }) =>
-            registration.pointIds.includes(pointId) && matchesScope(registration, agentType),
-        )
-        .sort(
+      const prepared = prepareRegistrationBoundary<TCtx>(registration);
+      const order = registrationCount;
+      registrationCount += 1;
+
+      for (const pointId of prepared.pointIds) {
+        const entries = entriesByPoint.get(pointId) ?? [];
+        entries.push({ registration: prepared, order });
+        // Stable selection: ascending priority, registration order breaks ties.
+        entries.sort(
           (left, right) =>
-            left.registration.priority - right.registration.priority || left.index - right.index,
-        )
-        .map(({ registration }) => registration);
+            left.registration.priority - right.registration.priority || left.order - right.order,
+        );
+        entriesByPoint.set(pointId, entries);
+        selectionByPoint.set(
+          pointId,
+          entries.map((entry) => entry.registration),
+        );
+        if (isAgentTypeScoped(prepared)) agentTypeScopedPoints.add(pointId);
+      }
+    },
+
+    selectPoint(pointId, agentType) {
+      const selection = selectionByPoint.get(pointId);
+      if (selection === undefined) return NO_REGISTRATIONS;
+      // Only points carrying an agentType-scoped registration need the
+      // per-dispatch filter; every other point reuses the precomputed order.
+      if (!agentTypeScopedPoints.has(pointId)) return selection;
+      return selection.filter((registration) => matchesScope(registration, agentType));
     },
   };
 }

--- a/packages/policy/test/point-audit.test.ts
+++ b/packages/policy/test/point-audit.test.ts
@@ -59,6 +59,16 @@ describe("PolicyEngine canonical point audit", () => {
     const engine = PolicyEngine.create({
       auditEmit: (event, data) => events.push({ name: event.name, data }),
     });
+    // The snapshot exists to protect a policy from a mutable context, so it is
+    // only built for a point that has one. Register here to exercise it.
+    engine.register({
+      kind: "point",
+      name: "snapshot-consumer",
+      pointIds: ["dispatch.action.pre"],
+      effectCapabilities: { "dispatch.action.pre": [] },
+      priority: 0,
+      fn: () => PolicyDecision.allow({ policyId: "snapshot-consumer" }),
+    });
     const traceContext = {
       traceId: "trace-invalid-context",
       sessionId: "session-invalid-context",

--- a/packages/policy/test/point-dispatch.test.ts
+++ b/packages/policy/test/point-dispatch.test.ts
@@ -145,10 +145,10 @@ describe("PolicyEngine dispatchPoint selection", () => {
     expect(order).toEqual(["first", "second", "later"]);
   });
 
-  test("selects scoped registrations from the immutable agent type snapshot", async () => {
+  test("pins the agent type that selected a scoped registration into its context", async () => {
     const engine = PolicyEngine.create();
     let agentTypeReads = 0;
-    let invoked = false;
+    let observedAgentType: unknown;
     engine.register({
       kind: "point",
       name: "resident-only",
@@ -156,8 +156,8 @@ describe("PolicyEngine dispatchPoint selection", () => {
       effectCapabilities: { "dispatch.action.pre": [] },
       priority: 0,
       scope: { agentType: ["resident"] },
-      fn: () => {
-        invoked = true;
+      fn: (ctx) => {
+        observedAgentType = Reflect.get(ctx, "agentType");
         return PolicyDecision.allow({ policyId: "resident-only" });
       },
     });
@@ -171,8 +171,9 @@ describe("PolicyEngine dispatchPoint selection", () => {
     });
 
     expect(decision.verdict).toBe("allow");
-    expect(invoked).toBe(true);
-    expect(agentTypeReads).toBe(1);
+    // A context getter cannot answer the selector and the selected policy
+    // differently: the engine pins the value it selected on.
+    expect(observedAgentType).toBe("resident");
   });
 
   test("keeps point selection isolated with no legacy dispatch member", async () => {

--- a/packages/policy/test/unguarded-point.test.ts
+++ b/packages/policy/test/unguarded-point.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import type { Policy } from "@openomni/protocol";
+import { PolicyDecision, PolicyEvent } from "@openomni/protocol";
+import { PolicyEngine } from "@openomni/policy";
+
+/**
+ * A point with no registration is unguarded. Nothing will read its context, so
+ * the engine does not clone or freeze it — the cost of materializing a context
+ * is only worth paying when a policy is about to receive it.
+ */
+describe("PolicyEngine unguarded point dispatch", () => {
+  function contextWithProbe(): {
+    readonly context: Record<string, unknown>;
+    reads(): number;
+  } {
+    let reads = 0;
+    return {
+      context: {
+        sessionId: "session-1",
+        runId: "run-1",
+        turnIndex: 0,
+        messages: [
+          {
+            get probe() {
+              reads += 1;
+              return "deep value";
+            },
+          },
+        ],
+      },
+      reads: () => reads,
+    };
+  }
+
+  test("does not descend into the context when no policy is registered", async () => {
+    const engine = PolicyEngine.create();
+    const probe = contextWithProbe();
+
+    const decision = await engine.dispatchPoint(
+      "run.turn.pre",
+      probe.context as Policy.PolicyPointInputMap["run.turn.pre"],
+    );
+
+    expect(decision.verdict).toBe("allow");
+    expect(probe.reads()).toBe(0);
+  });
+
+  test("descends into the context once a policy is registered at the point", async () => {
+    const engine = PolicyEngine.create();
+    engine.register({
+      kind: "point",
+      name: "context-consumer",
+      pointIds: ["run.turn.pre"],
+      effectCapabilities: { "run.turn.pre": [] },
+      priority: 0,
+      fn: () => PolicyDecision.allow({ policyId: "context-consumer" }),
+    });
+    const probe = contextWithProbe();
+
+    const decision = await engine.dispatchPoint(
+      "run.turn.pre",
+      probe.context as Policy.PolicyPointInputMap["run.turn.pre"],
+    );
+
+    expect(decision.verdict).toBe("allow");
+    expect(probe.reads()).toBeGreaterThan(0);
+  });
+
+  test("still enforces the point contract with no registration", async () => {
+    const engine = PolicyEngine.create();
+
+    const decision = await engine.dispatchPoint("dispatch.action.pre", {
+      actor: { kind: "system", actorId: "system:test" },
+      dispatchId: "dispatch-1",
+      action: "resident.ask",
+    } as unknown as Policy.PolicyPointInputMap["dispatch.action.pre"]);
+
+    expect(decision.verdict).toBe("deny");
+    expect(decision.reasonCodes).toContain("policy.context_missing");
+    expect(decision.effects.map((effect) => effect.type)).toEqual(["run.abort", "audit.annotate"]);
+  });
+
+  test("publishes a composed audit event carrying correlation", async () => {
+    const events: Array<{ readonly name: string; readonly data: unknown }> = [];
+    const engine = PolicyEngine.create({
+      auditEmit: (event, data) => events.push({ name: event.name, data }),
+    });
+    const traceContext = {
+      traceId: "trace-unguarded",
+      sessionId: "session-unguarded",
+      runId: "run-unguarded",
+    } as const;
+
+    await engine.dispatchPoint("run.turn.pre", {
+      sessionId: traceContext.sessionId,
+      runId: traceContext.runId,
+      turnIndex: 0,
+      traceContext,
+    });
+
+    const composed = events.find(({ name }) => name === PolicyEvent.DecisionComposed.name);
+    expect(composed?.data).toMatchObject({ ...traceContext, verdict: "allow" });
+  });
+
+  /**
+   * Snapshot-ability is a precondition for handing a context to a policy, not a
+   * property of the context itself. With no policy at the point there is
+   * nothing to hand it to, so a context that could never be frozen is allowed
+   * through rather than denied.
+   */
+  test("allows a context that could not be snapshotted", async () => {
+    const engine = PolicyEngine.create();
+
+    const decision = await engine.dispatchPoint("run.turn.pre", {
+      sessionId: "session-1",
+      runId: "run-1",
+      turnIndex: 0,
+      unsupported: new Map([["mutable", true]]),
+    });
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.reasonCodes).toEqual([]);
+  });
+});

--- a/packages/policy/test/unguarded-point.test.ts
+++ b/packages/policy/test/unguarded-point.test.ts
@@ -102,6 +102,57 @@ describe("PolicyEngine unguarded point dispatch", () => {
     expect(composed?.data).toMatchObject({ ...traceContext, verdict: "allow" });
   });
 
+  test("captures accessor-defined correlation into the audit record", async () => {
+    const events: Array<{ readonly name: string; readonly data: unknown }> = [];
+    const engine = PolicyEngine.create({
+      auditEmit: (event, data) => events.push({ name: event.name, data }),
+    });
+    const traceContext = {
+      traceId: "trace-accessor",
+      sessionId: "session-accessor",
+      runId: "run-accessor",
+    } as const;
+
+    // The full snapshot reads through a spread, which invokes accessors. The
+    // unguarded path must observe the same fields, or the composed event is
+    // dropped for want of a trace id.
+    await engine.dispatchPoint("run.turn.pre", {
+      sessionId: traceContext.sessionId,
+      runId: traceContext.runId,
+      turnIndex: 0,
+      get traceContext() {
+        return traceContext;
+      },
+    });
+
+    const composed = events.find(({ name }) => name === PolicyEvent.DecisionComposed.name);
+    expect(composed?.data).toMatchObject(traceContext);
+  });
+
+  test("keeps correlation when one field cannot be captured", async () => {
+    const events: Array<{ readonly name: string; readonly data: unknown }> = [];
+    const engine = PolicyEngine.create({
+      auditEmit: (event, data) => events.push({ name: event.name, data }),
+    });
+    const traceContext = {
+      traceId: "trace-partial",
+      sessionId: "session-partial",
+      runId: "run-partial",
+    } as const;
+
+    await engine.dispatchPoint("run.turn.pre", {
+      sessionId: traceContext.sessionId,
+      runId: traceContext.runId,
+      turnIndex: 0,
+      traceContext,
+      // Not capturable; must not suppress the fields beside it.
+      resourceDescriptor: new Map([["mutable", true]]) as never,
+    });
+
+    const composed = events.find(({ name }) => name === PolicyEvent.DecisionComposed.name);
+    expect(composed?.data).toMatchObject(traceContext);
+  });
+
   /**
    * Snapshot-ability is a precondition for handing a context to a policy, not a
    * property of the context itself. With no policy at the point there is

--- a/packages/policy/test/unguarded-point.test.ts
+++ b/packages/policy/test/unguarded-point.test.ts
@@ -129,7 +129,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
     expect(composed?.data).toMatchObject(traceContext);
   });
 
-  test("keeps correlation when one field cannot be captured", async () => {
+  test("keeps every capturable field when one cannot be captured", async () => {
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
       auditEmit: (event, data) => events.push({ name: event.name, data }),
@@ -145,12 +145,46 @@ describe("PolicyEngine unguarded point dispatch", () => {
       runId: traceContext.runId,
       turnIndex: 0,
       traceContext,
+      toolName: "tool:partial",
+      dispatchId: "dispatch-partial",
       // Not capturable; must not suppress the fields beside it.
       resourceDescriptor: new Map([["mutable", true]]) as never,
     });
 
     const composed = events.find(({ name }) => name === PolicyEvent.DecisionComposed.name);
-    expect(composed?.data).toMatchObject(traceContext);
+    expect(composed?.data).toMatchObject({ ...traceContext, resource: "tool:partial" });
+    // The uncapturable field is absent, not half-captured.
+    expect(composed?.data).not.toHaveProperty("resourceDescriptor");
+  });
+
+  /**
+   * `dispatchPoint` is a total function: every caller awaits a verdict. The
+   * unguarded path reads the caller's own object — `Reflect.get` for required
+   * keys, and a `.passthrough()` schema that walks every key — so a hostile
+   * accessor must become a decision, never an exception that bypasses
+   * fail-closed and fail-open alike.
+   */
+  test.each([
+    ["a required key", "sessionId"],
+    ["a correlation key", "traceContext"],
+    ["an unrelated key", "unrelated"],
+  ])("resolves to a verdict when %s throws on read", async (_label, key) => {
+    const engine = PolicyEngine.create();
+    const context: Record<string, unknown> = { sessionId: "s", runId: "r", turnIndex: 0 };
+    Object.defineProperty(context, key, {
+      enumerable: true,
+      get() {
+        throw new Error("hostile accessor");
+      },
+    });
+
+    const decision = await engine.dispatchPoint(
+      "run.turn.pre",
+      context as Policy.PolicyPointInputMap["run.turn.pre"],
+    );
+
+    expect(decision.verdict).toBe("deny");
+    expect(decision.reasonCodes).toContain("policy.input_invalid");
   });
 
   /**


### PR DESCRIPTION
Phase 0 of #606. Makes policy dispatch constant-cost at points that carry no registration.

> **Revised after independent adversarial review** (verdict: MERGE WITH CHANGES, 8 findings). Four requested changes applied in 50755078; measurement corrected in companion PR #607. Findings and responses: [comment](https://github.com/INONONO66/openomni/pull/608#issuecomment-5275449503). One finding became its own issue: **#609**.

## The problem

`dispatchPoint` ran its expensive work *before* the cheap check that would have made it unnecessary:

```
L33  snapshot = immutablePointSnapshot(ctx, ...)   structuredClone + recursive deep freeze
L58  validatePointContract(pointId, fullCtx)       zod safeParse of the whole context
L66  selected = registrations.selectPoint(...)
L67  if (selected.length === 0) return allow       <- the fast path, last
```

The context carries `state.messages` (`buildLifecyclePolicyContext` passes the run's whole history), so every dispatch cost O(history). The loop dispatches ~12 points per turn and the history grows each turn.

This is not hypothetical dead weight: **8 of 18 policy points have no production registration** (see #609), so those dispatches were paying full price for nothing.

## Result

Measured with `script/bench-policy-dispatch.ts` (#607) — median of five interleaved rounds, 2000 iterations, `run.turn.pre`, zero policies registered:

| context shape | history | before | after | |
|---|---|---|---|---|
| **correlated** (production shape) | 512 msgs | 2,109,914 ns | **6,127 ns** | **344×** |
| correlated | 8 msgs | 45,344 ns | 6,341 ns | 7× |
| minimal | 512 msgs | 2,108,860 ns | 1,592 ns | 1324× |
| minimal | 8 msgs | 40,634 ns | 1,669 ns | 24× |

Growth factor across history sizes goes from 46.5× / 51.9× to **0.97× / 0.95×** — constant.

Two shapes are reported because they diverge once a dispatch stops materializing its context: the remaining cost is audit-correlation capture, which reads seven specific keys. `correlated` carries them and is what production dispatches; `minimal` carries none and flatters the result. The first review draft measured only `minimal`.

**A point that has a registration is unchanged** — 39–47× growth, by design. The snapshot runs because a policy is about to receive it. Fixing that path means not putting the history into contexts whose point contract does not declare it, which lands with the agent rewrite (#606 Phase 2).

## What changed

**Ordering.** Selection runs first; a point with no registration never materializes its context.

**Precomputed selection.** Registrations are fixed at composition time, yet `selectPoint` re-derived order per dispatch through a `map/filter/sort/map` chain allocating four arrays. It now sorts once per point in `register()`, returns a shared **frozen** array, and skips the scope filter unless some registration at that point is agentType-scoped.

**Audit correlation now reads accessors.** `auditCorrelationContext` captured data properties only. That was tolerable when it was reachable only on snapshot failure; it became the audit context for every unguarded dispatch, so a context with an accessor-defined `traceContext` emitted **zero** audit events. Now uses `Reflect.get`, matching what the snapshot's spread observes, and takes one snapshot over the whole key set instead of one per key. Pinned red-first.

**Dead code.** `cloneRecord` / `cloneArray` / `cloneValue` — a mutually recursive island in the dispatch hot-path file with zero external callers, left behind when `structuredClone` replaced it.

## Behavior changes — review these specifically

**1. An unguarded point no longer denies an unsnapshotable context.**

A context containing a `Map`/`Date`/function/nested-proxy previously failed the snapshot and produced `policy.input_invalid` even with no policy registered. That path now returns `allow`. The point contract — required keys plus input schema — **still runs**, against the caller's object.

Reasoning: the snapshot is a precondition for handing a context to a policy, not a property of the context. With no policy at the point there is nothing to hand it to.

Review flagged that this lands on `work.complete.pre`, a fail-closed point documented as a shipped gate. Confirmed — and it is 8 points, not 1. The tripwire being removed was incidental (a structural-clone failure, not an authorization decision) and `completionCandidate` is typed `z.unknown()`, so the schema constrains nothing either. That ruling is **#609**, not this PR.

`point-audit.test.ts` now registers a policy to exercise the snapshot path it was written to cover. `unguarded-point.test.ts` pins the new behavior directly.

**2. The agent type is read once and pinned into the snapshot.**

Selection precedes the snapshot, so a getter could otherwise answer the selector and the policy differently. The engine writes the value it selected on into the snapshot.

`point-dispatch.test.ts` previously asserted `agentTypeReads === 1`; the count was a proxy for the guarantee, and the test now asserts the guarantee itself.

**Known divergences, documented rather than fixed** (all confined to contexts production does not build — plain object literals throughout):

- A required-key getter fires twice on the unguarded path (once for `requiredContext`, once for `safeParse`) versus once on the snapshot path. Two reads need not agree.
- A required key on the **prototype chain** passes `Reflect.get` but would not have survived `structuredClone`, so the unguarded path allows where the snapshot path denied.
- `Reflect.get` sees non-enumerable and prototype-chain `agentType` where the spread did not, so scoped selection widens. Fail-safe: `matchesScope` rejects `undefined`, so this can only select a superset, never a subset.

**Snapshot semantics are untouched.** `structuredClone` + `freezePlainValue` reject exactly what they rejected before. The doc comment describing them was wrong in three places (top-level transparent proxies are accepted, symbol-keyed properties are dropped rather than rejected, a nested class instance survives as a plain record) — all inherited behavior, now stated correctly.

An earlier draft replaced them with a single-pass clone-and-freeze, roughly halving the registered-point cost, but it accepted **nested** proxies that `structuredClone` rejects. Changing snapshot semantics inside a perf PR is the wrong trade; deferred.

## Verification

- `bun test --timeout 15000`: policy **73/73**, agent **386/386**, openomni **1066/1066**, server **462/462** — 0 fail, no hangs.
- `check-types` 13/13 · `build` · `lint` (913 guards / 7 side-effect / 976 ultracite) · `check-deps` · `check-import-cycles` (500 modules, 0) · `check-dead-exports` (18 known, none new) · `lint:tools`.
- Independent reviewer reproduced the magnitude by A/B-ing only the three policy sources against `origin/main`, and could not break selection ordering (300 randomized registration shapes, byte-identical) or snapshot rejection semantics (12-case hostile matrix, identical on both revisions).

Refs #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
