### PR TITLE
refactor(agent): one trace guard, not two (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -115,7 +115,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 
 | PR | title | status |
 |---|---|---|
-| — | remove the dead pipeline: `InMemoryCompactor`, `builtin:compaction`, `handleCompact`, the `Run.Outcome.compact` variant, middleware wiring | ⬜ |
+| — | remove `handleContinue`, `handleCompact`, and the `Run.Outcome` `continue`/`compact` variants. Both are unproduced: `packages/llm/src/run.ts` returns only `stop`, `aborted`, `error`, and no production site injects `config.llm.run`. **Owner-gated** — deleting a union member trips `lint:tools`' positional schema snapshot (`Run.Outcome#4`), whose `--update` needs sign-off, and `.omo/evidence/p3/protocol-concept-disposition.json` records this symbol as claimed by #498's run→llm `StepResult` move. Not splittable: `runner.ts`'s `_exhaustive: never` fails whichever half lands first | ⬜ |
+| — | `InMemoryCompactor` + `builtin:compaction` — **not dead**, and not covered by the row above. Reachable through `run.completion.pre` from an external policy plan (`compaction-policy-plan.test.ts` pins that path) and registered by the product kernel at `openomni/src/execution-runtime/middleware.ts`. Their fate is D5 and the compaction rewrite below, not a deletion | ⬜ |
 | — | `compaction/`: measure, adaptive policy with yield feedback, guard | ⬜ |
 | — | deterministic no-LLM reduction, cut planning, incremental summarization | ⬜ |
 | — | speculative overlap and bounded overflow retry | ⬜ |

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -105,7 +105,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#610](https://github.com/INONONO66/openomni/pull/610) | delete the unimplemented second event channel | ✅ |
 | [#621](https://github.com/INONONO66/openomni/pull/621) | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | 🟨 |
 | [#623](https://github.com/INONONO66/openomni/pull/623) | slop comments and `agentBaseForState`; the last `as unknown as` is earned, not removed | 🟨 |
-| — | file layout + FSM; duplicate helpers (`nonEmptyString` ×2, `requireRunTrace`/`requireExecutorTrace`) | ⬜ |
+| [#624](https://github.com/INONONO66/openomni/pull/624) | duplicate helpers: one `requireTrace`, one `nonEmptyString` | 🟨 |
+| — | file layout + FSM | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | — | dissolve `builtin/` per D5 | ⬜ |
 | — | retry no longer double-counts the turn budget | ⬜ |

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -42,6 +42,41 @@ export type RunTrace = TraceContext.Type & {
 };
 
 /**
+ * Builds a {@link RunTrace}, refusing an incomplete one.
+ *
+ * A run or a tool call whose traceId, sessionId, and runId were invented on
+ * its behalf emits records that correlate to nothing, and the caller never
+ * learns it forgot (#606). `subject` names the boundary that refused, and the
+ * message lists what was missing rather than only that something was.
+ *
+ * What is required is inheritance, not wire format. Whether the identity is
+ * expressible as a W3C `traceparent` is enforced by the emitter that puts it
+ * on the wire, which is the only place the format matters.
+ */
+export function requireTrace(
+  subject: string,
+  traceContext: TraceContext.Type | undefined,
+): RunTrace {
+  const traceId = nonEmptyString(traceContext?.traceId);
+  const sessionId = nonEmptyString(traceContext?.sessionId);
+  const runId = nonEmptyString(traceContext?.runId);
+  if (traceId === undefined || sessionId === undefined || runId === undefined) {
+    const missing = [
+      traceId === undefined ? "traceId" : undefined,
+      sessionId === undefined ? "sessionId" : undefined,
+      runId === undefined ? "runId" : undefined,
+    ].filter((field): field is string => field !== undefined);
+    throw new Error(`${subject} requires a trace context with ${missing.join(", ")}`);
+  }
+  return { ...traceContext, traceId, sessionId, runId };
+}
+
+/** A present, non-blank string. The one shape a trace field may take. */
+export function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
  * A run's identity, all four fields required. The runner builds exactly one of
  * these, from a trace it refused to mint (#606); nothing else may synthesize
  * one, so every consumer can read the fields rather than guess at them.

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -12,7 +12,7 @@ import {
   dispatchModelResponse,
   dispatchPreRun,
 } from "./lifecycle-dispatch";
-import { createRunState, type AgentRunBase, type RunTrace } from "./run-state";
+import { createRunState, nonEmptyString, requireTrace, type AgentRunBase } from "./run-state";
 
 /**
  * Runs an agent to a result.
@@ -31,7 +31,7 @@ export async function runAgent(
   let attempt = 1;
   let lastError = "";
 
-  const trace = requireRunTrace(input.traceContext);
+  const trace = requireTrace("agent run", input.traceContext);
   const { traceId, sessionId, runId } = trace;
   const actorId =
     nonEmptyString(input.metadata?.actorId) ?? nonEmptyString(trace.agentName) ?? runId;
@@ -142,36 +142,6 @@ function unknownOutcomeType(value: unknown): string {
 
   const type = value.type;
   return typeof type === "string" ? type : "unknown";
-}
-
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-/**
- * A run must arrive with an identity. Minting one here — which is what the
- * removed `TraceContext.empty()` plus three `?? crypto.randomUUID()` fallbacks
- * did — produces a run whose every event correlates to nothing, and the caller
- * never learns it forgot.
- *
- * What is required here is inheritance, not wire format. A run must carry the
- * identity of whatever asked for it; whether that identity is expressible as a
- * W3C `traceparent` is enforced by the emitter that puts it on the wire, which
- * is the only place the format matters.
- */
-function requireRunTrace(traceContext: ChatAgentInput["traceContext"]): RunTrace {
-  const traceId = nonEmptyString(traceContext?.traceId);
-  const sessionId = nonEmptyString(traceContext?.sessionId);
-  const runId = nonEmptyString(traceContext?.runId);
-  if (traceId === undefined || sessionId === undefined || runId === undefined) {
-    const missing = [
-      traceId === undefined ? "traceId" : undefined,
-      sessionId === undefined ? "sessionId" : undefined,
-      runId === undefined ? "runId" : undefined,
-    ].filter((field): field is string => field !== undefined);
-    throw new Error(`agent run requires a trace context with ${missing.join(", ")}`);
-  }
-  return { ...traceContext, traceId, sessionId, runId };
 }
 
 async function resolveProviderModel(model: {

--- a/packages/agent/src/core/execution/tool-executor.ts
+++ b/packages/agent/src/core/execution/tool-executor.ts
@@ -4,6 +4,7 @@ import type { AgentStep, TokenUsage } from "../types";
 import type { PolicyEngineInstance } from "../policy";
 import type { PolicyContext } from "../policy/types";
 import { effectOf, effectsOf, matchesToolPattern } from "./policy-effects";
+import { nonEmptyString, requireTrace } from "./run-state";
 
 type BlockedResultMetadata = {
   verdict: Policy.PolicyDecision["verdict"];
@@ -53,7 +54,7 @@ export function createToolExecutor(
   // The executor is built inside a turn, which is inside a run that already
   // refused to start without an identity. Minting one here would give a tool
   // call its own trace, detached from the run that made it.
-  const configured = requireExecutorTrace(traceContext);
+  const configured = requireTrace("tool executor", traceContext);
 
   function publishDecisionObserverError(
     activeTraceContext: TraceContext.Type,
@@ -245,22 +246,6 @@ export function createToolExecutor(
     const rewriteOutput = effectOf(postDecision, "tool.rewrite_output");
     return rewriteOutput ? { ...result, output: rewriteOutput.output } : result;
   };
-}
-
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function requireExecutorTrace(
-  traceContext: TraceContext.Type | undefined,
-): Required<Pick<TraceContext.Type, "traceId" | "sessionId" | "runId">> {
-  const traceId = nonEmptyString(traceContext?.traceId);
-  const sessionId = nonEmptyString(traceContext?.sessionId);
-  const runId = nonEmptyString(traceContext?.runId);
-  if (traceId === undefined || sessionId === undefined || runId === undefined) {
-    throw new Error("tool executor requires the run trace context");
-  }
-  return { traceId, sessionId, runId };
 }
 
 interface ToolPolicyRunContext {

--- a/packages/agent/test/core/execution/tool-executor.test.ts
+++ b/packages/agent/test/core/execution/tool-executor.test.ts
@@ -195,7 +195,7 @@ describe("createToolExecutor bus events", () => {
         toolExecutor: async () => ({ id: "r", toolCallId: "c", output: "" }),
         engine: PolicyEngine.create(),
       }),
-    ).toThrow("tool executor requires a trace context with");
+    ).toThrow("tool executor requires a trace context with traceId, sessionId, runId");
   });
 
   it("publishes actor from trace context on PermissionDenied", async () => {

--- a/packages/agent/test/core/execution/tool-executor.test.ts
+++ b/packages/agent/test/core/execution/tool-executor.test.ts
@@ -195,7 +195,7 @@ describe("createToolExecutor bus events", () => {
         toolExecutor: async () => ({ id: "r", toolCallId: "c", output: "" }),
         engine: PolicyEngine.create(),
       }),
-    ).toThrow("tool executor requires the run trace context");
+    ).toThrow("tool executor requires a trace context with");
   });
 
   it("publishes actor from trace context on PermissionDenied", async () => {


### PR DESCRIPTION
Phase 2. The `duplicate helpers` item the #623 reviewer found had been dropped from the roadmap row rather than done.

## Three helpers for one rule

`requireRunTrace` (`runner.ts`) and `requireExecutorTrace` (`tool-executor.ts`) read the same three fields through the same predicate and threw on the same condition. Each file also carried its own **byte-identical** copy of that predicate:

```ts
function nonEmptyString(value: unknown): string | undefined {
  return typeof value === "string" && value.length > 0 ? value : undefined;
}
```

It was the only duplicated function name in `packages/agent/src` (`grep '^function' | sort | uniq -d`).

## One rule, one place

`requireTrace(subject, traceContext)` now lives beside `RunTrace`, whose type it constructs, with `nonEmptyString` exported next to it. `subject` names the boundary that refused, so the two call sites keep distinguishable messages while sharing the check.

The doc comment that explained *why* the guard exists — "a run whose traceId, sessionId, and runId were invented on its behalf emits records that correlate to nothing, and the caller never learns it forgot" — moves with it, and now covers both callers instead of one.

## One behavior change, an improvement

The tool executor's message was:

> `tool executor requires the run trace context`

and is now:

> `tool executor requires a trace context with traceId, sessionId, runId`

The runner already listed the missing fields; a caller that forgot one should be told which. One test assertion updated to match.

## Verification

- `bun test` **3464 pass / 9 skip / 0 fail** — unchanged; agent alone 411 pass / 8 skip / 0 fail.
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK.

---

## Blocked, and why — the `Run.Outcome.compact` deletion

I attempted Phase 3's first row (`remove the dead pipeline: InMemoryCompactor, builtin:compaction, handleCompact, the Run.Outcome.compact variant`) before this and **backed it out**. Recording the finding so the next attempt starts from it.

**The `compact` outcome is genuinely dead.** `packages/llm/src` never returns `{type:"compact"}`, and nothing in production sets `config.llm.run`, so the real `llmRun` is always used. Git history shows the variant was added in #117 and never produced. Only tests construct it.

**But deleting it trips a gate that requires Owner sign-off:**

```
VIOLATION [schema-snapshot] Run.Outcome#4 — protocol type disappeared from the snapshot —
removing/renaming an event type silently corrupts the ledger fold; introduce a new type
and upcast on read (run --update only with Owner sign-off)
```

`script/conformance/schema-snapshot.json` tracks union members positionally (`Run.Outcome#0..#4`), so removing any member reads as `#4` disappearing. Worth noting for the decision: `Run.Outcome` appears nowhere in `packages/session/src` or `apps/server/src` — it is an in-process return type from `llm.run()` to the agent loop, not a persisted event — so the "ledger fold" rationale may not apply to this particular symbol.

**And the deletion cannot be split.** If `compact` stays in the union, `runner.ts`'s `const _exhaustive: never = outcome` forces an arm for it, so `handleCompact` cannot go without the protocol change.

Two decisions are needed and neither is mine: whether `Run.Outcome` is in scope for the snapshot ratchet at all, and whether to `--update` it. Also note Phase 3's row overstates what is dead — `InMemoryCompactor` and `builtin:compaction` remain reachable through `run.completion.pre` via an external policy plan, which `compaction-policy-plan.test.ts` exists to pin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies trace-context validation by replacing duplicate helpers with a single requireTrace(subject, traceContext) next to RunTrace. Improves diagnostics by making the tool executor error list missing fields; no other behavior changes.

- Adds requireTrace and exports nonEmptyString in packages/agent/src/core/execution/run-state.ts; runner and tool executor call it with “agent run” and “tool executor”.
- Removes local duplicates from runner.ts and tool-executor.ts; moves the guard’s doc to run-state.ts.
- Changes the tool executor error from “requires the run trace context” to “requires a trace context with traceId, sessionId, runId”; updates the refusing test to assert the full message.
- Updates docs/agent-core-rewrite.md to record the helper dedupe under #624 and clarify the compaction roadmap: InMemoryCompactor and builtin:compaction remain live; removing Run.Outcome continue/compact and their handlers is Owner-gated and cannot be split.

<sup>Written for commit 644ab8fa2e7409e9986a5cac373564c2224f027d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

