### PR TITLE
fix(agent): close the run loop's reason-code vocabulary (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -132,6 +132,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 |---|---|---|
 | [#637](https://github.com/INONONO66/openomni/pull/637) | close the run loop's reason-code vocabulary (rule 1's real target); amend rules 2–4 with what the tree shows | 🟨 |
 | — | rule 5: policy points with zero production registration vs an explicit allowlist | ⬜ |
+| — | close the tool source-label vocabulary (`tools.ts` consumer vs `define.ts`/`client-descriptor.ts` producers, two prefix separators already coexist) | ⬜ |
 | — | rule 3: core may not import `builtin/` — blocked on the Owner-gated `builtin:compaction` row | ⬜ |
 
 Then [#502](https://github.com/INONONO66/openomni/issues/502) runs against a `session` package that holds only durable facts.
@@ -149,9 +150,14 @@ since a rule that catches nothing is worse than no rule — it reads as coverage
    effect unions already make every policy-point and effect literal a compile
    error when misspelled — stricter than a regex, and it survives renames. What
    the rule was reaching for was real, but it was not in the literals the
-   compiler checks: it was in the three the compiler *couldn't* see, the reason
-   codes crossing in from openomni. Fixed as a closed vocabulary
-   (`core/policy/reason-codes.ts`) plus the `run-reason-code-vocabulary` guard.
+   compiler checks. The most consequential set the compiler *couldn't* see —
+   the three reason codes crossing in from openomni that the loop branches
+   on — is fixed as a closed vocabulary (`core/policy/reason-codes.ts`) plus
+   the `run-reason-code-vocabulary` guard. Not the only such set:
+   `tools.ts` classifies tool source from free-form label strings, and its
+   producers have already drifted (`define.ts` emits `source:`-prefixed labels,
+   `runtime/mcp/client-descriptor.ts` emits `source.`-prefixed ones — the
+   consumer strips both). That vocabulary is a follow-up row below.
 2. ~~`packages/agent/src/pure/` may not import the telemetry package.~~
    **Vacuous** — no such directory exists, and none of the phases created one.
 3. **Core may not import `builtin/` — still true, still violated.**

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -130,19 +130,41 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 
 | PR | title | status |
 |---|---|---|
-| — | boundary rules in `lint-guards.ts`; baselines; structure docs; `packages/agent/AGENTS.md` rewrite | ⬜ |
+| [#637](https://github.com/INONONO66/openomni/pull/637) | close the run loop's reason-code vocabulary (rule 1's real target); amend rules 2–4 with what the tree shows | 🟨 |
+| — | rule 5: policy points with zero production registration vs an explicit allowlist | ⬜ |
+| — | rule 3: core may not import `builtin/` — blocked on the Owner-gated `builtin:compaction` row | ⬜ |
 
 Then [#502](https://github.com/INONONO66/openomni/issues/502) runs against a `session` package that holds only durable facts.
 
 ## What Phase 4 locks
 
-Each becomes a `script/lint-guards.ts` rule, so the boundary survives the next contributor:
+Each was to become a `script/lint-guards.ts` rule so the boundary survives the
+next contributor. Checking them against the tree the earlier phases actually
+produced, only one of the five was both true and worth a rule. The list is
+amended below with what each turned out to be; the reasoning is the deliverable,
+since a rule that catches nothing is worse than no rule — it reads as coverage.
 
-1. Core files (`run.ts`, `turn.ts`, `tools.ts`, `effects.ts`, `state.ts`) contain no domain string literals.
-2. `packages/agent/src/pure/` may not import the telemetry package.
-3. Core may not import `builtin/`.
-4. No `crypto.randomUUID()` in a `traceId` position.
-5. The set of policy points with zero production registration equals an explicit allowlist — a point silently losing its last registration fails CI.
+1. ~~Core files contain no domain string literals.~~ **Redundant, and aimed at
+   the wrong target.** `dispatchPoint<TPointId extends PolicyPointId>` and the
+   effect unions already make every policy-point and effect literal a compile
+   error when misspelled — stricter than a regex, and it survives renames. What
+   the rule was reaching for was real, but it was not in the literals the
+   compiler checks: it was in the three the compiler *couldn't* see, the reason
+   codes crossing in from openomni. Fixed as a closed vocabulary
+   (`core/policy/reason-codes.ts`) plus the `run-reason-code-vocabulary` guard.
+2. ~~`packages/agent/src/pure/` may not import the telemetry package.~~
+   **Vacuous** — no such directory exists, and none of the phases created one.
+3. **Core may not import `builtin/` — still true, still violated.**
+   `core/policy/registry.ts:6` and `core/policy/index.ts:11` both import it. The
+   rule cannot land before the `builtin:compaction` row, which is Owner-gated.
+4. ~~No `crypto.randomUUID()` in a `traceId` position.~~ **Out of these
+   packages.** Every `randomUUID` in agent mints a *message* id, not a trace;
+   the D11 mint sites are 170 across server/openomni/session/coordinator, so
+   this belongs to the Phase 1 remainder, not here.
+5. **The set of policy points with zero production registration equals an
+   explicit allowlist** — a point silently losing its last registration fails
+   CI. Holds, implementable now, and the one rule of the five with nothing else
+   already enforcing it. Not yet written.
 
 ## Measurement
 

--- a/packages/agent/src/core/execution/turn.ts
+++ b/packages/agent/src/core/execution/turn.ts
@@ -115,7 +115,7 @@ export async function buildTurn(
     return {
       type: "complete",
       result: runResult(state, {
-        finishReason: reason === RunReasonCode.Stalled ? RunReasonCode.Stalled : "stop",
+        finishReason: reason === RunReasonCode.Stalled ? "stalled" : "stop",
         guardAborted: reason !== RunReasonCode.Stalled,
       }),
     };
@@ -392,7 +392,7 @@ export async function handleStop(
     const reason = PolicyDecision.reason(postTurnDecision, "stop");
     if (effectOf(postTurnDecision, "run.abort")) {
       return runResult(state, {
-        finishReason: reason === RunReasonCode.Stalled ? RunReasonCode.Stalled : "stop",
+        finishReason: reason === RunReasonCode.Stalled ? "stalled" : "stop",
         guardAborted: reason !== RunReasonCode.Stalled,
       });
     }

--- a/packages/agent/src/core/execution/turn.ts
+++ b/packages/agent/src/core/execution/turn.ts
@@ -3,6 +3,7 @@ import { type Message, Operational, PolicyDecision } from "@openomni/protocol";
 import type { BusEvent, Policy, Sink, Tool } from "@openomni/protocol";
 import { describeBudgetRemaining, effectiveBudgetThresholds } from "../budget";
 import { createAssistantMessage } from "../message-factory";
+import { RunReasonCode } from "../policy/reason-codes";
 import type { PolicyEngineInstance } from "../policy";
 import * as Retry from "../retry";
 import type { AgentResult, ChatAgentConfig, TokenUsage } from "../types";
@@ -114,15 +115,15 @@ export async function buildTurn(
     return {
       type: "complete",
       result: runResult(state, {
-        finishReason: reason === "stalled" ? "stalled" : "stop",
-        guardAborted: reason !== "stalled",
+        finishReason: reason === RunReasonCode.Stalled ? RunReasonCode.Stalled : "stop",
+        guardAborted: reason !== RunReasonCode.Stalled,
       }),
     };
   }
 
   PolicyEffectApplier.applyPromptMessageEffects(state, preTurnDecision);
 
-  if (preTurnDecision.reasonCodes.includes("budget_reassurance")) {
+  if (preTurnDecision.reasonCodes.includes(RunReasonCode.BudgetReassurance)) {
     const remaining = describeBudgetRemaining(state.budgetState, config.budget);
     emitBudgetReassurance(
       config.events,
@@ -131,7 +132,7 @@ export async function buildTurn(
       effectiveBudgetThresholds(config.budget).reassuranceThreshold,
     );
   }
-  if (preTurnDecision.reasonCodes.includes("budget_warning")) {
+  if (preTurnDecision.reasonCodes.includes(RunReasonCode.BudgetWarning)) {
     const remaining = describeBudgetRemaining(state.budgetState, config.budget);
     emitBudgetWarning(
       config.events,
@@ -391,8 +392,8 @@ export async function handleStop(
     const reason = PolicyDecision.reason(postTurnDecision, "stop");
     if (effectOf(postTurnDecision, "run.abort")) {
       return runResult(state, {
-        finishReason: reason === "stalled" ? "stalled" : "stop",
-        guardAborted: reason !== "stalled",
+        finishReason: reason === RunReasonCode.Stalled ? RunReasonCode.Stalled : "stop",
+        guardAborted: reason !== RunReasonCode.Stalled,
       });
     }
     publishDenyDiagnostic(config.events, "turn.finish", postTurnDecision, state, agentBase);

--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -43,3 +43,4 @@ export type PolicyEngineInstance = Omit<
 > & {
   readonly register: (registration: PolicyEngineRegistration) => void;
 };
+export * from "./reason-codes";

--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -43,4 +43,3 @@ export type PolicyEngineInstance = Omit<
 > & {
   readonly register: (registration: PolicyEngineRegistration) => void;
 };
-export * from "./reason-codes";

--- a/packages/agent/src/core/policy/reason-codes.ts
+++ b/packages/agent/src/core/policy/reason-codes.ts
@@ -10,7 +10,9 @@
  * reacting, and a stalled run records itself as an ordinary stop.
  *
  * So the vocabulary is closed and single-sourced. `script/lint-guards.ts`
- * rejects these values written as literals anywhere but here.
+ * rejects these values written as literals at producer (`reasonCodes:`) and
+ * consumer (comparison / `.includes`) positions in shipped source; the test
+ * pins asserting the raw strings are the layer that locks the values.
  */
 export const RunReasonCode = {
   /** The run made no progress; the loop reports `stalled`, not a guard abort. */
@@ -20,5 +22,3 @@ export const RunReasonCode = {
   /** Budget is ample; the loop emits `AgentExecution.BudgetReassurance`. */
   BudgetReassurance: "budget_reassurance",
 } as const;
-
-export type RunReasonCode = (typeof RunReasonCode)[keyof typeof RunReasonCode];

--- a/packages/agent/src/core/policy/reason-codes.ts
+++ b/packages/agent/src/core/policy/reason-codes.ts
@@ -1,0 +1,24 @@
+/**
+ * The reason codes the run loop branches on.
+ *
+ * These are not diagnostics. The loop reads them out of a decision to pick a
+ * terminal `finishReason`, to decide whether an abort was a guard's doing, and
+ * to emit budget telemetry — and the policies that produce them live in
+ * another package (D5: opinions register from the product side). A bare string
+ * on both ends of that boundary fails in the worst direction: rename the
+ * producer's literal and nothing breaks the build, the loop just stops
+ * reacting, and a stalled run records itself as an ordinary stop.
+ *
+ * So the vocabulary is closed and single-sourced. `script/lint-guards.ts`
+ * rejects these values written as literals anywhere but here.
+ */
+export const RunReasonCode = {
+  /** The run made no progress; the loop reports `stalled`, not a guard abort. */
+  Stalled: "stalled",
+  /** Budget is nearly spent; the loop emits `AgentExecution.BudgetWarning`. */
+  BudgetWarning: "budget_warning",
+  /** Budget is ample; the loop emits `AgentExecution.BudgetReassurance`. */
+  BudgetReassurance: "budget_reassurance",
+} as const;
+
+export type RunReasonCode = (typeof RunReasonCode)[keyof typeof RunReasonCode];

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -16,6 +16,7 @@ export { PolicyEngine, PolicyRegistry, defaultRegistry } from "./core/policy";
 // to say about what is left (D5). Exporting the functions without the types
 // leaves a consumer unable to name what it is holding.
 export { checkBudget, describeBudgetRemaining } from "./core/budget";
+export { RunReasonCode } from "./core/policy/reason-codes";
 export type { BudgetState, BudgetStatus } from "./core/budget";
 export type {
   CanonicalPolicyRegistration,

--- a/packages/openomni/src/execution-runtime/middleware/budget-nudge-policy.ts
+++ b/packages/openomni/src/execution-runtime/middleware/budget-nudge-policy.ts
@@ -1,5 +1,6 @@
 import { PolicyDecision } from "@openomni/protocol";
 import {
+  RunReasonCode,
   checkBudget,
   describeBudgetRemaining,
   type CanonicalPolicyRegistration,
@@ -24,7 +25,7 @@ export function createBudgetReassurancePolicy(): CanonicalPolicyRegistration {
         const remaining = describeBudgetRemaining(ctx.budgetState, ctx.budget);
         return PolicyDecision.allow({
           policyId: "builtin.budget.reassurance",
-          reasonCodes: ["budget_reassurance"],
+          reasonCodes: [RunReasonCode.BudgetReassurance],
           effects: [
             {
               type: "prompt.inject_message",
@@ -55,7 +56,7 @@ export function createBudgetWarningPolicy(): CanonicalPolicyRegistration {
         const remaining = describeBudgetRemaining(ctx.budgetState, ctx.budget);
         return PolicyDecision.allow({
           policyId: "builtin.budget.warning",
-          reasonCodes: ["budget_warning"],
+          reasonCodes: [RunReasonCode.BudgetWarning],
           effects: [
             {
               type: "prompt.inject_message",

--- a/packages/openomni/src/execution-runtime/middleware/idle-nudge-policy.ts
+++ b/packages/openomni/src/execution-runtime/middleware/idle-nudge-policy.ts
@@ -1,5 +1,6 @@
 import { PolicyDecision } from "@openomni/protocol";
 import { z } from "zod";
+import { RunReasonCode } from "@openomni/agent";
 import type {
   CanonicalPolicyRegistration,
   PolicyRegistryInstance,
@@ -50,8 +51,8 @@ export function createIdleNudgePolicy(config: IdleNudgeConfig = {}): CanonicalPo
       if (nudgeCount >= maxNudges) {
         return PolicyDecision.deny({
           policyId: "builtin.idle_nudge",
-          reasonCodes: ["stalled"],
-          effects: [{ type: "run.abort", reason: "stalled" }],
+          reasonCodes: [RunReasonCode.Stalled],
+          effects: [{ type: "run.abort", reason: RunReasonCode.Stalled }],
         });
       }
 

--- a/script/lint-guards.ts
+++ b/script/lint-guards.ts
@@ -5,7 +5,8 @@ type GuardRuleId =
   | "inline-channel-trigger-evaluation"
   | "inline-authorization-throw"
   | "missing-canonical-policy-evaluator"
-  | "policy-package-boundary";
+  | "policy-package-boundary"
+  | "run-reason-code-vocabulary";
 
 interface GuardViolation {
   readonly ruleId: GuardRuleId;
@@ -17,6 +18,7 @@ interface GuardViolation {
 interface SourceMatch {
   readonly index: number;
   readonly text: string;
+  readonly captured?: string;
 }
 
 const scanRoots = ["packages", "apps"];
@@ -46,15 +48,20 @@ const inlineAuthorizationThrowPatterns = [
  * package, so a literal at the producer is a coupling the compiler cannot see:
  * rename one end and the loop silently stops reacting.
  *
- * Scoped to `reasonCodes:` arrays in shipped source, which is where such a
- * rename originates. Deliberately NOT matched elsewhere: `"stalled"` is also a
+ * Scoped to shipped source, at the two positions a rename starts: producers
+ * (`reasonCodes:` arrays) and consumers (equality or `.includes` against one
+ * of the values). Deliberately NOT matched elsewhere: `"stalled"` is also a
  * value of the unrelated `AgentResult.finishReason` union, and a test that
  * asserts the literal is the pin proving the constant's value — routing those
- * through the constant would make them pass no matter what it became.
+ * through the constant would make them pass no matter what it became. A code
+ * reaching a `reasonCodes` array through a variable or helper parameter is
+ * also out of reach; the test pins are the layer that catches a wrong value.
  */
 const runReasonCodeSource = "packages/agent/src/core/policy/reason-codes.ts";
 const runReasonCodeLiteralPattern =
-  /reasonCodes:\s*\[[^\]]*?["'](stalled|budget_warning|budget_reassurance)["']/g;
+  /reasonCodes:\s*\[[^\]]*?["'`](stalled|budget_warning|budget_reassurance)["'`]/g;
+const runReasonCodeComparisonPattern =
+  /(?:[!=]==\s*|\.includes\()["'`](stalled|budget_warning|budget_reassurance)["'`]/g;
 
 const policyPackageBoundaryPattern =
   /(?:from\s+|import\s+)["'](@openomni\/(?:agent|session))[^"']*["']/g;
@@ -190,11 +197,14 @@ function validatePolicyPackageBoundary(filePath: string, source: string): GuardV
 function validateRunReasonCodeVocabulary(filePath: string, source: string): GuardViolation[] {
   if (filePath === runReasonCodeSource || !filePath.includes("/src/")) return [];
 
-  return matches(source, runReasonCodeLiteralPattern).map((match) => ({
+  return [
+    ...matches(source, runReasonCodeLiteralPattern),
+    ...matches(source, runReasonCodeComparisonPattern),
+  ].map((match) => ({
     filePath,
     line: lineNumberForOffset(source, match.index),
     ruleId: "run-reason-code-vocabulary",
-    message: `run reason code ${match.text} written as a literal; use RunReasonCode from @openomni/agent so a rename fails the build instead of the run loop`,
+    message: `run reason code "${match.captured}" written as a literal; use RunReasonCode from @openomni/agent so a rename fails the build instead of the run loop`,
   }));
 }
 
@@ -204,7 +214,7 @@ function matches(source: string, pattern: RegExp): SourceMatch[] {
 
   let match = pattern.exec(source);
   while (match !== null) {
-    results.push({ index: match.index, text: match[0] });
+    results.push({ index: match.index, text: match[0], captured: match[1] });
     match = pattern.exec(source);
   }
 

--- a/script/lint-guards.ts
+++ b/script/lint-guards.ts
@@ -40,6 +40,22 @@ const inlineAuthorizationThrowPatterns = [
   /if\s*\(\s*!\s*(?:[\w$]+\.)*(?:isAuthorized|authorized|hasAuthority|hasPermission|isAllowed|canAuthorize)(?:\s*\([^)]*\))?\s*\)\s*(?:\{\s*)?throw\b/gi,
   /if\s*\(\s*(?:[\w$]+\.)*(?:isAuthorized|authorized|hasAuthority|hasPermission|isAllowed|canAuthorize)\s*(?:===\s*false|!==\s*true)\s*\)\s*(?:\{\s*)?throw\b/gi,
 ];
+/**
+ * The run loop's closed reason-code vocabulary, declared once in
+ * `packages/agent/src/core/policy/reason-codes.ts` and produced from another
+ * package, so a literal at the producer is a coupling the compiler cannot see:
+ * rename one end and the loop silently stops reacting.
+ *
+ * Scoped to `reasonCodes:` arrays in shipped source, which is where such a
+ * rename originates. Deliberately NOT matched elsewhere: `"stalled"` is also a
+ * value of the unrelated `AgentResult.finishReason` union, and a test that
+ * asserts the literal is the pin proving the constant's value — routing those
+ * through the constant would make them pass no matter what it became.
+ */
+const runReasonCodeSource = "packages/agent/src/core/policy/reason-codes.ts";
+const runReasonCodeLiteralPattern =
+  /reasonCodes:\s*\[[^\]]*?["'](stalled|budget_warning|budget_reassurance)["']/g;
+
 const policyPackageBoundaryPattern =
   /(?:from\s+|import\s+)["'](@openomni\/(?:agent|session))[^"']*["']/g;
 
@@ -54,6 +70,7 @@ async function main(): Promise<void> {
     violations.push(...validateListMembership(filePath, source));
     violations.push(...validateInlineAuthorization(filePath, source));
     violations.push(...validatePolicyPackageBoundary(filePath, source));
+    violations.push(...validateRunReasonCodeVocabulary(filePath, source));
   }
 
   if (violations.length === 0) {
@@ -167,6 +184,17 @@ function validatePolicyPackageBoundary(filePath: string, source: string): GuardV
     filePath,
     line: lineNumberForOffset(source, match.index),
     message: "packages/policy must not import from @openomni/agent or @openomni/session",
+  }));
+}
+
+function validateRunReasonCodeVocabulary(filePath: string, source: string): GuardViolation[] {
+  if (filePath === runReasonCodeSource || !filePath.includes("/src/")) return [];
+
+  return matches(source, runReasonCodeLiteralPattern).map((match) => ({
+    filePath,
+    line: lineNumberForOffset(source, match.index),
+    ruleId: "run-reason-code-vocabulary",
+    message: `run reason code ${match.text} written as a literal; use RunReasonCode from @openomni/agent so a rename fails the build instead of the run loop`,
   }));
 }
 


### PR DESCRIPTION
Three reason codes cross from `@openomni/openomni` into the agent run loop as bare strings, and the loop branches on all three:

| code | producer | what the loop does with it |
|---|---|---|
| `stalled` | `idle-nudge-policy.ts:53` | picks `finishReason: "stalled"` vs `"stop"`, and sets `guardAborted` |
| `budget_warning` | `budget-nudge-policy.ts:58` | emits `AgentExecution.BudgetWarning` |
| `budget_reassurance` | `budget-nudge-policy.ts:27` | emits `AgentExecution.BudgetReassurance` |

Rename a producer's literal and nothing fails to compile. The loop just stops reacting — and in the `stalled` case a stalled run records itself as an ordinary `stop` with `guardAborted: true`, which is a wrong terminal record of exactly the kind #631/#632 chased.

Declares the three once in `core/policy/reason-codes.ts`, routes both ends through it, and adds a `run-reason-code-vocabulary` guard over `reasonCodes:` arrays in shipped source — where such a rename starts.

## The guard stops there on purpose

- `"stalled"` is *also* a value of the unrelated `AgentResult.finishReason` union. A guard matching the bare word conflates two vocabularies that merely share a spelling.
- The tests asserting the literals are the pins that prove the constants' *values*. Routing them through the constant would make them pass no matter what it became.

Both layers mutation-verified:

| mutation | result |
|---|---|
| producer reverts to `reasonCodes: ["budget_warning"]` | guard fires (1 violation) |
| producer swaps to the **wrong** constant | guard silent by design; test pin fails (1 fail) |

## Why this is what Phase 4's rule 1 was reaching for

Phase 4 listed five rules. Checked against the tree the earlier phases actually produced, only one of the five was both true and worth writing:

1. *"core files contain no domain string literals"* — **redundant**. `dispatchPoint<TPointId extends PolicyPointId>` and the effect unions already make those literals compile errors, which beats a regex. The literals the compiler *couldn't* see were these three. That is what this PR fixes.
2. *`packages/agent/src/pure/` may not import telemetry* — **vacuous**, no such directory exists.
3. *core may not import `builtin/`* — **still true, still violated** (`registry.ts:6`, `policy/index.ts:11`); blocked on the Owner-gated `builtin:compaction` row.
4. *no `randomUUID` in a traceId position* — **out of these packages**; every agent use mints a message id, and D11's 170 mint sites are in server/openomni/session/coordinator.
5. *policy points with zero production registration vs an allowlist* — holds, implementable, not yet written.

The plan doc now records that instead of the original list, and Phase 4 is split into the rows that remain.

## Verification

`bun test` 3462 pass / 9 skip / 0 fail (unchanged) · `check-types` 14/14 · `build` ok · `lint-guards` scans 924 files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the run loop’s reason-code vocabulary and enforces it at both producer and consumer sites to prevent silent behavior changes when codes are renamed. Old: policies emitted bare strings and the loop compared them directly; a rename compiled but broke behavior (e.g., stalled runs recorded as stop). New: single-sourced `RunReasonCode` in `@openomni/agent` used by producers and loop comparisons, plus a `run-reason-code-vocabulary` lint guard over producer arrays and consumer comparisons; `finishReason` still uses its own union.

- Updates `turn.ts` to compare against `RunReasonCode` while emitting literal `finishReason` values; budget telemetry branches use `RunReasonCode`.
- Centralizes constants in `packages/agent/src/core/policy/reason-codes.ts` and re-exports via `@openomni/agent`.
- Migrates `idle-nudge-policy` and `budget-nudge-policy` to `RunReasonCode`.
- Extends `script/lint-guards.ts` to flag literals in `reasonCodes:` arrays and in equality or `.includes` comparisons; adds the rule id to `GuardRuleId`. The guard excludes `finishReason` literals and test pins.
- Amends Phase 4 docs and notes the follow-up to close the tool source-label vocabulary.

**Required migration**
- Replace any string literals in `reasonCodes` arrays with `@openomni/agent` constants:
  - "stalled" -> `RunReasonCode.Stalled`
  - "budget_warning" -> `RunReasonCode.BudgetWarning`
  - "budget_reassurance" -> `RunReasonCode.BudgetReassurance`
- Replace any direct string comparisons or `.includes` against these codes with `RunReasonCode` constants. The guard will fail CI if literals remain.

<sup>Written for commit 2897016f118dcdd70dd4faec7da472b4f7c1a860. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

