### PR TITLE
test(server): refuse pin asserts the loud half (#606)

### DIFF
--- a/apps/server/test/context/middleware.test.ts
+++ b/apps/server/test/context/middleware.test.ts
@@ -149,8 +149,27 @@ describe("createContextMiddleware", () => {
     const middleware = createContextMiddleware({ workspaceRoot: ws });
     const mockCtx = { ...contextPolicyInput(), traceContext: undefined };
 
-    const result = await dispatchContextMiddleware(middleware, mockCtx);
+    // A bare allow is shape-identical to "middleware never selected", so the
+    // pin also asserts the LOUD half: the engine records the middleware error
+    // under its own trace (#656 review) — the drop is refuse-and-report, not
+    // silence.
+    const warns: Array<Record<string, unknown>> = [];
+    const engine = PolicyEngine.create<PolicyContext>({
+      traceContext: { traceId: "trace-engine", sessionId: "session-context", runId: "run-1" },
+      auditEmit: (descriptor, data) => {
+        if (descriptor.name === "operational.warn") warns.push(data as Record<string, unknown>);
+      },
+    });
+    engine.register(middleware);
+    const result = await engine.dispatchPoint("prompt.context.pre", {
+      ...mockCtx,
+      sessionId: "session-context",
+      runId: "run-1",
+      turnIndex: 0,
+    });
+
     expect(result).toMatchObject({ verdict: "allow", effects: [] });
+    expect(warns.some((warn) => warn.msg === "middleware error")).toBe(true);
   });
 
   it("returns allow when assembled context is empty string", async () => {

--- a/apps/server/test/context/middleware.test.ts
+++ b/apps/server/test/context/middleware.test.ts
@@ -169,7 +169,12 @@ describe("createContextMiddleware", () => {
     });
 
     expect(result).toMatchObject({ verdict: "allow", effects: [] });
-    expect(warns.some((warn) => warn.msg === "middleware error")).toBe(true);
+    const warn = warns.find((entry) => entry.msg === "middleware error");
+    if (warn === undefined) throw new Error("no middleware error was recorded");
+    // Attribution: the dispatch has no trace, so the record files under the
+    // engine trace — and the refusal, not some other throw, is the cause.
+    expect(warn.traceId).toBe("trace-engine");
+    expect((warn.context as { error: string }).error).toContain("requires the run trace context");
   });
 
   it("returns allow when assembled context is empty string", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #656 — lands the review NIT that missed the merge (the pre-push type-check rejected the commit while the merge in the same batch proceeded; the merged head is exactly the head the adversarial review PASSED, so only this NIT was outstanding).

The D11 refuse pin ("refuses to assemble without the run trace context") previously asserted only `{ verdict: "allow", effects: [] }` — shape-identical to "middleware never selected". Per the #656 review, it now also asserts the LOUD half: the engine records the middleware error under its own trace via `auditEmit`, proving the drop is refuse-and-report, not silence.

- Real `PolicyEngine.create<PolicyContext>` with engine-level `traceContext` and an `auditEmit` capture of `operational.warn`.
- `expect(warns.some((warn) => warn.msg === "middleware error")).toBe(true)` — `publishMiddlewareError` publishes exactly this msg under the engine trace.
- Direct `dispatchPoint` call satisfies the point-narrowed context (`sessionId`/`runId`/`turnIndex` literal).

## Verification

- `tsc --noEmit -p apps/server/tsconfig.test.json`: 0 errors
- `bun test apps/server/test/context/middleware.test.ts`: 10 pass / 0 fail
- Mutation: reverting the middleware to a fallback mint makes the warn assertion fail (no middleware error is published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the D11 refuse pin test to assert loud failure reporting, warn attribution, and refusal cause. Previously it only checked `{ verdict: "allow", effects: [] }`; now it verifies an `operational.warn` "middleware error" is recorded under the engine trace and that the message cites the missing run trace context.

- Pins trace attribution and cause: asserts `warn.traceId` matches the engine and `error` contains "requires the run trace context".
- Touches only apps/server/test/context/middleware.test.ts; uses a real PolicyEngine with `traceContext` and `auditEmit`, and dispatches with `sessionId`/`runId`/`turnIndex`. No production behavior changes.

<sup>Written for commit e235f32fbc7362f7d6c5b0f3164f34e9bc2fc22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded middleware coverage for requests missing trace context.
  * Verified that middleware errors generate an operational warning while preserving the expected allow result and empty effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->