### PR TITLE
refactor(protocol): trace batch 2 — pending events traceid (#606)

### DIFF
--- a/packages/protocol/src/communication/pending-ask.ts
+++ b/packages/protocol/src/communication/pending-ask.ts
@@ -88,6 +88,7 @@ export type CorrelationQuery = z.infer<typeof CorrelationQuery>;
 
 const EventBase = z.object({
   id: z.string().min(1),
+  traceId: z.string().min(1),
   status: Status,
   originSessionId: z.string().min(1),
   originRunId: z.string().min(1).optional(),

--- a/packages/protocol/src/communication/pending-interaction.ts
+++ b/packages/protocol/src/communication/pending-interaction.ts
@@ -99,6 +99,7 @@ export type CorrelationQuery = z.infer<typeof CorrelationQuery>;
 
 const EventBase = z.object({
   id: z.string().min(1),
+  traceId: z.string().min(1),
   workerRunId: z.string().min(1),
   sessionId: z.string().min(1),
   endpointId: z.string().min(1),

--- a/packages/protocol/test/communication/schema.test.ts
+++ b/packages/protocol/test/communication/schema.test.ts
@@ -67,6 +67,9 @@ describe("Communication protocol schemas", () => {
     };
     expect(Communication.PendingAsk.Events.Opened.schema.safeParse(askBase).success).toBe(false);
     expect(
+      Communication.PendingAsk.Events.Opened.schema.safeParse({ ...askBase, traceId: "" }).success,
+    ).toBe(false);
+    expect(
       Communication.PendingAsk.Events.Opened.schema.safeParse({ ...askBase, traceId: "trace-1" })
         .success,
     ).toBe(true);
@@ -82,6 +85,12 @@ describe("Communication protocol schemas", () => {
     };
     expect(
       Communication.PendingInteraction.Events.Opened.schema.safeParse(interactionBase).success,
+    ).toBe(false);
+    expect(
+      Communication.PendingInteraction.Events.Opened.schema.safeParse({
+        ...interactionBase,
+        traceId: "",
+      }).success,
     ).toBe(false);
     expect(
       Communication.PendingInteraction.Events.Opened.schema.safeParse({

--- a/packages/protocol/test/communication/schema.test.ts
+++ b/packages/protocol/test/communication/schema.test.ts
@@ -54,6 +54,43 @@ describe("Communication protocol schemas", () => {
     expect(parsed.correlation).toMatchObject({ replyToMessageId: "m-1" });
   });
 
+  test("PendingAsk and PendingInteraction events refuse an untraced payload", () => {
+    // Pin (D11): both stores are frozen writers today, so this is the whole
+    // contract — any future producer must carry the caller's trace or fail
+    // at parse instead of persisting as "untraced".
+    const askBase = {
+      id: "ask-1",
+      status: "open",
+      originSessionId: "session-1",
+      targetKind: "resident",
+      time: 1,
+    };
+    expect(Communication.PendingAsk.Events.Opened.schema.safeParse(askBase).success).toBe(false);
+    expect(
+      Communication.PendingAsk.Events.Opened.schema.safeParse({ ...askBase, traceId: "trace-1" })
+        .success,
+    ).toBe(true);
+
+    const interactionBase = {
+      id: "pi-1",
+      workerRunId: "run-1",
+      sessionId: "session-1",
+      endpointId: "telegram:seller-1",
+      channelId: "telegram:dm",
+      status: "open",
+      time: 1,
+    };
+    expect(
+      Communication.PendingInteraction.Events.Opened.schema.safeParse(interactionBase).success,
+    ).toBe(false);
+    expect(
+      Communication.PendingInteraction.Events.Opened.schema.safeParse({
+        ...interactionBase,
+        traceId: "trace-1",
+      }).success,
+    ).toBe(true);
+  });
+
   test("WorkerGrant defaults external task creation to false", () => {
     const parsed = Communication.WorkerGrant.Record.parse({
       id: "grant-1",


### PR DESCRIPTION
## Summary

Trace batch 2 of the D11 structural remainder (#606; batch plan in docs/agent-core-rewrite.md).

`PendingAsk` (5 definitions) and `PendingInteraction` (5 definitions) event bases gain required `traceId: z.string().min(1)`.

Both stores are **frozen writers** — every write method throws `FrozenError`, and no `Bus.publish` in the repo references these descriptors (re-verified this session). So this is a pure schema edit with zero producer churn: it removes nothing from today's untraced ledger population, but any future producer now must carry the caller's trace or fail at parse instead of persisting as `"untraced"`.

Snapshot impact: none — `BusEvent.define` descriptors are not snapshot keys.

## Pin

`packages/protocol/test/communication/schema.test.ts` — "PendingAsk and PendingInteraction events refuse an untraced payload": `safeParse` without `traceId` fails, with it passes, for both families. Mutation-verified: removing the field from either base fails exactly this test (4 pass / 1 fail), then restored (5 pass / 0 fail).

## Verification

- `tsc --noEmit` src+test (protocol, session): 0 errors
- `bun test packages/protocol/test/communication`: 5 pass / 0 fail
- `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires a non-empty traceId on PendingAsk and PendingInteraction event bases in `packages/protocol` to enforce tracing on future writes. Previously these events parsed without a trace and could persist as untraced; now payloads missing traceId or with an empty traceId fail to parse.

- Review notes: Schema-only change; both stores are frozen writers with no current producers or Bus.publish references. Tests pin failure for missing/empty traceId and success for a valid value. No runtime or snapshot impact.
- Migration: Producers of PendingAsk and PendingInteraction must include a non-empty traceId in payloads. No data or snapshot migration required.

<sup>Written for commit 1c8b7b808b42e444c8dc34c907299d10e754bfc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

