### PR TITLE
fix(agent): the runner owns both terminals (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -107,7 +107,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#623](https://github.com/INONONO66/openomni/pull/623) | slop comments and `agentBaseForState`; the last `as unknown as` is earned, not removed | 🟨 |
 | [#624](https://github.com/INONONO66/openomni/pull/624) | duplicate helpers: one `requireTrace`, one `nonEmptyString` | 🟨 |
 | [#631](https://github.com/INONONO66/openomni/pull/631) | one run exit, one terminal record — the observable half of D4's "started with no terminal is unrepresentable" | 🟨 |
-| — | file layout + the FSM guard itself (`run.ts`/`turn.ts`/`state.ts`, transition table as the injection-point map). Carries the two throw paths #631 could not close: an abort raised inside `Retry.sleep`, and a non-`Error` throw — both emit `agent.run.started` and no terminal | ⬜ |
+| [#632](https://github.com/INONONO66/openomni/pull/632) | the runner owns both terminals — every exit, return or throw, records one | 🟨 |
+| — | file layout + the FSM guard itself (`run.ts`/`turn.ts`/`state.ts`, the transition table doubling as the injection-point map, a serializable state tag) | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | [#625](https://github.com/INONONO66/openomni/pull/625) | dissolve `builtin/` per D5 — `builtin:idle-nudge` moves to openomni | 🟨 |
 | [#626](https://github.com/INONONO66/openomni/pull/626) | dissolve `builtin/` per D5 — the two budget nudges move to openomni | 🟨 |

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -124,23 +124,22 @@ export type BuildTurnResult =
 
 /**
  * What the run does after an attempt raised. `complete` carries the result a
- * guard settled on; the other two carry the error, which the caller either
- * sleeps on and retries or rethrows.
+ * guard settled on. The other two carry what the terminal record would need,
+ * because the runner owns that record and the wait between attempts: a run
+ * aborted mid-backoff has to report the reason and ceiling that were decided,
+ * not ones re-derived from the abort.
  */
+/** What the terminal record needs. Emitted by the runner, which owns it. */
+export interface RunFailureFacts {
+  readonly reason: RetryReason;
+  readonly attempt: number;
+  readonly maxAttempts: number;
+}
+
 export type ErrorDecision =
-  | { action: "retry"; errorMessage: string }
-  | { action: "complete"; result: AgentResult; errorMessage: string }
-  | {
-      action: "throw";
-      error: Error;
-      errorMessage: string;
-      /** What the record needs. Emitted by the runner, which owns the terminal. */
-      readonly failure: {
-        readonly reason: RetryReason;
-        readonly attempt: number;
-        readonly maxAttempts: number;
-      };
-    };
+  | { action: "retry"; backoffMs: number; failure: RunFailureFacts }
+  | { action: "complete"; result: AgentResult }
+  | { action: "throw"; error: Error; failure: RunFailureFacts };
 
 export function createRunState(input: ChatAgentInput & { traceContext: RunTrace }): RunState {
   const sessionId = input.traceContext.sessionId;

--- a/packages/agent/src/core/execution/run-state.ts
+++ b/packages/agent/src/core/execution/run-state.ts
@@ -9,6 +9,7 @@ import {
 } from "../budget";
 import type { AgentResult, AgentStep, ChatAgentConfig, ChatAgentInput, TokenUsage } from "../types";
 import type { DispatchContext } from "../policy";
+import type { RetryReason } from "../retry";
 import { createUserMessage, createAssistantMessage } from "../message-factory";
 
 function toMessagesWithParts(
@@ -129,7 +130,17 @@ export type BuildTurnResult =
 export type ErrorDecision =
   | { action: "retry"; errorMessage: string }
   | { action: "complete"; result: AgentResult; errorMessage: string }
-  | { action: "throw"; error: Error; errorMessage: string };
+  | {
+      action: "throw";
+      error: Error;
+      errorMessage: string;
+      /** What the record needs. Emitted by the runner, which owns the terminal. */
+      readonly failure: {
+        readonly reason: RetryReason;
+        readonly attempt: number;
+        readonly maxAttempts: number;
+      };
+    };
 
 export function createRunState(input: ChatAgentInput & { traceContext: RunTrace }): RunState {
   const sessionId = input.traceContext.sessionId;

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -3,7 +3,7 @@ import type { Sink } from "@openomni/protocol";
 import type { AgentResult, ChatAgentConfig, ChatAgentInput } from "../types";
 import * as Retry from "../retry";
 import { PolicyEngine, type PolicyEngineInstance } from "../policy";
-import { emitRunCompleted, emitRunStarted, emitTurnStart } from "./run-events";
+import { emitRunCompleted, emitRunFailed, emitRunStarted, emitTurnStart } from "./run-events";
 import { handleCompact, handleContinue, handleError, handleStop } from "./turn-outcome";
 import { assertToolExecutor, buildTurn, resolveToolChoice } from "./turn-prepare";
 import {
@@ -12,7 +12,13 @@ import {
   dispatchModelResponse,
   dispatchPreRun,
 } from "./lifecycle-dispatch";
-import { createRunState, nonEmptyString, requireTrace, type AgentRunBase } from "./run-state";
+import {
+  createRunState,
+  nonEmptyString,
+  requireTrace,
+  type AgentRunBase,
+  type ErrorDecision,
+} from "./run-state";
 
 /**
  * Runs an agent to a result.
@@ -29,6 +35,7 @@ export async function runAgent(
 ): Promise<AgentResult> {
   const retryPolicy = Retry.DEFAULT_RETRY_POLICY;
   let attempt = 1;
+  let thrownFailure: Extract<ErrorDecision, { action: "throw" }>["failure"] | undefined;
 
   const trace = requireTrace("agent run", input.traceContext);
   const { traceId, sessionId, runId } = trace;
@@ -49,106 +56,122 @@ export async function runAgent(
   const state = createRunState({ ...input, traceContext: trace });
 
   /**
-   * The run's one *returning* exit. Every terminal used to record itself, so
-   * only three of them did: a run a policy blocked emitted
-   * `agent.run.started` and nothing after it, and read as still in flight to
-   * an in-process observer of the stream.
-   *
-   * Failures record where they are decided — that is where the attempt count
-   * and the retry reason live. Two throw paths still record neither: an abort
-   * raised from inside `Retry.sleep`, which escapes past `emitRunFailed`
-   * because it rejects within the catch that would have emitted it, and a
-   * non-`Error` throw, which the catch rethrows untouched. Both predate this
-   * change and are carried on the FSM row, where a terminal state is the
-   * thing that makes them unrepresentable rather than merely unrecorded.
+   * The run's two terminals. Both live here because the run is opened here:
+   * a branch that records its own end can only be relied on for the ends it
+   * knows about, and the ends it does not know about are exactly the ones
+   * that go unrecorded. `handleError` used to emit the failure, so anything
+   * raised from inside it — an abort from `Retry.sleep`, a non-`Error` throw
+   * — escaped past its own record.
    */
   const finish = (result: AgentResult): AgentResult => {
     emitRunCompleted(config.events, state, agentBase, result.finishReason);
     return result;
   };
 
+  /** What a throw that never reached a retry decision can still say. */
+  const failureFacts = (error: unknown) => ({
+    reason: Retry.classifyRetryReason(error instanceof Error ? error.message : String(error)),
+    attempt,
+    maxAttempts: retryPolicy.maxAttempts,
+  });
+
   const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
   if (preRunResult) return finish(preRunResult);
 
-  for (;;) {
-    try {
-      const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
-        config.model,
-      );
-      const configuredToolChoice = resolveToolChoice(config);
+  try {
+    return await attempts();
+  } catch (error) {
+    emitRunFailed(
+      config.events,
+      agentBase,
+      error instanceof Error ? error.message : String(error),
+      thrownFailure ?? failureFacts(error),
+    );
+    throw error;
+  }
 
-      for (;;) {
-        const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
-        if (budgetResult) return finish(budgetResult);
-
-        emitTurnStart(config.events, state, agentBase);
-        const turnResult = await buildTurn(
-          state,
-          config,
-          engine,
-          providerModel,
-          configuredToolChoice,
-          trace,
-          agentBase,
-          sink,
+  async function attempts(): Promise<AgentResult> {
+    for (;;) {
+      try {
+        const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
+          config.model,
         );
-        if (turnResult.type === "complete") return finish(turnResult.result);
+        const configuredToolChoice = resolveToolChoice(config);
 
-        const runLlm = config.llm?.run ?? llmRun;
-        const modelRequestResult = await dispatchModelRequest(state, engine, config, agentBase);
-        if (modelRequestResult) return finish(modelRequestResult);
-        const outcome = await runLlm(turnResult.turn.runInput, turnResult.turn.trackingSink);
-        const modelResponseResult = await dispatchModelResponse(
+        for (;;) {
+          const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
+          if (budgetResult) return finish(budgetResult);
+
+          emitTurnStart(config.events, state, agentBase);
+          const turnResult = await buildTurn(
+            state,
+            config,
+            engine,
+            providerModel,
+            configuredToolChoice,
+            trace,
+            agentBase,
+            sink,
+          );
+          if (turnResult.type === "complete") return finish(turnResult.result);
+
+          const runLlm = config.llm?.run ?? llmRun;
+          const modelRequestResult = await dispatchModelRequest(state, engine, config, agentBase);
+          if (modelRequestResult) return finish(modelRequestResult);
+          const outcome = await runLlm(turnResult.turn.runInput, turnResult.turn.trackingSink);
+          const modelResponseResult = await dispatchModelResponse(
+            state,
+            engine,
+            config,
+            {
+              outcome,
+              responseTokens: turnResult.turn.turnUsage.outputTokens,
+            },
+            agentBase,
+          );
+          if (modelResponseResult) return finish(modelResponseResult);
+
+          if (outcome.type === "stop") {
+            const stopOutcome = await handleStop(state, config, engine, agentBase, turnResult.turn);
+            if (stopOutcome !== "continue") return finish(stopOutcome);
+            continue;
+          }
+
+          if (outcome.type === "continue") {
+            handleContinue(config.events, state, agentBase, turnResult.turn.turnUsage);
+            continue;
+          }
+
+          if (outcome.type === "compact") {
+            const compactOutcome = await handleCompact(state, engine, config, agentBase);
+            if (compactOutcome !== "continue") return finish(compactOutcome);
+            continue;
+          }
+
+          if (outcome.type === "aborted") throw new Error("aborted");
+          if (outcome.type === "error") throw new Error(outcome.error.message);
+          const _exhaustive: never = outcome;
+          throw new Error(`Unknown outcome type: ${unknownOutcomeType(_exhaustive)}`);
+        }
+      } catch (error) {
+        if (!(error instanceof Error)) throw error;
+        const decision = await handleError(
           state,
           engine,
           config,
-          {
-            outcome,
-            responseTokens: turnResult.turn.turnUsage.outputTokens,
-          },
           agentBase,
+          error,
+          attempt,
+          retryPolicy,
         );
-        if (modelResponseResult) return finish(modelResponseResult);
-
-        if (outcome.type === "stop") {
-          const stopOutcome = await handleStop(state, config, engine, agentBase, turnResult.turn);
-          if (stopOutcome !== "continue") return finish(stopOutcome);
+        if (decision.action === "retry") {
+          attempt += 1;
           continue;
         }
-
-        if (outcome.type === "continue") {
-          handleContinue(config.events, state, agentBase, turnResult.turn.turnUsage);
-          continue;
-        }
-
-        if (outcome.type === "compact") {
-          const compactOutcome = await handleCompact(state, engine, config, agentBase);
-          if (compactOutcome !== "continue") return finish(compactOutcome);
-          continue;
-        }
-
-        if (outcome.type === "aborted") throw new Error("aborted");
-        if (outcome.type === "error") throw new Error(outcome.error.message);
-        const _exhaustive: never = outcome;
-        throw new Error(`Unknown outcome type: ${unknownOutcomeType(_exhaustive)}`);
+        if (decision.action === "complete") return finish(decision.result);
+        thrownFailure = decision.failure;
+        throw decision.error;
       }
-    } catch (error) {
-      if (!(error instanceof Error)) throw error;
-      const decision = await handleError(
-        state,
-        engine,
-        config,
-        agentBase,
-        error,
-        attempt,
-        retryPolicy,
-      );
-      if (decision.action === "retry") {
-        attempt += 1;
-        continue;
-      }
-      if (decision.action === "complete") return finish(decision.result);
-      throw decision.error;
     }
   }
 }

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -17,7 +17,7 @@ import {
   nonEmptyString,
   requireTrace,
   type AgentRunBase,
-  type ErrorDecision,
+  type RunFailureFacts,
 } from "./run-state";
 
 /**
@@ -35,7 +35,7 @@ export async function runAgent(
 ): Promise<AgentResult> {
   const retryPolicy = Retry.DEFAULT_RETRY_POLICY;
   let attempt = 1;
-  let thrownFailure: Extract<ErrorDecision, { action: "throw" }>["failure"] | undefined;
+  let thrownFailure: RunFailureFacts | undefined;
 
   const trace = requireTrace("agent run", input.traceContext);
   const { traceId, sessionId, runId } = trace;
@@ -68,8 +68,12 @@ export async function runAgent(
     return result;
   };
 
-  /** What a throw that never reached a retry decision can still say. */
-  const failureFacts = (error: unknown) => ({
+  /**
+   * A throw that never reached a retry decision — nothing decided a reason or
+   * a ceiling for it, so the record says what the throw itself can support.
+   * Every path that *did* reach one carries the decided facts instead.
+   */
+  const undecidedFacts = (error: unknown): RunFailureFacts => ({
     reason: Retry.classifyRetryReason(error instanceof Error ? error.message : String(error)),
     attempt,
     maxAttempts: retryPolicy.maxAttempts,
@@ -79,18 +83,6 @@ export async function runAgent(
   if (preRunResult) return finish(preRunResult);
 
   try {
-    return await attempts();
-  } catch (error) {
-    emitRunFailed(
-      config.events,
-      agentBase,
-      error instanceof Error ? error.message : String(error),
-      thrownFailure ?? failureFacts(error),
-    );
-    throw error;
-  }
-
-  async function attempts(): Promise<AgentResult> {
     for (;;) {
       try {
         const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
@@ -165,6 +157,13 @@ export async function runAgent(
           retryPolicy,
         );
         if (decision.action === "retry") {
+          // Carried across the wait, not after it: an abort raises from inside
+          // `Retry.sleep`, and the reason and ceiling it has to report are the
+          // ones decided here — re-deriving them from the abort would make the
+          // terminal record contradict this run's own retry record.
+          thrownFailure = decision.failure;
+          await Retry.sleep(decision.backoffMs, config.signal);
+          thrownFailure = undefined;
           attempt += 1;
           continue;
         }
@@ -173,6 +172,14 @@ export async function runAgent(
         throw decision.error;
       }
     }
+  } catch (error) {
+    emitRunFailed(
+      config.events,
+      agentBase,
+      error instanceof Error ? error.message : String(error),
+      thrownFailure ?? undecidedFacts(error),
+    );
+    throw error;
   }
 }
 

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -166,11 +166,7 @@ export async function handleError(
 
   if (PolicyDecision.isBlocking(onErrorDecision)) {
     if (effectOf(onErrorDecision, "run.abort")) {
-      return {
-        action: "complete",
-        result: guardAbortedResult(state),
-        errorMessage: normalizedError.message,
-      };
+      return { action: "complete", result: guardAbortedResult(state) };
     }
     publishDenyDiagnostic(config.events, "error", onErrorDecision, state, agentBase);
   }
@@ -195,14 +191,16 @@ export async function handleError(
       reason: retryReason,
       backoffMs,
     });
-    await Retry.sleep(backoffMs, config.signal);
-    return { action: "retry", errorMessage: lastError };
+    return {
+      action: "retry",
+      backoffMs,
+      failure: { reason: retryReason, attempt, maxAttempts: effectiveRetryPolicy.maxAttempts },
+    };
   }
 
   return {
     action: "throw",
     error: normalizedError,
-    errorMessage: lastError,
     failure: { reason: retryReason, attempt, maxAttempts: effectiveRetryPolicy.maxAttempts },
   };
 }

--- a/packages/agent/src/core/execution/turn-outcome.ts
+++ b/packages/agent/src/core/execution/turn-outcome.ts
@@ -9,7 +9,6 @@ import {
   runResult,
   emitCompaction,
   emitErrorRetry,
-  emitRunFailed,
   emitTurnComplete,
   publishDenyDiagnostic,
 } from "./run-events";
@@ -200,12 +199,12 @@ export async function handleError(
     return { action: "retry", errorMessage: lastError };
   }
 
-  emitRunFailed(config.events, agentBase, lastError, {
-    reason: retryReason,
-    attempt,
-    maxAttempts: effectiveRetryPolicy.maxAttempts,
-  });
-  return { action: "throw", error: normalizedError, errorMessage: lastError };
+  return {
+    action: "throw",
+    error: normalizedError,
+    errorMessage: lastError,
+    failure: { reason: retryReason, attempt, maxAttempts: effectiveRetryPolicy.maxAttempts },
+  };
 }
 
 /**

--- a/packages/agent/test/core/execution/lifecycle-error.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import { AgentExecution, Operational } from "@openomni/protocol";
+import { AgentExecution } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
 import type { PolicyContext } from "../../../src/core/policy/types";
@@ -237,15 +237,12 @@ describe("handleError (error)", () => {
    * after a `run.retry_after` effect narrows the configured one, exists
    * nowhere else at all.
    */
-  it("records the decision on the terminal failure, with the narrowed ceiling", async () => {
-    const failures: Array<{
-      traceId: string;
-      sessionId?: string;
-      context?: Record<string, unknown>;
-    }> = [];
-    const unsubscribe = Bus.subscribe(Operational.Error, (event) => {
-      failures.push(event as unknown as (typeof failures)[number]);
-    });
+  /**
+   * `handleError` reports the facts; the runner records them (#632), so this
+   * asserts the report rather than the event. The record itself, and that a
+   * throw always produces one, is `run-terminal-record.test.ts`.
+   */
+  it("reports the decision on the terminal failure, with the narrowed ceiling", async () => {
     const engine = PolicyEngine.create();
     engine.register({
       kind: "point",
@@ -258,29 +255,21 @@ describe("handleError (error)", () => {
           { type: "run.retry_after", delayMs: 0, maxRetries: 1 },
         ]),
     });
-    const agentBase = makeAgentBase();
+    const decision = await handleError(
+      makeState(),
+      engine,
+      makeConfig(),
+      makeAgentBase(),
+      new Error("schema validation failed"),
+      // Not 1: `attempt` is a pass-through, and asserting it at its input
+      // value of 1 also holds when the field is hardcoded to 1.
+      2,
+      { maxAttempts: 5, backoffMs: { initial: 0, multiplier: 1, max: 0 } },
+    );
 
-    try {
-      await handleError(
-        makeState(),
-        engine,
-        makeConfig(),
-        agentBase,
-        new Error("schema validation failed"),
-        // Not 1: `attempt` is a pass-through, and asserting it at its input
-        // value of 1 also holds when the field is hardcoded to 1.
-        2,
-        { maxAttempts: 5, backoffMs: { initial: 0, multiplier: 1, max: 0 } },
-      );
-      await Bun.sleep(0);
-    } finally {
-      unsubscribe();
-    }
-
-    expect(failures).toHaveLength(1);
-    expect(failures[0]?.traceId).toBe(agentBase.traceId);
-    expect(failures[0]?.sessionId).toBe(agentBase.sessionId);
-    expect(failures[0]?.context).toEqual({
+    expect(decision.action).toBe("throw");
+    if (decision.action !== "throw") throw new Error("expected a terminal decision");
+    expect(decision.failure).toEqual({
       reason: "validation_error",
       attempt: 2,
       // 1 from the effect, not the 5 the policy configured.

--- a/packages/agent/test/core/execution/lifecycle-error.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-error.test.ts
@@ -81,7 +81,12 @@ describe("handleError (error)", () => {
     expect(decision.action).toBe("retry");
   });
 
-  it("applies run.retry_after delayMs before retrying", async () => {
+  /**
+   * The wait itself is the runner's since #632; what `handleError` decides is
+   * how long. `run-terminal-record.test.ts` covers what an abort during that
+   * wait records.
+   */
+  it("reports the run.retry_after delay as the backoff", async () => {
     Bus.reset();
     const engine = PolicyEngine.create();
     engine.register({
@@ -101,7 +106,6 @@ describe("handleError (error)", () => {
       backoffMs: { initial: 0, multiplier: 1, max: 0 },
     };
 
-    const started = Date.now();
     const decision = await handleError(
       state,
       engine,
@@ -113,46 +117,9 @@ describe("handleError (error)", () => {
     );
 
     expect(decision.action).toBe("retry");
-    expect(Date.now() - started).toBeGreaterThanOrEqual(15);
-  });
-
-  it("does not sleep when retry delay is already aborted", async () => {
-    Bus.reset();
-    const engine = PolicyEngine.create();
-    engine.register({
-      kind: "point",
-      name: "test-on-error-aborted-retry-delay",
-      pointIds: ["run.error.error"],
-      effectCapabilities: { "run.error.error": ["run.retry_after"] },
-      priority: 100,
-      fn: () =>
-        allow("test.aborted-retry-delay", "retry-after", [
-          { type: "run.retry_after", delayMs: 5_000 },
-        ]),
-    });
-
-    const controller = new AbortController();
-    controller.abort();
-    const state = makeState();
-    const config = makeConfig({ signal: controller.signal });
-    const retryPolicy = {
-      maxAttempts: 3,
-      backoffMs: { initial: 0, multiplier: 1, max: 0 },
-    };
-
-    const started = Date.now();
-    await expect(
-      handleError(
-        state,
-        engine,
-        config,
-        makeAgentBase(),
-        new Error("timeout while waiting"),
-        1,
-        retryPolicy,
-      ),
-    ).rejects.toThrow("aborted");
-    expect(Date.now() - started).toBeLessThan(500);
+    if (decision.action !== "retry") throw new Error("expected a retry decision");
+    // 20 from the effect, not the 0 the policy configured.
+    expect(decision.backoffMs).toBe(20);
   });
 
   it("applies run.retry_after maxRetries as a stricter retry ceiling", async () => {

--- a/packages/agent/test/core/execution/run-terminal-record.test.ts
+++ b/packages/agent/test/core/execution/run-terminal-record.test.ts
@@ -174,11 +174,21 @@ describe("a started run always records a terminal", () => {
   async function runThrowing(
     run: () => Promise<never>,
     signal?: AbortSignal,
-  ): Promise<{ readonly seen: string[]; readonly thrown: unknown }> {
+    middleware: PolicyEngineRegistration[] = [],
+  ): Promise<{
+    readonly seen: string[];
+    readonly thrown: unknown;
+    readonly failures: Array<{ context?: Record<string, unknown> }>;
+  }> {
     const seen: string[] = [];
-    const stop = Bus.observe((_event, payload) => {
+    const failures: Array<{ context?: Record<string, unknown> }> = [];
+    const stop = Bus.observe((event, payload) => {
       const msg = (payload as { msg?: string }).msg;
-      if (msg === "agent.run.started" || msg === "agent.run.failed") seen.push(msg);
+      if (msg === "agent.run.started") seen.push(msg);
+      if (event.name === Operational.Error.name && msg === "agent.run.failed") {
+        seen.push(msg);
+        failures.push(payload as { context?: Record<string, unknown> });
+      }
     });
     let thrown: unknown;
     try {
@@ -186,6 +196,7 @@ describe("a started run always records a terminal", () => {
         events: Bus,
         model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
         ...(signal === undefined ? {} : { signal }),
+        middleware,
         llm: createMockLlmConfig({
           getModels: async () => mockProviderData,
           fromModelsDevModel: () => mockProviderModel,
@@ -197,22 +208,50 @@ describe("a started run always records a terminal", () => {
     } finally {
       stop();
     }
-    return { seen, thrown };
+    return { seen, thrown, failures };
   }
 
   it("when the run is aborted while sleeping out a retry backoff", async () => {
     const controller = new AbortController();
-    const { seen, thrown } = await runThrowing(async () => {
-      controller.abort();
-      throw new Error("connection timeout");
-    }, controller.signal);
+    // The ceiling is narrowed so the decided facts and what could be
+    // re-derived from the abort differ: decided says 2, re-derived would say
+    // the configured 3.
+    const { seen, thrown, failures } = await runThrowing(
+      async () => {
+        controller.abort();
+        throw new Error("connection timeout");
+      },
+      controller.signal,
+      [
+        {
+          kind: "point",
+          name: "test:narrow-retries",
+          pointIds: ["run.error.error"],
+          effectCapabilities: { "run.error.error": ["run.retry_after"] },
+          priority: 100,
+          fn: () =>
+            PolicyDecision.allow({
+              policyId: "test.narrow-retries",
+              effects: [{ type: "run.retry_after", delayMs: 50, maxRetries: 2 }],
+            }),
+        } as PolicyEngineRegistration,
+      ],
+    );
 
     expect(thrown).toBeInstanceOf(Error);
     expect(seen).toEqual(["agent.run.started", "agent.run.failed"]);
+    // The reason and ceiling decided before the wait, not ones re-derived
+    // from the abort — otherwise the terminal contradicts this run's own
+    // `agent.error.retry`, which reported `timeout` at attempt 1 of 3.
+    expect(failures[0]?.context).toMatchObject({
+      reason: "timeout",
+      attempt: 1,
+      maxAttempts: 2,
+    });
   });
 
   it("when something throws a value that is not an Error", async () => {
-    const { seen, thrown } = await runThrowing(async () => {
+    const { seen, thrown, failures } = await runThrowing(async () => {
       // The point of the case: the runner must record a terminal even for a
       // throw it cannot narrow to `Error`.
       // biome-ignore lint/style/useThrowOnlyError: that is the subject here
@@ -221,5 +260,8 @@ describe("a started run always records a terminal", () => {
 
     expect(thrown).toBe("a plain string blow-up");
     expect(seen).toEqual(["agent.run.started", "agent.run.failed"]);
+    // Nothing decided a reason for this one, so the record says what the
+    // throw itself supports.
+    expect(failures[0]?.context).toMatchObject({ attempt: 1, maxAttempts: 3 });
   });
 });

--- a/packages/agent/test/core/execution/run-terminal-record.test.ts
+++ b/packages/agent/test/core/execution/run-terminal-record.test.ts
@@ -163,4 +163,63 @@ describe("a started run always records a terminal", () => {
 
     expect(seen).toEqual(["agent.run.started", "agent.run.completed"]);
   });
+
+  /**
+   * The two paths #631 left open. Both raise from a place that runs *after*
+   * `handleError` decided, so neither reached the record the decision would
+   * have produced — an abort from inside `Retry.sleep`, and a throw that is
+   * not an `Error` and so is rethrown untouched. The runner owns both
+   * terminals now, so both are recorded (#632).
+   */
+  async function runThrowing(
+    run: () => Promise<never>,
+    signal?: AbortSignal,
+  ): Promise<{ readonly seen: string[]; readonly thrown: unknown }> {
+    const seen: string[] = [];
+    const stop = Bus.observe((_event, payload) => {
+      const msg = (payload as { msg?: string }).msg;
+      if (msg === "agent.run.started" || msg === "agent.run.failed") seen.push(msg);
+    });
+    let thrown: unknown;
+    try {
+      await runAgent(runInput([{ role: "user", content: "hi" }]), {
+        events: Bus,
+        model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+        ...(signal === undefined ? {} : { signal }),
+        llm: createMockLlmConfig({
+          getModels: async () => mockProviderData,
+          fromModelsDevModel: () => mockProviderModel,
+          run,
+        }),
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      stop();
+    }
+    return { seen, thrown };
+  }
+
+  it("when the run is aborted while sleeping out a retry backoff", async () => {
+    const controller = new AbortController();
+    const { seen, thrown } = await runThrowing(async () => {
+      controller.abort();
+      throw new Error("connection timeout");
+    }, controller.signal);
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(seen).toEqual(["agent.run.started", "agent.run.failed"]);
+  });
+
+  it("when something throws a value that is not an Error", async () => {
+    const { seen, thrown } = await runThrowing(async () => {
+      // The point of the case: the runner must record a terminal even for a
+      // throw it cannot narrow to `Error`.
+      // biome-ignore lint/style/useThrowOnlyError: that is the subject here
+      throw "a plain string blow-up";
+    });
+
+    expect(thrown).toBe("a plain string blow-up");
+    expect(seen).toEqual(["agent.run.started", "agent.run.failed"]);
+  });
 });


### PR DESCRIPTION
Phase 2. Finishes what #631 started, and closes the two paths it recorded as open.

## What #631 left

It funneled every *returning* exit through one completion record. Two **throw** paths still emitted `agent.run.started` and nothing else: an abort raised inside `Retry.sleep`, and a throw that is not an `Error`.

Both escape for the same reason — `handleError` emitted the failure record itself, and both raise from inside the `catch` that would have emitted it. A branch that records its own end can only be relied on for the ends it knows about, and the ends it does not know about are exactly the ones that go unrecorded.

## The change

The failure record moves to the runner, beside the completion one. `handleError` **reports** instead: its decisions carry `RunFailureFacts` — the reason, the attempt, and the ceiling as narrowed by any `run.retry_after` — and the runner emits them.

**The wait moves too, and that is the substantive part.** `Retry.sleep` sat inside `handleError`, after the facts were computed and before they were returned, so an abort during a backoff raised where the decided facts existed but had not escaped. The first version of this PR fell back to re-deriving them, which produced a record that **contradicted the same run's own `agent.error.retry`**: `retryPolicy` is a module constant, so the fallback always reported `maxAttempts: 3` even when a `run.retry_after` effect had narrowed it to 2. Adversarial review caught that.

Now the runner awaits the backoff, with the decided facts set before the wait and cleared after it, so a later unrelated throw cannot read stale ones. What remains of the fallback is for throws that never reached a decision at all — and it says so.

## Verification

The two new cases **fail at the merge base and pass here**, which is the point of the PR.

They assert the record's `context`, not just its presence. The abort case narrows the ceiling on purpose: with the default policy the decided facts and the re-derivable ones coincide, which is why the first version of that assertion still passed with the mechanism deleted. With the narrowing, dropping the carried facts goes red.

- `bun test` **3462 pass / 9 skip / 0 fail**.
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK.

## Also

- `ErrorDecision.errorMessage` is deleted — written on every variant, read by nothing.
- The `attempts()` helper collapses back into a nested `try`, which is all it was for; it had inflated the diff without changing behavior.
- Two tests that observed `handleError` *sleeping* now assert what it *decides* (`decision.backoffMs`); what an abort during that wait records is `run-terminal-record.test.ts`, where the runner's guarantee lives.

## Scope

This is the **terminal** half of D4 — every started run reaches exactly one recorded end, whichever way it leaves, and that end carries the facts that were decided rather than reconstructed. What remains on that row is the state machine proper: the transition table doubling as the injection-point map, and a serializable state tag so resume can be layered on. Those make the guarantee structural rather than enforced by one `try`; this makes it true.