### PR TITLE
test(protocol): the other four packages' tests type-check (#606)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,7 @@
     "dev": "bun run src/index.ts",
     "start": "bun run src/index.ts",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/server/test/bootstrap/recovery.test.ts
+++ b/apps/server/test/bootstrap/recovery.test.ts
@@ -414,6 +414,7 @@ describe("server recovery", () => {
     await runRecovery({
       handler: async (message) => {
         handled.push({ id: message.id, text: message.text, surfaceKey: message.surfaceKey });
+        return null;
       },
       traceId: "trace-retry-queue",
       completionRuntime: {

--- a/apps/server/test/bootstrap/resident-inbound-wait.test.ts
+++ b/apps/server/test/bootstrap/resident-inbound-wait.test.ts
@@ -39,6 +39,7 @@ const serverConfig: ServerConfig = {
   telegram: { allowedUsers: [] },
   github: { allowedUsers: [] },
   discord: { allowedUsers: [] },
+  messaging: { grants: [] },
 };
 
 const originalBeginWait = WorkItemAttemptRun.beginWait;
@@ -211,6 +212,8 @@ describe("resident inbound wait kernel dispatch", () => {
       wait: true,
     });
     expect(typeof call[0].correlation).toBe("string");
+    const correlation = call[0].correlation;
+    if (typeof correlation !== "string") throw new Error("shape");
     expect(call[1]).toEqual({
       // The asking run's trace crosses the IPC hop and is what the Resident
       // dispatches under; the handler never starts a second one.
@@ -224,7 +227,7 @@ describe("resident inbound wait kernel dispatch", () => {
       workspaceRoot: "/workspace",
     });
     expect(result).toEqual({
-      requestId: call[0].correlation,
+      requestId: correlation,
       accepted: true,
       output: "Proceed carefully.",
     });

--- a/apps/server/test/connector/process-driver-completion.test.ts
+++ b/apps/server/test/connector/process-driver-completion.test.ts
@@ -179,7 +179,7 @@ describe("createConnectorEndpointProcessDriver completion stream", () => {
       completionService: testCompletionService(() => 1),
       connectorEndpointDriver: createConnectorEndpointProcessDriver(),
       now: () => 1,
-      readBackRecorder: (_workItemHash, readBack) =>
+      readBackRecorder: async (_workItemHash, readBack) =>
         WorkItem.ReadBackCheck.parse({
           kind: "citation_match",
           target: readBack.target,
@@ -260,7 +260,7 @@ describe("createConnectorEndpointProcessDriver completion stream", () => {
       completionService: testCompletionService(() => 1),
       connectorEndpointDriver: createConnectorEndpointProcessDriver(),
       now: () => 1,
-      readBackRecorder: (_workItemHash, readBack) => {
+      readBackRecorder: async (_workItemHash, readBack) => {
         recordedReadBacks.push(readBack);
         return WorkItem.ReadBackCheck.parse({
           kind: "citation_match",

--- a/apps/server/test/context/instructions.test.ts
+++ b/apps/server/test/context/instructions.test.ts
@@ -92,11 +92,14 @@ describe("InstructionLoader.discover", () => {
     const priorities = files.map((f) => f.priority);
 
     for (let i = 1; i < priorities.length; i++) {
-      expect(priorities[i]).toBeGreaterThanOrEqual(priorities[i - 1]);
+      const prev = priorities[i - 1];
+      const curr = priorities[i];
+      if (prev === undefined || curr === undefined) throw new Error("shape");
+      expect(curr).toBeGreaterThanOrEqual(prev);
     }
 
-    expect(files[0].label).toBe("Global");
-    expect(files[files.length - 1].label).toBe("Local");
+    expect(files[0]?.label).toBe("Global");
+    expect(files[files.length - 1]?.label).toBe("Local");
   });
 
   it("returns [] for empty directory with no relevant files", () => {

--- a/apps/server/test/context/middleware.test.ts
+++ b/apps/server/test/context/middleware.test.ts
@@ -46,7 +46,7 @@ async function dispatchContextMiddleware(
   middleware: ReturnType<typeof createContextMiddleware>,
   context: ContextPolicyInput,
 ) {
-  const engine = PolicyEngine.create({ audit: false });
+  const engine = PolicyEngine.create<PolicyContext>({ audit: false });
   engine.register(middleware);
   return engine.dispatchPoint("prompt.context.pre", context);
 }

--- a/apps/server/test/context/skills.test.ts
+++ b/apps/server/test/context/skills.test.ts
@@ -44,9 +44,9 @@ describe("SkillLoader.discover", () => {
     const skills = SkillLoader.discover(ws, emptyGlobalDir);
 
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe("my-skill");
-    expect(skills[0].description).toBe("A test skill");
-    expect(skills[0].path).toContain("SKILL.md");
+    expect(skills[0]?.name).toBe("my-skill");
+    expect(skills[0]?.description).toBe("A test skill");
+    expect(skills[0]?.path).toContain("SKILL.md");
   });
 
   it("parses frontmatter name and description correctly", () => {
@@ -60,8 +60,8 @@ describe("SkillLoader.discover", () => {
 
     const skills = SkillLoader.discover(ws, emptyGlobalDir);
 
-    expect(skills[0].name).toBe("parsed-name");
-    expect(skills[0].description).toBe("Parsed description");
+    expect(skills[0]?.name).toBe("parsed-name");
+    expect(skills[0]?.description).toBe("Parsed description");
   });
 
   it("falls back to directory name when frontmatter has no name", () => {
@@ -71,8 +71,8 @@ describe("SkillLoader.discover", () => {
 
     const skills = SkillLoader.discover(ws, emptyGlobalDir);
 
-    expect(skills[0].name).toBe("dir-fallback");
-    expect(skills[0].description).toBe("Only description");
+    expect(skills[0]?.name).toBe("dir-fallback");
+    expect(skills[0]?.description).toBe("Only description");
   });
 
   it("falls back to empty description when frontmatter has no description", () => {
@@ -82,7 +82,7 @@ describe("SkillLoader.discover", () => {
 
     const skills = SkillLoader.discover(ws, emptyGlobalDir);
 
-    expect(skills[0].description).toBe("");
+    expect(skills[0]?.description).toBe("");
   });
 
   it("handles malformed YAML frontmatter gracefully without crashing", () => {
@@ -92,7 +92,7 @@ describe("SkillLoader.discover", () => {
 
     expect(() => SkillLoader.discover(ws, emptyGlobalDir)).not.toThrow();
     const skills = SkillLoader.discover(ws, emptyGlobalDir);
-    expect(skills[0].name).toBe("bad-yaml");
+    expect(skills[0]?.name).toBe("bad-yaml");
   });
 
   it("discovers multiple skills", () => {
@@ -148,7 +148,7 @@ describe("SkillLoader.discover", () => {
 
     const match = skills.filter((s) => s.name === "shared-name");
     expect(match).toHaveLength(1);
-    expect(match[0].description).toBe("Project version");
+    expect(match[0]?.description).toBe("Project version");
   });
 
   it("returns empty array when no skills dir exists", () => {

--- a/apps/server/test/execution/e2e.test.ts
+++ b/apps/server/test/execution/e2e.test.ts
@@ -59,6 +59,7 @@ describe("coordinator dispatch path — direct mode", () => {
 
     expect(result.mode).toBe("direct");
     if (result.mode !== "direct") throw new Error("expected direct result");
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("mock response");
   });
 });

--- a/apps/server/test/execution/tool-catalog.test.ts
+++ b/apps/server/test/execution/tool-catalog.test.ts
@@ -72,13 +72,13 @@ describe("tool catalog", () => {
     expect(catalog).toHaveLength(7);
 
     const byName = Object.fromEntries(catalog.map((e) => [e.canonicalName, e]));
-    expect(byName.read.category).toBe("filesystem");
-    expect(byName.write.category).toBe("filesystem");
-    expect(byName.glob.category).toBe("filesystem");
-    expect(byName["grep.search"].category).toBe("filesystem");
-    expect(byName.bash.category).toBe("execution");
-    expect(byName.mcp_tool.category).toBe("mcp");
-    expect(byName.server_analyzer.category).toBe("filesystem");
+    expect(byName.read?.category).toBe("filesystem");
+    expect(byName.write?.category).toBe("filesystem");
+    expect(byName.glob?.category).toBe("filesystem");
+    expect(byName["grep.search"]?.category).toBe("filesystem");
+    expect(byName.bash?.category).toBe("execution");
+    expect(byName.mcp_tool?.category).toBe("mcp");
+    expect(byName.server_analyzer?.category).toBe("filesystem");
   });
 
   it("resolveToolSelection with categories filters to matching tools only", () => {

--- a/apps/server/test/execution/worker-full-stack.test.ts
+++ b/apps/server/test/execution/worker-full-stack.test.ts
@@ -8,16 +8,7 @@ import {
   type WorkerManagerFactory,
 } from "../../src/execution/coordinator";
 
-let capturedOnToolCall:
-  | ((
-      params: {
-        callId: string;
-        tool: string;
-        input: Record<string, unknown>;
-      },
-      context?: { signal?: AbortSignal },
-    ) => Promise<{ id: string; toolCallId: string; output: string; isError?: boolean }>)
-  | undefined;
+let capturedOnToolCall: Parameters<WorkerManagerFactory>[1]["toolRelay"];
 
 let mockPoolDispatch: (
   sessionId: string,
@@ -116,6 +107,7 @@ describe("system tool provider — read/glob", () => {
 describe("builtin middleware — tool permission", () => {
   function makeToolCtx(toolName: string) {
     return {
+      pointId: "tool.native.pre" as const,
       timing: "invoke.prepare" as const,
       steps: [],
       usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
@@ -186,6 +178,10 @@ describe("MCP proxy — worker.tool_call routes to generic dispatcher", () => {
     const controller = new AbortController();
     const result = await capturedOnToolCall(
       {
+        // runId/sessionId are required by the current ToolCallParams contract;
+        // the relay routes on `tool` and they do not affect the dispatcher path.
+        runId: crypto.randomUUID(),
+        sessionId: crypto.randomUUID(),
         callId,
         tool: "myserver.read_file",
         input: { path: "/tmp/test.txt" },
@@ -258,6 +254,7 @@ describe("concurrent sessions with tools", () => {
     for (const result of results) {
       expect(result.mode).toBe("direct");
       if (result.mode !== "direct") continue;
+      if (result.kind === "dropped") throw new Error("shape");
       expect(result.result.output).toMatch(/^handled:/);
     }
   });

--- a/apps/server/test/ingress-bridge.test.ts
+++ b/apps/server/test/ingress-bridge.test.ts
@@ -96,7 +96,9 @@ describe("ingress bridge transport boundary", () => {
     expect(event.meta && "pendingAsk" in event.meta).toBe(false);
     expect("externalMessageId" in event).toBe(false);
     expect(event.meta && "externalMessageId" in event.meta).toBe(false);
-    expect(event.meta?.correlation && "externalMessageId" in event.meta.correlation).toBe(false);
+    const correlation = event.meta?.correlation;
+    if (typeof correlation !== "object" || correlation === null) throw new Error("shape");
+    expect("externalMessageId" in correlation).toBe(false);
   });
 
   it("preserves a descriptor-only thread hint in event and correlation metadata", () => {
@@ -107,7 +109,11 @@ describe("ingress bridge transport boundary", () => {
     const event = buildInboundEvent(message, deps);
 
     expect(event.meta?.threadId).toBe("descriptor-thread");
-    expect(event.meta?.correlation?.threadId).toBe("descriptor-thread");
+    const correlation = event.meta?.correlation;
+    if (typeof correlation !== "object" || correlation === null || !("threadId" in correlation)) {
+      throw new Error("shape");
+    }
+    expect(correlation.threadId).toBe("descriptor-thread");
   });
 
   it("prefers an explicit message thread hint over a conflicting descriptor hint", () => {
@@ -118,7 +124,11 @@ describe("ingress bridge transport boundary", () => {
     const event = buildInboundEvent(message, deps);
 
     expect(event.meta?.threadId).toBe("explicit-thread");
-    expect(event.meta?.correlation?.threadId).toBe(event.meta?.threadId);
+    const correlation = event.meta?.correlation;
+    if (typeof correlation !== "object" || correlation === null || !("threadId" in correlation)) {
+      throw new Error("shape");
+    }
+    expect(correlation.threadId).toBe(event.meta?.threadId);
   });
 
   it("constructs the Resident agent from normalized transport facts", () => {

--- a/apps/server/test/ingress-routing-boundary.test.ts
+++ b/apps/server/test/ingress-routing-boundary.test.ts
@@ -295,7 +295,9 @@ type Provenance = Readonly<{
   name?: string;
 }>;
 
-function provenanceResolver(model: LexicalModel): (binding: Binding) => Provenance | undefined {
+function provenanceResolver(
+  model: LexicalModel,
+): (binding: Binding | undefined) => Provenance | undefined {
   const memo = new Map<Binding, Provenance | undefined>();
   const active = new Set<Binding>();
 
@@ -545,7 +547,7 @@ function kernelIngressCallCount(source: ts.SourceFile): number {
   });
   return calls;
 }
-function visit(source: ts.SourceFile, callback: (node: ts.Node) => void): void {
+function visit(source: ts.Node, callback: (node: ts.Node) => void): void {
   const walk = (node: ts.Node): void => {
     callback(node);
     ts.forEachChild(node, walk);

--- a/apps/server/test/tool/mcp/mcp-prefix-guard-canonical.test.ts
+++ b/apps/server/test/tool/mcp/mcp-prefix-guard-canonical.test.ts
@@ -51,9 +51,13 @@ function captureCanonicalDispatch(
   const createPolicyEngine = PolicyEngine.create;
   const policyEngineSpy = spyOn(PolicyEngine, "create").mockImplementation((options) => {
     const engine = createPolicyEngine(options);
-    engine.dispatch = async () => {
-      throw new Error("legacy policy dispatch must not run");
-    };
+    // The legacy `dispatch` method no longer exists on the engine interface;
+    // plant a throwing trap property so any residual legacy call site fails loudly.
+    Object.assign(engine, {
+      dispatch: async () => {
+        throw new Error("legacy policy dispatch must not run");
+      },
+    });
     const dispatchPoint = engine.dispatchPoint;
     engine.dispatchPoint = async (pointId, context) => {
       captured.push({ pointId, context });

--- a/apps/server/test/tool/mcp/provider-completion-events.test.ts
+++ b/apps/server/test/tool/mcp/provider-completion-events.test.ts
@@ -38,7 +38,7 @@ describe("McpToolProvider", () => {
 
       expect(result.isError).toBeFalsy();
       expect(publishedEvents).toHaveLength(1);
-      const event = publishedEvents[0].payload;
+      const event = publishedEvents[0]?.payload;
       if (
         typeof event !== "object" ||
         event === null ||

--- a/apps/server/test/tool/mcp/provider-dispatch-audit.test.ts
+++ b/apps/server/test/tool/mcp/provider-dispatch-audit.test.ts
@@ -50,11 +50,11 @@ describe("McpToolProvider", () => {
         "policy.action.requested",
         "mcp.tool.completed",
       ]);
-      expect(auditEvents[0].payload).toMatchObject({
+      expect(auditEvents[0]?.payload).toMatchObject({
         action: "mcp.tool.call",
         resource: "search.query",
       });
-      expect(auditEvents[1].payload).toMatchObject({
+      expect(auditEvents[1]?.payload).toMatchObject({
         toolCallId: "call-bus-success",
       });
     } finally {
@@ -154,15 +154,15 @@ describe("McpToolProvider", () => {
 
       const blockedEvents = allEvents.filter((event) => event.name === "policy.action.blocked");
       expect(blockedEvents).toHaveLength(3);
-      expect(blockedEvents[0].payload).toMatchObject({
+      expect(blockedEvents[0]?.payload).toMatchObject({
         resource: "ghost_query",
         reason: "Unknown tool: ghost_query",
       });
-      expect(blockedEvents[1].payload).toMatchObject({
+      expect(blockedEvents[1]?.payload).toMatchObject({
         resource: "search.query",
         reason: "MCP server not found: search",
       });
-      expect(blockedEvents[2].payload).toMatchObject({
+      expect(blockedEvents[2]?.payload).toMatchObject({
         resource: "query",
         reason: "MCP tool name must be prefixed with server name: query",
       });

--- a/apps/server/test/tool/mcp/provider.test.ts
+++ b/apps/server/test/tool/mcp/provider.test.ts
@@ -126,6 +126,7 @@ describe("McpToolProvider", () => {
     await provider.refreshTools();
 
     const [tool] = provider.listTools();
+    if (tool === undefined) throw new Error("shape");
     // Canonical labels lead: the grammar parsers take the first match, so a
     // remote spec's own `mcp.*` / `source:*` label must never outrank them.
     expect(tool.spec.labels).toEqual([

--- a/apps/server/tsconfig.test.json
+++ b/apps/server/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../.."
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/openomni/package.json
+++ b/packages/openomni/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
-    "check-types": "tsc --noEmit -p tsconfig.contract-test.json",
+    "check-types": "tsc --noEmit -p tsconfig.contract-test.json && tsc --noEmit -p tsconfig.test.json",
     "lint": "bunx biome check ./src",
     "test": "bun test",
     "bench": "bun run bench/index.ts",

--- a/packages/openomni/src/ingress/middleware/ingress-authority.ts
+++ b/packages/openomni/src/ingress/middleware/ingress-authority.ts
@@ -147,7 +147,15 @@ function evaluateIngressAuthority(event: Ingress.InboundEvent): Policy.PolicyDec
   return { ...decision, factsUsed: resourceLabels };
 }
 
-export function applyChannelGrantTreatment(
+export /**
+ * Stamps the treatment onto meta VERBATIM — no runtime validation against
+ * Actor.InboundTreatment. Today every producer is schema-derived (grants are
+ * Zod-parsed at write and read, and routing-resolution passes the parsed
+ * value), but a future caller bypassing those types stamps garbage into meta
+ * unchecked — a test carried an out-of-enum value through here for a year
+ * (#652 review). Convergence of this seam belongs to #498.
+ */
+function applyChannelGrantTreatment(
   event: Ingress.DirectEvent,
   grant: ChannelGrantStore.Grant,
   inboundTreatment: Actor.InboundTreatment,

--- a/packages/openomni/test/dispatch/completion-writer-contract.test.ts
+++ b/packages/openomni/test/dispatch/completion-writer-contract.test.ts
@@ -26,6 +26,8 @@ describe("default dispatch completion writer contract", () => {
       resumeCompletion: unsupported,
       reserveRequest: unsupported,
       assertReservationLease: unsupported,
+      hasActiveRequest: unsupported,
+      trackActiveRequest: unsupported,
     };
     const runtime = createDefaultDispatchRuntime({ completionAdmissionService: injected });
 

--- a/packages/openomni/test/dispatch/runtime-test-fixtures.ts
+++ b/packages/openomni/test/dispatch/runtime-test-fixtures.ts
@@ -1,6 +1,6 @@
 import { PolicyDecision, type Dispatch as DispatchProtocol } from "@openomni/protocol";
 import { Bus, Session, Storage } from "@openomni/session";
-import type { DispatchPolicyRegistration } from "../../src/dispatch/policy";
+import type { DispatchPolicyRegistration } from "../../src/dispatch/policy-registration";
 
 export const flushBus = () => new Promise((resolve) => queueMicrotask(resolve));
 

--- a/packages/openomni/test/dispatch/worker-completion-admission.test.ts
+++ b/packages/openomni/test/dispatch/worker-completion-admission.test.ts
@@ -72,7 +72,12 @@ type ReflectOptions = Omit<WorkerCompletionOptions, "completionService" | "verif
     verifierRegistry?: WorkerCompletionOptions["verifierRegistry"];
   }>;
 
-function completionServiceFor(options: ReflectOptions): CompletionAdmissionService {
+function completionServiceFor(
+  options: Pick<
+    ReflectOptions,
+    "completionService" | "completionPolicyEngine" | "stakesResolver" | "now"
+  >,
+): CompletionAdmissionService {
   return (
     options.completionService ??
     completionService({
@@ -142,7 +147,7 @@ beforeEach(() => {
 });
 
 async function startedItem(
-  executorKind: WorkItem.ExecutorKind,
+  executorKind?: WorkItem.ExecutorKind,
   criterionStatement = "recorded numeric operands satisfy eq",
 ): Promise<WorkItem.Info> {
   const created = await WorkItemStore.create({
@@ -351,14 +356,14 @@ describe("worker completion admission convergence", () => {
     if (!adapter) throw new Error("missing WorkItem adapter");
     const compareAndSet = adapter.compareAndSet.bind(adapter);
     let clock = 0;
-    adapter.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.compareAndSet = (hash, expectedHead, candidate) => {
       if (
         candidate.completionTerminalReceipt === undefined &&
         candidate.completionFacts.admissions.length === 1
       ) {
         clock = 5_001;
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
 
     const reflection = await reflectCoordinatorResult(
@@ -684,11 +689,11 @@ describe("worker completion admission convergence", () => {
       ],
     });
     let readBackCalls = 0;
-    const options = {
+    const options: ReflectOptions = {
       completionService: completionService({ ownerId: "process:one", now: () => NOW }),
       sourceOrigin: { source: "internal_worker" } as const,
       now: () => NOW,
-      async readBackRecorder(_hash: string, request: WorkItem.ReadBackRequest) {
+      async readBackRecorder(_hash, request) {
         readBackCalls += 1;
         if (readBackCalls > 1) throw new Error("duplicate delivery repeated read-back");
         if (request.kind !== "citation_match") throw new Error("unexpected read-back kind");
@@ -836,12 +841,12 @@ describe("worker completion admission convergence", () => {
       ],
     });
     let readBackCalls = 0;
-    const options = {
+    const options: ReflectOptions = {
       completionService: completionService({ ownerId: "process:one", now: () => NOW }),
       sourceOrigin: { source: "internal_worker" } as const,
       completionPolicyEngine: COMPLETION_POLICY_ENGINE,
       now: () => NOW,
-      readBackRecorder(_hash: string, request: WorkItem.ReadBackRequest) {
+      async readBackRecorder(_hash, request) {
         readBackCalls += 1;
         if (request.kind !== "citation_match") throw new Error("unexpected read-back kind");
         return WorkItem.ReadBackCheck.parse({
@@ -900,11 +905,11 @@ describe("worker completion admission convergence", () => {
     const readBackStarted = Promise.withResolvers<void>();
     const releaseReadBack = Promise.withResolvers<void>();
     let readBackCalls = 0;
-    const options = {
+    const options: ReflectOptions = {
       completionService: completionService({ ownerId: "process:one", now: () => NOW }),
       sourceOrigin: { source: "internal_worker" } as const,
       now: () => NOW,
-      async readBackRecorder(_hash: string, request: WorkItem.ReadBackRequest) {
+      async readBackRecorder(_hash, request) {
         readBackCalls += 1;
         if (readBackCalls > 1) throw new Error("concurrent delivery repeated read-back");
         readBackStarted.resolve();
@@ -960,8 +965,8 @@ describe("worker completion admission convergence", () => {
     let policyBCalls = 0;
     const policy = (
       name: string,
-      entered: PromiseWithResolvers<void>,
-      release: PromiseWithResolvers<void>,
+      entered: ReturnType<typeof Promise.withResolvers<void>>,
+      release: ReturnType<typeof Promise.withResolvers<void>>,
     ) => {
       const engine = PolicyEngine.create();
       engine.register({
@@ -1075,7 +1080,9 @@ describe("worker completion admission convergence", () => {
     await reflectCoordinatorResult(item.hash, succeeded(output), options);
     const blocked = WorkItemStore.get(item.hash);
     const evidence = blocked?.evidence[0];
-    if (!blocked || !evidence) throw new Error("missing blocked durable verifier evidence");
+    if (!blocked || evidence?.detail === undefined) {
+      throw new Error("missing blocked durable verifier evidence");
+    }
     const detail = JSON.parse(evidence.detail) as {
       recordedInputs: Record<string, unknown>;
     };
@@ -1539,14 +1546,14 @@ describe("worker completion admission convergence", () => {
       "hold-citation-replay",
     );
     let readBackCalls = 0;
-    const options = {
+    const options: ReflectOptions = {
       completionService: completionService({
         policyEngine: completionPolicyEngine,
         now: () => NOW,
       }),
       sourceOrigin: { source: "internal_worker" } as const,
       now: () => NOW,
-      readBackRecorder(_hash: string, request: WorkItem.ReadBackRequest) {
+      async readBackRecorder(_hash, request) {
         readBackCalls += 1;
         if (request.kind !== "citation_match") throw new Error("unexpected read-back kind");
         return WorkItem.ReadBackCheck.parse({

--- a/packages/openomni/test/dispatch/worker-completion-readback-deadline.test.ts
+++ b/packages/openomni/test/dispatch/worker-completion-readback-deadline.test.ts
@@ -99,7 +99,10 @@ function citationRequest(target: string) {
   } as const;
 }
 
-function successfulReadBackRecorder(_hash: string, request: WorkItem.ReadBackRequest) {
+const successfulReadBackRecorder: NonNullable<WorkerCompletionOptions["readBackRecorder"]> = async (
+  _hash,
+  request,
+) => {
   if (request.kind !== "citation_match") throw new Error("unexpected read-back kind");
   return WorkItem.ReadBackCheck.parse({
     kind: "citation_match",
@@ -110,7 +113,7 @@ function successfulReadBackRecorder(_hash: string, request: WorkItem.ReadBackReq
     observedAt: 1,
     statusCode: 200,
   });
-}
+};
 
 describe("worker completion read-back deadline", () => {
   beforeEach(() => {
@@ -198,7 +201,7 @@ describe("worker completion read-back deadline", () => {
         sourceOrigin: { source: "internal_worker" },
         readBackEnvelopeTimeoutMs: 10,
         now: () => clock,
-        readBackRecorder(_hash, request) {
+        async readBackRecorder(_hash, request) {
           if (request.kind !== "citation_match") throw new Error("unexpected read-back kind");
           clock = 20;
           return WorkItem.ReadBackCheck.parse({

--- a/packages/openomni/test/dispatch/worker-spawn-connector-endpoint.test.ts
+++ b/packages/openomni/test/dispatch/worker-spawn-connector-endpoint.test.ts
@@ -251,11 +251,11 @@ describe("worker.spawn connector endpoint dispatch wiring", () => {
     const adapter = Storage.get().workItem;
     if (!adapter) throw new Error("missing WorkItem adapter");
     const compareAndSet = adapter.compareAndSet.bind(adapter);
-    adapter.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.compareAndSet = (hash, expectedHead, candidate) => {
       if (candidate.evidence.some(({ passed }) => !passed)) {
         throw new Error("work item write failed");
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
 
     let caught: unknown;
@@ -294,11 +294,11 @@ describe("worker.spawn connector endpoint dispatch wiring", () => {
     const adapter = Storage.get().workItem;
     if (!adapter) throw new Error("missing WorkItem adapter");
     const compareAndSet = adapter.compareAndSet.bind(adapter);
-    adapter.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.compareAndSet = (hash, expectedHead, candidate) => {
       if (candidate.failureReason === "runtime exploded") {
         throw new Error("work item write failed");
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
     const handlers = createConnectorEndpointHandlers(async () => {
       throw new Error("runtime exploded");

--- a/packages/openomni/test/dispatch/worker-spawn-readback.test.ts
+++ b/packages/openomni/test/dispatch/worker-spawn-readback.test.ts
@@ -142,9 +142,9 @@ describe("worker.spawn read-back completion gate", () => {
         matchedText: "expected completion marker",
       },
     });
-    expect(workItems[0]?.completionReport?.claims[0]?.evidenceIds).toEqual([
-      workItems[0]?.evidence[0]?.id,
-    ]);
+    const readBackEvidenceId = workItems[0]?.evidence[0]?.id;
+    if (readBackEvidenceId === undefined) throw new Error("shape");
+    expect(workItems[0]?.completionReport?.claims[0]?.evidenceIds).toEqual([readBackEvidenceId]);
     expect(result).toMatchObject({
       output: {
         workItemHash: workItems[0]?.hash,

--- a/packages/openomni/test/dispatch/worker-spawn-reflection.test.ts
+++ b/packages/openomni/test/dispatch/worker-spawn-reflection.test.ts
@@ -336,9 +336,9 @@ describe("worker.spawn result reflection", () => {
     const workItems = WorkItemStore.list();
     expect(workItems).toHaveLength(1);
     expect(workItems[0] ? WorkItem.deriveStatus(workItems[0]) : undefined).toBe("completed");
-    expect(workItems[0]?.completionReport?.claims[0]?.evidenceIds).toEqual([
-      workItems[0]?.evidence[0]?.id,
-    ]);
+    const claimedEvidenceId = workItems[0]?.evidence[0]?.id;
+    if (claimedEvidenceId === undefined) throw new Error("shape");
+    expect(workItems[0]?.completionReport?.claims[0]?.evidenceIds).toEqual([claimedEvidenceId]);
     expect(result).toMatchObject({
       output: {
         workItemHash: workItems[0]?.hash,

--- a/packages/openomni/test/evidence/verifier-conformance-interleaving.test.ts
+++ b/packages/openomni/test/evidence/verifier-conformance-interleaving.test.ts
@@ -9,6 +9,10 @@ import {
 
 const digestA = `sha256:${"a".repeat(64)}`;
 
+function isJsonObject(value: unknown): value is { readonly [key: string]: unknown } {
+  return value !== null && !Array.isArray(value) && typeof value === "object";
+}
+
 function captureConformanceError(action: () => unknown): ReplayConformanceError {
   try {
     action();
@@ -112,13 +116,13 @@ describe("verifier replay interleaving and substitution conformance", () => {
       },
       (state, event) => {
         allStatesFrozen &&= Object.isFrozen(state);
-        if (
-          state === null ||
-          Array.isArray(state) ||
-          typeof state !== "object" ||
-          typeof state.total !== "number" ||
-          typeof event.value !== "number"
-        ) {
+        // Same runtime conditions as the original null/array/object/total
+        // chain; the predicate exists only because Array.isArray does not
+        // narrow readonly JSON arrays out of the union.
+        if (!isJsonObject(state) || typeof state.total !== "number") {
+          throw new Error("numeric object fold required");
+        }
+        if (typeof event.value !== "number") {
           throw new Error("numeric object fold required");
         }
         return { total: state.total + event.value };
@@ -131,13 +135,12 @@ describe("verifier replay interleaving and substitution conformance", () => {
   });
 
   test("substitutes recorded outputs without mutating the caller cassette", () => {
-    const commands = [
-      { op: "llm", promptHash: digestA },
-      { op: "device", id: "lamp" },
-    ];
-    const cassette = [
-      { command: commands[0], output: { text: "recorded" } },
-      { command: commands[1], output: { status: "off" } },
+    const llmCommand = { op: "llm", promptHash: digestA };
+    const deviceCommand = { op: "device", id: "lamp" };
+    const commands = [llmCommand, deviceCommand];
+    const cassette: Parameters<typeof substituteRecordedOutputs>[1] = [
+      { command: llmCommand, output: { text: "recorded" } },
+      { command: deviceCommand, output: { status: "off" } },
     ];
 
     const outputs = substituteRecordedOutputs(commands, cassette);
@@ -154,7 +157,7 @@ describe("verifier replay interleaving and substitution conformance", () => {
     ).toMatchObject({ kind: "unexpected_command", index: 1 });
     expect(
       captureConformanceError(() =>
-        substituteRecordedOutputs([{ op: "network", url: "redacted" }, commands[1]], cassette),
+        substituteRecordedOutputs([{ op: "network", url: "redacted" }, deviceCommand], cassette),
       ).facts,
     ).toMatchObject({ kind: "command_mismatch", index: 0 });
   });

--- a/packages/openomni/test/execution-runtime/child-agent-policy-construction.test.ts
+++ b/packages/openomni/test/execution-runtime/child-agent-policy-construction.test.ts
@@ -57,6 +57,13 @@ describe("child agent delegation construction settlement", () => {
         createChildAgentRuntime({
           ...(traceContext === undefined ? {} : { traceContext }),
           model: { provider: "test", id: "fixture" } as Model.Ref,
+          // Now-required options; the trace-context check throws before any
+          // of these are used, so a throwing agent factory is safe.
+          parentMessages: [],
+          parentTools: [],
+          createAgent: () => {
+            throw new Error("not under test");
+          },
         }),
       ).toThrow("child agent delegation requires the parent trace context");
     }

--- a/packages/openomni/test/execution-runtime/child-agent-sync-run-failure.test.ts
+++ b/packages/openomni/test/execution-runtime/child-agent-sync-run-failure.test.ts
@@ -50,6 +50,7 @@ describe("child agent synchronous run failure", () => {
 
     const failedChild = await runtime.spawn({ prompt: "fail synchronously" });
     const [failed] = await runtime.await([failedChild.id]);
+    if (failed === undefined) throw new Error("shape");
     const nextChild = await runtime.spawn({ prompt: "reuse capacity" });
     const [completed] = await runtime.await([nextChild.id]);
 

--- a/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
+++ b/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
@@ -259,7 +259,9 @@ describe("createInjectionQueueDrainPolicy", () => {
     });
     const engine = PolicyEngine.create({ audit: false });
     engine.register(createInjectionQueueDrainPolicy(queue));
-    const context: TurnPostContext = {
+    // No TurnPostContext annotation: that union covers every policy point and
+    // would erase the run.turn.post-specific `turnResult` the target requires.
+    const context = {
       ...baseContext("unused-run", session.id),
       traceContext: undefined,
       runId: "legacy-run",

--- a/packages/openomni/test/harness/stakes-driver-scenarios.ts
+++ b/packages/openomni/test/harness/stakes-driver-scenarios.ts
@@ -23,7 +23,7 @@ import {
 import type {
   CompletionStakesInjection,
   VoiceStakesInjection,
-} from "../../src/ledger/stakes-seams.js";
+} from "../../src/ledger/stakes-seam-contract.js";
 
 export { stakesDriverStatus };
 export type { StakesDriverReceipt, StakesDriverScenario };

--- a/packages/openomni/test/ingress/engine-internal.test.ts
+++ b/packages/openomni/test/ingress/engine-internal.test.ts
@@ -129,6 +129,7 @@ describe("ingestInternal", () => {
     }
 
     expect(result.mode).toBe("internal");
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBeTruthy();
     expect(decisions).toHaveLength(1);
     expect(IngressEvent.RoutingDecision.schema.parse(decisions[0])).toMatchObject({

--- a/packages/openomni/test/ingress/engine-isolation.test.ts
+++ b/packages/openomni/test/ingress/engine-isolation.test.ts
@@ -63,6 +63,7 @@ describe("ingress engine instance isolation", () => {
     const second = await engineB.ingest(directEvent("evt-observer-b"));
 
     // Each engine executed through its own resident runtime...
+    if (first.kind === "dropped" || second.kind === "dropped") throw new Error("shape");
     expect(first.result.output).toBe("engine-a");
     expect(second.result.output).toBe("engine-b");
     expect(runsA).toEqual(["engine-a"]);

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -121,6 +121,7 @@ describe("IngressEngine", () => {
     const result = await engine.ingest(event);
 
     expect(result.mode).toBe("direct");
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("direct response");
     expect(result.result.finishReason).toBe("stop");
   });
@@ -262,6 +263,7 @@ describe("IngressEngine", () => {
     const first = await engine.ingest(eventA);
     const second = await engine.ingest(eventB);
 
+    if (first.kind === "dropped" || second.kind === "dropped") throw new Error("shape");
     expect(first.sessionId).toBe(second.sessionId);
   });
 
@@ -294,6 +296,7 @@ describe("IngressEngine", () => {
       payload: "After reset",
     });
 
+    if (first.kind === "dropped" || second.kind === "dropped") throw new Error("shape");
     expect(first.sessionId).not.toBe(second.sessionId);
   });
 

--- a/packages/openomni/test/ingress/event-projector.test.ts
+++ b/packages/openomni/test/ingress/event-projector.test.ts
@@ -39,11 +39,13 @@ describe("IngressEventProjector", () => {
 
     const messages = Session.getMessages(sessionId);
     expect(messages).toHaveLength(1);
-    expect(messages[0].role).toBe("user");
+    const message = messages[0];
+    if (message === undefined) throw new Error("shape");
+    expect(message.role).toBe("user");
 
-    const parts = Session.getParts(messages[0].id);
+    const parts = Session.getParts(message.id);
     expect(parts).toHaveLength(1);
-    expect(parts[0].type).toBe("text");
+    expect(parts[0]?.type).toBe("text");
     expect((parts[0] as Message.TextPart).text).toBe("Hello, world!");
   });
 
@@ -69,7 +71,9 @@ describe("IngressEventProjector", () => {
     );
 
     const messages = Session.getMessages(sessionId);
-    const parts = Session.getParts(messages[0].id);
+    const message = messages[0];
+    if (message === undefined) throw new Error("shape");
+    const parts = Session.getParts(message.id);
     expect((parts[0] as Message.TextPart).text).toBe("Message from Discord");
   });
 
@@ -96,7 +100,9 @@ describe("IngressEventProjector", () => {
     );
 
     const messages = Session.getMessages(sessionId);
-    const parts = Session.getParts(messages[0].id);
+    const message = messages[0];
+    if (message === undefined) throw new Error("shape");
+    const parts = Session.getParts(message.id);
     expect((parts[0] as Message.TextPart).text).toBe(JSON.stringify(payload));
   });
 
@@ -123,7 +129,7 @@ describe("IngressEventProjector", () => {
 
     const messages = Session.getMessages(sessionId);
     expect((messages[0] as Message.UserMessage).agent).toBe("whatsapp");
-    expect(messages[0].role).toBe("user");
+    expect(messages[0]?.role).toBe("user");
   });
 
   it("should store both UserMessage and TextPart in session", () => {
@@ -151,6 +157,7 @@ describe("IngressEventProjector", () => {
     const messages = Session.getMessages(sessionId);
     expect(messages).toHaveLength(1);
     const message = messages[0];
+    if (message === undefined) throw new Error("shape");
     expect(message.role).toBe("user");
     expect(message.sessionID).toBe(sessionId);
 

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -258,6 +258,7 @@ describe("IngressHandlers", () => {
     expect(deliverMessage).toHaveBeenCalledWith(sessionId, "adjust your plan", undefined);
     expect(dispatch).not.toHaveBeenCalled();
     expect(workRunItems(sessionId)).toHaveLength(0);
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.finishReason).toBe("delivered");
     expect(storeDirectResultMock).toHaveBeenCalled();
   });
@@ -297,6 +298,7 @@ describe("IngressHandlers", () => {
     expect(deliverMessage).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(workRunItems(sessionId)[0]?.attemptTerminal?.outcome).toBe("succeeded");
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("resumed");
   });
 
@@ -337,6 +339,7 @@ describe("IngressHandlers", () => {
       coordinator: { dispatch },
     });
 
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.finishReason).toBe("background");
     expect(JSON.parse(result.result.output)).toMatchObject({
       accepted: true,

--- a/packages/openomni/test/ingress/integration.test.ts
+++ b/packages/openomni/test/ingress/integration.test.ts
@@ -97,6 +97,7 @@ describe("IngressEngine integration pipeline", () => {
 
       expect(first.mode).toBe("direct");
       expect(second.mode).toBe("direct");
+      if (first.kind === "dropped" || second.kind === "dropped") throw new Error("shape");
       expect(first.sessionId).toBe(second.sessionId);
     });
   });
@@ -130,6 +131,7 @@ describe("IngressEngine integration pipeline", () => {
         },
       });
 
+      if (first.kind === "dropped" || second.kind === "dropped") throw new Error("shape");
       expect(first.sessionId).not.toBe(second.sessionId);
     });
   });

--- a/packages/openomni/test/ingress/kernel-routing-access.test.ts
+++ b/packages/openomni/test/ingress/kernel-routing-access.test.ts
@@ -140,6 +140,7 @@ describe("IngressEngine access routing", () => {
     });
     expect(captured.actor).toMatchObject({ role: "user", trustTier: "owner" });
     expect(captured.treatment).toBe("full_access");
+    if (event.userId === undefined) throw new Error("shape");
     expect(
       ActorRegistry.resolveEndpoint(event.surface, event.userId, event.workspace),
     ).toBeUndefined();
@@ -174,6 +175,7 @@ describe("IngressEngine access routing", () => {
     }
 
     // Then
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("resident response");
     expect(observed.decisions).toHaveLength(1);
     expect(observed.decisions[0]).toMatchObject({
@@ -209,6 +211,7 @@ describe("IngressEngine access routing", () => {
     }
 
     // Then
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("resident response");
     expect(observed.decisions).toHaveLength(1);
     expect(observed.decisions[0]).toMatchObject({
@@ -275,6 +278,7 @@ describe("IngressEngine access routing", () => {
     }
 
     // Then
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("resident response");
     expect(observed.decisions).toHaveLength(1);
     expect(observed.decisions[0]).toMatchObject({

--- a/packages/openomni/test/ingress/kernel-routing-waits.test.ts
+++ b/packages/openomni/test/ingress/kernel-routing-waits.test.ts
@@ -216,6 +216,7 @@ describe("IngressEngine wait routing", () => {
     expect(order).toEqual(["publish", "execute"]);
     expect(routed).toHaveLength(1);
     expect(handlerWorkspaceRoot).toBe("/trusted/workspace");
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(sessionId);
     // #548: the store is frozen — routing leaves the legacy row as persisted.
     expect(PendingInteractionStore.get("pi-exact")?.status).toBe("open");
@@ -251,6 +252,7 @@ describe("IngressEngine wait routing", () => {
       pendingInteractionId: "pi-frozen-legacy",
     });
     expect(routed).toHaveLength(1);
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(sessionId);
     // The frozen row stays readable AND untransitioned (#548 read-only pin):
     // routing never depends on mutating it, so the row remains exactly as
@@ -274,6 +276,7 @@ describe("IngressEngine wait routing", () => {
       replyEvent("inbound-plain-text", "completed successfully"),
     );
 
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("");
     // #548: the store is frozen — routing leaves the legacy row as persisted.
     expect(PendingInteractionStore.get("pi-plain-text")?.status).toBe("open");
@@ -394,6 +397,7 @@ describe("IngressEngine wait routing", () => {
       runId: "run-connector-ask",
       actor: { trustTier: "assigned_worker" },
     });
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(sessionId);
     // #548: the store is frozen — routing leaves the legacy row as persisted.
     expect(PendingInteractionStore.get("pi-connector-ask")?.status).toBe("open");
@@ -553,6 +557,7 @@ describe("IngressEngine wait routing", () => {
       durableSessionId: ask.originSessionId,
       runId: ask.originRunId,
     });
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(ask.originSessionId);
     expect(PendingAskStore.get(ask.id)?.status).toBe("open");
   });
@@ -608,6 +613,7 @@ describe("IngressEngine wait routing", () => {
       activationId: "inbound-activation",
     });
     expect(projectedSessionId).toBe(ask.originSessionId);
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(ask.originSessionId);
     expect(residentExecutions).toEqual(["executed"]);
   });
@@ -959,6 +965,7 @@ describe("IngressEngine wait routing", () => {
 
     const result = await kernelEngine().ingest(replyEvent("inbound-structured-output"));
 
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.result.output).toBe("");
     // #548: the store is frozen — routing leaves the legacy row as persisted.
     expect(PendingInteractionStore.get("pi-structured-output")?.status).toBe("open");
@@ -1050,6 +1057,7 @@ describe("IngressEngine durable wait routing", () => {
         `wait.owner:session:${wait.ownerRef.id}`,
       ],
     });
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(wait.ownerRef.id);
     expect(residentExecutions).toEqual(["executed"]);
     const record = WaitStore.get("wait-session-owner");
@@ -1072,6 +1080,7 @@ describe("IngressEngine durable wait routing", () => {
 
     const result = await kernelEngine().ingest(replyEvent("inbound-wait-quorum-first"));
 
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(wait.ownerRef.id);
     const record = WaitStore.get("wait-quorum");
     expect(record).toMatchObject({ status: "open" });
@@ -1136,6 +1145,8 @@ describe("IngressEngine durable wait routing", () => {
     // owner receives the recorded resolution again.
     const second = await kernelEngine().ingest(replyEvent("inbound-wait-redelivery"));
 
+    if (first.kind === "dropped") throw new Error("shape");
+    if (second.kind === "dropped") throw new Error("shape");
     expect(first.sessionId).toBe(wait.ownerRef.id);
     expect(second.sessionId).toBe(wait.ownerRef.id);
     expect(residentExecutions).toEqual(["executed", "executed"]);
@@ -1335,6 +1346,8 @@ describe("IngressEngine durable wait routing", () => {
 
     const second = await kernelEngine().ingest(responderReply("inbound-wired-r2", "responder-2"));
 
+    if (first.kind === "dropped") throw new Error("shape");
+    if (second.kind === "dropped") throw new Error("shape");
     expect(first.sessionId).toBe(session.id);
     expect(second.sessionId).toBe(session.id);
     expect(residentExecutions).toEqual(["executed", "executed"]);
@@ -1352,6 +1365,7 @@ describe("IngressEngine durable wait routing", () => {
 
     const result = await kernelEngine().ingest(replyEvent("inbound-new-interaction"));
 
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(wait.ownerRef.id);
     expect(WaitStore.get("wait-new-interaction")).toMatchObject({ status: "resolved" });
     // No PendingInteraction row exists or can be created: the write surface
@@ -1392,6 +1406,7 @@ describe("IngressEngine durable wait routing", () => {
 
     const result = await kernelEngine().ingest(replyEvent("inbound-wait-tier"));
 
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(wait.ownerRef.id);
     expect(PendingInteractionStore.get("pi-shadowed")?.status).toBe("open");
   });

--- a/packages/openomni/test/ingress/kernel-routing.test.ts
+++ b/packages/openomni/test/ingress/kernel-routing.test.ts
@@ -25,6 +25,7 @@ describe("IngressEngine kernel routing", () => {
     const result = await kernelEngine().ingest(ownerEvent);
 
     // Then
+    if (result.kind === "dropped") throw new Error("shape");
     expect(result.sessionId).toBe(mappedSession.id);
     expect(result.result.output).toBe("resident response");
   });

--- a/packages/openomni/test/ingress/session-bridge.test.ts
+++ b/packages/openomni/test/ingress/session-bridge.test.ts
@@ -104,11 +104,13 @@ describe("SessionBridge", () => {
 
       const messages = Session.getMessages(sessionId);
       expect(messages).toHaveLength(1);
-      expect(messages[0].role).toBe("assistant");
+      const message = messages[0];
+      if (message === undefined) throw new Error("shape");
+      expect(message.role).toBe("assistant");
 
-      const parts = Session.getParts(messages[0].id);
+      const parts = Session.getParts(message.id);
       expect(parts).toHaveLength(1);
-      expect(parts[0].type).toBe("text");
+      expect(parts[0]?.type).toBe("text");
       expect((parts[0] as Message.TextPart).text).toBe(output);
     });
   });

--- a/packages/openomni/test/ingress/worker-run-cutover.test.ts
+++ b/packages/openomni/test/ingress/worker-run-cutover.test.ts
@@ -64,7 +64,7 @@ function createSession(): string {
   }).id;
 }
 
-function workerEvent(id: string, parentSessionId?: string): Ingress.InboundEvent {
+function workerEvent(id: string, parentSessionId?: string): Ingress.DirectEvent {
   return {
     id,
     surface: "tui",

--- a/packages/openomni/test/ledger/stakes-seam-binding-cases.ts
+++ b/packages/openomni/test/ledger/stakes-seam-binding-cases.ts
@@ -23,6 +23,26 @@ import {
 
 type CompletionMutation = BindingMutation<CompletionStakesBinding>;
 type VoiceMutation = BindingMutation<VoiceStakesBinding>;
+type LedgerStateFixture = StakesAuthoritySnapshot["state"];
+
+/** Like mutation(), but keeps the concrete snapshot type so the mutated value can flow back through the typed authority port. */
+function snapshotMutation(
+  name: string,
+  apply: (snapshot: StakesAuthoritySnapshot) => StakesAuthoritySnapshot,
+): Readonly<{ name: string; apply(snapshot: StakesAuthoritySnapshot): StakesAuthoritySnapshot }> {
+  return { name, apply };
+}
+
+/** Like mutation(), but keeps the concrete request type for the voice-authorization read path. */
+function voiceAuthorizationMutation(
+  name: string,
+  apply: (request: VoiceAuthorizationRequest) => VoiceAuthorizationRequest,
+): Readonly<{
+  name: string;
+  apply(request: VoiceAuthorizationRequest): VoiceAuthorizationRequest;
+}> {
+  return { name, apply };
+}
 
 const completionMutations: readonly CompletionMutation[] = [
   ...sharedBindingMutations,
@@ -98,7 +118,7 @@ export function registerStakesSeamBindingCases(): void {
 
 function harness() {
   const action = boundaryAction("trusted", 50_000_000);
-  const state = { window: stakesWindow, actions: [], knownFingerprints: [] };
+  const state: LedgerStateFixture = { window: stakesWindow, actions: [], knownFingerprints: [] };
   return {
     action,
     state,
@@ -110,7 +130,7 @@ function harness() {
 
 function authorityFor(
   action: ReturnType<typeof boundaryAction>,
-  state: ReturnType<typeof harness>["state"],
+  state: LedgerStateFixture,
 ): StakesAuthorityPort {
   return {
     read(request) {
@@ -139,7 +159,7 @@ function authorityWithSnapshotMutation(
 function snapshotFor(
   request: StakesAuthorityRequest,
   action: ReturnType<typeof boundaryAction>,
-  state: ReturnType<typeof harness>["state"],
+  state: LedgerStateFixture,
 ): StakesAuthoritySnapshot {
   return {
     action,
@@ -159,28 +179,28 @@ function snapshotMutations() {
     closesAt: stakesWindow.closesAt,
   });
   return [
-    mutation("action", (snapshot: StakesAuthoritySnapshot) => ({
+    snapshotMutation("action", (snapshot: StakesAuthoritySnapshot) => ({
       ...snapshot,
       action: { ...snapshot.action, actionId: "action:other" },
     })),
-    mutation("state", (snapshot: StakesAuthoritySnapshot) => ({
+    snapshotMutation("state", (snapshot: StakesAuthoritySnapshot) => ({
       ...snapshot,
       action: { ...snapshot.action, windowRef: otherWindow.windowRef },
       state: { ...snapshot.state, window: otherWindow },
     })),
-    mutation("basisRef", (snapshot: StakesAuthoritySnapshot) => ({
+    snapshotMutation("basisRef", (snapshot: StakesAuthoritySnapshot) => ({
       ...snapshot,
       basisRef: stakesDigest("snapshot-basis"),
     })),
-    mutation("asOfOwnerSeq", (snapshot: StakesAuthoritySnapshot) => ({
+    snapshotMutation("asOfOwnerSeq", (snapshot: StakesAuthoritySnapshot) => ({
       ...snapshot,
       asOfOwnerSeq: snapshot.asOfOwnerSeq + 1,
     })),
-    mutation("ledgerRangeDigest", (snapshot: StakesAuthoritySnapshot) => ({
+    snapshotMutation("ledgerRangeDigest", (snapshot: StakesAuthoritySnapshot) => ({
       ...snapshot,
       ledgerRangeDigest: stakesDigest("snapshot-ledger-range"),
     })),
-    mutation("noveltyBasisDigest", (snapshot: StakesAuthoritySnapshot) => ({
+    snapshotMutation("noveltyBasisDigest", (snapshot: StakesAuthoritySnapshot) => ({
       ...snapshot,
       noveltyBasisDigest: stakesDigest("snapshot-novelty-basis"),
     })),
@@ -188,27 +208,27 @@ function snapshotMutations() {
 }
 
 const voiceAuthorizationMutations = [
-  mutation("ownerKey", (request: VoiceAuthorizationRequest) => ({
+  voiceAuthorizationMutation("ownerKey", (request: VoiceAuthorizationRequest) => ({
     ...request,
     ownerKey: "owner:other",
   })),
-  mutation("evaluationId", (request: VoiceAuthorizationRequest) => ({
+  voiceAuthorizationMutation("evaluationId", (request: VoiceAuthorizationRequest) => ({
     ...request,
     evaluationId: "jester:other",
   })),
-  mutation("authorizationReceiptRef", (request: VoiceAuthorizationRequest) => ({
+  voiceAuthorizationMutation("authorizationReceiptRef", (request: VoiceAuthorizationRequest) => ({
     ...request,
     authorizationReceiptRef: stakesDigest("authorization-other"),
   })),
-  mutation("actionRef", (request: VoiceAuthorizationRequest) => ({
+  voiceAuthorizationMutation("actionRef", (request: VoiceAuthorizationRequest) => ({
     ...request,
     actionRef: "action:other",
   })),
-  mutation("windowRef", (request: VoiceAuthorizationRequest) => ({
+  voiceAuthorizationMutation("windowRef", (request: VoiceAuthorizationRequest) => ({
     ...request,
     windowRef: stakesDigest("authorization-window"),
   })),
-  mutation("asOfOwnerSeq", (request: VoiceAuthorizationRequest) => ({
+  voiceAuthorizationMutation("asOfOwnerSeq", (request: VoiceAuthorizationRequest) => ({
     ...request,
     asOfOwnerSeq: request.asOfOwnerSeq + 1,
   })),

--- a/packages/openomni/test/ledger/stakes-seam-cases.ts
+++ b/packages/openomni/test/ledger/stakes-seam-cases.ts
@@ -75,6 +75,7 @@ export function registerStakesSeamCases(): void {
         ok: false,
         denial: { code: "forged_local_value", surface: "authorized_voice" },
       });
+      if (forgedCompletion.ok || forgedVoice.ok) throw new Error("shape");
       expect(Object.isFrozen(forgedCompletion)).toBe(true);
       expect(Object.isFrozen(forgedCompletion.denial)).toBe(true);
       expect(Object.isFrozen(forgedVoice)).toBe(true);

--- a/packages/openomni/test/ledger/stakes-seam-request-cases.ts
+++ b/packages/openomni/test/ledger/stakes-seam-request-cases.ts
@@ -72,7 +72,7 @@ function issueWithCapturedRequest(binding: CompletionStakesBinding | VoiceStakes
 
 function authorityFor(
   action: ReturnType<typeof boundaryAction>,
-  state: { window: typeof stakesWindow; actions: []; knownFingerprints: [] },
+  state: { window: typeof stakesWindow; actions: never[]; knownFingerprints: never[] },
 ) {
   return {
     read(request: StakesAuthorityRequest) {

--- a/packages/openomni/test/policy/ingress-authority-validation.test.ts
+++ b/packages/openomni/test/policy/ingress-authority-validation.test.ts
@@ -94,9 +94,10 @@ describe("IngressAuthorityMiddleware trust and validation", () => {
         defaultTier: "observer",
         createdBy: "act_owner",
       },
-      // Stale fixture: the "normal" treatment was renamed "full_access" in
-      // Actor.InboundTreatment; the test still proves the passed treatment is
-      // stamped onto meta verbatim.
+      // "normal" was never in Actor.InboundTreatment — the enum was born
+      // full_access|evidence_only|drop (#250), and this fixture entered already
+      // illegal (#519). It passed for a year because the stamping path does no
+      // runtime validation; that finding is recorded at the stamping site.
       "full_access",
     );
 

--- a/packages/openomni/test/policy/ingress-authority-validation.test.ts
+++ b/packages/openomni/test/policy/ingress-authority-validation.test.ts
@@ -94,12 +94,15 @@ describe("IngressAuthorityMiddleware trust and validation", () => {
         defaultTier: "observer",
         createdBy: "act_owner",
       },
-      "normal",
+      // Stale fixture: the "normal" treatment was renamed "full_access" in
+      // Actor.InboundTreatment; the test still proves the passed treatment is
+      // stamped onto meta verbatim.
+      "full_access",
     );
 
     expect(treated.meta?.actor).toMatchObject({ role: "user", trustTier: "observer" });
     expect(treated.meta?.channelGrantId).toBe("grant-public-observer");
-    expect(treated.meta?.inboundTreatment).toBe("normal");
+    expect(treated.meta?.inboundTreatment).toBe("full_access");
   });
 
   test("channel grant treatment never overrides an explicit trust tier", () => {
@@ -116,7 +119,7 @@ describe("IngressAuthorityMiddleware trust and validation", () => {
         defaultTier: "observer",
         createdBy: "act_owner",
       },
-      "normal",
+      "full_access",
     );
 
     expect(treated.meta?.actor).toMatchObject({ trustTier: "manager" });

--- a/packages/openomni/test/resident/prompt.test.ts
+++ b/packages/openomni/test/resident/prompt.test.ts
@@ -32,11 +32,11 @@ describe("ResidentAgent prompt public surface", () => {
     expect(gptPrompt).toContain("# OpenOmni Resident");
     expect(claudePrompt).toContain("# OpenOmni Resident");
     expect(gptPrompt).not.toBe(claudePrompt);
-    expect(Object.hasOwn(ResidentAgent, "getPrompt")).toBe(true);
-    expect(Object.hasOwn(ResidentAgent, "promptVariants")).toBe(false);
-    expect(Object.hasOwn(ResidentAgent, "buildPrompt")).toBe(false);
-    expect(Object.hasOwn(ResidentAgent, "inferPromptFamily")).toBe(false);
-    expect(Object.hasOwn(ResidentAgent, "getPromptVariant")).toBe(false);
+    expect(Object.getOwnPropertyNames(ResidentAgent).includes("getPrompt")).toBe(true);
+    expect(Object.getOwnPropertyNames(ResidentAgent).includes("promptVariants")).toBe(false);
+    expect(Object.getOwnPropertyNames(ResidentAgent).includes("buildPrompt")).toBe(false);
+    expect(Object.getOwnPropertyNames(ResidentAgent).includes("inferPromptFamily")).toBe(false);
+    expect(Object.getOwnPropertyNames(ResidentAgent).includes("getPromptVariant")).toBe(false);
     expect(promptSource).not.toMatch(/\bexport\s+const\s+promptVariants\b/);
     expect(promptSource).not.toMatch(/\bexport\s+const\s+buildPrompt\b/);
     expect(promptSource).not.toMatch(/\bexport\s+const\s+inferPromptFamily\b/);

--- a/packages/openomni/test/wait/correlation.test.ts
+++ b/packages/openomni/test/wait/correlation.test.ts
@@ -326,12 +326,14 @@ describe("findWaitCandidates", () => {
     const wait = spyOn(WaitStore, "findByCorrelation").mockReturnValue([]);
     const pi = spyOn(PendingInteractionStore, "findByCorrelation").mockReturnValue([]);
     const pa = spyOn(PendingAskStore, "findByCorrelation").mockReturnValue([]);
-    const markAmbiguous = spyOn(PendingAskStore, "markAmbiguous").mockImplementation((id) =>
-      buildAsk(id),
-    );
-    const resolve = spyOn(PendingInteractionStore, "resolve").mockImplementation((id) =>
-      buildInteraction(id),
-    );
+    // The frozen stores type these writes as `never` (#548); the spies exist
+    // only to prove they are never called (asserted below).
+    const markAmbiguous = spyOn(PendingAskStore, "markAmbiguous").mockImplementation(() => {
+      throw new Error("frozen markAmbiguous must not be called");
+    });
+    const resolve = spyOn(PendingInteractionStore, "resolve").mockImplementation(() => {
+      throw new Error("frozen resolve must not be called");
+    });
 
     findWaitCandidates({ correlation, externalMessageId: "message-1" });
 

--- a/packages/openomni/test/work-item/completion-admission-boundary.test.ts
+++ b/packages/openomni/test/work-item/completion-admission-boundary.test.ts
@@ -250,8 +250,8 @@ function completionEvents(
 }> {
   const order: string[] = [];
   const admissionStates: WorkItem.Info[] = [];
-  let resolveAdmission = () => undefined;
-  let resolveCompleted = () => undefined;
+  let resolveAdmission: () => void = () => undefined;
+  let resolveCompleted: () => void = () => undefined;
   const admissionRecorded = new Promise<void>((resolve) => {
     resolveAdmission = resolve;
   });
@@ -392,11 +392,11 @@ describe("WorkItem completion admission service", () => {
     });
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
     class SimulatedBootCrash extends Error {}
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       if (candidate.completionTerminalReceipt !== undefined) {
         throw new SimulatedBootCrash("crash before terminal append");
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
 
     await expect(gateway.requestCompletion(first.request, first.report)).rejects.toBeInstanceOf(
@@ -471,7 +471,7 @@ describe("WorkItem completion admission service", () => {
       leaseExpiresAt: NOW,
     });
     expect(recoveryFence?.id).not.toBe(reserved.reservation.id);
-    expect(recoveryFence?.ownerId.startsWith("completion-recovery:")).toBe(true);
+    expect(recoveryFence?.ownerId?.startsWith("completion-recovery:")).toBe(true);
     expect(staleHolder.state).toBe("busy");
     expect(takeover.state).toBe("reserved");
     expect(takeover.reservation.ownerId).toBe("process:after-restart");
@@ -489,11 +489,11 @@ describe("WorkItem completion admission service", () => {
     });
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
     class SimulatedBootCrash extends Error {}
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       if (candidate.completionTerminalReceipt !== undefined) {
         throw new SimulatedBootCrash("crash before terminal append");
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
     await expect(gateway.requestCompletion(first.request, first.report)).rejects.toBeInstanceOf(
       SimulatedBootCrash,
@@ -567,11 +567,11 @@ describe("WorkItem completion admission service", () => {
     });
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
     class SimulatedBootCrash extends Error {}
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       if (candidate.completionTerminalReceipt !== undefined) {
         throw new SimulatedBootCrash("crash before terminal append");
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
 
     await expect(gateway.requestCompletion(first.request, first.report)).rejects.toBeInstanceOf(
@@ -750,7 +750,10 @@ describe("WorkItem completion admission service", () => {
       completed: true,
       admission: { decision: "owner_override", ownerOverrideReceiptRef },
     });
-    expect(result.admission.ownerOverrideReceiptRef).toBe(ownerOverrideReceiptRef);
+    const resultAdmission = Reflect.get(result as object, "admission");
+    expect(Reflect.get(resultAdmission as object, "ownerOverrideReceiptRef")).toBe(
+      ownerOverrideReceiptRef,
+    );
   });
 
   test("closes an Owner override without synthesizing a missing result", async () => {
@@ -897,6 +900,7 @@ describe("WorkItem completion admission service", () => {
       ({ requestId }) => requestId === request.id,
     );
     expect(originalAdmission).toBeDefined();
+    if (!originalAdmission) throw new Error("shape");
     expect(
       interrupted?.completionFacts.requestReservations.find(
         ({ requestId }) => requestId === request.id,
@@ -980,6 +984,7 @@ describe("WorkItem completion admission service", () => {
     );
     const originalAdmission = WorkItemStore.get(item.hash)?.completionFacts.admissions[0];
     expect(originalAdmission).toBeDefined();
+    if (!originalAdmission) throw new Error("shape");
 
     const replayService = guardedService(
       {
@@ -1001,8 +1006,9 @@ describe("WorkItem completion admission service", () => {
         completionTerminalReceipt: { admissionId: originalAdmission?.id },
       },
     });
-    expect(replay.workItem.completionFacts.admissions.map(({ id }) => id)).toEqual([
-      originalAdmission?.id,
+    const replayWorkItem = WorkItem.Info.parse(Reflect.get(replay as object, "workItem"));
+    expect(replayWorkItem.completionFacts.admissions.map(({ id }) => id)).toEqual([
+      originalAdmission.id,
     ]);
   });
 
@@ -1211,9 +1217,9 @@ describe("WorkItem completion admission service", () => {
     const { item, request, report } = await fixture();
     const candidates: WorkItem.Info[] = [];
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       candidates.push(candidate);
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
     const admissionAuthority = authority();
     const service = guardedService(admissionAuthority.resolver);
@@ -1225,6 +1231,7 @@ describe("WorkItem completion admission service", () => {
 
     const stored = WorkItemStore.get(item.hash);
     const admission = stored?.completionFacts.admissions[0];
+    if (!stored || !admission) throw new Error("shape");
     expect(candidates).toHaveLength(2);
     expect(candidates[0]?.completionFacts.admissions).toHaveLength(1);
     expect(candidates[0] ? WorkItem.deriveStatus(candidates[0]) : undefined).not.toBe("completed");
@@ -1481,7 +1488,7 @@ describe("WorkItem completion admission service", () => {
     const stored = WorkItemStore.get(first.item.hash);
     const expectedEvidenceIds = [firstEvidenceId, secondEvidenceId].sort();
 
-    expect(outcome.completed).toBe(true);
+    expect(Reflect.get(outcome as object, "completed")).toBe(true);
     expect(stored?.completionReport?.claims[0]?.evidenceIds).toEqual(expectedEvidenceIds);
     expect(
       stored?.completionFacts.admissions[0]?.completionReportSnapshot?.claims[0]?.evidenceIds,
@@ -1830,7 +1837,7 @@ describe("WorkItem completion admission service", () => {
     );
     const stored = WorkItemStore.get(item.hash);
 
-    expect(outcome.completed).toBe(true);
+    expect(Reflect.get(outcome as object, "completed")).toBe(true);
     expect(admissionAuthority.calls).toEqual([
       {
         itemHead: item.revision,
@@ -1853,10 +1860,10 @@ describe("WorkItem completion admission service", () => {
     const compareAndSet = firstAdapter.workItem.compareAndSet.bind(firstAdapter.workItem);
     let writeCount = 0;
     class SimulatedCrashError extends Error {}
-    firstAdapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    firstAdapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       writeCount += 1;
       if (writeCount === 2) throw new SimulatedCrashError("crash after admission");
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
     const admissionEvent = completionEvents(item.hash);
 
@@ -1981,10 +1988,10 @@ describe("WorkItem completion admission service", () => {
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
     let writeCount = 0;
     class SimulatedCrashError extends Error {}
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       writeCount += 1;
       if (writeCount === 2) throw new SimulatedCrashError("crash after Owner admission");
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
 
     await expect(service.requestCompletion(requestWithOverride, report)).rejects.toBeInstanceOf(
@@ -2319,8 +2326,9 @@ describe("WorkItem completion admission service", () => {
     stopCompleted();
     const stored = WorkItemStore.get(first.item.hash);
 
-    expect(firstOutcome.completed).toBe(true);
-    expect(replayOutcome?.completed).toBe(true);
+    expect(Reflect.get(firstOutcome as object, "completed")).toBe(true);
+    if (replayOutcome === undefined) throw new Error("shape");
+    expect(Reflect.get(replayOutcome as object, "completed")).toBe(true);
     expect(stored?.completionFacts.admissions).toHaveLength(1);
     expect(stored?.completionTerminalReceipt?.admissionId).toBe(
       stored?.completionFacts.admissions[0]?.id,
@@ -2387,7 +2395,7 @@ describe("WorkItem completion admission service", () => {
     const outcome = await pending;
     const stored = WorkItemStore.get(item.hash);
 
-    expect(outcome.completed).toBe(true);
+    expect(Reflect.get(outcome as object, "completed")).toBe(true);
     expect(authorityCalls).toBe(2);
     expect(stored?.name).toBe("mutated during authority");
     expect(stored?.completionFacts.admissions).toHaveLength(1);
@@ -2403,7 +2411,7 @@ describe("WorkItem completion admission service", () => {
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
     let terminalContended = false;
     let completedEvents = 0;
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       if (!terminalContended && candidate.completionTerminalReceipt !== undefined) {
         terminalContended = true;
         const current = adapter.workItem.get(hash);
@@ -2414,10 +2422,10 @@ describe("WorkItem completion admission service", () => {
           name: "mutated during terminal CAS",
           timestamps: { ...current.timestamps, updated: current.timestamps.updated + 1 },
         });
-        expect(compareAndSet(hash, expectedHead, competitor, writerCapability)).toBe(true);
+        expect(compareAndSet(hash, expectedHead, competitor)).toBe(true);
         return false;
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
     const stopCompleted = Bus.subscribe(WorkItem.Events.CompletedV2, (event) => {
       if (event.payload.hash === item.hash) completedEvents += 1;
@@ -2427,7 +2435,7 @@ describe("WorkItem completion admission service", () => {
     stopCompleted();
     const stored = WorkItemStore.get(item.hash);
 
-    expect(outcome.completed).toBe(true);
+    expect(Reflect.get(outcome as object, "completed")).toBe(true);
     expect(terminalContended).toBe(true);
     expect(stored?.name).toBe("mutated during terminal CAS");
     expect(stored?.completionFacts.admissions).toHaveLength(2);
@@ -2478,11 +2486,11 @@ describe("WorkItem completion admission service", () => {
     const service = guardedService(authority().resolver);
     if (!service) return;
     const compareAndSet = adapter.workItem.compareAndSet.bind(adapter.workItem);
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       if (candidate.completionTerminalReceipt !== undefined) {
         throw new Error("crash after admission before terminal completion");
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
     await expect(service.requestCompletion(request, report)).rejects.toThrow(
       "crash after admission before terminal completion",
@@ -2490,7 +2498,7 @@ describe("WorkItem completion admission service", () => {
     const admissionId = WorkItemStore.get(item.hash)?.completionFacts.admissions[0]?.id;
     if (!admissionId) throw new Error("missing recorded admission");
     let terminalContended = false;
-    adapter.workItem.compareAndSet = (hash, expectedHead, candidate, writerCapability) => {
+    adapter.workItem.compareAndSet = (hash, expectedHead, candidate) => {
       if (!terminalContended && candidate.completionTerminalReceipt !== undefined) {
         terminalContended = true;
         const current = adapter.workItem.get(hash);
@@ -2501,10 +2509,10 @@ describe("WorkItem completion admission service", () => {
           name: "head advanced during resume terminal CAS",
           timestamps: { ...current.timestamps, updated: current.timestamps.updated + 1 },
         });
-        expect(compareAndSet(hash, expectedHead, competitor, writerCapability)).toBe(true);
+        expect(compareAndSet(hash, expectedHead, competitor)).toBe(true);
         return false;
       }
-      return compareAndSet(hash, expectedHead, candidate, writerCapability);
+      return compareAndSet(hash, expectedHead, candidate);
     };
 
     const resumed = await service.resumeCompletion(item.hash, admissionId, report);

--- a/packages/openomni/test/work-item/completion-admission-boundary.test.ts
+++ b/packages/openomni/test/work-item/completion-admission-boundary.test.ts
@@ -350,6 +350,18 @@ afterEach(() => {
   for (const path of databasePaths.splice(0)) removeDatabase(path);
 });
 
+/**
+ * Typed replacement for the file's older Reflect.get idiom: returns unknown
+ * (never any) and fails the test loudly when the key is absent instead of
+ * yielding undefined into a matcher.
+ */
+function field(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null || !(key in value)) {
+    throw new Error(`shape: missing ${key}`);
+  }
+  return (value as Record<string, unknown>)[key];
+}
+
 describe("WorkItem completion admission service", () => {
   test("uses one kernel-internal guarded completion gateway for non-Worker origins", async () => {
     configure();
@@ -750,10 +762,8 @@ describe("WorkItem completion admission service", () => {
       completed: true,
       admission: { decision: "owner_override", ownerOverrideReceiptRef },
     });
-    const resultAdmission = Reflect.get(result as object, "admission");
-    expect(Reflect.get(resultAdmission as object, "ownerOverrideReceiptRef")).toBe(
-      ownerOverrideReceiptRef,
-    );
+    const resultAdmission = field(result, "admission");
+    expect(field(resultAdmission, "ownerOverrideReceiptRef")).toBe(ownerOverrideReceiptRef);
   });
 
   test("closes an Owner override without synthesizing a missing result", async () => {
@@ -1006,7 +1016,7 @@ describe("WorkItem completion admission service", () => {
         completionTerminalReceipt: { admissionId: originalAdmission?.id },
       },
     });
-    const replayWorkItem = WorkItem.Info.parse(Reflect.get(replay as object, "workItem"));
+    const replayWorkItem = WorkItem.Info.parse(field(replay, "workItem"));
     expect(replayWorkItem.completionFacts.admissions.map(({ id }) => id)).toEqual([
       originalAdmission.id,
     ]);
@@ -1488,7 +1498,7 @@ describe("WorkItem completion admission service", () => {
     const stored = WorkItemStore.get(first.item.hash);
     const expectedEvidenceIds = [firstEvidenceId, secondEvidenceId].sort();
 
-    expect(Reflect.get(outcome as object, "completed")).toBe(true);
+    expect(field(outcome, "completed")).toBe(true);
     expect(stored?.completionReport?.claims[0]?.evidenceIds).toEqual(expectedEvidenceIds);
     expect(
       stored?.completionFacts.admissions[0]?.completionReportSnapshot?.claims[0]?.evidenceIds,
@@ -1837,7 +1847,7 @@ describe("WorkItem completion admission service", () => {
     );
     const stored = WorkItemStore.get(item.hash);
 
-    expect(Reflect.get(outcome as object, "completed")).toBe(true);
+    expect(field(outcome, "completed")).toBe(true);
     expect(admissionAuthority.calls).toEqual([
       {
         itemHead: item.revision,
@@ -2326,9 +2336,9 @@ describe("WorkItem completion admission service", () => {
     stopCompleted();
     const stored = WorkItemStore.get(first.item.hash);
 
-    expect(Reflect.get(firstOutcome as object, "completed")).toBe(true);
+    expect(field(firstOutcome, "completed")).toBe(true);
     if (replayOutcome === undefined) throw new Error("shape");
-    expect(Reflect.get(replayOutcome as object, "completed")).toBe(true);
+    expect(field(replayOutcome, "completed")).toBe(true);
     expect(stored?.completionFacts.admissions).toHaveLength(1);
     expect(stored?.completionTerminalReceipt?.admissionId).toBe(
       stored?.completionFacts.admissions[0]?.id,
@@ -2395,7 +2405,7 @@ describe("WorkItem completion admission service", () => {
     const outcome = await pending;
     const stored = WorkItemStore.get(item.hash);
 
-    expect(Reflect.get(outcome as object, "completed")).toBe(true);
+    expect(field(outcome, "completed")).toBe(true);
     expect(authorityCalls).toBe(2);
     expect(stored?.name).toBe("mutated during authority");
     expect(stored?.completionFacts.admissions).toHaveLength(1);
@@ -2435,7 +2445,7 @@ describe("WorkItem completion admission service", () => {
     stopCompleted();
     const stored = WorkItemStore.get(item.hash);
 
-    expect(Reflect.get(outcome as object, "completed")).toBe(true);
+    expect(field(outcome, "completed")).toBe(true);
     expect(terminalContended).toBe(true);
     expect(stored?.name).toBe("mutated during terminal CAS");
     expect(stored?.completionFacts.admissions).toHaveLength(2);

--- a/packages/openomni/test/work-item/completion-admission-fold.test.ts
+++ b/packages/openomni/test/work-item/completion-admission-fold.test.ts
@@ -485,7 +485,9 @@ describe("completion admission pure fold", () => {
       name: "verification error criterion",
       facts: proposed({ verificationErrors: [verificationError("criterion:missing")] }),
     },
-  ] as const;
+    // No `as const`: the fold input requires mutable fact arrays, and the
+    // readonly tuples a const assertion infers are not assignable to them.
+  ];
   for (const invalidCase of invalidGraphCases) {
     test(`rejects a dangling or duplicate ${invalidCase.name}`, () => {
       const foldInput =

--- a/packages/openomni/test/work-item/completion-request-identity.test.ts
+++ b/packages/openomni/test/work-item/completion-request-identity.test.ts
@@ -17,11 +17,13 @@ describe("completion report identity", () => {
       caveats: [],
       followUps: [],
     };
+    const firstClaim = first.claims[0];
+    if (firstClaim === undefined) throw new Error("shape");
     const reordered: WorkItem.CompletionReport = {
       ...first,
       claims: [
         {
-          ...first.claims[0],
+          ...firstClaim,
           evidenceIds: ["evidence:one", "evidence:two"],
         },
       ],

--- a/packages/openomni/tsconfig.test.json
+++ b/packages/openomni/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "dev": "tsc --watch -p tsconfig.build.json",
     "lint": "bunx biome check ./src",
     "test": "bun test"

--- a/packages/protocol/test/actor.test.ts
+++ b/packages/protocol/test/actor.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import type { z } from "zod";
 import { Actor } from "../src/actor/index.js";
 
 describe("Actor protocol contracts", () => {
   test("parses canonical identity and endpoint records", () => {
     // Given
-    const identityInput = {
+    const identityInput: z.input<typeof Actor.Identity> = {
       id: "act_owner",
       kind: "human",
       trustTier: "owner",

--- a/packages/protocol/test/concept-diet/dead-surface.test.ts
+++ b/packages/protocol/test/concept-diet/dead-surface.test.ts
@@ -40,8 +40,10 @@ describe("#497 protocol dead-surface disposition ledger", () => {
   });
 
   test("every row carries exactly one disposition from the allowed set", () => {
+    const dispositions: readonly string[] = DISPOSITIONS;
     for (const row of inventory.symbols) {
-      expect(DISPOSITIONS).toContain(row.disposition);
+      if (typeof row.disposition !== "string") throw new Error("shape");
+      expect(dispositions).toContain(row.disposition);
     }
   });
 
@@ -50,7 +52,7 @@ describe("#497 protocol dead-surface disposition ledger", () => {
     const counts = computeCounts(inventory);
 
     // Then
-    expect(counts).toEqual(inventory.tally as Record<string, number>);
+    expect(inventory.tally).toEqual(counts);
     expect(validateInventory(inventory).tallyMatches).toBe(true);
   });
 

--- a/packages/protocol/test/ingress/routing-decision.test.ts
+++ b/packages/protocol/test/ingress/routing-decision.test.ts
@@ -1,23 +1,27 @@
 import { describe, expect, test } from "bun:test";
+import type { z } from "zod";
 import { IngressEvent } from "../../src/event/ingress.js";
 
 const RoutingDecision = IngressEvent.RoutingDecision;
 const routingDecisionSchema = RoutingDecision.schema;
+
+type RoutingDecisionInput = z.input<typeof routingDecisionSchema>;
 
 const baseDecision = {
   traceId: "trace-1",
   time: 1_750_000_000_000,
   inboundId: "inbound-1",
   surface: "discord:channel:42",
-  mode: "direct",
+  mode: "direct" as const,
   reason: "terminal routing decision",
   factsUsed: ["inbound.normalized", "surface.discord"],
   target: "resident",
 };
 
-const terminalCases = [
-  { stage: "blacklist", outcome: "drop" },
+const terminalCases: RoutingDecisionInput[] = [
+  { ...baseDecision, stage: "blacklist", outcome: "drop" },
   {
+    ...baseDecision,
     stage: "wait_correlation",
     outcome: "route",
     target: "worker-session:session-1",
@@ -29,16 +33,24 @@ const terminalCases = [
     inboundTreatment: "full_access",
   },
   {
+    ...baseDecision,
     stage: "wait_correlation",
     outcome: "ambiguous",
     candidateInteractionIds: ["pending_ask:ask-1", "pending_interaction:pi-2", "wait:wait-3"],
   },
   // Fail-closed wait stage (#215): a matched wait whose owner has no ingress
   // delivery path blocks instead of falling through to surface routing.
-  { stage: "wait_correlation", outcome: "block" },
-  { stage: "channel_ceiling", outcome: "block", inboundTreatment: "drop" },
-  { stage: "actor_identity", outcome: "block", actorId: "actor-2", trustTier: "observer" },
+  { ...baseDecision, stage: "wait_correlation", outcome: "block" },
+  { ...baseDecision, stage: "channel_ceiling", outcome: "block", inboundTreatment: "drop" },
   {
+    ...baseDecision,
+    stage: "actor_identity",
+    outcome: "block",
+    actorId: "actor-2",
+    trustTier: "observer",
+  },
+  {
+    ...baseDecision,
     stage: "surface_default",
     outcome: "route",
     mode: "internal",
@@ -76,7 +88,7 @@ describe("IngressEvent.RoutingDecision", () => {
   for (const terminal of terminalCases) {
     test(`parses the terminal ${terminal.stage}/${terminal.outcome} decision`, () => {
       // Given
-      const input = { ...baseDecision, ...terminal };
+      const input = terminal;
 
       // When
       const parsed = routingDecisionSchema.parse(input);

--- a/packages/protocol/test/mcp.test.ts
+++ b/packages/protocol/test/mcp.test.ts
@@ -14,6 +14,7 @@ describe("McpConfig.ServerConfig", () => {
 
     expect(config.name).toBe("filesystem");
     expect(config.transport).toBe("stdio");
+    if (config.transport !== "stdio") throw new Error("shape");
     expect(config.args).toEqual(["/tmp"]);
   });
 

--- a/packages/protocol/test/message.test.ts
+++ b/packages/protocol/test/message.test.ts
@@ -362,7 +362,7 @@ describe("Message.WithParts", () => {
 
     expect(wp.info.role).toBe("user");
     expect(wp.parts).toHaveLength(1);
-    expect(wp.parts[0].type).toBe("text");
+    expect(wp.parts[0]?.type).toBe("text");
   });
 
   test("rejects missing info", () => {

--- a/packages/protocol/test/policy/decision-effect.test.ts
+++ b/packages/protocol/test/policy/decision-effect.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import type { z } from "zod";
 import { Policy } from "../../src/policy/index";
 
 const it = test;
 
 describe("Policy decision and effect schemas", () => {
-  const effects = [
+  const effects: z.input<typeof Policy.PolicyEffect>[] = [
     { type: "prompt.append_context", context: "Prefer concise answers." },
     { type: "prompt.inject_message", message: "Use read-only tools.", role: "user" },
     { type: "prompt.replace", prompt: "You are running in locked-down mode." },

--- a/packages/protocol/test/policy/point-registry.test.ts
+++ b/packages/protocol/test/policy/point-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { z } from "zod";
 import { Policy, RuntimeResource } from "../../src/policy/index.js";
 
 const expectedPointIds = [
@@ -91,7 +92,10 @@ describe("PolicyPoint registry", () => {
   });
 
   test("registers the criterion-scoped asserted-result allowance", () => {
-    const effect = { type: "work.allow_asserted", criterionIds: ["criterion:publish"] };
+    const effect: z.input<typeof Policy.PolicyEffect> = {
+      type: "work.allow_asserted",
+      criterionIds: ["criterion:publish"],
+    };
     const parsed = Policy.PolicyEffect.safeParse(effect);
 
     expect(parsed.success).toBe(true);
@@ -129,9 +133,12 @@ describe("PolicyPoint registry", () => {
 
   test("exports an initial contract for every required 3-tier point", () => {
     expect(Object.keys(Policy.PolicyPoint.Registry).sort()).toEqual([...expectedPointIds].sort());
-    expect(Policy.PolicyPoint.RegistrySchema.parse(Policy.PolicyPoint.Registry)).toEqual(
+    // Widened to `unknown` so toEqual accepts the deeply-readonly Registry as
+    // the expectation; the runtime deep-equality assertion is unchanged.
+    const roundTripped: unknown = Policy.PolicyPoint.RegistrySchema.parse(
       Policy.PolicyPoint.Registry,
     );
+    expect(roundTripped).toEqual(Policy.PolicyPoint.Registry);
 
     for (const pointId of expectedPointIds) {
       const contract = Policy.PolicyPoint.Registry[pointId];

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -70,6 +70,7 @@ describe("Tool.StateRunning", () => {
     });
 
     expect(state.status).toBe("running");
+    if (state.status !== "running") throw new Error("shape");
     expect(state.time.start).toBe(-5);
   });
 
@@ -104,6 +105,7 @@ describe("Tool.StateCompleted", () => {
     });
 
     expect(state.status).toBe("completed");
+    if (state.status !== "completed") throw new Error("shape");
     expect(state.time.end).toBe(0);
     expect(state.metadata).toEqual({});
   });
@@ -155,6 +157,7 @@ describe("Tool.StateError", () => {
     });
 
     expect(state.status).toBe("error");
+    if (state.status !== "error") throw new Error("shape");
     expect(state.error).toBe("failed");
   });
 

--- a/packages/protocol/tsconfig.test.json
+++ b/packages/protocol/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "rootDir": "../.."
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.contract-test.json",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.contract-test.json && tsc --noEmit -p tsconfig.test.json",
     "lint": "bunx biome check ./src",
     "test": "bun test",
     "bench": "bun run bench/index.ts"

--- a/packages/session/test/app-connector/lifecycle.test.ts
+++ b/packages/session/test/app-connector/lifecycle.test.ts
@@ -132,6 +132,7 @@ describe("AppConnectorInstallationStore lifecycle", () => {
   test("rejects storage adapters without app connector installation support", () => {
     // Given
     const adapterWithoutAppConnector = {
+      transaction: <T>(operation: () => T): T => operation(),
       session: {
         get: () => undefined,
         set: () => undefined,

--- a/packages/session/test/artifact/artifact.test.ts
+++ b/packages/session/test/artifact/artifact.test.ts
@@ -102,8 +102,8 @@ describe("Artifact", () => {
 
       const items = await Artifact.list("sess-1");
       expect(items).toHaveLength(1);
-      expect(items[0].version).toBe(2);
-      expect(items[0].title).toBe("updated.txt");
+      expect(items[0]?.version).toBe(2);
+      expect(items[0]?.title).toBe("updated.txt");
     });
 
     it("isolates artifacts between sessions", async () => {
@@ -115,9 +115,9 @@ describe("Artifact", () => {
       const s1 = await Artifact.list("sess-1");
       const s2 = await Artifact.list("sess-2");
       expect(s1).toHaveLength(1);
-      expect(s1[0].id).toBe("art-1");
+      expect(s1[0]?.id).toBe("art-1");
       expect(s2).toHaveLength(1);
-      expect(s2[0].id).toBe("art-2");
+      expect(s2[0]?.id).toBe("art-2");
     });
   });
 
@@ -129,8 +129,8 @@ describe("Artifact", () => {
 
       const vers = await Artifact.versions("art-1");
       expect(vers).toHaveLength(1);
-      expect(vers[0].version).toBe(2);
-      expect(vers[0].title).toBe("v2");
+      expect(vers[0]?.version).toBe(2);
+      expect(vers[0]?.title).toBe("v2");
     });
 
     it("returns empty array for unknown artifact", async () => {

--- a/packages/session/test/bench/memory-regression.test.ts
+++ b/packages/session/test/bench/memory-regression.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { Message } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
-import { Session } from "../../src/session/index.ts";
-import { Storage } from "../../src/storage/storage.ts";
+import { Session } from "../../src/session/index.js";
+import { Storage } from "../../src/storage/storage.js";
 
 function measureRSS(): number {
   Bun.gc(true);
@@ -15,6 +15,7 @@ function createMemoryStorage(): Storage.Adapter {
   const parts = new Map<string, Map<string, Message.Part>>();
 
   return {
+    transaction: <T>(operation: () => T): T => operation(),
     session: {
       get(id) {
         return sessions.get(id);

--- a/packages/session/test/bus-persistence/bus-persistence.test.ts
+++ b/packages/session/test/bus-persistence/bus-persistence.test.ts
@@ -104,7 +104,9 @@ describe("BusPersistence", () => {
       duration_ms: 123,
       time_created: time,
     });
-    expect(JSON.parse(persisted[0].data)).toEqual({
+    const firstCompleted = persisted[0];
+    if (firstCompleted === undefined) throw new Error("shape");
+    expect(JSON.parse(firstCompleted.data)).toEqual({
       sessionId: session.id,
       runId: "run-1",
       traceId: "trace-1",
@@ -136,7 +138,9 @@ describe("BusPersistence", () => {
       trace_id: "trace-from-schema",
       time_created: time,
     });
-    expect(JSON.parse(persisted[0].data)).toEqual({
+    const firstNormalized = persisted[0];
+    if (firstNormalized === undefined) throw new Error("shape");
+    expect(JSON.parse(firstNormalized.data)).toEqual({
       sessionId: session.id,
       traceId: "trace-from-schema",
       time,
@@ -172,7 +176,9 @@ describe("BusPersistence", () => {
       session_id: session.id,
       trace_id: "trace-raw",
     });
-    expect(JSON.parse(persisted[0].data)).toEqual({
+    const firstRaw = persisted[0];
+    if (firstRaw === undefined) throw new Error("shape");
+    expect(JSON.parse(firstRaw.data)).toEqual({
       sessionId: session.id,
       traceId: "trace-raw",
       time: Date.UTC(2026, 4, 10, 1, 2, 6),
@@ -514,7 +520,10 @@ describe("BusPersistence", () => {
     });
     await BusPersistence.flush();
 
-    const data = JSON.parse((await waitForRows(1))[0].data) as {
+    const redactRows = await waitForRows(1);
+    const redactRow = redactRows[0];
+    if (redactRow === undefined) throw new Error("shape");
+    const data = JSON.parse(redactRow.data) as {
       context: {
         apiKey: string;
         credentials: string;
@@ -563,7 +572,10 @@ describe("BusPersistence", () => {
       context,
     });
 
-    const data = JSON.parse((await waitForRows(1))[0].data) as {
+    const cycleRows = await waitForRows(1);
+    const cycleRow = cycleRows[0];
+    if (cycleRow === undefined) throw new Error("shape");
+    const data = JSON.parse(cycleRow.data) as {
       context: { self: string; child: { parent: string } };
     };
     expect(data.context.self).toBe("[redacted]");
@@ -607,7 +619,10 @@ describe("BusPersistence", () => {
       writeSpy.mockRestore();
     }
 
-    const data = JSON.parse((await waitForRows(1))[0].data) as {
+    const msgRows = await waitForRows(1);
+    const msgRow = msgRows[0];
+    if (msgRow === undefined) throw new Error("shape");
+    const data = JSON.parse(msgRow.data) as {
       context: { msg: unknown; apiKey: string };
     };
     expect(data.context.msg).toEqual({ type: "string", length: 36 });

--- a/packages/session/test/bus-persistence/hash-chain.test.ts
+++ b/packages/session/test/bus-persistence/hash-chain.test.ts
@@ -109,9 +109,9 @@ describe("Hash Chain", () => {
 
     const rows = await waitForRows(1);
     expect(rows).toHaveLength(1);
-    expect(rows[0].prev_hash).toBe(GENESIS_SEED);
-    expect(rows[0].event_hash).toBeString();
-    expect(rows[0].event_hash).toHaveLength(64);
+    expect(rows[0]?.prev_hash).toBe(GENESIS_SEED);
+    expect(rows[0]?.event_hash).toBeString();
+    expect(rows[0]?.event_hash).toHaveLength(64);
   });
 
   test("hash chain links consecutive events", async () => {
@@ -130,9 +130,13 @@ describe("Hash Chain", () => {
     const rows = await waitForRows(3);
     expect(rows).toHaveLength(3);
 
-    expect(rows[0].prev_hash).toBe(GENESIS_SEED);
-    expect(rows[1].prev_hash).toBe(rows[0].event_hash);
-    expect(rows[2].prev_hash).toBe(rows[1].event_hash);
+    const [row0, row1, row2] = rows;
+    if (row0 === undefined || row1 === undefined || row2 === undefined) {
+      throw new Error("shape");
+    }
+    expect(row0.prev_hash).toBe(GENESIS_SEED);
+    expect(row1.prev_hash).toBe(row0.event_hash);
+    expect(row2.prev_hash).toBe(row1.event_hash);
   });
 
   test("event_chain audit table mirrors bus_event hashes", async () => {
@@ -151,10 +155,16 @@ describe("Hash Chain", () => {
     const events = busRows(session.id);
 
     expect(chain).toHaveLength(1);
-    expect(chain[0].event_hash).toBe(events[0].event_hash);
-    expect(chain[0].prev_hash).toBe(events[0].prev_hash);
-    expect(chain[0].event_type).toBe("test.hash.event");
-    expect(chain[0].session_id).toBe(session.id);
+    const chainHead = chain[0];
+    const eventHead = events[0];
+    if (chainHead === undefined || eventHead === undefined) throw new Error("shape");
+    if (eventHead.event_hash === null || eventHead.prev_hash === null) {
+      throw new Error("shape");
+    }
+    expect(chainHead.event_hash).toBe(eventHead.event_hash);
+    expect(chainHead.prev_hash).toBe(eventHead.prev_hash);
+    expect(chainHead.event_type).toBe("test.hash.event");
+    expect(chainHead.session_id).toBe(session.id);
   });
 
   test("verifyChainIntegrity reports valid for untampered chain", async () => {
@@ -193,15 +203,17 @@ describe("Hash Chain", () => {
 
     await waitForRows(3);
     const rows = busRows(session.id);
+    const tamperedRow = rows[1];
+    if (tamperedRow === undefined) throw new Error("shape");
 
     db()
       .query("UPDATE bus_event SET event_hash = ? WHERE id = ?")
-      .run("deadbeef".repeat(8), rows[1].id);
+      .run("deadbeef".repeat(8), tamperedRow.id);
 
     const result = await BusQuery.verifyChainIntegrity(session.id);
 
     expect(result.valid).toBe(false);
-    expect(result.brokenAtId).toBe(rows[1].id);
+    expect(result.brokenAtId).toBe(tamperedRow.id);
   });
 
   test("verifyChainIntegrity detects tampered data", async () => {
@@ -217,13 +229,17 @@ describe("Hash Chain", () => {
 
     await waitForRows(1);
     const rows = busRows(session.id);
+    const tamperedRow = rows[0];
+    if (tamperedRow === undefined) throw new Error("shape");
 
-    db().query("UPDATE bus_event SET data = ? WHERE id = ?").run('{"tampered":true}', rows[0].id);
+    db()
+      .query("UPDATE bus_event SET data = ? WHERE id = ?")
+      .run('{"tampered":true}', tamperedRow.id);
 
     const result = await BusQuery.verifyChainIntegrity(session.id);
 
     expect(result.valid).toBe(false);
-    expect(result.brokenAtId).toBe(rows[0].id);
+    expect(result.brokenAtId).toBe(tamperedRow.id);
   });
 
   test("verifyChainIntegrity detects broken prev_hash link", async () => {
@@ -241,15 +257,17 @@ describe("Hash Chain", () => {
 
     await waitForRows(3);
     const rows = busRows(session.id);
+    const tamperedRow = rows[2];
+    if (tamperedRow === undefined) throw new Error("shape");
 
     db()
       .query("UPDATE bus_event SET prev_hash = ? WHERE id = ?")
-      .run("wrong_prev_hash", rows[2].id);
+      .run("wrong_prev_hash", tamperedRow.id);
 
     const result = await BusQuery.verifyChainIntegrity(session.id);
 
     expect(result.valid).toBe(false);
-    expect(result.brokenAtId).toBe(rows[2].id);
+    expect(result.brokenAtId).toBe(tamperedRow.id);
   });
 
   test("session-scoped chains are independent", async () => {
@@ -274,8 +292,8 @@ describe("Hash Chain", () => {
     const rowsA = busRows(sessionA.id);
     const rowsB = busRows(sessionB.id);
 
-    expect(rowsA[0].prev_hash).toBe(GENESIS_SEED);
-    expect(rowsB[0].prev_hash).toBe(GENESIS_SEED);
+    expect(rowsA[0]?.prev_hash).toBe(GENESIS_SEED);
+    expect(rowsB[0]?.prev_hash).toBe(GENESIS_SEED);
 
     const resultA = await BusQuery.verifyChainIntegrity(sessionA.id);
     const resultB = await BusQuery.verifyChainIntegrity(sessionB.id);
@@ -327,9 +345,13 @@ describe("Hash Chain", () => {
     const audit = await BusQuery.listAuditChain(session.id);
 
     expect(audit).toHaveLength(3);
-    expect(audit[0].prevHash).toBe(GENESIS_SEED);
-    expect(audit[1].prevHash).toBe(audit[0].eventHash);
-    expect(audit[2].prevHash).toBe(audit[1].eventHash);
+    const [audit0, audit1, audit2] = audit;
+    if (audit0 === undefined || audit1 === undefined || audit2 === undefined) {
+      throw new Error("shape");
+    }
+    expect(audit0.prevHash).toBe(GENESIS_SEED);
+    expect(audit1.prevHash).toBe(audit0.eventHash);
+    expect(audit2.prevHash).toBe(audit1.eventHash);
     for (const record of audit) {
       expect(record.sessionId).toBe(session.id);
       expect(record.eventType).toBe("test.hash.event");

--- a/packages/session/test/integration/observability.test.ts
+++ b/packages/session/test/integration/observability.test.ts
@@ -134,8 +134,8 @@ describe("Observability Pipeline Integration", () => {
 
       const history = await BusQuery.getWorkerRunHistory(sessionId);
       expect(history).toHaveLength(1);
-      expect(history[0].runId).toBe(runId);
-      expect(history[0].status).toBe("succeeded");
+      expect(history[0]?.runId).toBe(runId);
+      expect(history[0]?.status).toBe("succeeded");
 
       const eventLogCount = db().query("SELECT COUNT(*) as count FROM event_log").get() as {
         count: number;

--- a/packages/session/test/session/message-status.test.ts
+++ b/packages/session/test/session/message-status.test.ts
@@ -122,6 +122,7 @@ describe("message status tracking", () => {
 
     expect(queryStatus("msg-5")).toBe("completed");
 
+    if (adapter.message.setStatus === undefined) throw new Error("shape");
     adapter.message.setStatus("msg-5", "processing");
     expect(queryStatus("msg-5")).toBe("processing");
   });

--- a/packages/session/test/session/pagination.test.ts
+++ b/packages/session/test/session/pagination.test.ts
@@ -49,6 +49,7 @@ describe("Session.listMessagesPage", () => {
     ]);
 
     expect(page1.nextCursor).toBeDefined();
+    if (page1.nextCursor === null) throw new Error("shape");
     const page2 = Session.listMessagesPage(session.id, { limit: 10, before: page1.nextCursor });
     expect(page2.items).toHaveLength(10);
     expect(page2.more).toBe(true);

--- a/packages/session/test/storage/initialize.test.ts
+++ b/packages/session/test/storage/initialize.test.ts
@@ -38,6 +38,7 @@ describe("Storage.initialize", () => {
       title: "Persisted",
       model: { providerID: "test", modelID: "test-model" },
       time: { created: Date.now(), updated: Date.now() },
+      spawnDepth: 0,
     };
     Storage.getAdapter().session.set("s1", session);
 
@@ -82,6 +83,7 @@ describe("Storage.initialize", () => {
         title: "Isolated",
         model: { providerID: "test", modelID: "test" },
         time: { created: 1, updated: 1 },
+        spawnDepth: 0,
       });
     });
 

--- a/packages/session/test/storage/read-validation.test.ts
+++ b/packages/session/test/storage/read-validation.test.ts
@@ -139,6 +139,7 @@ describe("sqlite adapters fail closed on corrupt rows", () => {
       id: "grant-corrupt",
       workerRunId: "run-corrupt",
       allowedActions: ["worker.send"],
+      canCreateExternalTasks: false,
     });
 
     // Structurally-valid-looking but schema-invalid: missing id/workerRunId/

--- a/packages/session/test/surface-key/persistence.test.ts
+++ b/packages/session/test/surface-key/persistence.test.ts
@@ -25,7 +25,10 @@ describe("SurfaceKey SQLite persistence", () => {
   });
 
   test("persists across Storage re-init", () => {
-    const session = Session.create({ title: "persist-test" });
+    const session = Session.create({
+      title: "persist-test",
+      model: { providerID: "test", modelID: "test-model" },
+    });
     SurfaceKey.register("telegram:bot:chat:123", session.id);
 
     Storage.configure(new SqliteStorageAdapter(dbPath));
@@ -34,7 +37,10 @@ describe("SurfaceKey SQLite persistence", () => {
   });
 
   test("unregister removes from SQLite", () => {
-    const session = Session.create({ title: "unregister-test" });
+    const session = Session.create({
+      title: "unregister-test",
+      model: { providerID: "test", modelID: "test-model" },
+    });
     SurfaceKey.register("slack:ws:dm:U1", session.id);
 
     SurfaceKey.unregister("slack:ws:dm:U1");
@@ -45,8 +51,14 @@ describe("SurfaceKey SQLite persistence", () => {
   });
 
   test("re-register updates session in SQLite", () => {
-    const session1 = Session.create({ title: "old-session" });
-    const session2 = Session.create({ title: "new-session" });
+    const session1 = Session.create({
+      title: "old-session",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    const session2 = Session.create({
+      title: "new-session",
+      model: { providerID: "test", modelID: "test-model" },
+    });
     SurfaceKey.register("slack:ws:channel:C1", session1.id);
     SurfaceKey.register("slack:ws:channel:C1", session2.id);
 

--- a/packages/session/test/ttl.test.ts
+++ b/packages/session/test/ttl.test.ts
@@ -132,7 +132,7 @@ describe("Session TTL", () => {
 
       const sessions = Session.list();
       expect(sessions.length).toBe(1);
-      expect(sessions[0].id).toBe(activeSession.id);
+      expect(sessions[0]?.id).toBe(activeSession.id);
 
       // list() is a pure read: the expired row survives until the sweep.
       const stillStored = Storage.getAdapter().session.get(expiredSession.id);

--- a/packages/session/test/worker-grant/store.test.ts
+++ b/packages/session/test/worker-grant/store.test.ts
@@ -39,6 +39,7 @@ describe("WorkerGrantStore", () => {
       workerRunId: "run-1",
       allowedActions: ["worker.send"],
       allowedSessionIds: ["session-1"],
+      canCreateExternalTasks: false,
     });
 
     expect(
@@ -162,6 +163,7 @@ describe("WorkerGrantStore", () => {
       allowedActions: ["worker.send"],
       allowedSessionIds: ["session-1"],
       expiresAt: Date.now() - 1,
+      canCreateExternalTasks: false,
     });
 
     expect(
@@ -187,6 +189,7 @@ describe("WorkerGrantStore", () => {
       id: "grant-stale",
       workerRunId: "run-stale",
       allowedActions: ["worker.send"],
+      canCreateExternalTasks: false,
     });
     const staleConcurrentUpdate = {
       ...created,

--- a/packages/session/tsconfig.test.json
+++ b/packages/session/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../.."
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
+  "globalDependencies": ["script/**"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
The #614 remainder. Four packages ran their suites green while **473 type errors** sat in the test code — apps/server 128, session 130, openomni 200, protocol 15. The runner never sees types, so the rot was invisible: fixtures missing now-required fields, unions read without narrowing, indexed access without guards, mocks carrying a parameter the `Storage` interface dropped, one fixture stamping a treatment value the enum renamed away.

## Structure

Each package gains a `tsconfig.test.json` on the agent/llm pattern (#614), wired into `check-types` so the rot cannot regrow. Cross-package src imports in server/session/protocol tests needed `rootDir` widened to the repo root; protocol's one script-importing test additionally needed `allowImportingTsExtensions`. 68 test files, +430/−224, **zero src files touched**.

## Fix discipline (adversarial-review bait, stated up front)

- Assertions unchanged except **one stale literal**: `"normal"` → `"full_access"`, chasing the `Actor.InboundTreatment` enum — the test proved verbatim treatment-stamping with a value *outside the current enum*; it proves the same property with a legal one.
- Unions narrowed with the repo's throw-on-shape idiom; `noUncheckedIndexedAccess` via guards/`?.`.
- Zero `any`, zero `as unknown as`, zero `@ts-expect-error`, no option loosening (grep-verified over the full diff).
- `toEqual` overload failures fixed by typing inputs as `z.input<…>`, not by casting expectations. One commented `unknown` widening for the deeply-readonly PolicyPoint Registry round-trip (runtime assertion unchanged).

## Fixtures that gained now-required fields (meaning-affecting, for review)

1. openomni ingress-authority-validation — the enum literal above (only assertion change).
2. session surface-key persistence — `Session.create` gains required `model`.
3. openomni wait/correlation — frozen stores (#548) type `markAmbiguous`/`resolve` as `never`; spies now throw (they exist only for `not.toHaveBeenCalled()`).
4. server resident-inbound-wait — `ServerConfig` gains required `messaging: { grants: [] }` (deny-all default).
5. server worker-full-stack — tool relay supplies required `runId`/`sessionId`; `makeToolCtx` gains required `pointId`.
6. session fixtures — `spawnDepth: 0`, `canCreateExternalTasks: false` (schema runtime defaults).
7. openomni child-agent-policy-construction — constructor's new required ports (empty + throwing stubs, unused before the pinned throw).
8. openomni compareAndSet mocks — dropped the removed 4th `writerCapability` arg (~13 sites; the current interface is 3-arg and the arg was ignored at runtime).

## Verification

All four at **0 test-type errors** · `check-types` 14/14 with the new configs wired (uncached full run) · `bun test` 3494 pass / 9 skip / 0 fail · `lint`, `lint:tools`, `check-deps` 0, `check-import-cycles`, ratchet 1 known/none new · `build` + `bench` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TypeScript type-checking for tests in `apps/server`, `packages/session`, `packages/openomni`, and `packages/protocol`, and wires them into each package’s `check-types`. This prevents silent test-only type rot; fixes stay in tests except a doc-only note in `packages/openomni` recording that channel-grant treatment is stamped verbatim (no runtime validation). One stale test literal changes from "normal" to "full_access" to use a legal enum value.

- Each package adds `tsconfig.test.json` and updates `check-types`; cross-repo imports widen `rootDir`, and `packages/protocol` enables `allowImportingTsExtensions`. `turbo.json` adds `globalDependencies: ["script/**"]` so `check-types` invalidates when scripts used by tests change.
- Tests narrow unions and guard indexed access; a local `field()` helper replaces `Reflect.get` patterns to avoid `any`.

**Migration for new or edited tests**
- Provide required fields in fixtures:
  - `Session.create` requires `model`; set `spawnDepth: 0` where applicable.
  - `ServerConfig` requires `messaging: { grants: [] }`.
  - Worker grants require `canCreateExternalTasks: false`.
- Match current test-only interfaces:
  - `readBackRecorder` is async.
  - `Storage.workItem.compareAndSet` takes 3 args.
  - Tool relay calls include `runId` and `sessionId`; contexts that route tools require a `pointId`.
  - Ad-hoc storage adapters implement `transaction`.
  - Child-agent runtime options require `parentMessages`, `parentTools`, and `createAgent`.
  - Injected completion admission services expose `hasActiveRequest` and `trackActiveRequest`.

<sup>Written for commit d23bbcd8df512a804198d0343af7bc943461590c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding explicit validation for missing, dropped, or malformed results.
  * Updated test fixtures and mocks to match current interfaces and required fields.
  * Strengthened coverage for ingress routing, dispatch, policy, persistence, and completion workflows.

* **Chores**
  * Added dedicated TypeScript configurations for test suites across packages.
  * Updated type-checking scripts to include test configurations.
  * Improved type safety throughout test utilities and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->