### PR TITLE
fix(coordinator): close failed bootstrap clients, one generation trace

### DIFF
--- a/packages/coordinator/src/worker-supervision/supervisor-requests.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor-requests.ts
@@ -92,9 +92,11 @@ function handleToolCall(
     return;
   }
   const p = parsed.data;
-  // Authenticate like every other worker→coordinator verb (see handleInboundWait
-  // and worker-bootstrap-handler): the env-injected token proves the request
-  // came from the worker this supervisor spawned.
+  // The env-injected token proves the request came from the worker this
+  // supervisor spawned. NOT every verb authenticates: the cancel verbs
+  // (worker.tool_call_cancel, worker.inbound_wait_cancel) carry no token by
+  // contract — their blast radius is bounded to aborting this worker's own
+  // in-flight calls, and the 0700 per-pool socket dir is the transport gate.
   if (p.authToken !== context.authToken) {
     respond(toolCallError(p, "unauthorized worker request"));
     return;

--- a/packages/coordinator/src/worker-supervision/supervisor.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor.ts
@@ -54,6 +54,10 @@ export class WorkerSupervisor {
   private restartCount = 0;
   private restartWindowStart = 0;
   private generation = 0;
+  // One trace per worker generation: minted at spawn (Owner-gated ring-2 mint,
+  // see #606 D11 remainder) and shared by every lifecycle event of that
+  // generation — Spawned/Ready/Exited and generation-scoped warns.
+  private generationTraceId = "";
   private running = false;
   private stopping = false;
   private readonly activeToolCalls = new Map<string, ActiveRequest>();
@@ -80,6 +84,7 @@ export class WorkerSupervisor {
 
   private doStart(): void {
     this.generation += 1;
+    this.generationTraceId = crypto.randomUUID();
     this.running = true;
     this.bootstrapped = false;
     this.proc = Bun.spawn(
@@ -92,7 +97,7 @@ export class WorkerSupervisor {
     );
     const generation = this.generation;
     this.events.publish(WorkerDriver.Spawned, {
-      traceId: crypto.randomUUID(),
+      traceId: this.generationTraceId,
       time: Date.now(),
       workerId: this.id,
       generation,
@@ -104,7 +109,7 @@ export class WorkerSupervisor {
       this.client = null;
       prev?.close();
       this.events.publish(WorkerDriver.Exited, {
-        traceId: crypto.randomUUID(),
+        traceId: this.generationTraceId,
         time: Date.now(),
         workerId: this.id,
         generation,
@@ -126,6 +131,7 @@ export class WorkerSupervisor {
         await new Promise<void>((r) => setTimeout(r, 250));
         continue;
       }
+      let attemptClient: Awaited<ReturnType<typeof connectIpcClient>> | undefined;
       try {
         const c = await connectIpcClient(this.socketPath, {
           connectTimeoutMs: 500,
@@ -149,10 +155,18 @@ export class WorkerSupervisor {
                     5_000,
                   )
                   .catch((err) => {
-                    console.warn("worker.tool_call_settled notification failed", {
-                      callId,
-                      workspaceRoot,
-                      error: err instanceof Error ? err.message : String(err),
+                    // Ledger, not console: swallowing this into stdout is the
+                    // exact failure mode the injected sink exists to prevent.
+                    this.events.publish(Operational.Warn, {
+                      traceId: this.generationTraceId,
+                      time: Date.now(),
+                      component: "coordinator",
+                      msg: "worker.tool_call_settled notification failed",
+                      context: {
+                        callId,
+                        ...(workspaceRoot ? { workspaceRoot } : {}),
+                        error: err instanceof Error ? err.message : String(err),
+                      },
                     });
                   });
               },
@@ -164,6 +178,7 @@ export class WorkerSupervisor {
             }
           },
         });
+        attemptClient = c;
         const bootstrapResult = await c.call(
           "coordinator.bootstrap",
           {
@@ -183,7 +198,7 @@ export class WorkerSupervisor {
         if (!this.stopping && this.running) {
           this.client = c;
           this.events.publish(WorkerDriver.Ready, {
-            traceId: crypto.randomUUID(),
+            traceId: this.generationTraceId,
             time: Date.now(),
             workerId: this.id,
             generation: this.generation,
@@ -193,6 +208,10 @@ export class WorkerSupervisor {
         }
         return;
       } catch (error) {
+        // A failed attempt must not leak its connected client: a stale one
+        // keeps live onRequest/onNotification handlers and can flip
+        // `bootstrapped` or answer worker requests alongside the winner.
+        attemptClient?.close();
         lastError = error instanceof Error ? error : new Error(String(error));
         await new Promise<void>((r) => setTimeout(r, 100));
       }
@@ -202,7 +221,7 @@ export class WorkerSupervisor {
       // doStart() fires this promise without awaiting it, so a throw here would
       // surface as an unhandled rejection; report and let waitReady() time out.
       this.events.publish(Operational.Warn, {
-        traceId: crypto.randomUUID(),
+        traceId: this.generationTraceId,
         time: Date.now(),
         component: "coordinator.worker",
         msg: "worker IPC connect failed within deadline",
@@ -221,7 +240,7 @@ export class WorkerSupervisor {
 
     const delayMs = resolveRestartDelay(this.restartCount);
     this.events.publish(WorkerDriver.Restarted, {
-      traceId: crypto.randomUUID(),
+      traceId: this.generationTraceId,
       time: Date.now(),
       workerId: this.id,
       restartCount: this.restartCount,
@@ -380,7 +399,7 @@ export class WorkerSupervisor {
       const graceMs = workerStopGraceMs();
       if ((await waitForWorkerExit(proc, graceMs)) === "timeout") {
         this.events.publish(Operational.Warn, {
-          traceId: crypto.randomUUID(),
+          traceId: this.generationTraceId,
           time: Date.now(),
           component: "coordinator.worker",
           msg: "worker did not stop within grace period; sending SIGKILL",

--- a/packages/coordinator/src/worker-supervision/supervisor.ts
+++ b/packages/coordinator/src/worker-supervision/supervisor.ts
@@ -121,6 +121,10 @@ export class WorkerSupervisor {
   }
 
   private async connectWithRetry(): Promise<void> {
+    // Snapshot THIS generation's trace: the settled-notification closure (and
+    // the deadline warn below) can fire after a crash re-minted the field —
+    // a warn for generation N must not file under N+1's trace.
+    const generationTraceId = this.generationTraceId;
     const deadline = Date.now() + WORKER_CONNECT_TIMEOUT_MS;
     let lastError: Error | null = null;
     const bootstrap = this.bootstrap;
@@ -158,7 +162,7 @@ export class WorkerSupervisor {
                     // Ledger, not console: swallowing this into stdout is the
                     // exact failure mode the injected sink exists to prevent.
                     this.events.publish(Operational.Warn, {
-                      traceId: this.generationTraceId,
+                      traceId: generationTraceId,
                       time: Date.now(),
                       component: "coordinator",
                       msg: "worker.tool_call_settled notification failed",
@@ -198,7 +202,7 @@ export class WorkerSupervisor {
         if (!this.stopping && this.running) {
           this.client = c;
           this.events.publish(WorkerDriver.Ready, {
-            traceId: this.generationTraceId,
+            traceId: generationTraceId,
             time: Date.now(),
             workerId: this.id,
             generation: this.generation,
@@ -221,7 +225,7 @@ export class WorkerSupervisor {
       // doStart() fires this promise without awaiting it, so a throw here would
       // surface as an unhandled rejection; report and let waitReady() time out.
       this.events.publish(Operational.Warn, {
-        traceId: this.generationTraceId,
+        traceId: generationTraceId,
         time: Date.now(),
         component: "coordinator.worker",
         msg: "worker IPC connect failed within deadline",

--- a/packages/coordinator/test/harness/rejecting-worker-fixture.ts
+++ b/packages/coordinator/test/harness/rejecting-worker-fixture.ts
@@ -1,0 +1,52 @@
+import { appendFileSync } from "node:fs";
+
+// A worker whose bootstrap always REJECTS, on a raw socket so every client
+// open/close is countable: the supervisor's connect loop must close each
+// failed attempt's client instead of leaking it. The test derives the peak
+// number of concurrently-live clients from the open/close log.
+function readCliArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const socketPath = readCliArg("--socket");
+if (!socketPath) {
+  console.error("rejecting-worker-fixture: missing --socket");
+  process.exit(1);
+}
+// The worker env is allowlisted, so the observable log path is derived from
+// the one channel the supervisor already provides: the socket path.
+const logPath = `${socketPath}.log`;
+
+Bun.listen<{ buffer: string }>({
+  unix: socketPath,
+  socket: {
+    open(socket) {
+      socket.data = { buffer: "" };
+      appendFileSync(logPath, "open\n");
+    },
+    close() {
+      appendFileSync(logPath, "close\n");
+    },
+    data(socket, chunk) {
+      socket.data.buffer += chunk.toString();
+      let newline = socket.data.buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = socket.data.buffer.slice(0, newline);
+        socket.data.buffer = socket.data.buffer.slice(newline + 1);
+        newline = socket.data.buffer.indexOf("\n");
+        if (line.trim().length === 0) continue;
+        const message = JSON.parse(line) as { type?: string; id?: string; method?: string };
+        if (message.type === "request" && message.id !== undefined) {
+          socket.write(
+            `${JSON.stringify({ v: 2, type: "response", id: message.id, result: { ok: false, error: "rejected by fixture" } })}\n`,
+          );
+        }
+      }
+    },
+  },
+});
+
+setInterval(() => {
+  // Keep the process alive; the supervisor kills it on stop().
+}, 1_000);

--- a/packages/coordinator/test/worker-supervision/bootstrap-leak.test.ts
+++ b/packages/coordinator/test/worker-supervision/bootstrap-leak.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkerSupervisor } from "../../src/worker-supervision/supervisor.js";
+
+const FIXTURE = new URL("../harness/rejecting-worker-fixture.ts", import.meta.url).pathname;
+
+let tempDir: string;
+let supervisor: WorkerSupervisor | undefined;
+
+afterEach(async () => {
+  await supervisor?.stop();
+  supervisor = undefined;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("a rejected bootstrap attempt closes its IPC client instead of leaking it", async () => {
+  tempDir = mkdtempSync(join(tmpdir(), "bootstrap-leak-"));
+  const logPath = join(tempDir, "openomni-worker-991.sock.log");
+
+  // Construction spawns the worker and begins the connect loop.
+  supervisor = new WorkerSupervisor({
+    id: 991,
+    script: FIXTURE,
+    socketDir: tempDir,
+    events: { publish: () => undefined },
+  });
+  // Long enough for several ~100ms retry rounds against the rejecting
+  // bootstrap; a leak accumulates one live client per round.
+  await new Promise((resolve) => setTimeout(resolve, 1_200));
+  await supervisor.stop();
+
+  const lines = readFileSync(logPath, "utf8")
+    .split("\n")
+    .filter((line) => line === "open" || line === "close");
+  let live = 0;
+  let peak = 0;
+  for (const line of lines) {
+    live += line === "open" ? 1 : -1;
+    peak = Math.max(peak, live);
+  }
+  const attempts = lines.filter((line) => line === "open").length;
+  // Sanity: the loop really retried more than once (else the pin is vacuous).
+  expect(attempts).toBeGreaterThan(2);
+  // Pin: failed attempts release their clients — at most the current attempt
+  // (plus one mid-handoff straggler) is ever alive at once.
+  expect(peak).toBeLessThanOrEqual(2);
+});

--- a/packages/coordinator/test/worker-supervision/bootstrap-leak.test.ts
+++ b/packages/coordinator/test/worker-supervision/bootstrap-leak.test.ts
@@ -6,13 +6,13 @@ import { WorkerSupervisor } from "../../src/worker-supervision/supervisor.js";
 
 const FIXTURE = new URL("../harness/rejecting-worker-fixture.ts", import.meta.url).pathname;
 
-let tempDir: string;
+let tempDir: string | undefined;
 let supervisor: WorkerSupervisor | undefined;
 
 afterEach(async () => {
   await supervisor?.stop();
   supervisor = undefined;
-  rmSync(tempDir, { recursive: true, force: true });
+  if (tempDir !== undefined) rmSync(tempDir, { recursive: true, force: true });
 });
 
 test("a rejected bootstrap attempt closes its IPC client instead of leaking it", async () => {


### PR DESCRIPTION
## Summary

Fixes the coordinator MAJOR + two MINORs from the 8-package adversarial audit (#606).

**MAJOR — IPC client leak in the bootstrap retry loop.** `connectWithRetry` connected a client, and if the bootstrap call threw or was rejected, retried every ~100ms WITHOUT closing it — up to dozens of connected Unix-socket clients per worker within the 10s deadline, each with live `onRequest`/`onNotification` handlers (a stale one can flip `bootstrapped` or answer worker requests alongside the winner). Failed attempts now `close()` in the catch.

**One trace per worker generation.** The six unrelated `crypto.randomUUID()` trace mints (Spawned/Ready/Exited/Restarted/connect-failed warn/SIGKILL warn) collapse onto ONE `generationTraceId` minted per `doStart()` — a worker generation's whole lifecycle now reads as one flow. Mint-site count drops 6 → 1 (+`authToken`, not a trace); the ring-2 Owner gate is untouched (no new deps, no W3C mint — the mint stays a uuid pending the Owner ruling recorded in #606).

**MINORs.** The `worker.tool_call_settled` failure warn now publishes `Operational.Warn` to the injected events sink instead of `console.warn` (the package's own options doc calls a swallowed Warn "the exact failure mode the ledger exists to prevent"); the false "Authenticate like every other worker→coordinator verb" comment is rewritten to state the real contract (the cancel verbs carry no token by design; bounded blast radius + 0700 socket dir).

## Pin (new)

`packages/coordinator/test/worker-supervision/bootstrap-leak.test.ts` + `test/harness/rejecting-worker-fixture.ts`: a raw-socket worker whose bootstrap always rejects logs every client open/close; the pin asserts >2 retry attempts happened AND peak concurrent clients ≤ 2. Mutation-verified: removing the `close()` fails the pin (peak climbs with each retry), restored green. The fixture derives its log path from the socket path because the worker env is allowlisted.

## Verification

- `bun test packages/coordinator`: 46 pass / 0 fail
- `tsc --noEmit` (coordinator): 0 errors; `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes an IPC client leak during coordinator bootstrap retries and consolidates worker lifecycle tracing to a single per-generation trace. Prevents stale clients from handling requests and ensures warns and lifecycle events correlate to the right generation.

- On bootstrap failure, close the connected IPC client before retrying. Old behavior retried without closing and accumulated live clients/handlers; new behavior keeps only the current attempt alive (peak ≤ 2 during handoff), eliminating races.
- Use one `generationTraceId` per `doStart()` and snapshot it inside the connect loop so deadline and `worker.tool_call_settled` warns file under the correct generation. Route `worker.tool_call_settled` failures to the injected events sink as `Operational.Warn` instead of `console.warn`.
- Clarify auth comment: cancel verbs intentionally carry no token; scope is limited to the worker’s own calls and protected by a 0700 per-pool socket directory. Add a pin test and a raw-socket rejecting worker fixture under `packages/coordinator` to verify retries and that peak concurrent clients remain ≤ 2. No migration required.

<sup>Written for commit f423b0e06307050034ae08f55111cd1ee3c7941c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

