### PR TITLE
feat(agent): the run's shape as a guard, not a driver (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -108,7 +108,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#624](https://github.com/INONONO66/openomni/pull/624) | duplicate helpers: one `requireTrace`, one `nonEmptyString` | 🟨 |
 | [#631](https://github.com/INONONO66/openomni/pull/631) | one run exit, one terminal record — the observable half of D4's "started with no terminal is unrepresentable" | 🟨 |
 | [#632](https://github.com/INONONO66/openomni/pull/632) | the runner owns both terminals — every exit, return or throw, records one | 🟨 |
-| — | file layout + the FSM guard itself (`run.ts`/`turn.ts`/`state.ts`, the transition table doubling as the injection-point map, a serializable state tag) | ⬜ |
+| [#633](https://github.com/INONONO66/openomni/pull/633) | the FSM guard: transition table as the injection-point map, terminals with no outgoing edges, serializable tag | 🟨 |
+| — | file layout (`run.ts`/`turn.ts`/`tools.ts`/`effects.ts`/`state.ts`), which Phase 4 rule 1 names | ⬜ |
 | [#622](https://github.com/INONONO66/openomni/pull/622) | drop the policy snapshot's `eventEmitter` carve-out — unreachable since #610, and `point-context-immutability.test.ts` asserts behavior with no production producer | 🟨 |
 | [#625](https://github.com/INONONO66/openomni/pull/625) | dissolve `builtin/` per D5 — `builtin:idle-nudge` moves to openomni | 🟨 |
 | [#626](https://github.com/INONONO66/openomni/pull/626) | dissolve `builtin/` per D5 — the two budget nudges move to openomni | 🟨 |

--- a/packages/agent/src/core/execution/run-machine.ts
+++ b/packages/agent/src/core/execution/run-machine.ts
@@ -1,0 +1,73 @@
+/**
+ * The run's shape, as a guard rather than a driver (D4).
+ *
+ * The loop still decides what happens next; this refuses an order that cannot
+ * happen. Two properties earn it:
+ *
+ *   - the terminal tags have no outgoing edges, so a run cannot end twice, and
+ *     `assertSettled` turns "ended without ending" from a convention every
+ *     `return` has to remember into something the run cannot leave without;
+ *   - the table is the injection-point map. Each non-terminal tag names the
+ *     policy point dispatched while the run is in it, so the order the points
+ *     fire in is stated once, here, instead of being implied by the order of
+ *     statements in the loop.
+ *
+ * The tag is a plain string by design: it is the part of a run's position that
+ * survives serialization, which is what a resume would need.
+ */
+export type RunTag =
+  | "opening"
+  | "pre_run"
+  | "turn_start"
+  | "awaiting_model"
+  | "settling"
+  | "retrying"
+  | "completed"
+  | "failed";
+
+/** The policy point dispatched while the run holds each tag. */
+export const RUN_POINT: Readonly<Partial<Record<RunTag, string>>> = Object.freeze({
+  pre_run: "run.lifecycle.pre",
+  turn_start: "run.turn.pre",
+  awaiting_model: "connection.llm.pre",
+  settling: "run.turn.post",
+  retrying: "run.error.error",
+});
+
+const EDGES: Readonly<Record<RunTag, readonly RunTag[]>> = Object.freeze({
+  opening: ["pre_run", "completed", "failed"],
+  pre_run: ["turn_start", "completed", "failed"],
+  turn_start: ["awaiting_model", "retrying", "completed", "failed"],
+  awaiting_model: ["settling", "retrying", "completed", "failed"],
+  settling: ["turn_start", "retrying", "completed", "failed"],
+  retrying: ["turn_start", "completed", "failed"],
+  completed: [],
+  failed: [],
+});
+
+export interface RunMachine {
+  /** Where the run is. Serializable by construction. */
+  readonly tag: () => RunTag;
+  /** Moves the run, refusing an edge the table does not have. */
+  readonly to: (next: RunTag) => void;
+  /** Throws unless the run reached a terminal. */
+  readonly assertSettled: () => void;
+}
+
+export function runMachine(): RunMachine {
+  let current: RunTag = "opening";
+  return {
+    tag: () => current,
+    to: (next) => {
+      if (!EDGES[current].includes(next)) {
+        throw new Error(`run cannot move from ${current} to ${next}`);
+      }
+      current = next;
+    },
+    assertSettled: () => {
+      if (EDGES[current].length > 0) {
+        throw new Error(`run left ${current} without reaching a terminal`);
+      }
+    },
+  };
+}

--- a/packages/agent/src/core/execution/runner.ts
+++ b/packages/agent/src/core/execution/runner.ts
@@ -4,6 +4,7 @@ import type { AgentResult, ChatAgentConfig, ChatAgentInput } from "../types";
 import * as Retry from "../retry";
 import { PolicyEngine, type PolicyEngineInstance } from "../policy";
 import { emitRunCompleted, emitRunFailed, emitRunStarted, emitTurnStart } from "./run-events";
+import { runMachine } from "./run-machine";
 import { handleCompact, handleContinue, handleError, handleStop } from "./turn-outcome";
 import { assertToolExecutor, buildTurn, resolveToolChoice } from "./turn-prepare";
 import {
@@ -63,7 +64,9 @@ export async function runAgent(
    * raised from inside it — an abort from `Retry.sleep`, a non-`Error` throw
    * — escaped past its own record.
    */
+  const machine = runMachine();
   const finish = (result: AgentResult): AgentResult => {
+    machine.to("completed");
     emitRunCompleted(config.events, state, agentBase, result.finishReason);
     return result;
   };
@@ -79,10 +82,11 @@ export async function runAgent(
     maxAttempts: retryPolicy.maxAttempts,
   });
 
-  const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
-  if (preRunResult) return finish(preRunResult);
-
   try {
+    machine.to("pre_run");
+    const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
+    if (preRunResult) return finish(preRunResult);
+
     for (;;) {
       try {
         const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
@@ -94,6 +98,7 @@ export async function runAgent(
           const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
           if (budgetResult) return finish(budgetResult);
 
+          machine.to("turn_start");
           emitTurnStart(config.events, state, agentBase);
           const turnResult = await buildTurn(
             state,
@@ -107,6 +112,7 @@ export async function runAgent(
           );
           if (turnResult.type === "complete") return finish(turnResult.result);
 
+          machine.to("awaiting_model");
           const runLlm = config.llm?.run ?? llmRun;
           const modelRequestResult = await dispatchModelRequest(state, engine, config, agentBase);
           if (modelRequestResult) return finish(modelRequestResult);
@@ -123,6 +129,7 @@ export async function runAgent(
           );
           if (modelResponseResult) return finish(modelResponseResult);
 
+          machine.to("settling");
           if (outcome.type === "stop") {
             const stopOutcome = await handleStop(state, config, engine, agentBase, turnResult.turn);
             if (stopOutcome !== "continue") return finish(stopOutcome);
@@ -157,6 +164,7 @@ export async function runAgent(
           retryPolicy,
         );
         if (decision.action === "retry") {
+          machine.to("retrying");
           // Carried across the wait, not after it: an abort raises from inside
           // `Retry.sleep`, and the reason and ceiling it has to report are the
           // ones decided here — re-deriving them from the abort would make the
@@ -179,7 +187,13 @@ export async function runAgent(
       error instanceof Error ? error.message : String(error),
       thrownFailure ?? undecidedFacts(error),
     );
+    machine.to("failed");
     throw error;
+  } finally {
+    // A `return` that skipped `finish` leaves here, and a throw from a
+    // `finally` outranks it — so "started with no terminal" stops being a
+    // convention every exit has to remember.
+    machine.assertSettled();
   }
 }
 

--- a/packages/agent/test/core/execution/run-machine.test.ts
+++ b/packages/agent/test/core/execution/run-machine.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { RUN_POINT, runMachine } from "../../../src/core/execution/run-machine";
+
+describe("the run machine", () => {
+  it("starts unopened and refuses to be read as settled", () => {
+    const machine = runMachine();
+    expect(machine.tag()).toBe("opening");
+    expect(() => machine.assertSettled()).toThrow("without reaching a terminal");
+  });
+
+  it("refuses an edge the table does not have", () => {
+    const machine = runMachine();
+    expect(() => machine.to("settling")).toThrow("cannot move from opening to settling");
+    expect(machine.tag()).toBe("opening");
+  });
+
+  /**
+   * The property the row exists for: a terminal has no outgoing edges, so a
+   * run cannot end twice and cannot resume after ending.
+   */
+  it("has no way out of a terminal", () => {
+    for (const terminal of ["completed", "failed"] as const) {
+      const machine = runMachine();
+      machine.to(terminal);
+      machine.assertSettled();
+      expect(() => machine.to("turn_start")).toThrow(`cannot move from ${terminal}`);
+      expect(() => machine.to(terminal)).toThrow(`cannot move from ${terminal}`);
+    }
+  });
+
+  it("walks the ordinary run", () => {
+    const machine = runMachine();
+    for (const tag of ["pre_run", "turn_start", "awaiting_model", "settling"] as const) {
+      machine.to(tag);
+      expect(machine.tag()).toBe(tag);
+    }
+    machine.to("turn_start");
+    machine.to("completed");
+    machine.assertSettled();
+  });
+
+  it("names the point dispatched in each non-terminal tag it guards", () => {
+    expect(RUN_POINT).toEqual({
+      pre_run: "run.lifecycle.pre",
+      turn_start: "run.turn.pre",
+      awaiting_model: "connection.llm.pre",
+      settling: "run.turn.post",
+      retrying: "run.error.error",
+    });
+  });
+});


### PR DESCRIPTION
Phase 2, the last behavioural row. Implements **D4**: *"FSM as a guard, not a driver — run and turn only."*

The loop still decides what happens next. The machine refuses an order that cannot happen.

## What it buys

**Terminals have no outgoing edges.** A run cannot end twice, and cannot resume after ending. That is the type-level half of "started with no terminal is unrepresentable".

**`assertSettled` in a `finally`** is the other half. #631 and #632 made every exit record a terminal by routing them through `finish`; that is a convention every `return` has to remember. Now the run cannot leave without one:

```
# a `return` that skips finish, with the guard:
error: run left awaiting_model without reaching a terminal

# the same, without it:
(a test assertion fails — but only because a test happens to cover that exit)
```

The guard is a net for the exits no test drives. It converts a silent omission into a loud, self-describing failure at the moment it happens. That is why it is not independently mutation-killable: with `finish` intact nothing bypasses it, and the paths where it would fire are by definition the untested ones.

**The table is the injection-point map.** Each non-terminal tag names the policy point dispatched while the run holds it:

```ts
export const RUN_POINT = {
  pre_run: "run.lifecycle.pre",
  turn_start: "run.turn.pre",
  awaiting_model: "connection.llm.pre",
  settling: "run.turn.post",
  retrying: "run.error.error",
};
```

so the order those points fire in is stated once, here, instead of being implied by the order of statements in a 190-line function.

**The tag is a plain string on purpose** — it is the part of a run's position that survives serialization, which is what a resume would need. Nothing depends on that yet; it is why the shape is a string union rather than a closure.

## It found two things while being wired

Both were mistakes in the map, not the loop, which is what writing the map down is for:

- A throw from `run.turn.pre` can reach a retry, so `turn_start -> retrying` is a real edge my first table omitted.
- I put the turn transition on the *attempt* loop rather than the *turn* loop, so a second turn within one attempt skipped it. That surfaced as `settling -> awaiting_model` being refused — and, because the transition sits inside the retried `try`, as a silently extra retry rather than a visible error. Worth knowing about the shape: a machine fault inside the retry region is absorbed by the retry handler.

## Verification

- 5 cases on the machine itself: the initial tag is not settled, an absent edge is refused without moving, **both terminals have no way out** (including no self-edge), the ordinary walk, and the point map.
- `bun test` **3467 pass / 9 skip / 0 fail** (base 3462, +5).
- `check-types` 14/14, `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports`, `check-ledger-schema-drift`, `build`, agent `bench` — all OK.

## What is left on the row

The file layout — `run.ts` / `turn.ts` / `tools.ts` / `effects.ts` / `state.ts`, which Phase 4 rule 1 names as the files that must contain no domain string literals. That is a rename pass, and it now has a shape to be named after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the agent run with a small FSM so the loop remains the driver but invalid transitions are refused. Old behavior allowed exits that skipped `finish` to silently pass; new behavior asserts in `finally` that the run reaches `completed` or `failed`, and terminals have no outgoing edges.

- Review and rollout
  - `runner.ts` integrates `runMachine`: transitions at `pre_run`, `turn_start`, `awaiting_model`, `settling`, `retrying`; `finish` sets `completed`; error path sets `failed`; `finally` enforces `assertSettled`.
  - Behavior change: any `return` that bypasses `finish` now throws “run left <tag> without reaching a terminal” at the moment it occurs.
  - `RUN_POINT` declares the injection-point map, making the policy event order explicit.
  - Fixed edges during wiring: added `turn_start -> retrying`; moved the turn transition into the turn loop to avoid skipped transitions. New tests cover terminal no-ops, invalid edges, ordinary walk, and the point map.

<sup>Written for commit a025f04c483e9d793cd440e940c8032f775e4f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle tracking for agent runs, including model waiting, retries, completion, and failure states.
  * Added validation to ensure runs finish in a completed or failed state.
  * Added serializable state and policy-point mappings for execution progress.

* **Bug Fixes**
  * Improved handling of early returns and errors by verifying that every run reaches a terminal state.

* **Documentation**
  * Updated the core roadmap to clarify the separation between lifecycle guard work and planned file-layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->