### PR TITLE
refactor(policy): drop the event-emitter carve-out (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -105,7 +105,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#610](https://github.com/INONONO66/openomni/pull/610) | delete the unimplemented second event channel | ✅ |
 | [#621](https://github.com/INONONO66/openomni/pull/621) | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | 🟨 |
 | — | file layout + FSM; slop comments, duplicate helpers, the last `as unknown as`, `agentBaseForState` | ⬜ |
-| — | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | ⬜ |
+| [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | — | dissolve `builtin/` per D5 | ⬜ |
 | — | retry no longer double-counts the turn budget | ⬜ |
 

--- a/packages/policy/src/engine/context.ts
+++ b/packages/policy/src/engine/context.ts
@@ -23,9 +23,7 @@ type ImmutablePointSnapshot<TValue extends object> =
  *     `structuredClone` ever sees it (only nested proxies are rejected);
  *   - symbol-keyed properties, silently dropped rather than rejected;
  *   - a nested class instance, cloned into a plain record.
- *
- * The one deliberate exception is the caller's event emitter, carried through
- * by reference.
+
  *
  * `added` is applied after the clone, so the engine's own fields — the point
  * identity and the agent type that drove registration selection — are the ones
@@ -50,17 +48,8 @@ export function immutablePointSnapshot(
   try {
     if (!isPlainRecord(value)) return { success: false };
     const source = { ...value } as Record<string, unknown>;
-    const eventEmitter = source.eventEmitter;
-    const preservesEventEmitter =
-      Object.getOwnPropertyDescriptor(source, "eventEmitter") !== undefined &&
-      isEventEmitterLike(eventEmitter);
-    if (preservesEventEmitter) delete source.eventEmitter;
-    const snapshot = {
-      ...structuredClone(source),
-      ...added,
-      ...(preservesEventEmitter && { eventEmitter }),
-    };
-    if (!freezePlainValue(snapshot, new WeakSet(), eventEmitter)) return { success: false };
+    const snapshot = { ...structuredClone(source), ...added };
+    if (!freezePlainValue(snapshot, new WeakSet())) return { success: false };
     return { success: true, value: snapshot };
   } catch {
     return { success: false };
@@ -127,12 +116,7 @@ function capturePerField(present: Readonly<Record<string, unknown>>): Record<str
   return fields;
 }
 
-function freezePlainValue(
-  value: unknown,
-  ancestors: WeakSet<object>,
-  preservedValue?: unknown,
-): boolean {
-  if (value === preservedValue) return true;
+function freezePlainValue(value: unknown, ancestors: WeakSet<object>): boolean {
   if (typeof value === "function" || typeof value === "symbol") return false;
   if (typeof value !== "object" || value === null) return true;
   if (ancestors.has(value)) return false;
@@ -140,17 +124,11 @@ function freezePlainValue(
 
   ancestors.add(value);
   for (const child of Object.values(value)) {
-    if (!freezePlainValue(child, ancestors, preservedValue)) return false;
+    if (!freezePlainValue(child, ancestors)) return false;
   }
   ancestors.delete(value);
   Object.freeze(value);
   return true;
-}
-
-function isEventEmitterLike(value: unknown): value is object {
-  return (
-    typeof value === "object" && value !== null && typeof Reflect.get(value, "emit") === "function"
-  );
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/policy/src/engine/context.ts
+++ b/packages/policy/src/engine/context.ts
@@ -23,7 +23,6 @@ type ImmutablePointSnapshot<TValue extends object> =
  *     `structuredClone` ever sees it (only nested proxies are rejected);
  *   - symbol-keyed properties, silently dropped rather than rejected;
  *   - a nested class instance, cloned into a plain record.
-
  *
  * `added` is applied after the clone, so the engine's own fields — the point
  * identity and the agent type that drove registration selection — are the ones

--- a/packages/policy/test/point-context-immutability.test.ts
+++ b/packages/policy/test/point-context-immutability.test.ts
@@ -75,6 +75,10 @@ describe("PolicyEngine canonical point context immutability", () => {
     { name: "Proxy", value: new Proxy({ value: "uncloneable" }, {}) },
     { name: "cyclic record", value: cyclic },
     { name: "non-plain object", value: new Date(0) },
+    // An object carrying a method is the shape an event emitter has. The
+    // engine used to hand one through by reference — a live object inside a
+    // frozen snapshot — for a caller that stopped existing at #610.
+    { name: "event emitter", value: { emit: () => undefined } },
   ]) {
     test(`returns input-invalid for ${testCase.name} context`, async () => {
       const engine = PolicyEngine.create();
@@ -101,28 +105,4 @@ describe("PolicyEngine canonical point context immutability", () => {
       expect(invoked).toBe(false);
     });
   }
-  test("preserves trusted event emitters outside structured cloning", async () => {
-    const engine = PolicyEngine.create();
-    const eventEmitter = { emit: () => undefined };
-    let observedEmitter: unknown;
-    engine.register({
-      kind: "point",
-      name: "event-emitter-context-policy",
-      pointIds: ["dispatch.action.pre"],
-      effectCapabilities: { "dispatch.action.pre": [] },
-      priority: 0,
-      fn: (ctx) => {
-        observedEmitter = Reflect.get(ctx, "eventEmitter");
-        return PolicyDecision.allow({ policyId: "event-emitter-context-policy" });
-      },
-    });
-
-    const decision = await engine.dispatchPoint("dispatch.action.pre", {
-      ...dispatchContext,
-      eventEmitter,
-    });
-
-    expect(decision.verdict).toBe("allow");
-    expect(observedEmitter).toBe(eventEmitter);
-  });
 });

--- a/packages/policy/test/point-context-immutability.test.ts
+++ b/packages/policy/test/point-context-immutability.test.ts
@@ -75,10 +75,6 @@ describe("PolicyEngine canonical point context immutability", () => {
     { name: "Proxy", value: new Proxy({ value: "uncloneable" }, {}) },
     { name: "cyclic record", value: cyclic },
     { name: "non-plain object", value: new Date(0) },
-    // An object carrying a method is the shape an event emitter has. The
-    // engine used to hand one through by reference — a live object inside a
-    // frozen snapshot — for a caller that stopped existing at #610.
-    { name: "event emitter", value: { emit: () => undefined } },
   ]) {
     test(`returns input-invalid for ${testCase.name} context`, async () => {
       const engine = PolicyEngine.create();
@@ -105,4 +101,36 @@ describe("PolicyEngine canonical point context immutability", () => {
       expect(invoked).toBe(false);
     });
   }
+
+  /**
+   * The carve-out this replaces keyed on the property name: it read
+   * `source.eventEmitter` and, when that held something with an `emit`
+   * method, spread it back into the snapshot by reference. The rejection
+   * table above cannot reach it — the loop puts every case under
+   * `unsupported`, so an emitter under any other key was always refused.
+   */
+  test("returns input-invalid for an eventEmitter-keyed emitter", async () => {
+    const engine = PolicyEngine.create();
+    let invoked = false;
+    engine.register({
+      kind: "point",
+      name: "event-emitter-context-policy",
+      pointIds: ["dispatch.action.pre"],
+      effectCapabilities: { "dispatch.action.pre": [] },
+      priority: 0,
+      fn: () => {
+        invoked = true;
+        return PolicyDecision.allow({ policyId: "event-emitter-context-policy" });
+      },
+    });
+
+    const decision = await engine.dispatchPoint("dispatch.action.pre", {
+      ...dispatchContext,
+      eventEmitter: { emit: () => undefined },
+    });
+
+    expect(decision.verdict).toBe("deny");
+    expect(decision.reasonCodes).toContain("policy.input_invalid");
+    expect(invoked).toBe(false);
+  });
 });


### PR DESCRIPTION
Phase 2. The row the plan describes as *"unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer."*

## What it was

`immutablePointSnapshot` pulled an `eventEmitter` out of the context, cloned everything else, then spread it back **by reference**:

```ts
const eventEmitter = source.eventEmitter;
const preservesEventEmitter =
  Object.getOwnPropertyDescriptor(source, "eventEmitter") !== undefined &&
  isEventEmitterLike(eventEmitter);
if (preservesEventEmitter) delete source.eventEmitter;
const snapshot = {
  ...structuredClone(source),
  ...added,
  ...(preservesEventEmitter && { eventEmitter }),
};
if (!freezePlainValue(snapshot, new WeakSet(), eventEmitter)) return { success: false };
```

A live object with a callable method, sitting inside what the function's own name calls an immutable snapshot — a fail-open exception inside a fail-closed boundary. `freezePlainValue` carried a third parameter (`preservedValue`) whose only job was to skip freezing it.

## Why it goes

Nothing has produced one since **#610** removed `AgentEventEmitter` and `ChatAgentConfig.eventEmitter`. No type declares the field — `GenericPolicyContext` never had it. The carve-out plus one test were the only remaining mentions in the tree:

```
$ grep -rn "eventEmitter\|EventEmitter" packages/*/src apps/*/src script
packages/policy/src/engine/context.ts:53,54,55,56,57,61,63,150   ← the carve-out
$ grep -rln "eventEmitter" packages/*/test apps/*/test
packages/policy/test/point-context-immutability.test.ts          ← the one test
```

Deleted: the extraction and re-spread, `isEventEmitterLike`, `preservedValue` and its short-circuit, and the doc comment's "one deliberate exception" paragraph.

## The behavior it replaces, and how it is pinned

Without the carve-out an emitter-shaped context takes the path every other live object already takes: `structuredClone` refuses it, and the dispatch denies with `policy.input_invalid`.

**The carve-out keyed on the property *name***, so the pin has to as well. The existing rejection table cannot express it — its loop puts every case under the key `unsupported`, and an `emit`-bearing object under any other key was already refused at the merge base. A standalone test dispatches with `eventEmitter: { emit }`.

Red-first, against `4a8d3de9`'s `context.ts` with the carve-out restored:

```
CARVE-OUT RESTORED: (fail) returns input-invalid for an eventEmitter-keyed emitter   8 pass  1 fail
AT HEAD:                                                                             9 pass  0 fail
```

## Verification

- `bun test` **3464 pass / 9 skip / 0 fail** — unchanged from base; policy alone 76 pass / 0 fail.
- The surviving clone guard is pinned too: replacing `structuredClone(source)` with `...source` takes the file to 1 fail.
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build` — all OK.

### One observation, deliberately not acted on

`freezePlainValue`'s `typeof value === "function" || typeof value === "symbol"` check does not fire today — `structuredClone` throws on both first, and every `added` argument at the three call sites is strings or `{}`. It stays: it is the sole guard on `added`, which bypasses the clone by construction, and under the `{ ...source, ...added }` mutation above it is what catches the function and emitter cases while only the Proxy row is caught by the clone. Flagging so nobody removes it as a follow-up cleanup.