### PR TITLE
fix(llm): type-check the test tree (#614)

### DIFF
--- a/packages/llm/AGENTS.md
+++ b/packages/llm/AGENTS.md
@@ -48,6 +48,7 @@ src/
 
 - Do NOT import `Bus` here. `llm` reports through the `events` port it is handed; reaching for the process-wide bus re-couples the package to an implementation the composition root is supposed to choose (#606). `check-deps` carries a separate `srcAllowedDeps` for this package — `src/` may import `@openomni/protocol` and nothing else, even though the manifest lists `telemetry` for the tests.
 - `packages/llm` sets `noEmit: true` in tsconfig — it does NOT produce a `dist/`. It is consumed as source by Bun.
+- Do NOT raise `lib` in `tsconfig.json`. `main` points at `src/index.ts`, so `agent` and `server` pull this package's sources into their own programs under their own `lib: ["ES2020"]` — widening here would let an ES2022 builtin pass llm's gate and surface as an error attributed to a consumer. The test tree, which nothing imports, is checked separately by `tsconfig.test.json` at ES2022; `check-types` runs both.
 - Do NOT add provider-specific logic to call sites. Keep SDK wiring in `provider/`, credential handling in `auth/`, and message/request shaping in `transform/`.
 - Do NOT bypass `Auth.get()` for credentials (e.g. reading env vars inline). All credentials flow through the namespace.
 - Do NOT hand-craft provider-specific request rewriting at call sites — keep it behind provider or transform modules so it stays in one place.

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -5,7 +5,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "lint": "bunx biome check ./src",
     "test": "bun test"
   },

--- a/packages/llm/src/provider/sdk.ts
+++ b/packages/llm/src/provider/sdk.ts
@@ -21,12 +21,19 @@ const BUNDLED_PROVIDERS = new Map<string, (options: SdkOptions) => BundledProvid
   ["@ai-sdk/openai", (options) => createOpenAI(options)],
 ]);
 
+/**
+ * What every path in this module actually produces. `LanguageModel` also
+ * admits a bare gateway model id string, which nothing here returns — leaving
+ * it in the signature only pushed casts onto callers.
+ */
+type ResolvedLanguageModel = Exclude<LanguageModel, string>;
+
 const SDK_CACHE = new Map<string, ProviderSDK>();
-const LANGUAGE_CACHE = new Map<string, LanguageModel>();
+const LANGUAGE_CACHE = new Map<string, ResolvedLanguageModel>();
 const PROVIDER_SDK_CACHE_MAX_ENTRIES = 64;
 const PROVIDER_LANGUAGE_CACHE_MAX_ENTRIES = 256;
 
-type CustomModelLoader = (sdk: ProviderSDK, modelID: string) => LanguageModel;
+type CustomModelLoader = (sdk: ProviderSDK, modelID: string) => ResolvedLanguageModel;
 
 interface CustomLoaderResult {
   getModel?: CustomModelLoader;
@@ -107,7 +114,7 @@ export function getSDK(model: Provider.Model, auth: Auth.Info): ProviderSDK {
   return sdk;
 }
 
-export function getLanguage(model: Provider.Model, auth: Auth.Info): LanguageModel {
+export function getLanguage(model: Provider.Model, auth: Auth.Info): ResolvedLanguageModel {
   const modelID = model.api?.id ?? model.id;
   const cacheKey = `${model.providerID}:${model.api?.npm ?? ""}:${model.api?.url ?? ""}:${modelID}:${authFingerprint(auth)}`;
   const cached = getCached(LANGUAGE_CACHE, cacheKey);
@@ -150,7 +157,7 @@ function resolveLanguageModel(
   providerID: string,
   auth: Auth.Info,
   custom: CustomLoaderResult | undefined,
-): LanguageModel {
+): ResolvedLanguageModel {
   if (providerID === "openai" && auth.type === "proxy" && isOpenAIProvider(sdk)) {
     return sdk.chat(modelID);
   }

--- a/packages/llm/test/message/to-model-messages.test.ts
+++ b/packages/llm/test/message/to-model-messages.test.ts
@@ -53,8 +53,8 @@ describe("toModelMessages", () => {
 
     const result = toModelMessages([userMsg], model);
     expect(result).toHaveLength(1);
-    expect(result[0].role).toBe("user");
-    expect(result[0].content).toBe("Hello");
+    expect(result[0]?.role).toBe("user");
+    expect(result[0]?.content).toBe("Hello");
   });
 
   test("converts AssistantMessage to model message", () => {
@@ -105,8 +105,8 @@ describe("toModelMessages", () => {
 
     const result = toModelMessages([assistantMsg], model);
     expect(result).toHaveLength(1);
-    expect(result[0].role).toBe("assistant");
-    expect(result[0].content).toBe("Response");
+    expect(result[0]?.role).toBe("assistant");
+    expect(result[0]?.content).toBe("Response");
   });
 
   test("preserves assistant reasoning parts during conversion", () => {
@@ -166,10 +166,10 @@ describe("toModelMessages", () => {
     const result = toModelMessages([assistantMsg], model);
 
     expect(result).toHaveLength(1);
-    expect(result[0].role).toBe("assistant");
+    expect(result[0]?.role).toBe("assistant");
     // Reasoning must come first: Anthropic rejects assistant turns where a
     // thinking block follows other content.
-    expect(result[0].content).toEqual([
+    expect(result[0]?.content).toEqual([
       { type: "reasoning", text: "I should preserve this." },
       { type: "text", text: "Final answer" },
     ]);
@@ -246,10 +246,10 @@ describe("toModelMessages", () => {
 
     const result = toModelMessages([userMsg, assistantMsg], model);
     expect(result).toHaveLength(2);
-    expect(result[0].role).toBe("user");
-    expect(result[0].content).toBe("Hello");
-    expect(result[1].role).toBe("assistant");
-    expect(result[1].content).toBe("Response");
+    expect(result[0]?.role).toBe("user");
+    expect(result[0]?.content).toBe("Hello");
+    expect(result[1]?.role).toBe("assistant");
+    expect(result[1]?.content).toBe("Response");
   });
 
   test("calls ProviderTransform.normalizeMessages", () => {
@@ -287,8 +287,8 @@ describe("toModelMessages", () => {
 
     const result = toModelMessages([userMsg], model);
     expect(result).toHaveLength(1);
-    expect(result[0].role).toBe("user");
-    expect(result[0].content).toBe("Hello");
+    expect(result[0]?.role).toBe("user");
+    expect(result[0]?.content).toBe("Hello");
   });
 });
 

--- a/packages/llm/test/provider/integration.test.ts
+++ b/packages/llm/test/provider/integration.test.ts
@@ -3,9 +3,6 @@ import type { Auth } from "../../src/auth";
 import { getSDK, getLanguage } from "../../src/provider/sdk";
 import { Provider } from "../../src/provider";
 
-type ModelRef = { readonly modelId?: string };
-type ProviderRef = { readonly provider?: string };
-
 function makeAnthropicModel(id?: string): Provider.Model {
   return {
     id: id ?? "claude-sonnet-4-20250514",
@@ -36,11 +33,11 @@ describe("Provider Integration", () => {
     const sdk = getSDK(model, auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
-    const sdkLm = sdk.languageModel(model.id) as ModelRef;
+    const sdkLm = sdk.languageModel(model.id);
     expect(sdkLm).toBeDefined();
     expect(sdkLm.modelId).toBe(model.id);
 
-    const lm = getLanguage(model, auth) as ModelRef;
+    const lm = getLanguage(model, auth);
     expect(lm).toBeDefined();
     expect(lm.modelId).toBe(model.id);
   });
@@ -55,11 +52,11 @@ describe("Provider Integration", () => {
     const sdk = getSDK(model, auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
-    const sdkLm = sdk.languageModel(model.id) as ModelRef;
+    const sdkLm = sdk.languageModel(model.id);
     expect(sdkLm).toBeDefined();
     expect(sdkLm.modelId).toBe(model.id);
 
-    const lm = getLanguage(model, auth) as ModelRef;
+    const lm = getLanguage(model, auth);
     expect(lm).toBeDefined();
     expect(lm.modelId).toBe(model.id);
   });
@@ -72,7 +69,7 @@ describe("Provider Integration", () => {
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
 
-    const lm = sdk.languageModel("gpt-4o") as ModelRef;
+    const lm = sdk.languageModel("gpt-4o");
     expect(lm).toBeDefined();
     expect(lm.modelId).toBe("gpt-4o");
   });
@@ -154,7 +151,7 @@ describe("Provider Integration", () => {
     const sdk = getSDK(model, auth);
     expect(typeof sdk.languageModel).toBe("function");
 
-    const lm = getLanguage(model, auth) as ModelRef & ProviderRef;
+    const lm = getLanguage(model, auth);
     expect(lm.modelId).toBe("custom-model");
     expect(lm.provider).toBe("custom.responses");
   });

--- a/packages/llm/test/provider/openai.test.ts
+++ b/packages/llm/test/provider/openai.test.ts
@@ -5,7 +5,8 @@ import type { Auth } from "../../src/auth";
 
 const originalFetch = globalThis.fetch;
 
-type ModelRef = { readonly modelId?: string; readonly config?: { readonly provider?: string } };
+/** `config` is an OpenAI SDK detail, absent from the `LanguageModelV3` interface. */
+type OpenAIModelRef = { readonly config?: { readonly provider?: string } };
 
 function makeModel(overrides?: Partial<Provider.Model>): Provider.Model {
   return {
@@ -29,7 +30,7 @@ describe("getSDK (OpenAI)", () => {
     const sdk = getSDK(makeModel(), auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel("gpt-4o") as ModelRef;
+    const lm = sdk.languageModel("gpt-4o");
     expect(lm).toBeDefined();
     expect(lm.modelId).toBe("gpt-4o");
   });
@@ -42,7 +43,7 @@ describe("getSDK (OpenAI)", () => {
     const sdk = getSDK(makeModel(), auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel("gpt-4o") as ModelRef;
+    const lm = sdk.languageModel("gpt-4o");
     expect(lm).toBeDefined();
     expect(lm.modelId).toBe("gpt-4o");
   });
@@ -56,7 +57,7 @@ describe("getSDK (OpenAI)", () => {
     const sdk = getSDK(makeModel(), auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel("gpt-4o") as ModelRef;
+    const lm = sdk.languageModel("gpt-4o");
     expect(lm).toBeDefined();
     expect(lm.modelId).toBe("gpt-4o");
   });
@@ -67,9 +68,9 @@ describe("getSDK (OpenAI)", () => {
       baseURL: "http://localhost:8317/v1",
       apiKey: "proxy-key",
     };
-    const lm = getLanguage(makeModel({ id: "gpt-5.4" }), auth) as ModelRef;
+    const lm = getLanguage(makeModel({ id: "gpt-5.4" }), auth);
 
     expect(lm.modelId).toBe("gpt-5.4");
-    expect(lm.config?.provider).toBe("openai.chat");
+    expect((lm as OpenAIModelRef).config?.provider).toBe("openai.chat");
   });
 });

--- a/packages/llm/test/provider/proxy-models.test.ts
+++ b/packages/llm/test/provider/proxy-models.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "bun:test";
 import { enrichWithCatalog, fetchProxyModels } from "../../src/provider/proxy-models";
 import type { Provider } from "../../src/provider/index";
 
+type FetchArgs = Parameters<typeof fetch>;
+
 function stubFetch(
-  handler: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>,
+  handler: (input: FetchArgs[0], init?: FetchArgs[1]) => Response | Promise<Response>,
 ): { restore: () => void } {
   const original = globalThis.fetch;
-  globalThis.fetch = handler;
+  // The stub answers calls; it does not carry `fetch.preconnect`, and nothing
+  // under test reaches for it. A single assertion, so the call signature is
+  // still checked — `as unknown as` here would wave through any shape.
+  globalThis.fetch = handler as typeof fetch;
   return {
     restore: () => {
       globalThis.fetch = original;
@@ -20,7 +25,7 @@ describe("proxy-models", () => {
       let capturedHeaders: Headers | undefined;
 
       const stub = stubFetch((_input, init) => {
-        capturedHeaders = new Headers(init?.headers as HeadersInit);
+        capturedHeaders = new Headers(init?.headers);
         return new Response(JSON.stringify({ data: [{ id: "test-model" }] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -40,7 +45,7 @@ describe("proxy-models", () => {
       let capturedHeaders: Headers | undefined;
 
       const stub = stubFetch((_input, init) => {
-        capturedHeaders = new Headers(init?.headers as HeadersInit);
+        capturedHeaders = new Headers(init?.headers);
         return new Response(JSON.stringify({ data: [{ id: "test-model" }] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },

--- a/packages/llm/test/provider/transform.test.ts
+++ b/packages/llm/test/provider/transform.test.ts
@@ -41,8 +41,8 @@ describe("ProviderTransform.normalizeMessages", () => {
     ];
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
     expect(result).toHaveLength(1);
-    expect(result[0].role).toBe("user");
-    expect(result[0].content).toBe("hello");
+    expect(result[0]?.role).toBe("user");
+    expect(result[0]?.content).toBe("hello");
   });
 
   test("anthropic filters empty text parts from array content", () => {
@@ -57,7 +57,7 @@ describe("ProviderTransform.normalizeMessages", () => {
     ];
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
     expect(result).toHaveLength(1);
-    expect(result[0].content).toEqual([{ type: "text", text: "actual content" }]);
+    expect(result[0]?.content).toEqual([{ type: "text", text: "actual content" }]);
   });
 
   test("anthropic removes message when all array parts are empty", () => {
@@ -90,16 +90,10 @@ describe("ProviderTransform.normalizeMessages", () => {
     ];
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
     expect(result).toHaveLength(1);
-    const content = result[0].content;
-    expect(Array.isArray(content)).toBe(true);
-    if (!Array.isArray(content)) {
-      expect.unreachable("content should be an array");
-    }
+    const content = result[0]?.content;
+    if (!Array.isArray(content)) throw new TypeError("expected array content");
     const part = content[0];
-    expect(part.type).toBe("tool-call");
-    if (part.type !== "tool-call") {
-      expect.unreachable("content part should be a tool call");
-    }
+    if (part?.type !== "tool-call") throw new TypeError("expected a tool-call part");
     expect(part.toolCallId).toBe("call_with_dots_and_slashes");
   });
 
@@ -118,16 +112,10 @@ describe("ProviderTransform.normalizeMessages", () => {
       },
     ];
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
-    const content = result[0].content;
-    expect(Array.isArray(content)).toBe(true);
-    if (!Array.isArray(content)) {
-      expect.unreachable("content should be an array");
-    }
+    const content = result[0]?.content;
+    if (!Array.isArray(content)) throw new TypeError("expected array content");
     const part = content[0];
-    expect(part.type).toBe("tool-result");
-    if (part.type !== "tool-result") {
-      expect.unreachable("content part should be a tool result");
-    }
+    if (part?.type !== "tool-result") throw new TypeError("expected a tool-result part");
     expect(part.toolCallId).toBe("id_with_special_chars");
   });
 
@@ -150,8 +138,8 @@ describe("ProviderTransform.normalizeMessages", () => {
       },
     ];
     const result = ProviderTransform.normalizeMessages(msgs, nonClaudeAnthropicModel);
-    const part = (result[0].content as Array<Record<string, unknown>>)[0];
-    expect(part.toolCallId).toBe("call.with.dots");
+    const part = (result[0]?.content as Array<Record<string, unknown>>)[0];
+    expect(part?.toolCallId).toBe("call.with.dots");
   });
 
   test("preserves non-text parts like tool-call in anthropic filtering", () => {
@@ -171,13 +159,10 @@ describe("ProviderTransform.normalizeMessages", () => {
     ];
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
     expect(result).toHaveLength(1);
-    const content = result[0].content;
-    expect(Array.isArray(content)).toBe(true);
-    if (!Array.isArray(content)) {
-      expect.unreachable("content should be an array");
-    }
+    const content = result[0]?.content;
+    if (!Array.isArray(content)) throw new TypeError("expected array content");
     expect(content.length).toBe(1);
-    expect(content[0].type).toBe("tool-call");
+    expect(content[0]?.type).toBe("tool-call");
   });
 
   test("preserves non-empty reasoning parts while filtering empty reasoning parts", () => {
@@ -194,7 +179,7 @@ describe("ProviderTransform.normalizeMessages", () => {
     const result = ProviderTransform.normalizeMessages(msgs, anthropicModel);
 
     expect(result).toHaveLength(1);
-    expect(result[0].content).toEqual([{ type: "reasoning", text: "keep me" }]);
+    expect(result[0]?.content).toEqual([{ type: "reasoning", text: "keep me" }]);
   });
 
   test("accepts Provider.Model directly", () => {
@@ -210,8 +195,8 @@ describe("ProviderTransform.normalizeMessages", () => {
     ];
     const result = ProviderTransform.normalizeMessages(msgs, model);
     expect(result).toHaveLength(1);
-    expect(result[0].role).toBe("user");
-    expect(result[0].content).toBe("hello");
+    expect(result[0]?.role).toBe("user");
+    expect(result[0]?.content).toBe("hello");
   });
 });
 
@@ -275,7 +260,7 @@ describe("ProviderTransform.applyAnthropicCaching", () => {
 
   test("does not mutate original messages", () => {
     const msgs: ModelMessage[] = [{ role: "user", content: "hello" }];
-    const original = { ...msgs[0] };
+    const original = structuredClone(msgs[0]);
     ProviderTransform.applyAnthropicCaching(msgs);
     expect(msgs[0]).toEqual(original);
   });

--- a/packages/llm/test/retry/retry.test.ts
+++ b/packages/llm/test/retry/retry.test.ts
@@ -356,7 +356,6 @@ describe("Retry", () => {
 describe("Retry.decide ratelimit-reset parsing (#532 candidate 3)", () => {
   function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
     return new APIError({
-      name: "APIError",
       message: "rate limited",
       isRetryable: true,
       statusCode: 429,
@@ -400,7 +399,6 @@ describe("Retry.decide ratelimit-reset parsing (#532 candidate 3)", () => {
 describe("Retry.decide (#532 candidate 3)", () => {
   function apiError(headers?: Record<string, string>): InstanceType<typeof APIError> {
     return new APIError({
-      name: "APIError",
       message: "rate limited",
       isRetryable: true,
       statusCode: 429,
@@ -448,7 +446,6 @@ describe("Retry.decide (#532 candidate 3)", () => {
 describe("Retry.decide cap semantics for inferred resets", () => {
   function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
     return new APIError({
-      name: "APIError",
       message: "rate limited",
       isRetryable: true,
       statusCode: 429,

--- a/packages/llm/tsconfig.test.json
+++ b/packages/llm/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "lib": ["ES2022"]
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes the llm half of #614. `packages/llm/tsconfig.json` had `include: ["src"]`, so **none** of the 24 files under `test/` were ever type-checked. Turning it on surfaced 56 errors — and they were not all test-local.

## `getLanguage` returned a type it never produces

Declared `LanguageModel`, which in `ai@6.0.141` is `GlobalProviderModelId | LanguageModelV3 | LanguageModelV2` — the first being a bare gateway model id string. Every reachable factory returns `LanguageModelV3` (`@ai-sdk/openai` `languageModel`/`chat`/`responses`, `@ai-sdk/anthropic` `languageModel`), the one custom loader returns `sdk.responses(...)`, and the cache is written only from the resolver. Nothing returns a string.

The loose return type bought nothing and pushed `as ModelRef` casts onto callers that wanted `modelId`. Narrowed to a local `Exclude<LanguageModel, string>` — no new import from `@ai-sdk/provider` — applied to the cache, the custom-loader type, and both resolver signatures. Narrowing a return type is covariant, so no consumer can break; the only production consumer is `run.ts:88` → `streamText`.

The casts in `integration.test.ts` and three of the four in `openai.test.ts` are deleted with it. The survivor reaches for `config`, an OpenAI SDK detail genuinely absent from the interface, and is now named `OpenAIModelRef` for that.

## `expect.unreachable` does not narrow

Four assertions read `part.toolCallId` off an un-narrowed union, because

```ts
if (part.type !== "tool-call") { expect.unreachable("..."); }
```

does not terminate control flow as far as TypeScript is concerned — never-return analysis does not apply to a method call on `expect`. Replaced with throwing guards, which narrow and state the thing once rather than asserting it and then re-checking it.

## Three keys that rode along unread

`new APIError({ name: "APIError", ... })` — `name` is not in the options schema. It was *not* silently dropped: `NamedError` stores `data` verbatim, so it appeared in `.data` and `toObject()`. Nothing reads it, zod does not declare it, so it goes.

## Why a second tsconfig rather than a `lib` bump

13 dead-export pins use `Object.hasOwn` (ES2022). Raising `lib` in `tsconfig.json` would **not** have made llm stricter: `main` points at `src/index.ts`, so `agent` and `server` compile llm's sources into their own programs under their own `lib: ["ES2020"]`. An ES2022 builtin in llm's `src` would then pass llm's gate and fail in a consumer, reported against the wrong package — probed and confirmed. So `tsconfig.json` stays ES2020/`["src"]`, the test tree moves to `tsconfig.test.json` at ES2022, and `check-types` runs both. That is the shape `agent` (bench) and `session` (contract-test) already use.

## Verification

- **The gate bites.** Injecting `const _probe: number = "nope"` into a test file fails `check-types` with TS2322 at that line; at the merge base the same injection exits 0. Turbo does not cache past it (`$TURBO_DEFAULT$` covers `test/`), and CI runs `check-types` in its matrix.
- **Attribution is right.** `Object.hasOwn` in llm's `src` now fails as `@openomni/llm:check-types: src/provider/transform.ts(...) TS2550` — not as an agent or server error.
- **No test was weakened.** Every changed indexed read expects a concrete value, so `undefined` still fails, and each is preceded by a length assertion. The throwing guards were mutation-checked against the source (wrong part type, identity `sanitizeToolCallID`, in-place mutation in `applyAnthropicCaching`, non-array content) and all still go red. `{ ...msgs[0] }` → `structuredClone` is strictly stronger. No suppression comment exists anywhere in the package.
- `bun test` 3466 pass / 9 skip / 0 fail; llm alone 243 pass, unchanged from base.
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps` (+`--self-test`), `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, `build:dist` + `smoke:dist`, agent bench — all OK.

`packages/agent` (143 errors) is the other half and lands separately. protocol, openomni, session and server stay open in #614.