### PR TITLE
refactor(agent): one output channel, not two (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -103,7 +103,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | PR | title | status |
 |---|---|---|
 | [#610](https://github.com/INONONO66/openomni/pull/610) | delete the unimplemented second event channel | ✅ |
-| — | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | ⬜ |
+| [#621](https://github.com/INONONO66/openomni/pull/621) | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | 🟨 |
 | — | file layout + FSM; slop comments, duplicate helpers, the last `as unknown as`, `agentBaseForState` | ⬜ |
 | — | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | ⬜ |
 | — | dissolve `builtin/` per D5 | ⬜ |

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -8,8 +8,8 @@
 src/
 ├── index.ts                    # Public API
 ├── core/
-│   ├── chat-agent.ts           # ChatAgent.create() — provides run() / stream()
-│   ├── types.ts                # ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, AgentEvent, AgentBudget, TokenUsage, Sink
+│   ├── chat-agent.ts           # ChatAgent.create() — provides run()
+│   ├── types.ts                # ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, AgentBudget, TokenUsage, Sink
 │   ├── budget.ts               # createBudgetState / checkBudget / recordTurn / recordToolCall / recordTokenUsage
 │   ├── retry.ts                # DEFAULT_RETRY_POLICY, classifyRetryReason, shouldRetry, sleep
 │   ├── prompt-builder.ts       # System prompt composition helpers
@@ -54,7 +54,7 @@ const result = await agent.run({
 
 Also exported from `@openomni/agent`:
 
-- Types: `ChatAgentConfig`, `ChatAgentInput`, `AgentResult`, `AgentStep`, `AgentEvent`, `AgentBudget`, `TokenUsage`, `Sink`
+- Types: `ChatAgentConfig`, `ChatAgentInput`, `AgentResult`, `AgentStep`, `AgentBudget`, `TokenUsage`, `Sink`
 - Policy: `PolicyEngine`, `PolicyContext`, `PolicyFn`, `CanonicalPolicyRegistration`, `PolicyEngineRegistration`, `PolicyRegistration` (legacy compatibility), `PolicyEngineInstance`
 - Runtime: `McpClient`, `McpServerConfig`
 
@@ -97,12 +97,12 @@ run.lifecycle.pre → run.turn.pre → prompt.context.pre → tool.catalog.pre
 ## TURN LIFECYCLE (core/execution)
 
 ```
-runner.ts (entry) [AsyncGenerator<AgentEvent>]
+runner.ts (entry) → Promise<AgentResult>
   ├─ retry loop (maxAttempts)
   │   ├─ build PolicyEngine (config.middleware only)
   │   ├─ dispatchPoint(run.lifecycle.pre)       → allow (with effects) / deny
   │   └─ turn loop (while budget ok)
-  │       ├─ checkBudget → if exceeded, dispatchPoint(run.lifecycle.post) + yield complete
+  │       ├─ checkBudget → if exceeded, dispatchPoint(run.lifecycle.post) + return result
   │       ├─ dispatchPoint(run.turn.pre)        → budget warnings, idle-nudge
   │       ├─ dispatchPoint(prompt.context.pre)  → context/prompt enrichment
   │       ├─ dispatchPoint(tool.catalog.pre)    → filter/modify tools exposed to LLM
@@ -116,7 +116,7 @@ runner.ts (entry) [AsyncGenerator<AgentEvent>]
   │       ├─ outcome === "stop"?
   │       │    ├─ dispatchPoint(run.turn.post)  → allow (with continuation effects) / deny
   │       │    ├─ if continuation: dispatchPoint(run.completion.pre) → loop
-  │       │    └─ else: dispatchPoint(run.lifecycle.post) + yield complete
+  │       │    └─ else: dispatchPoint(run.lifecycle.post) + return result
   │       └─ outcome === "error"/"aborted"?
   │            └─ dispatchPoint(run.error.error) → retry (shouldRetry) or throw
 ```

--- a/packages/agent/src/core/chat-agent.ts
+++ b/packages/agent/src/core/chat-agent.ts
@@ -1,26 +1,16 @@
 import type { Sink } from "@openomni/protocol";
-import type { ChatAgentConfig, ChatAgentInput, AgentResult, AgentEvent } from "./types";
-import { streamAgent } from "./execution/runner";
+import type { ChatAgentConfig, ChatAgentInput, AgentResult } from "./types";
+import { runAgent } from "./execution/runner";
 
 export interface ChatAgentInstance {
   run(input: ChatAgentInput, sink?: Sink): Promise<AgentResult>;
-  stream(input: ChatAgentInput, sink?: Sink): AsyncIterable<AgentEvent>;
 }
 
 export namespace ChatAgent {
   export function create(config: ChatAgentConfig): ChatAgentInstance {
     return {
-      async run(input: ChatAgentInput, sink?: Sink): Promise<AgentResult> {
-        let result: AgentResult | undefined;
-        for await (const event of streamAgent(input, config, sink)) {
-          if (event.type === "complete") result = event.result;
-          if (event.type === "error" && !event.willRetry) throw event.error;
-        }
-        if (!result) throw new Error("Agent completed without result");
-        return result;
-      },
-      async *stream(input: ChatAgentInput, sink?: Sink): AsyncIterable<AgentEvent> {
-        yield* streamAgent(input, config, sink);
+      run(input: ChatAgentInput, sink?: Sink): Promise<AgentResult> {
+        return runAgent(input, config, sink);
       },
     };
   }

--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -2,10 +2,10 @@ import { PolicyDecision, type Run } from "@openomni/protocol";
 import { effectOf, PolicyEffectApplier } from "./policy-effects";
 import { publishBudgetTelemetry } from "../budget";
 import type { PolicyEngineInstance } from "../policy";
-import type { AgentEvent, ChatAgentConfig } from "../types";
+import type { AgentResult, ChatAgentConfig } from "../types";
 import {
-  createGuardCompleteEvent,
-  createRunCompleteEvent,
+  guardAbortedResult,
+  runResult,
   emitRunCompleted,
   publishDenyDiagnostic,
 } from "./run-events";
@@ -21,7 +21,7 @@ export async function dispatchPreRun(
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
   agentBase: AgentRunBase = agentBaseForState(state),
-): Promise<AgentEvent | null> {
+): Promise<AgentResult | null> {
   const preRunDecision = await engine.dispatchPoint(
     "run.lifecycle.pre",
     buildLifecyclePolicyContext(state, config, agentBase, {
@@ -32,7 +32,7 @@ export async function dispatchPreRun(
   );
 
   if (PolicyDecision.isBlocking(preRunDecision)) {
-    return createGuardCompleteEvent(state, { text: "", steps: [] });
+    return guardAbortedResult(state, { text: "", steps: [] });
   }
 
   PolicyEffectApplier.applyPromptMessageEffects(state, preRunDecision);
@@ -44,7 +44,7 @@ export async function dispatchBudgetCheck(
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
   agentBase: AgentRunBase = agentBaseForState(state),
-): Promise<AgentEvent | null> {
+): Promise<AgentResult | null> {
   // The single per-turn owner of budget telemetry: emit here (command) and act
   // on the returned status. The run.turn.pre budget builtins read the status
   // via the pure checkBudget query, so the event is not re-emitted per policy.
@@ -67,7 +67,7 @@ export async function dispatchBudgetCheck(
     publishDenyDiagnostic(config.events, "run.finish", postRunDecision, state, agentBase);
   }
   emitRunCompleted(config.events, state, agentBase, "max-steps");
-  return createRunCompleteEvent(state, { finishReason: "max-steps" });
+  return runResult(state, { finishReason: "max-steps" });
 }
 
 type ModelResponseFacts = {
@@ -80,13 +80,13 @@ export async function dispatchModelRequest(
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
   agentBase: AgentRunBase = agentBaseForState(state),
-): Promise<AgentEvent | null> {
+): Promise<AgentResult | null> {
   const decision = await engine.dispatchPoint(
     "connection.llm.pre",
     buildLifecyclePolicyContext(state, config, agentBase, { modelId: config.model.id }),
   );
 
-  if (PolicyDecision.isBlocking(decision)) return createGuardCompleteEvent(state);
+  if (PolicyDecision.isBlocking(decision)) return guardAbortedResult(state);
   PolicyEffectApplier.applyPromptMessageEffects(state, decision);
   return null;
 }
@@ -97,7 +97,7 @@ export async function dispatchModelResponse(
   config: ChatAgentConfig,
   response: ModelResponseFacts,
   agentBase: AgentRunBase,
-): Promise<AgentEvent | null> {
+): Promise<AgentResult | null> {
   const decision = await engine.dispatchPoint(
     "connection.llm.post",
     buildLifecyclePolicyContext(state, config, agentBase, {
@@ -124,12 +124,12 @@ export async function dispatchModelResponse(
         state,
         agentBase,
       );
-      return createGuardCompleteEvent(state);
+      return guardAbortedResult(state);
     }
     PolicyEffectApplier.applyPromptMessageEffects(state, decision);
     return null;
   }
-  if (effectOf(decision, "run.abort")) return createGuardCompleteEvent(state);
+  if (effectOf(decision, "run.abort")) return guardAbortedResult(state);
   // model.response is post-boundary: plain denies are diagnostics unless they carry run.abort.
   publishDenyDiagnostic(config.events, "model.response", decision, state, agentBase);
   return null;

--- a/packages/agent/src/core/execution/run-events.ts
+++ b/packages/agent/src/core/execution/run-events.ts
@@ -1,7 +1,7 @@
 import { AgentExecution, Operational, PolicyDecision } from "@openomni/protocol";
 import type { BusEvent, Policy, TraceContext } from "@openomni/protocol";
 import type { RetryReason } from "../retry";
-import type { AgentEvent, AgentStep, TokenUsage } from "../types";
+import type { AgentResult, AgentStep, TokenUsage } from "../types";
 import { getCompactionCount, type AgentRunBase, type RunState } from "./run-state";
 
 export function emitRunStarted(
@@ -195,14 +195,14 @@ export function publishDenyDiagnostic(
 }
 
 // merged from run-result.ts (250-LOC split refold: single-importer stage)
-export function createGuardCompleteEvent(
+export function guardAbortedResult(
   state: RunState,
   options?: { text?: string; steps?: AgentStep[]; finishReason?: "stop" | "stalled" },
-): AgentEvent {
-  return createRunCompleteEvent(state, { ...options, guardAborted: true });
+): AgentResult {
+  return runResult(state, { ...options, guardAborted: true });
 }
 
-export function createRunCompleteEvent(
+export function runResult(
   state: RunState,
   options?: {
     text?: string;
@@ -210,24 +210,13 @@ export function createRunCompleteEvent(
     finishReason?: "stop" | "stalled" | "max-steps";
     guardAborted?: boolean;
   },
-): AgentEvent {
+): AgentResult {
   return {
-    type: "complete",
-    result: {
-      text: options?.text ?? state.lastAssistantText,
-      steps: options?.steps ?? state.steps,
-      usage: state.totalUsage,
-      finishReason: options?.finishReason ?? "stop",
-      ...(options?.guardAborted !== undefined && { guardAborted: options.guardAborted }),
-      compactionCount: getCompactionCount(state),
-    },
-  };
-}
-
-export function createRunErrorEvent(error: Error, willRetry: boolean): AgentEvent {
-  return {
-    type: "error",
-    error,
-    willRetry,
+    text: options?.text ?? state.lastAssistantText,
+    steps: options?.steps ?? state.steps,
+    usage: state.totalUsage,
+    finishReason: options?.finishReason ?? "stop",
+    ...(options?.guardAborted !== undefined && { guardAborted: options.guardAborted }),
+    compactionCount: getCompactionCount(state),
   };
 }

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -1,5 +1,5 @@
 import type { RunInput } from "@openomni/llm";
-import type { Message, Policy, Sink, Tool, TraceContext } from "@openomni/protocol";
+import type { Message, Policy, Sink, TraceContext } from "@openomni/protocol";
 import {
   createBudgetState,
   recordTokenUsage,
@@ -73,19 +73,7 @@ export interface TurnArtifacts {
    */
   readonly turnAssistant: { message?: Message.WithParts };
   readonly turnUsage: TokenUsage;
-  readonly turnToolCalls: Array<{
-    toolCallId: string;
-    toolName: string;
-    args: Record<string, unknown>;
-  }>;
-  readonly turnToolResults: Array<{
-    toolCallId: string;
-    result: Tool.Result;
-  }>;
-  readonly toolPolicyDecisions: Array<{
-    readonly timing: Policy.Timing;
-    readonly decision: Policy.PolicyDecision;
-  }>;
+  readonly toolPolicyDecisions: Array<{ readonly decision: Policy.PolicyDecision }>;
 }
 
 export type BuildTurnResult =
@@ -98,7 +86,7 @@ export type BuildTurnResult =
  * sleeps on and retries or rethrows.
  */
 export type ErrorDecision =
-  | { action: "retry"; error: Error; errorMessage: string }
+  | { action: "retry"; errorMessage: string }
   | { action: "complete"; result: AgentResult; errorMessage: string }
   | { action: "throw"; error: Error; errorMessage: string };
 

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -7,7 +7,7 @@ import {
   recordTurn,
   type BudgetState,
 } from "../budget";
-import type { AgentEvent, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
+import type { AgentResult, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
 import type { DispatchContext } from "../policy";
 import { createUserMessage, createAssistantMessage } from "../message-factory";
 
@@ -89,30 +89,18 @@ export interface TurnArtifacts {
 }
 
 export type BuildTurnResult =
-  | {
-      type: "ready";
-      budgetReassuranceEvent?: Extract<AgentEvent, { type: "budget_reassurance" }>;
-      budgetWarningEvent?: Extract<AgentEvent, { type: "budget_warning" }>;
-      turn: TurnArtifacts;
-    }
-  | { type: "complete"; event: AgentEvent };
+  | { type: "ready"; turn: TurnArtifacts }
+  | { type: "complete"; result: AgentResult };
 
-export type TurnDecision =
-  | {
-      kind: "continue";
-      messages: Message.WithParts[];
-      continuationCount: number;
-      compactionCount: number;
-      turnIndex: number;
-    }
-  | { kind: "complete"; event: AgentEvent }
-  | { kind: "error"; error: unknown }
-  | { kind: "abort"; event: AgentEvent };
-
+/**
+ * What the run does after an attempt raised. `complete` carries the result a
+ * guard settled on; the other two carry the error, which the caller either
+ * sleeps on and retries or rethrows.
+ */
 export type ErrorDecision =
-  | ({ action: "retry"; errorMessage: string } & Extract<TurnDecision, { kind: "error" }>)
-  | ({ action: "complete"; errorMessage: string } & Extract<TurnDecision, { kind: "abort" }>)
-  | ({ action: "throw"; errorMessage: string } & Extract<TurnDecision, { kind: "error" }>);
+  | { action: "retry"; error: Error; errorMessage: string }
+  | { action: "complete"; result: AgentResult; errorMessage: string }
+  | { action: "throw"; error: Error; errorMessage: string };
 
 export function createRunState(input: ChatAgentInput & { traceContext: RunTrace }): RunState {
   const sessionId = input.traceContext.sessionId;

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -1,6 +1,6 @@
 import { ModelsDev, Provider, run as llmRun } from "@openomni/llm";
 import type { Sink } from "@openomni/protocol";
-import type { AgentEvent, ChatAgentConfig, ChatAgentInput } from "../types";
+import type { AgentResult, ChatAgentConfig, ChatAgentInput } from "../types";
 import * as Retry from "../retry";
 import { PolicyEngine, type PolicyEngineInstance } from "../policy";
 import { emitRunStarted, emitTurnStart } from "./run-events";
@@ -14,11 +14,19 @@ import {
 } from "./lifecycle-dispatch";
 import { createRunState, type AgentRunBase, type RunTrace } from "./run-state";
 
-export async function* streamAgent(
+/**
+ * Runs an agent to a result.
+ *
+ * One output channel. Streaming goes to `sink` as it happens; the record of
+ * what happened goes to `config.events`; this returns what the run decided.
+ * The `AgentEvent` generator that used to carry all three had no consumer
+ * outside this package's own tests.
+ */
+export async function runAgent(
   input: ChatAgentInput,
   config: ChatAgentConfig,
   sink?: Sink,
-): AsyncGenerator<AgentEvent> {
+): Promise<AgentResult> {
   const retryPolicy = Retry.DEFAULT_RETRY_POLICY;
   let attempt = 1;
   let lastError = "";
@@ -38,11 +46,8 @@ export async function* streamAgent(
   const state = createRunState({ ...input, traceContext: trace });
   const engine = buildPolicyEngine(config, agentBase);
 
-  const preRunEvent = await dispatchPreRun(state, engine, config, agentBase);
-  if (preRunEvent) {
-    yield preRunEvent;
-    return;
-  }
+  const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
+  if (preRunResult) return preRunResult;
 
   while (attempt <= retryPolicy.maxAttempts) {
     try {
@@ -52,11 +57,8 @@ export async function* streamAgent(
       const configuredToolChoice = resolveToolChoice(config);
 
       while (true) {
-        const budgetEvent = await dispatchBudgetCheck(state, engine, config, agentBase);
-        if (budgetEvent) {
-          yield budgetEvent;
-          return;
-        }
+        const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
+        if (budgetResult) return budgetResult;
 
         emitTurnStart(config.events, state, agentBase);
         const turnResult = await buildTurn(
@@ -69,21 +71,13 @@ export async function* streamAgent(
           agentBase,
           sink,
         );
-        if (turnResult.type === "complete") {
-          yield turnResult.event;
-          return;
-        }
-        if (turnResult.budgetReassuranceEvent) yield turnResult.budgetReassuranceEvent;
-        if (turnResult.budgetWarningEvent) yield turnResult.budgetWarningEvent;
+        if (turnResult.type === "complete") return turnResult.result;
 
         const runLlm = config.llm?.run ?? llmRun;
-        const modelRequestEvent = await dispatchModelRequest(state, engine, config, agentBase);
-        if (modelRequestEvent) {
-          yield modelRequestEvent;
-          return;
-        }
+        const modelRequestResult = await dispatchModelRequest(state, engine, config, agentBase);
+        if (modelRequestResult) return modelRequestResult;
         const outcome = await runLlm(turnResult.turn.runInput, turnResult.turn.trackingSink);
-        const modelResponseEvent = await dispatchModelResponse(
+        const modelResponseResult = await dispatchModelResponse(
           state,
           engine,
           config,
@@ -93,28 +87,22 @@ export async function* streamAgent(
           },
           agentBase,
         );
-        if (modelResponseEvent) {
-          yield modelResponseEvent;
-          return;
-        }
+        if (modelResponseResult) return modelResponseResult;
 
         if (outcome.type === "stop") {
-          const decision = yield* handleStop(state, config, engine, agentBase, turnResult.turn);
-          if (decision === "continue") continue;
-          return;
+          const stopOutcome = await handleStop(state, config, engine, agentBase, turnResult.turn);
+          if (stopOutcome !== "continue") return stopOutcome;
+          continue;
         }
 
         if (outcome.type === "continue") {
-          yield* handleContinue(config.events, state, agentBase, turnResult.turn.turnUsage);
+          handleContinue(config.events, state, agentBase, turnResult.turn.turnUsage);
           continue;
         }
 
         if (outcome.type === "compact") {
-          const compactDecision = await handleCompact(state, engine, config, agentBase);
-          if (compactDecision !== "continue") {
-            yield compactDecision;
-            return;
-          }
+          const compactOutcome = await handleCompact(state, engine, config, agentBase);
+          if (compactOutcome !== "continue") return compactOutcome;
           continue;
         }
 
@@ -125,7 +113,7 @@ export async function* streamAgent(
       }
     } catch (error) {
       if (!(error instanceof Error)) throw error;
-      const decision = yield* handleError(
+      const decision = await handleError(
         state,
         engine,
         config,
@@ -139,7 +127,7 @@ export async function* streamAgent(
         attempt += 1;
         continue;
       }
-      if (decision.action === "complete") return;
+      if (decision.action === "complete") return decision.result;
       throw decision.error;
     }
   }

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -199,7 +199,7 @@ export async function handleError(
       backoffMs,
     });
     await Retry.sleep(backoffMs, config.signal);
-    return { action: "retry", error: normalizedError, errorMessage: lastError };
+    return { action: "retry", errorMessage: lastError };
   }
 
   emitRunFailed(config.events, agentBase, lastError, {

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -3,11 +3,10 @@ import { type Message, Operational, PolicyDecision } from "@openomni/protocol";
 import { effectOf, PolicyEffectApplier } from "./policy-effects";
 import { createAssistantMessage } from "../message-factory";
 import * as Retry from "../retry";
-import type { AgentEvent, ChatAgentConfig, TokenUsage } from "../types";
+import type { AgentResult, ChatAgentConfig, TokenUsage } from "../types";
 import {
-  createGuardCompleteEvent,
-  createRunCompleteEvent,
-  createRunErrorEvent,
+  guardAbortedResult,
+  runResult,
   emitCompaction,
   emitErrorRetry,
   emitRunCompleted,
@@ -26,50 +25,30 @@ import {
   type AgentRunBase,
   type RunState,
   type TurnArtifacts,
-  type TurnDecision,
 } from "./run-state";
 import type { PolicyEngineInstance } from "../policy";
 
-export async function* handleStop(
+/** The run ends with this result, or it takes another turn. */
+export type StopOutcome = AgentResult | "continue";
+
+export async function handleStop(
   state: RunState,
   config: ChatAgentConfig,
   engine: PolicyEngineInstance,
   agentBase: AgentRunBase,
   turn: TurnArtifacts,
-): AsyncGenerator<AgentEvent, "complete" | "continue"> {
+): Promise<StopOutcome> {
   emitTurnComplete(config.events, state, agentBase, turn.turnUsage);
-
-  if (state.lastAssistantText) yield { type: "text_chunk", text: state.lastAssistantText };
-  for (const toolCall of turn.turnToolCalls) {
-    yield { type: "tool_call_start", ...toolCall };
-  }
-  for (const toolResult of turn.turnToolResults) {
-    yield { type: "tool_call_complete", ...toolResult };
-  }
-  for (const entry of turn.toolPolicyDecisions) {
-    yield {
-      type: "hook_verdict",
-      timing: entry.timing,
-      action: entry.decision.verdict,
-      reason: PolicyDecision.reason(entry.decision, undefined),
-    };
-  }
 
   const toolAbort = turn.toolPolicyDecisions.find(
     (entry) => PolicyDecision.isBlocking(entry.decision) && effectOf(entry.decision, "run.abort"),
   );
 
-  yield { type: "turn_complete", turnIndex: state.turnIndex, usage: turn.turnUsage };
-
   const step = { type: "text" as const, content: state.lastAssistantText };
   appendRunStep(state, step);
   if (config.onStepFinish) await config.onStepFinish(step);
 
-  if (toolAbort) {
-    const event = createRunCompleteEvent(state, { finishReason: "stop", guardAborted: true });
-    yield event;
-    return "complete";
-  }
+  if (toolAbort) return runResult(state, { finishReason: "stop", guardAborted: true });
 
   // #546: the turn's assistant output always enters history — tool and
   // reasoning parts included, regardless of continuation — and it enters
@@ -92,13 +71,6 @@ export async function* handleStop(
     }),
   );
 
-  yield {
-    type: "hook_verdict",
-    timing: "turn.finish",
-    action: postTurnDecision.verdict,
-    reason: PolicyDecision.reason(postTurnDecision, undefined),
-  };
-
   if (!PolicyDecision.isBlocking(postTurnDecision)) {
     try {
       PolicyEffectApplier.applyMessageReplacementEffect(state, postTurnDecision);
@@ -115,8 +87,7 @@ export async function* handleStop(
         state,
         agentBase,
       );
-      yield createGuardCompleteEvent(state);
-      return "complete";
+      return guardAbortedResult(state);
     }
   }
 
@@ -128,44 +99,35 @@ export async function* handleStop(
   if (!PolicyDecision.isBlocking(postTurnDecision) && continuationMessages.length > 0) {
     appendRunMessages(state, continuationMessages);
     const blocked = await applyPostCompaction(state, engine, config, agentBase, true);
-    if (blocked) {
-      yield blocked;
-      return "complete";
-    }
+    if (blocked) return blocked;
     advanceRunContinuation(state);
-    return flowDecision(continueDecision(state));
+    return "continue";
   }
 
   if (PolicyDecision.isBlocking(postTurnDecision)) {
     const reason = PolicyDecision.reason(postTurnDecision, "stop");
     if (effectOf(postTurnDecision, "run.abort")) {
-      const event = createRunCompleteEvent(state, {
+      return runResult(state, {
         finishReason: reason === "stalled" ? "stalled" : "stop",
         guardAborted: reason !== "stalled",
       });
-      yield event;
-      return flowDecision({ kind: "abort", event });
     }
     publishDenyDiagnostic(config.events, "turn.finish", postTurnDecision, state, agentBase);
   }
 
   await dispatchPostRunTransform(state, engine, config, agentBase);
   emitRunCompleted(config.events, state, agentBase, "stop");
-  const event = createRunCompleteEvent(state, { finishReason: "stop" });
-  yield event;
-  return flowDecision({ kind: "complete", event });
+  return runResult(state, { finishReason: "stop" });
 }
 
-export async function* handleContinue(
+export function handleContinue(
   events: BusEvent.Sink,
   state: RunState,
   agentBase: AgentRunBase,
   turnUsage: TokenUsage,
-): AsyncGenerator<AgentEvent, "continue"> {
+): void {
   emitTurnComplete(events, state, agentBase, turnUsage);
-  yield { type: "turn_complete", turnIndex: state.turnIndex, usage: turnUsage };
   advanceRunTurn(state);
-  return continueFlowDecision(continueDecision(state));
 }
 
 export async function handleCompact(
@@ -173,14 +135,14 @@ export async function handleCompact(
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
   agentBase: AgentRunBase,
-): Promise<"continue" | AgentEvent> {
+): Promise<StopOutcome> {
   const blocked = await applyPostCompaction(state, engine, config, agentBase, false);
   if (blocked) return blocked;
   advanceRunTurn(state);
-  return continueFlowDecision(continueDecision(state));
+  return "continue";
 }
 
-export async function* handleError(
+export async function handleError(
   state: RunState,
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
@@ -188,7 +150,7 @@ export async function* handleError(
   error: unknown,
   attempt: number,
   retryPolicy: Parameters<typeof Retry.shouldRetry>[0],
-): AsyncGenerator<AgentEvent, ErrorDecision> {
+): Promise<ErrorDecision> {
   const normalizedError = error instanceof Error ? error : new Error(String(error));
   const onErrorDecision = await engine.dispatchPoint(
     "run.error.error",
@@ -207,9 +169,11 @@ export async function* handleError(
 
   if (PolicyDecision.isBlocking(onErrorDecision)) {
     if (effectOf(onErrorDecision, "run.abort")) {
-      const event: AgentEvent = createGuardCompleteEvent(state);
-      yield event;
-      return { action: "complete", kind: "abort", event, errorMessage: normalizedError.message };
+      return {
+        action: "complete",
+        result: guardAbortedResult(state),
+        errorMessage: normalizedError.message,
+      };
     }
     publishDenyDiagnostic(config.events, "error", onErrorDecision, state, agentBase);
   }
@@ -234,9 +198,8 @@ export async function* handleError(
       reason: retryReason,
       backoffMs,
     });
-    yield createRunErrorEvent(normalizedError, true);
     await Retry.sleep(backoffMs, config.signal);
-    return { action: "retry", kind: "error", error: normalizedError, errorMessage: lastError };
+    return { action: "retry", error: normalizedError, errorMessage: lastError };
   }
 
   emitRunFailed(config.events, agentBase, lastError, {
@@ -244,8 +207,7 @@ export async function* handleError(
     attempt,
     maxAttempts: effectiveRetryPolicy.maxAttempts,
   });
-  yield createRunErrorEvent(normalizedError, false);
-  return { action: "throw", kind: "error", error: normalizedError, errorMessage: lastError };
+  return { action: "throw", error: normalizedError, errorMessage: lastError };
 }
 
 /**
@@ -275,24 +237,6 @@ function resolveTurnAssistant(
   return createAssistantMessage("", parentID, state.sessionId);
 }
 
-function continueDecision(state: RunState): Extract<TurnDecision, { kind: "continue" }> {
-  return {
-    kind: "continue",
-    messages: state.messages,
-    continuationCount: state.continuationCount,
-    compactionCount: state.compactionCount,
-    turnIndex: state.turnIndex,
-  };
-}
-
-function flowDecision(decision: Exclude<TurnDecision, { kind: "error" }>): "continue" | "complete" {
-  return decision.kind === "continue" ? "continue" : "complete";
-}
-
-function continueFlowDecision(decision: Extract<TurnDecision, { kind: "continue" }>): "continue" {
-  return decision.kind;
-}
-
 // merged from completion-policy.ts (250-LOC split refold: single-importer stage)
 async function dispatchPostRunTransform(
   state: RunState,
@@ -318,7 +262,7 @@ async function applyPostCompaction(
   config: ChatAgentConfig,
   agentBase: AgentRunBase,
   isCompletion: boolean,
-): Promise<AgentEvent | null> {
+): Promise<AgentResult | null> {
   const compactionDecision = await engine.dispatchPoint(
     "run.completion.pre",
     buildLifecyclePolicyContext(state, config, agentBase, {
@@ -338,7 +282,7 @@ async function applyPostCompaction(
       state,
       agentBase,
     );
-    return createGuardCompleteEvent(state, { finishReason: "stop" });
+    return guardAbortedResult(state, { finishReason: "stop" });
   }
 
   let messages: Message.WithParts[] | undefined;
@@ -357,7 +301,7 @@ async function applyPostCompaction(
       state,
       agentBase,
     );
-    return createGuardCompleteEvent(state, { finishReason: "stop" });
+    return guardAbortedResult(state, { finishReason: "stop" });
   }
   if (messages !== undefined) {
     const messagesBefore = applyCompactionMessages(state, messages);

--- a/packages/agent/src/core/execution/turn-prepare.ts
+++ b/packages/agent/src/core/execution/turn-prepare.ts
@@ -3,11 +3,11 @@ import { type Message, PolicyDecision } from "@openomni/protocol";
 import type { Policy, Sink, Tool } from "@openomni/protocol";
 import { describeBudgetRemaining, effectiveBudgetThresholds } from "../budget";
 import type { PolicyEngineInstance } from "../policy";
-import type { AgentEvent, ChatAgentConfig, TokenUsage } from "../types";
+import type { ChatAgentConfig, TokenUsage } from "../types";
 import { createToolExecutor } from "./tool-executor";
 import {
-  createGuardCompleteEvent,
-  createRunCompleteEvent,
+  guardAbortedResult,
+  runResult,
   emitBudgetReassurance,
   emitBudgetWarning,
 } from "./run-events";
@@ -94,13 +94,11 @@ export async function buildTurn(
     buildLifecyclePolicyContext(state, config, agentBase, { turnIndex: state.turnIndex }),
   );
 
-  let budgetReassuranceEvent: Extract<AgentEvent, { type: "budget_reassurance" }> | undefined;
-  let budgetWarningEvent: Extract<AgentEvent, { type: "budget_warning" }> | undefined;
   if (PolicyDecision.isBlocking(preTurnDecision)) {
     const reason = PolicyDecision.reason(preTurnDecision, "stop");
     return {
       type: "complete",
-      event: createRunCompleteEvent(state, {
+      result: runResult(state, {
         finishReason: reason === "stalled" ? "stalled" : "stop",
         guardAborted: reason !== "stalled",
       }),
@@ -117,7 +115,6 @@ export async function buildTurn(
       remaining,
       effectiveBudgetThresholds(config.budget).reassuranceThreshold,
     );
-    budgetReassuranceEvent = { type: "budget_reassurance", remaining };
   }
   if (preTurnDecision.reasonCodes.includes("budget_warning")) {
     const remaining = describeBudgetRemaining(state.budgetState, config.budget);
@@ -127,7 +124,6 @@ export async function buildTurn(
       remaining,
       effectiveBudgetThresholds(config.budget).warningThreshold,
     );
-    budgetWarningEvent = { type: "budget_warning", remaining };
   }
 
   recordRunTurn(state);
@@ -162,7 +158,7 @@ export async function buildTurn(
 
   const systemResult = await buildTurnSystemPrompt(state, config, engine, agentBase);
   if (systemResult.blocked) {
-    return { type: "complete", event: createGuardCompleteEvent(state) };
+    return { type: "complete", result: guardAbortedResult(state) };
   }
   const system = systemResult.system;
 
@@ -182,7 +178,7 @@ export async function buildTurn(
   );
 
   if (PolicyDecision.isBlocking(toolSelectionDecision)) {
-    return { type: "complete", event: createGuardCompleteEvent(state) };
+    return { type: "complete", result: guardAbortedResult(state) };
   }
   const selectedTools = PolicyEffectApplier.applyToolFilterEffects(allTools, toolSelectionDecision);
 
@@ -205,8 +201,6 @@ export async function buildTurn(
 
   return {
     type: "ready",
-    budgetReassuranceEvent,
-    budgetWarningEvent,
     turn: {
       runInput: {
         // llm reports through the same port the agent was handed.

--- a/packages/agent/src/core/execution/turn-prepare.ts
+++ b/packages/agent/src/core/execution/turn-prepare.ts
@@ -129,7 +129,7 @@ export async function buildTurn(
   recordRunTurn(state);
   if (config.signal?.aborted) throw new Error("aborted");
 
-  const toolPolicyDecisions: Array<{ timing: Policy.Timing; decision: Policy.PolicyDecision }> = [];
+  const toolPolicyDecisions: TurnArtifacts["toolPolicyDecisions"] = [];
   const toolMetadata = buildToolMetadataMap(config.tools);
   const hookedExecutor = config.toolExecutor
     ? createToolExecutor({
@@ -148,8 +148,8 @@ export async function buildTurn(
           elapsedMs: Date.now() - state.startTime,
           usage: state.totalUsage,
         }),
-        onDecision: (timing, decision) => {
-          toolPolicyDecisions.push({ timing, decision });
+        onDecision: (_timing, decision) => {
+          toolPolicyDecisions.push({ decision });
         },
         traceContext: trace,
         signal: config.signal,
@@ -187,17 +187,8 @@ export async function buildTurn(
     outputTokens: 0,
     totalTokens: 0,
   };
-  const turnToolCalls: TurnArtifacts["turnToolCalls"] = [];
-  const turnToolResults: TurnArtifacts["turnToolResults"] = [];
   const turnAssistant: TurnArtifacts["turnAssistant"] = {};
-  const trackingSink = createTrackingSink(
-    state,
-    sink,
-    turnUsage,
-    turnToolCalls,
-    turnToolResults,
-    turnAssistant,
-  );
+  const trackingSink = createTrackingSink(state, sink, turnUsage, turnAssistant);
 
   return {
     type: "ready",
@@ -221,8 +212,6 @@ export async function buildTurn(
       trackingSink,
       turnAssistant,
       turnUsage,
-      turnToolCalls,
-      turnToolResults,
       toolPolicyDecisions,
     },
   };
@@ -232,8 +221,6 @@ function createTrackingSink(
   state: RunState,
   sink: Sink | undefined,
   turnUsage: TokenUsage,
-  turnToolCalls: TurnArtifacts["turnToolCalls"],
-  turnToolResults: TurnArtifacts["turnToolResults"],
   turnAssistant: TurnArtifacts["turnAssistant"],
 ): Sink {
   let prevInputTokens = 0;
@@ -268,18 +255,8 @@ function createTrackingSink(
       if (text) setLastAssistantText(state, text);
       sink?.onMessage(message);
     },
-    onToolCall: (call) => {
-      turnToolCalls.push({
-        toolCallId: call.id,
-        toolName: call.tool,
-        args: call.input,
-      });
-      sink?.onToolCall(call);
-    },
-    onToolResult: (result) => {
-      turnToolResults.push({ toolCallId: result.toolCallId, result });
-      sink?.onToolResult(result);
-    },
+    onToolCall: (call) => sink?.onToolCall(call),
+    onToolResult: (result) => sink?.onToolResult(result),
     // #547 C3: the fact stream passes through untouched — the transcript
     // record family subscribes to facts, not boundary snapshots.
     onFact: (fact) => sink?.onFact?.(fact),

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -2,7 +2,6 @@ import type {
   AgentProfile,
   BusEvent,
   Model,
-  Policy,
   RuntimeResource,
   Sink,
   Token,
@@ -66,26 +65,5 @@ export interface AgentResult {
   compactionCount?: number;
   guardAborted?: boolean;
 }
-
-export type AgentEvent =
-  | { type: "text_chunk"; text: string }
-  | {
-      type: "tool_call_start";
-      toolCallId: string;
-      toolName: string;
-      args: Record<string, unknown>;
-    }
-  | { type: "tool_call_complete"; toolCallId: string; result: Tool.Result }
-  | { type: "turn_complete"; turnIndex: number; usage: TokenUsage }
-  | { type: "error"; error: Error; willRetry: boolean }
-  | { type: "complete"; result: AgentResult }
-  | { type: "budget_warning"; remaining: string }
-  | { type: "budget_reassurance"; remaining: string }
-  | {
-      type: "hook_verdict";
-      timing: Policy.Timing;
-      action: Policy.PolicyDecision["verdict"];
-      reason?: string;
-    };
 
 export type { Sink };

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,7 +6,6 @@ export type {
   ChatAgentInput,
   AgentResult,
   AgentStep,
-  AgentEvent,
   AgentBudget,
   TokenUsage,
   Sink,

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Message, Run, Sink, Tool } from "@openomni/protocol";
-import type { AgentEvent, AgentStep } from "../src/core/types";
+import type { AgentStep } from "../src/core/types";
 import {
   createStopOutcome,
   createMockLlmConfig,
@@ -84,11 +84,8 @@ describe("ChatAgent", () => {
     mockProviderFromModelsDevModel.mockClear();
   });
 
-  it("create() returns instance with run and stream methods", () => {
-    const agent = createAgent();
-
-    expect(typeof agent.run).toBe("function");
-    expect(typeof agent.stream).toBe("function");
+  it("create() returns an instance with a run method", () => {
+    expect(typeof createAgent().run).toBe("function");
   });
 
   it("run() returns finishReason stop when LLM stops", async () => {
@@ -394,12 +391,9 @@ it("does not retry missing toolExecutor configuration errors", async () => {
     ],
   });
 
-  const events: AgentEvent[] = [];
   let configurationError: unknown;
   try {
-    for await (const event of agent.stream(runInput([{ role: "user", content: "Use a tool" }]))) {
-      events.push(event);
-    }
+    await agent.run(runInput([{ role: "user", content: "Use a tool" }]));
   } catch (error) {
     if (!(error instanceof Error)) throw error;
     configurationError = error;
@@ -409,5 +403,4 @@ it("does not retry missing toolExecutor configuration errors", async () => {
   expect((configurationError as Error).message).toContain(
     "toolExecutor is required when tools are provided",
   );
-  expect(events.filter((event) => event.type === "error" && event.willRetry)).toHaveLength(0);
 });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { Message, Run, Sink, Tool } from "@openomni/protocol";
+import { AgentExecution, type Message, type Run, type Sink, type Tool } from "@openomni/protocol";
 import type { AgentStep } from "../src/core/types";
 import {
   createStopOutcome,
@@ -391,13 +391,25 @@ it("does not retry missing toolExecutor configuration errors", async () => {
     ],
   });
 
+  // The subject is the *absence* of retries, so it has to be observed, not
+  // inferred from the throw: a classified-and-retried config error throws the
+  // same message three backoffs later.
+  const retries: unknown[] = [];
+  const stop = Bus.observe((event, payload) => {
+    if (event.name === AgentExecution.ErrorRetry.name) retries.push(payload);
+  });
+
   let configurationError: unknown;
   try {
     await agent.run(runInput([{ role: "user", content: "Use a tool" }]));
   } catch (error) {
     if (!(error instanceof Error)) throw error;
     configurationError = error;
+  } finally {
+    stop();
   }
+
+  expect(retries).toHaveLength(0);
 
   expect(configurationError).toBeInstanceOf(Error);
   expect((configurationError as Error).message).toContain(

--- a/packages/agent/test/core/execution/execution-verdicts-model.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts-model.test.ts
@@ -30,8 +30,8 @@ describe("model execution deny verdicts", () => {
 
     const result = await dispatchModelRequest(makeState(), engine, makeConfig());
 
-    expect(result?.type).toBe("complete");
-    if (result?.type === "complete") expect(result.result.guardAborted).toBe(true);
+    expect(result).not.toBeNull();
+    expect(result?.guardAborted).toBe(true);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -61,8 +61,6 @@ function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtifacts {
     },
     turnAssistant: {},
     turnUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    turnToolCalls: [],
-    turnToolResults: [],
     toolPolicyDecisions: [],
     ...overrides,
   };
@@ -170,8 +168,12 @@ describe("execution helper deny verdicts", () => {
     expect(result.result.guardAborted).toBe(true);
   });
 
-  it("emits a hook verdict and completes normally for turn.finish deny", async () => {
+  it("records a diagnostic and completes normally for turn.finish deny", async () => {
     Bus.reset();
+    const diagnostics: unknown[] = [];
+    const unsubscribe = Bus.observe((event, payload) => {
+      if (event.name === Operational.Info.name) diagnostics.push(payload);
+    });
     const engine = PolicyEngine.create();
     engine.register({
       kind: "point",
@@ -184,19 +186,20 @@ describe("execution helper deny verdicts", () => {
     const state = makeState();
     state.lastAssistantText = "done";
 
-    const outcome = await handleStop(
-      state,
-      makeConfig(),
-      engine,
-      makeAgentBase(),
-      makeTurnArtifacts(),
-    );
+    let outcome: Awaited<ReturnType<typeof handleStop>>;
+    try {
+      outcome = await handleStop(state, makeConfig(), engine, makeAgentBase(), makeTurnArtifacts());
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
 
     // A plain deny at turn.finish is a diagnostic, not an abort: the run ends
     // normally and `guardAborted` stays unset.
     expect(outcome).not.toBe("continue");
     if (outcome === "continue") throw new Error("expected the run to end");
     expect(outcome.guardAborted).toBeUndefined();
+    expect(hasDenyDiagnostic(diagnostics, "turn.finish")).toBe(true);
   });
 
   it("records a diagnostic and fail-closes completion.prepare deny", async () => {

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
-import type { AgentEvent, ChatAgentConfig } from "../../../src/core/types";
+import type { AgentResult, ChatAgentConfig } from "../../../src/core/types";
 import { buildTurn } from "../../../src/core/execution/turn-prepare";
-import { streamAgent } from "../../../src/core/execution/runner";
+import { runAgent } from "../../../src/core/execution/runner";
 import {
   createRunState,
   type AgentRunBase,
@@ -68,16 +68,11 @@ function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtifacts {
   };
 }
 
-async function collectEvents(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
-  const events: AgentEvent[] = [];
-  for await (const event of gen) events.push(event);
-  return events;
-}
-
-function expectComplete(event: AgentEvent | null): Extract<AgentEvent, { type: "complete" }> {
-  expect(event).not.toBeNull();
-  expect(event?.type).toBe("complete");
-  return event as Extract<AgentEvent, { type: "complete" }>;
+/** A dispatcher that ends the run returns its result; one that lets it run returns null. */
+function expectComplete(result: AgentResult | null): AgentResult {
+  expect(result).not.toBeNull();
+  if (result === null) throw new Error("expected the dispatcher to end the run");
+  return result;
 }
 
 describe("execution helper deny verdicts", () => {
@@ -93,16 +88,14 @@ describe("execution helper deny verdicts", () => {
       ["sessionId, runId", { traceId: "trace-1" }],
       ["runId", { traceId: "trace-1", sessionId: "sess-1" }],
     ] as const) {
-      const stream = streamAgent(
+      const run = runAgent(
         {
           messages: [{ role: "user", content: "hello" }],
           ...(traceContext ? { traceContext } : {}),
         },
         makeConfig(),
       );
-      await expect(stream.next()).rejects.toThrow(
-        `agent run requires a trace context with ${missing}`,
-      );
+      await expect(run).rejects.toThrow(`agent run requires a trace context with ${missing}`);
     }
   });
   it("fail-closes run.start deny before execution", async () => {
@@ -119,8 +112,8 @@ describe("execution helper deny verdicts", () => {
 
     const complete = expectComplete(await dispatchPreRun(makeState(), engine, makeConfig()));
 
-    expect(complete.result.guardAborted).toBe(true);
-    expect(complete.result.finishReason).toBe("stop");
+    expect(complete.guardAborted).toBe(true);
+    expect(complete.finishReason).toBe("stop");
   });
 
   it("fail-closes turn.start deny before building a turn", async () => {
@@ -146,9 +139,8 @@ describe("execution helper deny verdicts", () => {
     );
 
     expect(result.type).toBe("complete");
-    if (result.type === "complete" && result.event.type === "complete") {
-      expect(result.event.result.guardAborted).toBe(true);
-    }
+    if (result.type !== "complete") throw new Error("expected the turn to end");
+    expect(result.result.guardAborted).toBe(true);
   });
 
   it("fail-closes resources.prepare deny before exposing tools", async () => {
@@ -174,9 +166,8 @@ describe("execution helper deny verdicts", () => {
     );
 
     expect(result.type).toBe("complete");
-    if (result.type === "complete" && result.event.type === "complete") {
-      expect(result.event.result.guardAborted).toBe(true);
-    }
+    if (result.type !== "complete") throw new Error("expected the turn to end");
+    expect(result.result.guardAborted).toBe(true);
   });
 
   it("emits a hook verdict and completes normally for turn.finish deny", async () => {
@@ -193,17 +184,19 @@ describe("execution helper deny verdicts", () => {
     const state = makeState();
     state.lastAssistantText = "done";
 
-    const events = await collectEvents(
-      handleStop(state, makeConfig(), engine, makeAgentBase(), makeTurnArtifacts()),
+    const outcome = await handleStop(
+      state,
+      makeConfig(),
+      engine,
+      makeAgentBase(),
+      makeTurnArtifacts(),
     );
-    const hook = events.find((event) => event.type === "hook_verdict");
-    const complete = events.find((event) => event.type === "complete") as
-      | Extract<AgentEvent, { type: "complete" }>
-      | undefined;
 
-    expect(hook).toMatchObject({ timing: "turn.finish", action: "deny", reason: "post-turn" });
-    expect(complete).toBeDefined();
-    expect(complete?.result.guardAborted).toBeUndefined();
+    // A plain deny at turn.finish is a diagnostic, not an abort: the run ends
+    // normally and `guardAborted` stays unset.
+    expect(outcome).not.toBe("continue");
+    if (outcome === "continue") throw new Error("expected the run to end");
+    expect(outcome.guardAborted).toBeUndefined();
   });
 
   it("records a diagnostic and fail-closes completion.prepare deny", async () => {
@@ -227,10 +220,8 @@ describe("execution helper deny verdicts", () => {
       await Promise.resolve();
 
       expect(result).not.toBe("continue");
-      if (result !== "continue") {
-        expect(result.type).toBe("complete");
-        if (result.type === "complete") expect(result.result.guardAborted).toBe(true);
-      }
+      if (result === "continue") throw new Error("expected the run to end");
+      expect(result.guardAborted).toBe(true);
       expect(hasDenyDiagnostic(diagnostics, "completion.prepare")).toBe(true);
     } finally {
       unsubscribe();

--- a/packages/agent/test/core/execution/lifecycle-audit-facts.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-audit-facts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { CanonicalPolicyRegistrationGeneric } from "@openomni/policy";
 import type { Message, Run } from "@openomni/protocol";
 import { PolicyDecision } from "@openomni/protocol";
-import { streamAgent } from "../../../src/core/execution/runner";
+import { runAgent } from "../../../src/core/execution/runner";
 import type { PolicyContext } from "../../../src/core/policy/types";
 import type { ChatAgentConfig } from "../../../src/core/types";
 import { createMockLlmConfig, mockProviderData, mockProviderModel } from "../../helpers/mock-llm";
@@ -73,12 +73,8 @@ describe("canonical lifecycle audit facts", () => {
     };
 
     // When
-    for await (const _event of streamAgent(
-      runInput([{ role: "user", content: "continue once" }]),
-      config,
-    )) {
-      // The lifecycle observer is the asserted output.
-    }
+    // The lifecycle observer is the asserted output.
+    await runAgent(runInput([{ role: "user", content: "continue once" }]), config);
 
     // Then
     expect(responseTokens).toEqual([3, 4]);

--- a/packages/agent/test/core/execution/lifecycle-budget.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-budget.test.ts
@@ -66,7 +66,6 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
     const result = await dispatchBudgetCheck(state, engine, config, makeAgentBase());
 
     expect(result).not.toBeNull();
-    expect(result?.type).toBe("complete");
     expect(observedOutcomes).toEqual([{ type: "max-steps" }]);
   });
 

--- a/packages/agent/test/core/execution/lifecycle-completion.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-completion.test.ts
@@ -68,10 +68,8 @@ describe("completion.prepare dispatch", () => {
     const result = await handleCompact(makeState(), engine, makeConfig(), makeAgentBase());
 
     expect(result).not.toBe("continue");
-    if (result !== "continue") {
-      expect(result.type).toBe("complete");
-      if (result.type === "complete") expect(result.result.guardAborted).toBe(true);
-    }
+    if (result === "continue") throw new Error("expected the run to end");
+    expect(result.guardAborted).toBe(true);
   });
 
   it("completion.prepare continue verdict leaves state messages unchanged", async () => {

--- a/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
+++ b/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, ChatAgentConfig } from "../../../src/core/types";
+import type { ChatAgentConfig } from "../../../src/core/types";
 import {
   createRunState,
   type AgentRunBase,
@@ -57,12 +57,4 @@ export function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtif
     toolPolicyDecisions: [],
     ...overrides,
   };
-}
-
-export async function collectEvents(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
-  const events: AgentEvent[] = [];
-  for await (const event of gen) {
-    events.push(event);
-  }
-  return events;
 }

--- a/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
+++ b/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
@@ -52,8 +52,6 @@ export function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtif
     },
     turnAssistant: {},
     turnUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    turnToolCalls: [],
-    turnToolResults: [],
     toolPolicyDecisions: [],
     ...overrides,
   };

--- a/packages/agent/test/core/execution/lifecycle-error.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-error.test.ts
@@ -3,10 +3,9 @@ import { AgentExecution, Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
-import type { AgentEvent } from "../../../src/core/types";
 import { abortRun, allow } from "../../helpers/policy-decision";
 import { handleError } from "../../../src/core/execution/turn-outcome";
-import { collectEvents, makeAgentBase, makeConfig, makeState } from "./lifecycle-dispatch-fixture";
+import { makeAgentBase, makeConfig, makeState } from "./lifecycle-dispatch-fixture";
 
 describe("handleError (error)", () => {
   it("dispatches error and respects abort verdict", async () => {
@@ -30,26 +29,24 @@ describe("handleError (error)", () => {
       backoffMs: { initial: 0, multiplier: 1, max: 0 },
     };
 
-    const gen = handleError(state, engine, config, makeAgentBase(), error, 1, retryPolicy);
-    let result: IteratorResult<AgentEvent, unknown>;
-    const events: AgentEvent[] = [];
-    do {
-      result = await gen.next();
-      if (!result.done && result.value) events.push(result.value as AgentEvent);
-    } while (!result.done);
+    const decision = await handleError(
+      state,
+      engine,
+      config,
+      makeAgentBase(),
+      error,
+      1,
+      retryPolicy,
+    );
 
     expect(fn).toHaveBeenCalledTimes(1);
     const ctx = fn.mock.calls[0]?.[0] as PolicyContext;
     expect(ctx.timing).toBe("error");
     expect(ctx.toolInput?.error).toMatchObject({ name: "Error", message: error.message });
 
-    const decision = result.value as { action: string };
     expect(decision.action).toBe("complete");
-    const completeEvent = events.find((e) => e.type === "complete") as
-      | Extract<AgentEvent, { type: "complete" }>
-      | undefined;
-    expect(completeEvent).toBeDefined();
-    expect(completeEvent?.result.guardAborted).toBe(true);
+    if (decision.action !== "complete") throw new Error("expected a settled result");
+    expect(decision.result.guardAborted).toBe(true);
   });
 
   it("error continue verdict allows retry when retry policy permits", async () => {
@@ -72,13 +69,15 @@ describe("handleError (error)", () => {
       backoffMs: { initial: 0, multiplier: 1, max: 0 },
     };
 
-    const gen = handleError(state, engine, config, makeAgentBase(), error, 1, retryPolicy);
-    let result: IteratorResult<AgentEvent, unknown>;
-    do {
-      result = await gen.next();
-    } while (!result.done);
-
-    const decision = result.value as { action: string };
+    const decision = await handleError(
+      state,
+      engine,
+      config,
+      makeAgentBase(),
+      error,
+      1,
+      retryPolicy,
+    );
     expect(decision.action).toBe("retry");
   });
 
@@ -103,7 +102,7 @@ describe("handleError (error)", () => {
     };
 
     const started = Date.now();
-    const gen = handleError(
+    const decision = await handleError(
       state,
       engine,
       config,
@@ -112,12 +111,8 @@ describe("handleError (error)", () => {
       1,
       retryPolicy,
     );
-    let result: IteratorResult<AgentEvent, unknown>;
-    do {
-      result = await gen.next();
-    } while (!result.done);
 
-    expect((result.value as { action: string }).action).toBe("retry");
+    expect(decision.action).toBe("retry");
     expect(Date.now() - started).toBeGreaterThanOrEqual(15);
   });
 
@@ -146,18 +141,17 @@ describe("handleError (error)", () => {
     };
 
     const started = Date.now();
-    const gen = handleError(
-      state,
-      engine,
-      config,
-      makeAgentBase(),
-      new Error("timeout while waiting"),
-      1,
-      retryPolicy,
-    );
-    await gen.next();
-
-    await expect(gen.next()).rejects.toThrow("aborted");
+    await expect(
+      handleError(
+        state,
+        engine,
+        config,
+        makeAgentBase(),
+        new Error("timeout while waiting"),
+        1,
+        retryPolicy,
+      ),
+    ).rejects.toThrow("aborted");
     expect(Date.now() - started).toBeLessThan(500);
   });
 
@@ -183,20 +177,17 @@ describe("handleError (error)", () => {
       backoffMs: { initial: 0, multiplier: 1, max: 0 },
     };
 
-    const events = await collectEvents(
-      handleError(
-        state,
-        engine,
-        config,
-        makeAgentBase(),
-        new Error("timeout while waiting"),
-        2,
-        retryPolicy,
-      ),
+    const decision = await handleError(
+      state,
+      engine,
+      config,
+      makeAgentBase(),
+      new Error("timeout while waiting"),
+      2,
+      retryPolicy,
     );
 
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ type: "error", willRetry: false });
+    expect(decision.action).toBe("throw");
   });
 
   /**
@@ -214,18 +205,16 @@ describe("handleError (error)", () => {
     const agentBase = makeAgentBase();
 
     try {
-      await collectEvents(
-        handleError(
-          makeState(),
-          engine,
-          makeConfig(),
-          agentBase,
-          new Error("connection timeout"),
-          1,
-          // Non-zero: an assertion of `0` also holds when the field is
-          // hardcoded to 0, which is what the first version of this test did.
-          { maxAttempts: 3, backoffMs: { initial: 50, multiplier: 2, max: 1000 } },
-        ),
+      await handleError(
+        makeState(),
+        engine,
+        makeConfig(),
+        agentBase,
+        new Error("connection timeout"),
+        1,
+        // Non-zero: an assertion of `0` also holds when the field is
+        // hardcoded to 0, which is what the first version of this test did.
+        { maxAttempts: 3, backoffMs: { initial: 50, multiplier: 2, max: 1000 } },
       );
       await Bun.sleep(0);
     } finally {
@@ -272,18 +261,16 @@ describe("handleError (error)", () => {
     const agentBase = makeAgentBase();
 
     try {
-      await collectEvents(
-        handleError(
-          makeState(),
-          engine,
-          makeConfig(),
-          agentBase,
-          new Error("schema validation failed"),
-          // Not 1: `attempt` is a pass-through, and asserting it at its input
-          // value of 1 also holds when the field is hardcoded to 1.
-          2,
-          { maxAttempts: 5, backoffMs: { initial: 0, multiplier: 1, max: 0 } },
-        ),
+      await handleError(
+        makeState(),
+        engine,
+        makeConfig(),
+        agentBase,
+        new Error("schema validation failed"),
+        // Not 1: `attempt` is a pass-through, and asserting it at its input
+        // value of 1 also holds when the field is hardcoded to 1.
+        2,
+        { maxAttempts: 5, backoffMs: { initial: 0, multiplier: 1, max: 0 } },
       );
       await Bun.sleep(0);
     } finally {
@@ -325,16 +312,14 @@ describe("handleError (error)", () => {
     });
 
     try {
-      await collectEvents(
-        handleError(
-          makeState(),
-          engine,
-          makeConfig(),
-          makeAgentBase(),
-          new Error("connection timeout"),
-          1,
-          { maxAttempts: 5, backoffMs: { initial: 0, multiplier: 1, max: 0 } },
-        ),
+      await handleError(
+        makeState(),
+        engine,
+        makeConfig(),
+        makeAgentBase(),
+        new Error("connection timeout"),
+        1,
+        { maxAttempts: 5, backoffMs: { initial: 0, multiplier: 1, max: 0 } },
       );
       await Bun.sleep(0);
     } finally {

--- a/packages/agent/test/core/execution/lifecycle-model.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-model.test.ts
@@ -136,7 +136,7 @@ describe("model dispatch points", () => {
       makeAgentBase(),
     );
 
-    expect(result?.type).toBe("complete");
-    if (result?.type === "complete") expect(result.result.guardAborted).toBe(true);
+    expect(result).not.toBeNull();
+    expect(result?.guardAborted).toBe(true);
   });
 });

--- a/packages/agent/test/core/execution/lifecycle-run-start.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-run-start.test.ts
@@ -3,7 +3,6 @@ import type { Message } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
-import type { AgentEvent } from "../../../src/core/types";
 import { abortRun, allow, appendContext, inject } from "../../helpers/policy-decision";
 import { dispatchPreRun } from "../../../src/core/execution/lifecycle-dispatch";
 import { makeConfig, makeState } from "./lifecycle-dispatch-fixture";
@@ -47,10 +46,8 @@ describe("dispatchPreRun (run.start)", () => {
     const result = await dispatchPreRun(state, engine, makeConfig());
 
     expect(result).not.toBeNull();
-    expect(result?.type).toBe("complete");
-    const complete = result as Extract<AgentEvent, { type: "complete" }>;
-    expect(complete.result.guardAborted).toBe(true);
-    expect(complete.result.finishReason).toBe("stop");
+    expect(result?.guardAborted).toBe(true);
+    expect(result?.finishReason).toBe("stop");
   });
 
   it("injects user message when run.start policy returns inject", async () => {

--- a/packages/agent/test/core/execution/lifecycle-stop.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-stop.test.ts
@@ -2,11 +2,9 @@ import { describe, expect, it, mock } from "bun:test";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { CanonicalPolicyRegistration } from "../../../src/core/policy/types";
-import type { AgentEvent } from "../../../src/core/types";
 import { abortRun, allow, inject, replaceMessages } from "../../helpers/policy-decision";
 import { handleStop } from "../../../src/core/execution/turn-outcome";
 import {
-  collectEvents,
   makeAgentBase,
   makeConfig,
   makeState,
@@ -35,7 +33,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
     const config = makeConfig();
     const turn = makeTurnArtifacts();
 
-    const events = await collectEvents(handleStop(state, config, engine, makeAgentBase(), turn));
+    const outcome = await handleStop(state, config, engine, makeAgentBase(), turn);
 
     expect(fn).toHaveBeenCalledTimes(1);
     const ctx = fn.mock.calls[0]?.[0];
@@ -43,31 +41,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
     expect(ctx?.timing).toBe("turn.finish");
     expect(ctx?.isCompletion).toBe(true);
 
-    const completeEvent = events.find((e) => e.type === "complete");
-    expect(completeEvent).toBeDefined();
-  });
-
-  it("emits actual tool policy decision timings", async () => {
-    Bus.reset();
-    const engine = PolicyEngine.create();
-    const state = makeState();
-    state.lastAssistantText = "response text";
-    const turn = makeTurnArtifacts({
-      toolPolicyDecisions: [
-        { timing: "invoke.prepare", decision: allow("test.pre", "pre") },
-        { timing: "invoke.result", decision: allow("test.post", "post") },
-      ],
-    });
-
-    const events = await collectEvents(
-      handleStop(state, makeConfig(), engine, makeAgentBase(), turn),
-    );
-
-    expect(
-      events
-        .filter((event) => event.type === "hook_verdict")
-        .map((event) => (event as Extract<AgentEvent, { type: "hook_verdict" }>).timing),
-    ).toEqual(["invoke.prepare", "invoke.result", "turn.finish"]);
+    expect(outcome).not.toBe("continue");
   });
 
   it("turn.finish inject verdict causes continuation", async () => {
@@ -87,15 +61,9 @@ describe("handleStop (turn.finish + run.finish)", () => {
     const config = makeConfig();
     const turn = makeTurnArtifacts();
 
-    const gen = handleStop(state, config, engine, makeAgentBase(), turn);
-    let result: IteratorResult<AgentEvent, "complete" | "continue">;
-    const events: AgentEvent[] = [];
-    do {
-      result = await gen.next();
-      if (!result.done && result.value) events.push(result.value);
-    } while (!result.done);
+    const outcome = await handleStop(state, config, engine, makeAgentBase(), turn);
 
-    expect(result.value).toBe("continue");
+    expect(outcome).toBe("continue");
     expect(state.messages.length).toBeGreaterThan(1);
     expect(state.continuationCount).toBe(1);
   });
@@ -116,11 +84,15 @@ describe("handleStop (turn.finish + run.finish)", () => {
 
     const state = makeState();
     state.lastAssistantText = "text";
-    const events = await collectEvents(
-      handleStop(state, makeConfig(), engine, makeAgentBase(), makeTurnArtifacts()),
+    const outcome = await handleStop(
+      state,
+      makeConfig(),
+      engine,
+      makeAgentBase(),
+      makeTurnArtifacts(),
     );
 
-    expect(events.some((event) => event.type === "complete")).toBe(true);
+    expect(outcome).not.toBe("continue");
     expect(state.messages).toEqual(replacement);
   });
 
@@ -141,13 +113,9 @@ describe("handleStop (turn.finish + run.finish)", () => {
     const config = makeConfig();
     const turn = makeTurnArtifacts();
 
-    const events = await collectEvents(handleStop(state, config, engine, makeAgentBase(), turn));
-    const completeEvent = events.find((e) => e.type === "complete") as
-      | Extract<AgentEvent, { type: "complete" }>
-      | undefined;
-
-    expect(completeEvent).toBeDefined();
-    expect(completeEvent?.result.guardAborted).toBe(true);
+    const outcome = await handleStop(state, config, engine, makeAgentBase(), turn);
+    if (outcome === "continue") throw new Error("expected the run to end");
+    expect(outcome.guardAborted).toBe(true);
   });
 
   it("turn.finish abort with reason 'stalled' sets finishReason to stalled", async () => {
@@ -167,14 +135,10 @@ describe("handleStop (turn.finish + run.finish)", () => {
     const config = makeConfig();
     const turn = makeTurnArtifacts();
 
-    const events = await collectEvents(handleStop(state, config, engine, makeAgentBase(), turn));
-    const completeEvent = events.find((e) => e.type === "complete") as
-      | Extract<AgentEvent, { type: "complete" }>
-      | undefined;
-
-    expect(completeEvent).toBeDefined();
-    expect(completeEvent?.result.finishReason).toBe("stalled");
-    expect(completeEvent?.result.guardAborted).toBeFalsy();
+    const outcome = await handleStop(state, config, engine, makeAgentBase(), turn);
+    if (outcome === "continue") throw new Error("expected the run to end");
+    expect(outcome.finishReason).toBe("stalled");
+    expect(outcome.guardAborted).toBeFalsy();
   });
 
   it("dispatches run.finish without modifying final text", async () => {
@@ -194,12 +158,8 @@ describe("handleStop (turn.finish + run.finish)", () => {
     const config = makeConfig();
     const turn = makeTurnArtifacts();
 
-    const events = await collectEvents(handleStop(state, config, engine, makeAgentBase(), turn));
-    const completeEvent = events.find((e) => e.type === "complete") as
-      | Extract<AgentEvent, { type: "complete" }>
-      | undefined;
-
-    expect(completeEvent).toBeDefined();
-    expect(completeEvent?.result.text).toBe("original");
+    const outcome = await handleStop(state, config, engine, makeAgentBase(), turn);
+    if (outcome === "continue") throw new Error("expected the run to end");
+    expect(outcome.text).toBe("original");
   });
 });

--- a/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
@@ -67,10 +67,6 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     );
 
     expect(result.type).toBe("ready");
-    if (result.type === "ready") {
-      expect(result.budgetReassuranceEvent?.type).toBe("budget_reassurance");
-      expect(result.budgetWarningEvent).toBeUndefined();
-    }
   });
 
   it("buildTurn emits budget_warning event when reasonCodes includes budget_warning", async () => {
@@ -99,10 +95,6 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     );
 
     expect(result.type).toBe("ready");
-    if (result.type === "ready") {
-      expect(result.budgetWarningEvent?.type).toBe("budget_warning");
-      expect(result.budgetReassuranceEvent).toBeUndefined();
-    }
   });
 
   it("buildTurn does not emit budget events for unrelated inject messages", async () => {
@@ -134,10 +126,6 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     );
 
     expect(result.type).toBe("ready");
-    if (result.type === "ready") {
-      expect(result.budgetReassuranceEvent).toBeUndefined();
-      expect(result.budgetWarningEvent).toBeUndefined();
-    }
   });
 
   it("returns complete when turn.start policy returns abort", async () => {
@@ -164,9 +152,6 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     );
 
     expect(result.type).toBe("complete");
-    if (result.type === "complete") {
-      expect(result.event.type).toBe("complete");
-    }
   });
 
   it("appends turn.start context as a user message", async () => {

--- a/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, it, mock } from "bun:test";
 import { testProviderModel } from "../../helpers/provider-model";
 import type { CanonicalAuditDispatchContextGeneric } from "@openomni/policy";
-import type { RuntimeResource, Tool } from "@openomni/protocol";
+import { AgentExecution, type RuntimeResource, type Tool } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
 import { abortRun, allow, appendContext } from "../../helpers/policy-decision";
 import { buildTurn } from "../../../src/core/execution/turn-prepare";
 import { makeAgentBase, makeConfig, makeState, makeTrace } from "./lifecycle-dispatch-fixture";
+
+/**
+ * Budget nagging leaves on the events port, which is the only channel that
+ * carries it since #621. Pinned by name: the `AgentEvent` these tests used to
+ * read was built on the line beside the emit, so asserting on it never proved
+ * the emit happened.
+ */
+function collectBudgetNames(): { readonly names: string[]; readonly stop: () => void } {
+  const names: string[] = [];
+  const stop = Bus.observe((event) => {
+    if (
+      event.name === AgentExecution.BudgetReassurance.name ||
+      event.name === AgentExecution.BudgetWarning.name
+    ) {
+      names.push(event.name);
+    }
+  });
+  return { names, stop };
+}
 
 describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
   it("dispatches turn.start and returns ready on continue", async () => {
@@ -41,8 +60,9 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     expect(ctx.timing).toBe("turn.start");
   });
 
-  it("buildTurn emits budget_reassurance event when reasonCodes includes budget_reassurance", async () => {
+  it("buildTurn publishes budget reassurance when the verdict carries that reason code", async () => {
     Bus.reset();
+    const budget = collectBudgetNames();
     const engine = PolicyEngine.create();
     engine.register({
       kind: "point",
@@ -66,11 +86,15 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
       makeAgentBase(),
     );
 
+    budget.stop();
+
     expect(result.type).toBe("ready");
+    expect(budget.names).toEqual([AgentExecution.BudgetReassurance.name]);
   });
 
-  it("buildTurn emits budget_warning event when reasonCodes includes budget_warning", async () => {
+  it("buildTurn publishes a budget warning when the verdict carries that reason code", async () => {
     Bus.reset();
+    const budget = collectBudgetNames();
     const engine = PolicyEngine.create();
     engine.register({
       kind: "point",
@@ -94,11 +118,15 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
       makeAgentBase(),
     );
 
+    budget.stop();
+
     expect(result.type).toBe("ready");
+    expect(budget.names).toEqual([AgentExecution.BudgetWarning.name]);
   });
 
-  it("buildTurn does not emit budget events for unrelated inject messages", async () => {
+  it("buildTurn publishes no budget event for an unrelated inject message", async () => {
     Bus.reset();
+    const budget = collectBudgetNames();
     const engine = PolicyEngine.create();
     engine.register({
       kind: "point",
@@ -125,7 +153,10 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
       makeAgentBase(),
     );
 
+    budget.stop();
+
     expect(result.type).toBe("ready");
+    expect(budget.names).toEqual([]);
   });
 
   it("returns complete when turn.start policy returns abort", async () => {

--- a/packages/agent/test/core/execution/tool-selection.test.ts
+++ b/packages/agent/test/core/execution/tool-selection.test.ts
@@ -168,9 +168,8 @@ describe("resources.prepare dispatch", () => {
 
     expect(result.type).toBe("complete");
     if (result.type !== "complete") return;
-    expect(result.event).toMatchObject({
-      type: "complete",
-      result: { guardAborted: true },
+    expect(result.result).toMatchObject({
+      guardAborted: true,
     });
   });
 

--- a/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
@@ -37,8 +37,6 @@ function makeTurnArtifacts(): TurnArtifacts {
     },
     turnAssistant: {},
     turnUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-    turnToolCalls: [],
-    turnToolResults: [],
     toolPolicyDecisions: [],
   };
 }

--- a/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import type { AgentEvent } from "../../../src/core/types";
 import { PolicyEngine } from "../../../src/core/policy";
 import { handleStop } from "../../../src/core/execution/turn-outcome";
 import {
@@ -44,14 +43,6 @@ function makeTurnArtifacts(): TurnArtifacts {
   };
 }
 
-async function collectEvents(
-  gen: AsyncGenerator<AgentEvent, "complete" | "continue">,
-): Promise<AgentEvent[]> {
-  const events: AgentEvent[] = [];
-  for await (const event of gen) events.push(event);
-  return events;
-}
-
 describe("handleStop prompt injection provenance", () => {
   it("preserves assistant role through turn.finish continuation", async () => {
     const engine = PolicyEngine.create();
@@ -73,17 +64,15 @@ describe("handleStop prompt injection provenance", () => {
     const state = createRunState(runInput([{ role: "user", content: "parent request" }]));
     state.lastAssistantText = "partial response";
 
-    const events = await collectEvents(
-      handleStop(
-        state,
-        { events: Bus, model: { provider: "test", id: "test-model" } },
-        engine,
-        makeAgentBase(),
-        makeTurnArtifacts(),
-      ),
+    const outcome = await handleStop(
+      state,
+      { events: Bus, model: { provider: "test", id: "test-model" } },
+      engine,
+      makeAgentBase(),
+      makeTurnArtifacts(),
     );
 
-    expect(events.some((event) => event.type === "turn_complete")).toBe(true);
+    expect(outcome).toBe("continue");
     expect(state.continuationCount).toBe(1);
     expect(state.messages.at(-1)?.info).toMatchObject({
       role: "assistant",

--- a/packages/agent/test/core/policy/canonical-execution.test.ts
+++ b/packages/agent/test/core/policy/canonical-execution.test.ts
@@ -5,7 +5,7 @@ import { Operational, PolicyDecision } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { createToolExecutor } from "../../../src/core/execution/tool-executor";
 import { buildPolicyEngine } from "../../../src/core/execution/runner";
-import { streamAgent } from "../../../src/core/execution/runner";
+import { runAgent } from "../../../src/core/execution/runner";
 import {
   createBudgetReassurancePolicy,
   createBudgetWarningPolicy,
@@ -14,7 +14,7 @@ import {
   createToolPermissionPolicy,
 } from "../../../src/core/policy/builtin";
 import type { PolicyContext } from "../../../src/core/policy/types";
-import type { AgentEvent, ChatAgentConfig } from "../../../src/core/types";
+import type { ChatAgentConfig } from "../../../src/core/types";
 import {
   createMockLlmConfig,
   createStopOutcome,
@@ -127,13 +127,10 @@ describe("canonical ChatAgent policy execution", () => {
     };
 
     // When
-    const events: AgentEvent[] = [];
-    for await (const event of streamAgent(runInput([{ role: "user", content: "hi" }]), config)) {
-      events.push(event);
-    }
+    const result = await runAgent(runInput([{ role: "user", content: "hi" }]), config);
 
     // Then
-    expect(events.some((event) => event.type === "complete")).toBe(true);
+    expect(result.finishReason).toBe("stop");
     expect(seen.map((entry) => entry.pointId)).toEqual([...pointIds]);
     expect(new Set(seen.map((entry) => entry.sessionId)).size).toBe(1);
     expect(new Set(seen.map((entry) => entry.runId)).size).toBe(1);

--- a/packages/agent/test/core/policy/run-gate.test.ts
+++ b/packages/agent/test/core/policy/run-gate.test.ts
@@ -1,11 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Sink } from "@openomni/protocol";
-import type {
-  AgentEvent,
-  AgentResult,
-  ChatAgentConfig,
-  ChatAgentInput,
-} from "../../../src/core/types";
+import type { AgentResult, ChatAgentConfig, ChatAgentInput } from "../../../src/core/types";
 import type { PolicyContext } from "../../../src/core/policy";
 import {
   createStopOutcome,
@@ -33,10 +28,10 @@ const mockLlm = createMockLlmConfig({
   },
 });
 
-let streamAgent: typeof import("../../../src/core/execution/runner").streamAgent;
+let runAgent: typeof import("../../../src/core/execution/runner").runAgent;
 
 beforeAll(async () => {
-  ({ streamAgent } = await import("../../../src/core/execution/runner"));
+  ({ runAgent } = await import("../../../src/core/execution/runner"));
 });
 
 const defaultConfig: ChatAgentConfig = {
@@ -47,20 +42,11 @@ const defaultConfig: ChatAgentConfig = {
 
 const defaultInput: ChatAgentInput = runInput([{ role: "user", content: "hello" }]);
 
-async function collectEvents(
+function runWith(
   config: ChatAgentConfig,
   input: ChatAgentInput = defaultInput,
-): Promise<AgentEvent[]> {
-  const events: AgentEvent[] = [];
-  for await (const event of streamAgent(input, config)) {
-    events.push(event);
-  }
-  return events;
-}
-
-function getResult(events: AgentEvent[]): AgentResult | undefined {
-  const ev = events.find((e) => e.type === "complete");
-  return ev ? (ev as Extract<AgentEvent, { type: "complete" }>).result : undefined;
+): Promise<AgentResult> {
+  return runAgent(input, config);
 }
 
 beforeEach(() => {
@@ -76,7 +62,7 @@ describe("run.start middleware dispatch", () => {
       return allow();
     });
 
-    await collectEvents({
+    await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -99,7 +85,7 @@ describe("run.start middleware dispatch", () => {
   });
 
   it("abort → guardAborted: true and no LLM turn", async () => {
-    const events = await collectEvents({
+    const result = await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -113,17 +99,15 @@ describe("run.start middleware dispatch", () => {
       ],
     });
 
-    const result = getResult(events);
-    expect(result).toBeDefined();
-    expect(result?.guardAborted).toBe(true);
-    expect(result?.steps).toHaveLength(0);
+    expect(result.guardAborted).toBe(true);
+    expect(result.steps).toHaveLength(0);
     expect(callOrder).not.toContain("llm_turn");
   });
 
   it("inject → injected message appears in context passed to first LLM turn", async () => {
     const injectedContent = "injected-pre-run-context";
 
-    await collectEvents({
+    await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -152,7 +136,7 @@ describe("run.finish middleware dispatch", () => {
   it("fires after normal completion with result context", async () => {
     const postRunFn = mock((_ctx: PolicyContext) => allow());
 
-    await collectEvents({
+    await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -176,7 +160,7 @@ describe("run.finish middleware dispatch", () => {
   it("reports an honest max-steps outcome after budget exceeded", async () => {
     const postRunFn = mock((_ctx: PolicyContext) => allow());
 
-    const events = await collectEvents({
+    const result = await runWith({
       ...defaultConfig,
       budget: { maxTurns: 0 },
       middleware: [
@@ -191,8 +175,7 @@ describe("run.finish middleware dispatch", () => {
       ],
     });
 
-    const result = getResult(events);
-    expect(result?.finishReason).toBe("max-steps");
+    expect(result.finishReason).toBe("max-steps");
     expect(postRunFn).toHaveBeenCalledTimes(1);
     expect(Reflect.get(postRunFn.mock.calls[0]?.[0] ?? {}, "runOutcome")).toEqual({
       type: "max-steps",
@@ -202,7 +185,7 @@ describe("run.finish middleware dispatch", () => {
   it("does NOT fire after turn.start abort", async () => {
     const postRunFn = mock((_ctx: PolicyContext) => allow());
 
-    await collectEvents({
+    await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -230,7 +213,7 @@ describe("run.finish middleware dispatch", () => {
   it("does NOT fire after turn.finish abort", async () => {
     const postRunFn = mock((_ctx: PolicyContext) => allow());
 
-    await collectEvents({
+    await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -256,7 +239,7 @@ describe("run.finish middleware dispatch", () => {
   });
 
   it("run.finish allow leaves AgentResult.text unchanged", async () => {
-    const events = await collectEvents({
+    const result = await runWith({
       ...defaultConfig,
       middleware: [
         {
@@ -270,7 +253,6 @@ describe("run.finish middleware dispatch", () => {
       ],
     });
 
-    const result = getResult(events);
-    expect(result?.text).toBe("");
+    expect(result.text).toBe("");
   });
 });

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -1,6 +1,5 @@
 import { beforeAll, describe, expect, it, mock } from "bun:test";
-import type { Sink } from "@openomni/protocol";
-import type { AgentEvent } from "../../src/core/types";
+import type { Sink, Tool } from "@openomni/protocol";
 import {
   createStopOutcome,
   createMockLlmConfig,
@@ -33,19 +32,36 @@ const defaultConfig = {
 
 const defaultInput = runInput([{ role: "user" as const, content: "hello" }]);
 
-async function collectEvents(
-  agent: ReturnType<typeof ChatAgent.create>,
-  input = defaultInput,
-): Promise<AgentEvent[]> {
-  const events: AgentEvent[] = [];
-  for await (const event of agent.stream(input)) {
-    events.push(event);
-  }
-  return events;
+/**
+ * The caller's view of a run in progress. Since #610 this is the only one: the
+ * `AgentEvent` generator that used to narrate the same facts had no consumer
+ * outside these tests, so what a caller can observe is exactly what reaches
+ * the sink it passed plus the result it is returned.
+ */
+function collectingSink(): Sink & {
+  readonly texts: string[];
+  readonly toolCalls: Tool.Call[];
+  readonly toolResults: Tool.Result[];
+} {
+  const texts: string[] = [];
+  const toolCalls: Tool.Call[] = [];
+  const toolResults: Tool.Result[] = [];
+  return {
+    texts,
+    toolCalls,
+    toolResults,
+    onMessage: (message) => {
+      for (const part of message.parts) {
+        if (part.type === "text") texts.push(part.text);
+      }
+    },
+    onToolCall: (call) => toolCalls.push(call),
+    onToolResult: (result) => toolResults.push(result),
+  };
 }
 
-describe("ChatAgent.stream()", () => {
-  it("yields text_chunk and complete events for simple response", async () => {
+describe("ChatAgent.run() streaming", () => {
+  it("streams assistant text to the sink and returns the result", async () => {
     mockRunFn = async (_input, sink) => {
       sink.onMessage({
         info: {
@@ -79,22 +95,15 @@ describe("ChatAgent.stream()", () => {
       return createStopOutcome();
     };
 
-    const agent = ChatAgent.create(defaultConfig);
-    const events = await collectEvents(agent);
+    const sink = collectingSink();
+    const result = await ChatAgent.create(defaultConfig).run(defaultInput, sink);
 
-    const types = events.map((e) => e.type);
-    expect(types).toContain("text_chunk");
-    expect(types).toContain("turn_complete");
-    expect(types).toContain("complete");
-
-    const completeEvent = events.find((e) => e.type === "complete");
-    expect(completeEvent).toBeDefined();
-    if (completeEvent?.type === "complete") {
-      expect(completeEvent.result.finishReason).toBe("stop");
-    }
+    expect(sink.texts).toEqual(["Hello world"]);
+    expect(result.finishReason).toBe("stop");
+    expect(result.text).toBe("Hello world");
   });
 
-  it("yields tool_call_start and tool_call_complete events", async () => {
+  it("streams tool calls and their results to the sink", async () => {
     mockRunFn = async (input, sink) => {
       const call = { id: "call-1", tool: "test_tool", input: { q: "test" } };
       if (input.toolExecutor) {
@@ -144,62 +153,11 @@ describe("ChatAgent.stream()", () => {
       }),
     });
 
-    const events = await collectEvents(agent);
-    const types = events.map((e) => e.type);
+    const sink = collectingSink();
+    const result = await agent.run(defaultInput, sink);
 
-    expect(types).toContain("tool_call_start");
-    expect(types).toContain("tool_call_complete");
-    expect(types).toContain("complete");
-
-    const startEvent = events.find((e) => e.type === "tool_call_start");
-    if (startEvent?.type === "tool_call_start") {
-      expect(startEvent.toolName).toBe("test_tool");
-    }
-  });
-
-  it("stream() and run() produce same finishReason", async () => {
-    mockRunFn = async (_input, sink) => {
-      sink.onMessage({
-        info: {
-          id: "msg-3",
-          sessionID: "test",
-          role: "assistant",
-          time: { created: Date.now() },
-          parentID: "",
-          modelID: "claude-3-haiku-20240307",
-          providerID: "anthropic",
-          agent: "test",
-          path: { cwd: "", root: "" },
-          cost: 0,
-          tokens: {
-            input: 5,
-            output: 3,
-            reasoning: 0,
-            cache: { read: 0, write: 0 },
-          },
-        },
-        parts: [
-          {
-            id: "p3",
-            sessionID: "test",
-            messageID: "msg-3",
-            type: "text",
-            text: "Result",
-          },
-        ],
-      });
-      return createStopOutcome();
-    };
-
-    const agent = ChatAgent.create(defaultConfig);
-
-    const runResult = await agent.run(defaultInput);
-    const events = await collectEvents(agent);
-    const completeEvent = events.find((e) => e.type === "complete");
-
-    expect(runResult.finishReason).toBe("stop");
-    if (completeEvent?.type === "complete") {
-      expect(completeEvent.result.finishReason).toBe("stop");
-    }
+    expect(sink.toolCalls.map((call) => call.tool)).toEqual(["test_tool"]);
+    expect(sink.toolResults.map((r) => r.output)).toEqual(["tool result"]);
+    expect(result.finishReason).toBe("stop");
   });
 });

--- a/packages/agent/test/core/streaming.test.ts
+++ b/packages/agent/test/core/streaming.test.ts
@@ -33,10 +33,10 @@ const defaultConfig = {
 const defaultInput = runInput([{ role: "user" as const, content: "hello" }]);
 
 /**
- * The caller's view of a run in progress. Since #610 this is the only one: the
- * `AgentEvent` generator that used to narrate the same facts had no consumer
- * outside these tests, so what a caller can observe is exactly what reaches
- * the sink it passed plus the result it is returned.
+ * The caller's view of a run in progress, and since #621 the only one: the
+ * `AgentEvent` generator that narrated the same facts had no consumer outside
+ * these tests. What a caller can observe is exactly what reaches the sink it
+ * passed, plus the result it is returned.
  */
 function collectingSink(): Sink & {
   readonly texts: string[];

--- a/packages/agent/test/core/tool-permission-integration.test.ts
+++ b/packages/agent/test/core/tool-permission-integration.test.ts
@@ -458,18 +458,18 @@ describe("tool permission integration via toolExecutor", () => {
       ],
     });
 
-    const events = [] as Array<{ type: string; result?: Tool.Result }>;
-    for await (const event of agent.stream(runInput([{ role: "user", content: "stream" }]))) {
-      if (event.type === "tool_call_complete") {
-        events.push({ type: event.type, result: event.result });
-      } else {
-        events.push({ type: event.type });
-      }
-    }
+    // The denial reaches the caller on the sink it passed — the channel a
+    // caller actually has — not on a second one narrating the same fact.
+    const toolResults: Tool.Result[] = [];
+    await agent.run(runInput([{ role: "user", content: "stream" }]), {
+      onMessage: () => undefined,
+      onToolCall: () => undefined,
+      onToolResult: (result) => toolResults.push(result),
+    });
 
-    const toolResultEvent = events.find((event) => event.type === "tool_call_complete");
     expect(executor).toHaveBeenCalledTimes(0);
-    expect(toolResultEvent?.result?.isError).toBe(true);
-    expect(String(toolResultEvent?.result?.output)).toContain("input_rule_deny");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0]?.isError).toBe(true);
+    expect(String(toolResults[0]?.output)).toContain("input_rule_deny");
   });
 });

--- a/packages/protocol/src/sink/index.ts
+++ b/packages/protocol/src/sink/index.ts
@@ -10,7 +10,7 @@ export interface Sink {
    * emits no callback for an unmatched tool-result, #532-6, and settles
    * interruptions as error results), while the fact stream records those
    * anomalies as raw part lifecycle. The agent's trackingSink builds its
-   * public tool_call_start/tool_call_complete AgentEvents from these
+   * caller-visible tool call and result notifications from these
    * correlated pairs; deriving them from facts would change the anomaly-path
    * event stream.
    */


### PR DESCRIPTION
Phase 2, first slice. Implements **D3**.

`ChatAgent` exposed a `stream()` returning `AsyncIterable<AgentEvent>`, and every internal step was written as a generator to feed it. **Nothing outside this package's own tests ever consumed it.** Both real consumers already declare `run`-only structurally:

- `apps/server/src/execution/worker-runner-types.ts:19` — `Pick<ReturnType<typeof ChatAgent.create>, "run">`
- `packages/openomni/src/execution-runtime/child-agent/types.ts:79` — `Pick<ChatAgentInstance, "run">`

## Everything it narrated was already carried

| event | already carried by |
|---|---|
| `text_chunk`, `tool_call_start`, `tool_call_complete` | the caller's `Sink`, live |
| `turn_complete` | `emitTurnComplete` → `config.events` |
| `budget_warning`, `budget_reassurance` | `emitBudgetWarning` / `emitBudgetReassurance` — called on the lines that built the events |
| `hook_verdict` | nothing. It narrated every verdict including allows, to nobody; denies that matter go out as diagnostics |
| `complete`, `error` | the only two carrying a decision — both expressible as a return |

## The shape

`streamAgent` → `runAgent`, returning `AgentResult`. Every `yield event; return;` becomes `return result`.

- `handleStop` and `handleCompact` return `AgentResult | "continue"`.
- `handleContinue` has nothing left to yield — synchronous, returns `void`.
- `handleError` returns its `ErrorDecision` directly.
- `BuildTurnResult` loses its two budget-event fields; its `complete` arm carries a `result`.
- `ErrorDecision` stops piggybacking on `TurnDecision` via `Extract<>`, and `TurnDecision` — which existed to be collapsed back into a string by three one-line helpers — is deleted with them.
- The four lifecycle dispatchers return `AgentResult | null`.
- `createRunCompleteEvent`/`createGuardCompleteEvent` → `runResult`/`guardAbortedResult`; `createRunErrorEvent` deleted.

**`TurnArtifacts.turnToolCalls` and `turnToolResults` are deleted too.** D3's own rationale row says they "exist only to re-broadcast what the Sink already forwarded live" — their only readers were the yields this PR removes, leaving them write-only. `toolPolicyDecisions[].timing` goes with them (its surviving reader uses `decision` alone), as does the `error` on `ErrorDecision`'s retry variant.

Net **−302 lines**.

## Tests

Two are deleted rather than rewritten, because the deleted channel *was* their subject: one asserted the ordering of `hook_verdict` yields, the other that `stream()` and `run()` report the same `finishReason`.

Two more had to be **repaired, not just rewritten** — deleting the channel took their only grip on a real property, because they asserted the `AgentEvent` built on the line beside the emit:

- **Budget nagging.** Three `lifecycle-turn-pre` tests were left with one assertion each, identical across all three and unrelated to their names. They now collect `AgentExecution.BudgetReassurance` / `BudgetWarning` off the events port, negative case included. Red-first: renaming both reason codes takes the file to 2 fail.
- **Not retrying.** `agent.test.ts`'s "does not retry missing toolExecutor configuration errors" lost the assertion carrying its subject. It now counts `AgentExecution.ErrorRetry`. Red-first: moving `assertToolExecutor` inside the retry loop — a three-second regression — was invisible and now fails.

The turn.finish deny test also gained the diagnostic assertion that carries what its `hook_verdict` line used to; that path was previously ungated on both sides of the diff. Red-first: deleting the `publishDenyDiagnostic` call fails it.

The rest are rewritten against what survives — `streaming.test.ts` and the tool-permission stream case now assert on the `Sink` the caller passes, which is what a caller can actually observe.

## Docs

`packages/agent/AGENTS.md` described `stream()`, `AgentEvent`, and an `AsyncGenerator` entry point; `packages/protocol/src/sink/index.ts` named the deleted type in a comment. Both corrected. `docs/agent-core-rewrite.md` marks D3's row.

## Verification

- `bun test` **3464 pass / 9 skip / 0 fail** (3466 at base, −2 = the two deleted tests); agent alone 412 pass / 8 skip / 0 fail.
- `check-types` 14/14 including the test tree, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK.

Left for the next slice, per the plan: `agentBaseForState` (a default parameter production never takes), the file layout + FSM, and the `packages/policy` `eventEmitter` carve-out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Replaced the agent’s streaming execution method with `ChatAgent.run()`.
  - Removed the public `AgentEvent` type.
- **New Features**
  - `run()` now returns a complete `AgentResult` directly, including text, usage, finish reason, and abort status.
  - Tool calls and results remain available through caller-provided sinks.
  - Lifecycle and policy outcomes are reported directly, including guard-aborted and budget-related results.
- **Documentation**
  - Updated agent and sink API documentation to reflect the new execution and notification model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->