### PR TITLE
refactor(protocol): close the mcp server-label vocabulary (#606)

### DIFF
--- a/apps/server/src/bootstrap/worker-bootstrap.ts
+++ b/apps/server/src/bootstrap/worker-bootstrap.ts
@@ -54,7 +54,8 @@ function createToolCatalogEntry(
   tool: NativeTool,
   source: WorkerBootstrap.RuntimeToolCatalogEntry["source"],
 ): WorkerBootstrap.RuntimeToolCatalogEntry {
-  const mcpServer = source === "mcp" ? getMcpServerName(tool.spec.name) : undefined;
+  const mcpServer =
+    tool.descriptor?.source?.type === "mcp" ? tool.descriptor.source.serverId : undefined;
 
   return {
     canonicalName: tool.spec.name,
@@ -66,10 +67,4 @@ function createToolCatalogEntry(
     ...(tool.descriptor !== undefined && { descriptor: tool.descriptor }),
     ...(mcpServer !== undefined && { mcpServer }),
   };
-}
-
-function getMcpServerName(toolName: string): string | undefined {
-  if (!toolName.includes(".")) return undefined;
-  const [serverName] = toolName.split(".");
-  return serverName;
 }

--- a/apps/server/src/tool/mcp/provider-metadata.ts
+++ b/apps/server/src/tool/mcp/provider-metadata.ts
@@ -10,11 +10,13 @@ export function mcpToolMetadata(
   serverName: string,
   spec: Tool.Spec,
 ): { readonly labels: string[]; readonly descriptor: RuntimeResource.Descriptor } {
+  // Canonical labels first: the grammar parsers take the first match, so a
+  // remote spec shipping its own `mcp.*` or `source:*` label must not win.
   const labels = uniqueLabels([
-    ...(spec.labels ?? []),
     `tool:${spec.name}`,
     Tool.sourceLabel("mcp"),
     Tool.mcpServerLabel(serverName),
+    ...(spec.labels ?? []),
   ]);
 
   return {

--- a/apps/server/src/tool/mcp/provider-metadata.ts
+++ b/apps/server/src/tool/mcp/provider-metadata.ts
@@ -14,7 +14,7 @@ export function mcpToolMetadata(
     ...(spec.labels ?? []),
     `tool:${spec.name}`,
     Tool.sourceLabel("mcp"),
-    `mcp.${serverName}`,
+    Tool.mcpServerLabel(serverName),
   ]);
 
   return {

--- a/apps/server/test/bootstrap/credential-bootstrap.test.ts
+++ b/apps/server/test/bootstrap/credential-bootstrap.test.ts
@@ -34,7 +34,14 @@ function fakeMcpProviderWithTool(): Pick<McpToolProvider, "listTools"> {
   const tool = makeTool({ name: "filesystem.read", category: "mcp" });
   const metadata = mcpToolMetadata("filesystem", tool.spec);
   return {
-    listTools: () => [{ ...tool, labels: metadata.labels, descriptor: metadata.descriptor }],
+    listTools: () => [
+      {
+        ...tool,
+        spec: { ...tool.spec, labels: metadata.labels },
+        labels: metadata.labels,
+        descriptor: metadata.descriptor,
+      },
+    ],
   };
 }
 

--- a/apps/server/test/bootstrap/credential-bootstrap.test.ts
+++ b/apps/server/test/bootstrap/credential-bootstrap.test.ts
@@ -7,6 +7,7 @@ import { createServerDispatchOwners } from "../../src/bootstrap/dispatch-owners"
 import { assembleBootstrap } from "../../src/bootstrap/worker-bootstrap";
 import type { CustomToolProvider } from "../../src/tool/custom";
 import type { McpToolProvider } from "../../src/tool/mcp";
+import { mcpToolMetadata } from "../../src/tool/mcp/provider-metadata";
 
 const tempRoots: string[] = [];
 
@@ -30,13 +31,10 @@ function fakeMcpProvider(): Pick<McpToolProvider, "listTools"> {
 }
 
 function fakeMcpProviderWithTool(): Pick<McpToolProvider, "listTools"> {
+  const tool = makeTool({ name: "filesystem.read", category: "mcp" });
+  const metadata = mcpToolMetadata("filesystem", tool.spec);
   return {
-    listTools: () => [
-      makeTool({
-        name: "filesystem.read",
-        category: "mcp",
-      }),
-    ],
+    listTools: () => [{ ...tool, labels: metadata.labels, descriptor: metadata.descriptor }],
   };
 }
 

--- a/apps/server/test/tool/mcp/provider.test.ts
+++ b/apps/server/test/tool/mcp/provider.test.ts
@@ -126,11 +126,13 @@ describe("McpToolProvider", () => {
     await provider.refreshTools();
 
     const [tool] = provider.listTools();
+    // Canonical labels lead: the grammar parsers take the first match, so a
+    // remote spec's own `mcp.*` / `source:*` label must never outrank them.
     expect(tool.spec.labels).toEqual([
-      "custom.label",
       "tool:search.query",
       "source:mcp",
       "mcp.search",
+      "custom.label",
     ]);
     expect(tool.descriptor).toMatchObject({
       id: "tool:mcp:search:search.query",

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -132,8 +132,8 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 |---|---|---|
 | [#637](https://github.com/INONONO66/openomni/pull/637) | close the run loop's reason-code vocabulary (rule 1's real target); amend rules 2–4 with what the tree shows | ✅ |
 | [#638](https://github.com/INONONO66/openomni/pull/638) | rule 5: policy points with zero production registration vs an explicit allowlist (`policy-point-registration` guard, 9 of 18 pinned) | ✅ |
-| [#639](https://github.com/INONONO66/openomni/pull/639) | close the tool source-label vocabulary: grammar lives in `Tool.sourceLabel`/`Tool.sourceFromLabels` next to `Tool.Source`; dot separator retired; rejections pinned | 🟨 |
-| — | close the `mcp.<serverId>` label vocabulary: 2 producers in 2 packages + a third server-name derivation from tool names in `worker-bootstrap.ts` — the same multi-package raw-string shape #639 closed for source | ⬜ |
+| [#639](https://github.com/INONONO66/openomni/pull/639) | close the tool source-label vocabulary: grammar lives in `Tool.sourceLabel`/`Tool.sourceFromLabels` next to `Tool.Source`; dot separator retired; rejections pinned | ✅ |
+| [#640](https://github.com/INONONO66/openomni/pull/640) | close the `mcp.<serverId>` label vocabulary (`Tool.mcpServerLabel`/`Tool.mcpServerFromLabels`); `worker-bootstrap` reads the typed `descriptor.source.serverId` instead of re-deriving from the tool name | 🟨 |
 | — | rule 3: core may not import `builtin/` — blocked on the Owner-gated `builtin:compaction` row | ⬜ |
 
 Then [#502](https://github.com/INONONO66/openomni/issues/502) runs against a `session` package that holds only durable facts.

--- a/docs/agent-core-rewrite.md
+++ b/docs/agent-core-rewrite.md
@@ -134,6 +134,7 @@ Status legend: ⬜ not started · 🟨 in review · ✅ merged
 | [#638](https://github.com/INONONO66/openomni/pull/638) | rule 5: policy points with zero production registration vs an explicit allowlist (`policy-point-registration` guard, 9 of 18 pinned) | ✅ |
 | [#639](https://github.com/INONONO66/openomni/pull/639) | close the tool source-label vocabulary: grammar lives in `Tool.sourceLabel`/`Tool.sourceFromLabels` next to `Tool.Source`; dot separator retired; rejections pinned | ✅ |
 | [#640](https://github.com/INONONO66/openomni/pull/640) | close the `mcp.<serverId>` label vocabulary (`Tool.mcpServerLabel`/`Tool.mcpServerFromLabels`); `worker-bootstrap` reads the typed `descriptor.source.serverId` instead of re-deriving from the tool name | 🟨 |
+| — | `RuntimeToolCatalogEntry.mcpServer` is write-only on the wire — no production reader (#640 review); grow a consumer or delete the field (protocol schema surface, Owner review) | ⬜ |
 | — | rule 3: core may not import `builtin/` — blocked on the Owner-gated `builtin:compaction` row | ⬜ |
 
 Then [#502](https://github.com/INONONO66/openomni/issues/502) runs against a `session` package that holds only durable facts.

--- a/packages/agent/src/core/execution/tools.ts
+++ b/packages/agent/src/core/execution/tools.ts
@@ -272,7 +272,7 @@ interface McpToolPolicyTarget {
 type ToolPolicyTarget = NativeToolPolicyTarget | McpToolPolicyTarget;
 
 function mcpServerId(labels: readonly string[] | undefined): string | undefined {
-  return labels?.find((label) => label.startsWith("mcp."))?.slice("mcp.".length);
+  return Tool.mcpServerFromLabels(labels);
 }
 
 function sourceFromLabels(

--- a/packages/agent/src/runtime/mcp/client-descriptor.ts
+++ b/packages/agent/src/runtime/mcp/client-descriptor.ts
@@ -14,7 +14,7 @@ function createMcpToolDescriptor(serverId: string, remoteName: string): RuntimeR
       serverId,
       remoteName,
     },
-    labels: [Tool.sourceLabel("mcp"), `mcp.${serverId}`],
+    labels: [Tool.sourceLabel("mcp"), Tool.mcpServerLabel(serverId)],
     capabilities: ["network.write"],
     effects: ["external.write"],
   };

--- a/packages/protocol/src/mcp/index.ts
+++ b/packages/protocol/src/mcp/index.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 export namespace McpConfig {
   const BaseServerConfig = z.object({
-    name: z.string(),
+    // Non-empty: this name becomes the tool-name prefix, the mcp.<serverId>
+    // label, and descriptor.source.serverId — an empty one poisons all three.
+    name: z.string().min(1),
     headers: z.record(z.string(), z.string()).optional(),
     /** Per-request timeout in milliseconds for MCP tool discovery and tool calls. */
     timeout: z.number().int().nonnegative().optional(),

--- a/packages/protocol/src/tool/index.ts
+++ b/packages/protocol/src/tool/index.ts
@@ -31,6 +31,23 @@ export namespace Tool {
     return parsed.success ? parsed.data : undefined;
   }
 
+  /**
+   * MCP server provenance as a catalog label: `mcp.<serverId>`. Same
+   * cross-package shape as the source label — two producers, one consumer —
+   * so the same rule: the grammar is written once, here.
+   */
+  const mcpServerLabelPrefix = "mcp.";
+
+  export function mcpServerLabel(serverId: string): string {
+    return `${mcpServerLabelPrefix}${serverId}`;
+  }
+
+  export function mcpServerFromLabels(labels: readonly string[] | undefined): string | undefined {
+    const label = labels?.find((candidate) => candidate.startsWith(mcpServerLabelPrefix));
+    const serverId = label?.slice(mcpServerLabelPrefix.length);
+    return serverId ? serverId : undefined;
+  }
+
   export const RiskTier = z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]);
   export type RiskTier = z.infer<typeof RiskTier>;
 

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -377,6 +377,17 @@ describe("Tool source label grammar", () => {
     // `source:system`); the closed parser is the fix, so its rejections are
     // pinned as literally as its acceptances.
     expect(Tool.sourceFromLabels(["source.mcp", "mcp.fixture"])).toBeUndefined();
+  });
+
+  test("round-trips a server id through mcpServerLabel/mcpServerFromLabels", () => {
+    expect(Tool.mcpServerLabel("github")).toBe("mcp.github");
+    expect(Tool.mcpServerFromLabels(["source:mcp", "mcp.github"])).toBe("github");
+  });
+
+  test("yields no server id from a bare or absent mcp label", () => {
+    expect(Tool.mcpServerFromLabels(["mcp."])).toBeUndefined();
+    expect(Tool.mcpServerFromLabels(["source:mcp"])).toBeUndefined();
+    expect(Tool.mcpServerFromLabels(undefined)).toBeUndefined();
     expect(Tool.sourceFromLabels(["source:skill-mcp"])).toBeUndefined();
     expect(Tool.sourceFromLabels(["source:"])).toBeUndefined();
     expect(Tool.sourceFromLabels(undefined)).toBeUndefined();


### PR DESCRIPTION
The follow-up row #639's adversarial review opened. A tool's MCP server identity existed as **three forms of the same fact** with four derivation sites across three packages:

| form | site | read how |
|---|---|---|
| typed `descriptor.source.serverId` | set by `provider-metadata.ts` / `client-descriptor.ts` | structured |
| label `mcp.<serverId>` | produced in 2 packages, parsed in `tools.ts` | raw `startsWith("mcp.")` |
| tool-name prefix `<server>.<tool>` | split in `worker-bootstrap.ts` **and** `mcp-prefix-guard.ts` | raw `split(".")` |

## Changes

- `Tool.mcpServerLabel` / `Tool.mcpServerFromLabels` join the source grammar in protocol; both producers and the one consumer route through them. Spelling unchanged (`mcp.` — both ends already agreed; there was no drift to migrate, only a missing definition).
- `worker-bootstrap.ts` stops re-deriving the server name from the tool name and reads the typed `descriptor.source.serverId`. The name split was correct only because `convert.ts` happens to prefix names — a custom `McpClientLike` listing unprefixed names would have produced wrong provenance while the descriptor stayed right. `getMcpServerName` is deleted.
- The catalog test fixture now builds its MCP tool through the production `mcpToolMetadata`, so the fixture cannot drift from the shape every real tool carries.
- `mcp-prefix-guard.ts` **keeps** its own name split deliberately: validating the prefix claim is that guard's job — parsing the name there is the point, not a duplicate.
- Grammar round-trip and rejection pins added in `packages/protocol/test/tool.test.ts` (bare `mcp.`, absent label, no-label list).

## Verification

`bun test` 3466 pass / 9 skip / 0 fail · `check-types` 14/14 · `lint`, `lint:tools`, `check-dead-exports` 17 known/none new · `build` ok

Also flips the merged #639 plan row to ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the MCP server identity vocabulary and prevents drift. Previously we derived the server from a name prefix, a free-form `mcp.<serverId>` label, and the typed descriptor; now we define the label grammar once in `Tool`, read `descriptor.source.serverId` in `worker-bootstrap`, and enforce a non-empty server name to avoid incorrect provenance.

- Adds `Tool.mcpServerLabel`/`Tool.mcpServerFromLabels` in `packages/protocol`; both producers (`apps/server`, `packages/agent`) and the consumer (`packages/agent`) use them. Spelling stays `mcp.<serverId>`.
- `apps/server/src/bootstrap/worker-bootstrap.ts` reads `descriptor.source.serverId` and deletes `getMcpServerName`; the prefix guard keeps its own split for validation.
- Enforces non-empty `McpConfig.name` in `packages/protocol/src/mcp`; configs with empty names now fail validation.
- `mcpToolMetadata` puts canonical labels first to prevent remote specs from outranking them; tests pin label order and add round-trip/rejection cases; the catalog fixture mirrors `spec.labels` and descriptor.

<sup>Written for commit f02af0b40de370f1df635b3691c457cec56dc8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

