### PR TITLE
refactor(session): trace batch 3 — session events traceid (#606)

### DIFF
--- a/apps/server/src/bootstrap/recovery.ts
+++ b/apps/server/src/bootstrap/recovery.ts
@@ -249,7 +249,7 @@ export async function runRecovery(input: BootstrapRecoveryInput): Promise<void> 
     // Session TTL expiry: reads (Session.get/list) only filter expired rows;
     // this sweep is the one deliberate deletion point (same seam as the wait
     // sweep above — boot-time only until a periodic scheduler exists).
-    const expiredSessions = Session.sweepExpired();
+    const expiredSessions = Session.sweepExpired(id);
     if (expiredSessions.length > 0) {
       Bus.publish(Operational.Info, {
         traceId: id,

--- a/apps/server/test/bootstrap/recovery.test.ts
+++ b/apps/server/test/bootstrap/recovery.test.ts
@@ -38,6 +38,7 @@ async function seedFrozenPendingInteractionFixture(
   lifecycle: "open" | "follow_up" = "open",
 ): Promise<void> {
   const session = Session.create({
+    traceId: "trace-recovery",
     title: `${id}-session`,
     model: { providerID: "test", modelID: "test" },
   });
@@ -388,6 +389,7 @@ describe("server recovery", () => {
 
   it("replays interrupted inbound messages through the retry queue handler", async () => {
     const session = Session.create({
+      traceId: "trace-retry-queue",
       title: "surface:retry-queue",
       model: { providerID: "test", modelID: "test" },
     });
@@ -434,6 +436,7 @@ describe("server recovery", () => {
 
   it("swallows a throwing retry handler and finishes recovery", async () => {
     const session = Session.create({
+      traceId: "trace-retry-throw",
       title: "surface:retry-throw",
       model: { providerID: "test", modelID: "test" },
     });

--- a/apps/server/test/bootstrap/resident-inbound-wait.test.ts
+++ b/apps/server/test/bootstrap/resident-inbound-wait.test.ts
@@ -107,10 +107,12 @@ function attemptIdentity(prompt: string) {
 
 async function createActiveRun(runId: string) {
   const residentSession = Session.create({
+    traceId: "trace-test",
     title: "resident",
     model: { providerID: "test", modelID: "resident-model" },
   });
   const workerSession = Session.create({
+    traceId: "trace-test",
     title: "worker",
     model: { providerID: "test", modelID: "worker-model" },
   });

--- a/apps/server/test/execution/worker-runtime.test.ts
+++ b/apps/server/test/execution/worker-runtime.test.ts
@@ -144,7 +144,7 @@ describe("worker runtime input messages", () => {
   });
 
   test("uses the projected session prompt when it is already the latest user message", () => {
-    const session = Session.create({ title: "worker", model });
+    const session = Session.create({ traceId: "trace-worker-runtime", title: "worker", model });
     addTextMessage(session.id, "user", "do the work");
 
     expect(buildWorkerInputMessages(session.id, "do the work")).toEqual([
@@ -159,7 +159,7 @@ describe("worker runtime input messages", () => {
   });
 
   test("appends the request prompt after stale projected history", () => {
-    const session = Session.create({ title: "worker", model });
+    const session = Session.create({ traceId: "trace-worker-runtime", title: "worker", model });
     addTextMessage(session.id, "user", "old request");
     addTextMessage(session.id, "assistant", "old answer");
 

--- a/apps/server/test/integration/crash-recovery.test.ts
+++ b/apps/server/test/integration/crash-recovery.test.ts
@@ -38,6 +38,7 @@ afterEach(async () => {
 
 test("marks processing message as received when no assistant response", async () => {
   const session = Session.create({
+    traceId: "trace-test",
     title: "recovery",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/apps/server/test/integration/message-lifecycle.test.ts
+++ b/apps/server/test/integration/message-lifecycle.test.ts
@@ -37,6 +37,7 @@ afterEach(async () => {
 
 test("message status transitions received -> processing -> completed", () => {
   const session = Session.create({
+    traceId: "trace-message-lifecycle",
     title: "lifecycle",
     model: { providerID: "test", modelID: "test-model" },
   });
@@ -54,6 +55,7 @@ test("message status transitions received -> processing -> completed", () => {
 
 test("message defaults to completed when status is omitted", () => {
   const session = Session.create({
+    traceId: "trace-message-lifecycle",
     title: "lifecycle-default",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/apps/server/test/integration/session-persistence.test.ts
+++ b/apps/server/test/integration/session-persistence.test.ts
@@ -37,6 +37,7 @@ afterEach(async () => {
 
 test("session persists across storage re-init", () => {
   const session = Session.create({
+    traceId: "trace-session-persistence",
     title: "persist-session",
     model: { providerID: "test", modelID: "test-model" },
   });
@@ -52,6 +53,7 @@ test("session persists across storage re-init", () => {
 
 test("message persists with status across storage re-init", () => {
   const session = Session.create({
+    traceId: "trace-session-persistence",
     title: "persist-message",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/apps/server/test/server/observability.test.ts
+++ b/apps/server/test/server/observability.test.ts
@@ -59,6 +59,7 @@ describe("observability routes", () => {
   test("session event journal endpoint reads BusQuery aggregates without exposing payload data", async () => {
     const app = createRouter(undefined, { observabilityToken: "test-token" });
     const session = Session.create({
+      traceId: "trace-observability",
       title: "observability",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/apps/server/test/tool/mcp/provider-test-fixture.ts
+++ b/apps/server/test/tool/mcp/provider-test-fixture.ts
@@ -111,6 +111,7 @@ export function seedProvider(
 
 export function createLedgerSession(): Session.Info {
   return Session.create({
+    traceId: "trace-mcp-test",
     title: "mcp-ledger-test",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/packages/openomni/src/dispatch/handlers/connector-endpoint-worker.ts
+++ b/packages/openomni/src/dispatch/handlers/connector-endpoint-worker.ts
@@ -34,11 +34,12 @@ function resolveSessionId(command: Dispatch.Command, model: Model.Ref): string {
   const modelInfo = { providerID: model.provider, modelID: model.id };
   const session = command.target.parentSessionId
     ? Session.createChild({
+        traceId: command.traceId,
         parentSessionId: command.target.parentSessionId,
         title,
         model: modelInfo,
       })
-    : Session.create({ title, model: modelInfo });
+    : Session.create({ traceId: command.traceId, title, model: modelInfo });
   return session.id;
 }
 

--- a/packages/openomni/src/dispatch/handlers/worker-spawn-payload.ts
+++ b/packages/openomni/src/dispatch/handlers/worker-spawn-payload.ts
@@ -32,11 +32,12 @@ function resolveSessionId(command: Dispatch.Command, model: Model.Ref): string {
   const modelInfo = { providerID: model.provider, modelID: model.id };
   const session = command.target.parentSessionId
     ? Session.createChild({
+        traceId: command.traceId,
         parentSessionId: command.target.parentSessionId,
         title,
         model: modelInfo,
       })
-    : Session.create({ title, model: modelInfo });
+    : Session.create({ traceId: command.traceId, title, model: modelInfo });
   return session.id;
 }
 

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -78,11 +78,10 @@ export function createIngressEngine(deps: IngressEngineDeps = {}): IngressEngine
     });
 
     const agentModel = inboundEvent.agent.model;
-    const { session } = IngressSessionResolver.resolve(
-      inboundEvent,
-      { providerID: agentModel.provider, modelID: agentModel.id },
-      trace,
-    );
+    const { session } = IngressSessionResolver.resolve(inboundEvent, trace, {
+      providerID: agentModel.provider,
+      modelID: agentModel.id,
+    });
 
     const activeTrace = { ...trace, sessionId: session.id };
 

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -43,11 +43,11 @@ export namespace IngressSessionResolver {
 
   export function resolve(
     event: ResolvableEvent,
+    traceContext: TraceContextProtocol.Type,
     defaultModel: ModelConfig = {
       providerID: DEFAULT_DISPATCH_MODEL.provider,
       modelID: DEFAULT_DISPATCH_MODEL.id,
     },
-    traceContext?: TraceContextProtocol.Type,
   ): ResolveResult {
     const target = resolveTarget(event);
     let session: Session.Info;
@@ -71,12 +71,14 @@ export namespace IngressSessionResolver {
         session =
           parentSessionId && Session.get(parentSessionId)
             ? Session.createChild({
+                traceId: traceContext.traceId,
                 parentSessionId,
                 title: `Worker session from ${event.surface}`,
                 model: defaultModel,
                 workerMeta: { target: "worker", surface: event.surface },
               })
             : Session.create({
+                traceId: traceContext.traceId,
                 title: `Worker session from ${event.surface}`,
                 model: defaultModel,
               });
@@ -93,30 +95,32 @@ export namespace IngressSessionResolver {
         isNew = false;
       } else {
         const surfaceKey = extractSurfaceKey(event);
-        const resolved = resolveResidentSurfaceSession(surfaceKey, event.surface, defaultModel);
+        const resolved = resolveResidentSurfaceSession(
+          surfaceKey,
+          event.surface,
+          defaultModel,
+          traceContext.traceId,
+        );
         session = resolved.session;
         isNew = resolved.isNew;
       }
     }
 
-    if (traceContext) {
-      Bus.publish(IngressEvent.SessionResolved, {
-        traceId: traceContext.traceId,
-        sessionId: session.id,
-        isNew,
-        target: target.kind,
-        time: Date.now(),
-      });
-      return { session, isNew, trace: { ...traceContext, sessionId: session.id } };
-    }
-
-    return { session, isNew };
+    Bus.publish(IngressEvent.SessionResolved, {
+      traceId: traceContext.traceId,
+      sessionId: session.id,
+      isNew,
+      target: target.kind,
+      time: Date.now(),
+    });
+    return { session, isNew, trace: { ...traceContext, sessionId: session.id } };
   }
 
   function resolveResidentSurfaceSession(
     surfaceKey: string,
     surface: string,
     defaultModel: ModelConfig,
+    traceId: string,
   ): ResolveResult {
     let staleSessionId: string | undefined;
     let lastOwnerSessionId: string | undefined;
@@ -134,6 +138,7 @@ export namespace IngressSessionResolver {
       // Optimistically create a candidate and keep it only if the surface-key
       // claim succeeds; losing candidates are removed below.
       const candidate = Session.create({
+        traceId,
         title: `Session from ${surface}`,
         model: defaultModel,
       });
@@ -141,7 +146,7 @@ export namespace IngressSessionResolver {
       try {
         ownerSessionId = SurfaceKey.claim(surfaceKey, candidate.id, staleSessionId);
       } catch (err) {
-        Session.remove(candidate.id);
+        Session.remove(candidate.id, traceId);
         throw err;
       }
       lastOwnerSessionId = ownerSessionId;
@@ -149,7 +154,7 @@ export namespace IngressSessionResolver {
         return { session: candidate, isNew: true };
       }
 
-      Session.remove(candidate.id);
+      Session.remove(candidate.id, traceId);
       const owner = Session.get(ownerSessionId);
       if (owner) return { session: owner, isNew: false };
       staleSessionId = ownerSessionId;

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -23,10 +23,13 @@ interface ModelConfig {
   modelID: string;
 }
 
-interface ResolveResult {
+interface ResolvedSession {
   session: Session.Info;
   isNew: boolean;
-  trace?: TraceContextProtocol.Type;
+}
+
+interface ResolveResult extends ResolvedSession {
+  trace: TraceContextProtocol.Type;
 }
 
 export namespace IngressSessionResolver {
@@ -121,7 +124,7 @@ export namespace IngressSessionResolver {
     surface: string,
     defaultModel: ModelConfig,
     traceId: string,
-  ): ResolveResult {
+  ): ResolvedSession {
     let staleSessionId: string | undefined;
     let lastOwnerSessionId: string | undefined;
 

--- a/packages/openomni/test/dispatch/actor-cutover.test.ts
+++ b/packages/openomni/test/dispatch/actor-cutover.test.ts
@@ -54,6 +54,7 @@ function attemptIdentity(prompt: string) {
 describe("dispatch actor trustTier (#510 D2b)", () => {
   test("pin (d): a new run with attempt facts and no worker_run row derives assigned_worker", async () => {
     const session = Session.create({
+      traceId: "trace-test",
       title: "actor-cutover-new",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -92,6 +93,7 @@ describe("dispatch actor trustTier (#510 D2b)", () => {
 
   test("pin (d): a legacy frozen worker_run row still derives assigned_worker via upcast", () => {
     const session = Session.create({
+      traceId: "trace-test",
       title: "actor-cutover-legacy",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/openomni/test/dispatch/runtime-test-fixtures.ts
+++ b/packages/openomni/test/dispatch/runtime-test-fixtures.ts
@@ -15,6 +15,7 @@ export function resetDispatchTestState(): void {
 // satisfy the pending_interaction FK on worker_run_state).
 export async function createWorkerRunFixture(runId = "run-1", sessionTitle = `${runId}-session`) {
   const session = Session.create({
+    traceId: "trace-worker-run-fixture",
     title: sessionTitle,
     model: { providerID: "test", modelID: "test" },
   });

--- a/packages/openomni/test/dispatch/worker-spawn-gate.test.ts
+++ b/packages/openomni/test/dispatch/worker-spawn-gate.test.ts
@@ -187,6 +187,7 @@ describe("worker.spawn dispatch gate", () => {
 
   test("worker.spawn preserves parent session lineage when provided", async () => {
     const parent = Session.create({
+      traceId: "trace-worker-spawn-gate",
       title: "parent",
       model: { providerID: "test", modelID: "test" },
     });

--- a/packages/openomni/test/dispatch/worker-spawn-security.test.ts
+++ b/packages/openomni/test/dispatch/worker-spawn-security.test.ts
@@ -8,6 +8,7 @@ const TEST_DISPATCH_TRACE_ID = "trace-dispatch-test";
 
 function createSession(): string {
   return Session.create({
+    traceId: TEST_DISPATCH_TRACE_ID,
     title: "resident-session",
     model: { providerID: "test", modelID: "test" },
   }).id;

--- a/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
+++ b/packages/openomni/test/execution-runtime/injection-queue-policy.test.ts
@@ -162,6 +162,7 @@ describe("createInjectionQueueDrainPolicy", () => {
 
   it("persists only responses marked for history injection", async () => {
     const session = Session.create({
+      traceId: "trace-1",
       title: "Policy Test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -196,6 +197,7 @@ describe("createInjectionQueueDrainPolicy", () => {
   // seam must record the injected response as synthesized facts.
   it("resume keeps injected responses in a fact-bearing session, in recording order", async () => {
     const session = Session.create({
+      traceId: "trace-1",
       title: "Resume Merge",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -247,6 +249,7 @@ describe("createInjectionQueueDrainPolicy", () => {
 
   it("uses canonical run and session identifiers when trace context is absent", async () => {
     const session = Session.create({
+      traceId: "trace-1",
       title: "Legacy Context Policy Test",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/openomni/test/ingress/_kernel-routing-fixture.ts
+++ b/packages/openomni/test/ingress/_kernel-routing-fixture.ts
@@ -90,6 +90,7 @@ export function registerOwnerDm(): void {
 
 export function createMappedOwnerSession(): Session.Info {
   const session = Session.create({
+    traceId: "trace-test",
     title: "Owner DM",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/packages/openomni/test/ingress/engine.test.ts
+++ b/packages/openomni/test/ingress/engine.test.ts
@@ -130,6 +130,7 @@ describe("IngressEngine", () => {
   it("emits canonical target keys for worker ingress events", async () => {
     testState.responseQueue.push("worker response");
     const workerSession = Session.create({
+      traceId: "trace-test",
       title: "worker target key test",
       model: { providerID: "test", modelID: "fixture" },
     });

--- a/packages/openomni/test/ingress/event-projector.test.ts
+++ b/packages/openomni/test/ingress/event-projector.test.ts
@@ -11,6 +11,7 @@ describe("IngressEventProjector", () => {
     Storage.reset();
     Storage.initialize({ dbPath: ":memory:" });
     sessionId = Session.create({
+      traceId: "trace-test",
       title: "Test Session",
       model: { providerID: "anthropic", modelID: "claude-3-haiku" },
     }).id;

--- a/packages/openomni/test/ingress/handlers.test.ts
+++ b/packages/openomni/test/ingress/handlers.test.ts
@@ -40,6 +40,7 @@ afterAll(() => {
 
 function createSession(): string {
   return Session.create({
+    traceId: "trace-test",
     title: "Handlers Test Session",
     model: { providerID: "anthropic", modelID: "claude-3-haiku-20240307" },
   }).id;

--- a/packages/openomni/test/ingress/kernel-routing-waits.test.ts
+++ b/packages/openomni/test/ingress/kernel-routing-waits.test.ts
@@ -84,6 +84,7 @@ async function seedFrozenPending(
     });
   }
   const session = Session.create({
+    traceId: "trace-test",
     title: id,
     model: { providerID: "test", modelID: "test-model" },
   });
@@ -142,6 +143,7 @@ function createPendingAsk(
   originRunId: string | null = `run-${id}`,
 ): Communication.PendingAsk.Record {
   const session = Session.create({
+    traceId: "trace-test",
     title: sessionId,
     model: { providerID: "test", modelID: "test-model" },
   });
@@ -1020,6 +1022,7 @@ describe("IngressEngine durable wait routing", () => {
     overrides: Partial<Parameters<typeof WaitService.open>[0]> = {},
   ) {
     const session = Session.create({
+      traceId: "trace-test",
       title: id,
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -1287,6 +1290,7 @@ describe("IngressEngine durable wait routing", () => {
     registerResponder("actor-r2", "responder-2");
     registerResponder("actor-quorum-target", "quorum-target-1");
     const session = Session.create({
+      traceId: "trace-test",
       title: "wired-2-of-3",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/openomni/test/ingress/session-bridge.test.ts
+++ b/packages/openomni/test/ingress/session-bridge.test.ts
@@ -8,6 +8,7 @@ const TEST_MODEL = { provider: "anthropic", id: "claude-3-haiku" };
 
 function createTestSession(): string {
   return Session.create({
+    traceId: "trace-session-bridge",
     title: "Test Session",
     model: { providerID: "anthropic", modelID: "claude-3-haiku" },
   }).id;

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { SurfaceKey, Storage, Session } from "@openomni/session";
 import { IngressSessionResolver } from "../../src/ingress";
 
+/** resolve() with the test trace context; model stays on the resolver default unless given. */
+function resolveWithTrace(
+  event: Parameters<typeof IngressSessionResolver.resolve>[0],
+  model?: Parameters<typeof IngressSessionResolver.resolve>[2],
+) {
+  return IngressSessionResolver.resolve(event, { traceId: "trace-resolver-test" }, model);
+}
+
 describe("IngressSessionResolver", () => {
   beforeEach(() => {
     Storage.reset();
@@ -81,11 +89,12 @@ describe("IngressSessionResolver", () => {
   describe("resolve", () => {
     it("creates worker sessions as children when parent session is supplied", () => {
       const parent = Session.create({
+        traceId: "trace-resolver-test",
         title: "parent",
         model: { providerID: "test", modelID: "fixture" },
       });
 
-      const result = IngressSessionResolver.resolve({
+      const result = resolveWithTrace({
         surface: "resident-worker-tool",
         target: { kind: "worker", parentSessionId: parent.id },
       });
@@ -103,7 +112,7 @@ describe("IngressSessionResolver", () => {
         workspace: "team-a",
         channel: "C123",
       };
-      const result = IngressSessionResolver.resolve(event);
+      const result = resolveWithTrace(event);
 
       expect(result.isNew).toBe(true);
       expect(result.session.id).toBeDefined();
@@ -119,8 +128,8 @@ describe("IngressSessionResolver", () => {
         channel: "C123",
       };
 
-      const result1 = IngressSessionResolver.resolve(event);
-      const result2 = IngressSessionResolver.resolve(event);
+      const result1 = resolveWithTrace(event);
+      const result2 = resolveWithTrace(event);
 
       expect(result1.isNew).toBe(true);
       expect(result2.isNew).toBe(false);
@@ -135,6 +144,7 @@ describe("IngressSessionResolver", () => {
       };
       const key = IngressSessionResolver.extractSurfaceKey(event);
       const competing = Session.create({
+        traceId: "trace-resolver-test",
         title: "competing",
         model: { providerID: "test", modelID: "fixture" },
       });
@@ -148,7 +158,7 @@ describe("IngressSessionResolver", () => {
       };
 
       try {
-        const result = IngressSessionResolver.resolve(event);
+        const result = resolveWithTrace(event);
 
         expect(result.isNew).toBe(false);
         expect(result.session.id).toBe(competing.id);
@@ -173,7 +183,7 @@ describe("IngressSessionResolver", () => {
       };
 
       try {
-        expect(() => IngressSessionResolver.resolve(event)).toThrow("claim failed");
+        expect(() => resolveWithTrace(event)).toThrow("claim failed");
         expect(Session.list()).toEqual([]);
       } finally {
         surfaceKey.claim = originalClaim;
@@ -192,8 +202,8 @@ describe("IngressSessionResolver", () => {
         channel: "C456",
       };
 
-      const result1 = IngressSessionResolver.resolve(event1);
-      const result2 = IngressSessionResolver.resolve(event2);
+      const result1 = resolveWithTrace(event1);
+      const result2 = resolveWithTrace(event2);
 
       expect(result1.session.id).not.toBe(result2.session.id);
       expect(result1.isNew).toBe(true);
@@ -207,14 +217,14 @@ describe("IngressSessionResolver", () => {
       };
 
       // First resolve: creates new session
-      const result1 = IngressSessionResolver.resolve(event);
+      const result1 = resolveWithTrace(event);
       const sessionId1 = result1.session.id;
       expect(result1.isNew).toBe(true);
 
       // Delete the session
-      Session.remove(sessionId1);
+      Session.remove(sessionId1, "trace-resolver-test");
       // Second resolve: should create new session (stale key)
-      const result2 = IngressSessionResolver.resolve(event);
+      const result2 = resolveWithTrace(event);
       const sessionId2 = result2.session.id;
 
       expect(result2.isNew).toBe(true);
@@ -223,7 +233,7 @@ describe("IngressSessionResolver", () => {
 
     it("fails closed when worker target session is missing", () => {
       expect(() =>
-        IngressSessionResolver.resolve({
+        resolveWithTrace({
           surface: "internal",
           target: { kind: "worker", sessionId: "missing-session" },
         }),
@@ -240,7 +250,7 @@ describe("IngressSessionResolver", () => {
         modelID: "gpt-4",
       };
 
-      const result = IngressSessionResolver.resolve(event, customModel);
+      const result = resolveWithTrace(event, customModel);
 
       expect(result.session.model.providerID).toBe("openai");
       expect(result.session.model.modelID).toBe("gpt-4");

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { SurfaceKey, Storage, Session } from "@openomni/session";
+import { Bus } from "@openomni/telemetry";
 import { IngressSessionResolver } from "../../src/ingress";
 
 /** resolve() with the test trace context; model stays on the resolver default unless given. */
@@ -136,7 +137,7 @@ describe("IngressSessionResolver", () => {
       expect(result1.session.id).toBe(result2.session.id);
     });
 
-    it("returns a concurrent surface key owner instead of clobbering it", () => {
+    it("returns a concurrent surface key owner instead of clobbering it", async () => {
       const event = {
         surface: "slack",
         workspace: "team-a",
@@ -157,6 +158,10 @@ describe("IngressSessionResolver", () => {
         return originalClaim(claimKey, competing.id, expectedSessionId);
       };
 
+      const deleted: Array<{ traceId: string; id: string }> = [];
+      const unsub = Bus.subscribe(Session.Event.Deleted, (data) => {
+        deleted.push(data);
+      });
       try {
         const result = resolveWithTrace(event);
 
@@ -164,7 +169,14 @@ describe("IngressSessionResolver", () => {
         expect(result.session.id).toBe(competing.id);
         expect(SurfaceKey.lookup(key)).toBe(competing.id);
         expect(Session.list().map((session) => session.id)).toEqual([competing.id]);
+        // Pin (D11): the losing candidate's removal files under the inbound
+        // frame's trace — a wrong-but-nonempty id here would typecheck.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(deleted).toEqual([
+          { traceId: "trace-resolver-test", id: expect.not.stringMatching(competing.id) },
+        ]);
       } finally {
+        unsub();
         surfaceKey.claim = originalClaim;
       }
     });

--- a/packages/openomni/test/ingress/worker-run-cutover.test.ts
+++ b/packages/openomni/test/ingress/worker-run-cutover.test.ts
@@ -59,6 +59,7 @@ afterAll(() => {
 
 function createSession(): string {
   return Session.create({
+    traceId: "trace-test",
     title: "worker-run cutover",
     model: { providerID: "anthropic", modelID: "claude-3-haiku-20240307" },
   }).id;

--- a/packages/openomni/test/resident/runtime.test.ts
+++ b/packages/openomni/test/resident/runtime.test.ts
@@ -62,6 +62,7 @@ describe("ResidentRuntime", () => {
     });
 
     const session = Session.create({
+      traceId: "trace-test",
       title: "resident-runtime-test",
       model: { providerID: "test", modelID: "fixture" },
     });
@@ -102,6 +103,7 @@ describe("ResidentRuntime", () => {
     });
 
     const session = Session.create({
+      traceId: "trace-test",
       title: "resident-policy-plan-test",
       model: { providerID: "test", modelID: "fixture" },
     });

--- a/packages/session/src/session/events.ts
+++ b/packages/session/src/session/events.ts
@@ -3,13 +3,18 @@ import { BusEvent } from "@openomni/telemetry";
 import { SessionInfo } from "./info";
 
 export const Event = {
-  Created: BusEvent.define("session.created", z.object({ info: SessionInfo }), {
-    visibility: "internal",
-  }),
+  Created: BusEvent.define(
+    "session.created",
+    z.object({ traceId: z.string().min(1), info: SessionInfo }),
+    { visibility: "internal" },
+  ),
+  // Updated is ephemeral: dropped before persistence, so it carries no trace.
   Updated: BusEvent.define("session.updated", z.object({ info: SessionInfo }), {
     visibility: "ephemeral",
   }),
-  Deleted: BusEvent.define("session.deleted", z.object({ id: z.string() }), {
-    visibility: "internal",
-  }),
+  Deleted: BusEvent.define(
+    "session.deleted",
+    z.object({ traceId: z.string().min(1), id: z.string() }),
+    { visibility: "internal" },
+  ),
 };

--- a/packages/session/src/session/lifecycle.ts
+++ b/packages/session/src/session/lifecycle.ts
@@ -4,12 +4,14 @@ import { Storage } from "../storage/storage";
 import { Event } from "./events";
 
 type CreateInput = {
+  traceId: string;
   title: string;
   model: { providerID: string; modelID: string };
   ttlMs?: number;
 };
 
 type CreateChildInput = {
+  traceId: string;
   parentSessionId: string;
   title: string;
   model: { providerID: string; modelID: string };
@@ -37,7 +39,7 @@ export function create(input: CreateInput): SessionInfo {
   };
 
   Storage.getAdapter().session.set(id, session);
-  Bus.publish(Event.Created, { info: session });
+  Bus.publish(Event.Created, { traceId: input.traceId, info: session });
 
   return session;
 }
@@ -64,7 +66,7 @@ export function createChild(input: CreateChildInput): SessionInfo {
   };
 
   Storage.getAdapter().session.set(id, child);
-  Bus.publish(Event.Created, { info: child });
+  Bus.publish(Event.Created, { traceId: input.traceId, info: child });
 
   return child;
 }
@@ -100,12 +102,12 @@ export function list(): SessionInfo[] {
  * WaitService.sweepExpired; there is no periodic scheduler yet, so long-lived
  * processes re-sweep only on restart.
  */
-export function sweepExpired(now = Date.now()): SessionInfo[] {
+export function sweepExpired(traceId: string, now = Date.now()): SessionInfo[] {
   const expired = Storage.getAdapter()
     .session.list()
     .filter((session) => isExpired(session, now));
   for (const session of expired) {
-    remove(session.id);
+    remove(session.id, traceId);
   }
   return expired;
 }
@@ -141,7 +143,7 @@ export function update(id: string, input: UpdateInput): SessionInfo | undefined 
   return updated;
 }
 
-export function remove(id: string): boolean {
+export function remove(id: string, traceId: string): boolean {
   const adapter = Storage.getAdapter();
   const exists = adapter.session.get(id) !== undefined;
   if (exists) {
@@ -154,7 +156,7 @@ export function remove(id: string): boolean {
       adapter.message.remove(id, msg.id);
     }
     adapter.session.remove(id);
-    Bus.publish(Event.Deleted, { id });
+    Bus.publish(Event.Deleted, { traceId, id });
   }
   return exists;
 }
@@ -163,6 +165,6 @@ export async function suspend(id: string): Promise<boolean> {
   return get(id) !== undefined;
 }
 
-export async function abandon(id: string): Promise<boolean> {
-  return remove(id);
+export async function abandon(id: string, traceId: string): Promise<boolean> {
+  return remove(id, traceId);
 }

--- a/packages/session/test/bench/memory-regression.test.ts
+++ b/packages/session/test/bench/memory-regression.test.ts
@@ -75,6 +75,7 @@ function createMemoryStorage(): Storage.Adapter {
 
 function createSession(index: number): Session.Info {
   return Session.create({
+    traceId: "trace-memory-regression",
     title: `memory-regression-${index}`,
     model: { providerID: "test", modelID: "test-model" },
   });
@@ -91,7 +92,7 @@ describe("session memory regression", () => {
 
     for (let index = 0; index < 200; index += 1) {
       const session = createSession(index);
-      Session.remove(session.id);
+      Session.remove(session.id, "trace-memory-regression");
     }
 
     const final = measureRSS();
@@ -107,7 +108,10 @@ describe("session memory regression", () => {
         /* noop handler for leak test */
       });
       for (let eventIndex = 0; eventIndex < 10; eventIndex += 1) {
-        Bus.publish(Session.Event.Deleted, { id: `${index}-${eventIndex}` });
+        Bus.publish(Session.Event.Deleted, {
+          traceId: "trace-memory-regression",
+          id: `${index}-${eventIndex}`,
+        });
       }
       unsubscribe();
     }
@@ -122,7 +126,7 @@ describe("session memory regression", () => {
   test("storage adapter session CRUD does not leak", () => {
     const adapter = Storage.getAdapter();
     const warmupSession = createSession(0);
-    Session.remove(warmupSession.id);
+    Session.remove(warmupSession.id, "trace-memory-regression");
     const baseline = measureRSS();
 
     for (let index = 0; index < 500; index += 1) {

--- a/packages/session/test/bus-persistence/bus-persistence.test.ts
+++ b/packages/session/test/bus-persistence/bus-persistence.test.ts
@@ -49,6 +49,7 @@ async function waitForRows(expectedCount: number): Promise<BusEventRow[]> {
 
 function createSession(): ReturnType<typeof Session.create> {
   return Session.create({
+    traceId: "trace-bus-persistence",
     title: "bus persistence",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/packages/session/test/bus-persistence/hash-chain.test.ts
+++ b/packages/session/test/bus-persistence/hash-chain.test.ts
@@ -68,6 +68,7 @@ async function waitForRows(expectedCount: number): Promise<BusEventRow[]> {
 
 function createSession(): ReturnType<typeof Session.create> {
   return Session.create({
+    traceId: "trace-hash-chain",
     title: "hash chain test",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/packages/session/test/bus-persistence/scoped-emit-attribution.test.ts
+++ b/packages/session/test/bus-persistence/scoped-emit-attribution.test.ts
@@ -70,6 +70,7 @@ describe("scoped emit attribution", () => {
 
   test("declared identity is attributed; undeclared identity is dropped", async () => {
     const session = Session.create({
+      traceId: newTraceId(),
       title: "scoped emit",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/session/test/integration/observability.test.ts
+++ b/packages/session/test/integration/observability.test.ts
@@ -14,6 +14,7 @@ function db(): Database {
 
 function createSession(title = "test"): ReturnType<typeof Session.create> {
   return Session.create({
+    traceId: "trace-observability",
     title,
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/packages/session/test/pending-interaction/store.test.ts
+++ b/packages/session/test/pending-interaction/store.test.ts
@@ -19,6 +19,7 @@ const flushBus = () => new Promise<void>((resolve) => queueMicrotask(() => resol
 // adapter layer, exactly as pre-freeze rows persist on disk.
 async function createWorkerRun(runId: string): Promise<string> {
   const session = Session.create({
+    traceId: "trace-pending-interaction",
     title: `${runId}-session`,
     model: { providerID: "test", modelID: "test" },
   });

--- a/packages/session/test/session/events.test.ts
+++ b/packages/session/test/session/events.test.ts
@@ -60,6 +60,9 @@ describe("Session events carry the caller's trace (D11)", () => {
     expect(Session.Event.Created.schema.safeParse({ traceId: "", info }).success).toBe(false);
     expect(Session.Event.Created.schema.safeParse({ traceId: "trace-1", info }).success).toBe(true);
     expect(Session.Event.Deleted.schema.safeParse({ id: info.id }).success).toBe(false);
+    expect(Session.Event.Deleted.schema.safeParse({ traceId: "", id: info.id }).success).toBe(
+      false,
+    );
     expect(
       Session.Event.Deleted.schema.safeParse({ traceId: "trace-1", id: info.id }).success,
     ).toBe(true);

--- a/packages/session/test/session/events.test.ts
+++ b/packages/session/test/session/events.test.ts
@@ -1,0 +1,67 @@
+/// <reference types="bun" />
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Bus } from "@openomni/telemetry";
+import { Session } from "../../src/session";
+import { Storage } from "../../src/storage/storage";
+import "../../src/storage/initialize";
+
+/** Bus delivery is microtask-queued; flush before asserting on received events. */
+function flushBus(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("Session events carry the caller's trace (D11)", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  test("created and deleted inherit the input trace — no mint in the store", async () => {
+    const created: string[] = [];
+    const deleted: Array<{ traceId: string; id: string }> = [];
+    const unsubCreated = Bus.subscribe(Session.Event.Created, (data) => {
+      created.push(data.traceId);
+    });
+    const unsubDeleted = Bus.subscribe(Session.Event.Deleted, (data) => {
+      deleted.push(data);
+    });
+
+    const session = Session.create({
+      traceId: "trace-events-create",
+      title: "Events",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    const child = Session.createChild({
+      traceId: "trace-events-child",
+      parentSessionId: session.id,
+      title: "Child",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    Session.remove(child.id, "trace-events-remove");
+
+    await flushBus();
+    expect(created).toEqual(["trace-events-create", "trace-events-child"]);
+    expect(deleted).toEqual([{ traceId: "trace-events-remove", id: child.id }]);
+    unsubCreated();
+    unsubDeleted();
+  });
+
+  test("schemas refuse an untraced payload", () => {
+    // Enforcement is compile-time for typed producers; the schema states the
+    // invariant so any future strict consumer refuses. Updated stays traceless
+    // by design: it is ephemeral and never persists.
+    const info = Session.create({
+      traceId: "trace-events-schema",
+      title: "Schema",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    expect(Session.Event.Created.schema.safeParse({ info }).success).toBe(false);
+    expect(Session.Event.Created.schema.safeParse({ traceId: "", info }).success).toBe(false);
+    expect(Session.Event.Created.schema.safeParse({ traceId: "trace-1", info }).success).toBe(true);
+    expect(Session.Event.Deleted.schema.safeParse({ id: info.id }).success).toBe(false);
+    expect(
+      Session.Event.Deleted.schema.safeParse({ traceId: "trace-1", id: info.id }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/session/test/session/hydration.test.ts
+++ b/packages/session/test/session/hydration.test.ts
@@ -34,6 +34,7 @@ describe("Session.hydrateMessages", () => {
 
   test("hydrates messages with all parts", async () => {
     const session = Session.create({
+      traceId: "trace-hydration",
       title: "Hydration",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/session/test/session/lineage.test.ts
+++ b/packages/session/test/session/lineage.test.ts
@@ -11,11 +11,13 @@ describe("Session lineage APIs", () => {
 
   test("createChild links to parent and increments spawnDepth", () => {
     const parent = Session.create({
+      traceId: "trace-lineage",
       title: "Parent",
       model: { providerID: "test", modelID: "parent-model" },
     });
 
     const child = Session.createChild({
+      traceId: "trace-lineage",
       parentSessionId: parent.id,
       title: "Child",
       model: { providerID: "test", modelID: "child-model" },
@@ -29,17 +31,20 @@ describe("Session lineage APIs", () => {
 
   test("listChildren returns only direct children", () => {
     const parent = Session.create({
+      traceId: "trace-lineage",
       title: "Parent",
       model: { providerID: "test", modelID: "parent-model" },
     });
 
     const child = Session.createChild({
+      traceId: "trace-lineage",
       parentSessionId: parent.id,
       title: "Child",
       model: { providerID: "test", modelID: "child-model" },
     });
 
     const grandchild = Session.createChild({
+      traceId: "trace-lineage",
       parentSessionId: child.id,
       title: "Grandchild",
       model: { providerID: "test", modelID: "grandchild-model" },
@@ -52,17 +57,20 @@ describe("Session lineage APIs", () => {
 
   test("createChild increments spawnDepth from parent depth", () => {
     const root = Session.create({
+      traceId: "trace-lineage",
       title: "Root",
       model: { providerID: "test", modelID: "root-model" },
     });
 
     const child = Session.createChild({
+      traceId: "trace-lineage",
       parentSessionId: root.id,
       title: "Child",
       model: { providerID: "test", modelID: "child-model" },
     });
 
     const grandchild = Session.createChild({
+      traceId: "trace-lineage",
       parentSessionId: child.id,
       title: "Grandchild",
       model: { providerID: "test", modelID: "grandchild-model" },
@@ -75,11 +83,13 @@ describe("Session lineage APIs", () => {
 
   test("workerMeta round-trips through storage", () => {
     const parent = Session.create({
+      traceId: "trace-lineage",
       title: "Parent",
       model: { providerID: "test", modelID: "parent-model" },
     });
 
     const child = Session.createChild({
+      traceId: "trace-lineage",
       parentSessionId: parent.id,
       title: "Child",
       model: { providerID: "test", modelID: "child-model" },
@@ -105,6 +115,7 @@ describe("Session lineage APIs", () => {
   test("createChild rejects missing parents without creating a child", () => {
     expect(() =>
       Session.createChild({
+        traceId: "trace-lineage",
         parentSessionId: "missing-parent",
         title: "Orphan",
         model: { providerID: "test", modelID: "orphan-model" },

--- a/packages/session/test/session/message-status.test.ts
+++ b/packages/session/test/session/message-status.test.ts
@@ -56,6 +56,7 @@ describe("message status tracking", () => {
 
   test("addMessage without status defaults to 'completed'", () => {
     const session = Session.create({
+      traceId: "trace-message-status",
       title: "test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -68,6 +69,7 @@ describe("message status tracking", () => {
 
   test("addMessage with status 'received'", () => {
     const session = Session.create({
+      traceId: "trace-message-status",
       title: "test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -80,6 +82,7 @@ describe("message status tracking", () => {
 
   test("updateMessageStatus transitions through lifecycle", () => {
     const session = Session.create({
+      traceId: "trace-message-status",
       title: "test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -100,6 +103,7 @@ describe("message status tracking", () => {
     Storage.initialize({ dbPath: ":memory:" });
 
     const session = Session.create({
+      traceId: "trace-message-status",
       title: "test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -113,6 +117,7 @@ describe("message status tracking", () => {
 
   test("setStatus on adapter level", () => {
     const session = Session.create({
+      traceId: "trace-message-status",
       title: "test",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/session/test/session/metadata-hooks.test.ts
+++ b/packages/session/test/session/metadata-hooks.test.ts
@@ -65,6 +65,7 @@ describe("Session.addMessage metadata hooks", () => {
   describe("messageCount", () => {
     test("increments messageCount from undefined to 1 on first message", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -79,6 +80,7 @@ describe("Session.addMessage metadata hooks", () => {
 
     test("increments messageCount from 1 to 2 on second message", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -92,6 +94,7 @@ describe("Session.addMessage metadata hooks", () => {
 
     test("increments for both user and assistant messages", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -109,6 +112,7 @@ describe("Session.addMessage metadata hooks", () => {
   describe("tokens accumulation", () => {
     test("does NOT update tokens for user messages", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -121,6 +125,7 @@ describe("Session.addMessage metadata hooks", () => {
 
     test("accumulates tokens from assistant message when session has no initial tokens", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -137,6 +142,7 @@ describe("Session.addMessage metadata hooks", () => {
 
     test("accumulates tokens across multiple assistant messages", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -154,6 +160,7 @@ describe("Session.addMessage metadata hooks", () => {
 
     test("user messages between assistants do not affect tokens", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -174,6 +181,7 @@ describe("Session.addMessage metadata hooks", () => {
   describe("time.updated", () => {
     test("updates time.updated when message is added", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -194,6 +202,7 @@ describe("Session.addMessage metadata hooks", () => {
   describe("part updates", () => {
     test("publishes the owning session when adding a part", async () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Test",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -223,6 +232,7 @@ describe("Session.addMessage metadata hooks", () => {
 
     test("preserves other session fields when updating metadata", () => {
       const session = Session.create({
+        traceId: "trace-metadata-hooks",
         title: "Original Title",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 60000,

--- a/packages/session/test/session/pagination.test.ts
+++ b/packages/session/test/session/pagination.test.ts
@@ -23,6 +23,7 @@ describe("Session.listMessagesPage", () => {
 
   test("returns paged items with cursor and more flag", () => {
     const session = Session.create({
+      traceId: "trace-pagination",
       title: "Pagination",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -70,6 +71,7 @@ describe("Session.listMessagesPage", () => {
 
   test("returns empty page for empty session", () => {
     const session = Session.create({
+      traceId: "trace-pagination",
       title: "Empty",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/session/test/session/resume.test.ts
+++ b/packages/session/test/session/resume.test.ts
@@ -6,6 +6,7 @@ import "../../src/storage/initialize";
 
 function createSession() {
   return Session.create({
+    traceId: "trace-resume",
     title: "Resume",
     model: { providerID: "test", modelID: "test-model" },
   });
@@ -123,10 +124,10 @@ describe("Session resume and abandon APIs", () => {
     await expect(Session.suspend(session.id)).resolves.toBe(true);
     await expect(Session.suspend("missing-session")).resolves.toBe(false);
 
-    await expect(Session.abandon(session.id)).resolves.toBe(true);
+    await expect(Session.abandon(session.id, "trace-resume")).resolves.toBe(true);
     expect(Session.get(session.id)).toBeUndefined();
     expect(Session.getMessages(session.id)).toEqual([]);
     expect(Session.getParts(assistant.id)).toEqual([]);
-    await expect(Session.abandon(session.id)).resolves.toBe(false);
+    await expect(Session.abandon(session.id, "trace-resume")).resolves.toBe(false);
   });
 });

--- a/packages/session/test/session/transcript-store.test.ts
+++ b/packages/session/test/session/transcript-store.test.ts
@@ -51,6 +51,7 @@ function reopenStorage(): void {
 
 function createSession() {
   return Session.create({
+    traceId: "trace-transcript-store",
     title: "transcript",
     model: { providerID: "test", modelID: "test-model" },
   });

--- a/packages/session/test/storage/read-validation.test.ts
+++ b/packages/session/test/storage/read-validation.test.ts
@@ -42,7 +42,11 @@ function corruptRow(dbPath: string, table: string, id: string, data: string): vo
 }
 
 async function seedWorkerRun(runId: string): Promise<string> {
-  const session = Session.create({ title: runId, model: { providerID: "test", modelID: "test" } });
+  const session = Session.create({
+    traceId: "trace-read-validation",
+    title: runId,
+    model: { providerID: "test", modelID: "test" },
+  });
   const adapter = Storage.getAdapter().workerRunState;
   if (!adapter) throw new Error("workerRunState sub-adapter missing");
   adapter.create(session.id, {
@@ -160,6 +164,7 @@ describe("sqlite adapters fail closed on corrupt rows", () => {
 
   test("a corrupt message row rejects on read", () => {
     const session = Session.create({
+      traceId: "trace-read-validation",
       title: "s",
       model: { providerID: "test", modelID: "test" },
     });
@@ -173,6 +178,7 @@ describe("sqlite adapters fail closed on corrupt rows", () => {
 
   test("a corrupt part row rejects on read", () => {
     const session = Session.create({
+      traceId: "trace-read-validation",
       title: "s",
       model: { providerID: "test", modelID: "test" },
     });

--- a/packages/session/test/surface-key/persistence.test.ts
+++ b/packages/session/test/surface-key/persistence.test.ts
@@ -26,6 +26,7 @@ describe("SurfaceKey SQLite persistence", () => {
 
   test("persists across Storage re-init", () => {
     const session = Session.create({
+      traceId: "trace-surface-key",
       title: "persist-test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -38,6 +39,7 @@ describe("SurfaceKey SQLite persistence", () => {
 
   test("unregister removes from SQLite", () => {
     const session = Session.create({
+      traceId: "trace-surface-key",
       title: "unregister-test",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -52,10 +54,12 @@ describe("SurfaceKey SQLite persistence", () => {
 
   test("re-register updates session in SQLite", () => {
     const session1 = Session.create({
+      traceId: "trace-surface-key",
       title: "old-session",
       model: { providerID: "test", modelID: "test-model" },
     });
     const session2 = Session.create({
+      traceId: "trace-surface-key",
       title: "new-session",
       model: { providerID: "test", modelID: "test-model" },
     });

--- a/packages/session/test/ttl.test.ts
+++ b/packages/session/test/ttl.test.ts
@@ -20,6 +20,7 @@ describe("Session TTL", () => {
   describe("create with ttlMs", () => {
     test("should create session without expiresAt when ttlMs not provided", () => {
       const session = Session.create({
+        traceId: "trace-ttl-test",
         title: "Test Session",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -32,6 +33,7 @@ describe("Session TTL", () => {
       const beforeCreate = Date.now();
 
       const session = Session.create({
+        traceId: "trace-ttl-test",
         title: "Test Session",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs,
@@ -46,6 +48,7 @@ describe("Session TTL", () => {
   describe("get with expiry", () => {
     test("should return session when not expired", () => {
       const session = Session.create({
+        traceId: "trace-ttl-test",
         title: "Test Session",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 5000,
@@ -60,6 +63,7 @@ describe("Session TTL", () => {
       // Reads are pure: expiry filtering never writes. Deletion is the
       // explicit sweep's job (sweepExpired below).
       const session = Session.create({
+        traceId: "trace-ttl-test",
         title: "Test Session",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -1000,
@@ -83,6 +87,7 @@ describe("Session TTL", () => {
 
     test("should return session without expiresAt normally", () => {
       const session = Session.create({
+        traceId: "trace-ttl-test",
         title: "Test Session",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -96,12 +101,14 @@ describe("Session TTL", () => {
   describe("list with expiry", () => {
     test("should include non-expired sessions", () => {
       const session1 = Session.create({
+        traceId: "trace-ttl-test",
         title: "Session 1",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 5000,
       });
 
       const session2 = Session.create({
+        traceId: "trace-ttl-test",
         title: "Session 2",
         model: { providerID: "test", modelID: "test-model" },
       });
@@ -114,12 +121,14 @@ describe("Session TTL", () => {
 
     test("should exclude expired sessions WITHOUT deleting them", async () => {
       const expiredSession = Session.create({
+        traceId: "trace-ttl-test",
         title: "Expired Session",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -1000,
       });
 
       const activeSession = Session.create({
+        traceId: "trace-ttl-test",
         title: "Active Session",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 5000,
@@ -144,23 +153,27 @@ describe("Session TTL", () => {
 
     test("should handle mixed sessions correctly and stay stable across repeated reads", () => {
       const expired1 = Session.create({
+        traceId: "trace-ttl-test",
         title: "Expired 1",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -1000,
       });
 
       const active1 = Session.create({
+        traceId: "trace-ttl-test",
         title: "Active 1",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 5000,
       });
 
       const noExpiry = Session.create({
+        traceId: "trace-ttl-test",
         title: "No Expiry",
         model: { providerID: "test", modelID: "test-model" },
       });
 
       const expired2 = Session.create({
+        traceId: "trace-ttl-test",
         title: "Expired 2",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -2000,
@@ -187,30 +200,33 @@ describe("Session TTL", () => {
   describe("sweepExpired", () => {
     test("removes expired sessions and leaves the rest untouched", async () => {
       const expired = Session.create({
+        traceId: "trace-ttl-test",
         title: "Expired",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: -1000,
       });
       const active = Session.create({
+        traceId: "trace-ttl-test",
         title: "Active",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 5000,
       });
       const noExpiry = Session.create({
+        traceId: "trace-ttl-test",
         title: "No Expiry",
         model: { providerID: "test", modelID: "test-model" },
       });
 
-      const deleted: string[] = [];
+      const deleted: Array<{ traceId: string; id: string }> = [];
       const unsub = Bus.subscribe(Session.Event.Deleted, (data) => {
-        deleted.push(data.id);
+        deleted.push({ traceId: data.traceId, id: data.id });
       });
 
-      const swept = Session.sweepExpired();
+      const swept = Session.sweepExpired("trace-ttl-test");
 
       expect(swept.map((s) => s.id)).toEqual([expired.id]);
       await flushBus();
-      expect(deleted).toEqual([expired.id]);
+      expect(deleted).toEqual([{ traceId: "trace-ttl-test", id: expired.id }]);
       expect(Storage.getAdapter().session.get(expired.id)).toBeUndefined();
       expect(Storage.getAdapter().session.get(active.id)).toBeDefined();
       expect(Storage.getAdapter().session.get(noExpiry.id)).toBeDefined();
@@ -219,12 +235,13 @@ describe("Session TTL", () => {
 
     test("is a no-op when nothing is expired", () => {
       Session.create({
+        traceId: "trace-ttl-test",
         title: "Active",
         model: { providerID: "test", modelID: "test-model" },
         ttlMs: 5000,
       });
 
-      expect(Session.sweepExpired()).toEqual([]);
+      expect(Session.sweepExpired("trace-ttl-test")).toEqual([]);
       expect(Storage.getAdapter().session.list().length).toBe(1);
     });
   });

--- a/packages/session/test/work-item/integration.test.ts
+++ b/packages/session/test/work-item/integration.test.ts
@@ -87,6 +87,7 @@ describe("WorkItem integration", () => {
 
   test("persists WorkItem bus events through BusPersistence", async () => {
     const sessionId = Session.create({
+      traceId: "trace-work-item",
       title: "WorkItem pipeline",
       model: { providerID: "test", modelID: "test" },
     }).id;

--- a/packages/session/test/worker-grant/store.test.ts
+++ b/packages/session/test/worker-grant/store.test.ts
@@ -16,6 +16,7 @@ afterEach(() => {
 // adapter layer, exactly as pre-freeze rows persist on disk.
 async function createWorkerRun(runId: string, sessionId = `${runId}-session`): Promise<void> {
   const session = Session.create({
+    traceId: "trace-worker-grant",
     title: sessionId,
     model: { providerID: "test", modelID: "test" },
   });


### PR DESCRIPTION
## Summary

Trace batch 3 of the D11 structural remainder (#606; batch plan in docs/agent-core-rewrite.md).

`session.created` / `session.deleted` gain required `traceId` and the store inherits it from the caller — no mint anywhere in the path:

- `Session.create` / `Session.createChild` inputs gain required `traceId: string`; the Created publish carries it.
- `Session.remove(id, traceId)`, `Session.sweepExpired(traceId, now?)`, `Session.abandon(id, traceId)` — the Deleted publish carries the caller's trace (the boot recovery sweep passes its existing boot trace).
- `session.updated` stays traceless by design: it is `ephemeral` and dropped before persistence (noted in the schema).
- `SessionResolver.resolve` — `traceContext` tightens optional → **required** (the only production caller, the ingress engine, always passed it), and threads into the worker-branch creates, the resident surface-key candidate loop (`create` + both losing-candidate `remove`s), and the `SessionResolved` publish, whose now-dead `if (traceContext)` gate is deleted. Param order becomes `(event, traceContext, defaultModel?)` — the required param moves ahead of the defaulted one (`useDefaultParameterLast`).
- Dispatch handlers (`worker-spawn-payload`, `connector-endpoint-worker`) pass `command.traceId` into session creation.

Production result: every `session.created`/`session.deleted` ledger row now files under the ingress frame's or dispatch command's trace instead of `"untraced"`.

## Pins

- `packages/session/test/session/events.test.ts` (new): (1) created/createChild/remove publishes inherit the exact input traces — mutation-verified: re-minting in the store (`crypto.randomUUID()`) fails the pin; (2) schemas refuse absent AND empty `traceId` (enforcement is compile-time for typed producers; the schema states the invariant for future strict consumers).
- `packages/session/test/ttl.test.ts`: the sweep pin now asserts the Deleted event carries the sweep's trace end-to-end.

## Verification

- `tsc --noEmit` src+test: session, openomni, server — 0 errors
- `bun test` session+openomni+server: **1777 pass / 0 fail**
- `bun run lint`, `bun run lint:tools`: clean (snapshot untouched — event descriptors are not snapshot keys)

Test-fallout scope: 40 test/fixture files, literal per-file trace ids following each file's idiom; one assertion strengthened (ttl sweep), none weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads caller-provided trace through the session lifecycle. `session.created`/`session.deleted` now include a non-empty `traceId`, attributing rows to the ingress/dispatch frame instead of “untraced”.

- Pass a non-empty `traceId` to `Session.create({ traceId, ... })`, `Session.createChild({ traceId, ... })`, `Session.remove(id, traceId)`, `Session.abandon(id, traceId)`, and `Session.sweepExpired(traceId, now?)` in `@openomni/session`.
- Update resolver calls to `IngressSessionResolver.resolve(event, traceContext, defaultModel?)`; `traceContext` is required.

**Review notes**
- Event schemas: `session.created` and `session.deleted` carry `traceId`; `session.updated` stays ephemeral and traceless.
- Resolver threads `traceContext.traceId` into worker and resident-surface paths; losing candidate deletes use the inbound trace.
- `packages/openomni` dispatch handlers pass `command.traceId`; server recovery passes boot id into `Session.sweepExpired`.
- Tests pin trace propagation end-to-end, including the losing-candidate delete in the resident surface-key path.

<sup>Written for commit 254f4bb8cce0c607220e11b2e02e9be7fb358468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

