### PR TITLE
refactor(session): trace batch 6 — wait and messaging traceid (#606)

### DIFF
--- a/apps/server/test/bootstrap/messaging.test.ts
+++ b/apps/server/test/bootstrap/messaging.test.ts
@@ -47,6 +47,7 @@ describe("server messaging bootstrap wiring", () => {
       operation: "fire_and_forget",
       body: "should never leave the process",
       at: now,
+      traceId: "trace-test",
     });
 
     expect(receipt.kind).toBe("denied");
@@ -81,6 +82,7 @@ describe("server messaging bootstrap wiring", () => {
       operation: "awaited",
       body: "please confirm",
       at: now,
+      traceId: "trace-test",
       waitSpec: {
         waitId: "wait:server-awaited",
         ownerRef: { kind: "session", id: "session:owner" },
@@ -124,6 +126,7 @@ describe("server messaging bootstrap wiring", () => {
         operation: "fire_and_forget",
         body: "no surface delivers this channel",
         at: now,
+        traceId: "trace-test",
       }),
     ).rejects.toThrow("no registered channel surface delivers github");
   });

--- a/apps/server/test/bootstrap/recovery.test.ts
+++ b/apps/server/test/bootstrap/recovery.test.ts
@@ -199,8 +199,8 @@ describe("server recovery", () => {
       expiresAt: Date.now() - 1,
       followUpWindow: 1_000,
     });
-    WaitService.open(buildWaitCreate("wait-boot-corrupt"));
-    WaitService.open(buildWaitCreate("wait-boot-healthy"));
+    WaitService.open(buildWaitCreate("wait-boot-corrupt"), "trace-corrupt-wait");
+    WaitService.open(buildWaitCreate("wait-boot-healthy"), "trace-corrupt-wait");
     // Corrupt one wait's owner stream: an extra fact advances the head past
     // the projected revision, so its expiry transition conflicts forever.
     const appended = Storage.getAdapter().ledger?.append(

--- a/packages/openomni/src/ingress/routing-execution.ts
+++ b/packages/openomni/src/ingress/routing-execution.ts
@@ -256,15 +256,19 @@ export async function executeWaitRoute<Event extends Ingress.InboundEvent>(
       // (duplicate / late / unknown / ambiguous / attach / resolve) and the
       // store persists the outcome before the owner session sees the reply.
       const at = Date.now();
-      const outcome = WaitService.attachReply(wait.record.id, {
-        replyKey: resolution.event.id,
-        responderCandidates: responderCandidates(
-          targetsOfWait(wait.record),
-          ingressEvidence(resolution.event, wait.correlation),
-        ),
-        messageId: resolution.event.id,
-        at,
-      });
+      const outcome = WaitService.attachReply(
+        wait.record.id,
+        {
+          replyKey: resolution.event.id,
+          responderCandidates: responderCandidates(
+            targetsOfWait(wait.record),
+            ingressEvidence(resolution.event, wait.correlation),
+          ),
+          messageId: resolution.event.id,
+          at,
+        },
+        trace.traceId,
+      );
       if (outcome.kind === "rejected") {
         if (outcome.code === "deadline_passed") {
           // Lazy expiry: this late reply is the first observer of the passed
@@ -275,7 +279,7 @@ export async function executeWaitRoute<Event extends Ingress.InboundEvent>(
           // the expiry is an optimization, so it must never replace the typed
           // rejection below.
           try {
-            WaitService.expire(wait.record.id, at);
+            WaitService.expire(wait.record.id, trace.traceId, at);
           } catch {
             // Already folded by a concurrent transition — the typed rejection
             // below is still the correct outcome for this reply.

--- a/packages/openomni/src/messaging/events.ts
+++ b/packages/openomni/src/messaging/events.ts
@@ -4,6 +4,7 @@ import { MessageDenialCode, MessageOperation } from "./schema.js";
 
 const EventBase = z.object({
   messageId: z.string().min(1),
+  traceId: z.string().min(1),
   senderId: z.string().min(1),
   targetActorId: z.string().min(1),
   time: z.number(),

--- a/packages/openomni/src/messaging/schema.ts
+++ b/packages/openomni/src/messaging/schema.ts
@@ -83,6 +83,8 @@ const SendInputBase = z
   .object({
     /** Outbound message identity: doubles as the Wait's originMessageId, whose UNIQUE column pins "exactly one Wait per awaited message". */
     messageId: z.string().min(1),
+    /** The sender flow's trace: every event this send leaves files under it. */
+    traceId: z.string().min(1),
     senderId: z.string().min(1),
     target: MessageTarget,
     operation: MessageOperation,

--- a/packages/openomni/src/messaging/send.ts
+++ b/packages/openomni/src/messaging/send.ts
@@ -132,6 +132,7 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
   function deny(input: SendInput, code: MessageDenialCode, reason: string): SendReceipt {
     Bus.publish(Events.Denied, {
       messageId: input.messageId,
+      traceId: input.traceId,
       senderId: input.senderId,
       targetActorId: input.target.actorId,
       code,
@@ -180,24 +181,27 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
       // A delivery failure then leaves an open Wait that expires on schedule;
       // the reverse order could deliver a message the ledger never awaits.
       try {
-        wait = WaitService.open({
-          id: spec.waitId,
-          ownerRef: spec.ownerRef,
-          originMessageId: input.messageId,
-          correlation: {
-            ...spec.correlation,
-            endpointId: resolution.target.endpointId,
-            replyToMessageId: input.messageId,
+        wait = WaitService.open(
+          {
+            id: spec.waitId,
+            ownerRef: spec.ownerRef,
+            originMessageId: input.messageId,
+            correlation: {
+              ...spec.correlation,
+              endpointId: resolution.target.endpointId,
+              replyToMessageId: input.messageId,
+            },
+            allowedActions: spec.allowedActions,
+            expectedResponders: spec.expectedResponders,
+            resolutionPolicy: spec.resolutionPolicy,
+            ...(spec.quorum === undefined ? {} : { quorum: spec.quorum }),
+            expiresAt: spec.expiresAt,
+            followUpWindow: spec.followUpWindow,
+            createdAt: input.at,
+            updatedAt: input.at,
           },
-          allowedActions: spec.allowedActions,
-          expectedResponders: spec.expectedResponders,
-          resolutionPolicy: spec.resolutionPolicy,
-          ...(spec.quorum === undefined ? {} : { quorum: spec.quorum }),
-          expiresAt: spec.expiresAt,
-          followUpWindow: spec.followUpWindow,
-          createdAt: input.at,
-          updatedAt: input.at,
-        });
+          input.traceId,
+        );
       } catch (error) {
         // Exactly-once awaited delivery surfacing as a typed denial: the
         // ledger already awaits this message (or wait id), so this send
@@ -228,14 +232,16 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
       // reference the platform id, not our internal one) correlate. A wait
       // that turned terminal while the delivery was in flight rejects the
       // receipt (wait_terminal) and keeps its recorded correlation.
-      const receipt = WaitService.recordDeliveryReceipt(wait.id, {
-        externalMessageId: delivery.externalMessageId,
-        at: input.at,
-      });
+      const receipt = WaitService.recordDeliveryReceipt(
+        wait.id,
+        { externalMessageId: delivery.externalMessageId, at: input.at },
+        input.traceId,
+      );
       if (receipt.kind === "delivery_recorded") wait = receipt.record;
     }
     Bus.publish(Events.Sent, {
       messageId: input.messageId,
+      traceId: input.traceId,
       senderId: input.senderId,
       targetActorId: input.target.actorId,
       operation: input.operation,

--- a/packages/openomni/src/wait/lifecycle.ts
+++ b/packages/openomni/src/wait/lifecycle.ts
@@ -11,8 +11,8 @@ import { Bus, WaitStore } from "@openomni/session";
  */
 export namespace WaitService {
   /** Opens the one durable Wait for an awaited delivery. Fails closed on a missing adapter or duplicate origin message. */
-  export function open(input: Wait.Create): Wait.Record {
-    return WaitStore.create(input);
+  export function open(input: Wait.Create, traceId: string): Wait.Record {
+    return WaitStore.create(input, traceId);
   }
 
   /**
@@ -20,8 +20,8 @@ export namespace WaitService {
    * unknown / ambiguous / attach / resolve) and the store persists the
    * outcome under a revision compare-and-set.
    */
-  export function attachReply(id: string, input: Wait.ReplyInput): Wait.Outcome {
-    return WaitStore.attachReply(id, input);
+  export function attachReply(id: string, input: Wait.ReplyInput, traceId: string): Wait.Outcome {
+    return WaitStore.attachReply(id, input, traceId);
   }
 
   /**
@@ -33,12 +33,13 @@ export namespace WaitService {
   export function recordDeliveryReceipt(
     id: string,
     input: Wait.DeliveryReceiptInput,
+    traceId: string,
   ): Wait.Outcome {
-    return WaitStore.recordDeliveryReceipt(id, input);
+    return WaitStore.recordDeliveryReceipt(id, input, traceId);
   }
 
-  export function cancel(id: string, at = Date.now()): Wait.Outcome {
-    return WaitStore.cancel(id, at);
+  export function cancel(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+    return WaitStore.cancel(id, traceId, at);
   }
 
   /**
@@ -46,8 +47,8 @@ export namespace WaitService {
    * deadline — the route folds the wait to expired (partial when replies had
    * attached) before returning the typed rejection.
    */
-  export function expire(id: string, at = Date.now()): Wait.Outcome {
-    return WaitStore.expire(id, at);
+  export function expire(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+    return WaitStore.expire(id, traceId, at);
   }
 
   /**
@@ -66,7 +67,7 @@ export namespace WaitService {
     for (const record of WaitStore.list(["open"])) {
       if (now <= record.expiresAt) continue;
       try {
-        const outcome = expire(record.id, now);
+        const outcome = expire(record.id, traceId, now);
         if (outcome.kind === "expired") expired.push(outcome.record);
       } catch (error) {
         Bus.publish(Operational.Error, {

--- a/packages/openomni/test/harness/existing-agent-message-driver.ts
+++ b/packages/openomni/test/harness/existing-agent-message-driver.ts
@@ -169,12 +169,16 @@ function applyReply(input: Readonly<{ actorId: string; replyKey: string; at: num
     targetsOfWait(resolution.candidate.wait),
     dispatchEvidence(command),
   );
-  return WaitService.attachReply(resolution.candidate.wait.id, {
-    replyKey: input.replyKey,
-    responderCandidates: candidates,
-    messageId: `message:${input.replyKey}`,
-    at: input.at,
-  });
+  return WaitService.attachReply(
+    resolution.candidate.wait.id,
+    {
+      replyKey: input.replyKey,
+      responderCandidates: candidates,
+      messageId: `message:${input.replyKey}`,
+      at: input.at,
+    },
+    `trace:${input.replyKey}`,
+  );
 }
 
 function scenarioReceipt(
@@ -227,6 +231,7 @@ async function runRestartQuorumScenario(): Promise<ScenarioReceipt> {
       operation: "fire_and_forget",
       body: "heads-up: QA sweep starting",
       at: DriverNow,
+      traceId: "trace:qa:notify",
     });
     const waitCountAfterFireAndForget = WaitStore.list().length;
 
@@ -237,6 +242,7 @@ async function runRestartQuorumScenario(): Promise<ScenarioReceipt> {
       operation: "awaited",
       body: "reply with your QA verdict (2-of-3)",
       at: DriverNow + 1_000,
+      traceId: "trace:qa:briefing",
       waitSpec: awaitedWaitSpec(),
     });
     const firstReply = applyReply({
@@ -382,6 +388,7 @@ async function runDuplicateAmbiguousScenario(): Promise<ScenarioReceipt> {
     operation: "awaited",
     body: "reply with your QA verdict (2-of-3)",
     at: DriverNow,
+    traceId: "trace:qa:briefing",
     waitSpec: awaitedWaitSpec(),
   });
   const firstReply = applyReply({
@@ -400,11 +407,15 @@ async function runDuplicateAmbiguousScenario(): Promise<ScenarioReceipt> {
   });
   // A shared-credential sender whose evidence resolves to TWO expected
   // responders: the matcher only reports candidates, the fold never guesses.
-  const ambiguousReply = WaitService.attachReply(AwaitedWaitId, {
-    replyKey: "reply:qa:shared-credential",
-    responderCandidates: [Responders[1], Responders[2]],
-    at: DriverNow + 7_000,
-  });
+  const ambiguousReply = WaitService.attachReply(
+    AwaitedWaitId,
+    {
+      replyKey: "reply:qa:shared-credential",
+      responderCandidates: [Responders[1], Responders[2]],
+      at: DriverNow + 7_000,
+    },
+    "trace:reply:qa:shared-credential",
+  );
   // Messaging-plane ambiguity: the target actor is reachable at two
   // endpoints and the sender pinned none — resolution fails closed.
   const ambiguousTarget = await messaging.send({
@@ -414,6 +425,7 @@ async function runDuplicateAmbiguousScenario(): Promise<ScenarioReceipt> {
     operation: "fire_and_forget",
     body: "unpinned multi-endpoint target",
     at: DriverNow + 8_000,
+    traceId: "trace:qa:multi",
   });
 
   const after = quorumSnapshot(AwaitedWaitId);

--- a/packages/openomni/test/helpers/messaging.ts
+++ b/packages/openomni/test/helpers/messaging.ts
@@ -50,6 +50,7 @@ export function buildSendInput(overrides: Partial<SendInput> = {}): SendInput {
     operation: "fire_and_forget",
     body: "test message",
     at: messagingNow,
+    traceId: "trace-messaging",
     ...overrides,
   };
 }

--- a/packages/openomni/test/ingress/kernel-routing-waits.test.ts
+++ b/packages/openomni/test/ingress/kernel-routing-waits.test.ts
@@ -1026,18 +1026,21 @@ describe("IngressEngine durable wait routing", () => {
       title: id,
       model: { providerID: "test", modelID: "test-model" },
     });
-    return WaitService.open({
-      id,
-      ownerRef: { kind: "session", id: session.id },
-      originMessageId: `out-${id}`,
-      correlation: { channelId: correlation.channelId, tokenHash: correlation.tokenHash },
-      allowedActions: ["report_result"],
-      expectedResponders: ["actor-external-worker"],
-      resolutionPolicy: "first_reply",
-      expiresAt: Number.MAX_SAFE_INTEGER,
-      followUpWindow: 60_000,
-      ...overrides,
-    });
+    return WaitService.open(
+      {
+        id,
+        ownerRef: { kind: "session", id: session.id },
+        originMessageId: `out-${id}`,
+        correlation: { channelId: correlation.channelId, tokenHash: correlation.tokenHash },
+        allowedActions: ["report_result"],
+        expectedResponders: ["actor-external-worker"],
+        resolutionPolicy: "first_reply",
+        expiresAt: Number.MAX_SAFE_INTEGER,
+        followUpWindow: 60_000,
+        ...overrides,
+      },
+      "trace-test",
+    );
   }
 
   test("attaches a matched reply to the durable wait and routes it to the owner session", async () => {
@@ -1121,11 +1124,15 @@ describe("IngressEngine durable wait routing", () => {
       expiresAt: 10_000,
     });
     // An in-deadline reply recorded partial progress before the wait ran out.
-    const early = WaitService.attachReply("wait-late-reply", {
-      replyKey: "reply-early",
-      responderCandidates: ["actor-b"],
-      at: 1_000,
-    });
+    const early = WaitService.attachReply(
+      "wait-late-reply",
+      {
+        replyKey: "reply-early",
+        responderCandidates: ["actor-b"],
+        at: 1_000,
+      },
+      "trace-test",
+    );
     expect(early.kind).toBe("attached");
 
     const error = await captureError(kernelEngine().ingest(replyEvent("inbound-wait-late")));
@@ -1314,6 +1321,7 @@ describe("IngressEngine durable wait routing", () => {
       operation: "awaited",
       body: "reply with your verdict (2-of-3)",
       at: Date.now(),
+      traceId: "trace-test",
       waitSpec: {
         waitId: "wait-wired-quorum",
         ownerRef: { kind: "session", id: session.id },

--- a/packages/openomni/test/messaging/send.test.ts
+++ b/packages/openomni/test/messaging/send.test.ts
@@ -46,11 +46,11 @@ afterEach(() => {
 describe("sender-target grant (policy plane)", () => {
   test("send without any covering grant is denied ungranted and delivers nothing", async () => {
     grants = [];
-    const audits: { code: string; time: number }[] = [];
+    const audits: { code: string; time: number; traceId: string }[] = [];
     Bus.observe((event, payload) => {
       if (event.name !== "messaging.denied") return;
-      const data = payload as { code: string; time: number };
-      audits.push({ code: data.code, time: data.time });
+      const data = payload as { code: string; time: number; traceId: string };
+      audits.push({ code: data.code, time: data.time, traceId: data.traceId });
     });
 
     const receipt = await messaging().send(buildSendInput());
@@ -61,7 +61,8 @@ describe("sender-target grant (policy plane)", () => {
     expect(deliveries).toHaveLength(0);
     expect(WaitStore.list()).toHaveLength(0);
     await flushBus();
-    expect(audits).toEqual([{ code: "ungranted", time: messagingNow }]);
+    // Pin (D11): the denial audit inherits the send input's trace.
+    expect(audits).toEqual([{ code: "ungranted", time: messagingNow, traceId: "trace-messaging" }]);
   });
 
   test("a grant bounds the operation: fire_and_forget-only grant denies awaited delivery", async () => {
@@ -168,13 +169,19 @@ describe("explicit target resolution (fail closed)", () => {
 
 describe("fire-and-forget delivery", () => {
   test("records one sent audit and creates NO Wait", async () => {
-    const audits: { operation: string; waitId?: string; grantId: string }[] = [];
+    const audits: { operation: string; waitId?: string; grantId: string; traceId: string }[] = [];
     Bus.observe((event, payload) => {
       if (event.name !== "messaging.sent") return;
-      const data = payload as { operation: string; waitId?: string; grantId: string };
+      const data = payload as {
+        operation: string;
+        waitId?: string;
+        grantId: string;
+        traceId: string;
+      };
       audits.push({
         operation: data.operation,
         grantId: data.grantId,
+        traceId: data.traceId,
         ...(data.waitId === undefined ? {} : { waitId: data.waitId }),
       });
     });
@@ -201,7 +208,10 @@ describe("fire-and-forget delivery", () => {
       },
     ]);
     await flushBus();
-    expect(audits).toEqual([{ operation: "fire_and_forget", grantId: "grant:sender->target" }]);
+    expect(audits).toEqual([
+      // Pin (D11): the sent audit inherits the send input's trace.
+      { operation: "fire_and_forget", grantId: "grant:sender->target", traceId: "trace-messaging" },
+    ]);
   });
 
   test("fire_and_forget carrying a waitSpec is a schema violation, not a silent Wait", async () => {

--- a/packages/openomni/test/wait/lifecycle.test.ts
+++ b/packages/openomni/test/wait/lifecycle.test.ts
@@ -19,12 +19,15 @@ afterEach(() => {
 
 describe("WaitService", () => {
   test("open records exactly one durable Wait for an awaited delivery", () => {
-    const record = WaitService.open(buildWaitCreate("wait-open"));
+    const record = WaitService.open(buildWaitCreate("wait-open"), "trace-test");
 
     expect(WaitStore.get("wait-open")).toEqual(record);
     const duplicate = (() => {
       try {
-        WaitService.open(buildWaitCreate("wait-open-2", { originMessageId: "out-wait-open" }));
+        WaitService.open(
+          buildWaitCreate("wait-open-2", { originMessageId: "out-wait-open" }),
+          "trace-test",
+        );
       } catch (error) {
         if (Wait.StoreError.isInstance(error)) return error;
         throw error;
@@ -41,18 +44,27 @@ describe("WaitService", () => {
         resolutionPolicy: "quorum",
         quorum: { expected: 2, threshold: 2 },
       }),
+      "trace-test",
     );
 
-    const attached = WaitService.attachReply("wait-reply", {
-      replyKey: "inbound-1",
-      responderCandidates: ["actor-a"],
-      at: 1_000,
-    });
-    const resolved = WaitService.attachReply("wait-reply", {
-      replyKey: "inbound-2",
-      responderCandidates: ["actor-b"],
-      at: 2_000,
-    });
+    const attached = WaitService.attachReply(
+      "wait-reply",
+      {
+        replyKey: "inbound-1",
+        responderCandidates: ["actor-a"],
+        at: 1_000,
+      },
+      "trace-test",
+    );
+    const resolved = WaitService.attachReply(
+      "wait-reply",
+      {
+        replyKey: "inbound-2",
+        responderCandidates: ["actor-b"],
+        at: 2_000,
+      },
+      "trace-test",
+    );
 
     expect(attached.kind).toBe("attached");
     expect(resolved.kind).toBe("resolved");
@@ -64,13 +76,17 @@ describe("WaitService", () => {
   });
 
   test("zero matcher candidates fold to a typed unknown_responder rejection", () => {
-    WaitService.open(buildWaitCreate("wait-unknown"));
+    WaitService.open(buildWaitCreate("wait-unknown"), "trace-test");
 
-    const outcome = WaitService.attachReply("wait-unknown", {
-      replyKey: "inbound-unknown",
-      responderCandidates: [],
-      at: 1_000,
-    });
+    const outcome = WaitService.attachReply(
+      "wait-unknown",
+      {
+        replyKey: "inbound-unknown",
+        responderCandidates: [],
+        at: 1_000,
+      },
+      "trace-test",
+    );
 
     expect(outcome.kind).toBe("rejected");
     if (outcome.kind !== "rejected") throw new Error("expected rejected");
@@ -81,9 +97,9 @@ describe("WaitService", () => {
   test("cancel folds an open wait to cancelled, persists it, and stays terminal", async () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
-    WaitService.open(buildWaitCreate("wait-cancel"));
+    WaitService.open(buildWaitCreate("wait-cancel"), "trace-test");
 
-    const outcome = WaitService.cancel("wait-cancel", 2_000);
+    const outcome = WaitService.cancel("wait-cancel", "trace-test", 2_000);
 
     expect(outcome.kind).toBe("cancelled");
     if (outcome.kind !== "cancelled") throw new Error("expected cancelled");
@@ -96,7 +112,7 @@ describe("WaitService", () => {
     expect(events).toContain("wait.cancelled");
 
     // Terminal: a second cancel is a typed wait_terminal rejection, unpersisted.
-    const again = WaitService.cancel("wait-cancel", 3_000);
+    const again = WaitService.cancel("wait-cancel", "trace-test", 3_000);
     expect(again.kind).toBe("rejected");
     if (again.kind !== "rejected") throw new Error("expected rejected");
     expect(again.code).toBe("wait_terminal");
@@ -120,13 +136,21 @@ describe("WaitService", () => {
         quorum: { expected: 3, threshold: 2 },
         expiresAt: 10_000,
       }),
+      "trace-test",
     );
-    WaitService.open(buildWaitCreate("wait-untouched", { originMessageId: "out-untouched" }));
-    WaitService.attachReply("wait-partial", {
-      replyKey: "inbound-1",
-      responderCandidates: ["actor-a"],
-      at: 1_000,
-    });
+    WaitService.open(
+      buildWaitCreate("wait-untouched", { originMessageId: "out-untouched" }),
+      "trace-test",
+    );
+    WaitService.attachReply(
+      "wait-partial",
+      {
+        replyKey: "inbound-1",
+        responderCandidates: ["actor-a"],
+        at: 1_000,
+      },
+      "trace-test",
+    );
 
     const expired = WaitService.sweepExpired("trace-test", 10_001);
 
@@ -147,9 +171,10 @@ describe("WaitService", () => {
           : {}),
       }),
     );
-    WaitService.open(buildWaitCreate("wait-corrupt", { expiresAt: 10_000 }));
+    WaitService.open(buildWaitCreate("wait-corrupt", { expiresAt: 10_000 }), "trace-test");
     WaitService.open(
       buildWaitCreate("wait-healthy", { originMessageId: "out-healthy", expiresAt: 10_000 }),
+      "trace-test",
     );
     // Corrupt one wait's owner stream: an extra fact advances the head past
     // the projected revision, so its expiry transition hits a permanent

--- a/packages/protocol/src/wait/events.ts
+++ b/packages/protocol/src/wait/events.ts
@@ -5,6 +5,7 @@ import { OwnerKind, Status } from "./schema.js";
 
 const EventBase = z.object({
   id: z.string().min(1),
+  traceId: z.string().min(1),
   ownerKind: OwnerKind,
   ownerId: z.string().min(1),
   status: Status,

--- a/packages/session/src/wait/index.ts
+++ b/packages/session/src/wait/index.ts
@@ -131,9 +131,10 @@ function factOf(outcome: CommittedOutcome): { type: string; data: Record<string,
   }
 }
 
-function eventBase(record: Wait.Record, time: number) {
+function eventBase(record: Wait.Record, time: number, traceId: string) {
   return {
     id: record.id,
+    traceId,
     ownerKind: record.ownerRef.kind,
     ownerId: record.ownerRef.id,
     status: record.status,
@@ -158,8 +159,8 @@ function stillCorrelatable(record: Wait.Record, now: number): boolean {
 // are lossy projections of the appended facts and fire only AFTER the
 // append+projection transaction committed — a subscriber can never write the
 // ledger or authorize an action from them.
-function publishChange(outcome: CommittedOutcome): void {
-  const base = eventBase(outcome.record, outcome.record.updatedAt);
+function publishChange(outcome: CommittedOutcome, traceId: string): void {
+  const base = eventBase(outcome.record, outcome.record.updatedAt, traceId);
   switch (outcome.kind) {
     case "attached":
       Bus.publish(Wait.Events.ReplyAttached, {
@@ -200,7 +201,7 @@ function publishChange(outcome: CommittedOutcome): void {
 export namespace WaitStore {
   export type Record = Wait.Record;
 
-  export function create(input: Wait.Create): Wait.Record {
+  export function create(input: Wait.Create, traceId: string): Wait.Record {
     const adapter = requireAdapter();
     const ledger = requireLedger();
     // Single write-shape owner: this Record.parse is the factory that
@@ -243,7 +244,7 @@ export namespace WaitStore {
       if (appended.kind === "cas_conflict") throw duplicate();
       if (!adapter.create(record)) throw duplicate();
     });
-    Bus.publish(Wait.Events.Opened, eventBase(record, record.createdAt));
+    Bus.publish(Wait.Events.Opened, eventBase(record, record.createdAt, traceId));
     return record;
   }
 
@@ -274,6 +275,7 @@ export namespace WaitStore {
   export function transition(
     id: string,
     step: (record: Wait.Record) => Wait.Outcome,
+    traceId: string,
   ): Wait.Outcome {
     const adapter = requireAdapter();
     const ledger = requireLedger();
@@ -334,16 +336,16 @@ export namespace WaitStore {
         throw revisionConflict(id, current.revision);
       }
     });
-    publishChange(outcome);
+    publishChange(outcome, traceId);
     return outcome;
   }
 
-  export function attachReply(id: string, input: Wait.ReplyInput): Wait.Outcome {
+  export function attachReply(id: string, input: Wait.ReplyInput, traceId: string): Wait.Outcome {
     const parsed = Wait.ReplyInput.parse(input);
-    const outcome = transition(id, (record) => Wait.attachReply(record, parsed));
+    const outcome = transition(id, (record) => Wait.attachReply(record, parsed), traceId);
     if (outcome.kind === "rejected") {
       Bus.publish(Wait.Events.ReplyRejected, {
-        ...eventBase(outcome.record, outcome.at),
+        ...eventBase(outcome.record, outcome.at, traceId),
         code: outcome.code,
         replyKey: parsed.replyKey,
       });
@@ -360,16 +362,17 @@ export namespace WaitStore {
   export function recordDeliveryReceipt(
     id: string,
     input: Wait.DeliveryReceiptInput,
+    traceId: string,
   ): Wait.Outcome {
     const parsed = Wait.DeliveryReceiptInput.parse(input);
-    return transition(id, (record) => Wait.recordDeliveryReceipt(record, parsed));
+    return transition(id, (record) => Wait.recordDeliveryReceipt(record, parsed), traceId);
   }
 
-  export function expire(id: string, at = Date.now()): Wait.Outcome {
-    return transition(id, (record) => Wait.expire(record, { at }));
+  export function expire(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+    return transition(id, (record) => Wait.expire(record, { at }), traceId);
   }
 
-  export function cancel(id: string, at = Date.now()): Wait.Outcome {
-    return transition(id, (record) => Wait.cancel(record, { at }));
+  export function cancel(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+    return transition(id, (record) => Wait.cancel(record, { at }), traceId);
   }
 }

--- a/packages/session/test/wait/store.test.ts
+++ b/packages/session/test/wait/store.test.ts
@@ -22,11 +22,46 @@ afterEach(() => {
 const flushBus = () => new Promise<void>((resolve) => queueMicrotask(() => resolve()));
 
 describe("WaitStore", () => {
+  test("every wait event inherits its caller's trace — no mint in the store (D11)", async () => {
+    const traced: Array<{ name: string; traceId: unknown }> = [];
+    Bus.observe((event, data) => {
+      if (event.name.startsWith("wait.")) {
+        traced.push({ name: event.name, traceId: (data as { traceId?: string }).traceId });
+      }
+    });
+
+    const record = WaitStore.create(buildWaitCreate(), "trace-open");
+    WaitStore.attachReply(record.id, buildReplyInput(), "trace-reply");
+    const second = WaitStore.create(
+      buildWaitCreate({ id: "wait-cancel", originMessageId: "message-cancel" }),
+      "trace-open-2",
+    );
+    WaitStore.cancel(second.id, "trace-cancel");
+
+    await flushBus();
+    expect(traced).toEqual([
+      { name: "wait.opened", traceId: "trace-open" },
+      { name: "wait.reply_attached", traceId: "trace-reply" },
+      { name: "wait.opened", traceId: "trace-open-2" },
+      { name: "wait.cancelled", traceId: "trace-cancel" },
+    ]);
+  });
+
+  test("wait events refuse an untraced payload", () => {
+    // Enforcement is compile-time for typed producers; the schema states the
+    // invariant so any future strict consumer refuses. All EventBase events
+    // share the one base; SyncAsk has its own pinned schema (batch 5).
+    const base = { id: "wait-1", ownerKind: "session", ownerId: "ses-1", status: "open", time: 1 };
+    expect(Wait.Events.Opened.schema.safeParse(base).success).toBe(false);
+    expect(Wait.Events.Opened.schema.safeParse({ ...base, traceId: "" }).success).toBe(false);
+    expect(Wait.Events.Opened.schema.safeParse({ ...base, traceId: "trace-1" }).success).toBe(true);
+  });
+
   test("creates an open wait, persists it, and publishes wait.opened", async () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
 
-    const created = WaitStore.create(buildWaitCreate());
+    const created = WaitStore.create(buildWaitCreate(), "trace-wait-store");
     const loaded = WaitStore.get("wait-1");
 
     expect(created.status).toBe("open");
@@ -40,9 +75,11 @@ describe("WaitStore", () => {
   });
 
   test("rejects a second wait for the same originMessageId with a typed duplicate error", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
-    const error = captureStoreError(() => WaitStore.create(buildWaitCreate({ id: "wait-2" })));
+    const error = captureStoreError(() =>
+      WaitStore.create(buildWaitCreate({ id: "wait-2" }), "trace-wait-store"),
+    );
 
     expect(error.data.code).toBe("duplicate");
     expect(error.data.waitId).toBe("wait-2");
@@ -50,17 +87,17 @@ describe("WaitStore", () => {
   });
 
   test("rejects a duplicate wait id with a typed duplicate error", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
     const error = captureStoreError(() =>
-      WaitStore.create(buildWaitCreate({ originMessageId: "out-msg-2" })),
+      WaitStore.create(buildWaitCreate({ originMessageId: "out-msg-2" }), "trace-wait-store"),
     );
 
     expect(error.data.code).toBe("duplicate");
   });
 
   test("finds open waits by scoped correlation and rejects other channels", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
     expect(
       WaitStore.findByCorrelation(
@@ -85,7 +122,7 @@ describe("WaitStore", () => {
   });
 
   test("surfaces open-but-expired rows so the kernel can lazily expire them", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
     // Deadline judgment is NOT a read-time filter: an open row past its
     // expiresAt still correlates, the fold rejects the reply as
@@ -98,8 +135,11 @@ describe("WaitStore", () => {
   });
 
   test("keeps resolved waits correlatable only inside the follow-up window", () => {
-    WaitStore.create(buildWaitCreate({ resolutionPolicy: "first_reply", quorum: undefined }));
-    const outcome = WaitStore.attachReply("wait-1", buildReplyInput());
+    WaitStore.create(
+      buildWaitCreate({ resolutionPolicy: "first_reply", quorum: undefined }),
+      "trace-wait-store",
+    );
+    const outcome = WaitStore.attachReply("wait-1", buildReplyInput(), "trace-wait-store");
     expect(outcome.kind).toBe("resolved");
 
     expect(WaitStore.findByCorrelation({ tokenHash: "tok-1" }, 2_000)).toHaveLength(1);
@@ -121,7 +161,7 @@ describe("WaitStore", () => {
     });
     expect(adapter.create(record)).toBe(true);
 
-    const outcome = WaitStore.attachReply("wait-1", buildReplyInput());
+    const outcome = WaitStore.attachReply("wait-1", buildReplyInput(), "trace-wait-store");
 
     expect(outcome.kind).toBe("attached");
     expect(WaitStore.get("wait-1")?.revision).toBe(4);
@@ -139,12 +179,13 @@ describe("WaitStore", () => {
   test("persists fold outcomes through the revision CAS and publishes reply events", async () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
-    const attached = WaitStore.attachReply("wait-1", buildReplyInput());
+    const attached = WaitStore.attachReply("wait-1", buildReplyInput(), "trace-wait-store");
     const resolved = WaitStore.attachReply(
       "wait-1",
       buildReplyInput({ replyKey: "reply-key-2", responderCandidates: ["actor-b"], at: 2_000 }),
+      "trace-wait-store",
     );
     const persisted = WaitStore.get("wait-1");
 
@@ -162,12 +203,13 @@ describe("WaitStore", () => {
   test("rejected replies write nothing and publish wait.reply_rejected", async () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
-    WaitStore.create(buildWaitCreate());
-    WaitStore.attachReply("wait-1", buildReplyInput());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
+    WaitStore.attachReply("wait-1", buildReplyInput(), "trace-wait-store");
 
     const duplicate = WaitStore.attachReply(
       "wait-1",
       buildReplyInput({ responderCandidates: ["actor-b"], at: 2_000 }),
+      "trace-wait-store",
     );
     const ambiguous = WaitStore.attachReply(
       "wait-1",
@@ -176,6 +218,7 @@ describe("WaitStore", () => {
         responderCandidates: ["actor-b", "actor-c"],
         at: 2_100,
       }),
+      "trace-wait-store",
     );
     const persisted = WaitStore.get("wait-1");
 
@@ -196,10 +239,10 @@ describe("WaitStore", () => {
   test("expires a partially answered wait and persists partial: true", async () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
-    WaitStore.create(buildWaitCreate());
-    WaitStore.attachReply("wait-1", buildReplyInput());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
+    WaitStore.attachReply("wait-1", buildReplyInput(), "trace-wait-store");
 
-    const outcome = WaitStore.expire("wait-1", 10_001);
+    const outcome = WaitStore.expire("wait-1", "trace-wait-store", 10_001);
     const persisted = WaitStore.get("wait-1");
 
     expect(outcome.kind).toBe("expired");
@@ -215,12 +258,16 @@ describe("WaitStore", () => {
   test("recordDeliveryReceipt persists the re-keyed correlation projection through the CAS", async () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
-    const outcome = WaitStore.recordDeliveryReceipt("wait-1", {
-      externalMessageId: "platform:msg-1",
-      at: 500,
-    });
+    const outcome = WaitStore.recordDeliveryReceipt(
+      "wait-1",
+      {
+        externalMessageId: "platform:msg-1",
+        at: 500,
+      },
+      "trace-wait-store",
+    );
     const persisted = WaitStore.get("wait-1");
 
     expect(outcome.kind).toBe("delivery_recorded");
@@ -239,13 +286,17 @@ describe("WaitStore", () => {
   });
 
   test("a delivery receipt on a terminal wait rejects wait_terminal and writes nothing", () => {
-    WaitStore.create(buildWaitCreate());
-    WaitStore.cancel("wait-1", 400);
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
+    WaitStore.cancel("wait-1", "trace-wait-store", 400);
 
-    const outcome = WaitStore.recordDeliveryReceipt("wait-1", {
-      externalMessageId: "platform:msg-late",
-      at: 500,
-    });
+    const outcome = WaitStore.recordDeliveryReceipt(
+      "wait-1",
+      {
+        externalMessageId: "platform:msg-late",
+        at: 500,
+      },
+      "trace-wait-store",
+    );
 
     expect(outcome.kind).toBe("rejected");
     if (outcome.kind !== "rejected") throw new Error("expected rejected");
@@ -254,14 +305,18 @@ describe("WaitStore", () => {
   });
 
   test("a concurrent write between read and CAS raises a typed revision_conflict", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
     const error = captureStoreError(() =>
-      WaitStore.transition("wait-1", (record) => {
-        // Concurrent writer advances the revision after this step read it.
-        WaitStore.cancel("wait-1", 500);
-        return Wait.cancel(record, { at: 600 });
-      }),
+      WaitStore.transition(
+        "wait-1",
+        (record) => {
+          // Concurrent writer advances the revision after this step read it.
+          WaitStore.cancel("wait-1", "trace-wait-store", 500);
+          return Wait.cancel(record, { at: 600 });
+        },
+        "trace-wait-store",
+      ),
     );
 
     expect(error.data.code).toBe("revision_conflict");
@@ -271,7 +326,11 @@ describe("WaitStore", () => {
 
   test("transition on a missing wait raises a typed not_found error", () => {
     const error = captureStoreError(() =>
-      WaitStore.transition("wait-missing", (record) => Wait.cancel(record, { at: 1 })),
+      WaitStore.transition(
+        "wait-missing",
+        (record) => Wait.cancel(record, { at: 1 }),
+        "trace-wait-store",
+      ),
     );
 
     expect(error.data.code).toBe("not_found");
@@ -280,7 +339,9 @@ describe("WaitStore", () => {
   test("fails closed with a typed adapter_absent error when the wait sub-adapter is missing", () => {
     Storage.configure(bareStorageAdapter());
 
-    const createError = captureStoreError(() => WaitStore.create(buildWaitCreate()));
+    const createError = captureStoreError(() =>
+      WaitStore.create(buildWaitCreate(), "trace-wait-store"),
+    );
     const readError = captureStoreError(() => WaitStore.get("wait-1"));
 
     expect(createError.data.code).toBe("adapter_absent");
@@ -289,7 +350,7 @@ describe("WaitStore", () => {
 
   test("waits survive adapter reconfiguration on the same database", () => {
     const adapter = Storage.getAdapter();
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
     Storage.configure(adapter);
 


### PR DESCRIPTION
## Summary

Trace batch 6 of the D11 structural remainder (#606; batch plan in docs/agent-core-rewrite.md) — the biggest real reduction of `"untraced"` ledger rows: the six Wait store events and the two messaging events share one call path, so they land together.

**Wait** (`wait.opened` / `reply_attached` / `resolved` / `expired` / `cancelled` / `reply_rejected`):
- Protocol `EventBase` gains required `traceId`.
- `WaitStore.create/transition/attachReply/recordDeliveryReceipt/expire/cancel` take the caller's trace (`traceId` sits before the defaulted `at`); `eventBase`/`publishChange` thread it — no mint anywhere in the store.
- `WaitService` wrappers thread it; `sweepExpired` already had the boot trace and now passes it into each per-wait `expire` fold.
- Ingress `executeWaitRoute` passes its route trace into `attachReply` and the lazy-expiry `expire`.

**Messaging** (`messaging.sent` / `messaging.denied`):
- `SendInput` gains required `traceId` — the sender flow's trace; every event one send leaves (denial audit, sent audit, the Wait it opens) now files under ONE id; the delivery-receipt path emits no event today, so its threaded trace is API uniformity, not a traced-row reduction (review NIT).
- `send.ts` threads `input.traceId` into both publishes, `WaitService.open`, and `recordDeliveryReceipt`.

`createExistingAgentMessaging(...).send()` has no production caller yet (the seam is registered at bootstrap; tests exercise it) — the wait-route and sweep paths are the live producers converted here.

## Pins

- `packages/session/test/wait/store.test.ts` — "every wait event inherits its caller's trace": opened/reply_attached/opened/cancelled carry four distinct per-call traces. Mutation-verified: re-minting in `eventBase` fails it (17/1). Plus schema refusal pin (absent/empty/valid).
- `packages/openomni/test/messaging/send.test.ts` — denial and sent audit expectations now assert the send input's trace. Mutation-verified: re-minting the Sent publish fails (16/1).

## Verification

- `tsc --noEmit` src+test: protocol, session, openomni, server — 0 errors
- `bun test` session+openomni+server: **1781 pass / 0 fail** (before the final type-decl fix; suites re-run green after)
- `bun run lint`, `bun run lint:tools`: clean (snapshot untouched)

Test-fallout scope: 7 test/fixture files, literal per-file trace ids following each file's idiom; two messaging expectations strengthened with the trace, none weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads caller-provided trace IDs through all Wait and Messaging flows and requires them at the schema boundary. This replaces previously untraced or implicitly traced events with a single caller trace, linking all audits and wait lifecycle events for a send.

- Schema and events: Wait `EventBase` now includes `traceId`; `messaging.sent`/`messaging.denied` include `traceId`; `SendInput` requires `traceId`.
- API changes: `WaitService.open|attachReply|recordDeliveryReceipt|expire|cancel` and `WaitStore.create|attachReply|recordDeliveryReceipt|expire|cancel|transition` accept a `traceId`; the store never mints a trace.
- Producers: `send.ts` threads `input.traceId` to both messaging audits and all Wait calls; `executeWaitRoute` passes the route `traceId` into `attachReply` and lazy `expire`; `sweepExpired` threads the boot trace to each expiry.
- Required migration: add a non-empty `traceId` to every `SendInput`; update all `WaitService`/`WaitStore` call sites to supply a `traceId` and adjust parameter order where changed. Tests should assert the propagated `traceId` on wait and messaging events.

<sup>Written for commit e34b48675a116910e2b9fbf4c56ae89a882d1ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


