### PR TITLE
refactor(policy): pin the invariants, kill the dead lanes (#606)

### DIFF
--- a/packages/openomni/src/dispatch/policy-registration.ts
+++ b/packages/openomni/src/dispatch/policy-registration.ts
@@ -49,7 +49,6 @@ interface CanonicalFields {
   readonly scope: unknown;
   readonly failPolicy: unknown;
   readonly fn: unknown;
-  readonly propagate: unknown;
 }
 
 function isRecord(value: unknown): value is object {
@@ -69,7 +68,6 @@ function readCanonicalFields(value: object, name: unknown): CanonicalFields {
     scope: Reflect.get(value, "scope"),
     failPolicy: Reflect.get(value, "failPolicy"),
     fn: Reflect.get(value, "fn"),
-    propagate: Reflect.get(value, "propagate"),
   };
 }
 
@@ -165,11 +163,7 @@ function inspectDispatchPolicy(value: unknown): {
       scope,
       failPolicy: fields.failPolicy,
     });
-    if (
-      !metadata.success ||
-      !isCanonicalPolicyFunction(fields.fn) ||
-      (fields.propagate !== undefined && typeof fields.propagate !== "boolean")
-    ) {
+    if (!metadata.success || !isCanonicalPolicyFunction(fields.fn)) {
       throw new DispatchPolicyRegistrationError("invalid_policy_registration", name);
     }
     const trusted = {
@@ -181,7 +175,6 @@ function inspectDispatchPolicy(value: unknown): {
       ...(scope === undefined ? {} : { scope }),
       ...(metadata.data.failPolicy === undefined ? {} : { failPolicy: metadata.data.failPolicy }),
       fn: fields.fn,
-      ...(fields.propagate === undefined ? {} : { propagate: fields.propagate }),
     } satisfies DispatchPolicyRegistration;
     return { registration: Object.freeze(trusted), registrationName: name };
   } catch (error) {

--- a/packages/openomni/test/dispatch/runtime-policy-registration.test.ts
+++ b/packages/openomni/test/dispatch/runtime-policy-registration.test.ts
@@ -187,8 +187,7 @@ describe("DispatchRuntime policy registration boundary", () => {
       | "priority"
       | "scope"
       | "failPolicy"
-      | "fn"
-      | "propagate";
+      | "fn";
     const reads: Record<CanonicalField, number> = {
       kind: 0,
       name: 0,
@@ -198,7 +197,6 @@ describe("DispatchRuntime policy registration boundary", () => {
       scope: 0,
       failPolicy: 0,
       fn: 0,
-      propagate: 0,
     };
     function observed<Value>(field: CanonicalField, value: Value): Value {
       reads[field] += 1;
@@ -237,9 +235,6 @@ describe("DispatchRuntime policy registration boundary", () => {
           return PolicyDecision.deny({ policyId: "changing-point-policy" });
         });
       },
-      get propagate() {
-        return observed("propagate", undefined);
-      },
     });
 
     const result = await submission;
@@ -254,7 +249,6 @@ describe("DispatchRuntime policy registration boundary", () => {
       scope: 1,
       failPolicy: 1,
       fn: 1,
-      propagate: 1,
     });
     expect(policyCalls).toBe(1);
     expect(handlerWasCalled()).toBe(false);

--- a/packages/policy/src/effects/compose.ts
+++ b/packages/policy/src/effects/compose.ts
@@ -43,7 +43,7 @@ export function composeEffects(decisions: Policy.PolicyDecision[]): Policy.Effec
 
   return {
     verdict,
-    mergedEffects: [...merged.effects, ...merged.postConflicts.map(conflictDiagnostic)],
+    mergedEffects: merged.effects,
     obligations: verdict === "pending" ? collectObligations(orderedDecisions) : [],
     contributingPolicies,
   };

--- a/packages/policy/src/effects/conflicts.ts
+++ b/packages/policy/src/effects/conflicts.ts
@@ -1,11 +1,5 @@
 import type { Policy } from "@openomni/protocol";
-import {
-  FAIL_CLOSED_CONFLICT,
-  POST_BOUNDARY_CONFLICT,
-  type Conflict,
-  type EffectEntry,
-  type FieldOwner,
-} from "./types";
+import { FAIL_CLOSED_CONFLICT, type Conflict, type EffectEntry, type FieldOwner } from "./types";
 import { flattenRecord, pathsOverlap, stableHash } from "./records";
 
 export function collectPreConflicts(entries: EffectEntry[]): Conflict[] {
@@ -50,7 +44,6 @@ function collectRecordRewriteConflicts(
       if (owner && owner.valueHash !== valueHash) {
         if (owner.priority === entry.priority) {
           conflicts.push({
-            boundary: "pre",
             message: `${effectType}.${path} rewritten by ${owner.policyId} and ${entry.policyId}`,
           });
         }
@@ -111,7 +104,6 @@ function collectSingleValueConflicts(
     if (owner && owner.policyId !== entry.policyId && owner.valueHash !== valueHash) {
       if (owner.priority === entry.priority) {
         conflicts.push({
-          boundary: "pre",
           message: `${label}.${field} rewritten by ${owner.policyId} and ${entry.policyId}`,
         });
       }
@@ -162,7 +154,6 @@ function collectWritebackSuppressConflicts(entries: EffectEntry[]): Conflict[] {
         continue;
       }
       conflicts.push({
-        boundary: "pre",
         message: `writeback.suppress conflicts with writeback.rewrite from ${rewrite.policyId} and ${suppress.policyId}`,
       });
     }
@@ -179,23 +170,15 @@ function collectFilterApprovalConflicts(entries: EffectEntry[]): Conflict[] {
 
   return [
     {
-      boundary: "pre",
       message: `tool.filter conflicts with tool.require_approval from ${firstFilter.policyId} and ${firstApproval.policyId}`,
     },
   ];
 }
 
 export function conflictDiagnostic(conflict: Conflict): Policy.PolicyEffect {
-  const prefix = conflict.boundary === "pre" ? FAIL_CLOSED_CONFLICT : POST_BOUNDARY_CONFLICT;
-  const severity = conflict.boundary === "pre" ? "error" : "warning";
-
   return {
     type: "audit.annotate",
-    annotation: `${prefix}: ${conflict.message}`,
-    severity,
+    annotation: `${FAIL_CLOSED_CONFLICT}: ${conflict.message}`,
+    severity: "error",
   };
-}
-
-export function collectPostConflicts(_entries: readonly EffectEntry[]): Conflict[] {
-  return [];
 }

--- a/packages/policy/src/effects/merge/rules.ts
+++ b/packages/policy/src/effects/merge/rules.ts
@@ -14,11 +14,9 @@ import {
 } from "./accumulators";
 import { appendMergedEffects } from "./output";
 import { assertNever, deepMergeRecords } from "../records";
-import { collectPostConflicts } from "../conflicts";
 
 export function mergeEntries(entries: readonly EffectEntry[]): MergeResult {
   const merged: MergedEffect[] = [];
-  const postConflicts = collectPostConflicts(entries);
   const toolFilters = new Map<string, number>();
   let toolRewrite: { readonly input: Record<string, unknown>; readonly order: number } | undefined;
   let toolOutputRewrite: MergedEffect | undefined;
@@ -164,6 +162,5 @@ export function mergeEntries(entries: readonly EffectEntry[]): MergeResult {
 
   return {
     effects: merged.sort((left, right) => left.order - right.order).map(({ effect }) => effect),
-    postConflicts,
   };
 }

--- a/packages/policy/src/effects/types.ts
+++ b/packages/policy/src/effects/types.ts
@@ -1,7 +1,5 @@
 import type { Policy } from "@openomni/protocol";
 
-type Boundary = "pre" | "post";
-
 export interface OrderedDecision {
   readonly decision: Policy.PolicyDecision;
   readonly priority: number;
@@ -18,7 +16,6 @@ export interface EffectEntry {
 }
 
 export interface Conflict {
-  readonly boundary: Boundary;
   readonly message: string;
 }
 
@@ -52,8 +49,6 @@ export interface RetryAccumulator {
 
 export interface MergeResult {
   readonly effects: Policy.PolicyEffect[];
-  readonly postConflicts: Conflict[];
 }
 
 export const FAIL_CLOSED_CONFLICT = "policy.effect_conflict.fail_closed";
-export const POST_BOUNDARY_CONFLICT = "policy.effect_conflict.post_boundary";

--- a/packages/policy/src/engine/audit.ts
+++ b/packages/policy/src/engine/audit.ts
@@ -63,31 +63,11 @@ export function publishPolicyEvent(
   reg: { name: string },
   ctx: Readonly<AuditDispatchContextGeneric<GenericPolicyContext>>,
 ): void {
-  if (options.audit === false) return;
-
-  const traceContext = ctx.traceContext ?? options.traceContext;
-  const traceId = traceContext?.traceId;
-  const sessionId = options.audit?.sessionId ?? traceContext?.sessionId;
-  if (!sessionId || !traceId) return;
-
-  options.auditEmit?.(PolicyEvent.Evaluated, {
-    traceId,
-    sessionId,
-    ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
-    time: Date.now(),
+  publishAuditRecord(options, ctx, decision, {
+    descriptor: PolicyEvent.Evaluated,
+    action: resolveAction(ctx.timing),
+    resource: resolveResource(reg, ctx),
     policyId: decision.policyId,
-    actor: options.audit?.actor ?? buildActor(traceContext),
-    action: options.audit?.action ?? resolveAction(ctx.timing),
-    resource: options.audit?.resource ?? resolveResource(reg, ctx),
-    verdict: decision.verdict,
-    reason: auditReason(decision),
-    effects: decision.effects,
-    ...(decision.obligations !== undefined && { obligations: decision.obligations }),
-    reasonCodes: decision.reasonCodes,
-    ...(decision.factsUsed !== undefined && { factsUsed: decision.factsUsed }),
-    durationMs: decision.durationMs,
-    ...resolveAuditPoint(ctx),
-    ...(ctx.resourceDescriptor !== undefined && { resourceDescriptor: ctx.resourceDescriptor }),
   });
 }
 
@@ -97,6 +77,30 @@ export function publishComposedDecision(
   ctx: Readonly<AuditDispatchContextGeneric<GenericPolicyContext>>,
   decision: Policy.PolicyDecision,
 ): void {
+  publishAuditRecord(options, ctx, decision, {
+    descriptor: PolicyEvent.DecisionComposed,
+    action: resolveAction(timing),
+    resource: resolveComposedResource(ctx),
+  });
+}
+
+/**
+ * One assembly for both audit records: the pair drifted before (same gate,
+ * same 10-field record, hand-copied). Gating stays sessionId AND traceId —
+ * stricter than the middleware-error publishers, which file under a trace
+ * alone; an audit row without its session names nothing queryable.
+ */
+function publishAuditRecord(
+  options: PolicyEngineConfig,
+  ctx: Readonly<AuditDispatchContextGeneric<GenericPolicyContext>>,
+  decision: Policy.PolicyDecision,
+  record: {
+    descriptor: typeof PolicyEvent.Evaluated | typeof PolicyEvent.DecisionComposed;
+    action: string;
+    resource: string;
+    policyId?: string;
+  },
+): void {
   if (options.audit === false) return;
 
   const traceContext = ctx.traceContext ?? options.traceContext;
@@ -104,14 +108,15 @@ export function publishComposedDecision(
   const sessionId = options.audit?.sessionId ?? traceContext?.sessionId;
   if (!sessionId || !traceId) return;
 
-  options.auditEmit?.(PolicyEvent.DecisionComposed, {
+  options.auditEmit?.(record.descriptor, {
     traceId,
     sessionId,
     ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
     time: Date.now(),
+    ...(record.policyId !== undefined && { policyId: record.policyId }),
     actor: options.audit?.actor ?? buildActor(traceContext),
-    action: options.audit?.action ?? resolveAction(timing),
-    resource: options.audit?.resource ?? resolveComposedResource(ctx),
+    action: options.audit?.action ?? record.action,
+    resource: options.audit?.resource ?? record.resource,
     verdict: decision.verdict,
     reason: auditReason(decision),
     effects: decision.effects,

--- a/packages/policy/src/engine/index.ts
+++ b/packages/policy/src/engine/index.ts
@@ -5,7 +5,6 @@ export type {
   PolicyEngineConfig,
   GenericPolicyContext,
   CanonicalPolicyRegistrationGeneric,
-  PolicyEngineRegistrationGeneric,
   PolicyEngineInstanceGeneric,
   DispatchContextGeneric,
   CanonicalAuditDispatchContextGeneric,

--- a/packages/policy/src/engine/registration-validation.ts
+++ b/packages/policy/src/engine/registration-validation.ts
@@ -76,7 +76,6 @@ interface SharedMetadataFields {
   readonly scope: unknown;
   readonly failPolicy: unknown;
   readonly fn: unknown;
-  readonly propagate: unknown;
 }
 
 function readClassificationFields(registration: object): ClassificationFields {
@@ -94,7 +93,6 @@ function readSharedMetadataFields(registration: object): SharedMetadataFields {
     scope: Reflect.get(registration, "scope"),
     failPolicy: Reflect.get(registration, "failPolicy"),
     fn: Reflect.get(registration, "fn"),
-    propagate: Reflect.get(registration, "propagate"),
   };
 }
 
@@ -138,11 +136,7 @@ function prepareCanonicalRegistration<TCtx extends GenericPolicyContext>(
     ...fields,
     scope: captureScope(fields.scope),
   });
-  if (
-    !metadata.success ||
-    !isCanonicalPolicyFunction<TCtx>(fields.fn) ||
-    (fields.propagate !== undefined && typeof fields.propagate !== "boolean")
-  ) {
+  if (!metadata.success || !isCanonicalPolicyFunction<TCtx>(fields.fn)) {
     throw registrationError(name, "invalid_canonical_registration");
   }
   if (!isObject(fields.effectCapabilities)) {
@@ -165,7 +159,6 @@ function prepareCanonicalRegistration<TCtx extends GenericPolicyContext>(
     ...(scope === undefined ? {} : { scope }),
     ...(metadata.data.failPolicy === undefined ? {} : { failPolicy: metadata.data.failPolicy }),
     fn: fields.fn,
-    ...(fields.propagate === undefined ? {} : { propagate: fields.propagate }),
   } satisfies CanonicalPolicyRegistrationGeneric<TCtx>);
   return trusted;
 }

--- a/packages/policy/src/engine/telemetry.ts
+++ b/packages/policy/src/engine/telemetry.ts
@@ -23,6 +23,12 @@ export function recordDecision(
   return decision;
 }
 
+/** An empty trace id names nothing; every guard in the tree treats it as absent. */
+function nonEmptyTraceId(trace: TraceContext.Type | undefined): string | undefined {
+  const traceId = trace?.traceId;
+  return traceId !== undefined && traceId.length > 0 ? traceId : undefined;
+}
+
 /**
  * A middleware threw. Reported under the dispatch's trace, or the engine's,
  * or not at all.
@@ -38,12 +44,6 @@ export function recordDecision(
  * its trace — a wiring choice at `PolicyEngine.create`, not a runtime
  * accident.
  */
-/** An empty trace id names nothing; every guard in the tree treats it as absent. */
-function nonEmptyTraceId(trace: TraceContext.Type | undefined): string | undefined {
-  const traceId = trace?.traceId;
-  return traceId !== undefined && traceId.length > 0 ? traceId : undefined;
-}
-
 export function publishMiddlewareError(
   options: PolicyEngineConfig,
   dispatchTrace: TraceContext.Type | undefined,

--- a/packages/policy/src/engine/types.ts
+++ b/packages/policy/src/engine/types.ts
@@ -1,6 +1,5 @@
 import type { BusEvent, Message, Policy, RuntimeResource, TraceContext } from "@openomni/protocol";
 
-type AuditVisibility = "internal" | "llm_reason" | "user_audit";
 export type PolicyPointId = keyof typeof Policy.PolicyPoint.Registry;
 
 export interface GenericPolicyContext {
@@ -44,8 +43,6 @@ interface PolicyAuditConfig {
   readonly actor?: Record<string, unknown>;
   readonly action?: string;
   readonly resource?: string;
-  readonly visibility?: AuditVisibility;
-  readonly parentActionId?: string;
 }
 
 export type AuditEmit = <T>(event: BusEvent.Descriptor<T>, data: T) => void;
@@ -70,16 +67,7 @@ export interface CanonicalPolicyRegistrationGeneric<TCtx extends GenericPolicyCo
   readonly fn: (
     ctx: Readonly<CanonicalAuditDispatchContextGeneric<TCtx>>,
   ) => Promise<Policy.PolicyDecision> | Policy.PolicyDecision;
-  readonly propagate?: boolean;
 }
-
-/**
- * Canonical-only since #530: the legacy timing-based registration shape and
- * the legacy `dispatch(timing)` entry point are gone; `register()` rejects
- * timing shapes fail-closed at the trusted boundary.
- */
-export type PolicyEngineRegistrationGeneric<TCtx extends GenericPolicyContext> =
-  CanonicalPolicyRegistrationGeneric<TCtx>;
 
 export interface PolicyEngineInstanceGeneric<TCtx extends GenericPolicyContext> {
   register(reg: CanonicalPolicyRegistrationGeneric<TCtx>): void;

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -4,7 +4,6 @@ export type {
   PolicyEngineConfig,
   GenericPolicyContext,
   CanonicalPolicyRegistrationGeneric,
-  PolicyEngineRegistrationGeneric,
   PolicyEngineInstanceGeneric,
   DispatchContextGeneric,
   CanonicalAuditDispatchContextGeneric,

--- a/packages/policy/test/canonical-registration-boundary.test.ts
+++ b/packages/policy/test/canonical-registration-boundary.test.ts
@@ -33,7 +33,6 @@ describe("PolicyEngine canonical registration boundary", () => {
         priority: 0,
         scope: { agentType: ["resident"] },
         failPolicy: "fail-closed",
-        propagate: true,
         fn: allow,
       }),
     ).not.toThrow();
@@ -58,7 +57,6 @@ describe("PolicyEngine canonical registration boundary", () => {
       { scope: { agentType: "resident" } },
       { scope: { agentType: ["resident", 1] } },
       { failPolicy: "ignore" },
-      { propagate: "yes" },
     ];
 
     for (const override of malformed) {
@@ -79,7 +77,6 @@ test("reads each canonical boundary field once and stores the first trusted snap
     scope: 0,
     failPolicy: 0,
     fn: 0,
-    propagate: 0,
   };
   const first = <T>(field: keyof typeof reads, trusted: T, changed: T): T =>
     ++reads[field] === 1 ? trusted : changed;
@@ -117,9 +114,6 @@ test("reads each canonical boundary field once and stores the first trusted snap
         () => PolicyDecision.deny({ policyId: "changed-policy" }),
       );
     },
-    get propagate() {
-      return first("propagate", false, true);
-    },
   };
   const store = createPolicyRegistrationStore();
 
@@ -134,7 +128,6 @@ test("reads each canonical boundary field once and stores the first trusted snap
     priority: 10,
     scope: { agentType: ["resident"] },
     failPolicy: "fail-open",
-    propagate: false,
   });
   expect((await stored?.fn({ pointId: "run.lifecycle.post", timing: "run.finish" }))?.verdict).toBe(
     "allow",
@@ -148,7 +141,6 @@ test("reads each canonical boundary field once and stores the first trusted snap
     scope: 1,
     failPolicy: 1,
     fn: 1,
-    propagate: 1,
   });
 });
 
@@ -209,7 +201,7 @@ test("rejects a legacy-shaped proxy fail-closed without reclassifying its later 
   for (const field of ["kind", "name", "pointIds", "effectCapabilities"]) {
     expect(reads[field]).toBe(1);
   }
-  for (const field of ["timing", "priority", "scope", "failPolicy", "fn", "propagate"]) {
+  for (const field of ["timing", "priority", "scope", "failPolicy", "fn"]) {
     expect(reads[field]).toBeUndefined();
   }
 });
@@ -222,7 +214,6 @@ test("rejects legacy timing snapshot registrations fail-closed without storing t
     priority: 10,
     scope: { agentType: ["resident"] },
     failPolicy: "fail-open",
-    propagate: true,
     fn: () => PolicyDecision.allow({ policyId: "legacy-snapshot" }),
   };
 

--- a/packages/policy/test/invariant-smoke.test.ts
+++ b/packages/policy/test/invariant-smoke.test.ts
@@ -76,10 +76,12 @@ describe("engine invariants hold under the package's own suite", () => {
     const engine = PolicyEngine.create({ audit: false });
     engine.register(recorder("last", 100, calls));
     engine.register(recorder("first", 1, calls));
-    engine.register(recorder("middle", 50, calls));
+    engine.register(recorder("tie-a", 50, calls));
+    engine.register(recorder("tie-b", 50, calls));
 
     await engine.dispatchPoint(POINT, turnContext());
 
-    expect(calls).toEqual(["first", "middle", "last"]);
+    // Equal priority resolves by registration order (tie-a before tie-b).
+    expect(calls).toEqual(["first", "tie-a", "tie-b", "last"]);
   });
 });

--- a/packages/policy/test/invariant-smoke.test.ts
+++ b/packages/policy/test/invariant-smoke.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { PolicyDecision } from "@openomni/protocol";
+import { PolicyEngine } from "../src/index";
+
+/**
+ * In-package smoke pins for the engine's three headline invariants (#606
+ * audit): each previously survived mutation under this package's own suite —
+ * the only defense was packages/agent's conformance tests, so a policy-local
+ * refactor loop ran unprotected.
+ */
+const POINT = "run.turn.pre" as const;
+
+function turnContext() {
+  return {
+    sessionId: "session-invariant",
+    runId: "run-invariant",
+    turnIndex: 0,
+    traceContext: { traceId: "trace-invariant" },
+  };
+}
+
+function recorder(
+  name: string,
+  priority: number,
+  calls: string[],
+  verdict: "allow" | "deny" | "pending" = "allow",
+) {
+  return {
+    kind: "point" as const,
+    name,
+    pointIds: [POINT],
+    effectCapabilities: { [POINT]: [] },
+    priority,
+    fn: () => {
+      calls.push(name);
+      if (verdict === "deny") {
+        return PolicyDecision.deny({ policyId: name });
+      }
+      if (verdict === "pending") {
+        return PolicyDecision.pending({ policyId: name });
+      }
+      return PolicyDecision.allow({ policyId: name });
+    },
+  };
+}
+
+describe("engine invariants hold under the package's own suite", () => {
+  test("a deny short-circuits: later registrations never execute", async () => {
+    const calls: string[] = [];
+    const engine = PolicyEngine.create({ audit: false });
+    // Selection is ASCENDING priority: the priority-0 denier runs first and
+    // the priority-10 registration must never execute.
+    engine.register(recorder("denier", 0, calls, "deny"));
+    engine.register(recorder("after-deny", 10, calls));
+
+    const decision = await engine.dispatchPoint(POINT, turnContext());
+
+    expect(decision.verdict).toBe("deny");
+    expect(calls).toEqual(["denier"]);
+  });
+
+  test("pending outranks allow in composition", async () => {
+    const calls: string[] = [];
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register(recorder("allower", 0, calls));
+    engine.register(recorder("pender", 10, calls, "pending"));
+
+    const decision = await engine.dispatchPoint(POINT, turnContext());
+
+    expect(decision.verdict).toBe("pending");
+    expect(calls).toEqual(["allower", "pender"]);
+  });
+
+  test("priority orders evaluation — ascending, registration order breaks ties", async () => {
+    const calls: string[] = [];
+    const engine = PolicyEngine.create({ audit: false });
+    engine.register(recorder("last", 100, calls));
+    engine.register(recorder("first", 1, calls));
+    engine.register(recorder("middle", 50, calls));
+
+    await engine.dispatchPoint(POINT, turnContext());
+
+    expect(calls).toEqual(["first", "middle", "last"]);
+  });
+});

--- a/packages/policy/test/registration-overload.test.ts
+++ b/packages/policy/test/registration-overload.test.ts
@@ -2,13 +2,13 @@ import { expect, test } from "bun:test";
 import {
   PolicyEngine,
   type GenericPolicyContext,
-  type PolicyEngineRegistrationGeneric,
+  type CanonicalPolicyRegistrationGeneric,
 } from "@openomni/policy";
 import { PolicyDecision } from "@openomni/protocol";
 
 test("accepts union-typed registrations through the public engine overload", () => {
   const engine = PolicyEngine.create<GenericPolicyContext>();
-  const registerUnion = (registration: PolicyEngineRegistrationGeneric<GenericPolicyContext>) =>
+  const registerUnion = (registration: CanonicalPolicyRegistrationGeneric<GenericPolicyContext>) =>
     engine.register(registration);
 
   expect(() =>


### PR DESCRIPTION
## Summary

Policy-package batch from the 8-package adversarial audit (#606).

**In-package invariant pins (the audit's sharpest test-locality finding):** the engine's three headline semantics — deny short-circuit, pending-outranks-allow, priority-ordered evaluation — all survived mutation under the package's OWN suite; the only defense was `packages/agent`'s conformance tests, so a policy-local refactor loop ran unprotected. New `test/invariant-smoke.test.ts` pins all three (documenting the real contract: selection is ASCENDING priority, registration order breaks ties). Mutation-verified in-package: removing the deny short-circuit, flattening the pending compose, and dropping priority from selection each fail exactly one pin (2/1 × 3).

**Dead surface killed:**
- `propagate` — a registration field type-checked and frozen at TWO trust boundaries (policy registration-validation + openomni dispatch policy-registration) and read by NOBODY. Field, validations, snapshots, and every test fixture/census deleted.
- The post-boundary conflict lane — `collectPostConflicts` returned `[]` unconditionally since #451, making `MergeResult.postConflicts`, `POST_BOUNDARY_CONFLICT`, the `"post"` boundary, and compose's diagnostic spread unreachable vocabulary. Entire lane deleted; `conflictDiagnostic` states its only real case (fail-closed, error severity).
- `PolicyAuditConfig.visibility`/`parentActionId` + the parallel `AuditVisibility` type — accepted, never read.
- `PolicyEngineRegistrationGeneric` — a barrel-exported alias with one test consumer.

**MINOR dedup:** `publishPolicyEvent`/`publishComposedDecision` were ~90% hand-copied twins; one `publishAuditRecord` assembly now owns the record, with the gating asymmetry (session+trace here vs trace-only for middleware errors) stated on purpose. The "silence is the ruling" doctrine block is reattached to `publishMiddlewareError`, whose contract it describes (it sat orphaned above `nonEmptyTraceId`).

## Verification

- `bun test packages/policy packages/agent packages/openomni/test apps/server/test`: **1883 pass / 0 fail**
- `tsc --noEmit` (policy, agent src+test, openomni test): 0 errors; `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins core policy-engine invariants and removes the unused post-boundary conflict lane; consolidates audit publishing without changing gates. Old behavior exposed pre/post conflict boundaries; new behavior emits only fail-closed error annotations, with no side effects because the post lane was empty.

- Adds smoke tests that pin three invariants: deny short-circuits; pending outranks allow; evaluation is ascending priority with registration-order tie breaks.
- Deletes the post-boundary conflict path and boundary metadata; `conflictDiagnostic` always emits a fail-closed error and `composeEffects` returns only merged effects.
- Deduplicates audit publishing into `publishAuditRecord`; “Evaluated” and “DecisionComposed” still require both `sessionId` and `traceId`.

- Migration
  - Replace `PolicyEngineRegistrationGeneric` with `CanonicalPolicyRegistrationGeneric` from `@openomni/policy`.
  - Remove `propagate` from policy registrations (engine and `@openomni` dispatch boundary).
  - Stop providing `visibility` or `parentActionId` in `PolicyEngineConfig.audit`; these fields are removed.

<sup>Written for commit 543af13974a9935a955cc253ccd19c0f584150a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the legacy `propagate` registration option and related public type exports.
  * Removed obsolete audit visibility configuration options.
  * Simplified conflict reporting to fail-closed errors without boundary details.

* **Bug Fixes**
  * Improved policy decision composition and conflict handling.
  * Standardized audit records for evaluated and composed decisions.

* **Tests**
  * Added coverage for deny and pending decision precedence.
  * Added tests for policy evaluation priority and registration ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->