### PR TITLE
fix(policy): guard the generic create form; restore two pins (#606)

### DIFF
--- a/packages/openomni/src/execution-runtime/AGENTS.md
+++ b/packages/openomni/src/execution-runtime/AGENTS.md
@@ -6,7 +6,7 @@ Tool system, workspace safety, injection queue, cron bridge, and worker middlewa
 
 | Path | Purpose |
 | --- | --- |
-| `middleware.ts` | Builds worker middleware registrations from the gate-stamped `Execution.Request.policyPlan` (#479); builtin ids resolve through `defaultRegistry(events)` plus this package's own registrations (`registerIdleNudge` #625, `registerBudgetNudges` #626, `registerToolPermission` #629), `builtin:tool-permission` config is hydrated from `request.permissions`, required-but-unregistered ids fail closed. |
+| `middleware.ts` | Builds worker middleware registrations from the gate-stamped `Execution.Request.policyPlan` (#479); builtin ids resolve through this package's own registrations (`registerCompaction` #642, `registerIdleNudge` #625, `registerBudgetNudges` #626, `registerToolPermission` #629) on a registry it assembles itself — agent ships no `defaultRegistry` since #642, `builtin:tool-permission` config is hydrated from `request.permissions`, required-but-unregistered ids fail closed. |
 | `workspace-lock.ts` | Serializes workspace-mutating tool execution. |
 | `injection-queue.ts` | `InjectionQueue` — async response buffer keyed by `runId`; drained at `turn.finish` by the injection-queue policy. |
 | `cron-job-registry.ts` | `CronJobRegistry` — storage-backed registry of scheduled jobs with a process-local fallback; populated by `dispatch` `schedule.create` action. |

--- a/packages/openomni/src/execution-runtime/middleware/compaction-policy.ts
+++ b/packages/openomni/src/execution-runtime/middleware/compaction-policy.ts
@@ -17,9 +17,10 @@ const CompactionConfigSchema: z.ZodType<CompactionOptions, z.ZodTypeDef, unknown
 });
 
 /**
- * Ordering opinion, stated where opinions live: compaction runs after every
- * product policy at run.completion.pre has had its say about the messages it
- * is about to rewrite.
+ * Ordering opinion, stated where opinions live. Compaction is currently the
+ * only policy at run.completion.pre, so 900 is unopposed — the high value is
+ * the standing intent that any future policy at that point speaks before its
+ * messages are rewritten (the engine orders ascending).
  */
 export const COMPACTION_PRIORITY = 900;
 

--- a/packages/policy/test/registry-portability.test.ts
+++ b/packages/policy/test/registry-portability.test.ts
@@ -110,4 +110,69 @@ describe("PolicyRegistry portability", () => {
     expect(registrations.length).toBe(1);
     expect(registrations[0]?.name).toBe("policy-1");
   });
+
+  it("records the skipped optional policy under the caller's trace, and stays silent without one", () => {
+    // Moved here from agent's registry suite when defaultRegistry died (#642):
+    // this package owns resolve(), so it owns the pin. Two decisions live in
+    // publishOptionalPolicyMissing — the record itself, and the deliberate
+    // no-trace-no-record gate (a minted traceId correlates to nothing).
+    const registry = PolicyRegistry.create();
+    const emitted: unknown[] = [];
+
+    registry.resolve(
+      { policies: [{ id: "optional-missing", required: false, config: {} }], labels: [] },
+      {
+        traceId: "trace-optional-missing",
+        sessionId: "ses-optional-missing",
+        auditEmit: (_event, payload) => {
+          emitted.push(payload);
+        },
+      },
+    );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      traceId: "trace-optional-missing",
+      sessionId: "ses-optional-missing",
+      component: "agent.policy.registry",
+      msg: "optional policy missing",
+      context: { policyId: "optional-missing" },
+    });
+
+    const silent: unknown[] = [];
+    registry.resolve(
+      { policies: [{ id: "optional-missing", required: false, config: {} }], labels: [] },
+      {
+        auditEmit: (_event, payload) => {
+          silent.push(payload);
+        },
+      },
+    );
+    expect(silent).toHaveLength(0);
+  });
+
+  it("hands each factory the plan config and the resolve runtime", () => {
+    // The exported PolicyFactory contract: factory(config, runtime). Pinned by
+    // building the registration name from both.
+    const registry = PolicyRegistry.create();
+    registry.register("contract-policy", (config, runtime) => ({
+      kind: "point",
+      name: `contract:${runtime.agentName}:${(config as { mode: string }).mode}`,
+      pointIds: ["run.turn.pre"],
+      effectCapabilities: { "run.turn.pre": [] },
+      priority: 100,
+      fn: () => PolicyDecision.allow({ policyId: "contract" }),
+    }));
+
+    const registrations = registry.resolve(
+      {
+        policies: [{ id: "contract-policy", required: true, config: { mode: "strict" } }],
+        labels: [],
+      },
+      { agentName: "primary" },
+    );
+
+    expect(registrations.map((registration) => registration.name)).toEqual([
+      "contract:primary:strict",
+    ]);
+  });
 });

--- a/script/lint-guards.ts
+++ b/script/lint-guards.ts
@@ -99,7 +99,7 @@ const pointIdLiteralPattern = /["'`]([a-z][a-z._]+)["'`]/g;
  * registry of opinions. A registry populated inside the library is a default
  * the product did not choose.
  */
-const agentRegistryAssemblyPattern = /\bPolicyRegistry\s*\.\s*create\s*\(|\bdefaultRegistry\s*\(/g;
+const agentRegistryAssemblyPattern = /\bPolicyRegistry\s*\.\s*create\b|\bdefaultRegistry\s*\(/g;
 
 const policyPackageBoundaryPattern =
   /(?:from\s+|import\s+)["'](@openomni\/(?:agent|session))[^"']*["']/g;


### PR DESCRIPTION
**Why this is a separate PR**: #642's adversarial review set four merge conditions. The fix commit was rejected by commitlint (77-char header) while the merge command in the same batch went through — so #642 merged without them. This lands them immediately, unchanged from what the review verified.

## The four conditions

1. **MAJOR — guard regex defeated by the codebase's own idiom.** `agent-registry-assembly` matched `create\s*\(`, so `PolicyRegistry.create<PolicyContext>()` — the only form anyone writes, including the deleted `defaultRegistry` itself — passed lint. My mutation test had verified the ungeneric form only: I proved the wrong variant. The pattern now stops at the member access (`create\b`); the reviewer's exact counterexample fires at its line.
2. **MAJOR — lost pin, mutation-proven**: silencing `publishOptionalPolicyMissing` survived the full 3462-test suite. Restored in `registry-portability.test.ts` with both halves of the decision: the record under the caller's trace, and the deliberate no-trace-no-record gate. Mutation now fails.
3. **MAJOR — lost pin, mutation-proven**: `factory(policy.config, runtime)` → `factory(policy.config, {})` survived the suite. Restored: a factory that builds its name from `runtime.agentName`. Mutation now fails.
4. **MAJOR — doc desync**: the AGENTS.md of the very directory the registration moved into still said `defaultRegistry(events)`. Synced.

Plus the MINOR: `COMPACTION_PRIORITY`'s comment stated an ordering that does not exist (compaction is the only policy at `run.completion.pre`); it now states the fact and keeps the intent.

## Verification

Both restored pins mutation-verified (each mutation → 1 fail, clean → pass) · guard counterexample fires · `bun test` 3464 pass / 9 skip / 0 fail · `check-types` 14/14 · `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards registry assembly and restores two `PolicyRegistry` pins lost in #642. Previously the guard missed generic `PolicyRegistry.create<...>()`, optional-missing policies produced no audit, and factories received `{}` as runtime; now the guard catches the generic form, an audit record is emitted under the caller’s trace when present, and factories receive the real runtime again.

- Guards: `script/lint-guards.ts` updates the pattern to `create\b` so `PolicyRegistry.create<...>()` is flagged.
- Pins restored in `packages/policy/test/registry-portability.test.ts`:
  - `publishOptionalPolicyMissing` records under provided `traceId`; still silent without a trace.
  - `factory(config, runtime)` again receives the resolve runtime (e.g., `runtime.agentName`), restoring the contract.
- Docs/comments: `AGENTS.md` now reflects self-assembled registry (no `defaultRegistry`); `COMPACTION_PRIORITY` comment states current ordering intent.

<sup>Written for commit 0f22c640d57afe03699dcc310aefbfe07aa3f690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

