### PR TITLE
fix(session): stop laundering event subject ids into session_id (#606)

### DIFF
--- a/packages/session/src/bus-persistence/session-id.ts
+++ b/packages/session/src/bus-persistence/session-id.ts
@@ -9,11 +9,14 @@ export function defaultResolveSessionId(
   const root = toRecord(payload);
   if (!root) return undefined;
 
+  // NO root-level `id` fallback: `id` names the event's own subject (a
+  // waitId, grantId, cron job id — or a just-deleted session, whose FK row is
+  // gone). Attributing it as a sessionId FK-failed the insert and silently
+  // dropped the row; subject-scoped events belong to the sessionless chain.
   const direct =
     sessionIdFromRecord(root) ??
     stringFromRecord(root, "originSessionId") ??
-    sessionIdFromWorkerRun(root) ??
-    stringFromRecord(root, "id");
+    sessionIdFromWorkerRun(root);
   if (direct !== undefined) return direct;
 
   const nestedPayload = toRecord(root.payload);

--- a/packages/session/src/bus-persistence/session-id.ts
+++ b/packages/session/src/bus-persistence/session-id.ts
@@ -10,8 +10,8 @@ export function defaultResolveSessionId(
   if (!root) return undefined;
 
   // NO root-level `id` fallback: `id` names the event's own subject (a
-  // waitId, grantId, cron job id — or a just-deleted session, whose FK row is
-  // gone). Attributing it as a sessionId FK-failed the insert and silently
+  // waitId, a lookup-missed grantId — or a just-deleted session, whose FK row
+  // is gone). Attributing it as a sessionId FK-failed the insert and silently
   // dropped the row; subject-scoped events belong to the sessionless chain.
   const direct =
     sessionIdFromRecord(root) ??

--- a/packages/session/test/bus-persistence/persistence-attribution.test.ts
+++ b/packages/session/test/bus-persistence/persistence-attribution.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Bus } from "@openomni/telemetry";
+import { BusPersistence } from "../../src/bus-persistence/index.js";
+import { Session } from "../../src/session/index.js";
+import { Storage } from "../../src/storage/storage.js";
+import { WaitStore } from "../../src/wait/index.js";
+import { buildWaitCreate } from "../helpers/wait.js";
+import "../../src/storage/initialize.js";
+
+interface BusEventRow {
+  readonly session_id: string | null;
+  readonly event_type: string;
+  readonly trace_id: string;
+}
+
+function db(): Database {
+  const descriptor = Object.getOwnPropertyDescriptor(Storage.getAdapter(), "db");
+  if (descriptor?.value instanceof Database) return descriptor.value;
+  throw new Error("Expected SQLite-backed storage adapter");
+}
+
+function rows(eventType: string): BusEventRow[] {
+  return db()
+    .query("SELECT session_id, event_type, trace_id FROM bus_event WHERE event_type = ?")
+    .all(eventType) as BusEventRow[];
+}
+
+async function flushPersistence(): Promise<void> {
+  await new Promise((resolve) => queueMicrotask(resolve));
+  await new Promise((resolve) => queueMicrotask(resolve));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("persistence attribution refuses to launder foreign ids", () => {
+  beforeEach(() => {
+    Bus.reset();
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    BusPersistence.start();
+  });
+
+  afterEach(() => {
+    BusPersistence.stop();
+    Storage.reset();
+    Bus.reset();
+  });
+
+  test("wait events persist on the sessionless chain — a waitId is not a sessionId", async () => {
+    // The old root-level `id` attribution stamped session_id = waitId, which
+    // FK-failed against the session table and silently DROPPED every wait.*
+    // row. Wait events carry no session; they belong to the sessionless chain.
+    WaitStore.create(buildWaitCreate(), "trace-wait-persist");
+    await flushPersistence();
+
+    expect(rows("wait.opened")).toEqual([
+      { session_id: null, event_type: "wait.opened", trace_id: "trace-wait-persist" },
+    ]);
+  });
+
+  test("session.deleted persists after the row is gone — sessionless by design", async () => {
+    // Publishing after adapter removal means a session-attributed row can
+    // never satisfy the FK: the deletion event must outlive its session on
+    // the sessionless chain (the CASCADE-purge survivor the chain exists for).
+    const session = Session.create({
+      traceId: "trace-delete-persist",
+      title: "Doomed",
+      model: { providerID: "test", modelID: "test-model" },
+    });
+    await flushPersistence();
+    // While the session lives, its created row is session-attributed.
+    expect(rows("session.created")).toEqual([
+      { session_id: session.id, event_type: "session.created", trace_id: "trace-delete-persist" },
+    ]);
+
+    Session.remove(session.id, "trace-delete-persist");
+    await flushPersistence();
+
+    expect(rows("session.deleted")).toEqual([
+      { session_id: null, event_type: "session.deleted", trace_id: "trace-delete-persist" },
+    ]);
+    // The created row CASCADE-purges with its session BY DESIGN; the
+    // sessionless deleted row and the event_chain hashes are the survivors.
+    expect(rows("session.created")).toEqual([]);
+    const chain = db().query("SELECT event_type FROM event_chain ORDER BY seq ASC").all() as Array<{
+      event_type: string;
+    }>;
+    expect(chain.map((row) => row.event_type)).toContain("session.created");
+    expect(chain.map((row) => row.event_type)).toContain("session.deleted");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes both empirically-reproduced BLOCKERs from the 8-package adversarial audit (#606): the persistence attribution resolver's root-level `id` fallback treated any event's SUBJECT id (a waitId, grantId, cron job id — or a just-deleted session id) as a `session_id`, which FK-failed the insert against the `session` table and **silently dropped the row** (`console.warn` only).

Observable damage before this fix:
- **Every `wait.*` EventBase-family event was 100% lost at persistence** (`session_id = waitId` → FK fail) — the whole wait decision-family audit projection, including its `event_chain` rows.
- **`session.deleted` was unpersistable by construction** — it publishes after `adapter.session.remove`, so a session-attributed row can never satisfy the FK.

The fix deletes the one laundering leg (`stringFromRecord(root, "id")`) in `defaultResolveSessionId`. Subject-scoped events now land on the **sessionless chain** (`session_id NULL`), which the writer and chain-tip resolver already support:
- The `wait.*` EventBase family persists sessionless with traces intact (`wait.sync_ask` carries a root sessionId and always persisted); `worker_grant.*` rows keep their workerRunId-lookup attribution on the common path and fall back to sessionless only on a lookup miss (previously: dropped). `cron_job.*` events carry `jobId`, not root `id` — they were never affected (review correction).
- `session.deleted` persists sessionless — the CASCADE-purge survivor the chain design exists to memorialize (`session.created` rows CASCADE with their session BY DESIGN; `event_chain` keeps both hashes).
- `session.created`/`updated` attribution is untouched (it rides `info.id`, whose row exists at write); nested `payload.sessionId` and worker-run lookups are untouched.

## Pins (new file, both reproduce the BLOCKERs before the fix)

`packages/session/test/bus-persistence/persistence-attribution.test.ts`:
1. `WaitStore.create` → flush → `wait.opened` row exists, `session_id NULL`, correct trace. (Failed before: zero rows.)
2. create → flush (created row session-attributed) → remove → flush: `session.deleted` row exists sessionless; created row CASCADE-purged; `event_chain` carries both hashes. (Failed before: no deleted row ever.)

Mutation-verified: restoring the laundering leg fails exactly these two tests (0/2), fix restores green (2/0).

## Verification

- `bun test packages/session packages/openomni apps/server/test`: **2026 pass / 0 fail**
- `tsc --noEmit -p tsconfig.test.json` (session): 0 errors; `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops attributing event subject `id` values as `session_id` during bus persistence, preventing FK failures and dropped rows. Previously, a `root.id` fallback stamped non-session subjects (e.g., waitId or a just-deleted session id) as `session_id`; now only explicit session attribution is used and subject-scoped events persist on the sessionless chain (`session_id` NULL).

- Remove the `stringFromRecord(root, "id")` fallback in `packages/session/src/bus-persistence/session-id.ts`.
- Resolve `session_id` from `payload.sessionId`, `originSessionId`, or worker-run attribution; otherwise NULL. `session.created`/`updated` attribution is unchanged.
- Add tests in `packages/session/test/bus-persistence/persistence-attribution.test.ts` verifying `wait.opened` and `session.deleted` persist sessionless with traces intact.

**Rollout**
- Update queries/analytics on `bus_event` to allow `session_id` = NULL for `wait.*`, `worker_grant.*`, and `session.deleted`. No code migration required.

<sup>Written for commit 82ae9eec1c9ec1acf3399fce65125051ea0d9272. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session attribution for persisted events by removing unintended fallback to root event identifiers.
  * Ensured wait events remain sessionless, while session creation and deletion events retain the correct attribution.
  * Preserved event-chain records and cascade cleanup during session lifecycle operations.

* **Tests**
  * Added coverage for SQLite-backed persistence attribution and session lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
