### PR TITLE
chore: let the dead-export ratchet see the three packages (#606)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -30,6 +30,10 @@
       ],
       "project": ["src/**/*.ts", "test/**/*.ts"]
     },
+    "packages/agent": {
+      "entry": ["src/index.ts", "test/**/*.test.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
+    },
     "packages/coordinator": {
       "entry": ["src/index.ts", "test/**/*.test.ts", "test/harness/*.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts"]
@@ -38,9 +42,17 @@
       "entry": ["src/index.ts", "test/**/*.test.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts"]
     },
+    "packages/llm": {
+      "entry": ["src/index.ts", "test/**/*.test.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
+    },
     "packages/protocol": {
       "entry": ["src/index.ts", "test/**/*.test.ts", "test/**/*.d.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts", "test/**/*.d.ts"]
+    },
+    "packages/telemetry": {
+      "entry": ["src/index.ts", "test/**/*.test.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
     }
   }
 }


### PR DESCRIPTION
Found while reviewing #626: `check-dead-exports` has never looked at `packages/agent`, `packages/llm`, or `packages/telemetry`.

`knip.json` listed five workspaces — `.`, `apps/server`, `coordinator`, `ipc`, `protocol`. The three packages this whole effort is about were not among them, so knip never analysed a single file in any of them.

```
$ printf '\nexport const REVIEW_PROBE_UNUSED = 1;\n' >> packages/agent/src/index.ts
$ bun script/check-dead-exports.ts
OK: dead-export ratchet — 17 known issues, none new       ← blind
```

Same for llm and telemetry.

## The fix costs nothing

Adding the three leaves the baseline at **17 known issues, none new** — all three are already clean of dead exports. The point is the next one, not this one: a ratchet that cannot see a package cannot ratchet it, and D5 is actively reshaping these packages' public surfaces right now.

The gate bites where it matters:

| probe location | before | after |
|---|---|---|
| `packages/agent/src/core/budget.ts` | silent | **caught** |
| `packages/telemetry/src/trace.ts` | silent | **caught** |
| `packages/llm/src/message/index.ts` | silent | **caught** |
| `packages/llm/src/processor/index.ts` | silent | **caught** |
| `packages/llm/src/run.ts` | silent | still silent — see below |

`check-dead-exports --self-test` still discriminates.

## What it does not cover, and why I did not take it

Exports reachable from an entry file are treated as public API and go unreported. `src/index.ts` re-exports `run` by name, so everything in `run.ts` is entry-reachable and stays invisible. Closing that needs `includeEntryExports: true`, which reports **33 further entries** across the three packages — mostly types re-exported from `index.ts` that no in-repo consumer imports by name, plus a few real ones (`InMemoryCompactor`, the `PolicyRegistry` re-export).

That grows the baseline, and `script/check-dead-exports.ts`'s own header is explicit:

> baseline keys no longer reported pass at check time; the shrink happens via `--update` (autonomous and encouraged — **growing the baseline needs Owner sign-off in review**)

So it is recorded, not taken. Same disposition as the `Run.Outcome` schema-snapshot ruling in #624.

`packages/openomni`, `packages/policy`, and `packages/session` are also absent from the workspace list; adding them reports ~10 further entries and so needs the same sign-off. They are outside the three packages in scope here.

## Verification

`bun test` 3458 pass / 9 skip / 0 fail (unchanged), `check-dead-exports` + `--self-test`, `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-ledger-schema-drift` — all OK. The only file changed is `knip.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach the dead-export ratchet to scan `packages/agent`, `packages/llm`, and `packages/telemetry` by adding them to `knip.json`. Previously the ratchet (`check-dead-exports`) ignored these packages; now it analyzes them with no baseline change (still 17 known issues, none new).

- Change is limited to `knip.json`; no code or runtime behavior changes.
- Entry-reachable exports remain exempt; `includeEntryExports` stays off to avoid growing the baseline by 33 items and would require Owner sign-off.
- `packages/openomni`, `packages/policy`, and `packages/session` remain excluded; adding them would add ~10 baseline items and also needs sign-off.

<sup>Written for commit 296e74bf8a73bf87473759851d1950673051b2ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

