### PR TITLE
fix(agent): truthful docs, live vocabulary, one alias rule (#606)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,11 +51,11 @@
         "@openomni/llm": "workspace:*",
         "@openomni/policy": "workspace:*",
         "@openomni/protocol": "workspace:*",
-        "zod": "^3.22.4",
       },
       "devDependencies": {
         "@openomni/telemetry": "workspace:*",
         "@types/bun": "latest",
+        "zod": "^3.22.4",
       },
     },
     "packages/coordinator": {

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -41,7 +41,7 @@ const agent = ChatAgent.create({
 const result = await agent.run({
   messages: [{ role: "user", content: "Hello!" }],
 });
-// result.finishReason: 'stop' | 'tool-calls' | 'max-steps' | 'handoff' | 'stalled'
+// result.finishReason: 'stop' | 'max-steps' | 'stalled'
 // result.text / result.steps / result.usage
 ```
 

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -16,12 +16,11 @@ src/
 │   ├── execution/              # The agent loop. Phase 4 rule 1 names five of these: run.ts (entry), turn.ts (prepare + settle), tools.ts (tool.native/mcp pre/post dispatch), effects.ts (effect application), state.ts (run state + lifecycle context). Beside them: run-events.ts (the records), lifecycle-dispatch.ts (run-level points)
 │   └── policy/
 │       ├── index.ts            # Agent-scoped PolicyEngine facade over @openomni/policy
-│       └── types.ts            # PolicyContext, canonical/legacy registration aliases, PolicyEngineRegistration
+│       └── types.ts            # PolicyContext, canonical registration types, PolicyEngineRegistration
 ├── compaction/                 # D6 home (#641): compact.ts (Compaction mechanism + boundary guard), policy.ts (run.completion.pre seam adapter), index.ts (config type + factory)
 └── runtime/
-    ├── index.ts                # Re-exports mcp
     └── mcp/
-        ├── client.ts           # McpClient — connect / disconnect / listTools / callTool (stdio / sse / http)
+        ├── client.ts           # McpClient — connect / disconnect / listTools / callTool (stdio / sse / streamable-http)
 ```
 
 ## PUBLIC API
@@ -69,12 +68,12 @@ adds the one-line re-export in the same PR that imports it.
 | `budget?`        | `AgentBudget`                            | Max turns / tool calls / wall time / tool runtime (use `-1` for unlimited)  |
 | `toolExecutor?`  | `(call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>` | Custom tool executor; wrapped by `createToolExecutor` |
 | `signal?`        | `AbortSignal`                            | External cancellation                                                       |
-| `middleware?`    | `PolicyEngineRegistration[]`             | Caller-owned canonical point registrations; legacy timing registrations are accepted only for compatibility |
+| `middleware?`    | `PolicyEngineRegistration[]`             | Caller-owned canonical point registrations; legacy timing shapes are REJECTED fail-closed at registration (#530, typed `legacy_timing_registration`) |
 | `providerOptions?` | `Record<string, unknown>`              | Forwarded to the underlying provider SDK                                    |
 
 ## POLICY ENGINE
 
-The policy engine is the extension surface. `@openomni/agent` exposes an agent-scoped `PolicyEngine` facade over the generic engine in `@openomni/policy`; the facade binds the full agent `PolicyContext` and the explicit legacy-compatibility mapping. Agent execution dispatches through the registered policy points defined in `@openomni/protocol` `policy/point-registry.ts`:
+The policy engine is the extension surface. `@openomni/agent` exposes an agent-scoped `PolicyEngine` facade over the generic engine in `@openomni/policy`; the facade binds the full agent `PolicyContext`; legacy timing registrations are rejected fail-closed at the boundary (#530). Agent execution dispatches through the registered policy points defined in `@openomni/protocol` `policy/point-registry.ts`:
 
 ```
 run.lifecycle.pre → run.turn.pre → prompt.context.pre → tool.catalog.pre
@@ -83,7 +82,7 @@ run.lifecycle.pre → run.turn.pre → prompt.context.pre → tool.catalog.pre
         → run.turn.post → run.completion.pre → run.lifecycle.post → run.error.error
 ```
 
-- **Registration**: use `CanonicalPolicyRegistration { kind: "point", name, pointIds, effectCapabilities, priority, scope?, failPolicy?, fn }`. `pointIds` declares where the policy may run and `effectCapabilities` declares the effects it may return at each point. Lower `priority` runs first; `scope.agentType` optionally filters by agent kind; omitted `failPolicy` follows each protocol point contract. `PolicyEngineRegistration` also accepts the old timing-based `PolicyRegistration` shape, but only as an explicit compatibility boundary for existing callers.
+- **Registration**: use `CanonicalPolicyRegistration { kind: "point", name, pointIds, effectCapabilities, priority, scope?, failPolicy?, fn }`. `pointIds` declares where the policy may run and `effectCapabilities` declares the effects it may return at each point. Lower `priority` runs first; `scope.agentType` optionally filters by agent kind; omitted `failPolicy` follows each protocol point contract. `PolicyEngineRegistration` IS the canonical shape — the old timing-based form throws a typed `legacy_timing_registration` error at `register()` (#530); there is no compatibility path.
 - **Decision** (`Policy.PolicyDecision`): `allow | deny | pending`, with effects such as `prompt.inject_message`, `prompt.replace`, `tool.rewrite_input`, `run.replace_messages`, and `writeback.rewrite`.
 - **System prompt effects**: `dispatchPoint("prompt.context.pre", ...)` returns canonical prompt effects; composition happens through effect merging rather than legacy verdict transforms.
 - **Ownership**: `ChatAgent` registers only caller-supplied `middleware`; runtime builders own default policy assembly (budget, tool permission, compaction) and, per D5, increasingly the policies themselves.
@@ -99,7 +98,8 @@ run.lifecycle.pre → run.turn.pre → prompt.context.pre → tool.catalog.pre
 ```
 run.ts (entry) → Promise<AgentResult>
   ├─ retry loop (maxAttempts)
-  │   ├─ build PolicyEngine (config.middleware only)
+  ├─ build PolicyEngine once (config.middleware only)
+  │
   │   ├─ dispatchPoint(run.lifecycle.pre)       → allow (with effects) / deny
   │   └─ turn loop (while budget ok)
   │       ├─ checkBudget → if exceeded, dispatchPoint(run.lifecycle.post) + return result
@@ -149,7 +149,7 @@ When in doubt, keep the agent package as a loop engine and put product semantics
 
 - **Invocation-scoped core**: Every `ChatAgent.run()` is independent — no session mutation, storage, durable orchestration, or scheduler. Per-run state such as budget and memory lives on the call context. For future replayable WorkItem attempts, the host supplies captured nondeterministic inputs; this package does not discover or persist them. The normative attempt contract lives in the [kernel contract](../../docs/kernel-contract.md).
 - **Sink-driven**: Callers pass a `Sink` (from `@openomni/protocol`) to receive streaming output. The agent never creates sessions on its own.
-- **Policy > ad-hoc hooks**: New extensions MUST use canonical point registrations in `middleware: [...]`. `PolicyEngine.create()` is the single extension surface; timing registrations exist only for legacy compatibility.
+- **Policy > ad-hoc hooks**: New extensions MUST use canonical point registrations in `middleware: [...]`. `PolicyEngine.create()` is the single extension surface; timing registrations are rejected fail-closed (#530).
 - **Budget check before each turn**: `checkBudget()` runs before `llmRun()`, not after, so budget enforcement blocks the next turn cleanly.
 - **A retried attempt is the same turn**: `recordRunTurn` charges once per `turnIndex`, so an attempt that failed and was retried is free in the *turns* unit and bounded by `maxAttempts` instead. Tokens and tool calls still charge per attempt, because they were really spent (#630).
 - **Message format**: `ChatAgentInput.messages` is a simple `{ role: "user" | "assistant"; content: string }[]`. Richer `Message.WithParts[]` is used internally only.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,11 +16,11 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@openomni/llm": "workspace:*",
     "@openomni/policy": "workspace:*",
-    "@openomni/protocol": "workspace:*",
-    "zod": "^3.22.4"
+    "@openomni/protocol": "workspace:*"
   },
   "devDependencies": {
     "@openomni/telemetry": "workspace:*",
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "zod": "^3.22.4"
   }
 }

--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -45,11 +45,6 @@ interface BudgetEvaluation {
 }
 
 /**
- * Pure evaluator: the sole source of the 4-state budget verdict and the facts
- * telemetry needs. No Bus emit, no mutation — see {@link checkBudget} (query)
- * and {@link publishBudgetTelemetry} (command) for the split callers.
- */
-/**
  * The tool-call pool the budget actually enforces (-1 = unlimited). Exported
  * because the turn's step cap subtracts from this exact pool — a cap computed
  * against any other number starves or overshoots the real enforcement.
@@ -58,6 +53,11 @@ export function effectiveMaxToolCalls(budget?: AgentBudget): number {
   return budget?.maxToolCalls ?? 40;
 }
 
+/**
+ * Pure evaluator: the sole source of the 4-state budget verdict and the facts
+ * telemetry needs. No Bus emit, no mutation — see {@link checkBudget} (query)
+ * and {@link publishBudgetTelemetry} (command) for the split callers.
+ */
 function evaluateBudget(state: BudgetState, budget?: AgentBudget): BudgetEvaluation {
   const maxWallTimeMs = budget?.maxWallTimeMs ?? 5 * 60 * 1000;
   const maxTurns = budget?.maxTurns ?? 24;

--- a/packages/agent/src/core/execution/state.ts
+++ b/packages/agent/src/core/execution/state.ts
@@ -144,13 +144,6 @@ export type BuildTurnResult =
   | { type: "ready"; turn: TurnArtifacts }
   | { type: "complete"; result: AgentResult };
 
-/**
- * What the run does after an attempt raised. `complete` carries the result a
- * guard settled on. The other two carry what the terminal record would need,
- * because the runner owns that record and the wait between attempts: a run
- * aborted mid-backoff has to report the reason and ceiling that were decided,
- * not ones re-derived from the abort.
- */
 /** What the terminal record needs. Emitted by the runner, which owns it. */
 export interface RunFailureFacts {
   readonly reason: RetryReason;
@@ -158,6 +151,13 @@ export interface RunFailureFacts {
   readonly maxAttempts: number;
 }
 
+/**
+ * What the run does after an attempt raised. `complete` carries the result a
+ * guard settled on. The other two carry what the terminal record would need,
+ * because the runner owns that record and the wait between attempts: a run
+ * aborted mid-backoff has to report the reason and ceiling that were decided,
+ * not ones re-derived from the abort.
+ */
 export type ErrorDecision =
   | { action: "retry"; backoffMs: number; failure: RunFailureFacts }
   | { action: "complete"; result: AgentResult }

--- a/packages/agent/src/core/execution/turn.ts
+++ b/packages/agent/src/core/execution/turn.ts
@@ -98,9 +98,18 @@ function resolvePolicyToolName(
   toolName: string,
   metadata: Map<string, ToolPolicyMetadata>,
 ): string {
-  const toolMetadata = metadata.get(toolName) ?? metadata.get(toolName.replace(/_/g, "."));
+  // The resolved name must be a key the metadata map answers: an MCP tool
+  // registered "server.tool" and called with the underscore-mangled name has
+  // no `tool:` canonical label, and returning the mangled name unresolved
+  // sent its labels lookup into the void — downgrading the call from the
+  // fail-closed tool.mcp.pre to tool.native.pre (#606 audit).
+  const direct = metadata.get(toolName);
+  const dotted = toolName.replace(/_/g, ".");
+  const viaDotted = direct === undefined ? metadata.get(dotted) : undefined;
+  const toolMetadata = direct ?? viaDotted;
   const canonical = toolMetadata?.labels?.find((label) => label.startsWith("tool:"));
-  return canonical ? canonical.slice(5) : toolName;
+  if (canonical) return canonical.slice(5);
+  return viaDotted !== undefined ? dotted : toolName;
 }
 
 export async function buildTurn(

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -50,18 +50,18 @@ export interface ChatAgentInput {
 }
 
 export interface AgentStep {
-  type: "tool-call" | "text";
+  type: "text";
   content: string;
-  toolCalls?: Tool.Call[];
-  toolResults?: Tool.Result[];
 }
 
 export interface AgentResult {
   text: string;
   steps: AgentStep[];
   usage: TokenUsage;
-  finishReason: "stop" | "tool-calls" | "max-steps" | "handoff" | "stalled";
-  handoffTarget?: string;
+  // Every member has a producer: runResult emits stop|stalled|max-steps.
+  // The phantom "tool-calls"/"handoff" members (and handoffTarget) forced
+  // every consumer to handle states that could not occur (#606 audit).
+  finishReason: "stop" | "max-steps" | "stalled";
   compactionCount?: number;
   guardAborted?: boolean;
 }

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -54,10 +54,7 @@ export class McpClient {
   async connect(): Promise<void> {
     let transport: Transport | undefined;
     let closeTracker: TransportCloseTracker | undefined;
-    const transportType =
-      this.config.transport === "streamable-http"
-        ? ("streamable-http" as const)
-        : (this.config.transport as "stdio" | "sse" | "http");
+    const transportType = this.config.transport;
 
     try {
       transport = this.createTransport(this.config);

--- a/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
@@ -277,4 +277,55 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
       { pointId: "tool.mcp.post", serverId: "github" },
     ]);
   });
+
+  it("routes an underscore-mangled MCP call to tool.mcp.pre — never native (#606)", async () => {
+    // The tool registers under its dotted name with mcp labels and NO tool:
+    // canonical label; an executor calling the underscore-mangled alias must
+    // still resolve the labels — the old resolver returned the mangled name
+    // unresolved, downgrading the call to the fail-open tool.native.pre.
+    const seen: string[] = [];
+    const engine = PolicyEngine.create();
+    engine.register({
+      kind: "point",
+      name: "mcp-route-observer",
+      pointIds: ["tool.mcp.pre", "tool.mcp.post", "tool.native.pre", "tool.native.post"],
+      effectCapabilities: {
+        "tool.mcp.pre": [],
+        "tool.mcp.post": [],
+        "tool.native.pre": [],
+        "tool.native.post": [],
+      },
+      priority: 1,
+      fn: (ctx: Readonly<CanonicalAuditDispatchContextGeneric<PolicyContext>>) => {
+        seen.push(ctx.pointId as string);
+        return allow();
+      },
+    });
+    const mcpTool: Tool.Spec = {
+      name: "server.tool",
+      inputSchema: {},
+      labels: ["source:mcp", "mcp.server"],
+    };
+    const toolExecutor = mock(
+      async (call: Tool.Call): Promise<Tool.Result> => ({
+        id: "result",
+        toolCallId: call.id,
+        output: "ok",
+      }),
+    );
+    const result = await buildTurn(
+      makeState(),
+      makeConfig({ tools: [mcpTool], toolExecutor }),
+      engine,
+      testProviderModel,
+      undefined,
+      makeTrace(),
+      makeAgentBase(),
+    );
+    if (result.type !== "ready") throw new Error("expected a prepared turn");
+
+    await result.turn.runInput.toolExecutor?.({ id: "call", tool: "server_tool", input: {} });
+
+    expect(seen).toEqual(["tool.mcp.pre", "tool.mcp.post"]);
+  });
 });

--- a/packages/agent/test/core/execution/tools-verdicts.test.ts
+++ b/packages/agent/test/core/execution/tools-verdicts.test.ts
@@ -7,6 +7,7 @@ import {
   type Tool,
 } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
+import { matchesToolPattern } from "../../../src/core/execution/effects";
 import { createToolExecutor, type BlockedToolResult } from "../../../src/core/execution/tools";
 import { PolicyEngine, type PolicyRegistration } from "../../../src/core/policy";
 
@@ -218,6 +219,13 @@ describe("createToolExecutor effect application", () => {
       output: "[Denied: filtered_tool]",
       isError: true,
     });
+  });
+
+  it("a wildcard filter stops at the dot boundary — shell.* never blocks shellfish (#606)", () => {
+    expect(matchesToolPattern("shell.exec", "shell.*")).toBe(true);
+    expect(matchesToolPattern("shellfish", "shell.*")).toBe(false);
+    expect(matchesToolPattern("shell", "shell.*")).toBe(false);
+    expect(matchesToolPattern("shell.exec", "shell")).toBe(false);
   });
 
   it("allows non-matching tool.filter effects at invoke.prepare", async () => {

--- a/packages/agent/test/core/policy/conformance/no-bypass.test.ts
+++ b/packages/agent/test/core/policy/conformance/no-bypass.test.ts
@@ -172,8 +172,4 @@ describe("policy no-bypass conformance — known ungoverned paths", () => {
     "UNGOVERNED: WorkItem writes packages/session/src/work-item/index.ts — no policy gate",
     documentedSkip,
   );
-  itSkip(
-    "UNGOVERNED: Skill load/activation packages/openomni/src/skill/index.ts — no authorization policy point yet",
-    documentedSkip,
-  );
 });

--- a/packages/protocol/src/event/mcp.ts
+++ b/packages/protocol/src/event/mcp.ts
@@ -11,7 +11,7 @@ export namespace Mcp {
   export const Connected = BusEvent.define(
     "mcp.connected",
     Base.extend({
-      transport: z.enum(["stdio", "sse", "http", "streamable-http"]),
+      transport: z.enum(["stdio", "sse", "streamable-http"]),
       toolCount: z.number(),
     }),
     { visibility: "internal" },


### PR DESCRIPTION
## Summary

Agent batch from the 8-package adversarial audit (#606).

**MCP alias divergence fixed + pinned (audit MAJOR 3).** Tool-name normalization existed three ways with one divergence: `resolvePolicyToolName` returned an underscore-mangled call name UNRESOLVED when the tool had no `tool:` canonical label — so an MCP tool registered `server.tool` called as `server_tool` resolved labels to `undefined` and `policyTarget` routed it to the fail-open `tool.native.pre` instead of the fail-closed `tool.mcp.pre`. The resolver now returns a name the metadata map answers (canonical, else the dotted key that hit). New end-to-end pin in `lifecycle-turn-pre.test.ts` drives a mangled call through `buildTurn` and asserts `["tool.mcp.pre", "tool.mcp.post"]`; mutation-verified (reverting the resolver fails it).

**Dead run-contract vocabulary deleted (audit MAJOR 2).** `finishReason` members `"tool-calls"`/`"handoff"`, `handoffTarget`, and the `AgentStep` `"tool-call"` variant with `toolCalls?`/`toolResults?` had ZERO producers (`runResult` emits stop|stalled|max-steps; the only step ever appended is text). Every consumer — including openomni's child-agent — was forced to handle states that cannot occur. Deleted; zero ripple (typechecks clean across agent/openomni/server).

**Matcher boundary pinned (audit MAJOR 4).** `matchesToolPattern`'s dot boundary (`shell.*` must not block `shellfish`) was mutation-survivable across the whole suite; direct unit pin added, loose-prefix mutant killed (18/1).

**AGENTS.md told the opposite of the registration boundary three times** ("legacy timing registrations are accepted for compatibility") — the code rejects them fail-closed with typed `legacy_timing_registration` since #530, and the doc now says so at all three sites; the STRUCTURE tree drops the nonexistent `runtime/index.ts`, names the real `streamable-http` transport, and the run diagram builds the engine once (not per retry attempt).

**Smaller slop:** the mcp client's no-op ternary with its phantom `"http"` cast is deleted (`config.transport` is directly assignable) and the phantom `"http"` member leaves the mcp event enum (no producer could emit it); the stale UNGOVERNED skip for the deleted `openomni/src/skill` module is removed; `zod` moves to devDependencies (one type-only test import); the misattached budget/state docblocks sit on the functions they describe.

## Verification

- `bun test packages/agent packages/openomni/test`: **1342 pass / 0 fail** (395 agent incl. 2 new pins)
- `tsc --noEmit` src+test (agent, openomni, server): 0 errors; `bun run lint` + `bun script/check-deps.ts`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP tool alias resolution so underscore-mangled names route through the fail-closed `tool.mcp.pre`/`tool.mcp.post` (previously downgraded to `tool.native.pre`), removes dead agent result states, and pins dot-boundary matching; docs and samples now match the shipped vocabulary.

- MCP alias resolution: resolver returns the canonical `tool:` label when present, else the dotted alias if that key exists in metadata, ensuring calls like `server_tool` hit MCP boundaries.
- API vocabulary cleanup: `AgentResult.finishReason` is now `stop | max-steps | stalled`; `handoffTarget` and the `"tool-call"` `AgentStep` variant are removed; `AGENTS.md` sample reflects this.
- Matcher boundary: `matchesToolPattern` enforces a dot boundary (`shell.*` does not match `shellfish`); unit pin added.
- Docs: `AGENTS.md` now states legacy timing registrations are rejected fail-closed (`legacy_timing_registration`), the run builds the `PolicyEngine` once, and the runtime transport is `streamable-http`.
- Protocol/client: `@openomni/protocol` drops `"http"` from `Mcp.Connected.transport`; the MCP client uses the config transport directly.
- Dependencies: move `zod` to `devDependencies`.

**Migration**
- Remove references to `finishReason: "tool-calls" | "handoff"`, `handoffTarget`, and the `"tool-call"` `AgentStep` variant in external consumers.
- Expect underscore-mangled MCP tool aliases without a `tool:` label to be governed at `tool.mcp.pre`; update policies if you relied on `tool.native.pre`.

<sup>Written for commit 70c5903aa2795f7281635f752cd52a138544caae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for streamable HTTP MCP connections.
  - Improved resolution of MCP tools that use dotted names.

- **Bug Fixes**
  - Corrected wildcard tool matching to avoid unintended matches.
  - MCP lifecycle hooks now run for underscore-mangled tool calls.

- **Breaking Changes**
  - Legacy timing-based policy registrations are rejected with a typed error.
  - Removed tool-call and handoff finish reasons from agent results.
  - MCP connection events no longer accept the legacy `http` transport value.

- **Documentation**
  - Updated agent policy, runtime, and MCP guidance to reflect current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->