### PR TITLE
refactor(agent): delete the dead entry-export surface (#606)

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -9,7 +9,7 @@ src/
 ├── index.ts                    # Public API
 ├── core/
 │   ├── chat-agent.ts           # ChatAgent.create() — provides run()
-│   ├── types.ts                # ChatAgentConfig, ChatAgentInput, AgentResult, AgentStep, AgentBudget, TokenUsage, Sink
+│   ├── types.ts                # ChatAgentConfig, ChatAgentInput, AgentResult (+ internal AgentStep/AgentBudget/TokenUsage; Sink is protocol's, used in signatures)
 │   ├── budget.ts               # createBudgetState / checkBudget / recordTurn / recordToolCall / recordTokenUsage
 │   ├── retry.ts                # DEFAULT_RETRY_POLICY, classifyRetryReason, shouldRetry, sleep
 │   ├── message-factory.ts      # Message envelope helpers for injected messages
@@ -48,10 +48,15 @@ const result = await agent.run({
 
 Also exported from `@openomni/agent`:
 
-- Types: `ChatAgentConfig`, `ChatAgentInput`, `AgentResult`, `AgentStep`, `AgentBudget`, `TokenUsage`, `Sink`
-- Policy: `PolicyEngine`, `PolicyContext`, `PolicyFn`, `CanonicalPolicyRegistration`, `PolicyEngineRegistration`, `PolicyRegistration` (legacy compatibility), `PolicyEngineInstance`
-- Budget queries: `checkBudget`, `describeBudgetRemaining`, and the `BudgetState` / `BudgetStatus` they read and return — the accounting stays here, what to say about it does not (D5)
-- Runtime: `McpClient`, `McpServerConfig`
+- Types: `ChatAgentConfig`, `ChatAgentInput`, `AgentResult`
+- Policy: `PolicyEngine`, `PolicyRegistry`, `PolicyContext`, `PolicyFn`, `CanonicalPolicyRegistration`, `PolicyEngineRegistration`, `PolicyEngineInstance`, `PolicyRegistryInstance`
+- Budget queries: `checkBudget`, `describeBudgetRemaining`, `BudgetState` — the accounting stays here, what to say about it does not (D5)
+- Reason codes: `RunReasonCode`; Compaction: `createCompactionPolicy`, `CompactionOptions`; Runtime: `McpClient`
+
+The entry carries what a consumer somewhere actually imports (#647). Types
+reachable through exported signatures (`BudgetStatus`, `AgentStep`, `Sink`, …)
+stay exported at their definition sites; a consumer that needs to *name* one
+adds the one-line re-export in the same PR that imports it.
 
 ## ChatAgentConfig
 

--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -5,9 +5,8 @@ export type {
   PolicyFn,
   PolicyRegistration,
 } from "./types";
-export type { PolicyDecision, PolicyAuditConfig, PolicyEngineConfig } from "@openomni/policy";
 export { PolicyRegistry } from "@openomni/policy";
-export type { PolicyFactory, PolicyRegistryInstance } from "@openomni/policy";
+export type { PolicyRegistryInstance } from "@openomni/policy";
 
 import {
   PolicyEngine as GenericPolicyEngine,

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -65,5 +65,3 @@ export interface AgentResult {
   compactionCount?: number;
   guardAborted?: boolean;
 }
-
-export type { Sink };

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,9 +4,10 @@ export type { ChatAgentInstance } from "./core/chat-agent";
 export type { ChatAgentConfig, ChatAgentInput, AgentResult } from "./core/types";
 export { PolicyEngine, PolicyRegistry } from "./core/policy";
 // Budget accounting stays core (the limits are loop invariants); the queries
-// and the types they read and return are exported so a product can decide what
-// to say about what is left (D5). Exporting the functions without the types
-// leaves a consumer unable to name what it is holding.
+// are exported so a product can decide what to say about what is left (D5).
+// BudgetState rides along because openomni names it; BudgetStatus does not —
+// its consumers hold checkBudget's return structurally, and the entry carries
+// only what someone actually imports (#647).
 export { checkBudget, describeBudgetRemaining } from "./core/budget";
 export { RunReasonCode } from "./core/policy/reason-codes";
 export type { BudgetState } from "./core/budget";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,15 +1,7 @@
 // Agent package public API — ChatAgent only
 export { ChatAgent } from "./core/chat-agent";
 export type { ChatAgentInstance } from "./core/chat-agent";
-export type {
-  ChatAgentConfig,
-  ChatAgentInput,
-  AgentResult,
-  AgentStep,
-  AgentBudget,
-  TokenUsage,
-  Sink,
-} from "./core/types";
+export type { ChatAgentConfig, ChatAgentInput, AgentResult } from "./core/types";
 export { PolicyEngine, PolicyRegistry } from "./core/policy";
 // Budget accounting stays core (the limits are loop invariants); the queries
 // and the types they read and return are exported so a product can decide what
@@ -17,21 +9,15 @@ export { PolicyEngine, PolicyRegistry } from "./core/policy";
 // leaves a consumer unable to name what it is holding.
 export { checkBudget, describeBudgetRemaining } from "./core/budget";
 export { RunReasonCode } from "./core/policy/reason-codes";
-export type { BudgetState, BudgetStatus } from "./core/budget";
+export type { BudgetState } from "./core/budget";
 export type {
   CanonicalPolicyRegistration,
   PolicyContext,
   PolicyEngineRegistration,
   PolicyFn,
-  PolicyRegistration,
-  PolicyDecision,
-  PolicyAuditConfig,
-  PolicyEngineConfig,
   PolicyEngineInstance,
-  PolicyFactory,
   PolicyRegistryInstance,
 } from "./core/policy";
 export { McpClient } from "./runtime/mcp/index";
-export type { McpServerConfig } from "./runtime/mcp/index";
 export { createCompactionPolicy } from "./compaction";
 export type { CompactionOptions } from "./compaction";

--- a/packages/agent/src/runtime/mcp/index.ts
+++ b/packages/agent/src/runtime/mcp/index.ts
@@ -1,2 +1,1 @@
 export { McpClient } from "./client";
-export type { McpServerConfig } from "@openomni/protocol";

--- a/packages/telemetry/AGENTS.md
+++ b/packages/telemetry/AGENTS.md
@@ -50,9 +50,16 @@ First `settle()` wins, so an inner guard is not overwritten by an outer one on t
 
 ## WHAT IS WIRED TODAY
 
-`Bus`, `newTraceId`, and `newSpanId` have production consumers. Everything else — `span`, `child`, the sinks (`tee`, `noopSink`, `collector`), the `traceparent` codec, the span status helpers (`spanStatus`, `spanStatusMessage`), and the guards (`requireTraceScope`, `rootScope`, `isTraceId`, `isSpanId`, `InvalidTraceScopeError`) — is used only by this package's own tests, and `scope` only by a `packages/session` test fixture. `createSpanHandle` and `failedOutcome` are not exported from the barrel at all: `scope.ts` is their only consumer, and an export with no reader is the thing this rule exists to catch. The exported *types* — `Emitter`, `ScopeNarrowing`, `ScopeOptions`, `CollectedEvent`, `CollectingSink`, `TeeOptions`, `SpanHandle`, `SpanStatus`, `EmitPayload`, `SpanId`, `TraceId`, `TraceField`, `TraceScopeInput` — have no reader at all, not even a test. They are the public API's type surface and stand or fall with the functions they describe. `check-dead-exports` is satisfied because tests count as consumers, so it will not tell you this.
-
-That is deliberate and bounded: the surface exists so Phase 1b has something to convert *to*, and Phase 1b is what gives it callers. If Phase 1b is abandoned, this surface is dead and should be deleted, not kept for a future that is not coming.
+`Bus`, `newTraceId`, and `newSpanId` have production consumers. Everything else — `span`, `child`, the sinks (`tee`, `noopSink`, `collector`), the `traceparent` codec, the span status helpers (`spanStatus`, `spanStatusMessage`), and the guards (`requireTraceScope`, `rootScope`, `isTraceId`, `isSpanId`, `InvalidTraceScopeError`) — is used only by this package's own tests, and `scope` only by a `packages/session` test fixture. `createSpanHandle` and `failedOutcome` are not exported from the barrel at all: `scope.ts` is their only consumer, and an export with no reader is the thing this rule exists to catch. The reader-less *type* re-exports that used to ride the barrel (`Emitter`,
+`CollectingSink`, `SpanHandle`, …) were deleted in #647, which supersedes the
+earlier stand-or-fall doctrine here: Phase 1b shipped its consumers (they use
+`Bus` and the id mints, and hold everything else structurally), so the types
+never gained a reader and the entry no longer carries them. Definition-site
+exports remain where declaration emit or an internal importer needs them; a
+consumer that needs to name one adds the one-line barrel re-export in the same
+PR that imports it. `check-dead-exports` will not tell you any of this — entry
+exports are exempt, and tests count as consumers — so re-check with
+`bunx knip --include-entry-exports` when touching this surface.
 
 ## CONVENTIONS
 

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,10 +1,8 @@
 export { Bus, BusEvent } from "./bus";
 export { scope } from "./scope";
-export type { Emitter, ScopeNarrowing, ScopeOptions } from "./scope";
 export { collector, noopSink, tee } from "./sink";
-export type { CollectedEvent, CollectingSink, TeeOptions } from "./sink";
 export { spanStatus, spanStatusMessage } from "./span";
-export type { SpanHandle, SpanOutcome, SpanPair, SpanStatus } from "./span";
+export type { SpanOutcome, SpanPair } from "./span";
 export {
   fromTraceparent,
   InvalidTraceScopeError,
@@ -16,11 +14,4 @@ export {
   rootScope,
   toTraceparent,
 } from "./trace";
-export type {
-  EmitPayload,
-  SpanId,
-  TraceField,
-  TraceId,
-  TraceScope,
-  TraceScopeInput,
-} from "./trace";
+export type { TraceScope } from "./trace";

--- a/packages/telemetry/src/scope.ts
+++ b/packages/telemetry/src/scope.ts
@@ -13,7 +13,7 @@ import {
  * child run and a delegated actor belong to the same trace, and span linkage is
  * the emitter's job, not the caller's.
  */
-export type ScopeNarrowing = Omit<Partial<TraceScope>, "traceId" | "spanId" | "parentSpanId">;
+type ScopeNarrowing = Omit<Partial<TraceScope>, "traceId" | "spanId" | "parentSpanId">;
 
 export interface Emitter {
   /**

--- a/packages/telemetry/src/sink.ts
+++ b/packages/telemetry/src/sink.ts
@@ -1,6 +1,6 @@
 import type { BusEvent } from "@openomni/protocol";
 
-export interface CollectedEvent {
+interface CollectedEvent {
   readonly name: string;
   readonly data: unknown;
 }

--- a/packages/telemetry/src/trace.ts
+++ b/packages/telemetry/src/trace.ts
@@ -105,7 +105,7 @@ const TRACE_FIELDS = [
   "agentName",
 ] as const;
 
-export type TraceField = (typeof TRACE_FIELDS)[number];
+type TraceField = (typeof TRACE_FIELDS)[number];
 
 /** A payload with the emitter-owned fields removed. */
 export type EmitPayload<T> = Omit<T, TraceField | "time">;


### PR DESCRIPTION
The terminal goal is zero slop in agent/llm/telemetry, and this was the known remaining dead surface: the ratchet's entry-export exemption let barrels carry type re-exports **nothing imports**.

## What was mis-parked

The session had this filed under "Owner 판정 대기" — wrongly. Flipping `--include-entry-exports` into the ratchet config or growing the baseline needs Owner sign-off; **deleting the dead exports it surfaces is autonomous shrink** (the ratchet header's own words). This PR is the deletion, not the config flip.

## What died (agent 16, telemetry 16, llm 0 — knip `--include-entry-exports`, each verified)

- **agent root barrel**: `AgentStep`, `AgentBudget`, `TokenUsage`, `Sink`, `BudgetStatus`, `PolicyRegistration`, `PolicyDecision`, `PolicyAuditConfig`, `PolicyEngineConfig`, `PolicyFactory`, `McpServerConfig` type re-exports — no importer anywhere in the repo
- **agent `core/policy` barrel**: dead pass-throughs of `@openomni/policy` types
- **agent `core/types.ts` / `runtime/mcp/index.ts`**: `Sink` and `McpServerConfig` were pure pass-throughs of protocol types that every consumer already takes from `@openomni/protocol`
- **telemetry barrel**: `Emitter`, `ScopeNarrowing`, `ScopeOptions`, `CollectedEvent`, `CollectingSink`, `TeeOptions`, `SpanHandle`, `SpanStatus`, `EmitPayload`, `SpanId`, `TraceField`, `TraceId`, `TraceScopeInput` re-exports; definition-site `export` keywords dropped where tsc declaration emit does not require them (build adjudicated — everything that passed was genuinely dead)

## Not touched

Dead entry exports in openomni/session/ipc/server (outside the three named packages — separate sweep), the ratchet config, the baseline.

## Verification

knip `--include-entry-exports` → **0 remaining** in the three packages · `bun test` 3479 pass / 9 skip / 0 fail · `check-types` 14/14 · ratchet 17 known/none new · `lint`, `lint:tools`, `check-deps` 0, `check-import-cycles`, `build`, `bench` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes dead type re-exports from the `agent` and `telemetry` entry barrels so package entries only expose symbols with real consumers. No runtime behavior changes; docs now codify the “entry carries only what a consumer imports” rule.

- Migration
  - `agent`: If you imported `Sink` or `McpServerConfig` from `@openomni/agent`, import them from `@openomni/protocol`. Import policy types such as `PolicyDecision`, `PolicyAuditConfig`, `PolicyEngineConfig`, and `PolicyFactory` from `@openomni/policy`. `BudgetStatus` is no longer exported; use `BudgetState` with `checkBudget`/`describeBudgetRemaining`.
  - `telemetry`: Stop importing internal types (`Emitter`, `ScopeNarrowing`, `ScopeOptions`, `CollectedEvent`, `CollectingSink`, `TeeOptions`, `SpanHandle`, `SpanStatus`, `EmitPayload`, `SpanId`, `TraceField`, `TraceId`, `TraceScopeInput`) from the package root. Use the public surface (`Bus`, `scope`, `collector`, `noopSink`, `tee`, `spanStatus`, `spanStatusMessage`) and the retained types `SpanOutcome`, `SpanPair`, `TraceScope`.

<sup>Written for commit 974e9beb03d1a1faccdf44bc23895705e27a8fd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

