### PR TITLE
refactor(openomni): budget nagging is an opinion (#606)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ openomni/
 │   ├── agent/           # ChatAgent core (middleware-driven ReAct loop) + MCP client runtime — depends on telemetry for observation
 │   │   ├── src/core/           # ChatAgent, budget, retry, policy engine, memory, delegation, telemetry
 │   │   │   ├── execution/      # StreamEngine, ToolExecutor, compaction, parallel-tools
-│   │   │   └── policy/         # Agent policy facade + builtins (budget, compaction, tool-guard)
+│   │   │   └── policy/         # Agent policy facade + builtins (compaction, tool-guard)
 │   │   └── src/runtime/        # MCP client runtime
 │   │       └── mcp/            # McpClient
 │   ├── openomni/        # Product kernel: messaging, access, orchestration, ledger/evidence gates, tools runtime

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -109,7 +109,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | — | file layout + FSM | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | [#625](https://github.com/INONONO66/openomni/pull/625) | dissolve `builtin/` per D5 — `builtin:idle-nudge` moves to openomni | 🟨 |
-| — | dissolve `builtin/` per D5 — `builtin:tool-permission` and the two budget policies; then `defaultRegistry` and the directory go. `builtin:compaction` waits on the `Run.Outcome` ruling in Phase 3 below | ⬜ |
+| [#626](https://github.com/INONONO66/openomni/pull/626) | dissolve `builtin/` per D5 — the two budget nudges move to openomni | 🟨 |
+| — | dissolve `builtin/` per D5 — `builtin:tool-permission`; then `defaultRegistry` and the directory go. `builtin:compaction` waits on the `Run.Outcome` ruling in Phase 3 below | ⬜ |
 | — | retry no longer double-counts the turn budget | ⬜ |
 
 ### Phase 3 — compaction

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -116,7 +116,7 @@ Claims that are actually enforced in code today — docs may say "cannot" only a
 | Guarantee | Code |
 | --- | --- |
 | Workers cannot spawn new Workers, even with a matching WorkerGrant | `packages/openomni/src/dispatch/policy.ts`, `packages/openomni/src/execution-runtime/tool/agent/tools/dispatch.ts` |
-| Budget hard-stop ends execution at limits (turns, tool calls, wall time) | `packages/agent/src/core/budget.ts`, `packages/agent/src/core/policy/builtin/budget.ts` |
+| Budget hard-stop ends execution at limits (turns, tool calls, wall time) | `packages/agent/src/core/budget.ts`, `packages/agent/src/core/execution/lifecycle-dispatch.ts` |
 | Tool permission is fail-closed | `packages/agent/src/core/policy/builtin/tool-guard.ts` |
 | WorkItem terminal completion requires a matching durable admission for the current contract revision and basis | `packages/openomni/src/work-item/completion-admission.ts`, `packages/session/src/work-item/lifecycle.ts` |
 

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -88,10 +88,10 @@ run.lifecycle.pre → run.turn.pre → prompt.context.pre → tool.catalog.pre
 - **Ownership**: `ChatAgent` registers only caller-supplied `middleware`; runtime builders own default policy assembly (budget, tool permission, compaction) and, per D5, increasingly the policies themselves.
 - **Builtins** (resolved by id through `defaultRegistry(events)`, which hands the reporting builtins the caller's sink; stamped plans from the dispatch gate (#479) reference these ids). Per D5 these are moving out one at a time — an id listed here but not below is registered by `openomni` instead:
   - `builtin:tool-permission` (`tool-guard.ts`, fail-closed) — enforces `Policy.Permission` and `InputRule`; denial returns `run.abort` plus `audit.annotate`, while approval requirements return pending with `tool.require_approval`
-  - `builtin:budget-reassurance` / `builtin:budget-warning` — inject reassurance/warning system messages as budget consumption climbs
   - `builtin:compaction` — triggers `InMemoryCompactor.compact()` when the token threshold is exceeded
   A `required: true` plan entry whose id is not registered fails closed at middleware build (the worker run fails rather than silently skipping the policy).
-  - Moved out (#625): `builtin:idle-nudge` — `openomni`'s `execution-runtime/middleware/idle-nudge-policy.ts`, registered onto the same registry by `registerIdleNudge`
+  - Moved out (#625): `builtin:idle-nudge` — `openomni`'s `execution-runtime/middleware/idle-nudge-policy.ts`, registered by `registerIdleNudge`
+  - Moved out (#626): `builtin:budget-reassurance` / `builtin:budget-warning` — `openomni`'s `execution-runtime/middleware/budget-nudge-policy.ts`, registered by `registerBudgetNudges`. Budget *accounting* stays here; `checkBudget` and `describeBudgetRemaining` are exported so the product can decide what to say about what is left
 
 ## TURN LIFECYCLE (core/execution)
 
@@ -102,7 +102,7 @@ runner.ts (entry) → Promise<AgentResult>
   │   ├─ dispatchPoint(run.lifecycle.pre)       → allow (with effects) / deny
   │   └─ turn loop (while budget ok)
   │       ├─ checkBudget → if exceeded, dispatchPoint(run.lifecycle.post) + return result
-  │       ├─ dispatchPoint(run.turn.pre)        → budget warnings; idle-nudge (openomni)
+  │       ├─ dispatchPoint(run.turn.pre)        → budget nudges, idle-nudge (both openomni)
   │       ├─ dispatchPoint(prompt.context.pre)  → context/prompt enrichment
   │       ├─ dispatchPoint(tool.catalog.pre)    → filter/modify tools exposed to LLM
   │       ├─ dispatchPoint(connection.llm.pre)

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -20,7 +20,6 @@ src/
 │       ├── registry.ts         # PolicyRegistry + defaultRegistry(events) — builtin policy id → factory resolution
 │       ├── types.ts            # PolicyContext, canonical/legacy registration aliases, PolicyEngineRegistration
 │       └── builtin/
-│           ├── budget.ts       # createBudgetReassurancePolicy / createBudgetWarningPolicy
 │           ├── compaction.ts   # createCompactionPolicy
 │           └── tool-guard.ts   # createToolPermissionPolicy (fail-closed)
 └── runtime/
@@ -55,6 +54,7 @@ Also exported from `@openomni/agent`:
 
 - Types: `ChatAgentConfig`, `ChatAgentInput`, `AgentResult`, `AgentStep`, `AgentBudget`, `TokenUsage`, `Sink`
 - Policy: `PolicyEngine`, `PolicyContext`, `PolicyFn`, `CanonicalPolicyRegistration`, `PolicyEngineRegistration`, `PolicyRegistration` (legacy compatibility), `PolicyEngineInstance`
+- Budget queries: `checkBudget`, `describeBudgetRemaining`, and the `BudgetState` / `BudgetStatus` they read and return — the accounting stays here, what to say about it does not (D5)
 - Runtime: `McpClient`, `McpServerConfig`
 
 ## ChatAgentConfig

--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -41,8 +41,9 @@ export async function dispatchBudgetCheck(
   agentBase: AgentRunBase,
 ): Promise<AgentResult | null> {
   // The single per-turn owner of budget telemetry: emit here (command) and act
-  // on the returned status. The run.turn.pre budget builtins read the status
-  // via the pure checkBudget query, so the event is not re-emitted per policy.
+  // on the returned status. The budget nudges — openomni's, since D5 — read
+  // the same status through the pure checkBudget query at run.turn.pre, so the
+  // event is not re-emitted per policy.
   const budgetStatus = publishBudgetTelemetry(
     state.budgetState,
     agentBase,

--- a/packages/agent/src/core/policy/builtin/index.ts
+++ b/packages/agent/src/core/policy/builtin/index.ts
@@ -1,6 +1,2 @@
-export {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
-} from "./budget";
 export { createCompactionPolicy } from "./compaction";
 export { createToolPermissionPolicy } from "./tool-guard";

--- a/packages/agent/src/core/policy/registry.ts
+++ b/packages/agent/src/core/policy/registry.ts
@@ -4,12 +4,7 @@ import type { PolicyRegistryInstance } from "@openomni/policy";
 import { Policy } from "@openomni/protocol";
 import { z } from "zod";
 import type { CompactionOptions } from "../execution/compaction";
-import {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
-  createCompactionPolicy,
-  createToolPermissionPolicy,
-} from "./builtin";
+import { createCompactionPolicy, createToolPermissionPolicy } from "./builtin";
 import type { ToolPermissionPolicyConfig } from "./builtin/tool-guard";
 import type { PolicyContext } from "./types";
 
@@ -58,8 +53,6 @@ function parseToolPermissionConfig(config: unknown): Omit<ToolPermissionPolicyCo
 export function defaultRegistry(events: BusEvent.Sink): PolicyRegistryInstance<PolicyContext> {
   const registry = PolicyRegistry.create<PolicyContext>();
 
-  registry.register("builtin:budget-reassurance", () => createBudgetReassurancePolicy());
-  registry.register("builtin:budget-warning", () => createBudgetWarningPolicy());
   registry.register("builtin:compaction", (config) =>
     createCompactionPolicy({ ...parseCompactionConfig(config), events }),
   );

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,6 +11,9 @@ export type {
   Sink,
 } from "./core/types";
 export { PolicyEngine, PolicyRegistry, defaultRegistry } from "./core/policy";
+// Budget accounting stays core (the limits are loop invariants); the queries
+// are exported so a product can decide what to say about what is left (D5).
+export { checkBudget, describeBudgetRemaining } from "./core/budget";
 export type {
   CanonicalPolicyRegistration,
   PolicyContext,
@@ -26,10 +29,6 @@ export type {
 } from "./core/policy";
 export { McpClient } from "./runtime/mcp/index";
 export type { McpServerConfig } from "./runtime/mcp/index";
-export {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
-} from "./core/policy/builtin/budget";
 export { createCompactionPolicy } from "./core/policy/builtin/compaction";
 export { createToolPermissionPolicy } from "./core/policy/builtin/tool-guard";
 export { InMemoryCompactor } from "./core/execution/compaction";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,8 +12,11 @@ export type {
 } from "./core/types";
 export { PolicyEngine, PolicyRegistry, defaultRegistry } from "./core/policy";
 // Budget accounting stays core (the limits are loop invariants); the queries
-// are exported so a product can decide what to say about what is left (D5).
+// and the types they read and return are exported so a product can decide what
+// to say about what is left (D5). Exporting the functions without the types
+// leaves a consumer unable to name what it is holding.
 export { checkBudget, describeBudgetRemaining } from "./core/budget";
+export type { BudgetState, BudgetStatus } from "./core/budget";
 export type {
   CanonicalPolicyRegistration,
   PolicyContext,

--- a/packages/agent/test/core/policy/builtin-snapshots.test.ts
+++ b/packages/agent/test/core/policy/builtin-snapshots.test.ts
@@ -2,13 +2,9 @@ import { describe, expect, it } from "bun:test";
 import type { Message } from "@openomni/protocol";
 import type { BudgetState } from "../../../src/core/budget";
 import type { PolicyFn } from "../../../src/core/policy";
-import {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
-} from "../../../src/core/policy/builtin/budget";
 import { createCompactionPolicy } from "../../../src/core/policy/builtin/compaction";
 import { createToolPermissionPolicy } from "../../../src/core/policy/builtin/tool-guard";
-import { effectOf, firstReason } from "../../helpers/policy-decision";
+import { firstReason } from "../../helpers/policy-decision";
 import { Bus } from "@openomni/telemetry";
 
 function baseCtx(overrides?: Partial<Parameters<PolicyFn>[0]>): Parameters<PolicyFn>[0] {
@@ -59,48 +55,6 @@ function testMessage(id: string): Message.WithParts {
     ],
   };
 }
-
-describe("snapshot: budget-reassurance", () => {
-  it("continue — below 0.6 threshold", async () => {
-    const mw = createBudgetReassurancePolicy();
-    const verdict = await mw.fn(
-      baseCtx({ budgetState: budgetState({ turns: 5 }), budget: { maxTurns: 24 } }),
-    );
-    expect(verdict.verdict).toBe("allow");
-  });
-
-  it("inject — at 0.6 threshold", async () => {
-    const mw = createBudgetReassurancePolicy();
-    const verdict = await mw.fn(
-      baseCtx({ budgetState: budgetState({ turns: 15 }), budget: { maxTurns: 24 } }),
-    );
-    expect(verdict.verdict).toBe("allow");
-    expect(firstReason(verdict)).toBe("budget_reassurance");
-    expect(verdict.policyId).toBe("builtin.budget.reassurance");
-    expect(effectOf(verdict, "prompt.inject_message")?.message).toContain("[Budget Status]");
-  });
-});
-
-describe("snapshot: budget-warning", () => {
-  it("continue — below 0.8 threshold", async () => {
-    const mw = createBudgetWarningPolicy();
-    const verdict = await mw.fn(
-      baseCtx({ budgetState: budgetState({ turns: 10 }), budget: { maxTurns: 24 } }),
-    );
-    expect(verdict.verdict).toBe("allow");
-  });
-
-  it("inject — at 0.8 threshold", async () => {
-    const mw = createBudgetWarningPolicy();
-    const verdict = await mw.fn(
-      baseCtx({ budgetState: budgetState({ turns: 20 }), budget: { maxTurns: 24 } }),
-    );
-    expect(verdict.verdict).toBe("allow");
-    expect(firstReason(verdict)).toBe("budget_warning");
-    expect(verdict.policyId).toBe("builtin.budget.warning");
-    expect(effectOf(verdict, "prompt.inject_message")?.message).toContain("[Budget Warning]");
-  });
-});
 
 describe("snapshot: tool-permission", () => {
   it("continue — tool on allowlist", async () => {
@@ -159,26 +113,6 @@ describe("snapshot: compaction", () => {
 });
 
 describe("snapshot: canonical registration metadata", () => {
-  it("budget-reassurance: name, point, priority", () => {
-    const mw = createBudgetReassurancePolicy();
-    expect(mw.name).toBe("builtin:budget-reassurance");
-    expect(mw.pointIds).toEqual(["run.turn.pre"]);
-    expect(mw.effectCapabilities).toEqual({
-      "run.turn.pre": ["prompt.inject_message"],
-    });
-    expect(mw.priority).toBe(10);
-  });
-
-  it("budget-warning: name, point, priority", () => {
-    const mw = createBudgetWarningPolicy();
-    expect(mw.name).toBe("builtin:budget-warning");
-    expect(mw.pointIds).toEqual(["run.turn.pre"]);
-    expect(mw.effectCapabilities).toEqual({
-      "run.turn.pre": ["prompt.inject_message"],
-    });
-    expect(mw.priority).toBe(20);
-  });
-
   it("tool-permission: name, points, priority, failPolicy", () => {
     const mw = createToolPermissionPolicy({ events: Bus, permission: { action: "tool.call" } });
     expect(mw.name).toBe("builtin:tool-permission");

--- a/packages/agent/test/core/policy/canonical-execution.test.ts
+++ b/packages/agent/test/core/policy/canonical-execution.test.ts
@@ -7,8 +7,6 @@ import { createToolExecutor } from "../../../src/core/execution/tool-executor";
 import { buildPolicyEngine } from "../../../src/core/execution/runner";
 import { runAgent } from "../../../src/core/execution/runner";
 import {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
   createCompactionPolicy,
   createToolPermissionPolicy,
 } from "../../../src/core/policy/builtin";
@@ -281,15 +279,12 @@ describe("canonical builtin registrations", () => {
   it("declare their policy points and effect capabilities", () => {
     // Given / When
     const registrations = [
-      createBudgetReassurancePolicy(),
-      createBudgetWarningPolicy(),
       createCompactionPolicy({ events: Bus, contextWindowTokens: 100 }),
       createToolPermissionPolicy({ events: Bus, permission: { action: "tool.call" } }),
     ];
 
     // Then
-    expect(registrations[0]?.pointIds).toEqual(["run.turn.pre"]);
-    expect(registrations[2]?.pointIds).toEqual(["run.completion.pre"]);
-    expect(registrations[3]?.pointIds).toEqual(["tool.native.pre", "tool.mcp.pre"]);
+    expect(registrations[0]?.pointIds).toEqual(["run.completion.pre"]);
+    expect(registrations[1]?.pointIds).toEqual(["tool.native.pre", "tool.mcp.pre"]);
   });
 });

--- a/packages/agent/test/core/policy/registry.test.ts
+++ b/packages/agent/test/core/policy/registry.test.ts
@@ -6,12 +6,7 @@ import { PolicyRegistry, defaultRegistry } from "../../../src/core/policy";
 import type { PolicyFactory } from "../../../src/core/policy";
 import { allow } from "../../helpers/policy-decision";
 
-const builtinPolicyIds = [
-  "builtin:budget-reassurance",
-  "builtin:budget-warning",
-  "builtin:compaction",
-  "builtin:tool-permission",
-];
+const builtinPolicyIds = ["builtin:compaction", "builtin:tool-permission"];
 
 function plan(policies: Policy.PolicyPlan["policies"]): Policy.PolicyPlan {
   return { policies, labels: [] };

--- a/packages/openomni/src/execution-runtime/AGENTS.md
+++ b/packages/openomni/src/execution-runtime/AGENTS.md
@@ -6,7 +6,7 @@ Tool system, workspace safety, injection queue, cron bridge, and worker middlewa
 
 | Path | Purpose |
 | --- | --- |
-| `middleware.ts` | Builds worker middleware registrations from the gate-stamped `Execution.Request.policyPlan` (#479); builtin ids resolve through `defaultRegistry(events)` plus this package's own registrations (`registerIdleNudge`, #625), `builtin:tool-permission` config is hydrated from `request.permissions`, required-but-unregistered ids fail closed. |
+| `middleware.ts` | Builds worker middleware registrations from the gate-stamped `Execution.Request.policyPlan` (#479); builtin ids resolve through `defaultRegistry(events)` plus this package's own registrations (`registerIdleNudge` #625, `registerBudgetNudges` #626), `builtin:tool-permission` config is hydrated from `request.permissions`, required-but-unregistered ids fail closed. |
 | `workspace-lock.ts` | Serializes workspace-mutating tool execution. |
 | `injection-queue.ts` | `InjectionQueue` — async response buffer keyed by `runId`; drained at `turn.finish` by the injection-queue policy. |
 | `cron-job-registry.ts` | `CronJobRegistry` — storage-backed registry of scheduled jobs with a process-local fallback; populated by `dispatch` `schedule.create` action. |

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -1,6 +1,4 @@
 import {
-  createBudgetReassurancePolicy,
-  createBudgetWarningPolicy,
   createCompactionPolicy,
   createToolPermissionPolicy,
   defaultRegistry,
@@ -12,6 +10,11 @@ import type { Message } from "@openomni/protocol";
 import type { InjectionQueue } from "./injection-queue.js";
 import { createInjectionQueueDrainPolicy } from "./middleware/injection-queue-policy.js";
 import { createIdleNudgePolicy, registerIdleNudge } from "./middleware/idle-nudge-policy.js";
+import {
+  createBudgetReassurancePolicy,
+  createBudgetWarningPolicy,
+  registerBudgetNudges,
+} from "./middleware/budget-nudge-policy.js";
 
 type WorkerCompactionConfig = {
   readonly contextWindowTokens: number;
@@ -103,6 +106,7 @@ function resolvePoliciesFromPlan(
 ): PolicyEngineRegistration[] {
   const registry = defaultRegistry(Bus);
   registerIdleNudge(registry);
+  registerBudgetNudges(registry);
   return registry.resolve(
     plan,
     config.traceId === undefined ? {} : { traceId: config.traceId, auditEmit: Bus.publish },

--- a/packages/openomni/src/execution-runtime/middleware/budget-nudge-policy.ts
+++ b/packages/openomni/src/execution-runtime/middleware/budget-nudge-policy.ts
@@ -1,6 +1,11 @@
 import { PolicyDecision } from "@openomni/protocol";
-import { checkBudget, describeBudgetRemaining } from "../../budget";
-import type { CanonicalPolicyRegistration } from "../types";
+import {
+  checkBudget,
+  describeBudgetRemaining,
+  type CanonicalPolicyRegistration,
+  type PolicyContext,
+  type PolicyRegistryInstance,
+} from "@openomni/agent";
 
 export function createBudgetReassurancePolicy(): CanonicalPolicyRegistration {
   let issued = false;
@@ -62,4 +67,15 @@ export function createBudgetWarningPolicy(): CanonicalPolicyRegistration {
       return PolicyDecision.allow({ policyId: "builtin.budget.warning" });
     },
   };
+}
+
+/**
+ * Registers the two budget nudges. The core owns budget *accounting* — the
+ * limits are loop invariants and `checkBudget` is its query — but telling the
+ * model how much room it has left is an opinion about how to talk to a model,
+ * which is a product's call (D5).
+ */
+export function registerBudgetNudges(registry: PolicyRegistryInstance<PolicyContext>): void {
+  registry.register("builtin:budget-reassurance", () => createBudgetReassurancePolicy());
+  registry.register("builtin:budget-warning", () => createBudgetWarningPolicy());
 }

--- a/packages/openomni/test/execution-runtime/budget-nudge-policy.test.ts
+++ b/packages/openomni/test/execution-runtime/budget-nudge-policy.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "bun:test";
 import {
   createBudgetReassurancePolicy,
   createBudgetWarningPolicy,
-} from "../../../../src/core/policy/builtin/budget";
-import type { PolicyFn } from "../../../../src/core/policy";
-import type { BudgetState } from "../../../../src/core/budget";
+} from "../../src/execution-runtime/middleware/budget-nudge-policy";
+import type { PolicyFn } from "@openomni/agent";
+import type { BudgetState } from "@openomni/agent";
 import type { Policy } from "@openomni/protocol";
 
 function baseCtx(
@@ -51,6 +51,8 @@ describe("createBudgetReassurancePolicy", () => {
     const message = injectedMessage(verdict);
 
     expect(verdict.verdict).toBe("allow");
+    expect(verdict.policyId).toBe("builtin.budget.reassurance");
+    expect(verdict.reasonCodes).toContain("budget_reassurance");
     expect(message).toContain("[Budget Status]");
     expect(message).toContain("You have plenty of budget remaining");
     expect(message).toContain("Do NOT rush or skip tasks");
@@ -118,6 +120,8 @@ describe("createBudgetWarningPolicy", () => {
     const message = injectedMessage(verdict);
 
     expect(verdict.verdict).toBe("allow");
+    expect(verdict.policyId).toBe("builtin.budget.warning");
+    expect(verdict.reasonCodes).toContain("budget_warning");
     expect(message).toContain("[Budget Warning]");
     expect(message).toContain("Wrap up your current task");
     expect(message).toContain("provide a summary");
@@ -169,5 +173,30 @@ describe("createBudgetWarningPolicy", () => {
   it("has name builtin:budget-warning", () => {
     const middleware = createBudgetWarningPolicy();
     expect(middleware.name).toBe("builtin:budget-warning");
+  });
+});
+
+/**
+ * Carried from `agent`'s `builtin-snapshots` when the policies moved (#626).
+ * `effectCapabilities` is not decoration: the engine replaces any effect a
+ * registration did not declare for the point it fired at, so losing an entry
+ * silently drops the injected message at runtime while every direct
+ * `mw.fn(ctx)` assertion above still passes.
+ */
+describe("canonical registration metadata", () => {
+  it("budget-reassurance: name, point, capabilities, priority", () => {
+    const mw = createBudgetReassurancePolicy();
+    expect(mw.name).toBe("builtin:budget-reassurance");
+    expect(mw.pointIds).toEqual(["run.turn.pre"]);
+    expect(mw.effectCapabilities).toEqual({ "run.turn.pre": ["prompt.inject_message"] });
+    expect(mw.priority).toBe(10);
+  });
+
+  it("budget-warning: name, point, capabilities, priority", () => {
+    const mw = createBudgetWarningPolicy();
+    expect(mw.name).toBe("builtin:budget-warning");
+    expect(mw.pointIds).toEqual(["run.turn.pre"]);
+    expect(mw.effectCapabilities).toEqual({ "run.turn.pre": ["prompt.inject_message"] });
+    expect(mw.priority).toBe(20);
   });
 });


### PR DESCRIPTION
Phase 2, second move of **D5**. Follows #625 (idle nudge).

## The split D5 asks for

> Budget *limits*, tool timeout, and loop-breaking are loop invariants (config-driven, in core). Budget **nagging**, idle-nudge, and permission rulesets are opinions.

The core keeps the accounting — `BudgetState`, `recordTurn`, `checkBudget`, and the `exceeded` path in `dispatchBudgetCheck` that ends a run. What moves is the pair of policies that inject `[Budget Status]` / `[Budget Warning]` messages as consumption climbs. Telling a model how much room it has left is a decision about how to talk to a model, and that is a product's.

`packages/agent/src/core/policy/builtin/budget.ts` → `packages/openomni/src/execution-runtime/middleware/budget-nudge-policy.ts`, registered through the same public call any consumer would make:

```ts
export function registerBudgetNudges(registry: PolicyRegistryInstance<PolicyContext>): void {
  registry.register("builtin:budget-reassurance", () => createBudgetReassurancePolicy());
  registry.register("builtin:budget-warning", () => createBudgetWarningPolicy());
}
```

Enforcement did not move and is not coupled to the nudges: `dispatchBudgetCheck` runs at the top of every turn, before `run.turn.pre` dispatches, so an over-budget run ends identically for a consumer that never calls `registerBudgetNudges`.

## Four new exports on `@openomni/agent`

`checkBudget` and `describeBudgetRemaining` — pure queries over `BudgetState` — plus the `BudgetState` and `BudgetStatus` types they read and return. The functions alone were not enough: a consumer could call them but not name what it was holding, and the moved test was the first casualty (`import type { BudgetState }` was a TS2305). That error was invisible because `packages/openomni`'s `check-types` runs `tsconfig.contract-test.json`, whose include is `src` plus a single file — the test tree is not checked at all, which is #614's remaining work for this package. Verified with a scoped probe config: error before the type export, clean after.

## The snapshot pins travel this time

#625's review found that moving a policy out of `builtin-snapshots.test.ts` silently dropped three pins the moved behavior suite did not cover — most seriously `effectCapabilities`, since the engine replaces any effect a registration did not declare for the point it fired at, which would drop the injected message **at runtime** while every direct `mw.fn(ctx)` assertion still passed.

Same two blocks move here and the same pins go with them: `effectCapabilities` deep equality, `policyId`, and the reason codes. Verified red-first — emptying `effectCapabilities` → 2 fail, renaming a `policyId` → 1 fail.

## Verification

- `bun test` **3458 pass / 9 skip / 0 fail**. Base is 3462; the −4 is the four `snapshot: budget-*` behavior tests, all of whose subjects are covered by the fourteen tests now in openomni's suite.
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK.
- Wiring covered: removing the `registerBudgetNudges(registry)` call fails `buildWorkerMiddleware policy plan path` with `Required policy 'builtin:budget-reassurance' is not registered`.

## Docs

`packages/agent/AGENTS.md` (builtin list, `builtin/` tree, the "Also exported" list, lifecycle diagram), root `AGENTS.md` (file tree), `openomni`'s execution-runtime notes, and `docs/implementation-status.md` — whose *Structural guarantees* table cited the deleted `policy/builtin/budget.ts` as the enforcement site for the budget hard-stop. That citation was wrong before this PR too: the hard-stop is `dispatchBudgetCheck`, never the nudges. Repointed.

`check-deps`' doc-freshness gate is a commit-age heuristic with no content awareness, so none of this drift is caught automatically — the same class #625's review found.

## Remaining for D5

`builtin:tool-permission` is the last movable one; after it, `defaultRegistry` and the `builtin/` directory both go. It is the largest of the four — a 475-line agent-side integration suite drives `ChatAgent` through it, and only part of that suite's subject is the policy's own behavior — so it gets its own PR. `builtin:compaction` is held by the `Run.Outcome` ruling recorded in #624.

### Noted for follow-up, not fixed here

- `packages/openomni` has no `tsconfig.test.json`; its test tree carries pre-existing type errors and is why the `BudgetState` import above was invisible. That is #614's remaining scope.
- `packages/agent` is absent from `knip.json`'s workspaces, so `check-dead-exports` never reports exports from its `src/index.ts` — appending a probe export to it leaves the gate green. Pre-existing and repo-wide, but the D5 endgame leans on that surface.