### PR TITLE
refactor(agent): report through an injected port, not a bus (#606)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ package's tests may reach further than its runtime code, and the gate holds
 | `session` | protocol, telemetry |
 | `llm` | protocol, telemetry — `src/` protocol only |
 | `coordinator` | protocol, ipc |
-| `agent` | protocol, policy, llm, telemetry |
+| `agent` | protocol, policy, llm, telemetry — `src/` protocol, policy, llm |
 | `openomni` | any except itself |
 | `server` | composition root |
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,8 @@
     "dev": "bun run src/index.ts",
     "start": "bun run src/index.ts",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@openomni/agent": "workspace:*",

--- a/apps/server/src/execution/worker-runner.ts
+++ b/apps/server/src/execution/worker-runner.ts
@@ -23,6 +23,7 @@ import {
   createExecutionToolContext,
   selectRequestedTools,
 } from "./worker-runtime";
+import { Bus } from "@openomni/telemetry";
 
 export namespace WorkerRunner {
   export function spawnRun(options: WorkerRunnerSpawnOptions): void {
@@ -161,6 +162,7 @@ export namespace WorkerRunner {
         const exposedTools = tools ?? [];
 
         const agent = createAgent({
+          events: Bus,
           model: request.model,
           auth: resolveAuth(request.model.provider),
           allowAuthFallback: false,

--- a/apps/server/src/tool/mcp/provider.ts
+++ b/apps/server/src/tool/mcp/provider.ts
@@ -27,7 +27,7 @@ export class McpToolProvider implements ToolProvider {
   async addServer(config: McpServerConfig): Promise<void> {
     const client =
       this.options.createClient?.(config) ??
-      new McpClient(config, { traceId: this.options.traceId });
+      new McpClient(config, { traceId: this.options.traceId, events: Bus });
     try {
       await client.connect();
       this.clients.set(config.name, client);

--- a/apps/server/test/tool/mcp/provider-trace-audit.test.ts
+++ b/apps/server/test/tool/mcp/provider-trace-audit.test.ts
@@ -12,6 +12,7 @@ import {
   makeTool,
   seedProvider,
 } from "./provider-test-fixture";
+import { Bus } from "@openomni/telemetry";
 
 installStorageFixture();
 
@@ -207,6 +208,7 @@ describe("McpToolProvider canonical policy trace", () => {
         url: "https://example.test/mcp",
       },
       {
+        events: Bus,
         client: {
           connect: async () => undefined,
           close: async () => undefined,

--- a/bun.lock
+++ b/bun.lock
@@ -51,10 +51,10 @@
         "@openomni/llm": "workspace:*",
         "@openomni/policy": "workspace:*",
         "@openomni/protocol": "workspace:*",
-        "@openomni/telemetry": "workspace:*",
         "zod": "^3.22.4",
       },
       "devDependencies": {
+        "@openomni/telemetry": "workspace:*",
         "@types/bun": "latest",
       },
     },

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -92,7 +92,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 |---|---|---|
 | [#612](https://github.com/INONONO66/openomni/pull/612) | create `@openomni/telemetry`, move `Bus`, add scope/span/sink; `session` re-exports for compatibility | ✅ |
 | [#616](https://github.com/INONONO66/openomni/pull/616) | `agent` and `llm` drop `@openomni/session`; the allowlists close behind them | ✅ |
-| — | `agent` and `llm` take an injected `Sink` rather than importing `Bus` | ⬜ |
+| [#617](https://github.com/INONONO66/openomni/pull/617), [#618](https://github.com/INONONO66/openomni/pull/618) | `agent` and `llm` take an injected `Sink` rather than importing `Bus`; both `src/` trees are gate-enforced | ✅ |
 | [#612](https://github.com/INONONO66/openomni/pull/612) | move `TraceContext` off `packages/session` — it owned a second, contradictory trace convention | ✅ |
 | [#613](https://github.com/INONONO66/openomni/pull/613), [#615](https://github.com/INONONO66/openomni/pull/615) | convert every opaque-`traceId` site in `packages/agent/src` (D11) — 13 + 3, the package now mints none | ✅ |
 | — | convert the remaining 102 opaque-`traceId` sites (D11): server 72, openomni 11, session 10, coordinator 9 | ⬜ |

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -17,7 +17,7 @@ src/
 │   ├── execution/              # The agent loop, decomposed: runner.ts (entry), turn-prepare.ts / turn-outcome.ts (turn loop), lifecycle-dispatch.ts / completion-policy.ts (run.lifecycle/completion points), policy-effects*.ts (effect application), prompt-policy.ts, tool-executor.ts (tool.native/mcp pre/post dispatch), run-state.ts / run-events.ts / run-result.ts, compaction.ts (InMemoryCompactor)
 │   └── policy/
 │       ├── index.ts            # Agent-scoped PolicyEngine facade over @openomni/policy
-│       ├── registry.ts         # PolicyRegistry + defaultRegistry() — builtin policy id → factory resolution
+│       ├── registry.ts         # PolicyRegistry + defaultRegistry(events) — builtin policy id → factory resolution
 │       ├── types.ts            # PolicyContext, canonical/legacy registration aliases, PolicyEngineRegistration
 │       └── builtin/
 │           ├── budget.ts       # createBudgetReassurancePolicy / createBudgetWarningPolicy
@@ -62,6 +62,7 @@ Also exported from `@openomni/agent`:
 
 | Field            | Type                                     | Description                                                                 |
 | ---------------- | ---------------------------------------- | --------------------------------------------------------------------------- |
+| `events`         | `BusEvent.Sink`                          | Required. Where the run's records go — the loop reports through this port and never reaches for `Bus` |
 | `model`          | `Model.Ref`                              | Required LLM provider + model id                                            |
 | `systemPrompt?`  | `string`                                 | Base system prompt                                                          |
 | `tools?`         | `(Tool.Spec & { descriptor?: RuntimeResource.Descriptor })[]` | Tool specs plus optional structured policy provenance; descriptors survive catalog preparation and tool execution |
@@ -86,7 +87,7 @@ run.lifecycle.pre → run.turn.pre → prompt.context.pre → tool.catalog.pre
 - **Decision** (`Policy.PolicyDecision`): `allow | deny | pending`, with effects such as `prompt.inject_message`, `prompt.replace`, `tool.rewrite_input`, `run.replace_messages`, and `writeback.rewrite`.
 - **System prompt effects**: `dispatchPoint("prompt.context.pre", ...)` returns canonical prompt effects; composition happens through effect merging rather than legacy verdict transforms.
 - **Ownership**: `ChatAgent` registers only caller-supplied `middleware`; runtime builders own default policy assembly (budget, tool permission, compaction, idle nudge).
-- **Builtins** (resolved by id through `defaultRegistry()`; stamped plans from the dispatch gate (#479) reference these ids):
+- **Builtins** (resolved by id through `defaultRegistry(events)`, which hands the reporting builtins the caller's sink; stamped plans from the dispatch gate (#479) reference these ids):
   - `builtin:tool-permission` (`tool-guard.ts`, fail-closed) — enforces `Policy.Permission` and `InputRule`; denial returns `run.abort` plus `audit.annotate`, while approval requirements return pending with `tool.require_approval`
   - `builtin:budget-reassurance` / `builtin:budget-warning` — inject reassurance/warning system messages as budget consumption climbs
   - `builtin:idle-nudge` — detects idle ≥ threshold (default 60s), injects a nudge; after `maxNudges` (default 3) aborts with reason `stalled`

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/agent
 
-`ChatAgent` — an invocation-scoped LLM + tool ReAct loop driven by a policy engine — plus the MCP client runtime. Depends on `@openomni/protocol`, `@openomni/policy`, `@openomni/llm`, and `@openomni/telemetry` for observation. It reaches no durable storage, and `check-deps.ts` rejects the edge (#606).
+`ChatAgent` — an invocation-scoped LLM + tool ReAct loop driven by a policy engine — plus the MCP client runtime. Depends on `@openomni/protocol`, `@openomni/policy`, and `@openomni/llm`. It reports through an injected `BusEvent.Sink` on `ChatAgentConfig.events`, so `src/` imports no implementation of the observation channel and reaches no durable storage — `check-deps.ts` carries a `srcAllowedDeps` for this package that rejects both (#606).
 
 ## STRUCTURE
 
@@ -154,7 +154,7 @@ When in doubt, keep the agent package as a loop engine and put product semantics
 
 ## ANTI-PATTERNS
 
-- Reaching for `@openomni/session`. The loop owns no durable state; observation goes through `@openomni/telemetry` and orchestration that needs session state lives in `@openomni/openomni`. The allowlist in `check-deps.ts` no longer contains it, so this fails the gate rather than review.
+- Reaching for `@openomni/session` or `@openomni/telemetry` from `src/`. The loop owns no durable state and does not choose where its records go: it reports through `config.events`, and orchestration that needs session state lives in `@openomni/openomni`. `srcAllowedDeps` rejects both, so this fails the gate rather than review.
 - Do NOT extend behavior outside `middleware: [...]`. `PolicyEngine` is the single extension surface.
 - Do NOT bypass the policy engine by returning placeholder tool results in user code; use a `tool.native.pre` / `tool.mcp.pre` policy so behavior is uniform.
 - Do NOT add OpenOmni communication kernel logic here. No actor authority, PendingInteraction routing, channel grants, worker grants, SurfaceKey routing, or writeback decisions.

--- a/packages/agent/bench/index.ts
+++ b/packages/agent/bench/index.ts
@@ -6,7 +6,8 @@ import { InMemoryCompactor } from "../src/core/execution/compaction.ts";
 import { noopSink } from "@openomni/telemetry";
 
 /** The bench stands in for one run. It measures compaction, not reporting. */
-const BENCH_TRACE = { traceId: "trace-agent-bench", events: noopSink() };
+const BENCH_TRACE = { traceId: "trace-agent-bench" };
+const BENCH_EVENTS = noopSink();
 
 interface BenchmarkResult {
   readonly name: string;
@@ -31,7 +32,7 @@ for (const size of [20, 100, 500]) {
   bench.add(
     `compaction/${size}-messages`,
     async () => {
-      await InMemoryCompactor.compact(messages, compactionOptions, BENCH_TRACE);
+      await InMemoryCompactor.compact(messages, compactionOptions, BENCH_TRACE, BENCH_EVENTS);
     },
     { async: true },
   );

--- a/packages/agent/bench/index.ts
+++ b/packages/agent/bench/index.ts
@@ -3,9 +3,10 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { Bench } from "tinybench";
 import type { Message } from "@openomni/protocol";
 import { InMemoryCompactor } from "../src/core/execution/compaction.ts";
+import { noopSink } from "@openomni/telemetry";
 
-/** The bench stands in for one run; compaction records under its trace. */
-const BENCH_TRACE = { traceId: "trace-agent-bench" };
+/** The bench stands in for one run. It measures compaction, not reporting. */
+const BENCH_TRACE = { traceId: "trace-agent-bench", events: noopSink() };
 
 interface BenchmarkResult {
   readonly name: string;

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,10 +17,10 @@
     "@openomni/llm": "workspace:*",
     "@openomni/policy": "workspace:*",
     "@openomni/protocol": "workspace:*",
-    "@openomni/telemetry": "workspace:*",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@openomni/telemetry": "workspace:*",
     "@types/bun": "latest"
   }
 }

--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -1,5 +1,5 @@
+import type { BusEvent } from "@openomni/protocol";
 import { AgentProfile, Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import type { AgentBudget } from "./types";
 
 export interface BudgetState {
@@ -106,12 +106,13 @@ export function publishBudgetTelemetry(
   state: BudgetState,
   /** The run being reported on. Structural: this needs a trace and a session. */
   run: { readonly traceId: string; readonly sessionId: string },
+  events: BusEvent.Sink,
   budget?: AgentBudget,
 ): BudgetStatus {
   const evaluation = evaluateBudget(state, budget);
 
   if (evaluation.status === "exceeded") {
-    Bus.publish(Operational.Warn, {
+    events.publish(Operational.Warn, {
       traceId: run.traceId,
       sessionId: run.sessionId,
       time: Date.now(),
@@ -130,7 +131,7 @@ export function publishBudgetTelemetry(
     return evaluation.status;
   }
   if (evaluation.status === "warning") {
-    Bus.publish(Operational.Warn, {
+    events.publish(Operational.Warn, {
       traceId: run.traceId,
       sessionId: run.sessionId,
       time: Date.now(),
@@ -145,7 +146,7 @@ export function publishBudgetTelemetry(
     return evaluation.status;
   }
   if (evaluation.status === "reassurance") {
-    Bus.publish(Operational.Info, {
+    events.publish(Operational.Info, {
       traceId: run.traceId,
       sessionId: run.sessionId,
       time: Date.now(),

--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -1,5 +1,5 @@
+import type { BusEvent } from "@openomni/protocol";
 import { Operational, type Message } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 
 export interface CompactionOptions {
   contextWindowTokens: number;
@@ -49,7 +49,7 @@ export namespace InMemoryCompactor {
   export async function compact(
     messages: Message.WithParts[],
     options: CompactionOptions,
-    trace: { readonly traceId: string },
+    trace: { readonly traceId: string; readonly events: BusEvent.Sink },
   ): Promise<CompactionResult> {
     const protectRecent = options.protectRecentMessages ?? DEFAULT_PROTECT_RECENT;
 
@@ -97,9 +97,9 @@ export namespace InMemoryCompactor {
     }
 
     const compacted = [...summaryMessages, ...toKeep];
-    const { traceId } = trace;
+    const { traceId, events } = trace;
 
-    Bus.publish(Operational.Info, {
+    events.publish(Operational.Info, {
       traceId,
       time: Date.now(),
       component: "agent.compaction",

--- a/packages/agent/src/core/execution/compaction.ts
+++ b/packages/agent/src/core/execution/compaction.ts
@@ -45,11 +45,14 @@ export namespace InMemoryCompactor {
    * not configuration, and an optional field validated by a runtime throw
    * gives the compiler nothing — which is how the caller that supplied none
    * reached production.
+   * @param events Where the record of the rewrite goes. Beside the identity,
+   * not inside it: a destination is not something the trace says.
    */
   export async function compact(
     messages: Message.WithParts[],
     options: CompactionOptions,
-    trace: { readonly traceId: string; readonly events: BusEvent.Sink },
+    trace: { readonly traceId: string },
+    events: BusEvent.Sink,
   ): Promise<CompactionResult> {
     const protectRecent = options.protectRecentMessages ?? DEFAULT_PROTECT_RECENT;
 
@@ -97,10 +100,9 @@ export namespace InMemoryCompactor {
     }
 
     const compacted = [...summaryMessages, ...toKeep];
-    const { traceId, events } = trace;
 
     events.publish(Operational.Info, {
-      traceId,
+      traceId: trace.traceId,
       time: Date.now(),
       component: "agent.compaction",
       msg: "compaction triggered",

--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -49,7 +49,12 @@ export async function dispatchBudgetCheck(
   // The single per-turn owner of budget telemetry: emit here (command) and act
   // on the returned status. The run.turn.pre budget builtins read the status
   // via the pure checkBudget query, so the event is not re-emitted per policy.
-  const budgetStatus = publishBudgetTelemetry(state.budgetState, agentBase, config.budget);
+  const budgetStatus = publishBudgetTelemetry(
+    state.budgetState,
+    agentBase,
+    config.events,
+    config.budget,
+  );
   if (budgetStatus !== "exceeded") return null;
 
   const postRunDecision = await engine.dispatchPoint(
@@ -60,9 +65,9 @@ export async function dispatchBudgetCheck(
     }),
   );
   if (PolicyDecision.isBlocking(postRunDecision)) {
-    publishDenyDiagnostic("run.finish", postRunDecision, state, agentBase);
+    publishDenyDiagnostic(config.events, "run.finish", postRunDecision, state, agentBase);
   }
-  emitRunCompleted(state, agentBase, "max-steps");
+  emitRunCompleted(config.events, state, agentBase, "max-steps");
   return createRunCompleteEvent(state, { finishReason: "max-steps" });
 }
 
@@ -110,6 +115,7 @@ export async function dispatchModelResponse(
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       publishDenyDiagnostic(
+        config.events,
         "model.response",
         PolicyDecision.deny({
           policyId: "agent.policy.composed",
@@ -126,6 +132,6 @@ export async function dispatchModelResponse(
   }
   if (effectOf(decision, "run.abort")) return createGuardCompleteEvent(state);
   // model.response is post-boundary: plain denies are diagnostics unless they carry run.abort.
-  publishDenyDiagnostic("model.response", decision, state, agentBase);
+  publishDenyDiagnostic(config.events, "model.response", decision, state, agentBase);
   return null;
 }

--- a/packages/agent/src/core/execution/run-events.ts
+++ b/packages/agent/src/core/execution/run-events.ts
@@ -1,12 +1,15 @@
 import { AgentExecution, Operational, PolicyDecision } from "@openomni/protocol";
-import type { Policy, TraceContext } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import type { BusEvent, Policy, TraceContext } from "@openomni/protocol";
 import type { RetryReason } from "../retry";
 import type { AgentEvent, AgentStep, TokenUsage } from "../types";
 import { getCompactionCount, type AgentRunBase, type RunState } from "./run-state";
 
-export function emitRunStarted(trace: TraceContext.Type, modelId: string): void {
-  Bus.publish(Operational.Info, {
+export function emitRunStarted(
+  events: BusEvent.Sink,
+  trace: TraceContext.Type,
+  modelId: string,
+): void {
+  events.publish(Operational.Info, {
     traceId: trace.traceId,
     time: Date.now(),
     sessionId: trace.sessionId,
@@ -16,10 +19,14 @@ export function emitRunStarted(trace: TraceContext.Type, modelId: string): void 
   });
 }
 
-export function emitTurnStart(state: RunState, agentBase: AgentRunBase): void {
+export function emitTurnStart(
+  events: BusEvent.Sink,
+  state: RunState,
+  agentBase: AgentRunBase,
+): void {
   const turnIndex = state.turnIndex;
   const sessionId = agentBase.sessionId;
-  Bus.publish(AgentExecution.TurnStart, {
+  events.publish(AgentExecution.TurnStart, {
     ...agentBase,
     sessionId,
     time: Date.now(),
@@ -28,12 +35,13 @@ export function emitTurnStart(state: RunState, agentBase: AgentRunBase): void {
 }
 
 export function emitTurnComplete(
+  events: BusEvent.Sink,
   state: RunState,
   agentBase: AgentRunBase,
   turnUsage: TokenUsage,
 ): void {
   const sessionId = agentBase.sessionId;
-  Bus.publish(AgentExecution.TurnComplete, {
+  events.publish(AgentExecution.TurnComplete, {
     ...agentBase,
     sessionId,
     time: Date.now(),
@@ -47,11 +55,12 @@ export function emitTurnComplete(
 }
 
 export function emitBudgetReassurance(
+  events: BusEvent.Sink,
   agentBase: AgentRunBase,
   remaining: string,
   threshold: number,
 ): void {
-  Bus.publish(AgentExecution.BudgetReassurance, {
+  events.publish(AgentExecution.BudgetReassurance, {
     ...agentBase,
     time: Date.now(),
     remaining,
@@ -60,11 +69,12 @@ export function emitBudgetReassurance(
 }
 
 export function emitBudgetWarning(
+  events: BusEvent.Sink,
   agentBase: AgentRunBase,
   remaining: string,
   threshold: number,
 ): void {
-  Bus.publish(AgentExecution.BudgetWarning, {
+  events.publish(AgentExecution.BudgetWarning, {
     ...agentBase,
     time: Date.now(),
     remaining,
@@ -73,11 +83,12 @@ export function emitBudgetWarning(
 }
 
 export function emitRunCompleted(
+  events: BusEvent.Sink,
   state: RunState,
   agentBase: AgentRunBase,
   finishReason: "stop" | "max-steps",
 ): void {
-  Bus.publish(Operational.Info, {
+  events.publish(Operational.Info, {
     traceId: agentBase.traceId,
     time: Date.now(),
     sessionId: agentBase.sessionId,
@@ -92,6 +103,7 @@ export function emitRunCompleted(
 }
 
 export function emitErrorRetry(
+  events: BusEvent.Sink,
   agentBase: AgentRunBase,
   options: {
     readonly attempt: number;
@@ -102,7 +114,7 @@ export function emitErrorRetry(
   },
 ): void {
   const sessionId = agentBase.sessionId;
-  Bus.publish(AgentExecution.ErrorRetry, {
+  events.publish(AgentExecution.ErrorRetry, {
     ...agentBase,
     sessionId,
     time: Date.now(),
@@ -123,6 +135,7 @@ export function emitErrorRetry(
  * in the record.
  */
 export function emitRunFailed(
+  events: BusEvent.Sink,
   agentBase: AgentRunBase,
   error: string,
   decision: {
@@ -131,7 +144,7 @@ export function emitRunFailed(
     readonly maxAttempts: number;
   },
 ): void {
-  Bus.publish(Operational.Error, {
+  events.publish(Operational.Error, {
     traceId: agentBase.traceId,
     time: Date.now(),
     sessionId: agentBase.sessionId,
@@ -143,11 +156,12 @@ export function emitRunFailed(
 }
 
 export function emitCompaction(
+  events: BusEvent.Sink,
   agentBase: AgentRunBase,
   messagesBefore: number,
   messagesAfter: number,
 ): void {
-  Bus.publish(AgentExecution.Compaction, {
+  events.publish(AgentExecution.Compaction, {
     ...agentBase,
     time: Date.now(),
     messagesBefore,
@@ -156,6 +170,7 @@ export function emitCompaction(
 }
 
 export function publishDenyDiagnostic(
+  events: BusEvent.Sink,
   timing: Policy.Timing,
   decision: Policy.PolicyDecision,
   state: RunState,
@@ -163,7 +178,7 @@ export function publishDenyDiagnostic(
 ): void {
   const reason = PolicyDecision.reason(decision, "denied");
   const sessionId = agentBase.sessionId;
-  Bus.publish(Operational.Info, {
+  events.publish(Operational.Info, {
     traceId: agentBase.traceId,
     time: Date.now(),
     sessionId,

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -1,6 +1,5 @@
 import { ModelsDev, Provider, run as llmRun } from "@openomni/llm";
 import type { Sink } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import type { AgentEvent, ChatAgentConfig, ChatAgentInput } from "../types";
 import * as Retry from "../retry";
 import { PolicyEngine, type PolicyEngineInstance } from "../policy";
@@ -29,7 +28,7 @@ export async function* streamAgent(
   const actorId =
     nonEmptyString(input.metadata?.actorId) ?? nonEmptyString(trace.agentName) ?? runId;
   const agentBase = { traceId, sessionId, runId, actorId };
-  emitRunStarted(trace, config.model.id);
+  emitRunStarted(config.events, trace, config.model.id);
   assertToolExecutor(config);
 
   // #546: run state and pre-run dispatch are run-scoped, living across
@@ -59,7 +58,7 @@ export async function* streamAgent(
           return;
         }
 
-        emitTurnStart(state, agentBase);
+        emitTurnStart(config.events, state, agentBase);
         const turnResult = await buildTurn(
           state,
           config,
@@ -106,7 +105,7 @@ export async function* streamAgent(
         }
 
         if (outcome.type === "continue") {
-          yield* handleContinue(state, agentBase, turnResult.turn.turnUsage);
+          yield* handleContinue(config.events, state, agentBase, turnResult.turn.turnUsage);
           continue;
         }
 
@@ -222,7 +221,7 @@ export function buildPolicyEngine(
       sessionId: agentBase.sessionId,
       ...(agentBase.runId !== undefined && { runId: agentBase.runId }),
     },
-    auditEmit: Bus.publish,
+    auditEmit: (descriptor, data) => config.events.publish(descriptor, data),
   });
   for (const reg of config.middleware ?? []) {
     engine.register(reg);

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -1,6 +1,5 @@
-import type { Policy, RuntimeResource, Tool, TraceContext } from "@openomni/protocol";
+import type { BusEvent, Policy, RuntimeResource, Tool, TraceContext } from "@openomni/protocol";
 import { Operational, PolicyDecision, ToolExecution } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import type { AgentStep, TokenUsage } from "../types";
 import type { PolicyEngineInstance } from "../policy";
 import type { PolicyContext } from "../policy/types";
@@ -31,6 +30,8 @@ export interface ToolExecutorOptions {
   onDecision?: (timing: Policy.Timing, decision: Policy.PolicyDecision) => void | Promise<void>;
   traceContext?: TraceContext.Type;
   signal?: AbortSignal;
+  /** Where this executor's records go. */
+  events: BusEvent.Sink;
 }
 
 export function createToolExecutor(
@@ -47,6 +48,7 @@ export function createToolExecutor(
     onDecision,
     traceContext,
     signal,
+    events,
   } = options;
   // The executor is built inside a turn, which is inside a run that already
   // refused to start without an identity. Minting one here would give a tool
@@ -59,7 +61,7 @@ export function createToolExecutor(
     decision: Policy.PolicyDecision,
     err: unknown,
   ): void {
-    Bus.publish(Operational.Warn, {
+    events.publish(Operational.Warn, {
       traceId: activeTraceContext.traceId,
       time: Date.now(),
       component: "agent.tool-executor",
@@ -94,7 +96,7 @@ export function createToolExecutor(
     toolName: string,
     reason: string,
   ): void {
-    Bus.publish(ToolExecution.PermissionDenied, {
+    events.publish(ToolExecution.PermissionDenied, {
       ...eventBase,
       toolCallId: call.id,
       toolName,

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -1,5 +1,5 @@
+import type { BusEvent } from "@openomni/protocol";
 import { type Message, Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import { effectOf, PolicyEffectApplier } from "./policy-effects";
 import { createAssistantMessage } from "../message-factory";
 import * as Retry from "../retry";
@@ -37,7 +37,7 @@ export async function* handleStop(
   agentBase: AgentRunBase,
   turn: TurnArtifacts,
 ): AsyncGenerator<AgentEvent, "complete" | "continue"> {
-  emitTurnComplete(state, agentBase, turn.turnUsage);
+  emitTurnComplete(config.events, state, agentBase, turn.turnUsage);
 
   if (state.lastAssistantText) yield { type: "text_chunk", text: state.lastAssistantText };
   for (const toolCall of turn.turnToolCalls) {
@@ -76,7 +76,7 @@ export async function* handleStop(
   // BEFORE run.turn.post dispatch, so history-rewriting policies
   // (run.replace_messages) operate on a history that contains it and stay
   // the final word.
-  const assistantMessage = resolveTurnAssistant(state, turn, agentBase);
+  const assistantMessage = resolveTurnAssistant(config.events, state, turn, agentBase);
   appendRunMessages(state, [assistantMessage]);
 
   const postTurnDecision = await engine.dispatchPoint(
@@ -105,6 +105,7 @@ export async function* handleStop(
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       publishDenyDiagnostic(
+        config.events,
         "turn.finish",
         PolicyDecision.deny({
           policyId: "agent.policy.composed",
@@ -145,22 +146,23 @@ export async function* handleStop(
       yield event;
       return flowDecision({ kind: "abort", event });
     }
-    publishDenyDiagnostic("turn.finish", postTurnDecision, state, agentBase);
+    publishDenyDiagnostic(config.events, "turn.finish", postTurnDecision, state, agentBase);
   }
 
   await dispatchPostRunTransform(state, engine, config, agentBase);
-  emitRunCompleted(state, agentBase, "stop");
+  emitRunCompleted(config.events, state, agentBase, "stop");
   const event = createRunCompleteEvent(state, { finishReason: "stop" });
   yield event;
   return flowDecision({ kind: "complete", event });
 }
 
 export async function* handleContinue(
+  events: BusEvent.Sink,
   state: RunState,
   agentBase: AgentRunBase,
   turnUsage: TokenUsage,
 ): AsyncGenerator<AgentEvent, "continue"> {
-  emitTurnComplete(state, agentBase, turnUsage);
+  emitTurnComplete(events, state, agentBase, turnUsage);
   yield { type: "turn_complete", turnIndex: state.turnIndex, usage: turnUsage };
   advanceRunTurn(state);
   return continueFlowDecision(continueDecision(state));
@@ -209,7 +211,7 @@ export async function* handleError(
       yield event;
       return { action: "complete", kind: "abort", event, errorMessage: normalizedError.message };
     }
-    publishDenyDiagnostic("error", onErrorDecision, state, agentBase);
+    publishDenyDiagnostic(config.events, "error", onErrorDecision, state, agentBase);
   }
 
   const lastError = normalizedError.message;
@@ -225,7 +227,7 @@ export async function* handleError(
 
   if (Retry.shouldRetry(effectiveRetryPolicy, retryReason, attempt)) {
     const backoffMs = retryEffect?.delayMs ?? Retry.calculateBackoffMs(retryPolicy, attempt);
-    emitErrorRetry(agentBase, {
+    emitErrorRetry(config.events, agentBase, {
       attempt,
       maxAttempts: effectiveRetryPolicy.maxAttempts,
       error: lastError,
@@ -237,7 +239,7 @@ export async function* handleError(
     return { action: "retry", kind: "error", error: normalizedError, errorMessage: lastError };
   }
 
-  emitRunFailed(agentBase, lastError, {
+  emitRunFailed(config.events, agentBase, lastError, {
     reason: retryReason,
     attempt,
     maxAttempts: effectiveRetryPolicy.maxAttempts,
@@ -256,12 +258,13 @@ export async function* handleError(
  * resurrecting it would forge history.
  */
 function resolveTurnAssistant(
+  events: BusEvent.Sink,
   state: RunState,
   turn: TurnArtifacts,
   agentBase: AgentRunBase,
 ): Message.WithParts {
   if (turn.turnAssistant.message !== undefined) return turn.turnAssistant.message;
-  Bus.publish(Operational.Error, {
+  events.publish(Operational.Error, {
     traceId: agentBase.traceId,
     time: Date.now(),
     sessionId: agentBase.sessionId || state.sessionId,
@@ -305,7 +308,7 @@ async function dispatchPostRunTransform(
     }),
   );
   if (PolicyDecision.isBlocking(postRunDecision)) {
-    publishDenyDiagnostic("run.finish", postRunDecision, state, agentBase);
+    publishDenyDiagnostic(config.events, "run.finish", postRunDecision, state, agentBase);
   }
 }
 
@@ -328,7 +331,13 @@ async function applyPostCompaction(
   );
 
   if (PolicyDecision.isBlocking(compactionDecision)) {
-    publishDenyDiagnostic("completion.prepare", compactionDecision, state, agentBase);
+    publishDenyDiagnostic(
+      config.events,
+      "completion.prepare",
+      compactionDecision,
+      state,
+      agentBase,
+    );
     return createGuardCompleteEvent(state, { finishReason: "stop" });
   }
 
@@ -338,6 +347,7 @@ async function applyPostCompaction(
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     publishDenyDiagnostic(
+      config.events,
       "completion.prepare",
       PolicyDecision.deny({
         policyId: "agent.policy.composed",
@@ -351,7 +361,7 @@ async function applyPostCompaction(
   }
   if (messages !== undefined) {
     const messagesBefore = applyCompactionMessages(state, messages);
-    emitCompaction(agentBase, messagesBefore, state.messages.length);
+    emitCompaction(config.events, agentBase, messagesBefore, state.messages.length);
   }
   PolicyEffectApplier.applyPromptMessageEffects(state, compactionDecision);
 

--- a/packages/agent/src/core/execution/turn-prepare.ts
+++ b/packages/agent/src/core/execution/turn-prepare.ts
@@ -1,7 +1,6 @@
 import type { RunInput } from "@openomni/llm";
 import { type Message, PolicyDecision } from "@openomni/protocol";
 import type { Policy, Sink, Tool } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import { describeBudgetRemaining, effectiveBudgetThresholds } from "../budget";
 import type { PolicyEngineInstance } from "../policy";
 import type { AgentEvent, ChatAgentConfig, TokenUsage } from "../types";
@@ -113,6 +112,7 @@ export async function buildTurn(
   if (preTurnDecision.reasonCodes.includes("budget_reassurance")) {
     const remaining = describeBudgetRemaining(state.budgetState, config.budget);
     emitBudgetReassurance(
+      config.events,
       agentBase,
       remaining,
       effectiveBudgetThresholds(config.budget).reassuranceThreshold,
@@ -122,6 +122,7 @@ export async function buildTurn(
   if (preTurnDecision.reasonCodes.includes("budget_warning")) {
     const remaining = describeBudgetRemaining(state.budgetState, config.budget);
     emitBudgetWarning(
+      config.events,
       agentBase,
       remaining,
       effectiveBudgetThresholds(config.budget).warningThreshold,
@@ -136,6 +137,7 @@ export async function buildTurn(
   const toolMetadata = buildToolMetadataMap(config.tools);
   const hookedExecutor = config.toolExecutor
     ? createToolExecutor({
+        events: config.events,
         toolExecutor: config.toolExecutor,
         engine,
         getPolicyToolName: (toolName) => resolvePolicyToolName(toolName, toolMetadata),
@@ -207,9 +209,8 @@ export async function buildTurn(
     budgetWarningEvent,
     turn: {
       runInput: {
-        // The agent binds llm's observation port. Agent's own emits still
-        // reach for `Bus` directly; that is the next slice.
-        events: Bus,
+        // llm reports through the same port the agent was handed.
+        events: config.events,
         messages: state.messages,
         tools: selectedTools,
         system,

--- a/packages/agent/src/core/policy/builtin/compaction.ts
+++ b/packages/agent/src/core/policy/builtin/compaction.ts
@@ -40,7 +40,7 @@ export function createCompactionPolicy(config: CompactionConfig): CanonicalPolic
           reasonCodes: ["compaction_skipped_no_trace"],
         });
       }
-      const result = await InMemoryCompactor.compact(ctx.messages, compaction, { traceId, events });
+      const result = await InMemoryCompactor.compact(ctx.messages, compaction, { traceId }, events);
       if (!result.compacted) {
         return PolicyDecision.allow({ policyId: "builtin.compaction" });
       }

--- a/packages/agent/src/core/policy/builtin/compaction.ts
+++ b/packages/agent/src/core/policy/builtin/compaction.ts
@@ -1,10 +1,14 @@
-import { PolicyDecision } from "@openomni/protocol";
+import { PolicyDecision, type BusEvent } from "@openomni/protocol";
 import { InMemoryCompactor, type CompactionOptions } from "../../execution/compaction";
 import type { CanonicalPolicyRegistration } from "../types";
 
-type CompactionConfig = CompactionOptions;
+type CompactionConfig = CompactionOptions & {
+  /** Where the compaction record goes. The policy reports; it does not decide. */
+  readonly events: BusEvent.Sink;
+};
 
 export function createCompactionPolicy(config: CompactionConfig): CanonicalPolicyRegistration {
+  const { events, ...compaction } = config;
   return {
     name: "builtin:compaction",
     kind: "point",
@@ -20,7 +24,7 @@ export function createCompactionPolicy(config: CompactionConfig): CanonicalPolic
       }
 
       const totalTokens = ctx.budgetState.totalInputTokens + ctx.budgetState.totalOutputTokens;
-      if (!InMemoryCompactor.shouldCompact(totalTokens, config)) {
+      if (!InMemoryCompactor.shouldCompact(totalTokens, compaction)) {
         return PolicyDecision.allow({ policyId: "builtin.compaction" });
       }
 
@@ -36,7 +40,7 @@ export function createCompactionPolicy(config: CompactionConfig): CanonicalPolic
           reasonCodes: ["compaction_skipped_no_trace"],
         });
       }
-      const result = await InMemoryCompactor.compact(ctx.messages, config, { traceId });
+      const result = await InMemoryCompactor.compact(ctx.messages, compaction, { traceId, events });
       if (!result.compacted) {
         return PolicyDecision.allow({ policyId: "builtin.compaction" });
       }

--- a/packages/agent/src/core/policy/builtin/tool-guard.ts
+++ b/packages/agent/src/core/policy/builtin/tool-guard.ts
@@ -1,11 +1,13 @@
+import type { BusEvent } from "@openomni/protocol";
 import { Operational, Policy, PolicyDecision } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import type { CanonicalPolicyRegistration } from "../types";
 
 const TOOL_CALL_ACTION = "tool.call";
 
 export interface ToolPermissionPolicyConfig {
   permission: Policy.Permission;
+  /** Where a failed evaluation is reported. The guard denies; it does not decide where. */
+  events: BusEvent.Sink;
 }
 
 /**
@@ -54,7 +56,7 @@ export function createToolPermissionPolicy(
         });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        Bus.publish(Operational.Debug, {
+        config.events.publish(Operational.Debug, {
           traceId: requireGuardTraceId(ctx),
           time: Date.now(),
           component: "agent.policy.tool-permission",

--- a/packages/agent/src/core/policy/registry.ts
+++ b/packages/agent/src/core/policy/registry.ts
@@ -37,9 +37,9 @@ const IdleNudgeConfigSchema: z.ZodType<IdleNudgeConfig, z.ZodTypeDef, unknown> =
 });
 
 /**
- * Wire shape only. A plain `z.object` strips unknown keys, so a policy plan
- * cannot smuggle an `events` of its own and redirect where the evidence of its
- * own decision goes — the strip is the guard here, not the spread order below.
+ * Wire shape only: the output type omits `events`, and a plain `z.object`
+ * strips what the shape does not name. A policy plan therefore cannot smuggle
+ * a sink of its own and redirect where the evidence of its own decision goes.
  */
 const ToolPermissionConfigSchema: z.ZodType<
   Omit<ToolPermissionPolicyConfig, "events">,

--- a/packages/agent/src/core/policy/registry.ts
+++ b/packages/agent/src/core/policy/registry.ts
@@ -36,7 +36,11 @@ const IdleNudgeConfigSchema: z.ZodType<IdleNudgeConfig, z.ZodTypeDef, unknown> =
   maxNudges: z.number().optional(),
 });
 
-/** Wire shape only — `events` is injected by the registry, never parsed. */
+/**
+ * Wire shape only. A plain `z.object` strips unknown keys, so a policy plan
+ * cannot smuggle an `events` of its own and redirect where the evidence of its
+ * own decision goes — the strip is the guard here, not the spread order below.
+ */
 const ToolPermissionConfigSchema: z.ZodType<
   Omit<ToolPermissionPolicyConfig, "events">,
   z.ZodTypeDef,

--- a/packages/agent/src/core/policy/registry.ts
+++ b/packages/agent/src/core/policy/registry.ts
@@ -1,3 +1,4 @@
+import type { BusEvent } from "@openomni/protocol";
 import { PolicyRegistry } from "@openomni/policy";
 import type { PolicyRegistryInstance } from "@openomni/policy";
 import { Policy } from "@openomni/protocol";
@@ -35,8 +36,12 @@ const IdleNudgeConfigSchema: z.ZodType<IdleNudgeConfig, z.ZodTypeDef, unknown> =
   maxNudges: z.number().optional(),
 });
 
-const ToolPermissionConfigSchema: z.ZodType<ToolPermissionPolicyConfig, z.ZodTypeDef, unknown> =
-  z.object({ permission: Policy.Permission });
+/** Wire shape only — `events` is injected by the registry, never parsed. */
+const ToolPermissionConfigSchema: z.ZodType<
+  Omit<ToolPermissionPolicyConfig, "events">,
+  z.ZodTypeDef,
+  unknown
+> = z.object({ permission: Policy.Permission });
 
 function parseCompactionConfig(config: unknown): CompactionOptions {
   return CompactionConfigSchema.parse(config);
@@ -46,25 +51,30 @@ function parseIdleNudgeConfig(config: unknown): IdleNudgeConfig {
   return IdleNudgeConfigSchema.parse(config ?? {});
 }
 
-function parseToolPermissionConfig(config: unknown): ToolPermissionPolicyConfig {
+function parseToolPermissionConfig(config: unknown): Omit<ToolPermissionPolicyConfig, "events"> {
   return ToolPermissionConfigSchema.parse(
     config === undefined ? { permission: { action: "tool.call" } } : config,
   );
 }
 
-export function defaultRegistry(): PolicyRegistryInstance<PolicyContext> {
+/**
+ * @param events Where the built-ins that report send their records. Passed in
+ * rather than reached for: a policy decides, and where the evidence of that
+ * decision goes is the composition root's call.
+ */
+export function defaultRegistry(events: BusEvent.Sink): PolicyRegistryInstance<PolicyContext> {
   const registry = PolicyRegistry.create<PolicyContext>();
 
   registry.register("builtin:budget-reassurance", () => createBudgetReassurancePolicy());
   registry.register("builtin:budget-warning", () => createBudgetWarningPolicy());
   registry.register("builtin:compaction", (config) =>
-    createCompactionPolicy(parseCompactionConfig(config)),
+    createCompactionPolicy({ ...parseCompactionConfig(config), events }),
   );
   registry.register("builtin:idle-nudge", (config) =>
     createIdleNudgePolicy(parseIdleNudgeConfig(config)),
   );
   registry.register("builtin:tool-permission", (config) =>
-    createToolPermissionPolicy(parseToolPermissionConfig(config)),
+    createToolPermissionPolicy({ ...parseToolPermissionConfig(config), events }),
   );
 
   return registry;

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentProfile,
+  BusEvent,
   Model,
   Policy,
   RuntimeResource,
@@ -19,6 +20,12 @@ type AgentToolSpec = Tool.Spec & {
 };
 
 export interface ChatAgentConfig {
+  /**
+   * Where the run's records go. A port, not `Bus`: what sits behind it is the
+   * composition root's choice, tests bind a collector, and P2 can split a
+   * fail-closed ledger append from the lossy bus without touching the loop.
+   */
+  events: BusEvent.Sink;
   systemPrompt?: string;
   tools?: AgentToolSpec[];
   model: Model.Ref;

--- a/packages/agent/src/runtime/mcp/client-types.ts
+++ b/packages/agent/src/runtime/mcp/client-types.ts
@@ -1,6 +1,6 @@
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { McpServerConfig } from "@openomni/protocol";
+import type { BusEvent, McpServerConfig } from "@openomni/protocol";
 
 export type McpClientHandle = Pick<Client, "connect" | "close" | "listTools" | "callTool">;
 
@@ -16,4 +16,6 @@ export interface McpClientDependencies {
    * observation does not get to invent an identity for itself.
    */
   readonly traceId?: string;
+  /** Where this client's records go. Supplied by whatever created it. */
+  readonly events: BusEvent.Sink;
 }

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -3,7 +3,6 @@ import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.j
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { BusEvent, McpServerConfig, Tool } from "@openomni/protocol";
 import { Mcp, Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import {
   cleanupFailedConnection,
   type TransportCloseTracker,
@@ -25,13 +24,15 @@ export class McpClient {
   private config: McpServerConfig;
   private createTransport: McpTransportFactory;
   private readonly lifecycleTraceId: string | undefined;
+  private readonly events: BusEvent.Sink;
   private connected = false;
 
-  constructor(config: McpServerConfig, dependencies: McpClientDependencies = {}) {
+  constructor(config: McpServerConfig, dependencies: McpClientDependencies) {
     this.config = config;
     this.client = dependencies.client ?? new Client({ name: "openomni-agent", version: "0.1.0" });
     this.createTransport = dependencies.createTransport ?? createTransport;
     this.lifecycleTraceId = dependencies.traceId;
+    this.events = dependencies.events;
   }
 
   /**
@@ -47,7 +48,7 @@ export class McpClient {
   ): void {
     const traceId = this.lifecycleTraceId;
     if (traceId === undefined || traceId.length === 0) return;
-    Bus.publish(descriptor, { ...payload, traceId } as T);
+    this.events.publish(descriptor, { ...payload, traceId } as T);
   }
 
   async connect(): Promise<void> {
@@ -142,7 +143,7 @@ export class McpClient {
 
     const startTime = Date.now();
 
-    Bus.publish(Mcp.ToolCalled, {
+    this.events.publish(Mcp.ToolCalled, {
       traceId,
       serverName: this.config.name,
       toolName: strippedName,
@@ -168,7 +169,7 @@ export class McpClient {
         toolCallId,
       );
     } catch (err) {
-      Bus.publish(Mcp.ToolFailed, {
+      this.events.publish(Mcp.ToolFailed, {
         traceId,
         serverName: this.config.name,
         toolName: strippedName,

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./helpers/mock-llm";
 import { allow, continueWithPrompt } from "./helpers/policy-decision";
 import { runInput } from "./helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 let mockRunFn: MockLlmFn = async () => createStopOutcome();
 
@@ -70,6 +71,7 @@ function createAssistantMessage(text: string): Message.WithParts {
 
 function createAgent() {
   return ChatAgent.create({
+    events: Bus,
     model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     llm: mockLlm,
   });
@@ -112,6 +114,7 @@ describe("ChatAgent", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       budget: { maxTurns: 1, maxToolCalls: 10 },
@@ -142,6 +145,7 @@ describe("ChatAgent", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       budget: { maxTurns: 10, maxToolCalls: 7 },
@@ -164,6 +168,7 @@ describe("ChatAgent", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       signal: controller.signal,
@@ -193,6 +198,7 @@ describe("ChatAgent", () => {
 
     const stepFinishCalls: AgentStep[] = [];
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       onStepFinish: (step) => {
@@ -268,6 +274,7 @@ it("uses toolExecutor when provided to execute tool calls", async () => {
   };
 
   const agent = ChatAgent.create({
+    events: Bus,
     model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     llm: mockLlm,
     toolExecutor: executor,
@@ -304,6 +311,7 @@ it("passes the agent abort signal to toolExecutor calls", async () => {
   };
 
   const agent = ChatAgent.create({
+    events: Bus,
     model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     llm: mockLlm,
     signal: controller.signal,
@@ -338,6 +346,7 @@ it("handles toolExecutor errors by setting isError: true", async () => {
   };
 
   const agent = ChatAgent.create({
+    events: Bus,
     model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     llm: mockLlm,
     toolExecutor: async () => {
@@ -352,6 +361,7 @@ it("handles toolExecutor errors by setting isError: true", async () => {
 
 it("throws when tools are configured without toolExecutor", async () => {
   const agent = ChatAgent.create({
+    events: Bus,
     model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     llm: mockLlm,
     tools: [
@@ -371,6 +381,7 @@ it("throws when tools are configured without toolExecutor", async () => {
 
 it("does not retry missing toolExecutor configuration errors", async () => {
   const agent = ChatAgent.create({
+    events: Bus,
     model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
     llm: mockLlm,
     tools: [

--- a/packages/agent/test/core/budget.test.ts
+++ b/packages/agent/test/core/budget.test.ts
@@ -128,7 +128,9 @@ describe("publishBudgetTelemetry is the command (emits once, returns status)", (
     });
 
     try {
-      publishBudgetTelemetry({ ...createBudgetState(), turns: 20 }, TEST_RUN, { maxTurns: 24 });
+      publishBudgetTelemetry({ ...createBudgetState(), turns: 20 }, TEST_RUN, Bus, {
+        maxTurns: 24,
+      });
       await Bun.sleep(0);
     } finally {
       unsubscribe();
@@ -147,7 +149,7 @@ describe("publishBudgetTelemetry is the command (emits once, returns status)", (
 
     try {
       // 15/24 sits between the reassurance threshold and the warning one.
-      const status = publishBudgetTelemetry({ ...createBudgetState(), turns: 15 }, TEST_RUN, {
+      const status = publishBudgetTelemetry({ ...createBudgetState(), turns: 15 }, TEST_RUN, Bus, {
         maxTurns: 24,
       });
       expect(status).toBe("reassurance");
@@ -168,7 +170,7 @@ describe("publishBudgetTelemetry is the command (emits once, returns status)", (
     });
 
     try {
-      const status = publishBudgetTelemetry({ ...createBudgetState(), turns: 30 }, TEST_RUN, {
+      const status = publishBudgetTelemetry({ ...createBudgetState(), turns: 30 }, TEST_RUN, Bus, {
         maxTurns: 24,
       });
       expect(status).toBe("exceeded");
@@ -185,7 +187,7 @@ describe("publishBudgetTelemetry is the command (emits once, returns status)", (
     const s = { ...createBudgetState(), turns: 20 };
     let status: string | undefined;
     const emits = await countOperationalEmits(() => {
-      status = publishBudgetTelemetry(s, TEST_RUN, { maxTurns: 24 });
+      status = publishBudgetTelemetry(s, TEST_RUN, Bus, { maxTurns: 24 });
     });
     expect(status).toBe("warning");
     expect(emits).toBe(1);
@@ -195,7 +197,7 @@ describe("publishBudgetTelemetry is the command (emits once, returns status)", (
     const s = { ...createBudgetState(), turns: 5 };
     let status: string | undefined;
     const emits = await countOperationalEmits(() => {
-      status = publishBudgetTelemetry(s, TEST_RUN, { maxTurns: 24 });
+      status = publishBudgetTelemetry(s, TEST_RUN, Bus, { maxTurns: 24 });
     });
     expect(status).toBe("ok");
     expect(emits).toBe(0);

--- a/packages/agent/test/core/execution/compaction-lifecycle.test.ts
+++ b/packages/agent/test/core/execution/compaction-lifecycle.test.ts
@@ -40,7 +40,9 @@ describe("compaction through the lifecycle", () => {
       seen.push(event as unknown as { traceId: string });
     });
     const engine = PolicyEngine.create();
-    engine.register(createCompactionPolicy({ contextWindowTokens: 100, protectRecentMessages: 2 }));
+    engine.register(
+      createCompactionPolicy({ contextWindowTokens: 100, protectRecentMessages: 2, events: Bus }),
+    );
     const agentBase = makeAgentBase();
 
     const state = makeState();
@@ -63,7 +65,9 @@ describe("compaction through the lifecycle", () => {
 
   it("compacts rather than aborting when the threshold is exceeded", async () => {
     const engine = PolicyEngine.create();
-    engine.register(createCompactionPolicy({ contextWindowTokens: 100, protectRecentMessages: 2 }));
+    engine.register(
+      createCompactionPolicy({ contextWindowTokens: 100, protectRecentMessages: 2, events: Bus }),
+    );
 
     const state = makeState();
     state.messages = Array.from({ length: 12 }, (_unused, index) =>

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -96,7 +96,8 @@ describe("InMemoryCompactor", () => {
       await InMemoryCompactor.compact(
         Array.from({ length: 12 }, (_unused, index) => makeUserMessage(`message ${index}`)),
         { contextWindowTokens: 1000, protectRecentMessages: 2 },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       await Bun.sleep(0);
     } finally {
@@ -207,7 +208,8 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(false);
       expect(result.removedCount).toBe(0);
@@ -224,7 +226,8 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 4,
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(true);
       expect(result.removedCount).toBe(6);
@@ -248,7 +251,8 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(true);
       expect(result.messages).toHaveLength(6);
@@ -270,7 +274,8 @@ describe("InMemoryCompactor", () => {
           protectRecentMessages: 4,
           onSummarize: async () => "Summary of removed messages",
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(true);
       const allTexts = result.messages.flatMap((m) =>
@@ -287,7 +292,8 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(false);
     });
@@ -315,7 +321,8 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 3,
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(true);
       expect(result.messages[0]?.info.role).toBe("user");
@@ -343,7 +350,8 @@ describe("InMemoryCompactor", () => {
             contextWindowTokens: 1000,
             protectRecentMessages: 3,
           },
-          { traceId: TEST_TRACE_ID, events: Bus },
+          { traceId: TEST_TRACE_ID },
+          Bus,
         );
       } catch (error) {
         caught = error;
@@ -372,7 +380,8 @@ describe("InMemoryCompactor", () => {
           protectRecentMessages: 3,
           onSummarize: async () => "anchored",
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       expect(result.compacted).toBe(true);
       expect(result.removedCount).toBe(5);
@@ -391,7 +400,8 @@ describe("InMemoryCompactor", () => {
           protectRecentMessages: 4,
           onSummarize: async () => "summary",
         },
-        { traceId: TEST_TRACE_ID, events: Bus },
+        { traceId: TEST_TRACE_ID },
+        Bus,
       );
       const summary = result.messages[0];
       expect(summary?.info.role).toBe("user");

--- a/packages/agent/test/core/execution/compaction.test.ts
+++ b/packages/agent/test/core/execution/compaction.test.ts
@@ -96,7 +96,7 @@ describe("InMemoryCompactor", () => {
       await InMemoryCompactor.compact(
         Array.from({ length: 12 }, (_unused, index) => makeUserMessage(`message ${index}`)),
         { contextWindowTokens: 1000, protectRecentMessages: 2 },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       await Bun.sleep(0);
     } finally {
@@ -207,7 +207,7 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(false);
       expect(result.removedCount).toBe(0);
@@ -224,7 +224,7 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 4,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(true);
       expect(result.removedCount).toBe(6);
@@ -248,7 +248,7 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(true);
       expect(result.messages).toHaveLength(6);
@@ -270,7 +270,7 @@ describe("InMemoryCompactor", () => {
           protectRecentMessages: 4,
           onSummarize: async () => "Summary of removed messages",
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(true);
       const allTexts = result.messages.flatMap((m) =>
@@ -287,7 +287,7 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(false);
     });
@@ -315,7 +315,7 @@ describe("InMemoryCompactor", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 3,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(true);
       expect(result.messages[0]?.info.role).toBe("user");
@@ -343,7 +343,7 @@ describe("InMemoryCompactor", () => {
             contextWindowTokens: 1000,
             protectRecentMessages: 3,
           },
-          { traceId: TEST_TRACE_ID },
+          { traceId: TEST_TRACE_ID, events: Bus },
         );
       } catch (error) {
         caught = error;
@@ -372,7 +372,7 @@ describe("InMemoryCompactor", () => {
           protectRecentMessages: 3,
           onSummarize: async () => "anchored",
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       expect(result.compacted).toBe(true);
       expect(result.removedCount).toBe(5);
@@ -391,7 +391,7 @@ describe("InMemoryCompactor", () => {
           protectRecentMessages: 4,
           onSummarize: async () => "summary",
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, events: Bus },
       );
       const summary = result.messages[0];
       expect(summary?.info.role).toBe("user");

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -25,6 +25,7 @@ function makeInput() {
 
 function makeConfig(overrides?: Partial<ChatAgentConfig>): ChatAgentConfig {
   return {
+    events: Bus,
     model: { provider: "test", id: "test-model" },
     systemPrompt: "test",
     ...overrides,
@@ -46,6 +47,7 @@ function makeTrace(): RunTrace {
 function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtifacts {
   return {
     runInput: {
+      events: Bus,
       messages: [],
       tools: [],
       model: providerModel,

--- a/packages/agent/test/core/execution/lifecycle-audit-facts.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-audit-facts.test.ts
@@ -7,6 +7,7 @@ import type { PolicyContext } from "../../../src/core/policy/types";
 import type { ChatAgentConfig } from "../../../src/core/types";
 import { createMockLlmConfig, mockProviderData, mockProviderModel } from "../../helpers/mock-llm";
 import { runInput } from "../../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 function assistantMessage(outputTokens: number): Message.WithParts {
   const id = `assistant-${outputTokens}`;
@@ -56,6 +57,7 @@ describe("canonical lifecycle audit facts", () => {
     } satisfies CanonicalPolicyRegistrationGeneric<PolicyContext>;
     const outcomes: readonly Run.Outcome[] = [{ type: "continue" }, { type: "stop" }];
     const config: ChatAgentConfig = {
+      events: Bus,
       model: { provider: "test", id: "model" },
       middleware: [observer],
       llm: createMockLlmConfig({

--- a/packages/agent/test/core/execution/lifecycle-budget.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-budget.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Operational, PolicyDecision } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { Bus, collector } from "@openomni/telemetry";
 import { dispatchBudgetCheck } from "../../../src/core/execution/lifecycle-dispatch";
 import { PolicyEngine, type PolicyContext } from "../../../src/core/policy";
 import { makeAgentBase, makeConfig, makeState } from "./lifecycle-dispatch-fixture";
@@ -77,5 +77,34 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
 
     const result = await dispatchBudgetCheck(state, engine, config, makeAgentBase());
     expect(result).toBeNull();
+  });
+
+  /**
+   * The point of the port. The loop reports to whatever the composition root
+   * hands it — no process-wide `Bus`, and P2 can put a fail-closed ledger
+   * append behind this without touching the loop.
+   */
+  it("reports through the injected sink, not a global bus", async () => {
+    const collected = collector();
+    const busSaw: string[] = [];
+    const unsubscribe = Bus.observe((descriptor) => busSaw.push(descriptor.name));
+    const agentBase = makeAgentBase();
+    const state = makeState();
+    state.budgetState.turns = 20;
+
+    try {
+      await dispatchBudgetCheck(
+        state,
+        PolicyEngine.create(),
+        makeConfig({ events: collected, budget: { maxTurns: 24 } }),
+        agentBase,
+      );
+      await Bun.sleep(0);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(collected.named(Operational.Warn.name)).toHaveLength(1);
+    expect(busSaw).toEqual([]);
   });
 });

--- a/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
+++ b/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
@@ -7,6 +7,7 @@ import {
   type TurnArtifacts,
 } from "../../../src/core/execution/run-state";
 import { runInput } from "../../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 function makeInput() {
   return runInput([{ role: "user", content: "hello" }]);
@@ -14,6 +15,7 @@ function makeInput() {
 
 export function makeConfig(overrides?: Partial<ChatAgentConfig>): ChatAgentConfig {
   return {
+    events: Bus,
     model: { provider: "test", id: "test-model" },
     systemPrompt: "test",
     ...overrides,
@@ -37,6 +39,7 @@ export function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtif
     runInput: {
       messages: [],
       tools: [],
+      events: Bus,
       model: { provider: "test", id: "test-model" },
       maxSteps: 24,
     },

--- a/packages/agent/test/core/execution/tool-executor-context.test.ts
+++ b/packages/agent/test/core/execution/tool-executor-context.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "bun:test";
 import type { Tool } from "@openomni/protocol";
 import { createToolExecutor } from "../../../src/core/execution/tool-executor";
 import { PolicyEngine } from "../../../src/core/policy";
+import { Bus } from "@openomni/telemetry";
 
 describe("createToolExecutor execution context", () => {
   it("forwards the active trace while preserving the per-call cancellation signal", async () => {
@@ -17,6 +18,7 @@ describe("createToolExecutor execution context", () => {
     };
     let capturedContext: Tool.ExecutionContext | undefined;
     const executor = createToolExecutor({
+      events: Bus,
       engine: PolicyEngine.create(),
       signal: fallbackController.signal,
       traceContext,
@@ -50,6 +52,7 @@ describe("createToolExecutor execution context", () => {
     const callTrace = { traceId: "trace-call", sessionId: "session-call", runId: "run-call" };
     let capturedContext: Tool.ExecutionContext | undefined;
     const executor = createToolExecutor({
+      events: Bus,
       engine: PolicyEngine.create(),
       signal: fallbackController.signal,
       traceContext: fallbackTrace,

--- a/packages/agent/test/core/execution/tool-executor-sole-emitter.test.ts
+++ b/packages/agent/test/core/execution/tool-executor-sole-emitter.test.ts
@@ -61,6 +61,7 @@ describe("sole emitter — worker executor owns ToolExecution events", () => {
     Bus.subscribe(ToolExecution.Completed, (d) => completed.push(d));
 
     const executor = createToolExecutor({
+      events: Bus,
       toolExecutor: emittingBaseExecutor({ output: "ok" }),
       engine: PolicyEngine.create(),
       traceContext: { traceId: "trace-sole", sessionId: "sess-sole", runId: "run-1" },
@@ -79,6 +80,7 @@ describe("sole emitter — worker executor owns ToolExecution events", () => {
     Bus.subscribe(ToolExecution.Completed, (d) => completed.push(d));
 
     const executor = createToolExecutor({
+      events: Bus,
       toolExecutor: emittingBaseExecutor({ output: "err", isError: true }),
       engine: PolicyEngine.create(),
       traceContext: { traceId: "trace-sole-err", sessionId: "sess-sole-err", runId: "run-1" },
@@ -97,6 +99,7 @@ describe("sole emitter — worker executor owns ToolExecution events", () => {
     Bus.subscribe(ToolExecution.Completed, (d) => completed.push(d));
 
     const executor = createToolExecutor({
+      events: Bus,
       toolExecutor: emittingBaseExecutor({ output: "boom", throws: new Error("boom") }),
       engine: PolicyEngine.create(),
       traceContext: { traceId: "trace-sole-throw", sessionId: "sess-sole-throw", runId: "run-1" },

--- a/packages/agent/test/core/execution/tool-executor-verdicts.test.ts
+++ b/packages/agent/test/core/execution/tool-executor-verdicts.test.ts
@@ -68,6 +68,7 @@ describe("createToolExecutor invoke.prepare verdict handling", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       engine,
       traceContext: { traceId: "trace-deny", sessionId: "sess-deny", runId: "run-1" },
       toolExecutor: async (call) => {
@@ -97,6 +98,7 @@ describe("createToolExecutor invoke.prepare verdict handling", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => {
@@ -122,6 +124,7 @@ describe("createToolExecutor invoke.prepare verdict handling", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => {
@@ -152,6 +155,7 @@ describe("createToolExecutor invoke.prepare verdict handling", () => {
       }),
     );
     const skipExecutor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine: skipEngine,
       toolExecutor: async (call) => {
@@ -175,6 +179,7 @@ describe("createToolExecutor invoke.prepare verdict handling", () => {
       }),
     );
     const abortExecutor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine: abortEngine,
       toolExecutor: async (call) => {
@@ -204,6 +209,7 @@ describe("createToolExecutor effect application", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => {
@@ -232,6 +238,7 @@ describe("createToolExecutor effect application", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => {
@@ -259,6 +266,7 @@ describe("createToolExecutor effect application", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => {
@@ -287,6 +295,7 @@ describe("createToolExecutor effect application", () => {
       }),
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => {
@@ -326,6 +335,7 @@ describe("createToolExecutor effect application", () => {
       },
     ]);
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => ({
@@ -365,6 +375,7 @@ describe("createToolExecutor effect application", () => {
       },
     ]);
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => ({
@@ -408,6 +419,7 @@ describe("createToolExecutor effect application", () => {
       },
     ]);
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       toolExecutor: async (call) => ({
@@ -442,6 +454,7 @@ describe("createToolExecutor effect application", () => {
       },
     ]);
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       getToolLabels: () => ["source.mcp", "mcp.fixture"],
@@ -461,6 +474,7 @@ describe("createToolExecutor effect application", () => {
     // tool runs — never a silent allow.
     let invoked = 0;
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine: PolicyEngine.create(),
       getToolLabels: () => ["source.mcp"],
@@ -504,6 +518,7 @@ describe("createToolExecutor effect application", () => {
         },
       ]);
       const executor = createToolExecutor({
+        events: Bus,
         traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
         engine,
         toolExecutor: async (call) => {
@@ -549,6 +564,7 @@ describe("createToolExecutor effect application", () => {
         },
       ]);
       const executor = createToolExecutor({
+        events: Bus,
         traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
         engine,
         toolExecutor: async (call) => {
@@ -594,6 +610,7 @@ describe("createToolExecutor effect application", () => {
         },
       ]);
       const executor = createToolExecutor({
+        events: Bus,
         traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
         engine,
         onDecision: (timing, decision) => {
@@ -629,6 +646,7 @@ describe("createToolExecutor effect application", () => {
         },
       ]);
       const executor = createToolExecutor({
+        events: Bus,
         traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
         engine,
         onDecision: () => {
@@ -686,6 +704,7 @@ describe("createToolExecutor effect application", () => {
         },
       ]);
       const executor = createToolExecutor({
+        events: Bus,
         traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
         engine,
         onDecision: async () => {

--- a/packages/agent/test/core/execution/tool-executor.test.ts
+++ b/packages/agent/test/core/execution/tool-executor.test.ts
@@ -46,6 +46,7 @@ describe("createToolExecutor bus events", () => {
     const delegatedContexts: unknown[] = [];
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: async (call, context) => {
         delegatedContexts.push(context?.traceContext);
@@ -74,6 +75,7 @@ describe("createToolExecutor bus events", () => {
     Bus.subscribe(ToolExecution.Completed, (d) => completed.push(d));
 
     const executor = createToolExecutor({
+      events: Bus,
       toolExecutor: async (call) => ({
         id: "r1",
         toolCallId: call.id,
@@ -108,6 +110,7 @@ describe("createToolExecutor bus events", () => {
     engine.register(abortMiddleware("Blocked: test rule"));
 
     const executor = createToolExecutor({
+      events: Bus,
       toolExecutor: async () => ({ id: "r1", toolCallId: "x", output: "never", isError: false }),
       engine,
       traceContext: { traceId: "trace-3", sessionId: "sess-3", runId: "run-1" },
@@ -138,6 +141,7 @@ describe("createToolExecutor bus events", () => {
     Bus.subscribe(ToolExecution.Completed, (d) => completed.push(d));
 
     const executor = createToolExecutor({
+      events: Bus,
       toolExecutor: async () => {
         throw new Error("boom");
       },
@@ -155,6 +159,7 @@ describe("createToolExecutor bus events", () => {
   it("reports tool duration for budget accounting on success and failure", async () => {
     const durations: number[] = [];
     const successExecutor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: async (call) => ({
         id: "r1",
@@ -168,6 +173,7 @@ describe("createToolExecutor bus events", () => {
     await successExecutor(makeCall("call-budget-ok"));
 
     const failureExecutor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: async () => {
         throw new Error("boom");
@@ -185,6 +191,7 @@ describe("createToolExecutor bus events", () => {
   it("refuses to build without the run trace context", () => {
     expect(() =>
       createToolExecutor({
+        events: Bus,
         toolExecutor: async () => ({ id: "r", toolCallId: "c", output: "" }),
         engine: PolicyEngine.create(),
       }),
@@ -199,6 +206,7 @@ describe("createToolExecutor bus events", () => {
     const denyEngine = makeEngine();
     denyEngine.register(abortMiddleware("Blocked: actor rule"));
     const denyExecutor = createToolExecutor({
+      events: Bus,
       toolExecutor: async () => ({ id: "r2", toolCallId: "x", output: "never", isError: false }),
       engine: denyEngine,
       traceContext: {

--- a/packages/agent/test/core/execution/tool-history.test.ts
+++ b/packages/agent/test/core/execution/tool-history.test.ts
@@ -7,6 +7,7 @@ import type { PolicyRegistration } from "../../../src/core/policy";
 import { createErrorOutcome, createStopOutcome, type MockLlmFn } from "../../helpers/mock-llm";
 import { allow, continueWithPrompt } from "../../helpers/policy-decision";
 import { runInput } from "../../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 /**
  * C2 (#546): the model must see its own prior tool use. These tests pin the
@@ -149,6 +150,7 @@ describe("tool-bearing history (#546)", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: { run, resolveProviderModel: async () => providerModel },
       middleware: [injectOnceMiddleware()],
@@ -203,6 +205,7 @@ describe("tool-bearing history (#546)", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: { run, resolveProviderModel: async () => providerModel },
       middleware: [
@@ -259,6 +262,7 @@ describe("tool-bearing history (#546)", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: { run, resolveProviderModel: async () => providerModel },
       middleware: [
@@ -336,6 +340,7 @@ describe("tool-bearing history regressions (#546 fix-first)", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: { run, resolveProviderModel: async () => providerModel },
       middleware: [
@@ -387,6 +392,7 @@ describe("tool-bearing history regressions (#546 fix-first)", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: { run, resolveProviderModel: async () => providerModel },
       middleware: [
@@ -440,6 +446,7 @@ describe("tool-bearing history regressions (#546 fix-first)", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: { run, resolveProviderModel: async () => providerModel },
       middleware: [

--- a/packages/agent/test/core/execution/tool-selection.test.ts
+++ b/packages/agent/test/core/execution/tool-selection.test.ts
@@ -28,6 +28,7 @@ function makeLabeledTool(name: string, labels: string[]): Tool.Spec {
 
 function makeConfig(tools: Tool.Spec[]): ChatAgentConfig {
   return {
+    events: Bus,
     model: { provider: "test", id: "test-model" },
     tools,
     systemPrompt: "test system prompt",

--- a/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../src/core/execution/run-state";
 import { allow } from "../../helpers/policy-decision";
 import { runInput } from "../../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 function makeAgentBase(): AgentRunBase {
   return { traceId: "trace-1", sessionId: "sess-1" };
@@ -19,6 +20,7 @@ function makeTurnArtifacts(): TurnArtifacts {
     runInput: {
       messages: [],
       tools: [],
+      events: Bus,
       model: { provider: "test", id: "test-model" },
       maxSteps: 24,
     },
@@ -67,7 +69,7 @@ describe("handleStop prompt injection provenance", () => {
     const events = await collectEvents(
       handleStop(
         state,
-        { model: { provider: "test", id: "test-model" } },
+        { events: Bus, model: { provider: "test", id: "test-model" } },
         engine,
         makeAgentBase(),
         makeTurnArtifacts(),

--- a/packages/agent/test/core/policy/builtin-snapshots.test.ts
+++ b/packages/agent/test/core/policy/builtin-snapshots.test.ts
@@ -10,6 +10,7 @@ import { createCompactionPolicy } from "../../../src/core/policy/builtin/compact
 import { createIdleNudgePolicy } from "../../../src/core/policy/builtin/idle-nudge";
 import { createToolPermissionPolicy } from "../../../src/core/policy/builtin/tool-guard";
 import { effectOf, firstReason } from "../../helpers/policy-decision";
+import { Bus } from "@openomni/telemetry";
 
 function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
   return {
@@ -113,6 +114,7 @@ describe("snapshot: budget-warning", () => {
 describe("snapshot: tool-permission", () => {
   it("continue — tool on allowlist", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: ["read_file", "write_file"] },
     });
     const verdict = await mw.fn(
@@ -128,6 +130,7 @@ describe("snapshot: tool-permission", () => {
 
   it("abort — tool not on allowlist", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: ["read_file"] },
     });
     const verdict = await mw.fn(
@@ -146,7 +149,11 @@ describe("snapshot: tool-permission", () => {
 
 describe("snapshot: compaction", () => {
   it("continue — below token threshold", async () => {
-    const mw = createCompactionPolicy({ contextWindowTokens: 10000, thresholdRatio: 0.8 });
+    const mw = createCompactionPolicy({
+      events: Bus,
+      contextWindowTokens: 10000,
+      thresholdRatio: 0.8,
+    });
     const verdict = await mw.fn(
       baseCtx({
         messages: [testMessage("m1"), testMessage("m2")],
@@ -191,7 +198,7 @@ describe("snapshot: canonical registration metadata", () => {
   });
 
   it("tool-permission: name, points, priority, failPolicy", () => {
-    const mw = createToolPermissionPolicy({ permission: { action: "tool.call" } });
+    const mw = createToolPermissionPolicy({ events: Bus, permission: { action: "tool.call" } });
     expect(mw.name).toBe("builtin:tool-permission");
     expect(mw.pointIds).toEqual(["tool.native.pre", "tool.mcp.pre"]);
     expect(mw.effectCapabilities).toEqual({
@@ -203,7 +210,7 @@ describe("snapshot: canonical registration metadata", () => {
   });
 
   it("compaction: name, point, priority", () => {
-    const mw = createCompactionPolicy({ contextWindowTokens: 1000 });
+    const mw = createCompactionPolicy({ events: Bus, contextWindowTokens: 1000 });
     expect(mw.name).toBe("builtin:compaction");
     expect(mw.pointIds).toEqual(["run.completion.pre"]);
     expect(mw.effectCapabilities).toEqual({

--- a/packages/agent/test/core/policy/builtin/compaction.test.ts
+++ b/packages/agent/test/core/policy/builtin/compaction.test.ts
@@ -5,6 +5,7 @@ import { createCompactionPolicy } from "../../../../src/core/policy/builtin/comp
 import type { PolicyContext } from "../../../../src/core/policy";
 import type { BudgetState } from "../../../../src/core/budget";
 import { effectOf } from "../../../helpers/policy-decision";
+import { Bus } from "@openomni/telemetry";
 
 function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
   return {
@@ -62,6 +63,7 @@ describe("createCompactionPolicy", () => {
    */
   it("skips rather than aborting when no trace reaches it", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 100,
       protectRecentMessages: 2,
     });
@@ -80,6 +82,7 @@ describe("createCompactionPolicy", () => {
   });
   it("continues when below threshold", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 10000,
       thresholdRatio: 0.8,
     });
@@ -97,6 +100,7 @@ describe("createCompactionPolicy", () => {
 
   it("transforms when above threshold", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
       thresholdRatio: 0.8,
       protectRecentMessages: 2,
@@ -118,6 +122,7 @@ describe("createCompactionPolicy", () => {
 
   it("transforms when reserve budget is reached before ratio threshold", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
       thresholdRatio: 0.95,
       reserveTokens: 250,
@@ -140,6 +145,7 @@ describe("createCompactionPolicy", () => {
 
   it("continues when no messages in context", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
       thresholdRatio: 0.8,
     });
@@ -156,6 +162,7 @@ describe("createCompactionPolicy", () => {
 
   it("continues when empty messages array", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
       thresholdRatio: 0.8,
     });
@@ -172,6 +179,7 @@ describe("createCompactionPolicy", () => {
 
   it("continues when no budget state", async () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
       thresholdRatio: 0.8,
     });
@@ -189,6 +197,7 @@ describe("createCompactionPolicy", () => {
 
   it("has priority 900", () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
     });
 
@@ -197,6 +206,7 @@ describe("createCompactionPolicy", () => {
 
   it("has name builtin:compaction", () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
     });
 
@@ -205,6 +215,7 @@ describe("createCompactionPolicy", () => {
 
   it("registers the canonical completion point", () => {
     const middleware = createCompactionPolicy({
+      events: Bus,
       contextWindowTokens: 1000,
     });
 

--- a/packages/agent/test/core/policy/builtin/tool-guard.test.ts
+++ b/packages/agent/test/core/policy/builtin/tool-guard.test.ts
@@ -7,7 +7,7 @@ import type { PolicyContext } from "../../../../src/core/policy";
 function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
   return {
     timing: "invoke.prepare",
-    traceContext: { traceId: "trace-builtin-test", events: Bus },
+    traceContext: { traceId: "trace-builtin-test" },
     steps: [],
     usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     turnCount: 0,
@@ -54,7 +54,7 @@ describe("createToolPermissionPolicy", () => {
     try {
       await mw.fn(
         baseCtx({
-          traceContext: { traceId: "trace-guard-report", events: Bus },
+          traceContext: { traceId: "trace-guard-report" },
           toolName: "shell_exec",
           toolCallId: "call-reported",
           toolInput: hostileInput,

--- a/packages/agent/test/core/policy/builtin/tool-guard.test.ts
+++ b/packages/agent/test/core/policy/builtin/tool-guard.test.ts
@@ -93,7 +93,7 @@ describe("createToolPermissionPolicy", () => {
       },
     });
 
-    for (const traceContext of [undefined, { traceId: "", events: Bus }]) {
+    for (const traceContext of [undefined, { traceId: "" }]) {
       await expect(
         mw.fn(
           baseCtx({

--- a/packages/agent/test/core/policy/builtin/tool-guard.test.ts
+++ b/packages/agent/test/core/policy/builtin/tool-guard.test.ts
@@ -7,7 +7,7 @@ import type { PolicyContext } from "../../../../src/core/policy";
 function baseCtx(overrides?: Partial<PolicyContext>): PolicyContext {
   return {
     timing: "invoke.prepare",
-    traceContext: { traceId: "trace-builtin-test" },
+    traceContext: { traceId: "trace-builtin-test", events: Bus },
     steps: [],
     usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     turnCount: 0,
@@ -36,6 +36,7 @@ describe("createToolPermissionPolicy", () => {
       },
     );
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: {
         action: "tool.call",
         inputRules: [
@@ -53,7 +54,7 @@ describe("createToolPermissionPolicy", () => {
     try {
       await mw.fn(
         baseCtx({
-          traceContext: { traceId: "trace-guard-report" },
+          traceContext: { traceId: "trace-guard-report", events: Bus },
           toolName: "shell_exec",
           toolCallId: "call-reported",
           toolInput: hostileInput,
@@ -77,6 +78,7 @@ describe("createToolPermissionPolicy", () => {
       },
     );
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: {
         action: "tool.call",
         inputRules: [
@@ -91,7 +93,7 @@ describe("createToolPermissionPolicy", () => {
       },
     });
 
-    for (const traceContext of [undefined, { traceId: "" }]) {
+    for (const traceContext of [undefined, { traceId: "", events: Bus }]) {
       await expect(
         mw.fn(
           baseCtx({
@@ -106,6 +108,7 @@ describe("createToolPermissionPolicy", () => {
   });
   it("continue — tool on allowlist", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: ["read_file", "write_file"] },
     });
     const verdict = await mw.fn(
@@ -121,6 +124,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("abort — tool not on allowlist (allowlist_miss)", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: ["read_file"] },
     });
     const verdict = await mw.fn(
@@ -137,6 +141,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("abort — tool on denylist", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", denylist: ["dangerous_tool"] },
     });
     const verdict = await mw.fn(
@@ -153,6 +158,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("abort — empty allowlist denies everything (allowlist_empty)", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: [] },
     });
     const verdict = await mw.fn(
@@ -168,6 +174,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("continue — no toolName in context", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: ["read_file"] },
     });
     const verdict = await mw.fn(baseCtx());
@@ -176,6 +183,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("continue — wildcard allowlist allows everything", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", allowlist: ["*"] },
     });
     const verdict = await mw.fn(
@@ -190,6 +198,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("abort — inputRule deny overrides allowlist", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: {
         action: "tool.call",
         allowlist: ["shell_exec"],
@@ -218,6 +227,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("continue — permission without explicit action gets normalized to tool.call", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "", allowlist: ["read_file"] },
     });
     const verdict = await mw.fn(
@@ -241,6 +251,7 @@ describe("createToolPermissionPolicy", () => {
       },
     );
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: {
         action: "tool.call",
         inputRules: [
@@ -270,7 +281,7 @@ describe("createToolPermissionPolicy", () => {
   });
 
   it("registers canonical metadata", () => {
-    const mw = createToolPermissionPolicy({ permission: { action: "tool.call" } });
+    const mw = createToolPermissionPolicy({ events: Bus, permission: { action: "tool.call" } });
     expect(mw.name).toBe("builtin:tool-permission");
     expect(mw.pointIds).toEqual(["tool.native.pre", "tool.mcp.pre"]);
     expect(mw.priority).toBe(0);
@@ -279,6 +290,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("abort — denyLabels match blocks tool", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call", denyLabels: ["risk.tier-3"] },
     });
     const verdict = await mw.fn(
@@ -295,6 +307,7 @@ describe("createToolPermissionPolicy", () => {
 
   it("continue — no permission rules means default allow", async () => {
     const mw = createToolPermissionPolicy({
+      events: Bus,
       permission: { action: "tool.call" },
     });
     const verdict = await mw.fn(

--- a/packages/agent/test/core/policy/canonical-execution.test.ts
+++ b/packages/agent/test/core/policy/canonical-execution.test.ts
@@ -33,6 +33,7 @@ describe("canonical ChatAgent policy execution", () => {
     const legacy = mock(() => allow());
     const engine = buildPolicyEngine(
       {
+        events: Bus,
         model: { provider: "test", id: "model" },
         middleware: [
           {
@@ -115,6 +116,7 @@ describe("canonical ChatAgent policy execution", () => {
       },
     } satisfies CanonicalPolicyRegistrationGeneric<PolicyContext>;
     const config: ChatAgentConfig = {
+      events: Bus,
       model: { provider: "test", id: "model-1" },
       middleware: [middleware],
       llm: createMockLlmConfig({
@@ -157,6 +159,7 @@ describe("canonical tool policy execution", () => {
     });
     const engine = buildPolicyEngine(
       {
+        events: Bus,
         model: { provider: "test", id: "model" },
         middleware: [
           {
@@ -178,6 +181,7 @@ describe("canonical tool policy execution", () => {
       { traceId: "trace", sessionId: "session", runId: "run" },
     );
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       engine,
       onDecision: () => {
@@ -212,6 +216,7 @@ describe("canonical tool policy execution", () => {
     const seen: Array<{ readonly pointId: string; readonly serverId: unknown }> = [];
     const engine = buildPolicyEngine(
       {
+        events: Bus,
         model: { provider: "test", id: "model" },
         middleware: [
           {
@@ -230,6 +235,7 @@ describe("canonical tool policy execution", () => {
       { traceId: "trace", sessionId: "session", runId: "run" },
     );
     const executor = createToolExecutor({
+      events: Bus,
       engine,
       traceContext: { traceId: "trace", sessionId: "session", runId: "run" },
       getToolLabels: () => ["source.mcp", "mcp.filesystem"],
@@ -254,10 +260,11 @@ describe("canonical tool policy execution", () => {
       output: "ok",
     }));
     const engine = buildPolicyEngine(
-      { model: { provider: "test", id: "model" } },
+      { events: Bus, model: { provider: "test", id: "model" } },
       { traceId: "trace", sessionId: "session", runId: "run" },
     );
     const executor = createToolExecutor({
+      events: Bus,
       engine,
       traceContext: { traceId: "trace", sessionId: "session", runId: "run" },
       getToolLabels: () => ["source.mcp"],
@@ -280,9 +287,9 @@ describe("canonical builtin registrations", () => {
     const registrations = [
       createBudgetReassurancePolicy(),
       createBudgetWarningPolicy(),
-      createCompactionPolicy({ contextWindowTokens: 100 }),
+      createCompactionPolicy({ events: Bus, contextWindowTokens: 100 }),
       createIdleNudgePolicy(),
-      createToolPermissionPolicy({ permission: { action: "tool.call" } }),
+      createToolPermissionPolicy({ events: Bus, permission: { action: "tool.call" } }),
     ];
 
     // Then

--- a/packages/agent/test/core/policy/compaction-policy-plan.test.ts
+++ b/packages/agent/test/core/policy/compaction-policy-plan.test.ts
@@ -4,9 +4,10 @@ import type { BudgetState } from "../../../src/core/budget";
 import { defaultRegistry } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy";
 import { effectOf } from "../../helpers/policy-decision";
+import { Bus } from "@openomni/telemetry";
 
 // #546 review F5: production configs never pass WorkerMiddlewareConfig.compaction,
-// but defaultRegistry() registers builtin:compaction, so an external PolicyPlan
+// but defaultRegistry(Bus) registers builtin:compaction, so an external PolicyPlan
 // can activate compaction anyway. This suite proves the commit boundary
 // invariant holds on that backdoor path over tool-bearing history.
 
@@ -114,7 +115,7 @@ describe("policyPlan-activated compaction (builtin:compaction backdoor)", () => 
       ],
       labels: [],
     };
-    const registrations = defaultRegistry().resolve(plan, {});
+    const registrations = defaultRegistry(Bus).resolve(plan, {});
     const registration = registrations[0];
     if (registration === undefined || !("kind" in registration)) {
       throw new Error("expected canonical builtin:compaction registration");

--- a/packages/agent/test/core/policy/compaction-policy-plan.test.ts
+++ b/packages/agent/test/core/policy/compaction-policy-plan.test.ts
@@ -7,7 +7,7 @@ import { effectOf } from "../../helpers/policy-decision";
 import { Bus } from "@openomni/telemetry";
 
 // #546 review F5: production configs never pass WorkerMiddlewareConfig.compaction,
-// but defaultRegistry(Bus) registers builtin:compaction, so an external PolicyPlan
+// but defaultRegistry registers builtin:compaction, so an external PolicyPlan
 // can activate compaction anyway. This suite proves the commit boundary
 // invariant holds on that backdoor path over tool-bearing history.
 

--- a/packages/agent/test/core/policy/conformance/no-bypass.test.ts
+++ b/packages/agent/test/core/policy/conformance/no-bypass.test.ts
@@ -6,6 +6,7 @@ import {
   type PolicyContext,
   type PolicyRegistration,
 } from "../../../../src/core/policy";
+import { Bus } from "@openomni/telemetry";
 
 const itSkip = Reflect.get(it, "skip") as (label: string, fn: () => void) => void;
 const documentedSkip = () => {
@@ -80,6 +81,7 @@ describe("policy no-bypass conformance — agent governed paths", () => {
     engine.register(denyAllInvokePre("native tool denied by conformance policy"));
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: nativeExecutor,
       engine,
@@ -115,6 +117,7 @@ describe("policy no-bypass conformance — agent governed paths", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: mcpExecutor,
       engine,

--- a/packages/agent/test/core/policy/dispatch-completion.test.ts
+++ b/packages/agent/test/core/policy/dispatch-completion.test.ts
@@ -10,6 +10,7 @@ import {
   rewriteToolInput,
   rewriteToolOutput,
 } from "../../helpers/policy-decision";
+import { Bus } from "@openomni/telemetry";
 
 function newID(prefix: string): string {
   return `${prefix}-${Math.random().toString(16).slice(2)}`;
@@ -31,6 +32,7 @@ describe("tool.native.post middleware dispatch", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: async (call) => ({
         id: newID("result"),
@@ -65,6 +67,7 @@ describe("tool.native.post middleware dispatch", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: async (call) => ({
         id: newID("result"),
@@ -99,6 +102,7 @@ describe("tool.native.post middleware dispatch", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: async (call) => ({
         id: newID("result"),
@@ -141,6 +145,7 @@ describe("tool.native.pre middleware dispatch", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: baseExecutor,
       engine,
@@ -175,6 +180,7 @@ describe("tool.native.pre middleware dispatch", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: baseExecutor,
       engine,
@@ -206,6 +212,7 @@ describe("tool.native.pre middleware dispatch", () => {
     });
 
     const executor = createToolExecutor({
+      events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
       toolExecutor: baseExecutor,
       engine,

--- a/packages/agent/test/core/policy/idle-nudge-dispatch.test.ts
+++ b/packages/agent/test/core/policy/idle-nudge-dispatch.test.ts
@@ -4,6 +4,7 @@ import { createToolExecutor } from "../../../src/core/execution/tool-executor";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { CanonicalPolicyRegistration } from "../../../src/core/policy";
 import { createIdleNudgePolicy } from "../../../src/core/policy/builtin/idle-nudge";
+import { Bus } from "@openomni/telemetry";
 
 it("dispatches idle-nudge at the canonical native tool result point", async () => {
   // Given
@@ -22,6 +23,7 @@ it("dispatches idle-nudge at the canonical native tool result point", async () =
   const engine = PolicyEngine.create();
   engine.register(observedIdleNudge);
   const executor = createToolExecutor({
+    events: Bus,
     traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
     engine,
     toolExecutor: async (call) => ({

--- a/packages/agent/test/core/policy/registry.test.ts
+++ b/packages/agent/test/core/policy/registry.test.ts
@@ -19,7 +19,7 @@ function plan(policies: Policy.PolicyPlan["policies"]): Policy.PolicyPlan {
 }
 
 describe("PolicyRegistry", () => {
-  it("defaultRegistry(Bus) has all builtins registered", () => {
+  it("defaultRegistry has all builtins registered", () => {
     const registry = defaultRegistry(Bus);
 
     expect(registry.list()).toEqual(builtinPolicyIds);
@@ -48,7 +48,7 @@ describe("PolicyRegistry", () => {
     expect(registrations[0]?.name).toBe("test:primary:strict");
   });
 
-  it("defaultRegistry(Bus) resolves typed builtin configs", () => {
+  it("defaultRegistry resolves typed builtin configs", () => {
     const registrations = defaultRegistry(Bus).resolve(
       plan([
         {
@@ -73,7 +73,7 @@ describe("PolicyRegistry", () => {
     ]);
   });
 
-  it("defaultRegistry(Bus) resolves configless default builtin policies", () => {
+  it("defaultRegistry resolves configless default builtin policies", () => {
     const registrations = defaultRegistry(Bus).resolve(
       plan([
         { id: "builtin:idle-nudge", required: true },
@@ -88,7 +88,7 @@ describe("PolicyRegistry", () => {
     ]);
   });
 
-  it("defaultRegistry(Bus) rejects malformed builtin configs at resolution", () => {
+  it("defaultRegistry rejects malformed builtin configs at resolution", () => {
     expect(() =>
       defaultRegistry(Bus).resolve(
         plan([{ id: "builtin:compaction", required: true, config: { thresholdRatio: 0.8 } }]),
@@ -160,9 +160,10 @@ describe("PolicyRegistry", () => {
         {
           id: "builtin:tool-permission",
           required: true,
-          // `events` is not wire config: the schema strips it, and the registry
-          // spreads the injected sink last. Both have to hold, or a policy plan
-          // could redirect where its own evidence goes.
+          // `events` is not wire config: the schema's output type omits it, so
+          // parse drops this. Pinned as an outcome — the injected sink gets the
+          // record and the smuggled one stays empty — not as a claim about
+          // which layer of the registry produced that outcome.
           config: {
             permission: {
               action: "tool.call",

--- a/packages/agent/test/core/policy/registry.test.ts
+++ b/packages/agent/test/core/policy/registry.test.ts
@@ -19,8 +19,8 @@ function plan(policies: Policy.PolicyPlan["policies"]): Policy.PolicyPlan {
 }
 
 describe("PolicyRegistry", () => {
-  it("defaultRegistry() has all builtins registered", () => {
-    const registry = defaultRegistry();
+  it("defaultRegistry(Bus) has all builtins registered", () => {
+    const registry = defaultRegistry(Bus);
 
     expect(registry.list()).toEqual(builtinPolicyIds);
     for (const id of builtinPolicyIds) {
@@ -48,8 +48,8 @@ describe("PolicyRegistry", () => {
     expect(registrations[0]?.name).toBe("test:primary:strict");
   });
 
-  it("defaultRegistry() resolves typed builtin configs", () => {
-    const registrations = defaultRegistry().resolve(
+  it("defaultRegistry(Bus) resolves typed builtin configs", () => {
+    const registrations = defaultRegistry(Bus).resolve(
       plan([
         {
           id: "builtin:compaction",
@@ -73,8 +73,8 @@ describe("PolicyRegistry", () => {
     ]);
   });
 
-  it("defaultRegistry() resolves configless default builtin policies", () => {
-    const registrations = defaultRegistry().resolve(
+  it("defaultRegistry(Bus) resolves configless default builtin policies", () => {
+    const registrations = defaultRegistry(Bus).resolve(
       plan([
         { id: "builtin:idle-nudge", required: true },
         { id: "builtin:tool-permission", required: true },
@@ -88,9 +88,9 @@ describe("PolicyRegistry", () => {
     ]);
   });
 
-  it("defaultRegistry() rejects malformed builtin configs at resolution", () => {
+  it("defaultRegistry(Bus) rejects malformed builtin configs at resolution", () => {
     expect(() =>
-      defaultRegistry().resolve(
+      defaultRegistry(Bus).resolve(
         plan([{ id: "builtin:compaction", required: true, config: { thresholdRatio: 0.8 } }]),
         {},
       ),
@@ -115,6 +115,7 @@ describe("PolicyRegistry", () => {
     try {
       const registry = PolicyRegistry.create();
       registry.register("present.policy", () => ({
+        events: Bus,
         name: "present.policy",
         timing: "turn.start",
         priority: 10,

--- a/packages/agent/test/core/policy/registry.test.ts
+++ b/packages/agent/test/core/policy/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Operational, type Policy } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { Bus, collector } from "@openomni/telemetry";
 import { z } from "zod";
 import { PolicyRegistry, defaultRegistry } from "../../../src/core/policy";
 import type { PolicyFactory } from "../../../src/core/policy";
@@ -115,7 +115,6 @@ describe("PolicyRegistry", () => {
     try {
       const registry = PolicyRegistry.create();
       registry.register("present.policy", () => ({
-        events: Bus,
         name: "present.policy",
         timing: "turn.start",
         priority: 10,
@@ -151,5 +150,64 @@ describe("PolicyRegistry", () => {
       unsubscribe();
       Bus.reset();
     }
+  });
+
+  it("hands the built-ins the injected sink, and a plan cannot supply its own", async () => {
+    const injected = collector();
+    const smuggled = collector();
+    const registrations = defaultRegistry(injected).resolve(
+      plan([
+        {
+          id: "builtin:tool-permission",
+          required: true,
+          // `events` is not wire config: the schema strips it, and the registry
+          // spreads the injected sink last. Both have to hold, or a policy plan
+          // could redirect where its own evidence goes.
+          config: {
+            permission: {
+              action: "tool.call",
+              inputRules: [
+                {
+                  toolPattern: "shell_exec",
+                  field: "cmd",
+                  pattern: "^rm\\s",
+                  action: "deny",
+                  priority: 10,
+                },
+              ],
+            },
+            events: smuggled,
+          },
+        },
+      ]),
+      {},
+    );
+
+    const guard = registrations.find((r) => r.name === "builtin:tool-permission");
+    if (!guard) throw new Error("expected builtin:tool-permission");
+
+    const hostile = new Proxy<Record<string, unknown>>(
+      {},
+      {
+        get: () => {
+          throw new Error("hostile tool input");
+        },
+      },
+    );
+    await guard.fn({
+      timing: "invoke.prepare",
+      traceContext: { traceId: "trace-registry-inject" },
+      steps: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      turnCount: 0,
+      isCompletion: false,
+      continuationCount: 0,
+      elapsedMs: 0,
+      toolName: "shell_exec",
+      toolInput: hostile,
+    } as never);
+
+    expect(injected.events.length).toBeGreaterThan(0);
+    expect(smuggled.events).toHaveLength(0);
   });
 });

--- a/packages/agent/test/core/policy/run-gate.test.ts
+++ b/packages/agent/test/core/policy/run-gate.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../helpers/mock-llm";
 import { abortRun, allow, inject } from "../../helpers/policy-decision";
 import { runInput } from "../../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 let mockRunFn: MockLlmFn = async () => createStopOutcome();
 
@@ -39,6 +40,7 @@ beforeAll(async () => {
 });
 
 const defaultConfig: ChatAgentConfig = {
+  events: Bus,
   model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
   llm: mockLlm,
 };

--- a/packages/agent/test/core/run-delegation.test.ts
+++ b/packages/agent/test/core/run-delegation.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../helpers/mock-llm";
 import { allow, abortRun, continueWithPrompt, replaceMessages } from "../helpers/policy-decision";
 import { runInput } from "../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 let mockRunFn: MockLlmFn = async () => createStopOutcome();
 
@@ -26,6 +27,7 @@ beforeAll(async () => {
 });
 
 const defaultConfig = {
+  events: Bus,
   model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
   llm: mockLlm,
 };
@@ -93,6 +95,7 @@ describe("run() delegation contract", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       ...defaultConfig,
       middleware: [
         {
@@ -160,6 +163,7 @@ describe("run() delegation contract", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       ...defaultConfig,
       middleware: [
         {
@@ -201,6 +205,7 @@ describe("run() delegation contract", () => {
       | undefined;
 
     const agent = ChatAgent.create({
+      events: Bus,
       ...defaultConfig,
       middleware: [
         {
@@ -234,6 +239,7 @@ describe("run() delegation contract", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       ...defaultConfig,
       middleware: [
         {

--- a/packages/agent/test/core/run-delegation.test.ts
+++ b/packages/agent/test/core/run-delegation.test.ts
@@ -95,7 +95,6 @@ describe("run() delegation contract", () => {
     };
 
     const agent = ChatAgent.create({
-      events: Bus,
       ...defaultConfig,
       middleware: [
         {
@@ -163,7 +162,6 @@ describe("run() delegation contract", () => {
     };
 
     const agent = ChatAgent.create({
-      events: Bus,
       ...defaultConfig,
       middleware: [
         {
@@ -205,7 +203,6 @@ describe("run() delegation contract", () => {
       | undefined;
 
     const agent = ChatAgent.create({
-      events: Bus,
       ...defaultConfig,
       middleware: [
         {
@@ -239,7 +236,6 @@ describe("run() delegation contract", () => {
     };
 
     const agent = ChatAgent.create({
-      events: Bus,
       ...defaultConfig,
       middleware: [
         {

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -135,7 +135,6 @@ describe("ChatAgent.stream()", () => {
     };
 
     const agent = ChatAgent.create({
-      events: Bus,
       ...defaultConfig,
       toolExecutor: async (call) => ({
         id: crypto.randomUUID(),

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -9,6 +9,7 @@ import {
   type MockLlmFn,
 } from "../helpers/mock-llm";
 import { runInput } from "../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 let mockRunFn: MockLlmFn = async () => createStopOutcome();
 
@@ -25,6 +26,7 @@ beforeAll(async () => {
 });
 
 const defaultConfig = {
+  events: Bus,
   model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
   llm: mockLlm,
 };
@@ -133,6 +135,7 @@ describe("ChatAgent.stream()", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       ...defaultConfig,
       toolExecutor: async (call) => ({
         id: crypto.randomUUID(),

--- a/packages/agent/test/core/tool-permission-integration.test.ts
+++ b/packages/agent/test/core/tool-permission-integration.test.ts
@@ -8,6 +8,7 @@ import {
   type MockLlmFn,
 } from "../helpers/mock-llm";
 import { runInput } from "../helpers/run-input";
+import { Bus } from "@openomni/telemetry";
 
 let mockRunFn: MockLlmFn = async () => createStopOutcome();
 
@@ -107,6 +108,7 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [
@@ -118,6 +120,7 @@ describe("tool permission integration via toolExecutor", () => {
       toolExecutor: executor,
       middleware: [
         createToolPermissionPolicy({
+          events: Bus,
           permission: {
             action: "tool.call",
             inputRules: [
@@ -169,6 +172,7 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [
@@ -180,6 +184,7 @@ describe("tool permission integration via toolExecutor", () => {
       toolExecutor: executor,
       middleware: [
         createToolPermissionPolicy({
+          events: Bus,
           permission: {
             action: "tool.call",
             requireApproval: ["bash"],
@@ -223,6 +228,7 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [
@@ -234,6 +240,7 @@ describe("tool permission integration via toolExecutor", () => {
       toolExecutor: executor,
       middleware: [
         createToolPermissionPolicy({
+          events: Bus,
           permission: {
             action: "tool.call",
             allowlist: ["bash"],
@@ -288,11 +295,12 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [writeTool],
       toolExecutor: executor,
-      middleware: [createToolPermissionPolicy({ permission: labelPermission })],
+      middleware: [createToolPermissionPolicy({ events: Bus, permission: labelPermission })],
     });
 
     await agent.run(runInput([{ role: "user", content: "write file" }]), {
@@ -341,11 +349,12 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [grepTool],
       toolExecutor: executor,
-      middleware: [createToolPermissionPolicy({ permission })],
+      middleware: [createToolPermissionPolicy({ events: Bus, permission })],
     });
 
     await agent.run(runInput([{ role: "user", content: "search files" }]), {
@@ -382,6 +391,7 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [
@@ -419,6 +429,7 @@ describe("tool permission integration via toolExecutor", () => {
     };
 
     const agent = ChatAgent.create({
+      events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
       llm: mockLlm,
       tools: [
@@ -430,6 +441,7 @@ describe("tool permission integration via toolExecutor", () => {
       toolExecutor: executor,
       middleware: [
         createToolPermissionPolicy({
+          events: Bus,
           permission: {
             action: "tool.call",
             inputRules: [

--- a/packages/agent/test/runtime/mcp/client-trace.test.ts
+++ b/packages/agent/test/runtime/mcp/client-trace.test.ts
@@ -14,6 +14,7 @@ const config = {
 
 function createClient(callTool: McpClientHandle["callTool"]): McpClient {
   return new McpClient(config, {
+    events: Bus,
     traceId: TEST_LIFECYCLE_TRACE_ID,
     client: {
       connect: async () => undefined,
@@ -103,6 +104,7 @@ describe("McpClient call audit trace", () => {
     const seen: string[] = [];
     const unsubscribe = Bus.observe((descriptor) => seen.push(descriptor.name));
     const client = new McpClient(config, {
+      events: Bus,
       ...(traceId === undefined ? {} : { traceId }),
       client: {
         connect: async () => undefined,

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -61,6 +61,7 @@ describe("McpClient tool descriptors", () => {
         command: "mcp-server-filesystem",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: createStubClient([
           {
@@ -97,7 +98,7 @@ describe("McpClient tool descriptors", () => {
         transport: "sse",
         url: "https://example.test/mcp",
       },
-      { client: createStubClient([{ name: "search" }]) },
+      { events: Bus, client: createStubClient([{ name: "search" }]) },
     );
 
     const [tool] = (await client.listTools()) as ToolSpecWithDescriptor[];
@@ -121,7 +122,7 @@ describe("McpClient request options", () => {
         transport: "sse",
         url: "https://example.test/mcp",
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     await client.listTools();
@@ -138,7 +139,7 @@ describe("McpClient request options", () => {
         transport: "sse",
         url: "https://example.test/mcp",
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     await client.listTools({ signal });
@@ -158,7 +159,7 @@ describe("McpClient request options", () => {
         url: "https://example.test/mcp",
         timeout: 0,
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     await client.listTools();
@@ -176,6 +177,7 @@ describe("McpClient request options", () => {
         timeout: 1234,
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: sdkClient,
         createTransport: () => createTransportStub(),
@@ -199,7 +201,7 @@ describe("McpClient request options", () => {
         url: "https://example.test/mcp",
         timeout: 2500,
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     await client.listTools({ signal });
@@ -220,12 +222,12 @@ describe("McpClient request options", () => {
         command: "mcp-server-filesystem",
         timeout: 5000,
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     const result = await client.callTool("filesystem.read_file", { path: "README.md" }, "call-1", {
       signal,
-      traceContext: { traceId: "trace-mcp-call" },
+      traceContext: { traceId: "trace-mcp-call", events: Bus },
     });
 
     expect(result.output).toBe("ok");
@@ -244,7 +246,7 @@ describe("McpClient request options", () => {
         url: "https://example.test/mcp",
         headers: { Authorization: "Bearer token" },
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     await client.connect();
@@ -271,7 +273,7 @@ describe("McpClient request options", () => {
           url: "https://example.test/mcp",
           headers: { Authorization: "Bearer token" },
         },
-        { client: sdkClient },
+        { events: Bus, client: sdkClient },
       );
 
       await client.connect();
@@ -297,7 +299,7 @@ describe("McpClient request options", () => {
         headers: { "x-api-key": "secret" },
         retries: 4,
       },
-      { client: sdkClient },
+      { events: Bus, client: sdkClient },
     );
 
     await client.connect();
@@ -427,6 +429,7 @@ describe("McpClient connection cleanup", () => {
         command: "mcp-server-filesystem",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: sdkClient,
         createTransport: () => transport,
@@ -450,6 +453,7 @@ describe("McpClient connection cleanup", () => {
         url: "https://example.test/mcp",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: sdkClient,
         createTransport: () => transport,
@@ -476,6 +480,7 @@ describe("McpClient connection cleanup", () => {
         command: "mcp-server-filesystem",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: sdkClient,
         createTransport: () => transport,
@@ -520,6 +525,7 @@ describe("McpClient connection cleanup", () => {
         command: "mcp-server-filesystem",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: sdkClient,
         createTransport: () => transport,
@@ -570,6 +576,7 @@ describe("McpClient connection cleanup", () => {
         command: "mcp-server-filesystem",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: createStubClient([]),
         createTransport: () => {
@@ -619,7 +626,7 @@ describe("McpClient connection cleanup", () => {
         transport: "invalid",
         command: "mcp-server-filesystem",
       } as never,
-      { traceId: TEST_LIFECYCLE_TRACE_ID },
+      { traceId: TEST_LIFECYCLE_TRACE_ID, events: Bus },
     );
 
     try {
@@ -647,6 +654,7 @@ describe("McpClient connection cleanup", () => {
         command: "mcp-server-filesystem",
       },
       {
+        events: Bus,
         traceId: TEST_LIFECYCLE_TRACE_ID,
         client: sdkClient,
         createTransport: () => transport,

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -227,7 +227,7 @@ describe("McpClient request options", () => {
 
     const result = await client.callTool("filesystem.read_file", { path: "README.md" }, "call-1", {
       signal,
-      traceContext: { traceId: "trace-mcp-call", events: Bus },
+      traceContext: { traceId: "trace-mcp-call" },
     });
 
     expect(result.output).toBe("ok");

--- a/packages/openomni/src/execution-runtime/AGENTS.md
+++ b/packages/openomni/src/execution-runtime/AGENTS.md
@@ -6,7 +6,7 @@ Tool system, workspace safety, injection queue, cron bridge, and worker middlewa
 
 | Path | Purpose |
 | --- | --- |
-| `middleware.ts` | Builds worker middleware registrations from the gate-stamped `Execution.Request.policyPlan` (#479); builtin ids resolve through `defaultRegistry()`, `builtin:tool-permission` config is hydrated from `request.permissions`, required-but-unregistered ids fail closed. |
+| `middleware.ts` | Builds worker middleware registrations from the gate-stamped `Execution.Request.policyPlan` (#479); builtin ids resolve through `defaultRegistry(events)`, `builtin:tool-permission` config is hydrated from `request.permissions`, required-but-unregistered ids fail closed. |
 | `workspace-lock.ts` | Serializes workspace-mutating tool execution. |
 | `injection-queue.ts` | `InjectionQueue` — async response buffer keyed by `runId`; drained at `turn.finish` by the injection-queue policy. |
 | `cron-job-registry.ts` | `CronJobRegistry` — storage-backed registry of scheduled jobs with a process-local fallback; populated by `dispatch` `schedule.create` action. |

--- a/packages/openomni/src/execution-runtime/child-agent/runtime.ts
+++ b/packages/openomni/src/execution-runtime/child-agent/runtime.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_MAX_OUTPUT_CHARS,
   snapshot,
 } from "./types.js";
+import { Bus } from "@openomni/telemetry";
 
 async function dispatchAcceptedDelegationFailure(
   policy: ReturnType<typeof createDelegationPolicyRuntime>,
@@ -183,6 +184,7 @@ export function createChildAgentRuntime(options: ChildAgentRuntimeOptions): Chil
                   })
                 : undefined;
             agent = options.createAgent({
+              events: Bus,
               model: options.model,
               systemPrompt: options.systemPrompt,
               signal: controller.signal,

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -74,7 +74,7 @@ function buildAgentLifecycleMiddleware(
   return [
     createBudgetReassurancePolicy(),
     createBudgetWarningPolicy(),
-    ...(compaction ? [createCompactionPolicy(compaction)] : []),
+    ...(compaction ? [createCompactionPolicy({ ...compaction, events: Bus })] : []),
   ];
 }
 
@@ -92,6 +92,7 @@ function buildLegacyPermissionMiddleware(
   return [
     createToolPermissionPolicy({
       permission: config.permissions ?? DEFAULT_TOOL_PERMISSION,
+      events: Bus,
     }),
   ];
 }
@@ -100,7 +101,7 @@ function resolvePoliciesFromPlan(
   plan: Policy.PolicyPlan,
   config: WorkerMiddlewareConfig,
 ): PolicyEngineRegistration[] {
-  const registry = defaultRegistry();
+  const registry = defaultRegistry(Bus);
   return registry.resolve(
     plan,
     config.traceId === undefined ? {} : { traceId: config.traceId, auditEmit: Bus.publish },

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -125,6 +125,9 @@ function buildResidentAgentConfig(ctx: ResidentRunContext, runId: string): ChatA
   const agent = ctx.event.agent as RuntimeAgentDef;
 
   return {
+    // The kernel is a composition layer: it chooses what observation
+    // reaches, and hands the loop a port rather than a global.
+    events: Bus,
     model: ctx.event.agent.model,
     systemPrompt: ctx.event.agent.systemPrompt,
     budget: ctx.event.agent.budget,

--- a/packages/openomni/test/policy/integration.test.ts
+++ b/packages/openomni/test/policy/integration.test.ts
@@ -3,6 +3,7 @@ import { PolicyEngine, defaultRegistry, type PolicyContext } from "@openomni/age
 import { PolicyDecision, type Policy } from "@openomni/protocol";
 import { buildWorkerMiddleware } from "../../src/execution-runtime/middleware";
 import { PolicyResolver } from "../../src/policy";
+import { Bus } from "@openomni/telemetry";
 
 type PreDispatchContext = Omit<PolicyContext, "timing"> & {
   readonly sessionId?: string;
@@ -49,7 +50,7 @@ describe("policy pipeline integration", () => {
     ]);
     expect(plan.labels).toEqual(["actor.owner", "agent.reviewer", "run.direct", "surface.github"]);
 
-    const registry = defaultRegistry();
+    const registry = defaultRegistry(Bus);
     registry.register("test:github-surface-guard", () => ({
       kind: "point",
       name: "test:github-surface-guard",
@@ -110,7 +111,7 @@ describe("policy pipeline integration", () => {
       surfaceLabels: ["surface:github"],
     });
 
-    const registry = defaultRegistry();
+    const registry = defaultRegistry(Bus);
     registry.register("policy:github-review-readonly", () => ({
       kind: "point",
       name: "policy:github-review-readonly",
@@ -190,7 +191,7 @@ describe("policy pipeline integration", () => {
       labels: ["agent:reviewer", "surface:github"],
     };
 
-    expect(() => defaultRegistry().resolve(plan, { agentName: "reviewer" })).toThrow(
+    expect(() => defaultRegistry(Bus).resolve(plan, { agentName: "reviewer" })).toThrow(
       "Required policy 'policy:missing-required' is not registered",
     );
   });

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -124,14 +124,17 @@ const RULES: Record<PackageKey, PackageRule> = {
     displayName: "agent",
     packageJsonPath: "packages/agent/package.json",
     packageName: "@openomni/agent",
-    // The loop owns no durable state. Same reason as llm: the ledger edge was
-    // `Bus`'s old address, and the ratchet keeps it closed (#606).
+    // The manifest may carry `telemetry` — the tests bind `Bus` behind the
+    // port, and `check-deps` counts devDependencies.
     allowedDeps: new Set([
       "@openomni/protocol",
       "@openomni/policy",
       "@openomni/llm",
       "@openomni/telemetry",
     ]),
+    // `src/` may not. The loop reports through an injected `BusEvent.Sink`
+    // and owns no durable state (#606).
+    srcAllowedDeps: new Set(["@openomni/protocol", "@openomni/policy", "@openomni/llm"]),
   },
   openomni: {
     displayName: "openomni",


### PR DESCRIPTION
Phase 1b's last slice. **`packages/agent/src` no longer imports `Bus`**, and `check-deps` rejects it if it tries.

## The port

All 22 publish sites route through `ChatAgentConfig.events`, a `BusEvent.Sink`. The config already reached every emitter, so the port travels with the run it reports for rather than being reached for.

`run-events.ts` held ten of the 22, and every function there already took `agentBase` — so the port sits **beside** the identity, not inside it. Where a record goes is not part of what it says.

| site | how it gets the port |
|---|---|
| `run-events.ts` (10) | parameter beside `agentBase` |
| `budget.ts` (3) | parameter beside the run it reports on |
| `runtime/mcp/client.ts` (3) | the dependency bag that already carries its trace |
| `tool-executor.ts` (2) | `ToolExecutorOptions` |
| `compaction.ts`, `turn-outcome.ts`, `runner.ts`, `tool-guard.ts` (4) | the caller that owns them |

`defaultRegistry(events)` hands it to the built-ins that report. `buildPolicyEngine`'s `auditEmit` binds the same port instead of `Bus.publish`.

## Schema vs. injection

`ToolPermissionConfigSchema` is typed `Omit<ToolPermissionPolicyConfig, "events">`. The schema validates wire config; the port is injected and never parsed.

## The gate closes behind it

`srcAllowedDeps` — added in #617 for llm — applies here: `src/` may import protocol, policy and llm; the manifest keeps telemetry for the tests. Verified:

```
agent src reaches for Bus  1 VIOLATION
```

## Where the singleton lives now

`packages/openomni` and `apps/server` bind `Bus` at their own seams — a composition layer choosing an implementation, which is what it is for.

## Pinned

A test binds a collector and asserts the global bus sees nothing:

```
port bypassed -> global Bus   1 fail
```

## Verification

- `bun test --timeout 15000` — 3465 pass, 9 skip, 0 fail
- `check-types` 14/14, `lint`, `lint:tools`, `lint:guards`, `lint:side-effects`
- `check-deps` (+ `--self-test`), `check-import-cycles`, `check-dead-exports`, `check-coverage-ratchet`, `check-ledger-schema-drift` — all OK
- `bun run --cwd packages/agent bench` — OK

Refs #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all agent telemetry through an injected `BusEvent.Sink` port instead of the global `Bus`. Previously `@openomni/agent` published directly; now emits flow via `ChatAgentConfig.events`, and composition layers bind `Bus` for production while tests/bench supply sinks.

- Removes all `Bus` imports from `packages/agent/src`; adds `events: BusEvent.Sink` to `ChatAgentConfig` and threads it through run events, runner, budget, compaction, turn handlers, tool executor (`ToolExecutorOptions.events`), LLM `RunInput`, and `McpClient` (constructor now requires `events`).
- Splits compaction identity from destination: `InMemoryCompactor.compact(messages, options, trace, events)`. `defaultRegistry(events)` injects the sink into built-ins; `createCompactionPolicy({ …, events })` and `createToolPermissionPolicy({ …, events })` require it. Server, `packages/openomni` runtimes, and middleware now pass `Bus`; bench uses `noopSink()`.
- `ToolPermissionConfigSchema` strips plan-supplied `events` (`Omit<…, "events">`), so policy plans cannot redirect reporting.
- `check-deps` enforces `srcAllowedDeps` for `@openomni/agent` (`src/` limited to `@openomni/protocol`, `@openomni/policy`, `@openomni/llm`); `@openomni/telemetry` moves to `devDependencies`. Server gains a `test` script.

**Migration**
- Pass `events` when creating a `ChatAgent`, building the registry with `defaultRegistry(events)`, constructing an `McpClient`, and creating a tool executor.
- Update any direct `InMemoryCompactor.compact` calls to include `events` as the fourth argument.
- Do not import `@openomni/telemetry` from `@openomni/agent/src`; use the injected sink. Policy plans must not include `events`.

<sup>Written for commit 31df79c2ca873576a6fb89c07fc2fdeff9e6b612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized event and telemetry reporting through configurable event sinks.
  * Improved consistency of lifecycle, budget, compaction, tool, policy, and MCP activity tracing.
  * Preserved existing agent behavior while enabling shared event tracking across worker, child, and resident agents.

* **Documentation**
  * Updated telemetry guidance, dependency boundaries, and implementation status documentation.

* **Tests**
  * Expanded coverage for injected event reporting and prevention of unintended global event emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->