### PR TITLE
refactor(session): trace batch 4 — worker-grant events traceid (#606)

### DIFF
--- a/packages/openomni/src/dispatch/policy.ts
+++ b/packages/openomni/src/dispatch/policy.ts
@@ -102,7 +102,7 @@ export function createDefaultDispatchPolicy(): DispatchPolicyRegistration {
       }
 
       if (actor.kind === "worker" && action.startsWith("schedule.")) {
-        const granted = evaluateWorkerGrant(actor, action, target);
+        const granted = evaluateWorkerGrant(actor, action, target, requireDispatchTraceId(ctx));
         return decide(EffectiveAuthority.workerGrant(granted, "dispatch.worker.schedule.denied"));
       }
 
@@ -139,12 +139,12 @@ export function createDefaultDispatchPolicy(): DispatchPolicyRegistration {
       }
 
       if (actor.kind === "worker" && isWorkerScopedEgress(action)) {
-        const granted = evaluateWorkerGrant(actor, action, target);
+        const granted = evaluateWorkerGrant(actor, action, target, requireDispatchTraceId(ctx));
         return decide(EffectiveAuthority.workerGrant(granted, "dispatch.worker.scope.denied"));
       }
 
       if (actor.kind === "worker" && isExternalEgress(action)) {
-        const granted = evaluateWorkerGrant(actor, action, target);
+        const granted = evaluateWorkerGrant(actor, action, target, requireDispatchTraceId(ctx));
         return decide(EffectiveAuthority.workerGrant(granted, "dispatch.worker.external.denied"));
       }
 
@@ -208,13 +208,28 @@ function isWorkerScopedEgress(action: string): boolean {
   return action === "worker.send" || action === "worker.resume" || action === "worker.cancel";
 }
 
+// A missing trace here is a wiring bug: the runtime builds every dispatch
+// point's traceContext from the command. The policy is fail-closed, so the
+// throw surfaces as a deny plus a recorded middleware error — never a mint.
+function requireDispatchTraceId(ctx: {
+  readonly traceContext?: { readonly traceId?: string };
+}): string {
+  const traceId = ctx.traceContext?.traceId;
+  if (traceId === undefined || traceId.length === 0) {
+    throw new Error("worker grant evaluation requires the command trace context");
+  }
+  return traceId;
+}
+
 function evaluateWorkerGrant(
   actor: Dispatch.ActorContext,
   action: string,
   target: Dispatch.Target | undefined,
+  traceId: string,
 ): { allowed: boolean; reason: string } {
   if (!actor.workerRunId) return { allowed: false, reason: "worker_grant.worker_run.required" };
   return WorkerGrantStore.evaluate({
+    traceId,
     workerRunId: actor.workerRunId,
     action,
     sessionId: target?.sessionId ?? target?.parentSessionId ?? actor.sessionId,

--- a/packages/openomni/src/dispatch/policy.ts
+++ b/packages/openomni/src/dispatch/policy.ts
@@ -210,7 +210,9 @@ function isWorkerScopedEgress(action: string): boolean {
 
 // A missing trace here is a wiring bug: the runtime builds every dispatch
 // point's traceContext from the command. The policy is fail-closed, so the
-// throw surfaces as a deny plus a recorded middleware error — never a mint.
+// throw surfaces as an unconditional deny — never a mint. The middleware
+// error record is trace-gated: it files because the runtime also gives the
+// ENGINE the command trace (with neither trace, the engine denies silently).
 function requireDispatchTraceId(ctx: {
   readonly traceContext?: { readonly traceId?: string };
 }): string {

--- a/packages/openomni/test/dispatch/runtime-effective-authority.test.ts
+++ b/packages/openomni/test/dispatch/runtime-effective-authority.test.ts
@@ -141,13 +141,16 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-effective-worker-send",
-      workerRunId: "run-1",
-      allowedActions: ["worker.send"],
-      allowedSessionIds: ["child-session"],
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-effective-worker-send",
+        workerRunId: "run-1",
+        allowedActions: ["worker.send"],
+        allowedSessionIds: ["child-session"],
+        canCreateExternalTasks: false,
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const result = await runtime.submit(
       {

--- a/packages/openomni/test/dispatch/runtime-worker-authority.test.ts
+++ b/packages/openomni/test/dispatch/runtime-worker-authority.test.ts
@@ -40,13 +40,16 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-worker-spawn",
-      workerRunId: "run-1",
-      allowedActions: ["worker.spawn"],
-      allowedSessionIds: ["parent-session"],
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-worker-spawn",
+        workerRunId: "run-1",
+        allowedActions: ["worker.spawn"],
+        allowedSessionIds: ["parent-session"],
+        canCreateExternalTasks: false,
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const result = await runtime.submit(
       {
@@ -147,13 +150,16 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-worker-send",
-      workerRunId: "run-1",
-      allowedActions: ["worker.send"],
-      allowedSessionIds: ["child-session"],
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-worker-send",
+        workerRunId: "run-1",
+        allowedActions: ["worker.send"],
+        allowedSessionIds: ["child-session"],
+        canCreateExternalTasks: false,
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const allowed = await runtime.submit(
       {

--- a/packages/openomni/test/dispatch/runtime-worker-external-authority.test.ts
+++ b/packages/openomni/test/dispatch/runtime-worker-external-authority.test.ts
@@ -37,13 +37,16 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-api-ask",
-      workerRunId: "run-1",
-      allowedActions: ["api.ask"],
-      allowedEndpointIds: ["api:research"],
-      canCreateExternalTasks: true,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-api-ask",
+        workerRunId: "run-1",
+        allowedActions: ["api.ask"],
+        allowedEndpointIds: ["api:research"],
+        canCreateExternalTasks: true,
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const allowed = await runtime.submit(
       {
@@ -74,13 +77,16 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-empty-endpoints",
-      workerRunId: "run-1",
-      allowedActions: ["api.ask"],
-      allowedEndpointIds: [],
-      canCreateExternalTasks: true,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-empty-endpoints",
+        workerRunId: "run-1",
+        allowedActions: ["api.ask"],
+        allowedEndpointIds: [],
+        canCreateExternalTasks: true,
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const result = await runtime.submit(
       {
@@ -111,14 +117,17 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-manager-constrained",
-      workerRunId: "run-1",
-      allowedActions: ["external.ask"],
-      allowedEndpointIds: ["human:advisor"],
-      canCreateExternalTasks: true,
-      managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-manager-constrained",
+        workerRunId: "run-1",
+        allowedActions: ["external.ask"],
+        allowedEndpointIds: ["human:advisor"],
+        canCreateExternalTasks: true,
+        managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const result = await runtime.submit(
       {
@@ -148,14 +157,17 @@ describe("DispatchRuntime", () => {
 
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-manager-labels",
-      workerRunId: "run-1",
-      allowedActions: ["external.ask"],
-      allowedEndpointIds: ["human:advisor"],
-      canCreateExternalTasks: true,
-      managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-manager-labels",
+        workerRunId: "run-1",
+        allowedActions: ["external.ask"],
+        allowedEndpointIds: ["human:advisor"],
+        canCreateExternalTasks: true,
+        managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const result = await runtime.submit(
       {
@@ -184,13 +196,16 @@ describe("DispatchRuntime", () => {
     runtime.register("external.ask", () => ({ output: "should not route" }));
     Storage.initialize({ dbPath: ":memory:" });
     await createWorkerRunFixture("run-1");
-    WorkerGrantStore.create({
-      id: "grant-external-followup",
-      workerRunId: "run-1",
-      allowedActions: ["external.ask"],
-      allowedEndpointIds: ["human:advisor"],
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-external-followup",
+        workerRunId: "run-1",
+        allowedActions: ["external.ask"],
+        allowedEndpointIds: ["human:advisor"],
+        canCreateExternalTasks: false,
+      },
+      TEST_DISPATCH_TRACE_ID,
+    );
 
     const result = await runtime.submit(
       {

--- a/packages/protocol/src/communication/worker-grant.ts
+++ b/packages/protocol/src/communication/worker-grant.ts
@@ -51,6 +51,7 @@ export type Create = z.infer<typeof Create>;
 
 export const Evaluation = z
   .object({
+    traceId: z.string().min(1),
     workerRunId: z.string().min(1),
     action: z.string().min(1),
     sessionId: z.string().min(1).optional(),
@@ -74,6 +75,7 @@ export type EvaluationResult = z.infer<typeof EvaluationResult>;
 
 const EventBase = z.object({
   id: z.string().min(1),
+  traceId: z.string().min(1),
   workerRunId: z.string().min(1),
   status: Status,
   version: z.number().int().min(1),

--- a/packages/protocol/test/communication/schema.test.ts
+++ b/packages/protocol/test/communication/schema.test.ts
@@ -100,6 +100,51 @@ describe("Communication protocol schemas", () => {
     ).toBe(true);
   });
 
+  test("WorkerGrant events refuse an untraced payload", () => {
+    // Enforcement is compile-time for typed producers; the schema states the
+    // invariant so any future strict consumer refuses. All five events extend
+    // the one EventBase and none re-declares traceId.
+    const base = {
+      id: "grant-1",
+      workerRunId: "run-1",
+      status: "active",
+      version: 1,
+      time: 1,
+    };
+    expect(Communication.WorkerGrant.Events.Created.schema.safeParse(base).success).toBe(false);
+    expect(
+      Communication.WorkerGrant.Events.Created.schema.safeParse({ ...base, traceId: "" }).success,
+    ).toBe(false);
+    expect(
+      Communication.WorkerGrant.Events.Created.schema.safeParse({ ...base, traceId: "trace-1" })
+        .success,
+    ).toBe(true);
+    expect(
+      Communication.WorkerGrant.Events.Evaluated.schema.safeParse({
+        ...base,
+        allowed: true,
+        reason: "worker_grant.allowed",
+        action: "worker.send",
+      }).success,
+    ).toBe(false);
+    expect(
+      Communication.WorkerGrant.Events.Evaluated.schema.safeParse({
+        ...base,
+        traceId: "trace-1",
+        allowed: true,
+        reason: "worker_grant.allowed",
+        action: "worker.send",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      Communication.WorkerGrant.Evaluation.safeParse({
+        workerRunId: "run-1",
+        action: "worker.send",
+      }).success,
+    ).toBe(false);
+  });
+
   test("WorkerGrant defaults external task creation to false", () => {
     const parsed = Communication.WorkerGrant.Record.parse({
       id: "grant-1",

--- a/packages/session/src/worker-grant/index.ts
+++ b/packages/session/src/worker-grant/index.ts
@@ -12,9 +12,10 @@ function requireAdapter() {
   );
 }
 
-function eventBase(record: Communication.WorkerGrant.Record) {
+function eventBase(record: Communication.WorkerGrant.Record, traceId: string) {
   return {
     id: record.id,
+    traceId,
     workerRunId: record.workerRunId,
     status: record.status,
     version: record.version,
@@ -86,12 +87,13 @@ function evaluateRecord(
 export namespace WorkerGrantStore {
   export function create(
     input: Communication.WorkerGrant.Create,
+    traceId: string,
   ): Communication.WorkerGrant.Record {
     const adapter = requireAdapter();
     const record = createRecord(input);
     if (adapter.get(record.id)) throw new Error(`WorkerGrant already exists: ${record.id}`);
     adapter.create(record);
-    Bus.publish(Communication.WorkerGrant.Events.Created, eventBase(record));
+    Bus.publish(Communication.WorkerGrant.Events.Created, eventBase(record, traceId));
     return record;
   }
 
@@ -103,6 +105,7 @@ export namespace WorkerGrantStore {
     id: string,
     patch: Partial<Omit<Communication.WorkerGrant.Record, "id" | "workerRunId">>,
     event: "updated" | "revoked" | "expired",
+    traceId: string,
   ): Communication.WorkerGrant.Record {
     const adapter = requireAdapter();
     const current = adapter.get(id);
@@ -120,23 +123,26 @@ export namespace WorkerGrantStore {
         : event === "revoked"
           ? Communication.WorkerGrant.Events.Revoked
           : Communication.WorkerGrant.Events.Expired;
-    Bus.publish(descriptor, eventBase(updated));
+    Bus.publish(descriptor, eventBase(updated, traceId));
     return updated;
   }
 
-  export function revoke(id: string): Communication.WorkerGrant.Record {
-    return persistUpdate(id, { status: "revoked", revokedAt: Date.now() }, "revoked");
+  export function revoke(id: string, traceId: string): Communication.WorkerGrant.Record {
+    return persistUpdate(id, { status: "revoked", revokedAt: Date.now() }, "revoked", traceId);
   }
 
-  function expire(id: string): Communication.WorkerGrant.Record {
-    return persistUpdate(id, { status: "expired" }, "expired");
+  function expire(id: string, traceId: string): Communication.WorkerGrant.Record {
+    return persistUpdate(id, { status: "expired" }, "expired", traceId);
   }
 
-  export function cleanupExpired(workerRunId?: string): Communication.WorkerGrant.Record[] {
+  export function cleanupExpired(
+    traceId: string,
+    workerRunId?: string,
+  ): Communication.WorkerGrant.Record[] {
     return requireAdapter()
       .list(workerRunId)
       .filter((grant) => isPastExpiry(grant))
-      .map((grant) => expire(grant.id));
+      .map((grant) => expire(grant.id, traceId));
   }
 
   export function evaluate(
@@ -152,7 +158,7 @@ export namespace WorkerGrantStore {
     for (const grant of grants) {
       const result = evaluateRecord(grant, parsed);
       Bus.publish(Communication.WorkerGrant.Events.Evaluated, {
-        ...eventBase(grant),
+        ...eventBase(grant, parsed.traceId),
         allowed: result.allowed,
         reason: result.reason,
         action: parsed.action,

--- a/packages/session/test/storage/read-validation.test.ts
+++ b/packages/session/test/storage/read-validation.test.ts
@@ -135,12 +135,15 @@ describe("sqlite adapters fail closed on corrupt rows", () => {
 
   test("a corrupt worker_grant row rejects on read instead of reaching evaluate()", async () => {
     await seedWorkerRun("run-corrupt");
-    WorkerGrantStore.create({
-      id: "grant-corrupt",
-      workerRunId: "run-corrupt",
-      allowedActions: ["worker.send"],
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-corrupt",
+        workerRunId: "run-corrupt",
+        allowedActions: ["worker.send"],
+        canCreateExternalTasks: false,
+      },
+      "trace-read-validation",
+    );
 
     // Structurally-valid-looking but schema-invalid: missing id/workerRunId/
     // version/timestamps. Before the fix this row parses to an object that
@@ -154,7 +157,11 @@ describe("sqlite adapters fail closed on corrupt rows", () => {
 
     expect(() => WorkerGrantStore.get("grant-corrupt")).toThrow();
     expect(() =>
-      WorkerGrantStore.evaluate({ workerRunId: "run-corrupt", action: "worker.send" }),
+      WorkerGrantStore.evaluate({
+        traceId: "trace-read-validation",
+        workerRunId: "run-corrupt",
+        action: "worker.send",
+      }),
     ).toThrow();
   });
 

--- a/packages/session/test/worker-grant/store.test.ts
+++ b/packages/session/test/worker-grant/store.test.ts
@@ -176,7 +176,13 @@ describe("WorkerGrantStore", () => {
   test("evaluation stays read-only for past-expiry active grants; cleanup emits expiration", async () => {
     await createWorkerRun("run-expired");
     const events: string[] = [];
-    Bus.observe((event) => events.push(event.name));
+    const expired: Array<{ name: string; traceId: unknown }> = [];
+    Bus.observe((event, data) => {
+      events.push(event.name);
+      if (event.name === "worker_grant.expired") {
+        expired.push({ name: event.name, traceId: (data as { traceId?: string }).traceId });
+      }
+    });
     WorkerGrantStore.create(
       {
         id: "grant-expired",
@@ -200,10 +206,13 @@ describe("WorkerGrantStore", () => {
 
     expect(WorkerGrantStore.get("grant-expired")?.status).toBe("active");
 
-    WorkerGrantStore.cleanupExpired("trace-grant-test", "run-expired");
+    WorkerGrantStore.cleanupExpired("trace-cleanup", "run-expired");
     expect(WorkerGrantStore.get("grant-expired")?.status).toBe("expired");
     await new Promise((resolve) => queueMicrotask(resolve));
-    expect(events).toContain("worker_grant.expired");
+    // Pin (D11): (traceId, workerRunId?) is swap-prone — both are strings and
+    // the old signature was (workerRunId?). Asserting the exact trace catches
+    // a stale-style cleanupExpired(runId) call that stamps the runId as trace.
+    expect(expired).toEqual([{ name: "worker_grant.expired", traceId: "trace-cleanup" }]);
     expect(events.filter((event) => event === "worker_grant.updated")).toHaveLength(0);
   });
 

--- a/packages/session/test/worker-grant/store.test.ts
+++ b/packages/session/test/worker-grant/store.test.ts
@@ -34,26 +34,31 @@ async function createWorkerRun(runId: string, sessionId = `${runId}-session`): P
 describe("WorkerGrantStore", () => {
   test("evaluates active matching grants and denies revoked grants", async () => {
     await createWorkerRun("run-1");
-    WorkerGrantStore.create({
-      id: "grant-1",
-      workerRunId: "run-1",
-      allowedActions: ["worker.send"],
-      allowedSessionIds: ["session-1"],
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-1",
+        workerRunId: "run-1",
+        allowedActions: ["worker.send"],
+        allowedSessionIds: ["session-1"],
+        canCreateExternalTasks: false,
+      },
+      "trace-grant-test",
+    );
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-1",
         action: "worker.send",
         sessionId: "session-1",
       }),
     ).toMatchObject({ allowed: true, grantId: "grant-1" });
 
-    WorkerGrantStore.revoke("grant-1");
+    WorkerGrantStore.revoke("grant-1", "trace-grant-test");
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-1",
         action: "worker.send",
         sessionId: "session-1",
@@ -63,16 +68,20 @@ describe("WorkerGrantStore", () => {
 
   test("requires explicit manager grant for new external tasks", async () => {
     await createWorkerRun("run-2");
-    WorkerGrantStore.create({
-      id: "grant-2",
-      workerRunId: "run-2",
-      allowedActions: ["external.ask"],
-      canCreateExternalTasks: true,
-      managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-2",
+        workerRunId: "run-2",
+        allowedActions: ["external.ask"],
+        canCreateExternalTasks: true,
+        managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
+      },
+      "trace-grant-test",
+    );
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-2",
         action: "external.ask",
         createsExternalTask: true,
@@ -83,6 +92,7 @@ describe("WorkerGrantStore", () => {
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-2",
         action: "external.ask",
         createsExternalTask: true,
@@ -93,6 +103,7 @@ describe("WorkerGrantStore", () => {
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-2",
         action: "external.ask",
         createsExternalTask: true,
@@ -103,6 +114,7 @@ describe("WorkerGrantStore", () => {
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-2",
         action: "external.ask",
         createsExternalTask: true,
@@ -114,16 +126,20 @@ describe("WorkerGrantStore", () => {
 
   test("treats explicit empty scope lists as deny-all", async () => {
     await createWorkerRun("run-empty");
-    WorkerGrantStore.create({
-      id: "grant-empty-endpoints",
-      workerRunId: "run-empty",
-      allowedActions: ["api.ask"],
-      allowedEndpointIds: [],
-      canCreateExternalTasks: true,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-empty-endpoints",
+        workerRunId: "run-empty",
+        allowedActions: ["api.ask"],
+        allowedEndpointIds: [],
+        canCreateExternalTasks: true,
+      },
+      "trace-grant-test",
+    );
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-empty",
         action: "api.ask",
         endpointId: "api:any",
@@ -134,17 +150,21 @@ describe("WorkerGrantStore", () => {
 
   test("manager constraints fail closed when evaluation omits required context", async () => {
     await createWorkerRun("run-manager");
-    WorkerGrantStore.create({
-      id: "grant-manager-context",
-      workerRunId: "run-manager",
-      allowedActions: ["external.ask"],
-      allowedEndpointIds: ["human:advisor"],
-      canCreateExternalTasks: true,
-      managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-manager-context",
+        workerRunId: "run-manager",
+        allowedActions: ["external.ask"],
+        allowedEndpointIds: ["human:advisor"],
+        canCreateExternalTasks: true,
+        managerGrant: { allowedActorGroups: ["design"], riskCeiling: "low" },
+      },
+      "trace-grant-test",
+    );
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-manager",
         action: "external.ask",
         endpointId: "human:advisor",
@@ -157,17 +177,21 @@ describe("WorkerGrantStore", () => {
     await createWorkerRun("run-expired");
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
-    WorkerGrantStore.create({
-      id: "grant-expired",
-      workerRunId: "run-expired",
-      allowedActions: ["worker.send"],
-      allowedSessionIds: ["session-1"],
-      expiresAt: Date.now() - 1,
-      canCreateExternalTasks: false,
-    });
+    WorkerGrantStore.create(
+      {
+        id: "grant-expired",
+        workerRunId: "run-expired",
+        allowedActions: ["worker.send"],
+        allowedSessionIds: ["session-1"],
+        expiresAt: Date.now() - 1,
+        canCreateExternalTasks: false,
+      },
+      "trace-grant-test",
+    );
 
     expect(
       WorkerGrantStore.evaluate({
+        traceId: "trace-grant-test",
         workerRunId: "run-expired",
         action: "worker.send",
         sessionId: "session-1",
@@ -176,21 +200,57 @@ describe("WorkerGrantStore", () => {
 
     expect(WorkerGrantStore.get("grant-expired")?.status).toBe("active");
 
-    WorkerGrantStore.cleanupExpired("run-expired");
+    WorkerGrantStore.cleanupExpired("trace-grant-test", "run-expired");
     expect(WorkerGrantStore.get("grant-expired")?.status).toBe("expired");
     await new Promise((resolve) => queueMicrotask(resolve));
     expect(events).toContain("worker_grant.expired");
     expect(events.filter((event) => event === "worker_grant.updated")).toHaveLength(0);
   });
 
+  test("every grant event inherits the caller's trace — no mint in the store (D11)", async () => {
+    await createWorkerRun("run-trace");
+    const traced: Array<{ name: string; traceId: unknown }> = [];
+    Bus.observe((event, data) => {
+      if (event.name.startsWith("worker_grant.")) {
+        traced.push({ name: event.name, traceId: (data as { traceId?: string }).traceId });
+      }
+    });
+
+    WorkerGrantStore.create(
+      {
+        id: "grant-trace",
+        workerRunId: "run-trace",
+        allowedActions: ["worker.send"],
+        canCreateExternalTasks: false,
+      },
+      "trace-create",
+    );
+    WorkerGrantStore.evaluate({
+      traceId: "trace-evaluate",
+      workerRunId: "run-trace",
+      action: "worker.send",
+    });
+    WorkerGrantStore.revoke("grant-trace", "trace-revoke");
+
+    await new Promise((resolve) => queueMicrotask(resolve));
+    expect(traced).toEqual([
+      { name: "worker_grant.created", traceId: "trace-create" },
+      { name: "worker_grant.evaluated", traceId: "trace-evaluate" },
+      { name: "worker_grant.revoked", traceId: "trace-revoke" },
+    ]);
+  });
+
   test("stale direct adapter writes cannot reactivate a revoked grant", async () => {
     await createWorkerRun("run-stale");
-    const created = WorkerGrantStore.create({
-      id: "grant-stale",
-      workerRunId: "run-stale",
-      allowedActions: ["worker.send"],
-      canCreateExternalTasks: false,
-    });
+    const created = WorkerGrantStore.create(
+      {
+        id: "grant-stale",
+        workerRunId: "run-stale",
+        allowedActions: ["worker.send"],
+        canCreateExternalTasks: false,
+      },
+      "trace-grant-test",
+    );
     const staleConcurrentUpdate = {
       ...created,
       status: "active" as const,
@@ -198,7 +258,7 @@ describe("WorkerGrantStore", () => {
       updatedAt: Date.now() + 60_000,
     };
 
-    WorkerGrantStore.revoke("grant-stale");
+    WorkerGrantStore.revoke("grant-stale", "trace-grant-test");
     Storage.get().workerGrant?.set(staleConcurrentUpdate);
 
     expect(WorkerGrantStore.get("grant-stale")).toMatchObject({


### PR DESCRIPTION
## Summary

Trace batch 4 of the D11 structural remainder (#606; batch plan in docs/agent-core-rewrite.md).

WorkerGrant's five events gain required `traceId`, inherited from the caller — this includes `worker_grant.evaluated`, which fires once **per grant row scanned** on every worker-actor dispatch decision and was the highest-volume producer of `"untraced"` ledger rows.

- `Communication.WorkerGrant.Evaluation` gains required `traceId` — the evaluated publish carries the evaluation request's trace.
- `Communication.WorkerGrant.Events` base gains required `traceId` (Created/Updated/Revoked/Expired/Evaluated).
- `WorkerGrantStore`: `create(input, traceId)`, `revoke(id, traceId)`, `cleanupExpired(traceId, workerRunId?)`; `eventBase(record, traceId)`; `persistUpdate` threads it.
- The one live production caller — the dispatch default-authority policy — passes the command's trace: `evaluateWorkerGrant(actor, action, target, requireDispatchTraceId(ctx))`. A missing `ctx.traceContext` is a wiring bug (the runtime builds it from the command on every dispatch point), so the helper throws; the policy is **fail-closed**, so that surfaces as a deny plus a recorded middleware error — never a mint. `create`/`revoke`/`cleanupExpired` have no production callers today (test fixtures only).

## Pins

- `packages/session/test/worker-grant/store.test.ts` — "every grant event inherits the caller's trace": created/evaluated/revoked publishes carry the exact per-call traces. Mutation-verified: re-minting the evaluated trace in the store fails the pin (6/1), restored green (7/0).
- `packages/protocol/test/communication/schema.test.ts` — WorkerGrant events refuse absent AND empty `traceId`; `Evaluation` refuses an untraced request. (Enforcement is compile-time for typed producers; the schema states the invariant for future strict consumers.)

## Verification

- `tsc --noEmit` src+test: protocol, session, openomni, server — 0 errors
- `bun test` session+openomni+protocol: **1802 pass / 0 fail**
- `bun run lint`, `bun run lint:tools`: clean (snapshot untouched — event descriptors are not snapshot keys; `Evaluation` is also not a snapshot key, verified by lint:tools passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a non-empty traceId on all WorkerGrant events and evaluations, threaded from the caller. Previously publishes could be untraced; now every publish carries the caller’s trace, and a missing dispatch trace fails closed (deny, no mint). Also updates cleanupExpired to take (traceId, workerRunId?) and enforces dispatch traces via a new requireDispatchTraceId helper.

- Protocol: `Communication.WorkerGrant.Events` and `Communication.WorkerGrant.Evaluation` require `traceId` (`packages/protocol`).
- Store: `WorkerGrantStore.create(input, traceId)`, `revoke(id, traceId)`, `cleanupExpired(traceId, workerRunId?)`; `evaluate({ traceId, ... })` publishes `Evaluated` with the request trace; `eventBase`/`persistUpdate` thread it (`packages/session`).
- Dispatch: Default policy passes the command trace via `requireDispatchTraceId(ctx)` to `evaluateWorkerGrant(...)`; missing `ctx.traceContext.traceId` throws and yields a deny with a recorded middleware error (`packages/openomni`).
- Tests: Updated to pass a dispatch trace; pins that `cleanupExpired` uses the provided trace and that every grant event inherits the caller’s trace.

**Migration**
- Update all `WorkerGrantStore.create(...)`, `revoke(...)`, and `cleanupExpired(...)` calls to pass a `traceId` (new order: `cleanupExpired(traceId, workerRunId?)`).
- Ensure all `WorkerGrantStore.evaluate(...)` calls include `traceId`.
- From dispatch, pass the command trace to `evaluateWorkerGrant(...)` and ensure `ctx.traceContext.traceId` is set.
- Align producers with `packages/protocol` schemas: WorkerGrant event payloads and evaluation requests must include `traceId`.

<sup>Written for commit 2dffddb886785e21d8f665add106910c101b15fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

