### PR TITLE
refactor(llm): report through an injected port, not a global bus (#606)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
           bun run script/check-coverage-ratchet.ts --self-test
           bun run script/check-dead-exports.ts --self-test
           bun run script/check-import-cycles.ts --self-test
+          bun run script/check-deps.ts --self-test
       - run: bun run script/check-dead-exports.ts
       - run: bun run script/check-import-cycles.ts
       - run: bun run script/check-ledger-schema-drift.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,9 @@ everything                       ←  openomni  ←  server
 
 Read as `X ← Y`: Y may depend on X. Exactly what `script/check-deps.ts`
 allows, package by package — the table is the contract, the sketch is a
-reading aid:
+reading aid. Where a row names two sets, the second is `srcAllowedDeps`: the
+package's tests may reach further than its runtime code, and the gate holds
+`<pkg>/src/` to the narrower one.
 
 | package | may depend on |
 | --- | --- |
@@ -58,7 +60,7 @@ reading aid:
 | `telemetry` | protocol |
 | `ipc` | protocol |
 | `session` | protocol, telemetry |
-| `llm` | protocol, telemetry |
+| `llm` | protocol, telemetry — `src/` protocol only |
 | `coordinator` | protocol, ipc |
 | `agent` | protocol, policy, llm, telemetry |
 | `openomni` | any except itself |

--- a/bun.lock
+++ b/bun.lock
@@ -88,11 +88,11 @@
         "@ai-sdk/anthropic": "^3.0.64",
         "@ai-sdk/openai": "^3.0.48",
         "@openomni/protocol": "workspace:*",
-        "@openomni/telemetry": "workspace:*",
         "ai": "^6.0.141",
         "zod": "^3.22.4",
       },
       "devDependencies": {
+        "@openomni/telemetry": "workspace:*",
         "@types/bun": "latest",
       },
     },

--- a/packages/agent/src/core/execution/turn-prepare.ts
+++ b/packages/agent/src/core/execution/turn-prepare.ts
@@ -1,6 +1,7 @@
 import type { RunInput } from "@openomni/llm";
 import { type Message, PolicyDecision } from "@openomni/protocol";
 import type { Policy, Sink, Tool } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
 import { describeBudgetRemaining, effectiveBudgetThresholds } from "../budget";
 import type { PolicyEngineInstance } from "../policy";
 import type { AgentEvent, ChatAgentConfig, TokenUsage } from "../types";
@@ -206,6 +207,9 @@ export async function buildTurn(
     budgetWarningEvent,
     turn: {
       runInput: {
+        // The agent binds llm's observation port. Agent's own emits still
+        // reach for `Bus` directly; that is the next slice.
+        events: Bus,
         messages: state.messages,
         tools: selectedTools,
         system,

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -46,7 +46,7 @@ src/
 
 ## ANTI-PATTERNS
 
-- Do NOT import `Bus` here. `llm` reports through the `events` port it is handed; reaching for the process-wide bus re-couples the package to an implementation the composition root is supposed to choose (#606). `check-deps`' source scan is what keeps `src/` clean.
+- Do NOT import `Bus` here. `llm` reports through the `events` port it is handed; reaching for the process-wide bus re-couples the package to an implementation the composition root is supposed to choose (#606). `check-deps` carries a separate `srcAllowedDeps` for this package — `src/` may import `@openomni/protocol` and nothing else, even though the manifest lists `telemetry` for the tests.
 - `packages/llm` sets `noEmit: true` in tsconfig — it does NOT produce a `dist/`. It is consumed as source by Bun.
 - Do NOT add provider-specific logic to call sites. Keep SDK wiring in `provider/`, credential handling in `auth/`, and message/request shaping in `transform/`.
 - Do NOT bypass `Auth.get()` for credentials (e.g. reading env vars inline). All credentials flow through the namespace.

--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/llm
 
-LLM provider abstraction. Handles auth (API key + proxy), provider SDK wiring, streaming, retry, message conversion, token usage accounting, and the `run()` entry point. Depends on `@openomni/protocol` and `@openomni/telemetry` — nothing durable (#606).
+LLM provider abstraction. Handles auth (API key + proxy), provider SDK wiring, streaming, retry, message conversion, token usage accounting, and the `run()` entry point. Depends on `@openomni/protocol` only. It reports what it did through an injected `BusEvent.Sink`, so it imports no implementation of the observation channel and nothing durable (#606).
 
 ## STRUCTURE
 
@@ -12,7 +12,7 @@ src/
 ├── message/
 │   └── index.ts      # toModelMessages() — Message.WithParts[] → AI SDK messages
 ├── processor/
-│   ├── index.ts      # Processor.create() — bounded retry loop, sink projection to Bus telemetry, status snapshots
+│   ├── index.ts      # Processor.create() — bounded retry loop, sink projection through the injected events port, status snapshots
 │   └── stream-events.ts # Stream event projection: text/reasoning/tool/step parts + interruption cleanup
 ├── retry/
 │   └── index.ts      # Retry.delay / sleep / isRetryable — exponential backoff + retry-after
@@ -33,12 +33,12 @@ src/
 ## KEY PATTERNS
 
 - **Narrow root public API**: `src/index.ts` intentionally exports only `Auth`, `Provider`, `ModelsDev`, LLM error classes, `run`, `RunInput`, and `TokenTracker`. Do not add session/protocol helpers, `ProviderTransform`, `fetchProxyModels`, `enrichWithCatalog`, `Processor`, `Retry`, `Message`, `Tool`, or `toModelMessages` back to the root barrel. Use deep imports inside `packages/llm` tests/internal code when those helpers are needed.
-- **`run()` entry point**: Takes `RunInput` (messages, tools, required model, optional auth, system, toolExecutor, toolChoice, maxSteps, providerOptions), drives a Processor loop, and returns `Run.Outcome` via the injected `Sink`. `RunInput.model` is required; do not reintroduce model-less/noop fallback behavior in `run()`.
+- **`run()` entry point**: Takes `RunInput` (messages, tools, required model, required `trace` and `events`, optional auth, system, toolExecutor, toolChoice, maxSteps, providerOptions), drives a Processor loop, and returns `Run.Outcome` via the injected `Sink`. `RunInput.model` is required; do not reintroduce model-less/noop fallback behavior in `run()`.
 - **Provider.Model**: Zod schema with capabilities, cost, limits, status. Built from `models.dev` data via `Provider.fromModelsDevModel()`. `Provider.listModels()` / `listProviders()` / `getProviderInfo()` surface catalog lookups.
 - **Auth.Info** (discriminated union): `{ type: "api", key }` | `{ type: "proxy", baseURL, apiKey? }`. Stored via `Auth.set(providerId, info)` and read by `getSDK()` before each call.
 - **SDK wiring** (`provider/sdk.ts`): `getSDK(model, auth)` resolves to Anthropic / OpenAI. Custom OpenAI-compatible endpoints use `@ai-sdk/openai` with `baseURL` / `name`, keeping returned language models on the same AI SDK provider type version. SDK and `LanguageModel` instances are cached per `providerID:npm:modelID:auth` key. Provider-specific behavior belongs in `provider/`, `auth/`, or `transform/`, not in call sites.
 - **Provider transforms** (`provider/transform.ts`): `normalizeMessages()` filters empty blocks, sanitizes tool-call IDs, applies Anthropic ephemeral caching to the last two user/assistant messages. This is an internal/deep import surface, not a root export.
-- **Processor**: Created via `Processor.create({ assistantMessage, sessionID, model, abort, sink?, createStream, maxRetryAttempts?, trace? })`. `process({ system })` resolves on stream completion and throws on abort/terminal error; `run()` maps that to `Run.Outcome` and publishes `LlmCall.Completed` on success or `LlmCall.Failed` (with `aborted`) otherwise — every `Started` gets a terminal event. Parts are published **copy-on-write**: a published part object is never mutated afterwards, so sink consumers may hold snapshots; text/reasoning parts carry the accumulated text on every delta. Tool parts go `running` (with `time.start`) at `tool-call` and close with a real duration at `tool-result`. Processor owns `tool-call`/`tool-result` stream projection; tool *execution* happens only in `run()`'s AI SDK `execute` callback, which must not directly emit tool sink events. Status snapshots are `busy` → (`retry`…) → `idle`, exactly one `idle` per process() call.
+- **Processor**: Created via `Processor.create({ assistantMessage, sessionID, model, abort, trace, events, sink?, createStream, maxRetryAttempts? })`. `trace` and `events` are required: a record filed without a trace names nothing, and `events` is where every record goes. `process({ system })` resolves on stream completion and throws on abort/terminal error; `run()` maps that to `Run.Outcome` and publishes `LlmCall.Completed` on success or `LlmCall.Failed` (with `aborted`) otherwise — every `Started` gets a terminal event. Parts are published **copy-on-write**: a published part object is never mutated afterwards, so sink consumers may hold snapshots; text/reasoning parts carry the accumulated text on every delta. Tool parts go `running` (with `time.start`) at `tool-call` and close with a real duration at `tool-result`. Processor owns `tool-call`/`tool-result` stream projection; tool *execution* happens only in `run()`'s AI SDK `execute` callback, which must not directly emit tool sink events. Status snapshots are `busy` → (`retry`…) → `idle`, exactly one `idle` per process() call.
 - **Retry**: raw AI SDK errors (`AI_APICallError`) must pass through `coerceApiError` before classification — their retry fields live on the error object, not under `.data`, and never match `APIError.isInstance`. `Retry.isRetryable` classifies by payload sniffing (message, then responseBody), then statusCode (429 / ≥500), then trusts the provider `isRetryable` flag. `Retry.delay(attempt, error?)` respects `retry-after` / `retry-after-ms` headers; fallback backoff is capped at 30s whether or not headers are present. Processor retrying is finite by default; do not use unbounded retry loops or publish `Number.MAX_SAFE_INTEGER` as a retry cap.
 - **TokenTracker**: Extracts token usage from AI SDK/provider responses. Runtime accounting stores token counts on the assistant message, keyed by that message's provider/model identity. The llm package does not calculate dollar cost.
 - **ModelsDev**: Lazy-loads the catalog from `models.dev` into a local cache, falls back to a bundled snapshot. Respects `OPENOMNI_MODELS_URL`, `OPENOMNI_MODELS_PATH`, `OPENOMNI_DISABLE_MODELS_FETCH`. Remote/cache catalog data is untrusted: only providers backed by bundled AI SDK packages are exposed, provider `api` URLs are stripped, and model-level provider overrides are stripped before caching/returning.
@@ -46,6 +46,7 @@ src/
 
 ## ANTI-PATTERNS
 
+- Do NOT import `Bus` here. `llm` reports through the `events` port it is handed; reaching for the process-wide bus re-couples the package to an implementation the composition root is supposed to choose (#606). `check-deps`' source scan is what keeps `src/` clean.
 - `packages/llm` sets `noEmit: true` in tsconfig — it does NOT produce a `dist/`. It is consumed as source by Bun.
 - Do NOT add provider-specific logic to call sites. Keep SDK wiring in `provider/`, credential handling in `auth/`, and message/request shaping in `transform/`.
 - Do NOT bypass `Auth.get()` for credentials (e.g. reading env vars inline). All credentials flow through the namespace.

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -13,11 +13,11 @@
     "@ai-sdk/anthropic": "^3.0.64",
     "@ai-sdk/openai": "^3.0.48",
     "@openomni/protocol": "workspace:*",
-    "@openomni/telemetry": "workspace:*",
     "ai": "^6.0.141",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@openomni/telemetry": "workspace:*",
     "@types/bun": "latest"
   }
 }

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -2,11 +2,11 @@ import {
   LlmCall,
   Operational,
   Transcript,
+  type BusEvent,
   type Message,
   type Sink,
   type Tool,
 } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import { coerceApiError } from "../error";
 import { Retry } from "../retry";
 import type { Provider } from "../provider";
@@ -39,8 +39,19 @@ export namespace Processor {
     abort: AbortSignal;
     maxRetryAttempts?: number;
     sink?: Sink;
+    /**
+     * Where observation goes. A port, not `Bus`: the composition root decides
+     * what is behind it, tests bind a collector, and P2 can split a
+     * fail-closed ledger append from the lossy bus without touching this file.
+     */
+    events: BusEvent.Sink;
     createStream: (input: StreamInput) => Promise<Stream>;
-    trace?: { traceId: string; sessionId: string; runId?: string; provider?: string };
+    /**
+     * The call's identity. Required: `run()` always has it, and making it
+     * optional is what justified filing records under `traceId ?? sessionID`
+     * — a session id in the field every reader treats as a trace.
+     */
+    trace: { traceId: string; sessionId: string; runId?: string; provider?: string };
   }
 
   interface ProcessorInfo {
@@ -64,6 +75,7 @@ export namespace Processor {
       model,
       abort,
       sink: configuredSink = createNoopSink(),
+      events,
       createStream,
       maxRetryAttempts = DEFAULT_MAX_RETRY_ATTEMPTS,
       trace,
@@ -72,7 +84,7 @@ export namespace Processor {
     const retryAttemptLimit = Number.isFinite(maxRetryAttempts)
       ? Math.max(0, Math.floor(maxRetryAttempts))
       : DEFAULT_MAX_RETRY_ATTEMPTS;
-    const sink = createProjectedSink(configuredSink, sessionID, trace?.traceId);
+    const sink = createProjectedSink(events, configuredSink, sessionID, trace.traceId);
 
     let folded: Message.WithParts | undefined;
 
@@ -93,7 +105,7 @@ export namespace Processor {
     }
 
     function debugNote(msg: string, data?: Record<string, unknown>): void {
-      publishInfo(sessionID, trace?.traceId, msg, data);
+      publishInfo(events, sessionID, trace.traceId, msg, data);
     }
 
     return {
@@ -102,7 +114,7 @@ export namespace Processor {
       },
 
       async process(streamInput: StreamInput): Promise<void> {
-        publishStatus(sessionID, trace?.traceId, "busy");
+        publishStatus(events, sessionID, trace.traceId, "busy");
         let attempt = 0;
         let attemptSeq = 0;
 
@@ -187,7 +199,7 @@ export namespace Processor {
                 if (!decision.retry && decision.reason !== "non_retryable" && trace) {
                   // A retryable error declined for another reason (e.g. the
                   // server-directed wait exceeded the cap) must say why.
-                  Bus.publish(Operational.Error, {
+                  events.publish(Operational.Error, {
                     traceId: trace.traceId,
                     time: Date.now(),
                     sessionId: trace.sessionId,
@@ -214,7 +226,7 @@ export namespace Processor {
 
               const delayMs = decision.delayMs;
               if (trace) {
-                Bus.publish(LlmCall.RetryDecided, {
+                events.publish(LlmCall.RetryDecided, {
                   traceId: trace.traceId,
                   sessionId: trace.sessionId,
                   ...(trace.runId !== undefined && { runId: trace.runId }),
@@ -226,7 +238,7 @@ export namespace Processor {
                 });
 
                 if (publishesRateLimited(retryReason)) {
-                  Bus.publish(LlmCall.RateLimited, {
+                  events.publish(LlmCall.RateLimited, {
                     traceId: trace.traceId,
                     sessionId: trace.sessionId,
                     ...(trace.runId !== undefined && { runId: trace.runId }),
@@ -237,13 +249,13 @@ export namespace Processor {
                 }
               }
 
-              publishStatus(sessionID, trace?.traceId, "retry");
+              publishStatus(events, sessionID, trace.traceId, "retry");
 
               await Retry.sleep(delayMs, abort);
             }
           }
         } finally {
-          publishStatus(sessionID, trace?.traceId, "idle");
+          publishStatus(events, sessionID, trace.traceId, "idle");
         }
       },
     };
@@ -266,14 +278,17 @@ export namespace Processor {
   }
 
   function publishInfo(
+    events: BusEvent.Sink,
     sessionID: string,
     traceId: string | undefined,
     message: string,
     data?: Record<string, unknown>,
   ): void {
-    if (!sessionID) return;
-    Bus.publish(Operational.Info, {
-      traceId: traceId ?? sessionID,
+    // No trace, no record. The previous `traceId ?? sessionID` put a value of
+    // the wrong kind in the field every reader treats as a trace (#606 D11).
+    if (!sessionID || traceId === undefined || traceId.length === 0) return;
+    events.publish(Operational.Info, {
+      traceId,
       time: Date.now(),
       sessionId: sessionID,
       component: "llm.processor",
@@ -282,9 +297,14 @@ export namespace Processor {
     });
   }
 
-  function createProjectedSink(sink: Sink, sessionID: string, traceId?: string): Sink {
+  function createProjectedSink(
+    events: BusEvent.Sink,
+    sink: Sink,
+    sessionID: string,
+    traceId?: string,
+  ): Sink {
     function publish(message: string, data?: Record<string, unknown>): void {
-      publishInfo(sessionID, traceId, message, data);
+      publishInfo(events, sessionID, traceId, message, data);
     }
 
     return {
@@ -335,8 +355,13 @@ export namespace Processor {
    * hop was removed; the operational publish — the only observable effect it
    * ever had — stays, under the same msg name for log continuity.
    */
-  function publishStatus(sessionID: string, traceId: string | undefined, stateType: string): void {
-    publishInfo(sessionID, traceId, "sink.snapshot", { stateType });
+  function publishStatus(
+    events: BusEvent.Sink,
+    sessionID: string,
+    traceId: string | undefined,
+    stateType: string,
+  ): void {
+    publishInfo(events, sessionID, traceId, "sink.snapshot", { stateType });
   }
 
   function summarizeRecord(input: Record<string, unknown>): string {

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -40,9 +40,11 @@ export namespace Processor {
     maxRetryAttempts?: number;
     sink?: Sink;
     /**
-     * Where observation goes. A port, not `Bus`: the composition root decides
-     * what is behind it, tests bind a collector, and P2 can split a
+     * Where observation goes. A port, not `Bus`, so that what sits behind it
+     * is the caller's choice: tests bind a collector, and P2 can split a
      * fail-closed ledger append from the lossy bus without touching this file.
+     * Today the agent hard-binds `Bus` at `turn-prepare.ts` — moving that to
+     * the composition root is the next slice, not something this file knows.
      */
     events: BusEvent.Sink;
     createStream: (input: StreamInput) => Promise<Stream>;

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -196,7 +196,7 @@ export namespace Processor {
               const decision = Retry.decide(attempt + 1, apiError ?? e);
 
               if (!decision.retry || ++attempt > retryAttemptLimit) {
-                if (!decision.retry && decision.reason !== "non_retryable" && trace) {
+                if (!decision.retry && decision.reason !== "non_retryable") {
                   // A retryable error declined for another reason (e.g. the
                   // server-directed wait exceeded the cap) must say why.
                   events.publish(Operational.Error, {
@@ -225,28 +225,26 @@ export namespace Processor {
               finishAttempt("error");
 
               const delayMs = decision.delayMs;
-              if (trace) {
-                events.publish(LlmCall.RetryDecided, {
+              events.publish(LlmCall.RetryDecided, {
+                traceId: trace.traceId,
+                sessionId: trace.sessionId,
+                ...(trace.runId !== undefined && { runId: trace.runId }),
+                attempt,
+                maxAttempts: retryAttemptLimit,
+                reason: retryReason,
+                backoffMs: delayMs,
+                time: Date.now(),
+              });
+
+              if (publishesRateLimited(retryReason)) {
+                events.publish(LlmCall.RateLimited, {
                   traceId: trace.traceId,
                   sessionId: trace.sessionId,
                   ...(trace.runId !== undefined && { runId: trace.runId }),
-                  attempt,
-                  maxAttempts: retryAttemptLimit,
-                  reason: retryReason,
-                  backoffMs: delayMs,
+                  provider: trace.provider ?? model.providerID,
+                  retryAfterMs: delayMs,
                   time: Date.now(),
                 });
-
-                if (publishesRateLimited(retryReason)) {
-                  events.publish(LlmCall.RateLimited, {
-                    traceId: trace.traceId,
-                    sessionId: trace.sessionId,
-                    ...(trace.runId !== undefined && { runId: trace.runId }),
-                    provider: trace.provider ?? model.providerID,
-                    retryAfterMs: delayMs,
-                    time: Date.now(),
-                  });
-                }
               }
 
               publishStatus(events, sessionID, trace.traceId, "retry");
@@ -280,13 +278,11 @@ export namespace Processor {
   function publishInfo(
     events: BusEvent.Sink,
     sessionID: string,
-    traceId: string | undefined,
+    traceId: string,
     message: string,
     data?: Record<string, unknown>,
   ): void {
-    // No trace, no record. The previous `traceId ?? sessionID` put a value of
-    // the wrong kind in the field every reader treats as a trace (#606 D11).
-    if (!sessionID || traceId === undefined || traceId.length === 0) return;
+    if (!sessionID) return;
     events.publish(Operational.Info, {
       traceId,
       time: Date.now(),
@@ -301,7 +297,7 @@ export namespace Processor {
     events: BusEvent.Sink,
     sink: Sink,
     sessionID: string,
-    traceId?: string,
+    traceId: string,
   ): Sink {
     function publish(message: string, data?: Record<string, unknown>): void {
       publishInfo(events, sessionID, traceId, message, data);
@@ -358,7 +354,7 @@ export namespace Processor {
   function publishStatus(
     events: BusEvent.Sink,
     sessionID: string,
-    traceId: string | undefined,
+    traceId: string,
     stateType: string,
   ): void {
     publishInfo(events, sessionID, traceId, "sink.snapshot", { stateType });

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -34,7 +34,7 @@ export interface RunInput {
    */
   trace: { traceId: string; sessionId: string; runId: string };
   /**
-   * Where observation goes. See `Processor.Options.events` — the port exists so
+   * Where observation goes. See `Processor.ProcessorOptions.events` — the port exists so
    * `llm` reports what it did without reaching for a process-wide singleton.
    */
   events: BusEvent.Sink;
@@ -204,7 +204,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   input.events.publish(LlmCall.Started, {
     traceId,
     sessionId: sessionID,
-    ...(input.trace.runId !== undefined && { runId: input.trace.runId }),
+    runId: input.trace.runId,
     provider,
     model: modelId,
     messageCount: messages.length,

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -49,6 +49,9 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   }
 
   const { traceId, sessionId: sessionID } = input.trace;
+  if (traceId.length === 0 || sessionID.length === 0) {
+    throw new Error("llm run requires a non-empty traceId and sessionId");
+  }
   const messageID = `msg-${crypto.randomUUID()}`;
   const parentID = messages[messages.length - 1]?.info.id || "";
 

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -204,7 +204,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   input.events.publish(LlmCall.Started, {
     traceId,
     sessionId: sessionID,
-    ...(input.trace?.runId !== undefined && { runId: input.trace.runId }),
+    ...(input.trace.runId !== undefined && { runId: input.trace.runId }),
     provider,
     model: modelId,
     messageCount: messages.length,

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -1,4 +1,4 @@
-import type { Sink, Message, Tool, Run } from "@openomni/protocol";
+import type { BusEvent, Sink, Message, Tool, Run } from "@openomni/protocol";
 import { LlmCall, Operational } from "@openomni/protocol";
 import type { SDKMessage } from "./message";
 import { Processor } from "./processor";
@@ -7,7 +7,6 @@ import type { Provider } from "./provider";
 import { ProviderTransform } from "./provider/transform";
 import { getLanguage } from "./provider/sdk";
 import { Auth } from "./auth/storage";
-import { Bus } from "@openomni/telemetry";
 
 /**
  * Input for the run() function.
@@ -34,6 +33,11 @@ export interface RunInput {
    * correlates to nothing.
    */
   trace: { traceId: string; sessionId: string; runId: string };
+  /**
+   * Where observation goes. See `Processor.Options.events` — the port exists so
+   * `llm` reports what it did without reaching for a process-wide singleton.
+   */
+  events: BusEvent.Sink;
 }
 
 export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
@@ -137,7 +141,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
       maxRetries: 0,
       stopWhen: ai.stepCountIs(input.maxSteps ?? 24),
       onError: ({ error }: { error: unknown }) => {
-        Bus.publish(Operational.Error, {
+        input.events.publish(Operational.Error, {
           traceId,
           time: Date.now(),
           sessionId: sessionID,
@@ -179,6 +183,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   const modelId = model.id;
 
   const processor = Processor.create({
+    events: input.events,
     assistantMessage,
     sessionID,
     model,
@@ -193,7 +198,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
     },
   });
 
-  Bus.publish(LlmCall.Started, {
+  input.events.publish(LlmCall.Started, {
     traceId,
     sessionId: sessionID,
     ...(input.trace?.runId !== undefined && { runId: input.trace.runId }),
@@ -213,7 +218,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
     const finalTokens = processor.message.tokens;
     const finishReason = processor.message.finish ?? "unknown";
 
-    Bus.publish(LlmCall.Completed, {
+    input.events.publish(LlmCall.Completed, {
       traceId,
       sessionId: sessionID,
       runId: input.trace.runId,
@@ -234,7 +239,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
     const err = error instanceof Error ? error : new Error(String(error));
     const aborted = abortSignal.aborted;
 
-    Bus.publish(LlmCall.Failed, {
+    input.events.publish(LlmCall.Failed, {
       traceId,
       sessionId: sessionID,
       runId: input.trace.runId,

--- a/packages/llm/test/processor/emission-measurement.test.ts
+++ b/packages/llm/test/processor/emission-measurement.test.ts
@@ -92,7 +92,7 @@ describe("Processor emission measurement (#545 T2)", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-measure" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield* scenario() as Array<{ type: string }>;

--- a/packages/llm/test/processor/emission-measurement.test.ts
+++ b/packages/llm/test/processor/emission-measurement.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Message, Sink } from "@openomni/protocol";
 import { Processor } from "../../src/processor";
 import type { Provider } from "../../src/provider";
+import { Bus } from "@openomni/telemetry";
 
 /**
  * #545 T2 measurement harness: streams a fixed synthetic 2000-delta/3-part
@@ -90,6 +91,8 @@ describe("Processor emission measurement (#545 T2)", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield* scenario() as Array<{ type: string }>;

--- a/packages/llm/test/processor/fold-emission.test.ts
+++ b/packages/llm/test/processor/fold-emission.test.ts
@@ -72,6 +72,8 @@ function createProcessor(cap: Capture, overrides: Partial<Processor.ProcessorOpt
     model,
     abort: new AbortController().signal,
     sink: cap.sink,
+    events: Bus,
+    trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
     createStream: streamOf([{ type: "finish" }]),
     ...overrides,
   });
@@ -93,6 +95,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("emits onMessage only at part boundaries, never per token", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "Hello" },
@@ -118,6 +122,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("already-emitted snapshots are immune to later stream progress", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "Hello" },
@@ -151,6 +157,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("emits transcript facts in fold order with attempt identity", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "Hi" },
@@ -184,6 +192,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
     let attemptCount = 0;
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: async () => ({
         fullStream: (async function* () {
           attemptCount++;
@@ -214,6 +224,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
     let attemptCount = 0;
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: async () => ({
         fullStream: (async function* () {
           attemptCount++;
@@ -248,6 +260,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("length finish fails incomplete tool calls with no salvage", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "tool-call", toolCallId: "call-cut", toolName: "lookup", input: { q: "x" } },
         {
@@ -277,6 +291,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("opens a text block for an orphan text-delta (malformed sequence normalization)", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-delta", text: "orphan" },
         { type: "text-end", providerMetadata: {} },
@@ -295,6 +311,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("ignores a duplicate block end", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "once" },
@@ -315,6 +333,8 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("captures the provider reasoning signature on the completed part", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "reasoning-start", id: "r1", providerMetadata: {} },
         { type: "reasoning-delta", id: "r1", text: "thinking" },

--- a/packages/llm/test/processor/fold-emission.test.ts
+++ b/packages/llm/test/processor/fold-emission.test.ts
@@ -95,8 +95,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("emits onMessage only at part boundaries, never per token", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "Hello" },
@@ -122,8 +120,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("already-emitted snapshots are immune to later stream progress", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "Hello" },
@@ -157,8 +153,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("emits transcript facts in fold order with attempt identity", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "Hi" },
@@ -192,8 +186,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
     let attemptCount = 0;
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: async () => ({
         fullStream: (async function* () {
           attemptCount++;
@@ -224,8 +216,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
     let attemptCount = 0;
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: async () => ({
         fullStream: (async function* () {
           attemptCount++;
@@ -260,8 +250,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("length finish fails incomplete tool calls with no salvage", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "tool-call", toolCallId: "call-cut", toolName: "lookup", input: { q: "x" } },
         {
@@ -291,8 +279,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("opens a text block for an orphan text-delta (malformed sequence normalization)", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-delta", text: "orphan" },
         { type: "text-end", providerMetadata: {} },
@@ -311,8 +297,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("ignores a duplicate block end", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "text-start", providerMetadata: {} },
         { type: "text-delta", text: "once" },
@@ -333,8 +317,6 @@ describe("Processor fold-based emission (#545 T2)", () => {
   test("captures the provider reasoning signature on the completed part", async () => {
     const cap = capture();
     const processor = createProcessor(cap, {
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-fold" },
       createStream: streamOf([
         { type: "reasoning-start", id: "r1", providerMetadata: {} },
         { type: "reasoning-delta", id: "r1", text: "thinking" },

--- a/packages/llm/test/processor/processor.test.ts
+++ b/packages/llm/test/processor/processor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, beforeEach } from "bun:test";
 import { LlmCall, Operational, type Message, type Sink, type Tool } from "@openomni/protocol";
-import { Bus, collector } from "@openomni/telemetry";
+import { collector } from "@openomni/telemetry";
 import { Processor } from "../../src/processor";
 import { APIError } from "../../src/error";
 import type { Provider } from "../../src/provider";
@@ -129,7 +129,6 @@ describe("Processor", () => {
   });
 
   afterEach(() => {
-    Bus.reset();
     events.reset();
   });
 
@@ -415,7 +414,7 @@ describe("Processor", () => {
       expect(statusStates(events)).toEqual(["busy", "idle"]);
     });
 
-    test("projects sink callbacks to Bus events", async () => {
+    test("projects sink callbacks onto the events port", async () => {
       const sinkEvents: string[] = [];
       const toolCalls: Tool.Call[] = [];
       const toolResults: Tool.Result[] = [];
@@ -460,22 +459,17 @@ describe("Processor", () => {
       expect(toolResults).toHaveLength(1);
       expect(toolResults[0]?.toolCallId).toBe("call-1");
 
-      expect(processorInfo(events).every((event) => event.component === "llm.processor")).toBe(
-        true,
-      );
-      expect(processorInfo(events).every((event) => event.sessionId === "session-456")).toBe(true);
+      const infoEvents = processorInfo(events);
+      expect(infoEvents.every((event) => event.component === "llm.processor")).toBe(true);
+      expect(infoEvents.every((event) => event.sessionId === "session-456")).toBe(true);
       // sink.* diagnostics must join to llm.call.* events via the run traceId.
-      expect(processorInfo(events).every((event) => event.traceId === "trace-projection")).toBe(
-        true,
-      );
-      expect(processorInfo(events).every((event) => typeof event.time === "number")).toBe(true);
+      expect(infoEvents.every((event) => event.traceId === "trace-projection")).toBe(true);
+      expect(infoEvents.every((event) => typeof event.time === "number")).toBe(true);
 
-      const messageEvents = processorInfo(events).filter((event) => event.msg === "sink.message");
-      const snapshotEvents = processorInfo(events).filter((event) => event.msg === "sink.snapshot");
-      const toolStarted = processorInfo(events).find((event) => event.msg === "sink.tool.started");
-      const toolCompleted = processorInfo(events).find(
-        (event) => event.msg === "sink.tool.completed",
-      );
+      const messageEvents = infoEvents.filter((event) => event.msg === "sink.message");
+      const snapshotEvents = infoEvents.filter((event) => event.msg === "sink.snapshot");
+      const toolStarted = infoEvents.find((event) => event.msg === "sink.tool.started");
+      const toolCompleted = infoEvents.find((event) => event.msg === "sink.tool.completed");
 
       expect(messageEvents.length).toBe(messages.length);
       expect(snapshotEvents.length).toBe(2);

--- a/packages/llm/test/processor/processor.test.ts
+++ b/packages/llm/test/processor/processor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, beforeEach } from "bun:test";
 import { LlmCall, Operational, type Message, type Sink, type Tool } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { Bus, collector } from "@openomni/telemetry";
 import { Processor } from "../../src/processor";
 import { APIError } from "../../src/error";
 import type { Provider } from "../../src/provider";
@@ -66,20 +66,28 @@ function capturingSink(): PartsCapture {
  * Run-status telemetry (busy/retry/idle) is published on the Operational bus
  * as "sink.snapshot" (the Sink.onSnapshot hop was removed — no consumer).
  */
-function captureStatusStates(): { states: string[]; unsub: () => void } {
-  const states: string[] = [];
-  const unsub = Bus.subscribe(Operational.Info, (data) => {
-    if (data.component === "llm.processor" && data.msg === "sink.snapshot") {
-      states.push(String((data.context as Record<string, unknown> | undefined)?.stateType));
-    }
-  });
-  return { states, unsub };
+function statusStates(events: ReturnType<typeof collector>): string[] {
+  return events
+    .named(Operational.Info.name)
+    .map((event) => event as OperationalInfoPayload)
+    .filter((data) => data.component === "llm.processor" && data.msg === "sink.snapshot")
+    .map((data) => String((data.context as Record<string, unknown> | undefined)?.stateType));
+}
+
+function processorInfo(events: ReturnType<typeof collector>): OperationalInfoPayload[] {
+  return events
+    .named(Operational.Info.name)
+    .map((event) => event as OperationalInfoPayload)
+    .filter((data) => data.component === "llm.processor");
 }
 
 describe("Processor", () => {
   let mockAssistantMessage: Message.AssistantMessage;
   let mockModel: Provider.Model;
   let abortController: AbortController;
+  /** The port under test. Reading here rather than off `Bus` is what makes a
+   * re-mint through the global bus fail instead of pass. */
+  const events = collector();
 
   beforeEach(() => {
     abortController = new AbortController();
@@ -122,6 +130,7 @@ describe("Processor", () => {
 
   afterEach(() => {
     Bus.reset();
+    events.reset();
   });
 
   function createProcessor(overrides: Partial<Processor.ProcessorOptions> = {}) {
@@ -130,7 +139,7 @@ describe("Processor", () => {
       sessionID: "session-456",
       model: mockModel,
       abort: abortController.signal,
-      events: Bus,
+      events,
       trace: { traceId: "trace-processor-test", sessionId: "session-456" },
       createStream: streamOf([{ type: "finish" }]),
       ...overrides,
@@ -151,7 +160,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -175,7 +183,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -197,7 +204,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "reasoning-start", id: "r1", providerMetadata: {} },
           { type: "reasoning-delta", id: "r1", text: "Step 1" },
@@ -222,7 +228,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "step-start" },
           {
@@ -264,7 +269,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello   " },
@@ -291,7 +295,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "First" },
@@ -315,7 +318,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "reasoning-start", id: "r1", providerMetadata: {} },
           { type: "reasoning-start", id: "r1", providerMetadata: {} },
@@ -340,7 +342,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: streamOf([
           { type: "tool-call", toolCallId: "call-orphan", toolName: "lookup", args: { q: "x" } },
           { type: "finish" },
@@ -366,7 +367,6 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -407,24 +407,15 @@ describe("Processor", () => {
     });
 
     test("publishes exactly one busy and one idle status on success", async () => {
-      const { states, unsub } = captureStatusStates();
       const processor = createProcessor();
 
       await processor.process({ system: "" });
       await new Promise((resolve) => queueMicrotask(resolve));
-      unsub();
 
-      expect(states).toEqual(["busy", "idle"]);
+      expect(statusStates(events)).toEqual(["busy", "idle"]);
     });
 
     test("projects sink callbacks to Bus events", async () => {
-      const busEvents: OperationalInfoPayload[] = [];
-      const unsub = Bus.subscribe(Operational.Info, (data) => {
-        if (data.component === "llm.processor") {
-          busEvents.push(data);
-        }
-      });
-
       const sinkEvents: string[] = [];
       const toolCalls: Tool.Call[] = [];
       const toolResults: Tool.Result[] = [];
@@ -448,7 +439,6 @@ describe("Processor", () => {
       const processor = createProcessor({
         sink,
         trace: { traceId: "trace-projection", sessionId: "session-456" },
-        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -470,16 +460,22 @@ describe("Processor", () => {
       expect(toolResults).toHaveLength(1);
       expect(toolResults[0]?.toolCallId).toBe("call-1");
 
-      expect(busEvents.every((event) => event.component === "llm.processor")).toBe(true);
-      expect(busEvents.every((event) => event.sessionId === "session-456")).toBe(true);
+      expect(processorInfo(events).every((event) => event.component === "llm.processor")).toBe(
+        true,
+      );
+      expect(processorInfo(events).every((event) => event.sessionId === "session-456")).toBe(true);
       // sink.* diagnostics must join to llm.call.* events via the run traceId.
-      expect(busEvents.every((event) => event.traceId === "trace-projection")).toBe(true);
-      expect(busEvents.every((event) => typeof event.time === "number")).toBe(true);
+      expect(processorInfo(events).every((event) => event.traceId === "trace-projection")).toBe(
+        true,
+      );
+      expect(processorInfo(events).every((event) => typeof event.time === "number")).toBe(true);
 
-      const messageEvents = busEvents.filter((event) => event.msg === "sink.message");
-      const snapshotEvents = busEvents.filter((event) => event.msg === "sink.snapshot");
-      const toolStarted = busEvents.find((event) => event.msg === "sink.tool.started");
-      const toolCompleted = busEvents.find((event) => event.msg === "sink.tool.completed");
+      const messageEvents = processorInfo(events).filter((event) => event.msg === "sink.message");
+      const snapshotEvents = processorInfo(events).filter((event) => event.msg === "sink.snapshot");
+      const toolStarted = processorInfo(events).find((event) => event.msg === "sink.tool.started");
+      const toolCompleted = processorInfo(events).find(
+        (event) => event.msg === "sink.tool.completed",
+      );
 
       expect(messageEvents.length).toBe(messages.length);
       expect(snapshotEvents.length).toBe(2);
@@ -492,8 +488,6 @@ describe("Processor", () => {
         toolCallId: "call-1",
         outputLength: 2,
       });
-
-      unsub();
     });
 
     test("respects abort signal during stream processing", async () => {
@@ -523,7 +517,6 @@ describe("Processor", () => {
       });
 
       const processor = createProcessor({
-        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -552,7 +545,6 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         sink,
-        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -577,7 +569,6 @@ describe("Processor", () => {
       let attemptCount = 0;
 
       const processor = createProcessor({
-        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -604,12 +595,6 @@ describe("Processor", () => {
       let attemptCount = 0;
       const retries: Array<{ runId?: string; reason: string; backoffMs: number }> = [];
       const rateLimits: Array<{ runId?: string; provider: string; retryAfterMs: number }> = [];
-      const unsubRetry = Bus.subscribe(LlmCall.RetryDecided, (event) => {
-        retries.push(event);
-      });
-      const unsubRateLimit = Bus.subscribe(LlmCall.RateLimited, (event) => {
-        rateLimits.push(event);
-      });
 
       const processor = createProcessor({
         trace: {
@@ -618,7 +603,6 @@ describe("Processor", () => {
           runId: "run-processor-retry",
           provider: "anthropic",
         },
-        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -637,8 +621,8 @@ describe("Processor", () => {
       });
 
       await processor.process({ system: "" });
-      unsubRetry();
-      unsubRateLimit();
+      retries.push(...events.named(LlmCall.RetryDecided.name).map((event) => event as never));
+      rateLimits.push(...events.named(LlmCall.RateLimited.name).map((event) => event as never));
 
       expect(retries).toHaveLength(1);
       expect(retries[0]).toMatchObject({
@@ -664,9 +648,6 @@ describe("Processor", () => {
       // limit. The typed reason switch must catch it.
       let attemptCount = 0;
       const rateLimits: Array<{ provider: string; retryAfterMs: number }> = [];
-      const unsubRateLimit = Bus.subscribe(LlmCall.RateLimited, (event) => {
-        rateLimits.push(event);
-      });
 
       const processor = createProcessor({
         trace: {
@@ -674,7 +655,6 @@ describe("Processor", () => {
           sessionId: "session-456",
           provider: "anthropic",
         },
-        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -698,7 +678,7 @@ describe("Processor", () => {
       });
 
       await processor.process({ system: "" });
-      unsubRateLimit();
+      rateLimits.push(...events.named(LlmCall.RateLimited.name).map((event) => event as never));
 
       expect(attemptCount).toBe(2);
       expect(rateLimits).toHaveLength(1);
@@ -707,7 +687,7 @@ describe("Processor", () => {
 
     test("throws original error instance for non-retryable errors and settles cleanly", async () => {
       const capture = capturingSink();
-      const { states, unsub } = captureStatusStates();
+
       const errorInstance = new APIError({
         message: "Specific error",
         statusCode: 500,
@@ -716,7 +696,6 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         sink: capture.sink,
-        events: Bus,
         createStream: async () => ({
           fullStream: (async function* (shouldThrow = true) {
             yield { type: "tool-call", toolCallId: "call-1", toolName: "lookup", args: {} };
@@ -734,8 +713,7 @@ describe("Processor", () => {
 
       // Exactly one idle transition, and the pending tool is closed out once.
       await new Promise((resolve) => queueMicrotask(resolve));
-      unsub();
-      expect(states).toEqual(["busy", "idle"]);
+      expect(statusStates(events)).toEqual(["busy", "idle"]);
       expect(capture.toolResults).toHaveLength(1);
       expect(capture.toolResults[0]).toMatchObject({
         toolCallId: "call-1",
@@ -760,7 +738,6 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         model: modelWithCatalogCost,
-        events: Bus,
         createStream: streamOf([
           {
             type: "step-finish",
@@ -789,7 +766,6 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         model: modelNoCost,
-        events: Bus,
         createStream: streamOf([
           {
             type: "step-finish",
@@ -817,7 +793,6 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         model: modelWithCatalogCost,
-        events: Bus,
         createStream: streamOf([
           {
             type: "step-finish",

--- a/packages/llm/test/processor/processor.test.ts
+++ b/packages/llm/test/processor/processor.test.ts
@@ -130,6 +130,8 @@ describe("Processor", () => {
       sessionID: "session-456",
       model: mockModel,
       abort: abortController.signal,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-456" },
       createStream: streamOf([{ type: "finish" }]),
       ...overrides,
     });
@@ -149,6 +151,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -172,6 +175,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -193,6 +197,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "reasoning-start", id: "r1", providerMetadata: {} },
           { type: "reasoning-delta", id: "r1", text: "Step 1" },
@@ -217,6 +222,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "step-start" },
           {
@@ -258,6 +264,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello   " },
@@ -284,6 +291,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "First" },
@@ -307,6 +315,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "reasoning-start", id: "r1", providerMetadata: {} },
           { type: "reasoning-start", id: "r1", providerMetadata: {} },
@@ -331,6 +340,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: streamOf([
           { type: "tool-call", toolCallId: "call-orphan", toolName: "lookup", args: { q: "x" } },
           { type: "finish" },
@@ -356,6 +366,7 @@ describe("Processor", () => {
       const capture = capturingSink();
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -437,6 +448,7 @@ describe("Processor", () => {
       const processor = createProcessor({
         sink,
         trace: { traceId: "trace-projection", sessionId: "session-456" },
+        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -511,6 +523,7 @@ describe("Processor", () => {
       });
 
       const processor = createProcessor({
+        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -539,6 +552,7 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         sink,
+        events: Bus,
         createStream: streamOf([
           { type: "text-start", providerMetadata: {} },
           { type: "text-delta", text: "Hello" },
@@ -563,6 +577,7 @@ describe("Processor", () => {
       let attemptCount = 0;
 
       const processor = createProcessor({
+        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -603,6 +618,7 @@ describe("Processor", () => {
           runId: "run-processor-retry",
           provider: "anthropic",
         },
+        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -658,6 +674,7 @@ describe("Processor", () => {
           sessionId: "session-456",
           provider: "anthropic",
         },
+        events: Bus,
         createStream: async () => ({
           fullStream: (async function* () {
             attemptCount++;
@@ -699,6 +716,7 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         sink: capture.sink,
+        events: Bus,
         createStream: async () => ({
           fullStream: (async function* (shouldThrow = true) {
             yield { type: "tool-call", toolCallId: "call-1", toolName: "lookup", args: {} };
@@ -742,6 +760,7 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         model: modelWithCatalogCost,
+        events: Bus,
         createStream: streamOf([
           {
             type: "step-finish",
@@ -770,6 +789,7 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         model: modelNoCost,
+        events: Bus,
         createStream: streamOf([
           {
             type: "step-finish",
@@ -797,6 +817,7 @@ describe("Processor", () => {
 
       const processor = createProcessor({
         model: modelWithCatalogCost,
+        events: Bus,
         createStream: streamOf([
           {
             type: "step-finish",

--- a/packages/llm/test/processor/processor.test.ts
+++ b/packages/llm/test/processor/processor.test.ts
@@ -63,22 +63,20 @@ function capturingSink(): PartsCapture {
 }
 
 /**
- * Run-status telemetry (busy/retry/idle) is published on the Operational bus
- * as "sink.snapshot" (the Sink.onSnapshot hop was removed — no consumer).
+ * Run-status telemetry (busy/retry/idle) goes to the injected events port as
+ * an `Operational.Info` named "sink.snapshot" (the `Sink.onSnapshot` hop was
+ * removed — no consumer).
  */
-function statusStates(events: ReturnType<typeof collector>): string[] {
-  return events
-    .named(Operational.Info.name)
-    .map((event) => event as OperationalInfoPayload)
-    .filter((data) => data.component === "llm.processor" && data.msg === "sink.snapshot")
-    .map((data) => String((data.context as Record<string, unknown> | undefined)?.stateType));
-}
-
 function processorInfo(events: ReturnType<typeof collector>): OperationalInfoPayload[] {
   return events
     .named(Operational.Info.name)
     .map((event) => event as OperationalInfoPayload)
     .filter((data) => data.component === "llm.processor");
+}
+function statusStates(events: ReturnType<typeof collector>): string[] {
+  return processorInfo(events)
+    .filter((data) => data.msg === "sink.snapshot")
+    .map((data) => String((data.context as Record<string, unknown> | undefined)?.stateType));
 }
 
 describe("Processor", () => {

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -99,7 +99,6 @@ describe("Processor retry header-delay cap (#532 candidate 3)", () => {
   const events = collector();
 
   afterEach(() => {
-    Bus.reset();
     events.reset();
   });
 
@@ -138,7 +137,8 @@ describe("Processor retry header-delay cap (#532 candidate 3)", () => {
     const declined = events
       .named(Operational.Error.name)
       .map((event) => event as { component?: string; traceId?: string });
-    expect(declined.filter((event) => event.component === "llm.retry")).toHaveLength(1);
-    expect(declined[0]?.traceId).toBe("trace-retry-cap");
+    const fromRetry = declined.filter((event) => event.component === "llm.retry");
+    expect(fromRetry).toHaveLength(1);
+    expect(fromRetry[0]?.traceId).toBe("trace-retry-cap");
   });
 });

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -67,6 +67,7 @@ describe("Processor retry cap", () => {
         traceId: "trace-processor-retry-cap",
         sessionId: "session-retry-cap",
       },
+      events: Bus,
       createStream: async () => ({
         fullStream: (async function* () {
           const error = retryErrors[attemptCount];
@@ -110,6 +111,8 @@ describe("Processor retry header-delay cap (#532 candidate 3)", () => {
         onToolCall: () => undefined,
         onToolResult: () => undefined,
       },
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield { type: "text-start", id: "t" };

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { LlmCall, type Message } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { LlmCall, Operational, type Message } from "@openomni/protocol";
+import { Bus, collector } from "@openomni/telemetry";
 import { APIError } from "../../src/error";
 import { Processor } from "../../src/processor";
 import type { Provider } from "../../src/provider";
@@ -96,8 +96,11 @@ describe("Processor retry cap", () => {
 });
 
 describe("Processor retry header-delay cap (#532 candidate 3)", () => {
+  const events = collector();
+
   afterEach(() => {
     Bus.reset();
+    events.reset();
   });
 
   test("a server-directed wait above the cap fails fast instead of stalling", async () => {
@@ -111,8 +114,8 @@ describe("Processor retry header-delay cap (#532 candidate 3)", () => {
         onToolCall: () => undefined,
         onToolResult: () => undefined,
       },
-      events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      events,
+      trace: { traceId: "trace-retry-cap", sessionId: "session-retry-cap" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield { type: "text-start", id: "t" };
@@ -129,5 +132,13 @@ describe("Processor retry header-delay cap (#532 candidate 3)", () => {
     await expect(processor.process({ system: "" })).rejects.toBeDefined();
     // Under the old policy this would have slept for an hour mid-run.
     expect(Date.now() - startedAt).toBeLessThan(1000);
+
+    // A retryable error declined for a reason other than "non_retryable" has
+    // to say why, and say it through the port.
+    const declined = events
+      .named(Operational.Error.name)
+      .map((event) => event as { component?: string; traceId?: string });
+    expect(declined.filter((event) => event.component === "llm.retry")).toHaveLength(1);
+    expect(declined[0]?.traceId).toBe("trace-retry-cap");
   });
 });

--- a/packages/llm/test/processor/tool-result.test.ts
+++ b/packages/llm/test/processor/tool-result.test.ts
@@ -53,6 +53,8 @@ describe("Processor tool result projection", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -117,6 +119,8 @@ describe("Processor tool result projection", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -158,6 +162,8 @@ describe("Processor tool result projection", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -205,6 +211,8 @@ describe("Processor tool result projection", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -251,6 +259,8 @@ describe("Processor tool output normalization", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -296,6 +306,8 @@ describe("Processor tool error normalization", () => {
       model,
       abort: new AbortController().signal,
       sink,
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -355,6 +367,8 @@ describe("Processor abort settlement grace (#532 candidate 2)", () => {
       model,
       abort: abortController.signal,
       sink: captureSink(messages),
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -398,6 +412,8 @@ describe("Processor abort settlement grace (#532 candidate 2)", () => {
       model,
       abort: abortController.signal,
       sink: captureSink(messages),
+      events: Bus,
+      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {

--- a/packages/llm/test/processor/tool-result.test.ts
+++ b/packages/llm/test/processor/tool-result.test.ts
@@ -54,7 +54,7 @@ describe("Processor tool result projection", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -120,7 +120,7 @@ describe("Processor tool result projection", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -163,7 +163,7 @@ describe("Processor tool result projection", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -212,7 +212,7 @@ describe("Processor tool result projection", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -260,7 +260,7 @@ describe("Processor tool output normalization", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -307,7 +307,7 @@ describe("Processor tool error normalization", () => {
       abort: new AbortController().signal,
       sink,
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -368,7 +368,7 @@ describe("Processor abort settlement grace (#532 candidate 2)", () => {
       abort: abortController.signal,
       sink: captureSink(messages),
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {
@@ -413,7 +413,7 @@ describe("Processor abort settlement grace (#532 candidate 2)", () => {
       abort: abortController.signal,
       sink: captureSink(messages),
       events: Bus,
-      trace: { traceId: "trace-processor-test", sessionId: "session-processor-test" },
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
       createStream: async () => ({
         fullStream: (async function* () {
           yield {

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Sink } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { Bus, newTraceId } from "@openomni/telemetry";
 
 const TEST_TRACE = { traceId: newTraceId(), sessionId: "session-test", runId: "run-test" };
 
@@ -56,6 +56,7 @@ describe("run() streamText arguments", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [],
         toolChoice: "required",
@@ -93,6 +94,7 @@ describe("run() streamText arguments", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [],
         model: {

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Sink } from "@openomni/protocol";
-import { Bus, newTraceId } from "@openomni/telemetry";
+import { Bus, collector, newTraceId } from "@openomni/telemetry";
+import { Operational } from "@openomni/protocol";
 
 const TEST_TRACE = { traceId: newTraceId(), sessionId: "session-test", runId: "run-test" };
 
@@ -116,5 +117,49 @@ describe("run() streamText arguments", () => {
     const stopWhen = streamArgs.stopWhen as (input: { steps: unknown[] }) => boolean;
     expect(stopWhen({ steps: Array.from({ length: 23 }) })).toBe(false);
     expect(stopWhen({ steps: Array.from({ length: 24 }) })).toBe(true);
+  });
+
+  /**
+   * `streamText`'s `onError` is the one publish site the happy and failure
+   * paths both miss, so it was free to route back to a global bus.
+   */
+  test("reports a stream error through the injected sink", async () => {
+    const collected = collector();
+    const busSaw: string[] = [];
+    const unsubscribe = Bus.observe((descriptor) => busSaw.push(descriptor.name));
+
+    try {
+      await run(
+        {
+          trace: TEST_TRACE,
+          events: collected,
+          messages: [],
+          tools: [],
+          auth: { type: "api", key: "test-key-run" },
+          model: {
+            id: "claude-3-haiku",
+            providerID: TEST_PROVIDER_ID,
+            name: "Claude 3 Haiku Test",
+            api: { npm: "@ai-sdk/anthropic" },
+          },
+        },
+        mockSink,
+      );
+      const onError = aiCapture.__openomniAiStreamArgs?.onError as
+        | ((payload: { error: unknown }) => void)
+        | undefined;
+      expect(onError).toBeFunction();
+      onError?.({ error: new Error("upstream exploded") });
+      await Bun.sleep(0);
+    } finally {
+      unsubscribe();
+    }
+
+    const errors = collected
+      .named(Operational.Error.name)
+      .map((event) => event as { component?: string; error?: string });
+    expect(errors.filter((event) => event.component === "llm.stream")).toHaveLength(1);
+    expect(errors[0]?.error).toContain("upstream exploded");
+    expect(busSaw).toEqual([]);
   });
 });

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -148,8 +148,8 @@ describe("run() streamText arguments", () => {
       const onError = aiCapture.__openomniAiStreamArgs?.onError as
         | ((payload: { error: unknown }) => void)
         | undefined;
-      expect(onError).toBeFunction();
-      onError?.({ error: new Error("upstream exploded") });
+      if (onError === undefined) throw new Error("streamText received no onError");
+      onError({ error: new Error("upstream exploded") });
       await Bun.sleep(0);
     } finally {
       unsubscribe();
@@ -158,8 +158,9 @@ describe("run() streamText arguments", () => {
     const errors = collected
       .named(Operational.Error.name)
       .map((event) => event as { component?: string; error?: string });
-    expect(errors.filter((event) => event.component === "llm.stream")).toHaveLength(1);
-    expect(errors[0]?.error).toContain("upstream exploded");
+    const fromStream = errors.filter((event) => event.component === "llm.stream");
+    expect(fromStream).toHaveLength(1);
+    expect(fromStream[0]?.error).toContain("upstream exploded");
     expect(busSaw).toEqual([]);
   });
 });

--- a/packages/llm/test/run-tool-execution.test.ts
+++ b/packages/llm/test/run-tool-execution.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Sink, Tool } from "@openomni/protocol";
 import type { Provider } from "../src/provider";
-import { newTraceId } from "@openomni/telemetry";
+import { Bus, newTraceId } from "@openomni/telemetry";
 
 const TEST_TRACE = { traceId: newTraceId(), sessionId: "session-test", runId: "run-test" };
 
@@ -76,6 +76,7 @@ describe("run() tool execution ownership", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [
           {
@@ -129,6 +130,7 @@ describe("run() tool execution ownership", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [
           {
@@ -171,6 +173,7 @@ describe("run() tool execution ownership", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [
           {

--- a/packages/llm/test/run-tool-schema.test.ts
+++ b/packages/llm/test/run-tool-schema.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import type { Sink, Tool } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { Bus, newTraceId } from "@openomni/telemetry";
 
 const TEST_TRACE = { traceId: newTraceId(), sessionId: "session-test", runId: "run-test" };
 
@@ -54,6 +54,7 @@ describe("run() with model - tool schema conversion", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [
           {
@@ -97,6 +98,7 @@ describe("run() with model - tool schema conversion", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [
           { name: "first_tool", description: "first", inputSchema: { type: "object" } },
@@ -129,6 +131,7 @@ describe("run() with model - tool schema conversion", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [
           {
@@ -161,6 +164,7 @@ describe("run() with model - tool schema conversion", () => {
     await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [] as Tool.Spec[],
         system: "you are helpful",

--- a/packages/llm/test/run.test.ts
+++ b/packages/llm/test/run.test.ts
@@ -309,6 +309,9 @@ describe("run", () => {
     }
 
     expect(collected.named(LlmCall.Started.name)).toHaveLength(1);
+    // Every `Started` gets a terminal event — the success half of the pair the
+    // failure test covers.
+    expect(collected.named(LlmCall.Completed.name)).toHaveLength(1);
     // Not filtered to `llm.*`: an `operational.*` record routed back through
     // the global bus is the same defect, and the filter hid six of the eight
     // publish sites from this assertion.

--- a/packages/llm/test/run.test.ts
+++ b/packages/llm/test/run.test.ts
@@ -309,6 +309,62 @@ describe("run", () => {
     }
 
     expect(collected.named(LlmCall.Started.name)).toHaveLength(1);
-    expect(busSaw.filter((name) => name.startsWith("llm."))).toEqual([]);
+    // Not filtered to `llm.*`: an `operational.*` record routed back through
+    // the global bus is the same defect, and the filter hid six of the eight
+    // publish sites from this assertion.
+    expect(busSaw).toEqual([]);
+  });
+
+  /**
+   * The failure path publishes three of the eight records, and the happy path
+   * never reaches it — so without this the port is unpinned there.
+   */
+  test("reports a failed call through the injected sink too", async () => {
+    const collected = collector();
+    const busSaw: string[] = [];
+    const unsubscribe = Bus.observe((descriptor) => busSaw.push(descriptor.name));
+
+    try {
+      const outcome = await run(
+        {
+          messages: [],
+          tools: [],
+          model: {
+            id: "claude-3-haiku",
+            providerID: "no-auth-provider-port-test",
+            name: "Test Model",
+            api: { npm: "@ai-sdk/anthropic" },
+          },
+          trace: TEST_TRACE,
+          events: collected,
+        },
+        mockSink,
+      );
+      expect(outcome.type).toBe("error");
+      await Bun.sleep(0);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(collected.named(LlmCall.Started.name)).toHaveLength(1);
+    expect(collected.named(LlmCall.Failed.name)).toHaveLength(1);
+    expect(busSaw).toEqual([]);
+  });
+
+  /**
+   * Refused at the boundary rather than half-dropped: an empty trace used to
+   * silence the processor's records while `run` kept publishing malformed
+   * ones, which displaces the wrong-kind defect instead of closing it.
+   */
+  test.each([
+    ["traceId", { traceId: "", sessionId: "s", runId: "r" }],
+    ["sessionId", { traceId: "t", sessionId: "", runId: "r" }],
+  ])("refuses an empty %s", async (_field, trace) => {
+    await expect(
+      run(
+        { messages: [], tools: [], model: testModel, auth: testAuth, trace, events: collector() },
+        mockSink,
+      ),
+    ).rejects.toThrow("llm run requires a non-empty traceId and sessionId");
   });
 });

--- a/packages/llm/test/run.test.ts
+++ b/packages/llm/test/run.test.ts
@@ -3,7 +3,7 @@ import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { LlmCall, type Message, type Sink, type Tool } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { Bus, collector } from "@openomni/telemetry";
 import { Auth } from "../src/auth";
 import type { Provider } from "../src/provider";
 import { newTraceId } from "@openomni/telemetry";
@@ -88,6 +88,7 @@ describe("run", () => {
   test("returns RunOutcome with stop type", async () => {
     const input: import("../src/run").RunInput = {
       trace: TEST_TRACE,
+      events: Bus,
       messages: [],
       tools: [],
       model: testModel,
@@ -104,6 +105,7 @@ describe("run", () => {
     const abortController = new AbortController();
     const input: import("../src/run").RunInput = {
       trace: TEST_TRACE,
+      events: Bus,
       messages: [],
       tools: [],
       model: testModel,
@@ -122,6 +124,7 @@ describe("run", () => {
   test("returns error outcome when auth is not configured", async () => {
     const input: import("../src/run").RunInput = {
       trace: TEST_TRACE,
+      events: Bus,
       messages: [],
       tools: [],
       model: {
@@ -158,6 +161,7 @@ describe("run", () => {
           api: { npm: "@ai-sdk/anthropic" },
         },
         trace: { traceId: "trace-run-failed", sessionId: "session-failed", runId: "run-failed" },
+        events: Bus,
       },
       mockSink,
     );
@@ -182,6 +186,7 @@ describe("run", () => {
         const outcome = await run(
           {
             trace: TEST_TRACE,
+            events: Bus,
             messages: [],
             tools: [],
             allowAuthFallback: false,
@@ -209,6 +214,7 @@ describe("run", () => {
 
     const input: import("../src/run").RunInput = {
       trace: TEST_TRACE,
+      events: Bus,
       messages: [],
       tools: [],
       model: testModel,
@@ -226,6 +232,7 @@ describe("run", () => {
   test("calls sink methods during execution", async () => {
     const input: import("../src/run").RunInput = {
       trace: TEST_TRACE,
+      events: Bus,
       messages: [],
       tools: [],
       model: testModel,
@@ -256,6 +263,7 @@ describe("run", () => {
     const outcome = await run(
       {
         trace: TEST_TRACE,
+        events: Bus,
         messages: [],
         tools: [],
         model: testModel,
@@ -271,5 +279,36 @@ describe("run", () => {
     expect(textParts.length).toBe(1);
     expect(textParts[0]?.text).toBe("hello world");
     expect(textParts.some((part) => part.text === "")).toBe(false);
+  });
+
+  /**
+   * The point of the port. `llm` reports what it did to whatever the caller
+   * hands it — no process-wide `Bus`, nothing to reset between tests, and P2
+   * can put a fail-closed ledger append behind this without touching `run()`.
+   */
+  test("reports through the injected sink, not a global bus", async () => {
+    const collected = collector();
+    const busSaw: string[] = [];
+    const unsubscribe = Bus.observe((descriptor) => busSaw.push(descriptor.name));
+
+    try {
+      await run(
+        {
+          messages: [],
+          tools: [],
+          model: testModel,
+          auth: testAuth,
+          trace: TEST_TRACE,
+          events: collected,
+        },
+        mockSink,
+      );
+      await Bun.sleep(0);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(collected.named(LlmCall.Started.name)).toHaveLength(1);
+    expect(busSaw.filter((name) => name.startsWith("llm."))).toEqual([]);
   });
 });

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -48,6 +48,13 @@ type PackageRule = {
   packageJsonPath: string;
   packageName: string;
   allowedDeps: "none" | "any-except-self" | Set<string>;
+  /**
+   * Tighter allowlist for `<pkg>/src/` alone, when a package's runtime surface
+   * is narrower than what its tests need. Without it a test-only dependency
+   * silently re-permits the same import in production code, which is how a
+   * closed boundary reopens without any gate noticing.
+   */
+  srcAllowedDeps?: Set<string>;
 };
 
 const SHOW_FIX_SUGGESTIONS = Bun.argv.includes("--fix-suggestions");
@@ -106,13 +113,12 @@ const RULES: Record<PackageKey, PackageRule> = {
     displayName: "llm",
     packageJsonPath: "packages/llm/package.json",
     packageName: "@openomni/llm",
-    // `packages/llm/src` is protocol-only: it reads and writes the model and
-    // reports through an injected `BusEvent.Sink`, so it imports no
-    // implementation of the observation channel at all (#606). `telemetry`
-    // stays listed because the tests bind `Bus`/`collector` behind that port,
-    // and `check-deps` counts devDependencies; the source-import scan is what
-    // proves `src/` clean.
+    // The manifest may carry `telemetry` — the tests bind `Bus`/`collector`
+    // behind the port, and `check-deps` counts devDependencies.
     allowedDeps: new Set(["@openomni/protocol", "@openomni/telemetry"]),
+    // `src/` may not. It reports through an injected `BusEvent.Sink` and
+    // imports no implementation of the observation channel at all (#606).
+    srcAllowedDeps: new Set(["@openomni/protocol"]),
   },
   agent: {
     displayName: "agent",
@@ -156,6 +162,12 @@ const DEP_FIELDS = [
   "peerDependencies",
   "optionalDependencies",
 ] as const;
+
+/** The layer check for `<pkg>/src/`, which may be stricter than the manifest's. */
+function isAllowedSourceDep(rule: PackageRule, dep: string): boolean {
+  if (!dep.startsWith("@openomni/")) return true;
+  return rule.srcAllowedDeps === undefined ? isAllowedDep(rule, dep) : rule.srcAllowedDeps.has(dep);
+}
 
 function isAllowedDep(rule: PackageRule, dep: string): boolean {
   if (!dep.startsWith("@openomni/")) {
@@ -322,7 +334,7 @@ async function validateSourceImportDirection(): Promise<string[]> {
     let match = importPattern.exec(source);
     while (match !== null) {
       const dep = match[1];
-      if (!isAllowedDep(owner.rule, dep)) {
+      if (!isAllowedSourceDep(owner.rule, dep)) {
         const line = lineNumberForOffset(source, match.index);
         violations.push(
           `VIOLATION: ${filePath}:${line} source-imports ${dep} — not allowed by layer order for ${owner.rule.displayName} (manifest check cannot see phantom imports)`,

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -106,9 +106,12 @@ const RULES: Record<PackageKey, PackageRule> = {
     displayName: "llm",
     packageJsonPath: "packages/llm/package.json",
     packageName: "@openomni/llm",
-    // No durable storage: llm reads and writes the model, and reports what it
-    // did through the observation channel. The `@openomni/session` edge came
-    // from `Bus` living in the ledger package; it does not any more (#606).
+    // `packages/llm/src` is protocol-only: it reads and writes the model and
+    // reports through an injected `BusEvent.Sink`, so it imports no
+    // implementation of the observation channel at all (#606). `telemetry`
+    // stays listed because the tests bind `Bus`/`collector` behind that port,
+    // and `check-deps` counts devDependencies; the source-import scan is what
+    // proves `src/` clean.
     allowedDeps: new Set(["@openomni/protocol", "@openomni/telemetry"]),
   },
   agent: {

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -603,7 +603,51 @@ async function checkDocFreshness(): Promise<string[]> {
   return warnings;
 }
 
+/**
+ * Proves the layer rules discriminate, on synthetic inputs only — it reads no
+ * package and writes nothing.
+ *
+ * `srcAllowedDeps` is the reason this exists: a rule that narrows `src/` below
+ * the manifest can be deleted and every gate stays green, because the thing it
+ * forbids is exactly the thing the manifest still permits. That is the shape
+ * of a decorative gate, which is what this file is supposed to prevent.
+ */
+function selfTest(): void {
+  const twoTier: PackageRule = {
+    displayName: "self-test",
+    packageJsonPath: "",
+    packageName: "@openomni/self-test",
+    allowedDeps: new Set(["@openomni/protocol", "@openomni/telemetry"]),
+    srcAllowedDeps: new Set(["@openomni/protocol"]),
+  };
+  const oneTier: PackageRule = { ...twoTier, srcAllowedDeps: undefined };
+
+  const cases: Array<[string, boolean]> = [
+    ["manifest permits what the manifest lists", isAllowedDep(twoTier, "@openomni/telemetry")],
+    [
+      "src refuses what only the manifest lists",
+      !isAllowedSourceDep(twoTier, "@openomni/telemetry"),
+    ],
+    ["src permits its own narrower set", isAllowedSourceDep(twoTier, "@openomni/protocol")],
+    ["src refuses what neither lists", !isAllowedSourceDep(twoTier, "@openomni/session")],
+    [
+      "no srcAllowedDeps falls back to the manifest",
+      isAllowedSourceDep(oneTier, "@openomni/telemetry"),
+    ],
+    ["external packages are never layered", isAllowedSourceDep(twoTier, "zod")],
+  ];
+
+  const failed = cases.filter(([, ok]) => !ok).map(([name]) => name);
+  if (failed.length > 0) {
+    for (const name of failed) console.error(`SELF-TEST FAILED: ${name}`);
+    process.exit(1);
+  }
+  console.log(`OK: check-deps self-test — ${cases.length} layer discriminations hold`);
+  process.exit(0);
+}
+
 async function main(): Promise<void> {
+  if (Bun.argv.includes("--self-test")) selfTest();
   const depViolations = await validateDependencyDirection();
   const sourceImportViolations = await validateSourceImportDirection();
   const deepImportViolations = await validateDeepImports();

--- a/script/lint-side-effects.ts
+++ b/script/lint-side-effects.ts
@@ -76,7 +76,7 @@ const rules: readonly SideEffectRule[] = [
     filePath: "packages/llm/src/processor/index.ts",
     sideEffect: /\bsink\.on(?:Message|ToolCall|ToolResult|Snapshot)\(/g,
     requiredBefore: [
-      "const sink = createProjectedSink(configuredSink, sessionID, trace?.traceId);",
+      "const sink = createProjectedSink(events, configuredSink, sessionID, trace.traceId);",
     ],
     message: "processor sink side effects must flow through createProjectedSink",
   },


### PR DESCRIPTION
Phase 1b's remaining half, first package. **`packages/llm/src` no longer imports `Bus`.**

## The port

`RunInput.events` and `Processor.Options.events` are `BusEvent.Sink` — the port `@openomni/protocol` already declared for exactly this. The composition root decides what is behind it, a test binds a collector, and P2 can put a fail-closed ledger append there without touching `run()`.

Named `events`, not `sink`: `llm` already has a `Sink` — the streaming projection with `onMessage`/`onFact` — and two things called sink in one options bag is how the wrong one gets passed.

The agent binds it at the seam (`turn-prepare.ts`) for now. Agent's own 22 emit sites are the next slice.

## `Processor.Options.trace` becomes required

It was optional, and that optionality is what justified this:

```ts
traceId: traceId ?? sessionID,   // publishInfo, before
```

A session id written into the field every reader treats as a trace — the wrong-kind defect D11 names. `run()` has always supplied a trace; nothing but the fallback needed it optional. Records with no trace are dropped now, the ruling `packages/policy` already applies.

## Pinned where it matters

The payoff test binds a collector and asserts the global `Bus` sees **no** `llm.*` event:

```
port bypassed -> global Bus   1 fail
```

Routing a single publish back through `Bus` fails it.

## Note on the guard

`script/lint-side-effects.ts`'s `processor-projected-sink` rule pins the `createProjectedSink(...)` call by literal string, so the signature change required updating the expected text. The rule still enforces the same invariant.

## Verification

- `bun test --timeout 15000` — 3460 pass, 9 skip, 0 fail
- `check-types` 14/14, `lint`, `lint:tools`, `lint:guards`, `lint:side-effects`
- `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-coverage-ratchet`, `check-ledger-schema-drift` — all OK

Refs #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `llm` telemetry through an injected `events: BusEvent.Sink` and enforces a protocol‑only boundary for `packages/llm/src`. Previously `llm` published on the global `Bus` with an optional trace; now `run()`/`Processor.create()` require `events` and a non‑empty `trace`, and all eight publish sites (including retry‑declined and `streamText.onError`) report through the port.

- Migration
  - Callers of `run()` must pass `events: BusEvent.Sink` and a `trace` with non‑empty `traceId` and `sessionId` (empty values throw).
  - Callers of `Processor.create()` must pass `events` and a required `trace` ({ traceId, sessionId[, runId, provider] }).
  - Code/tests that observed `llm.*` on the global `Bus` must observe the injected sink instead (e.g., a `collector()` or a bound `Bus`).
  - `createProjectedSink(...)` now takes `(events, sink, sessionID, traceId)`.

- Notes for review
  - `packages/llm/src` is protocol‑only and imports no `Bus`; `script/check-deps.ts` enforces this with `srcAllowedDeps` and a `--self-test` CI gate. `AGENTS.md` documents the two‑tier rule; `@openomni/telemetry` moved to `devDependencies` for tests.
  - Tests pin 8/8 publishes against both reroute and deletion; the global `Bus` sees none from `llm`. `run()` emits `LlmCall.Started`/`Completed`/`Failed` and stream errors through `events`.
  - The agent binds the port at `packages/agent/src/core/execution/turn-prepare.ts` with `events: Bus`; agent emits remain on `Bus`.
  - `script/lint-side-effects.ts` pins the new `createProjectedSink` call shape.

<sup>Written for commit 61bc57cbe6a2da15543475caec0870b1498386d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent event reporting for LLM runs, including started, completed, failed, retry, rate-limit, and streaming error events.
  - Events can now be routed through the active run context, improving isolation and observability.
  - Added validation to reject runs with missing or empty trace and session identifiers.

- **Bug Fixes**
  - Prevented run-specific events from being published through unrelated global event channels.
  - Improved reporting of streaming and retry failures with associated trace information.

- **Documentation**
  - Clarified event and trace requirements and recommended integration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->