### PR TITLE
refactor(openomni): sweep the dead value exports repo-wide (#606)

### DIFF
--- a/apps/server/src/agents/registry.ts
+++ b/apps/server/src/agents/registry.ts
@@ -16,10 +16,6 @@ export function getAgentDefinition(name: string): AgentDefinition | undefined {
   return factory?.();
 }
 
-export function getAllAgentNames(): string[] {
-  return [...agentSources.keys()];
-}
-
 export function createAllAgents(): Map<string, AgentDefinition> {
   const result = new Map<string, AgentDefinition>();
   for (const [name, factory] of agentSources) {

--- a/apps/server/src/channel/discord/gateway.ts
+++ b/apps/server/src/channel/discord/gateway.ts
@@ -310,9 +310,9 @@ export class DiscordGateway {
 }
 
 // merged from reconnect-backoff.ts (#453 hygiene: sub-30-LOC single-importer)
-export const FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
+const FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 const MAX_BACKOFF_MS = 60_000;
 
-export function calculateBackoff(attempt: number): number {
+function calculateBackoff(attempt: number): number {
   return Math.min(1000 * 2 ** attempt, MAX_BACKOFF_MS) + Math.random() * 1000;
 }

--- a/apps/server/src/channel/discord/surface.ts
+++ b/apps/server/src/channel/discord/surface.ts
@@ -185,7 +185,7 @@ import type { ChannelClient } from "../types";
 
 const DISCORD_MESSAGE_LIMIT = 2000;
 
-export async function sendDiscordMessage(
+async function sendDiscordMessage(
   client: ChannelClient,
   channelId: string,
   message: Adapter.OutboundMessage,

--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -79,7 +79,7 @@ export function buildAgentDef(agentName: string, deps: BridgeDeps): Ingress.Agen
   return buildAgentDefFromEntries(definition, deps, selectToolEntries(definition, deps));
 }
 
-export function buildResidentAgentDef(deps: BridgeDeps): Ingress.AgentDef {
+function buildResidentAgentDef(deps: BridgeDeps): Ingress.AgentDef {
   const model = deps.defaultModel ?? DEFAULT_DISPATCH_MODEL;
   const definition: AgentDefinition = {
     name: "resident",

--- a/apps/server/src/tool/mcp/provider-audit.ts
+++ b/apps/server/src/tool/mcp/provider-audit.ts
@@ -2,7 +2,6 @@
 export const MCP_TOOL_ACTION = "mcp.tool.call";
 
 /** @internal Package-local helper for McpToolProvider only. */
-/** @internal Package-local helper for McpToolProvider only. */
 export function buildActor(
   sessionId: string | undefined,
   actor: Record<string, unknown> | undefined = undefined,

--- a/apps/server/src/tool/mcp/provider-audit.ts
+++ b/apps/server/src/tool/mcp/provider-audit.ts
@@ -1,14 +1,7 @@
-import type { Tool } from "@openomni/protocol";
-
 /** @internal Package-local helper for McpToolProvider only. */
 export const MCP_TOOL_ACTION = "mcp.tool.call";
 
 /** @internal Package-local helper for McpToolProvider only. */
-export function readSessionId(call: Tool.Call): string | undefined {
-  const sessionId = call.input.sessionId;
-  return typeof sessionId === "string" && sessionId.length > 0 ? sessionId : undefined;
-}
-
 /** @internal Package-local helper for McpToolProvider only. */
 export function buildActor(
   sessionId: string | undefined,

--- a/packages/coordinator/test/harness/ipc.ts
+++ b/packages/coordinator/test/harness/ipc.ts
@@ -1,29 +1,4 @@
-import net from "node:net";
-
 export interface UnixSocketHandle {
   send: (msg: object) => void;
   close: () => void;
-}
-
-export function connectUnixSocket(socketPath: string, timeoutMs = 5000): Promise<UnixSocketHandle> {
-  return new Promise((resolve, reject) => {
-    const socket = net.createConnection(socketPath);
-    const timer = setTimeout(() => {
-      socket.destroy();
-      reject(new Error(`connect timeout: ${socketPath}`));
-    }, timeoutMs);
-
-    socket.once("connect", () => {
-      clearTimeout(timer);
-      resolve({
-        send: (msg) => socket.write(`${JSON.stringify(msg)}\n`),
-        close: () => socket.destroy(),
-      });
-    });
-
-    socket.once("error", (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-  });
 }

--- a/packages/coordinator/test/harness/ipc.ts
+++ b/packages/coordinator/test/harness/ipc.ts
@@ -1,4 +1,0 @@
-export interface UnixSocketHandle {
-  send: (msg: object) => void;
-  close: () => void;
-}

--- a/packages/ipc/src/index.ts
+++ b/packages/ipc/src/index.ts
@@ -4,5 +4,5 @@
 // barrel as a published contract; it never grows a kernel/ledger/policy import.
 export { connectIpcClient, type ConnectIpcClientOptions, type IpcClient } from "./client";
 export { IpcConnectionError, IpcProtocolError, IpcTimeoutError } from "./errors";
-export { encode, LineDecoder } from "./framing";
+export { encode } from "./framing";
 export { createIpcServer } from "./server";

--- a/packages/openomni/src/execution-runtime/tool/builtins/edit.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/edit.ts
@@ -127,7 +127,7 @@ function isSha256Hex(value: string): boolean {
 }
 
 // merged from edit-prompt.ts (#453 hygiene: sub-30-LOC single-importer)
-export const EDIT_PROMPT = `Replace an exact substring in a file within the workspace.
+const EDIT_PROMPT = `Replace an exact substring in a file within the workspace.
 oldString must already exist in the file and must differ from newString.
 Default behavior replaces the first occurrence; set replaceAll=true to replace every match.
 Set expectedFileHash to the current file SHA-256 hash to reject stale edits.`;

--- a/packages/openomni/src/execution-runtime/tool/builtins/glob.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/glob.ts
@@ -75,6 +75,6 @@ export function createGlobTool(workspaceRoot: string) {
 }
 
 // merged from glob-prompt.ts (#453 hygiene: sub-30-LOC single-importer)
-export const GLOB_PROMPT = `Match files against a glob pattern (e.g. '**/*.ts') inside the workspace.
+const GLOB_PROMPT = `Match files against a glob pattern (e.g. '**/*.ts') inside the workspace.
 Results are sorted newest-first by mtime and capped at 100 entries.
 Paths must stay within the workspace root; symlink escapes are rejected.`;

--- a/packages/openomni/src/execution-runtime/tool/builtins/grep.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/grep.ts
@@ -212,6 +212,6 @@ export function createGrepTool(workspaceRoot: string): NativeTool {
 }
 
 // merged from grep-prompt.ts (#453 hygiene: sub-30-LOC single-importer)
-export const GREP_PROMPT = `Search file contents for a regex pattern across the workspace.
+const GREP_PROMPT = `Search file contents for a regex pattern across the workspace.
 Use include (glob) to narrow the files searched and ignoreCase for case-insensitive matches.
 Returns up to 100 entries as {file, line, text}. Paths must stay within the workspace root.`;

--- a/packages/openomni/src/execution-runtime/tool/builtins/read.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/read.ts
@@ -71,6 +71,6 @@ export function createReadTool(workspaceRoot: string) {
 }
 
 // merged from read-prompt.ts (#453 hygiene: sub-30-LOC single-importer)
-export const READ_PROMPT = `Read file contents or list a directory inside the workspace.
+const READ_PROMPT = `Read file contents or list a directory inside the workspace.
 Files return line-prefixed text (1-indexed); directories return sorted entries with trailing slash for subdirectories.
 Use offset and limit for paginated reads of large files. Paths must stay within the workspace root.`;

--- a/packages/openomni/src/execution-runtime/tool/builtins/write.ts
+++ b/packages/openomni/src/execution-runtime/tool/builtins/write.ts
@@ -37,6 +37,6 @@ export function createWriteTool(workspaceRoot: string) {
 }
 
 // merged from write-prompt.ts (#453 hygiene: sub-30-LOC single-importer)
-export const WRITE_PROMPT = `Write content to a file inside the workspace.
+const WRITE_PROMPT = `Write content to a file inside the workspace.
 Creates parent directories as needed and overwrites any existing file at the path.
 The path must stay within the workspace root; symlink escapes are rejected.`;

--- a/packages/openomni/src/execution-runtime/tool/executor.ts
+++ b/packages/openomni/src/execution-runtime/tool/executor.ts
@@ -480,7 +480,7 @@ function requireCallTraceId(context: ToolExecutionContext | undefined): string {
   return traceId;
 }
 
-export function createErrorResult(call: Tool.Call, message: string): Tool.Result {
+function createErrorResult(call: Tool.Call, message: string): Tool.Result {
   return {
     id: crypto.randomUUID(),
     toolCallId: call.id,

--- a/packages/openomni/src/messaging/index.ts
+++ b/packages/openomni/src/messaging/index.ts
@@ -1,15 +1,6 @@
 // Existing-agent messaging (#215): the delivery-created public surface,
 // exported as the `@openomni/openomni/messaging` subpath.
-export { Events as MessagingEvents } from "./events.js";
-export {
-  AwaitSpec,
-  MessageDenialCode,
-  MessageOperation,
-  MessageTarget,
-  SendInput,
-  SenderTargetGrant,
-  resolveSenderTargetGrant,
-} from "./schema.js";
+export { SendInput, SenderTargetGrant } from "./schema.js";
 export type { DeliveryTarget, SendReceipt } from "./schema.js";
 export { createExistingAgentMessaging } from "./send.js";
 export type {

--- a/packages/openomni/src/messaging/schema.ts
+++ b/packages/openomni/src/messaging/schema.ts
@@ -64,7 +64,7 @@ export type MessageDenialCode = z.infer<typeof MessageDenialCode>;
  * NOT re-refined here — `Wait.Record.parse` at WaitStore.create is the one
  * enforcement layer for that invariant (#215 rule 4).
  */
-export const AwaitSpec = z
+const AwaitSpec = z
   .object({
     waitId: z.string().min(1),
     ownerRef: WaitSchemas.OwnerRef,
@@ -78,7 +78,6 @@ export const AwaitSpec = z
     correlation: WaitSchemas.Correlation.optional(),
   })
   .strict();
-export type AwaitSpec = z.infer<typeof AwaitSpec>;
 
 const SendInputBase = z
   .object({

--- a/packages/openomni/src/projection/flat-event.ts
+++ b/packages/openomni/src/projection/flat-event.ts
@@ -66,8 +66,7 @@ export type Verdict = z.infer<typeof Verdict>;
  * verifier-registry-contract.ts, mirrored by protocol `ResultValue`). A step
  * with no verification carries `null` (see `ProjectionStep.verifierStatus`).
  */
-export const VerifierStatus = z.enum(["verified", "refuted", "inconclusive", "asserted"]);
-export type VerifierStatus = z.infer<typeof VerifierStatus>;
+const VerifierStatus = z.enum(["verified", "refuted", "inconclusive", "asserted"]);
 
 // ---------------------------------------------------------------------------
 // verdict mapper — PURE, throw-on-unknown
@@ -193,14 +192,14 @@ export const FLAT_EVENT_FIELDS = Object.keys(FlatEvent.shape) as (keyof FlatEven
  * same way, on any machine, at any time. `timeCreated`/`streamId`/`seq` come
  * straight off the immutable row — the fold NEVER reads `Date.now()`.
  */
-export const StepOrder = z
+const StepOrder = z
   .object({
     timeCreated: z.number().int(),
     streamId: z.string().min(1),
     seq: z.number().int().nonnegative(),
   })
   .strict();
-export type StepOrder = z.infer<typeof StepOrder>;
+type StepOrder = z.infer<typeof StepOrder>;
 
 /**
  * One assembled per-step fact bundle. The assembler (later increments) reads

--- a/packages/openomni/src/projection/index.ts
+++ b/packages/openomni/src/projection/index.ts
@@ -7,7 +7,4 @@ export {
   mapVerdict,
   ProjectionInput,
   ProjectionStep,
-  StepOrder,
-  Verdict,
-  VerifierStatus,
 } from "./flat-event.js";

--- a/packages/session/src/bus-persistence/event-query.ts
+++ b/packages/session/src/bus-persistence/event-query.ts
@@ -45,7 +45,7 @@ export function listForLlmReasoning(
 }
 
 // merged from event-record-mapper.ts (#453 hygiene: sub-30-LOC single-importer)
-export function toEventRecord(row: BusEventRow): EventRecord {
+function toEventRecord(row: BusEventRow): EventRecord {
   return {
     id: String(row.id),
     sessionId: row.session_id,

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -6,7 +6,7 @@ export { BusQuery } from "./bus-persistence/query";
 export { Storage, SqliteStorageAdapter, initialize } from "./storage";
 export type { InitializeOptions } from "./storage";
 export { Session } from "./session";
-export { TranscriptRecordingError, TranscriptStore } from "./session/transcript";
+export { TranscriptStore } from "./session/transcript";
 export { SurfaceKey } from "./surface-key";
 export { Artifact } from "./artifact/index";
 export { AppConnectorInstallationStore } from "./app-connector/index.js";

--- a/packages/session/src/storage/sqlite-part-adapter.ts
+++ b/packages/session/src/storage/sqlite-part-adapter.ts
@@ -58,7 +58,7 @@ export function createSqlitePartAdapter(db: Database): Storage.Adapter["part"] {
 
 // merged from part-time.ts (#453 hygiene: sub-30-LOC single-importer)
 
-export function getPartStartTime(part: Message.Part): number | undefined {
+function getPartStartTime(part: Message.Part): number | undefined {
   if ((part.type === "text" || part.type === "reasoning") && part.time?.start !== undefined) {
     return part.time.start;
   }

--- a/script/check-protocol-disposition.ts
+++ b/script/check-protocol-disposition.ts
@@ -408,7 +408,7 @@ export function readInventory(path: string): Inventory {
   return JSON.parse(readFileSync(path, "utf8")) as Inventory;
 }
 
-export function readFixture(path: string): Fixture {
+function readFixture(path: string): Fixture {
   return JSON.parse(readFileSync(path, "utf8")) as Fixture;
 }
 

--- a/script/conformance/knip-baseline.json
+++ b/script/conformance/knip-baseline.json
@@ -1,19 +1,5 @@
 {
   "grandfathered": [
-    "exports apps/server/src/agents/registry.ts getAllAgentNames",
-    "exports apps/server/src/channel/discord/gateway.ts calculateBackoff",
-    "exports apps/server/src/channel/discord/gateway.ts FATAL_CLOSE_CODES",
-    "exports apps/server/src/channel/discord/surface.ts sendDiscordMessage",
-    "exports apps/server/src/ingress/bridge.ts buildResidentAgentDef",
-    "exports apps/server/src/tool/mcp/provider-audit.ts readSessionId",
-    "exports packages/openomni/src/execution-runtime/tool/builtins/edit.ts EDIT_PROMPT",
-    "exports packages/openomni/src/execution-runtime/tool/builtins/glob.ts GLOB_PROMPT",
-    "exports packages/openomni/src/execution-runtime/tool/builtins/grep.ts GREP_PROMPT",
-    "exports packages/openomni/src/execution-runtime/tool/builtins/read.ts READ_PROMPT",
-    "exports packages/openomni/src/execution-runtime/tool/builtins/write.ts WRITE_PROMPT",
-    "exports packages/openomni/src/execution-runtime/tool/executor.ts createErrorResult",
-    "exports packages/session/src/bus-persistence/event-query.ts toEventRecord",
-    "exports packages/session/src/storage/sqlite-part-adapter.ts getPartStartTime",
     "files packages/openomni/test/dispatch/policy-registration.contract-test.ts",
     "types packages/openomni/src/execution-runtime/child-agent/types.ts ChildStatus",
     "types packages/openomni/src/execution-runtime/child-agent/types.ts DelegationPolicyPointId"

--- a/script/report-breadcrumbs.ts
+++ b/script/report-breadcrumbs.ts
@@ -43,7 +43,7 @@ export interface BreadcrumbRef {
 }
 
 /** Extracts `#NNN` comment refs from one file's source. */
-export function scanSource(filePath: string, source: string): BreadcrumbRef[] {
+function scanSource(filePath: string, source: string): BreadcrumbRef[] {
   const refs: BreadcrumbRef[] = [];
   const lines = source.split("\n");
   let inBlockComment = false;
@@ -92,7 +92,7 @@ export function scanSource(filePath: string, source: string): BreadcrumbRef[] {
   return refs;
 }
 
-export function groupByIssue(refs: readonly BreadcrumbRef[]): Map<number, BreadcrumbRef[]> {
+function groupByIssue(refs: readonly BreadcrumbRef[]): Map<number, BreadcrumbRef[]> {
   const grouped = new Map<number, BreadcrumbRef[]>();
   for (const ref of refs) {
     const bucket = grouped.get(ref.issue);


### PR DESCRIPTION
The value-export half of #647's knip listing (`--include-entry-exports`), across the rest of the repo (server, openomni, session, ipc, coordinator harness, script). Every item was verified against its actual readers before choosing its fate:

| fate | items |
|---|---|
| **export keyword dropped** (same-file-only consumers) | 5 builtin tool `*_PROMPT` constants, `createErrorResult`, `sendDiscordMessage`, `calculateBackoff`, `FATAL_CLOSE_CODES`, `buildResidentAgentDef`, `toEventRecord`, `StepOrder`/`VerifierStatus`/`AwaitSpec` zod consts, 3 script helpers |
| **deleted outright** (zero references) | `getAllAgentNames`, `readSessionId`, `connectUnixSocket`, plus the orphaned `AwaitSpec`/`VerifierStatus` type aliases their own files stopped reading |
| **barrel line removed, definition kept** (tests import the module directly) | ipc `LineDecoder`, session `TranscriptRecordingError`, messaging `MessagingEvents`/`AwaitSpec`/`MessageDenialCode`/`MessageOperation`/`MessageTarget`/`resolveSenderTargetGrant`, projection `StepOrder`/`Verdict`/`VerifierStatus` |

One correction the build caught mid-sweep: `getPartStartTime` looked zero-ref but had a same-file caller — restored un-exported rather than deleted.

## Ratchet shrink

The deletions cleared **14 of the ratchet's 17 baselined issues**; the baseline shrinks with them (`--update`, the autonomous direction per the script's own header). 3 remain. Self-test passes.

## Not in this PR

The ~82 remaining dead *type* re-exports in openomni/ledger/evidence/ipc surfaces — same class, separate sweep (this PR is the value list).

## Verification

`bun test` 3479 pass / 9 skip / 0 fail · `check-types` 14/14 · `lint`, `lint:tools`, `check-deps` 0, `check-import-cycles`, ratchet 3 known/none new + self-test · `build` + `bench` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes dead value exports repo‑wide and deletes a dead coordinator test harness, shrinking the public surface and clearing knip findings. Previously, many symbols were exported despite only local use; now zero‑use exports are removed and local‑only symbols are file‑scoped. 14 knip baseline issues cleared; no runtime behavior changes expected.

- Migration
  - Stop importing deleted functions: getAllAgentNames, readSessionId, connectUnixSocket.
  - `@openomni/openomni/messaging` now only re‑exports `SendInput` and `SenderTargetGrant`; do not import `MessagingEvents`, `AwaitSpec`, `MessageDenialCode`, `MessageOperation`, `MessageTarget`, or `resolveSenderTargetGrant` from this subpath.
  - `@openomni/ipc` no longer exports `LineDecoder`; import it from its defining module if still needed.
  - `@openomni/session` no longer exports `TranscriptRecordingError`; import it from its transcript module if still needed.
  - Treat these as internal‑only and do not import: FATAL_CLOSE_CODES, calculateBackoff, sendDiscordMessage, the builtin tool PROMPT constants, createErrorResult, toEventRecord, getPartStartTime, and the projection/messaging zod enums and schemas (StepOrder, VerifierStatus, Verdict, AwaitSpec).

<sup>Written for commit a5b32d000cd621d7009bbc58de371abeefa294af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

