### PR TITLE
refactor(openomni): trace batch 5 — sync-ask audit traceid (#606)

### DIFF
--- a/apps/server/test/bootstrap/dispatch-owners.test.ts
+++ b/apps/server/test/bootstrap/dispatch-owners.test.ts
@@ -263,11 +263,12 @@ describe("createServerDispatchOwners", () => {
 
   test("routes connector question bridge requests through resident.ask", async () => {
     const eventNames: string[] = [];
-    const syncAskPhases: string[] = [];
+    const syncAsks: Array<{ phase: string; traceId: string }> = [];
     const unsubscribe = Bus.observe((event, payload) => {
       if (event.name.startsWith("dispatch.")) eventNames.push(event.name);
       if (event.name === Wait.Events.SyncAsk.name) {
-        syncAskPhases.push(Wait.Events.SyncAsk.schema.parse(payload).phase);
+        const parsed = Wait.Events.SyncAsk.schema.parse(payload);
+        syncAsks.push({ phase: parsed.phase, traceId: parsed.traceId });
       }
     });
     const residentCalls: ResidentRuntimeCall[] = [];
@@ -342,7 +343,12 @@ describe("createServerDispatchOwners", () => {
       expect(eventNames).toContain(DispatchProtocol.Events.Completed.name);
       // The synchronous resident.ask path records wait.sync_ask audit events
       // only and writes no PendingAsk row (#215 owner decision 2).
-      expect(syncAskPhases).toEqual(["opened", "answered"]);
+      // Pin (D11): the nested resident.ask inherits the worker run's trace —
+      // the handler passthrough is value-asserted, not just type-checked.
+      expect(syncAsks).toEqual([
+        { phase: "opened", traceId: "trace_fake" },
+        { phase: "answered", traceId: "trace_fake" },
+      ]);
       expect(PendingAskStore.list()).toHaveLength(0);
     } finally {
       unsubscribe();

--- a/packages/openomni/src/dispatch/handlers/resident.ts
+++ b/packages/openomni/src/dispatch/handlers/resident.ts
@@ -81,6 +81,7 @@ function auditSyncAsk(
 ): void {
   WaitService.auditSyncAsk({
     dispatchId: command.dispatchId,
+    traceId: command.traceId,
     sessionId: command.actor.sessionId ?? command.sessionId ?? fallbackSessionId,
     phase,
   });

--- a/packages/openomni/src/wait/lifecycle.ts
+++ b/packages/openomni/src/wait/lifecycle.ts
@@ -91,6 +91,7 @@ export namespace WaitService {
    */
   export function auditSyncAsk(input: {
     dispatchId: string;
+    traceId: string;
     sessionId: string;
     phase: "opened" | "answered" | "failed";
   }): void {

--- a/packages/openomni/test/wait/lifecycle.test.ts
+++ b/packages/openomni/test/wait/lifecycle.test.ts
@@ -197,7 +197,8 @@ describe("WaitService", () => {
     });
 
     await flushBus();
-    // Pin (D11): both audit events inherit the dispatch command's trace.
+    // Pin (D11): the service publishes exactly the caller's trace (the
+    // handler-level passthrough is pinned in dispatch-owners.test.ts).
     expect(seen.map((event) => event.phase)).toEqual(["opened", "answered"]);
     expect(seen.every((event) => event.traceId === "trace-sync-ask")).toBe(true);
     expect(WaitStore.list()).toHaveLength(0);

--- a/packages/openomni/test/wait/lifecycle.test.ts
+++ b/packages/openomni/test/wait/lifecycle.test.ts
@@ -177,17 +177,38 @@ describe("WaitService", () => {
   });
 
   test("auditSyncAsk publishes the audit event and never writes a Wait row", async () => {
-    const phases: string[] = [];
+    const seen: Array<{ phase: string; traceId: string }> = [];
     Bus.observe((event, payload) => {
       if (event.name !== "wait.sync_ask") return;
-      phases.push((payload as { phase: string }).phase);
+      seen.push(payload as { phase: string; traceId: string });
     });
 
-    WaitService.auditSyncAsk({ dispatchId: "dispatch-1", sessionId: "ses-1", phase: "opened" });
-    WaitService.auditSyncAsk({ dispatchId: "dispatch-1", sessionId: "ses-1", phase: "answered" });
+    WaitService.auditSyncAsk({
+      dispatchId: "dispatch-1",
+      traceId: "trace-sync-ask",
+      sessionId: "ses-1",
+      phase: "opened",
+    });
+    WaitService.auditSyncAsk({
+      dispatchId: "dispatch-1",
+      traceId: "trace-sync-ask",
+      sessionId: "ses-1",
+      phase: "answered",
+    });
 
     await flushBus();
-    expect(phases).toEqual(["opened", "answered"]);
+    // Pin (D11): both audit events inherit the dispatch command's trace.
+    expect(seen.map((event) => event.phase)).toEqual(["opened", "answered"]);
+    expect(seen.every((event) => event.traceId === "trace-sync-ask")).toBe(true);
     expect(WaitStore.list()).toHaveLength(0);
+  });
+
+  test("wait.sync_ask refuses an untraced payload", () => {
+    const base = { dispatchId: "dispatch-1", sessionId: "ses-1", phase: "opened", time: 1 };
+    expect(Wait.Events.SyncAsk.schema.safeParse(base).success).toBe(false);
+    expect(Wait.Events.SyncAsk.schema.safeParse({ ...base, traceId: "" }).success).toBe(false);
+    expect(Wait.Events.SyncAsk.schema.safeParse({ ...base, traceId: "trace-1" }).success).toBe(
+      true,
+    );
   });
 });

--- a/packages/protocol/src/wait/events.ts
+++ b/packages/protocol/src/wait/events.ts
@@ -50,6 +50,7 @@ export const Events = {
     "wait.sync_ask",
     z.object({
       dispatchId: z.string().min(1),
+      traceId: z.string().min(1),
       sessionId: z.string().min(1),
       phase: z.enum(["opened", "answered", "failed"]),
       time: z.number(),


### PR DESCRIPTION
## Summary

Trace batch 5 of the D11 structural remainder (#606; batch plan in docs/agent-core-rewrite.md). Smallest batch: one definition, one producer, one caller.

`wait.sync_ask` — the audit trail for the synchronous in-process `resident.ask` path (#215 owner decision 2, the only trace that path leaves) — gains required `traceId`:

- `Wait.Events.SyncAsk` schema + required `traceId: z.string().min(1)`.
- `WaitService.auditSyncAsk` input gains required `traceId`.
- The single production caller, the resident dispatch handler's `auditSyncAsk`, passes `command.traceId` — so all three phases (opened/answered/failed) of one ask now file under the dispatch command's trace.

## Pins

`packages/openomni/test/wait/lifecycle.test.ts`:
- The existing sync-ask test now asserts both phases inherit the exact input trace. Mutation-verified: re-minting in the publish (`crypto.randomUUID()`) fails it (7/1), restored green (8/0).
- New schema pin: absent AND empty `traceId` refused, non-empty accepted.

## Verification

- `tsc --noEmit` src+test: protocol, openomni, server — 0 errors
- `bun test packages/openomni/test/wait`: 8 pass / 0 fail
- `bun run lint`, `bun run lint:tools`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds required trace correlation to `wait.sync_ask` audits for the synchronous `resident.ask` path to meet #606. Previously events had no trace; now they require a non-empty `traceId`, and the resident dispatch handler forwards `command.traceId` so all phases share the dispatch trace.

- `packages/protocol` updates `Wait.Events.SyncAsk` schema to require `traceId`; rejects missing or empty values.
- `packages/openomni` updates `WaitService.auditSyncAsk` to require `traceId`; the resident dispatch handler passes `command.traceId`.
- Tests in `packages/openomni/test/wait/lifecycle.test.ts` and `apps/server/test/bootstrap/dispatch-owners.test.ts` pin trace passthrough end-to-end and assert no `Wait`/`PendingAsk` rows are written.

**Migration**
- Producers of `wait.sync_ask` must provide a non-empty `traceId` to `WaitService.auditSyncAsk`.

<sup>Written for commit f276911965ce03cc1114bfa6b95f803eafe7221f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronous ask events now consistently retain their trace ID across opened and answered phases.
  * Added validation to reject events with missing or empty trace IDs.
  * Improved event tracking without creating unnecessary wait records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->