### PR TITLE
fix(session): record-without-act writes fail closed (#606)

### DIFF
--- a/apps/server/src/bootstrap/resident-inbound-wait.ts
+++ b/apps/server/src/bootstrap/resident-inbound-wait.ts
@@ -1,6 +1,8 @@
 import type { InboundWaitParams, InboundWaitResult } from "@openomni/coordinator";
 import type { DispatchRuntime } from "@openomni/openomni";
+import { Operational } from "@openomni/protocol";
 import { WorkItemAttemptRun } from "@openomni/session";
+import { Bus } from "@openomni/telemetry";
 import type { ServerConfig } from "../config";
 
 export type ResidentInboundWaitConfig = {
@@ -90,8 +92,24 @@ export function createResidentInboundWaitHandler(
       };
     } finally {
       // Release the wait if it is still ours; a run finished mid-wait keeps
-      // its terminal record (endWait is a no-op receipt then).
-      await WorkItemAttemptRun.endWait(sessionId, runId, traceId);
+      // its terminal record (endWait is a no-op receipt then). A failed
+      // release (e.g. a BUSY store) must not discard the answer the resident
+      // already produced — record it and let the blocker age out.
+      try {
+        await WorkItemAttemptRun.endWait(sessionId, runId, traceId);
+      } catch (releaseError) {
+        Bus.publish(Operational.Warn, {
+          traceId,
+          time: Date.now(),
+          sessionId,
+          component: "server",
+          msg: "inbound-wait release failed; answer kept, blocker ages out",
+          context: {
+            runId,
+            error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+          },
+        });
+      }
     }
   };
 }

--- a/packages/openomni/src/ingress/handlers.ts
+++ b/packages/openomni/src/ingress/handlers.ts
@@ -1,5 +1,6 @@
 import {
   IngressEvent,
+  Operational,
   type Execution,
   type Ingress,
   type TraceContext as TraceContextProtocol,
@@ -169,6 +170,32 @@ export namespace IngressHandlers {
     );
   }
 
+  /**
+   * Last-resort recorder for a terminal-fact write that itself failed (e.g.
+   * SQLITE_BUSY rethrown by the store): the run's outcome is already decided,
+   * so the failure must be RECORDED, never rethrown — an escape here from the
+   * background dispatch's void IIFE is an unhandled rejection that kills the
+   * whole process under bun.
+   */
+  function recordTerminalFactFailure(
+    ctx: HandlerContext,
+    request: Execution.Request,
+    stage: string,
+    error: unknown,
+  ): void {
+    Bus.publish(Operational.Error, {
+      traceId: requireTraceId(ctx),
+      time: Date.now(),
+      sessionId: ctx.sessionId,
+      component: "ingress",
+      msg: `run terminal fact write failed (${stage})`,
+      context: {
+        runId: request.runId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+
   async function markDispatchThrown(
     ctx: HandlerContext,
     request: Execution.Request,
@@ -293,7 +320,14 @@ export namespace IngressHandlers {
     void (async () => {
       try {
         const result = await coordinator.dispatch(ctx.sessionId, request);
-        await finishCoordinatorDispatch(ctx, request, result);
+        try {
+          await finishCoordinatorDispatch(ctx, request, result);
+        } catch (finishError) {
+          // The dispatch SUCCEEDED: a failed fact write must not fall into
+          // the dispatch-thrown arm below (which would record the succeeded
+          // run as "interrupted").
+          recordTerminalFactFailure(ctx, request, "finish", finishError);
+        }
         if (result.output) {
           SessionBridge.storeDirectResult(
             requireTraceId(ctx),
@@ -309,7 +343,11 @@ export namespace IngressHandlers {
         publishFailed(ctx, target, start, result.error ?? result.status);
       } catch (error) {
         publishFailed(ctx, target, start, error);
-        await markDispatchThrown(ctx, request, error);
+        try {
+          await markDispatchThrown(ctx, request, error);
+        } catch (finishError) {
+          recordTerminalFactFailure(ctx, request, "interrupted", finishError);
+        }
       }
     })();
   }
@@ -411,7 +449,13 @@ export namespace IngressHandlers {
     let coordinatorResult: Execution.Result;
     try {
       coordinatorResult = await ctx.coordinator.dispatch(ctx.sessionId, request);
-      await finishCoordinatorDispatch(ctx, request, coordinatorResult);
+      try {
+        await finishCoordinatorDispatch(ctx, request, coordinatorResult);
+      } catch (finishError) {
+        // The dispatch already produced its result; record the fact-write
+        // failure instead of mislabeling the run "interrupted" below.
+        recordTerminalFactFailure(ctx, request, "finish", finishError);
+      }
       if (coordinatorResult.status !== "succeeded") {
         if (coordinatorResult.status === "cancelled") {
           const output = coordinatorResult.output ?? coordinatorResult.error ?? "cancelled";
@@ -438,7 +482,12 @@ export namespace IngressHandlers {
       }
     } catch (error) {
       publishFailed(ctx, target, start, error);
-      await markDispatchThrown(ctx, request, error);
+      try {
+        await markDispatchThrown(ctx, request, error);
+      } catch (finishError) {
+        // Never mask the original dispatch error with the fact-write failure.
+        recordTerminalFactFailure(ctx, request, "interrupted", finishError);
+      }
       throw error;
     }
     const output = coordinatorResult.output ?? "";

--- a/packages/openomni/test/ingress/terminal-fact-boundary.test.ts
+++ b/packages/openomni/test/ingress/terminal-fact-boundary.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Operational, type Ingress } from "@openomni/protocol";
+import { Session, Storage, WorkItemAttemptRun } from "@openomni/session";
+import { Bus } from "@openomni/telemetry";
+import { IngressHandlers } from "../../src/ingress/handlers";
+import type { CoordinatorLike } from "../../src/ingress/coordinator-like";
+
+function createSession(): string {
+  return Session.create({
+    traceId: "trace-test",
+    title: "Terminal Fact Boundary",
+    model: { providerID: "anthropic", modelID: "claude-3-haiku-20240307" },
+  }).id;
+}
+
+function workerEvent(sessionId: string): Ingress.ResolvedInboundEvent {
+  return {
+    id: "event-boundary-1",
+    traceId: "trace-test",
+    surface: "tui",
+    mode: "direct",
+    payload: "do the thing",
+    target: { kind: "worker", sessionId },
+    // `background` rides the open runtime bag (isBackgroundWorkerIngress
+    // reads it structurally).
+    runtime: { background: true } as Ingress.ResolvedInboundEvent["runtime"],
+    agent: { model: { provider: "anthropic", id: "claude-3-haiku-20240307" } },
+  };
+}
+
+/**
+ * Arms WorkItemAttemptRun.finish to throw the store's BUSY error: the
+ * attempt-run setup writes must succeed, only the IIFE's deferred terminal
+ * fact write fails — matching the #670 review PoC.
+ */
+function armableBusyFinish(): { arm: () => void; restore: () => void } {
+  const original = WorkItemAttemptRun.finish;
+  let armed = false;
+  WorkItemAttemptRun.finish = async (...args: Parameters<typeof original>) => {
+    if (!armed) return original(...args);
+    const busy = new Error("WorkItem storage busy: wi_test — database is locked") as Error & {
+      code: string;
+    };
+    busy.code = "unavailable";
+    throw busy;
+  };
+  return {
+    arm: () => {
+      armed = true;
+    },
+    restore: () => {
+      WorkItemAttemptRun.finish = original;
+    },
+  };
+}
+
+async function flushBackground(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+describe("terminal-fact failures record, never kill (#606 review)", () => {
+  beforeEach(() => {
+    Bus.reset();
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    Storage.reset();
+    Bus.reset();
+  });
+
+  it("a busy interrupted-fact write in the background IIFE records instead of rejecting", async () => {
+    const sessionId = createSession();
+    const errors: Array<Record<string, unknown>> = [];
+    Bus.observe((event, data) => {
+      if (event.name === Operational.Error.name) errors.push(data as Record<string, unknown>);
+    });
+    // The dispatch waits for the test's signal so the busy arm is in place
+    // BEFORE the IIFE's failure path runs its terminal fact write.
+    let releaseDispatch: () => void = () => undefined;
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const coordinator: CoordinatorLike = {
+      dispatch: async () => {
+        await dispatchGate;
+        throw new Error("worker exploded");
+      },
+    };
+    const busy = armableBusyFinish();
+    try {
+      // Pin: pre-fix this chain rejected the void IIFE — an unhandled
+      // rejection that kills the whole process under bun (#670 review PoC).
+      const result = await IngressHandlers.handleDirect({
+        sessionId,
+        traceContext: { traceId: "trace-boundary" },
+        event: workerEvent(sessionId),
+        coordinator,
+      });
+      expect(result).toMatchObject({ result: { finishReason: "background" } });
+      busy.arm();
+      releaseDispatch();
+      await flushBackground();
+    } finally {
+      busy.restore();
+    }
+    expect(
+      errors.some(
+        (error) =>
+          error.msg === "run terminal fact write failed (interrupted)" &&
+          error.traceId === "trace-boundary",
+      ),
+    ).toBe(true);
+  });
+
+  it("a busy finish on the SUCCESS path records — never an interrupted fact", async () => {
+    const sessionId = createSession();
+    const errors: string[] = [];
+    Bus.observe((event, data) => {
+      if (event.name === Operational.Error.name) {
+        errors.push(String((data as { msg?: unknown }).msg));
+      }
+    });
+    let releaseDispatch: () => void = () => undefined;
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const coordinator: CoordinatorLike = {
+      dispatch: async () => {
+        await dispatchGate;
+        return { runId: "run-boundary", sessionId, status: "succeeded" as const, output: "done" };
+      },
+    };
+    const busy = armableBusyFinish();
+    try {
+      const result = await IngressHandlers.handleDirect({
+        sessionId,
+        traceContext: { traceId: "trace-boundary" },
+        event: workerEvent(sessionId),
+        coordinator,
+      });
+      expect(result).toMatchObject({ result: { finishReason: "background" } });
+      busy.arm();
+      releaseDispatch();
+      await flushBackground();
+    } finally {
+      busy.restore();
+    }
+    expect(errors).toContain("run terminal fact write failed (finish)");
+    expect(errors).not.toContain("run terminal fact write failed (interrupted)");
+  });
+});

--- a/packages/session/src/session/messages.ts
+++ b/packages/session/src/session/messages.ts
@@ -19,7 +19,12 @@ export function addMessage(
 ): void {
   const adapter = Storage.getAdapter();
   const session = adapter.session.get(sessionID);
-  if (!session) return;
+  if (!session) {
+    // Fail closed: ingress appends its message.write ledger fact BEFORE this
+    // call — returning silently here left record-without-act with zero
+    // telemetry (unexplained message loss the ledger claims happened).
+    throw new Error(`addMessage: session not found: ${sessionID}`);
+  }
 
   const status = options?.status ?? "completed";
 

--- a/packages/session/src/work-item/attempt-run.ts
+++ b/packages/session/src/work-item/attempt-run.ts
@@ -1,7 +1,7 @@
 import { WorkItem, type WorkerRun } from "@openomni/protocol";
 import { Storage } from "../storage/storage.js";
 import { WorkerRunStateStore } from "../worker-run/state-store.js";
-import { WorkItemRevisionError, WorkItemUnavailableError } from "./facts.js";
+import { WorkItemRevisionError } from "./facts.js";
 import { mutate } from "./mutation.js";
 
 /**
@@ -169,12 +169,11 @@ async function mutateRun(
   } catch (error) {
     // Contention (a concurrent transition won the head) and losing the
     // acquire race both mean "not acquired/finished" — the caller retries
-    // from a fresh read or reports the run as no longer active.
-    if (
-      error instanceof AttemptRunNotActiveError ||
-      error instanceof WorkItemRevisionError ||
-      error instanceof WorkItemUnavailableError
-    ) {
+    // from a fresh read or reports the run as no longer active. A BUSY
+    // storage layer is NEITHER: swallowing WorkItemUnavailableError here
+    // silently lost terminal attempt facts (runs stuck "running" forever),
+    // so it rethrows to the caller like every other storage failure.
+    if (error instanceof AttemptRunNotActiveError || error instanceof WorkItemRevisionError) {
       return false;
     }
     throw error;

--- a/packages/session/src/work-item/create.ts
+++ b/packages/session/src/work-item/create.ts
@@ -1,4 +1,4 @@
-import { Operational, WorkItem } from "@openomni/protocol";
+import { WorkItem } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { Storage } from "../storage/storage.js";
 import { buildWorkItem } from "./builder.js";
@@ -19,14 +19,10 @@ export async function createWorkItem(
   const storage = Storage.get();
   const workItem = storage.workItem;
   if (!workItem) {
-    Bus.publish(Operational.Warn, {
-      traceId,
-      time: Date.now(),
-      sessionId: input.sessionId,
-      component: "work-item",
-      msg: "WorkItem storage not configured, skipping create",
-    });
-    return buildWorkItem(input, Date.now());
+    // Fail closed like every other WorkItem write (facts.ts): the old warn-
+    // and-fabricate path returned a phantom Info that was never persisted —
+    // a hash indistinguishable from a real create.
+    throw new Error("WorkItem storage not configured — refusing to fabricate a work item");
   }
   const ledger = requireWorkItemLedger(storage);
 

--- a/packages/session/src/work-item/work-item.test.ts
+++ b/packages/session/src/work-item/work-item.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { Operational, WorkItem } from "@openomni/protocol";
+import { WorkItem } from "@openomni/protocol";
 import { ZodError } from "zod";
 import { Bus } from "@openomni/telemetry";
 import { SqliteStorageAdapter } from "../storage/sqlite-storage.js";
@@ -764,9 +764,7 @@ describe("WorkItemStore", () => {
     await expect(WorkItemStore.retry("missing", "trace-test")).resolves.toBeUndefined();
   });
 
-  test("degrades gracefully when work item storage is missing", async () => {
-    const warnings: unknown[] = [];
-    Bus.subscribe(Operational.Warn, (event) => warnings.push(event));
+  test("refuses to fabricate a work item when storage is missing (#606)", async () => {
     Storage.configure({
       transaction: (operation) => operation(),
       session: {
@@ -789,13 +787,10 @@ describe("WorkItemStore", () => {
       },
     });
 
-    const item = await createItem("graceful");
-    await flushBus();
-
-    expect(item.hash).toStartWith("wi_");
-    expect(WorkItem.deriveStatus(item)).toBe("pending");
-    expect(warnings).toHaveLength(1);
-    expect(WorkItemStore.get(item.hash)).toBeUndefined();
+    // The old "graceful" path returned a phantom Info that was never
+    // persisted — a hash indistinguishable from a real create. WorkItem
+    // writes fail closed (facts.ts); creation is a write.
+    await expect(createItem("graceful")).rejects.toThrow("refusing to fabricate");
   });
 
   test("rolls back WorkItem graph removal and publishes no events when deletion fails", async () => {

--- a/packages/session/test/session/metadata-hooks.test.ts
+++ b/packages/session/test/session/metadata-hooks.test.ts
@@ -225,9 +225,11 @@ describe("Session.addMessage metadata hooks", () => {
   });
 
   describe("edge cases", () => {
-    test("does not throw when session does not exist", () => {
+    test("refuses a write for a missing session — no silent drop", () => {
+      // Pin (#606 audit): ingress records its ledger fact BEFORE this call;
+      // a silent return here was record-without-act with zero telemetry.
       const msg = makeUserMessage("nonexistent-session");
-      expect(() => Session.addMessage("nonexistent-session", msg)).not.toThrow();
+      expect(() => Session.addMessage("nonexistent-session", msg)).toThrow("session not found");
     });
 
     test("preserves other session fields when updating metadata", () => {

--- a/packages/session/test/work-item/attempt-run.test.ts
+++ b/packages/session/test/work-item/attempt-run.test.ts
@@ -107,6 +107,32 @@ afterEach(() => {
 });
 
 describe("WorkItemAttemptRun", () => {
+  test("finish rethrows a BUSY storage layer instead of reporting not-active (#606)", async () => {
+    await seedRun("sess-busy", "run-busy");
+    const workItem = Storage.get().workItem;
+    if (!workItem) throw new Error("workItem adapter missing");
+    const original = workItem.compareAndSet.bind(workItem);
+    // SQLITE_BUSY shape as pinned by sqlite-busy.test.ts; facts.ts maps it to
+    // WorkItemUnavailableError. The old catch swallowed it into `false`, which
+    // callers discard — a busy DB silently lost the terminal attempt fact.
+    Object.defineProperty(workItem, "compareAndSet", {
+      configurable: true,
+      value: () => {
+        const busy = new Error("database is locked") as Error & { code: string; errno: number };
+        busy.code = "SQLITE_BUSY";
+        busy.errno = 5;
+        throw busy;
+      },
+    });
+    try {
+      await expect(
+        WorkItemAttemptRun.finish("sess-busy", "run-busy", "succeeded", "trace-busy", {}),
+      ).rejects.toThrow();
+    } finally {
+      Object.defineProperty(workItem, "compareAndSet", { configurable: true, value: original });
+    }
+  });
+
   test("find returns the attempt-fact view with parent session and executor", async () => {
     const hash = await seedRun("sess-view", "run-view");
 

--- a/packages/session/test/work-item/failclosed.test.ts
+++ b/packages/session/test/work-item/failclosed.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Storage } from "../../src/storage/storage";
+import { createWorkItem } from "../../src/work-item/create";
+import "../../src/storage/initialize";
+
+describe("work-item writes fail closed (#606 audit)", () => {
+  beforeEach(() => {
+    Storage.reset();
+  });
+
+  test("create refuses without the workItem adapter — no phantom Info", async () => {
+    // Bare storage: no workItem sub-adapter. The old path warned and returned
+    // a fabricated, never-persisted Info whose hash looked real.
+    Storage.initialize({ dbPath: ":memory:" });
+    const adapter = Storage.getAdapter();
+    Object.defineProperty(Storage.get(), "workItem", { value: undefined, configurable: true });
+
+    await expect(
+      createWorkItem(
+        {
+          name: "phantom",
+          sourceMessageId: "msg-1",
+          sourceChannel: "test",
+          intent: "test",
+          goal: "never persisted",
+          acceptanceCriteria: ["none"],
+          sessionId: "ses-1",
+        },
+        "trace-failclosed",
+      ),
+    ).rejects.toThrow("refusing to fabricate");
+    void adapter;
+  });
+});

--- a/packages/session/test/work-item/failclosed.test.ts
+++ b/packages/session/test/work-item/failclosed.test.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Storage } from "../../src/storage/storage";
 import { createWorkItem } from "../../src/work-item/create";
 import "../../src/storage/initialize";
 
 describe("work-item writes fail closed (#606 audit)", () => {
   beforeEach(() => {
+    Storage.reset();
+  });
+
+  afterEach(() => {
     Storage.reset();
   });
 


### PR DESCRIPTION
## Summary

Three fail-closed fixes from the session audit's MAJOR list (#606) — each one a silent-loss path in a live write:

1. **`Session.addMessage` silent drop.** When the session row was absent it returned silently — but ingress appends its `ingress.*.message.write` ledger fact BEFORE this call (enforced by `lint-side-effects`), so a missing session produced record-without-act with zero telemetry: message loss the ledger claims happened. Now throws `addMessage: session not found`.

2. **BUSY swallow lost terminal attempt facts.** `mutateRun`'s catch treated `WorkItemUnavailableError` (SQLITE_BUSY) like contention and returned `false` — which the dispatch/ingress `finish()` callers discard (recovery.ts:33 consumes it), so a busy storage layer silently lost the terminal attempt fact and runs stayed "running" forever. Contention (`AttemptRunNotActiveError`/`WorkItemRevisionError`) still maps to `false`; BUSY rethrows like every other storage failure.

3. **`createWorkItem` fail-open phantom.** With no workItem adapter it warned and returned a fabricated, never-persisted `WorkItem.Info` — a hash indistinguishable from a real create, directly against `facts.ts`'s declared fail-closed rule for WorkItem writes. Now refuses.

## Pins (all mutation-verified)

- `metadata-hooks.test.ts` — the old "does not throw when session does not exist" pin (which enshrined the drop) is rewritten to assert the refusal; restoring `return` fails it.
- `attempt-run.test.ts` — new: a SQLITE_BUSY-shaped `compareAndSet` makes `finish` REJECT instead of reporting not-active; restoring the swallow fails it (7/1).
- `failclosed.test.ts` — new: `createWorkItem` without the adapter rejects with "refusing to fabricate".
- `work-item.test.ts` (src-colocated — CI caught it, my test-dir sweep missed it): the "degrades gracefully" test that ENSHRINED the phantom create is rewritten as a refusal pin.

**Review round 2 (blast-radius boundaries, per adversarial FAIL):** a new `recordTerminalFactFailure` records fact-write failures under the flow's trace and never rethrows — the background dispatch IIFE can no longer reject (an unhandled rejection kills the whole process under bun, empirically); success-path `finishCoordinatorDispatch` failures no longer mislabel a succeeded run "interrupted"; `handleDirect` rethrows the ORIGINAL dispatch error, never the fact-write failure; resident-inbound-wait keeps a produced answer when the wait release itself fails (Operational.Warn, blocker ages out). New pins for the boundaries (mutation-verified): `terminal-fact-boundary.test.ts` — the gated-dispatch IIFE pin (busy interrupted-fact write records under the flow trace, nothing rejects) and the success-path sibling ("(finish)" recorded, no "(interrupted)" mislabel). The inbound-wait answer-kept pin is the agreed immediate follow-up (lowest-stakes seam, disproportionate harness cost here). Boot recovery stays fail-fast by the reviewer's own assessment.

## Verification

- `bun test packages/session packages/openomni/test apps/server/test` (src-colocated tests included): **1856 pass / 0 fail** at the review-delta head
- `tsc --noEmit -p tsconfig.test.json` (session): 0 errors; `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closes three session/work-item write paths and records terminal fact write failures without crashing dispatch. Old: `Session.addMessage` returned on missing sessions, `WorkItemAttemptRun.finish` swallowed `SQLITE_BUSY` as not-active, `createWorkItem` fabricated an unpersisted item, and terminal fact writes could kill the process or mislabel runs as “interrupted.” New: `addMessage` throws “session not found,” `finish` rethrows BUSY (contention still returns false), `createWorkItem` throws when the `workItem` adapter is missing, and `@openomni/openomni` ingress records terminal fact write failures to Operational telemetry and preserves the run’s outcome; resident inbound wait logs and keeps the answer if `endWait` fails.

- Migration
  - Handle thrown errors from `Session.addMessage` when the session is missing.
  - Treat `SQLITE_BUSY` from `WorkItemAttemptRun.finish` as a storage failure; do not interpret it as “not active.”
  - Configure a `workItem` storage adapter before calling `createWorkItem`; creation now fails if it is absent.

<sup>Written for commit f8c29af23e5cc0786c5741a0b88781aa0c058a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing sessions now produce a clear error when messages are added.
  * Storage failures during work-item creation and updates are surfaced instead of being silently ignored.
  * Prevented creation of misleading, unpersisted work items when storage is unavailable.
  * Retained expected handling for temporary contention and inactive work-item runs.

* **Tests**
  * Added coverage for missing-session errors and storage-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

