### PR TITLE
fix(agent): a run that started always records that it ended (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -107,7 +107,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#623](https://github.com/INONONO66/openomni/pull/623) | slop comments and `agentBaseForState`; the last `as unknown as` is earned, not removed | 🟨 |
 | [#624](https://github.com/INONONO66/openomni/pull/624) | duplicate helpers: one `requireTrace`, one `nonEmptyString` | 🟨 |
 | [#631](https://github.com/INONONO66/openomni/pull/631) | one run exit, one terminal record — the observable half of D4's "started with no terminal is unrepresentable" | 🟨 |
-| — | file layout + the FSM guard itself (`run.ts`/`turn.ts`/`state.ts`, transition table as the injection-point map) | ⬜ |
+| — | file layout + the FSM guard itself (`run.ts`/`turn.ts`/`state.ts`, transition table as the injection-point map). Carries the two throw paths #631 could not close: an abort raised inside `Retry.sleep`, and a non-`Error` throw — both emit `agent.run.started` and no terminal | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | [#625](https://github.com/INONONO66/openomni/pull/625) | dissolve `builtin/` per D5 — `builtin:idle-nudge` moves to openomni | 🟨 |
 | [#626](https://github.com/INONONO66/openomni/pull/626) | dissolve `builtin/` per D5 — the two budget nudges move to openomni | 🟨 |

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -106,7 +106,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#621](https://github.com/INONONO66/openomni/pull/621) | single output channel: remove the `AgentEvent` generator and `ChatAgent.stream` | 🟨 |
 | [#623](https://github.com/INONONO66/openomni/pull/623) | slop comments and `agentBaseForState`; the last `as unknown as` is earned, not removed | 🟨 |
 | [#624](https://github.com/INONONO66/openomni/pull/624) | duplicate helpers: one `requireTrace`, one `nonEmptyString` | 🟨 |
-| — | file layout + FSM | ⬜ |
+| [#631](https://github.com/INONONO66/openomni/pull/631) | one run exit, one terminal record — the observable half of D4's "started with no terminal is unrepresentable" | 🟨 |
+| — | file layout + the FSM guard itself (`run.ts`/`turn.ts`/`state.ts`, transition table as the injection-point map) | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | [#625](https://github.com/INONONO66/openomni/pull/625) | dissolve `builtin/` per D5 — `builtin:idle-nudge` moves to openomni | 🟨 |
 | [#626](https://github.com/INONONO66/openomni/pull/626) | dissolve `builtin/` per D5 — the two budget nudges move to openomni | 🟨 |

--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -3,12 +3,7 @@ import { effectOf, PolicyEffectApplier } from "./policy-effects";
 import { publishBudgetTelemetry } from "../budget";
 import type { PolicyEngineInstance } from "../policy";
 import type { AgentResult, ChatAgentConfig } from "../types";
-import {
-  guardAbortedResult,
-  runResult,
-  emitRunCompleted,
-  publishDenyDiagnostic,
-} from "./run-events";
+import { guardAbortedResult, runResult, publishDenyDiagnostic } from "./run-events";
 import { buildLifecyclePolicyContext, type AgentRunBase, type RunState } from "./run-state";
 
 export async function dispatchPreRun(
@@ -62,7 +57,6 @@ export async function dispatchBudgetCheck(
   if (PolicyDecision.isBlocking(postRunDecision)) {
     publishDenyDiagnostic(config.events, "run.finish", postRunDecision, state, agentBase);
   }
-  emitRunCompleted(config.events, state, agentBase, "max-steps");
   return runResult(state, { finishReason: "max-steps" });
 }
 

--- a/packages/agent/src/core/execution/run-events.ts
+++ b/packages/agent/src/core/execution/run-events.ts
@@ -86,7 +86,7 @@ export function emitRunCompleted(
   events: BusEvent.Sink,
   state: RunState,
   agentBase: AgentRunBase,
-  finishReason: "stop" | "max-steps",
+  finishReason: AgentResult["finishReason"],
 ): void {
   events.publish(Operational.Info, {
     traceId: agentBase.traceId,

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -35,7 +35,11 @@ export async function runAgent(
   const actorId =
     nonEmptyString(input.metadata?.actorId) ?? nonEmptyString(trace.agentName) ?? runId;
   const agentBase = { traceId, sessionId, runId, actorId };
+  // Both validators run before the run is opened: `buildPolicyEngine`
+  // rejects a malformed middleware registration, and a configuration error
+  // must not open a run it cannot close.
   assertToolExecutor(config);
+  const engine = buildPolicyEngine(config, agentBase);
   emitRunStarted(config.events, trace, config.model.id);
 
   // #546: run state and pre-run dispatch are run-scoped, living across
@@ -43,14 +47,20 @@ export async function runAgent(
   // artifacts), never the history, budget/usage (no double-billing reset),
   // or run.lifecycle.pre effects (prompt injections apply exactly once).
   const state = createRunState({ ...input, traceContext: trace });
-  const engine = buildPolicyEngine(config, agentBase);
 
   /**
-   * The run's one exit. Every terminal used to record itself, so only three of
-   * them did: a run a policy blocked emitted `agent.run.started` and nothing
-   * after it, and read as permanently in flight to anything folding the
-   * stream. Failures still record where they are decided, because that is
-   * where the attempt count and retry reason live.
+   * The run's one *returning* exit. Every terminal used to record itself, so
+   * only three of them did: a run a policy blocked emitted
+   * `agent.run.started` and nothing after it, and read as still in flight to
+   * an in-process observer of the stream.
+   *
+   * Failures record where they are decided — that is where the attempt count
+   * and the retry reason live. Two throw paths still record neither: an abort
+   * raised from inside `Retry.sleep`, which escapes past `emitRunFailed`
+   * because it rejects within the catch that would have emitted it, and a
+   * non-`Error` throw, which the catch rethrows untouched. Both predate this
+   * change and are carried on the FSM row, where a terminal state is the
+   * thing that makes them unrepresentable rather than merely unrecorded.
    */
   const finish = (result: AgentResult): AgentResult => {
     emitRunCompleted(config.events, state, agentBase, result.finishReason);
@@ -67,7 +77,7 @@ export async function runAgent(
       );
       const configuredToolChoice = resolveToolChoice(config);
 
-      while (true) {
+      for (;;) {
         const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
         if (budgetResult) return finish(budgetResult);
 

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -3,7 +3,7 @@ import type { Sink } from "@openomni/protocol";
 import type { AgentResult, ChatAgentConfig, ChatAgentInput } from "../types";
 import * as Retry from "../retry";
 import { PolicyEngine, type PolicyEngineInstance } from "../policy";
-import { emitRunStarted, emitTurnStart } from "./run-events";
+import { emitRunCompleted, emitRunStarted, emitTurnStart } from "./run-events";
 import { handleCompact, handleContinue, handleError, handleStop } from "./turn-outcome";
 import { assertToolExecutor, buildTurn, resolveToolChoice } from "./turn-prepare";
 import {
@@ -29,15 +29,14 @@ export async function runAgent(
 ): Promise<AgentResult> {
   const retryPolicy = Retry.DEFAULT_RETRY_POLICY;
   let attempt = 1;
-  let lastError = "";
 
   const trace = requireTrace("agent run", input.traceContext);
   const { traceId, sessionId, runId } = trace;
   const actorId =
     nonEmptyString(input.metadata?.actorId) ?? nonEmptyString(trace.agentName) ?? runId;
   const agentBase = { traceId, sessionId, runId, actorId };
-  emitRunStarted(config.events, trace, config.model.id);
   assertToolExecutor(config);
+  emitRunStarted(config.events, trace, config.model.id);
 
   // #546: run state and pre-run dispatch are run-scoped, living across
   // attempts — an agent-level retry regenerates only the attempt (turn
@@ -46,10 +45,22 @@ export async function runAgent(
   const state = createRunState({ ...input, traceContext: trace });
   const engine = buildPolicyEngine(config, agentBase);
 
-  const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
-  if (preRunResult) return preRunResult;
+  /**
+   * The run's one exit. Every terminal used to record itself, so only three of
+   * them did: a run a policy blocked emitted `agent.run.started` and nothing
+   * after it, and read as permanently in flight to anything folding the
+   * stream. Failures still record where they are decided, because that is
+   * where the attempt count and retry reason live.
+   */
+  const finish = (result: AgentResult): AgentResult => {
+    emitRunCompleted(config.events, state, agentBase, result.finishReason);
+    return result;
+  };
 
-  while (attempt <= retryPolicy.maxAttempts) {
+  const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
+  if (preRunResult) return finish(preRunResult);
+
+  for (;;) {
     try {
       const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
         config.model,
@@ -58,7 +69,7 @@ export async function runAgent(
 
       while (true) {
         const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
-        if (budgetResult) return budgetResult;
+        if (budgetResult) return finish(budgetResult);
 
         emitTurnStart(config.events, state, agentBase);
         const turnResult = await buildTurn(
@@ -71,11 +82,11 @@ export async function runAgent(
           agentBase,
           sink,
         );
-        if (turnResult.type === "complete") return turnResult.result;
+        if (turnResult.type === "complete") return finish(turnResult.result);
 
         const runLlm = config.llm?.run ?? llmRun;
         const modelRequestResult = await dispatchModelRequest(state, engine, config, agentBase);
-        if (modelRequestResult) return modelRequestResult;
+        if (modelRequestResult) return finish(modelRequestResult);
         const outcome = await runLlm(turnResult.turn.runInput, turnResult.turn.trackingSink);
         const modelResponseResult = await dispatchModelResponse(
           state,
@@ -87,11 +98,11 @@ export async function runAgent(
           },
           agentBase,
         );
-        if (modelResponseResult) return modelResponseResult;
+        if (modelResponseResult) return finish(modelResponseResult);
 
         if (outcome.type === "stop") {
           const stopOutcome = await handleStop(state, config, engine, agentBase, turnResult.turn);
-          if (stopOutcome !== "continue") return stopOutcome;
+          if (stopOutcome !== "continue") return finish(stopOutcome);
           continue;
         }
 
@@ -102,7 +113,7 @@ export async function runAgent(
 
         if (outcome.type === "compact") {
           const compactOutcome = await handleCompact(state, engine, config, agentBase);
-          if (compactOutcome !== "continue") return compactOutcome;
+          if (compactOutcome !== "continue") return finish(compactOutcome);
           continue;
         }
 
@@ -122,17 +133,14 @@ export async function runAgent(
         attempt,
         retryPolicy,
       );
-      lastError = decision.errorMessage;
       if (decision.action === "retry") {
         attempt += 1;
         continue;
       }
-      if (decision.action === "complete") return decision.result;
+      if (decision.action === "complete") return finish(decision.result);
       throw decision.error;
     }
   }
-
-  throw new Error(lastError || "Max retry attempts exceeded");
 }
 
 function unknownOutcomeType(value: unknown): string {

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -9,7 +9,6 @@ import {
   runResult,
   emitCompaction,
   emitErrorRetry,
-  emitRunCompleted,
   emitRunFailed,
   emitTurnComplete,
   publishDenyDiagnostic,
@@ -116,7 +115,6 @@ export async function handleStop(
   }
 
   await dispatchPostRunTransform(state, engine, config, agentBase);
-  emitRunCompleted(config.events, state, agentBase, "stop");
   return runResult(state, { finishReason: "stop" });
 }
 

--- a/packages/agent/test/core/execution/run-terminal-record.test.ts
+++ b/packages/agent/test/core/execution/run-terminal-record.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { Operational, PolicyDecision } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
+import { runAgent } from "../../../src/core/execution/runner";
+import type { PolicyEngineRegistration } from "../../../src/core/policy";
+import {
+  createMockLlmConfig,
+  createStopOutcome,
+  mockProviderData,
+  mockProviderModel,
+} from "../../helpers/mock-llm";
+import { runInput } from "../../helpers/run-input";
+
+/**
+ * Every run that started has to end on the record too.
+ *
+ * `agent.run.started` fires unconditionally, but the terminal used to be
+ * emitted by whichever branch happened to end the run — and only three of them
+ * did. A run a policy blocked emitted a start and nothing after it, so anything
+ * folding the stream saw it as permanently in flight.
+ */
+async function runWith(middleware: PolicyEngineRegistration[]): Promise<string[]> {
+  const seen: string[] = [];
+  const stop = Bus.observe((event, payload) => {
+    if (event.name !== Operational.Info.name) return;
+    const msg = (payload as { msg?: string }).msg;
+    if (msg === "agent.run.started" || msg === "agent.run.completed") seen.push(msg);
+  });
+  try {
+    await runAgent(runInput([{ role: "user", content: "hi" }]), {
+      events: Bus,
+      model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      middleware,
+      llm: createMockLlmConfig({
+        getModels: async () => mockProviderData,
+        fromModelsDevModel: () => mockProviderModel,
+        run: async () => createStopOutcome(),
+      }),
+    });
+  } finally {
+    stop();
+  }
+  return seen;
+}
+
+function blockAt(point: "run.lifecycle.pre" | "run.turn.pre"): PolicyEngineRegistration {
+  return {
+    kind: "point",
+    name: `test:block-${point}`,
+    pointIds: [point],
+    effectCapabilities: { [point]: ["run.abort"] },
+    priority: 100,
+    fn: () =>
+      PolicyDecision.deny({
+        policyId: "test.block",
+        reasonCodes: ["blocked"],
+        effects: [{ type: "run.abort", reason: "blocked" }],
+      }),
+  } as PolicyEngineRegistration;
+}
+
+describe("a started run always records a terminal", () => {
+  it("on the ordinary path", async () => {
+    expect(await runWith([])).toEqual(["agent.run.started", "agent.run.completed"]);
+  });
+
+  it("when a policy blocks the run before its first turn", async () => {
+    expect(await runWith([blockAt("run.lifecycle.pre")])).toEqual([
+      "agent.run.started",
+      "agent.run.completed",
+    ]);
+  });
+
+  it("when a policy blocks the turn", async () => {
+    expect(await runWith([blockAt("run.turn.pre")])).toEqual([
+      "agent.run.started",
+      "agent.run.completed",
+    ]);
+  });
+});

--- a/packages/agent/test/core/execution/run-terminal-record.test.ts
+++ b/packages/agent/test/core/execution/run-terminal-record.test.ts
@@ -19,7 +19,10 @@ import { runInput } from "../../helpers/run-input";
  * did. A run a policy blocked emitted a start and nothing after it, so anything
  * folding the stream saw it as permanently in flight.
  */
-async function runWith(middleware: PolicyEngineRegistration[]): Promise<string[]> {
+async function runWith(
+  middleware: PolicyEngineRegistration[],
+  budget?: { readonly maxTurns: number },
+): Promise<string[]> {
   const seen: string[] = [];
   const stop = Bus.observe((event, payload) => {
     if (event.name !== Operational.Info.name) return;
@@ -30,6 +33,7 @@ async function runWith(middleware: PolicyEngineRegistration[]): Promise<string[]
     await runAgent(runInput([{ role: "user", content: "hi" }]), {
       events: Bus,
       model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+      ...(budget === undefined ? {} : { budget }),
       middleware,
       llm: createMockLlmConfig({
         getModels: async () => mockProviderData,
@@ -43,7 +47,13 @@ async function runWith(middleware: PolicyEngineRegistration[]): Promise<string[]
   return seen;
 }
 
-function blockAt(point: "run.lifecycle.pre" | "run.turn.pre"): PolicyEngineRegistration {
+type BlockablePoint =
+  | "run.lifecycle.pre"
+  | "run.turn.pre"
+  | "connection.llm.pre"
+  | "connection.llm.post";
+
+function blockAt(point: BlockablePoint): PolicyEngineRegistration {
   return {
     kind: "point",
     name: `test:block-${point}`,
@@ -76,5 +86,81 @@ describe("a started run always records a terminal", () => {
       "agent.run.started",
       "agent.run.completed",
     ]);
+  });
+
+  it("when a policy blocks the model request", async () => {
+    expect(await runWith([blockAt("connection.llm.pre")])).toEqual([
+      "agent.run.started",
+      "agent.run.completed",
+    ]);
+  });
+
+  it("when a policy aborts on the model response", async () => {
+    expect(await runWith([blockAt("connection.llm.post")])).toEqual([
+      "agent.run.started",
+      "agent.run.completed",
+    ]);
+  });
+
+  /**
+   * The one terminal this change *moved* rather than added — it lived in
+   * `dispatchBudgetCheck` before. Nothing asserted it on either side, so
+   * dropping it during the move would have left the whole suite green.
+   */
+  it("when the turn budget is exhausted", async () => {
+    expect(await runWith([], { maxTurns: 0 })).toEqual([
+      "agent.run.started",
+      "agent.run.completed",
+    ]);
+  });
+
+  /**
+   * The error path's own terminal: a `run.error.error` policy that aborts
+   * settles the run rather than rethrowing, so it returns a result and must
+   * record like any other exit.
+   *
+   * The one remaining exit without a case is the `compact` outcome, which no
+   * llm run produces — it is dead alongside `Run.Outcome.compact`, whose
+   * deletion is the Owner-gated item recorded in #624.
+   */
+  it("when a guard aborts the run on error", async () => {
+    const seen: string[] = [];
+    const stop = Bus.observe((event, payload) => {
+      if (event.name !== Operational.Info.name) return;
+      const msg = (payload as { msg?: string }).msg;
+      if (msg === "agent.run.started" || msg === "agent.run.completed") seen.push(msg);
+    });
+    try {
+      await runAgent(runInput([{ role: "user", content: "hi" }]), {
+        events: Bus,
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        middleware: [
+          {
+            kind: "point",
+            name: "test:abort-on-error",
+            pointIds: ["run.error.error"],
+            effectCapabilities: { "run.error.error": ["run.abort"] },
+            priority: 100,
+            fn: () =>
+              PolicyDecision.deny({
+                policyId: "test.abort-on-error",
+                reasonCodes: ["blocked"],
+                effects: [{ type: "run.abort", reason: "blocked" }],
+              }),
+          },
+        ],
+        llm: createMockLlmConfig({
+          getModels: async () => mockProviderData,
+          fromModelsDevModel: () => mockProviderModel,
+          run: async () => {
+            throw new Error("transient provider hiccup");
+          },
+        }),
+      });
+    } finally {
+      stop();
+    }
+
+    expect(seen).toEqual(["agent.run.started", "agent.run.completed"]);
   });
 });


### PR DESCRIPTION
Phase 2. The observable half of **D4** — *"terminal states have no outgoing edges, making 'started with no terminal' unrepresentable"* — taken before the state machine, because it is a live defect on its own.

## The hole

`emitRunStarted` fires for every run. The terminal record was emitted by whichever branch happened to end the run, and only **three** of them did: a normal stop, an exhausted budget, and a failure. Every other exit recorded nothing — a deny at `run.lifecycle.pre`, `run.turn.pre`, `connection.llm.pre` or `connection.llm.post`, a blocked system prompt, a denied tool catalog, an abort at `turn.finish`, a completion-gate block, a guard abort on error.

A run a policy blocked emitted `agent.run.started` and nothing after it, and read as still in flight to an in-process observer. Copying the new test onto the merge base fails on the deny cases and passes on the ordinary one — the hole is demonstrated, not asserted.

## One returning exit

```ts
const finish = (result: AgentResult): AgentResult => {
  emitRunCompleted(config.events, state, agentBase, result.finishReason);
  return result;
};
```

All eight `return`s go through it; the two branches that recorded themselves no longer do, and nothing double-emits. Failures record where they are decided — that is where the attempt count and the retry reason live.

**Both configuration validators now run before the run is opened.** `assertToolExecutor` moved above `emitRunStarted`, and so did `buildPolicyEngine`: `engine.register` throws on a malformed middleware registration, so any misconfigured `config.middleware` was opening a run it could not close. Adversarial review caught that one — the first version of this PR claimed the property while leaving the second validator seven lines below.

`emitRunCompleted`'s `finishReason` widens to `AgentResult["finishReason"]`, which is what the exits carry — `stalled` was previously unrepresentable in the record.

## Two dead guards go with it

The retry loop read `while (attempt <= retryPolicy.maxAttempts)`. `shouldRetry` already enforces that ceiling, returning `false` at `attempt >= maxAttempts`, so the condition was always true and the `Max retry attempts exceeded` line after the loop was unreachable. `for (;;)` says what the loop does: it exits on the retry decision. `lastError` existed only to feed that line. The inner loop becomes `for (;;)` too — it was `while (true)` seven lines away.

## Verification

Seven cases, and the funnel is pinned **per exit**: unfunneling any one of the eight sites individually and running the file gives a failure for seven of them. The eighth is the `compact` outcome, which no llm run produces and which is dead alongside `Run.Outcome.compact` (the Owner-gated item in #624).

The first version of this PR claimed per-exit sensitivity on the strength of one sample; review swept all eight and found **three** guarded. The gap that mattered was the budget terminal, which this change *moved* out of `dispatchBudgetCheck` — nothing asserted it on either side, so dropping it during the move would have left the whole suite green. Cases for exhausted budget, denied model request, aborted model response, and a guard abort on error close that.

- Deleting the emit from `finish`: 3 fail. Double-emitting: 3 fail.
- `bun test` **3461 pass / 9 skip / 0 fail** (base 3454, +7).
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK.

## What this does not close

Two **throw** paths still record neither terminal: an abort raised inside `Retry.sleep`, which escapes past `emitRunFailed` because it rejects within the catch that would have emitted it, and a non-`Error` throw, which the catch rethrows untouched. Both predate this change. The docstring says so rather than claiming an unconditional invariant, and the FSM row carries them — a terminal *state* is what makes them unrepresentable rather than merely unrecorded.

Scope note: `Operational.Info` is ephemeral and is dropped before ledger persistence, so the audience for this pair is in-process observers and stdout, not a durable fold. The asymmetry is real — `agent.run.failed` is `Operational.Error` and does persist — and belongs to whoever decides the visibility of the pair.