### PR TITLE
refactor(agent): delete the fabricated run identity (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -104,7 +104,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 |---|---|---|
 | [#610](https://github.com/INONONO66/openomni/pull/610) | delete the unimplemented second event channel | ✅ |
 | [#621](https://github.com/INONONO66/openomni/pull/621) | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | 🟨 |
-| — | file layout + FSM; slop comments, duplicate helpers, the last `as unknown as`, `agentBaseForState` | ⬜ |
+| [#623](https://github.com/INONONO66/openomni/pull/623) | slop comments and `agentBaseForState`; the last `as unknown as` is earned, not removed | 🟨 |
+| — | file layout + FSM | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | — | dissolve `builtin/` per D5 | ⬜ |
 | — | retry no longer double-counts the turn budget | ⬜ |

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -105,7 +105,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#610](https://github.com/INONONO66/openomni/pull/610) | delete the unimplemented second event channel | ✅ |
 | [#621](https://github.com/INONONO66/openomni/pull/621) | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | 🟨 |
 | [#623](https://github.com/INONONO66/openomni/pull/623) | slop comments and `agentBaseForState`; the last `as unknown as` is earned, not removed | 🟨 |
-| — | file layout + FSM | ⬜ |
+| — | file layout + FSM; duplicate helpers (`nonEmptyString` ×2, `requireRunTrace`/`requireExecutorTrace`) | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | — | dissolve `builtin/` per D5 | ⬜ |
 | — | retry no longer double-counts the turn budget | ⬜ |

--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -9,18 +9,13 @@ import {
   emitRunCompleted,
   publishDenyDiagnostic,
 } from "./run-events";
-import {
-  agentBaseForState,
-  buildLifecyclePolicyContext,
-  type AgentRunBase,
-  type RunState,
-} from "./run-state";
+import { buildLifecyclePolicyContext, type AgentRunBase, type RunState } from "./run-state";
 
 export async function dispatchPreRun(
   state: RunState,
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
-  agentBase: AgentRunBase = agentBaseForState(state),
+  agentBase: AgentRunBase,
 ): Promise<AgentResult | null> {
   const preRunDecision = await engine.dispatchPoint(
     "run.lifecycle.pre",
@@ -43,7 +38,7 @@ export async function dispatchBudgetCheck(
   state: RunState,
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
-  agentBase: AgentRunBase = agentBaseForState(state),
+  agentBase: AgentRunBase,
 ): Promise<AgentResult | null> {
   // The single per-turn owner of budget telemetry: emit here (command) and act
   // on the returned status. The run.turn.pre budget builtins read the status
@@ -79,7 +74,7 @@ export async function dispatchModelRequest(
   state: RunState,
   engine: PolicyEngineInstance,
   config: ChatAgentConfig,
-  agentBase: AgentRunBase = agentBaseForState(state),
+  agentBase: AgentRunBase,
 ): Promise<AgentResult | null> {
   const decision = await engine.dispatchPoint(
     "connection.llm.pre",

--- a/packages/agent/src/core/execution/policy-effects.ts
+++ b/packages/agent/src/core/execution/policy-effects.ts
@@ -28,7 +28,6 @@ export function matchesToolPattern(toolName: string, pattern: string): boolean {
   return toolName === pattern;
 }
 
-// merged from policy-effects-apply.ts (250-LOC split refold: single-importer stage)
 export namespace PolicyEffectApplier {
   export function continuationMessages(
     decision: Policy.PolicyDecision,

--- a/packages/agent/src/core/execution/run-events.ts
+++ b/packages/agent/src/core/execution/run-events.ts
@@ -194,7 +194,6 @@ export function publishDenyDiagnostic(
   });
 }
 
-// merged from run-result.ts (250-LOC split refold: single-importer stage)
 export function guardAbortedResult(
   state: RunState,
   options?: { text?: string; steps?: AgentStep[]; finishReason?: "stop" | "stalled" },

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -11,7 +11,6 @@ import type { AgentResult, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsag
 import type { DispatchContext } from "../policy";
 import { createUserMessage, createAssistantMessage } from "../message-factory";
 
-// merged from shared.ts (fragment sweep: single-consumer fn)
 function toMessagesWithParts(
   messages: ChatAgentInput["messages"],
   source: string,
@@ -42,10 +41,15 @@ export type RunTrace = TraceContext.Type & {
   readonly runId: string;
 };
 
+/**
+ * A run's identity, all four fields required. The runner builds exactly one of
+ * these, from a trace it refused to mint (#606); nothing else may synthesize
+ * one, so every consumer can read the fields rather than guess at them.
+ */
 export interface AgentRunBase {
   readonly traceId: string;
   readonly sessionId: string;
-  readonly runId?: string;
+  readonly runId: string;
   readonly actorId: string;
 }
 
@@ -165,7 +169,6 @@ export function applyCompactionMessages(state: RunState, messages: Message.WithP
   return messagesBefore;
 }
 
-// merged from lifecycle-context.ts (250-LOC split refold: single-importer stage)
 type LifecyclePolicyContextOverrides = Partial<
   Pick<
     DispatchContext,
@@ -203,26 +206,22 @@ export function buildLifecyclePolicyContext<
     // fail-closed point, which reads as the run aborting.
     traceContext: {
       traceId: agentBase.traceId,
-      sessionId: agentBase.sessionId || state.sessionId,
-      ...(agentBase.runId === undefined ? {} : { runId: agentBase.runId }),
+      sessionId: agentBase.sessionId,
+      runId: agentBase.runId,
     },
     ...rest,
     actorId: agentBase.actorId,
-    sessionId: agentBase.sessionId || state.sessionId,
-    runId: agentBase.runId || agentBase.traceId,
+    sessionId: agentBase.sessionId,
+    runId: agentBase.runId,
+    // The generic is what makes each point's declared inputs type-check at the
+    // eleven call sites; the cost is this one cast. TypeScript cannot prove an
+    // object literal satisfies `Omit<TOverrides, K>` while `TOverrides` is
+    // still a parameter, and a single assertion is rejected as
+    // non-overlapping for the same reason.
   } as unknown as Omit<DispatchContext, "actorId" | "sessionId" | "runId"> &
     Omit<TOverrides, "actorId" | "sessionId" | "runId"> & {
       readonly actorId: string;
       readonly sessionId: string;
       readonly runId: string;
     };
-}
-
-export function agentBaseForState(state: RunState): AgentRunBase {
-  return {
-    traceId: state.sessionId,
-    sessionId: state.sessionId,
-    runId: state.sessionId,
-    actorId: state.sessionId,
-  };
 }

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -174,7 +174,6 @@ function requireRunTrace(traceContext: ChatAgentInput["traceContext"]): RunTrace
   return { ...traceContext, traceId, sessionId, runId };
 }
 
-// merged from shared.ts (fragment sweep: single-consumer fn)
 async function resolveProviderModel(model: {
   provider: string;
   id: string;
@@ -198,7 +197,6 @@ async function resolveProviderModel(model: {
   throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
 }
 
-// merged from policy-engine-builder.ts (250-LOC split refold: single-importer stage)
 export function buildPolicyEngine(
   config: ChatAgentConfig,
   agentBase: AgentRunBase,
@@ -207,7 +205,7 @@ export function buildPolicyEngine(
     traceContext: {
       traceId: agentBase.traceId,
       sessionId: agentBase.sessionId,
-      ...(agentBase.runId !== undefined && { runId: agentBase.runId }),
+      runId: agentBase.runId,
     },
     auditEmit: (descriptor, data) => config.events.publish(descriptor, data),
   });

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -263,7 +263,6 @@ function requireExecutorTrace(
   return { traceId, sessionId, runId };
 }
 
-// merged from tool-policy-dispatch.ts (250-LOC split refold: single-importer stage)
 interface ToolPolicyRunContext {
   readonly sessionId: string;
   readonly runId: string;

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -229,7 +229,7 @@ function resolveTurnAssistant(
   events.publish(Operational.Error, {
     traceId: agentBase.traceId,
     time: Date.now(),
-    sessionId: agentBase.sessionId || state.sessionId,
+    sessionId: agentBase.sessionId,
     component: "agent.turn",
     msg: "llm sink emitted no assistant snapshot — test stub?",
   });
@@ -237,7 +237,6 @@ function resolveTurnAssistant(
   return createAssistantMessage("", parentID, state.sessionId);
 }
 
-// merged from completion-policy.ts (250-LOC split refold: single-importer stage)
 async function dispatchPostRunTransform(
   state: RunState,
   engine: PolicyEngineInstance,

--- a/packages/agent/src/core/execution/turn-prepare.ts
+++ b/packages/agent/src/core/execution/turn-prepare.ts
@@ -27,7 +27,6 @@ export function resolveToolChoice(
   return config.toolChoice;
 }
 
-// merged from prompt-builder.ts (fragment sweep: single-caller fn)
 export function buildSystemPrompt(
   basePrompt: string | undefined,
   tools: Tool.Spec[],
@@ -263,7 +262,6 @@ function createTrackingSink(
   };
 }
 
-// merged from prompt-policy.ts (250-LOC split refold: single-importer stage)
 async function buildTurnSystemPrompt(
   state: RunState,
   config: ChatAgentConfig,

--- a/packages/agent/test/core/execution/compaction-lifecycle.test.ts
+++ b/packages/agent/test/core/execution/compaction-lifecycle.test.ts
@@ -20,7 +20,13 @@ import { makeAgentBase, makeConfig, makeState } from "./lifecycle-dispatch-fixtu
 describe("compaction through the lifecycle", () => {
   it("the lifecycle context carries the run's trace", () => {
     const agentBase = makeAgentBase();
-    const ctx = buildLifecyclePolicyContext(makeState(), makeConfig(), agentBase, {
+    const state = makeState();
+    // `makeState` mints its own session id, so these differ — which is what
+    // makes the assertions below discriminate. The context used to read
+    // `agentBase.sessionId || state.sessionId` and `agentBase.runId ||
+    // agentBase.traceId`; either fallback firing would show up here.
+    expect(state.sessionId).not.toBe(agentBase.sessionId);
+    const ctx = buildLifecyclePolicyContext(state, makeConfig(), agentBase, {
       isCompletion: true,
     });
 
@@ -32,6 +38,8 @@ describe("compaction through the lifecycle", () => {
       sessionId: agentBase.sessionId,
       runId: agentBase.runId,
     });
+    expect(ctx.sessionId).toBe(agentBase.sessionId);
+    expect(ctx.runId).toBe(agentBase.runId);
   });
 
   it("files the compaction record under the run's trace, not a minted one", async () => {

--- a/packages/agent/test/core/execution/execution-verdicts-model.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts-model.test.ts
@@ -28,7 +28,7 @@ describe("model execution deny verdicts", () => {
       fn,
     });
 
-    const result = await dispatchModelRequest(makeState(), engine, makeConfig());
+    const result = await dispatchModelRequest(makeState(), engine, makeConfig(), makeAgentBase());
 
     expect(result).not.toBeNull();
     expect(result?.guardAborted).toBe(true);

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -108,7 +108,9 @@ describe("execution helper deny verdicts", () => {
       fn: () => deny("test.deny", "blocked"),
     });
 
-    const complete = expectComplete(await dispatchPreRun(makeState(), engine, makeConfig()));
+    const complete = expectComplete(
+      await dispatchPreRun(makeState(), engine, makeConfig(), makeAgentBase()),
+    );
 
     expect(complete.guardAborted).toBe(true);
     expect(complete.finishReason).toBe("stop");

--- a/packages/agent/test/core/execution/lifecycle-model.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-model.test.ts
@@ -24,7 +24,7 @@ describe("model dispatch points", () => {
     });
 
     const state = makeState();
-    const result = await dispatchModelRequest(state, engine, makeConfig());
+    const result = await dispatchModelRequest(state, engine, makeConfig(), makeAgentBase());
 
     expect(result).toBeNull();
     expect(fn).toHaveBeenCalledTimes(1);
@@ -76,7 +76,7 @@ describe("model dispatch points", () => {
     });
 
     const state = makeState();
-    const result = await dispatchModelRequest(state, engine, makeConfig());
+    const result = await dispatchModelRequest(state, engine, makeConfig(), makeAgentBase());
 
     expect(result).toBeNull();
     const lastMessage = state.messages[state.messages.length - 1];

--- a/packages/agent/test/core/execution/lifecycle-run-start.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-run-start.test.ts
@@ -5,7 +5,7 @@ import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
 import { abortRun, allow, appendContext, inject } from "../../helpers/policy-decision";
 import { dispatchPreRun } from "../../../src/core/execution/lifecycle-dispatch";
-import { makeConfig, makeState } from "./lifecycle-dispatch-fixture";
+import { makeAgentBase, makeConfig, makeState } from "./lifecycle-dispatch-fixture";
 
 describe("dispatchPreRun (run.start)", () => {
   it("dispatches run.start and allows continuation on continue verdict", async () => {
@@ -22,7 +22,7 @@ describe("dispatchPreRun (run.start)", () => {
     });
 
     const state = makeState();
-    const result = await dispatchPreRun(state, engine, makeConfig());
+    const result = await dispatchPreRun(state, engine, makeConfig(), makeAgentBase());
 
     expect(result).toBeNull();
     expect(fn).toHaveBeenCalledTimes(1);
@@ -43,7 +43,7 @@ describe("dispatchPreRun (run.start)", () => {
     });
 
     const state = makeState();
-    const result = await dispatchPreRun(state, engine, makeConfig());
+    const result = await dispatchPreRun(state, engine, makeConfig(), makeAgentBase());
 
     expect(result).not.toBeNull();
     expect(result?.guardAborted).toBe(true);
@@ -64,7 +64,7 @@ describe("dispatchPreRun (run.start)", () => {
 
     const state = makeState();
     const messagesBefore = state.messages.length;
-    const result = await dispatchPreRun(state, engine, makeConfig());
+    const result = await dispatchPreRun(state, engine, makeConfig(), makeAgentBase());
 
     expect(result).toBeNull();
     expect(state.messages.length).toBe(messagesBefore + 1);
@@ -92,7 +92,7 @@ it("appends run.start context as a user message", async () => {
   });
 
   const state = makeState();
-  const result = await dispatchPreRun(state, engine, makeConfig());
+  const result = await dispatchPreRun(state, engine, makeConfig(), makeAgentBase());
 
   expect(result).toBeNull();
   expect(state.messages.at(-1)?.parts).toContainEqual(

--- a/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-outcome-provenance.test.ts
@@ -11,9 +11,9 @@ import { runInput } from "../../helpers/run-input";
 import { testProviderModel } from "../../helpers/provider-model";
 import { Bus } from "@openomni/telemetry";
 
-// The run and the input it produces share one identity. Derived this way
-// round, not the other: `AgentRunBase.runId` is optional and `RunInput.trace`'s
-// is not, so reading it back off the base would widen it.
+// The run and the input it produces share one identity, stated once. The base
+// is the origin because that is the direction production runs in: the runner
+// derives both from the trace it was handed.
 const runTrace = { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" };
 
 function makeAgentBase(): AgentRunBase {


### PR DESCRIPTION
Phase 2. The named slop from the plan's `file layout + FSM` row, minus the FSM and the duplicate helpers — both stay tracked on the remaining row.

## `agentBaseForState`

```ts
export function agentBaseForState(state: RunState): AgentRunBase {
  return {
    traceId: state.sessionId,
    sessionId: state.sessionId,
    runId: state.sessionId,
    actorId: state.sessionId,
  };
}
```

It built a run's identity by putting `state.sessionId` into all four fields. It was reached only through a default parameter on three lifecycle dispatchers:

```ts
agentBase: AgentRunBase = agentBaseForState(state),
```

and only by tests. The runner passes the base it derives from a trace it **refused to mint** (`requireRunTrace`, #613). So the guard that PR put at the run boundary had a back door two files over, and eight tests were quietly running against a trace id that was a session id.

The default is gone; those eight call sites now pass `makeAgentBase()`.

## What that unlocks

With no synthesizer left, every `AgentRunBase` in the tree comes from one place, so `runId` becomes **required** rather than optional. That removes four fallbacks that could not fire on a well-formed base:

- `sessionId: agentBase.sessionId || state.sessionId` — twice in `buildLifecyclePolicyContext`, once in `resolveTurnAssistant`'s diagnostic
- `runId: agentBase.runId || agentBase.traceId` — a run id defaulting to a trace id
- `...(agentBase.runId === undefined ? {} : { runId })` — in `buildLifecyclePolicyContext` and `buildPolicyEngine`

**And it is pinned.** Reverting to the old semantics left the entire monorepo suite green — nothing asserted where a lifecycle point's identity comes from. The existing trace assertion in `compaction-lifecycle.test.ts` already ran with a base whose session id differs from the state's, so it now covers the top-level fields too. Red-first: the old `sessionId || state.sessionId` / `runId || traceId` fails it.

## Comments that narrate a refactor

Ten of these, deleted:

```
// merged from shared.ts (fragment sweep: single-consumer fn)
// merged from lifecycle-context.ts (250-LOC split refold: single-importer stage)
```

They record what happened to the repo, not what the code does. (19 of the same class survive in other packages — out of scope here.)

## The last `as unknown as` — kept, and now explained

`buildLifecyclePolicyContext`'s generic is what makes each point's declared inputs type-check at its eleven call sites. Removing it fails **10 of the 11**, each naming the input it can no longer see (`runOutcome`, `modelId`, `responseTokens`, `turnIndex`, `turnResult`, `errorCode`, `completionCandidate`, `availableTools`). Keeping it costs one cast: TypeScript cannot prove an object literal satisfies `Omit<TOverrides, K>` while `TOverrides` is still a parameter, and narrowing to a single `as` is rejected —

```
error TS2352: ... may be a mistake because neither type sufficiently overlaps
  ... is not comparable to type 'Omit<TOverrides, "sessionId" | "runId" | "actorId">'
```

Verified both ways. The cast is earned; it now says so.

## Verification

- `bun test` **3464 pass / 9 skip / 0 fail** — unchanged from base; agent alone 411 pass / 8 skip / 0 fail, also unchanged.
- The eight tests that relied on the default are the proof it was load-bearing for tests only: making the parameter required at the merge base, with no other change, leaves `src` and `bench` compiling clean and breaks exactly those eight with `TS2554`.
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, `build:dist` + `smoke:dist`, agent `bench` — all OK.