### PR TITLE
feat(policy): pin the zero-registration policy points (#606)

### DIFF
--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -172,7 +172,7 @@ since a rule that catches nothing is worse than no rule — it reads as coverage
    CI. Holds, and the one rule of the five with nothing else already enforcing
    it: written as the `policy-point-registration` guard, pinned both ways
    (losing a last registration fails; a stale allowlist entry fails). 9 of the
-   18 registered points are acknowledged empty.
+   18 registry points are acknowledged empty.
 
 ## Measurement
 

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -131,7 +131,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | PR | title | status |
 |---|---|---|
 | [#637](https://github.com/INONONO66/openomni/pull/637) | close the run loop's reason-code vocabulary (rule 1's real target); amend rules 2–4 with what the tree shows | 🟨 |
-| — | rule 5: policy points with zero production registration vs an explicit allowlist | ⬜ |
+| [#638](https://github.com/INONONO66/openomni/pull/638) | rule 5: policy points with zero production registration vs an explicit allowlist (`policy-point-registration` guard, 9 of 18 pinned) | 🟨 |
 | — | close the tool source-label vocabulary (`tools.ts` consumer vs `define.ts`/`client-descriptor.ts` producers, two prefix separators already coexist) | ⬜ |
 | — | rule 3: core may not import `builtin/` — blocked on the Owner-gated `builtin:compaction` row | ⬜ |
 
@@ -169,8 +169,10 @@ since a rule that catches nothing is worse than no rule — it reads as coverage
    this belongs to the Phase 1 remainder, not here.
 5. **The set of policy points with zero production registration equals an
    explicit allowlist** — a point silently losing its last registration fails
-   CI. Holds, implementable now, and the one rule of the five with nothing else
-   already enforcing it. Not yet written.
+   CI. Holds, and the one rule of the five with nothing else already enforcing
+   it: written as the `policy-point-registration` guard, pinned both ways
+   (losing a last registration fails; a stale allowlist entry fails). 9 of the
+   18 registered points are acknowledged empty.
 
 ## Measurement
 

--- a/script/lint-guards.ts
+++ b/script/lint-guards.ts
@@ -89,7 +89,7 @@ const policyPointsWithoutProductionRegistration = new Set([
   "tool.catalog.pre",
   "work.complete.pre",
 ]);
-const pointIdsArrayPattern = /pointIds:\s*\[([^\]]*)\]/g;
+const pointIdsArrayPattern = /\bpointIds:\s*\[([^\]]*)\]/g;
 const pointIdLiteralPattern = /["'`]([a-z][a-z._]+)["'`]/g;
 
 const policyPackageBoundaryPattern =

--- a/script/lint-guards.ts
+++ b/script/lint-guards.ts
@@ -1,4 +1,4 @@
-export {};
+import { Policy } from "../packages/protocol/src/index";
 
 type GuardRuleId =
   | "ad-hoc-list-membership"
@@ -6,7 +6,8 @@ type GuardRuleId =
   | "inline-authorization-throw"
   | "missing-canonical-policy-evaluator"
   | "policy-package-boundary"
-  | "run-reason-code-vocabulary";
+  | "run-reason-code-vocabulary"
+  | "policy-point-registration";
 
 interface GuardViolation {
   readonly ruleId: GuardRuleId;
@@ -63,6 +64,34 @@ const runReasonCodeLiteralPattern =
 const runReasonCodeComparisonPattern =
   /(?:[!=]==\s*|\.includes\()["'`](stalled|budget_warning|budget_reassurance)["'`]/g;
 
+/**
+ * Policy points the engine dispatches at but nothing in shipped source
+ * registers a policy for — dispatch runs, collects no opinions, allows.
+ * That is a legitimate state for an extension point, but reaching it by
+ * losing a registration is a silent behavioral regression: the policy
+ * stops running and every suite that doesn't exercise the full product
+ * wiring stays green. So the zero-registration set is pinned both ways —
+ * a point leaving it means this list is stale; a point entering it means
+ * a registration was lost (or must be acknowledged here, in review).
+ *
+ * This counts registration *sites* (`pointIds:` literals under `/src/`),
+ * not live wiring — a site that exists but is never reached is out of a
+ * static guard's reach.
+ */
+const policyPointsWithoutProductionRegistration = new Set([
+  "connection.llm.pre",
+  "connection.llm.post",
+  "delegation.worker.pre",
+  "delegation.worker.post",
+  "run.error.error",
+  "run.lifecycle.pre",
+  "run.lifecycle.post",
+  "tool.catalog.pre",
+  "work.complete.pre",
+]);
+const pointIdsArrayPattern = /pointIds:\s*\[([^\]]*)\]/g;
+const pointIdLiteralPattern = /["'`]([a-z][a-z._]+)["'`]/g;
+
 const policyPackageBoundaryPattern =
   /(?:from\s+|import\s+)["'](@openomni\/(?:agent|session))[^"']*["']/g;
 
@@ -70,8 +99,10 @@ async function main(): Promise<void> {
   const files = await collectSourceFiles();
   const violations: GuardViolation[] = [];
 
+  const registeredPoints = new Map<string, string>();
   for (const filePath of files) {
     const source = await Bun.file(filePath).text();
+    collectPolicyPointRegistrations(filePath, source, registeredPoints);
     violations.push(...validateCanonicalPolicyUsage(filePath, source));
     violations.push(...validateChannelTriggerEvaluation(filePath, source));
     violations.push(...validateListMembership(filePath, source));
@@ -79,6 +110,8 @@ async function main(): Promise<void> {
     violations.push(...validatePolicyPackageBoundary(filePath, source));
     violations.push(...validateRunReasonCodeVocabulary(filePath, source));
   }
+
+  violations.push(...validatePolicyPointRegistrations(registeredPoints));
 
   if (violations.length === 0) {
     process.stdout.write(`OK: guard lint scanned ${files.length} TypeScript files\n`);
@@ -206,6 +239,48 @@ function validateRunReasonCodeVocabulary(filePath: string, source: string): Guar
     ruleId: "run-reason-code-vocabulary",
     message: `run reason code "${match.captured}" written as a literal; use RunReasonCode from @openomni/agent so a rename fails the build instead of the run loop`,
   }));
+}
+
+function collectPolicyPointRegistrations(
+  filePath: string,
+  source: string,
+  registeredPoints: Map<string, string>,
+): void {
+  if (!filePath.includes("/src/")) return;
+
+  for (const arrayMatch of matches(source, pointIdsArrayPattern)) {
+    for (const idMatch of matches(arrayMatch.captured ?? "", pointIdLiteralPattern)) {
+      const pointId = idMatch.captured ?? "";
+      if (!registeredPoints.has(pointId)) registeredPoints.set(pointId, filePath);
+    }
+  }
+}
+
+function validatePolicyPointRegistrations(registeredPoints: Map<string, string>): GuardViolation[] {
+  const violations: GuardViolation[] = [];
+
+  for (const pointId of Object.keys(Policy.PolicyPoint.Registry)) {
+    const registeredAt = registeredPoints.get(pointId);
+    const allowlisted = policyPointsWithoutProductionRegistration.has(pointId);
+    if (registeredAt === undefined && !allowlisted) {
+      violations.push({
+        filePath: "script/lint-guards.ts",
+        line: 0,
+        ruleId: "policy-point-registration",
+        message: `policy point "${pointId}" has no production registration site left — a policy silently stopped running, or acknowledge the empty point in policyPointsWithoutProductionRegistration`,
+      });
+    }
+    if (registeredAt !== undefined && allowlisted) {
+      violations.push({
+        filePath: registeredAt,
+        line: 0,
+        ruleId: "policy-point-registration",
+        message: `policy point "${pointId}" is registered here but still listed in policyPointsWithoutProductionRegistration — remove the stale allowlist entry`,
+      });
+    }
+  }
+
+  return violations;
 }
 
 function matches(source: string, pattern: RegExp): SourceMatch[] {


### PR DESCRIPTION
Phase 4 rule 5 — the one rule of the five that survived verification against the tree (see #637).

The engine dispatches at 18 registered policy points; **9 have no production registration anywhere in shipped source** (`connection.llm.pre/post`, `delegation.worker.pre/post`, `run.error.error`, `run.lifecycle.pre/post`, `tool.catalog.pre`, `work.complete.pre`). An empty point dispatches, collects no opinions, and allows — legitimate for an extension point, but arriving there by *losing* a registration is a silent behavioral regression, the same failure family as `effectCapabilities` drops: nothing fails, the policy just stops running.

The `policy-point-registration` guard in `script/lint-guards.ts`:

- reads the 18-point list from `Policy.PolicyPoint.Registry` in protocol source — no copied list to drift
- counts `pointIds:` registration sites in files under `/src/` (production only; tests don't count as wiring)
- pins the empty set **both ways**:

| mutation | result |
|---|---|
| `injection-queue-policy.ts` loses its `pointIds` (last site for `run.turn.post`) | CI fails naming the point |
| a point registers while still allowlisted | CI fails naming the file and the stale entry |
| clean tree | 924 files scanned, OK |

Stated limit (in the guard's comment): this counts registration *sites*, not live wiring — a site that exists but is never reached is beyond a static check.

## Verification

`bun test` 3462 pass / 9 skip / 0 fail · `check-types` 14/14 · `lint`, `lint:tools`, `check-deps`, `check-import-cycles`, `check-dead-exports` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins zero‑registration policy points in CI to prevent silent regressions. Previously, empty policy points allowed by default without detection; now the `policy-point-registration` guard fails CI when a point loses its last production registration or when a registered point remains on the allowlist.

- Reads `Policy.PolicyPoint.Registry`, scans `/src/` for `pointIds:` registration sites, and checks both directions (missing registration or stale allowlist entry). Counts registration sites, not live wiring. Seeds the allowlist with 9 of 18 points.
- Anchors the `pointIds:` matcher with a word boundary to avoid false positives from keys like `allowedEndpointIds:`.
- Required: If you intentionally leave a point empty, add its id to `policyPointsWithoutProductionRegistration`. If you register a point, remove its id from that allowlist or restore/add a `pointIds:` site.

<sup>Written for commit 83ef5825f42135b1ebf0f7541f0bba2ac2cc8bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

