### PR TITLE
fix(agent): a retried attempt is the same turn (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -112,7 +112,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#626](https://github.com/INONONO66/openomni/pull/626) | dissolve `builtin/` per D5 — the two budget nudges move to openomni | 🟨 |
 | [#629](https://github.com/INONONO66/openomni/pull/629) | dissolve `builtin/` per D5 — `builtin:tool-permission` moves to openomni | 🟨 |
 | — | dissolve `builtin/` per D5 — `builtin:compaction` is the last one, and its fate is the compaction rewrite in Phase 3, not a move. `defaultRegistry` and the directory go with it | ⬜ |
-| — | retry no longer double-counts the turn budget | ⬜ |
+| [#630](https://github.com/INONONO66/openomni/pull/630) | retry no longer double-counts the turn budget | 🟨 |
 
 ### Phase 3 — compaction
 

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -149,6 +149,7 @@ When in doubt, keep the agent package as a loop engine and put product semantics
 - **Sink-driven**: Callers pass a `Sink` (from `@openomni/protocol`) to receive streaming output. The agent never creates sessions on its own.
 - **Policy > ad-hoc hooks**: New extensions MUST use canonical point registrations in `middleware: [...]`. `PolicyEngine.create()` is the single extension surface; timing registrations exist only for legacy compatibility.
 - **Budget check before each turn**: `checkBudget()` runs before `llmRun()`, not after, so budget enforcement blocks the next turn cleanly.
+- **A retried attempt is the same turn**: `recordRunTurn` charges once per `turnIndex`, so an attempt that failed and was retried is free in the *turns* unit and bounded by `maxAttempts` instead. Tokens and tool calls still charge per attempt, because they were really spent (#630).
 - **Message format**: `ChatAgentInput.messages` is a simple `{ role: "user" | "assistant"; content: string }[]`. Richer `Message.WithParts[]` is used internally only.
 
 ## ANTI-PATTERNS

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -98,6 +98,8 @@ export interface RunState {
   continuationCount: number;
   compactionCount: number;
   turnIndex: number;
+  /** The last `turnIndex` charged to the budget; -1 before the first turn. */
+  chargedTurnIndex: number;
   readonly startTime: number;
 }
 
@@ -145,6 +147,7 @@ export function createRunState(input: ChatAgentInput & { traceContext: RunTrace 
     continuationCount: 0,
     compactionCount: 0,
     turnIndex: 0,
+    chargedTurnIndex: -1,
     startTime: Date.now(),
   };
 }
@@ -153,7 +156,16 @@ export function getCompactionCount(state: RunState): number | undefined {
   return state.compactionCount > 0 ? state.compactionCount : undefined;
 }
 
+/**
+ * Charges the turn budget for the turn about to run, once.
+ *
+ * A retried attempt is the same turn tried again: the runner re-enters
+ * `buildTurn` without advancing `turnIndex`, so charging per attempt would let
+ * a transient provider error eat headroom an operator sized in turns of work.
+ */
 export function recordRunTurn(state: RunState): void {
+  if (state.chargedTurnIndex === state.turnIndex) return;
+  state.chargedTurnIndex = state.turnIndex;
   state.budgetState = recordTurn(state.budgetState);
 }
 

--- a/packages/agent/test/core/execution/retry-turn-budget.test.ts
+++ b/packages/agent/test/core/execution/retry-turn-budget.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import { PolicyDecision } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
 import {
   advanceRunTurn,
   createRunState,
   recordRunTurn,
 } from "../../../src/core/execution/run-state";
+import { runAgent } from "../../../src/core/execution/runner";
+import {
+  createMockLlmConfig,
+  createStopOutcome,
+  mockProviderData,
+  mockProviderModel,
+} from "../../helpers/mock-llm";
 import { runInput } from "../../helpers/run-input";
 
 /**
@@ -38,5 +47,65 @@ describe("turn budget across retries", () => {
     recordRunTurn(state);
 
     expect(state.budgetState.turns).toBe(2);
+  });
+});
+
+/**
+ * The same fact through a real run. `run.lifecycle.post` fires once, from
+ * `dispatchPostRunTransform`, after every charge — so it reads the run's total.
+ *
+ * This is the case #630's first attempt wrongly concluded could not exist: that
+ * harness never let the retry succeed, so `handleStop` never ran and the only
+ * `run.lifecycle.post` came from mid-run. It is also the only guard on the
+ * runner's call site — resetting `chargedTurnIndex` in the retry branch leaves
+ * the two unit cases above green.
+ */
+describe("turn budget across retries, through a run", () => {
+  it("reports one turn for a run whose first attempt failed", async () => {
+    let calls = 0;
+    const postRunTurnCounts: unknown[] = [];
+
+    const result = await runAgent(runInput([{ role: "user", content: "hi" }]), {
+      events: Bus,
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      middleware: [
+        {
+          kind: "point",
+          name: "test:no-backoff",
+          pointIds: ["run.error.error"],
+          effectCapabilities: { "run.error.error": ["run.retry_after"] },
+          priority: 0,
+          fn: () =>
+            PolicyDecision.allow({
+              policyId: "test.no-backoff",
+              effects: [{ type: "run.retry_after", delayMs: 0 }],
+            }),
+        },
+        {
+          kind: "point",
+          name: "test:post-run-observer",
+          pointIds: ["run.lifecycle.post"],
+          effectCapabilities: { "run.lifecycle.post": [] },
+          priority: 0,
+          fn: (ctx) => {
+            postRunTurnCounts.push(Reflect.get(ctx, "turnCount"));
+            return PolicyDecision.allow({ policyId: "test.post-run-observer" });
+          },
+        },
+      ],
+      llm: createMockLlmConfig({
+        getModels: async () => mockProviderData,
+        fromModelsDevModel: () => mockProviderModel,
+        run: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error("transient provider hiccup");
+          return createStopOutcome();
+        },
+      }),
+    });
+
+    expect(calls).toBe(2);
+    expect(result.finishReason).toBe("stop");
+    expect(postRunTurnCounts).toEqual([1]);
   });
 });

--- a/packages/agent/test/core/execution/retry-turn-budget.test.ts
+++ b/packages/agent/test/core/execution/retry-turn-budget.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  advanceRunTurn,
+  createRunState,
+  recordRunTurn,
+} from "../../../src/core/execution/run-state";
+import { runInput } from "../../helpers/run-input";
+
+/**
+ * A retried attempt is the same turn, tried again.
+ *
+ * `buildTurn` charges the turn budget before the model call, and the runner
+ * re-enters `buildTurn` on retry without advancing `turnIndex` — so charging
+ * per entry let a transient provider error eat headroom an operator sized in
+ * turns of work. Instrumenting `recordRunTurn` on a run whose first model call
+ * throws showed two charges at `turnIndex=0`, taking `turns` to 2 for one turn
+ * of work.
+ */
+describe("turn budget across retries", () => {
+  it("charges a turn once however many attempts it takes", () => {
+    const state = createRunState(runInput([{ role: "user", content: "hi" }]));
+
+    recordRunTurn(state);
+    expect(state.budgetState.turns).toBe(1);
+
+    // The retry: same turn, re-entered.
+    recordRunTurn(state);
+    recordRunTurn(state);
+    expect(state.budgetState.turns).toBe(1);
+  });
+
+  it("charges again once the run moves to the next turn", () => {
+    const state = createRunState(runInput([{ role: "user", content: "hi" }]));
+
+    recordRunTurn(state);
+    advanceRunTurn(state);
+    recordRunTurn(state);
+    recordRunTurn(state);
+
+    expect(state.budgetState.turns).toBe(2);
+  });
+});


### PR DESCRIPTION
Phase 2. The plan's `retry no longer double-counts the turn budget` row.

## The bug

`buildTurn` charges the turn budget *before* the model call, and the runner re-enters `buildTurn` on retry without advancing `turnIndex`. So a turn that failed once and succeeded on the second attempt cost **two** turns of budget.

Instrumented on a run whose first model call throws:

```
CHARGE turnIndex= 0 turns= 0
CHARGE turnIndex= 0 turns= 1
```

Production-reachable, not a test-stub path: `packages/llm/src/run.ts` returns `{type:"error"}`, the runner rethrows it, `handleError` classifies it retryable, and the outer loop re-enters at the same `turnIndex`.

Operator-visible: with `budget: { maxTurns: 2 }`, one flaky attempt then two real turns ends `max-steps` before this fix and `stop` after. An operator sizing `maxTurns` is sizing turns of *work*; a transient provider error is not work.

## The fix

```ts
export function recordRunTurn(state: RunState): void {
  if (state.chargedTurnIndex === state.turnIndex) return;
  state.chargedTurnIndex = state.turnIndex;
  state.budgetState = recordTurn(state.budgetState);
}
```

`advanceRunTurn` and `advanceRunContinuation` move the index, so a real next turn charges normally. Tokens and tool calls still charge per attempt, because they were really spent.

Moving the charge after the model call would be worse: `dispatchBudgetCheck`, the `run.turn.pre` budget nudges, and the tool executor's `getContext().turnCount` all read `turns` mid-turn and would go stale, and `maxTurns` could be overrun by one.

## Where it is pinned

Three cases, all red-first:

- **the helper's contract** — charge once however many attempts; charge again once the run moves on. Kills every mutation of the guard itself (remove it, invert the comparison, assign before the early return, initialise to `0`).
- **through a real run** — a `run.lifecycle.post` observer reads `turnCount` after every charge: `1` with the fix, `2` without. This is the only guard on the runner's *call site*: adding `state.chargedTurnIndex = -1` to the retry branch — the kind of "reset for the new attempt" edit someone will make — leaves the unit cases green and restores the double charge. With this case it fails.

### A correction to this PR's earlier description

I first claimed no runner-level observation point could discriminate, `run.lifecycle.post` included. That was wrong, and adversarial review caught it. `run.turn.pre` genuinely cannot — it fires before its own turn is charged — but `run.lifecycle.post` fires once, from `dispatchPostRunTransform`, after every charge. My discarded harness never let the retry *succeed*, so `handleStop` never ran and the only `run.lifecycle.post` I observed came from mid-run: exactly the shaped-around-the-harness mistake I said I was avoiding. `run.turn.post`, `agent.run.completed` telemetry, and `finishReason` under `maxTurns` discriminate too.

## Verification

- `bun test` **3454 pass / 9 skip / 0 fail** (base 3451, +3).
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK. Coverage for `packages/agent` improves.

## Docs

One line in `packages/agent/AGENTS.md` KEY PATTERNS, beside the existing budget bullet — that is where a reader looks for turn accounting, and it was incomplete rather than stale.