### PR TITLE
fix(server): the boot window buffers, the ask parser refuses (#606)

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -70,6 +70,14 @@ export async function main(options: MainOptions = {}): Promise<void> {
   // it is ONE trace. Every line the boot emits carries it, so a failed startup
   // reads as a single sequence instead of eight unrelated records.
   const bootTraceId = newTraceId();
+  // Persistence needs the dbPath FROM config, so config loads first — but
+  // everything it publishes (malformed config.json → defaults, rejected
+  // grants/MCP entries) would land in a subscriber-less Bus and vanish.
+  // Buffer the pre-persistence window and republish once the journal is up.
+  const preBootEvents: Array<Parameters<typeof Bus.publish>> = [];
+  const stopBuffering = Bus.observe((descriptor, data) => {
+    preBootEvents.push([descriptor, data] as Parameters<typeof Bus.publish>);
+  });
   const config = loadConfig(bootTraceId);
   if (process.env.OPENOMNI_MODE === "local") {
     throw new Error("OPENOMNI_MODE=local is disabled; OpenOmni requires coordinator mode");
@@ -78,6 +86,8 @@ export async function main(options: MainOptions = {}): Promise<void> {
   mkdirSync(dirname(config.storage.dbPath), { recursive: true });
   const completionWriter = initialize({ dbPath: config.storage.dbPath });
   BusPersistence.start();
+  stopBuffering();
+  for (const [descriptor, data] of preBootEvents) Bus.publish(descriptor, data);
 
   const systemProvider = new SystemToolProvider(config.workspace?.root);
   const agentProviderRef: { current?: AgentToolProvider } = {};

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -86,8 +86,12 @@ export async function main(options: MainOptions = {}): Promise<void> {
   mkdirSync(dirname(config.storage.dbPath), { recursive: true });
   const completionWriter = initialize({ dbPath: config.storage.dbPath });
   BusPersistence.start();
+  // Observer delivery is microtask-queued: without this turn the buffer is
+  // provably EMPTY at the republish (the #676 review demonstrated it live).
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
   stopBuffering();
   for (const [descriptor, data] of preBootEvents) Bus.publish(descriptor, data);
+  preBootEvents.length = 0;
 
   const systemProvider = new SystemToolProvider(config.workspace?.root);
   const agentProviderRef: { current?: AgentToolProvider } = {};

--- a/apps/server/src/bootstrap/resident-inbound-wait.ts
+++ b/apps/server/src/bootstrap/resident-inbound-wait.ts
@@ -3,6 +3,7 @@ import type { DispatchRuntime } from "@openomni/openomni";
 import { Operational } from "@openomni/protocol";
 import { WorkItemAttemptRun } from "@openomni/session";
 import { Bus } from "@openomni/telemetry";
+import { z } from "zod";
 import type { ServerConfig } from "../config";
 
 export type ResidentInboundWaitConfig = {
@@ -10,16 +11,12 @@ export type ResidentInboundWaitConfig = {
   readonly dispatchRuntime: Pick<DispatchRuntime, "submit">;
 };
 
-// The kernel resident.ask handler returns { output, finishReason }; test
-// doubles may return the answer as a bare string.
-function residentAskOutput(output: unknown): string {
-  if (typeof output === "string") return output;
-  if (output && typeof output === "object" && "output" in output) {
-    const nested = (output as { output?: unknown }).output;
-    if (typeof nested === "string") return nested;
-  }
-  return "";
-}
+// The kernel resident.ask handler returns { output: string, ... }. STRICT
+// like dispatch-owners' question bridge (#606 audit): the old lenient shape
+// existed for test doubles returning bare strings, and it laundered any
+// unexpected shape into an empty "answer" reported as accepted:true — a
+// worker asking a question got "" and treated it as the resident's reply.
+const residentAskDispatchOutput = z.object({ output: z.string() });
 
 export function createResidentInboundWaitHandler(
   config: ResidentInboundWaitConfig,
@@ -85,10 +82,20 @@ export function createResidentInboundWaitHandler(
             `worker.inbound_wait dispatch ${dispatchResult.status}`,
         };
       }
+      const parsedOutput = residentAskDispatchOutput.safeParse(dispatchResult.output);
+      if (!parsedOutput.success) {
+        // Refuse, never launder: the old lenient shape turned any unexpected
+        // envelope into an empty "answer" reported accepted:true.
+        return {
+          requestId,
+          accepted: false,
+          error: `resident.ask returned an invalid inbound-wait response: ${parsedOutput.error.message}`,
+        };
+      }
       return {
         requestId,
         accepted: true,
-        output: residentAskOutput(dispatchResult.output),
+        output: parsedOutput.data.output,
       };
     } finally {
       // Release the wait if it is still ours; a run finished mid-wait keeps

--- a/apps/server/src/bootstrap/shutdown.ts
+++ b/apps/server/src/bootstrap/shutdown.ts
@@ -4,6 +4,8 @@ import { Bus } from "@openomni/telemetry";
 import { newTraceId } from "@openomni/telemetry";
 import type { McpToolProvider } from "../tool/mcp";
 
+const CHANNEL_TEARDOWN_GRACE_MS = 5_000;
+
 interface ClosableStorage {
   close(): void;
 }
@@ -53,7 +55,13 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
       deps.server.stop(true);
       await deps.mcpProvider.disconnectAll();
-      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      // Channel stop() is synchronous fire-and-forget (poller/gateway
+      // teardown) — in-flight I/O (a long-poll response, a close frame, a
+      // final reply) has no awaitable handle. This grace window lets those
+      // last publishes land before the telemetry drain below; shortening it
+      // drops tail events, it does not make shutdown more correct. Making
+      // the stops awaitable would retire it.
+      await new Promise((resolve) => setTimeout(resolve, CHANNEL_TEARDOWN_GRACE_MS));
       // Accepted-append drain (#510 D1). Decision-class appends need no
       // drain of their own: they run inside synchronous bun:sqlite
       // transactions, which the event loop cannot interleave — reaching

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -27,6 +27,8 @@ const ipcAuthToken = process.env.OPENOMNI_WORKER_IPC_TOKEN;
 delete process.env.OPENOMNI_WORKER_IPC_TOKEN;
 
 if (!socketPath) {
+  // Pre-initialize there is no journal and no observer: stderr or nothing.
+  process.stderr.write("worker-entry: missing --socket argument\\n");
   Bus.publish(Operational.Error, {
     traceId: workerBootTraceId,
     time: Date.now(),
@@ -37,6 +39,8 @@ if (!socketPath) {
 }
 
 if (!ipcAuthToken) {
+  // Pre-initialize there is no journal and no observer: stderr or nothing.
+  process.stderr.write("worker-entry: missing IPC auth token\\n");
   Bus.publish(Operational.Error, {
     traceId: workerBootTraceId,
     time: Date.now(),

--- a/apps/server/src/execution/worker-entry.ts
+++ b/apps/server/src/execution/worker-entry.ts
@@ -28,7 +28,7 @@ delete process.env.OPENOMNI_WORKER_IPC_TOKEN;
 
 if (!socketPath) {
   // Pre-initialize there is no journal and no observer: stderr or nothing.
-  process.stderr.write("worker-entry: missing --socket argument\\n");
+  process.stderr.write("worker-entry: missing --socket argument\n");
   Bus.publish(Operational.Error, {
     traceId: workerBootTraceId,
     time: Date.now(),
@@ -40,7 +40,7 @@ if (!socketPath) {
 
 if (!ipcAuthToken) {
   // Pre-initialize there is no journal and no observer: stderr or nothing.
-  process.stderr.write("worker-entry: missing IPC auth token\\n");
+  process.stderr.write("worker-entry: missing IPC auth token\n");
   Bus.publish(Operational.Error, {
     traceId: workerBootTraceId,
     time: Date.now(),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,6 +4,10 @@ import { Bus } from "@openomni/telemetry";
 import { main } from "./bootstrap";
 
 main().catch((error) => {
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  // A boot that dies before BusPersistence.start() publishes into a
+  // subscriber-less Bus — stderr is the only outlet that always exists.
+  process.stderr.write(`openomni fatal: ${message}\n`);
   Bus.publish(Operational.Error, {
     traceId: newTraceId(),
     time: Date.now(),

--- a/apps/server/test/bootstrap/preboot-buffer.test.ts
+++ b/apps/server/test/bootstrap/preboot-buffer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
 import { Operational } from "@openomni/protocol";
 import { BusPersistence, Storage } from "@openomni/session";
 import { Bus } from "@openomni/telemetry";
@@ -14,6 +15,22 @@ function journalRows(): Array<{ event_type: string; trace_id: string }> {
 }
 
 describe("pre-persistence boot window (#606 / #676 review)", () => {
+  test("main() keeps the microtask turn between persistence start and republish", () => {
+    // Binds the pin to the bootstrap source (repo precedent:
+    // context/integration.test.ts): the sequence pin below locks the Bus
+    // mechanism, but a future edit deleting the await from main() would
+    // regress silently without this.
+    const bootstrapSrc = readFileSync(
+      new URL("../../src/bootstrap/index.ts", import.meta.url),
+      "utf8",
+    );
+    const startIndex = bootstrapSrc.indexOf("BusPersistence.start();");
+    const republishIndex = bootstrapSrc.indexOf("of preBootEvents) Bus.publish");
+    expect(startIndex).toBeGreaterThan(-1);
+    expect(republishIndex).toBeGreaterThan(startIndex);
+    expect(bootstrapSrc.slice(startIndex, republishIndex)).toContain("queueMicrotask");
+  });
+
   beforeEach(() => {
     Bus.reset();
     Storage.reset();

--- a/apps/server/test/bootstrap/preboot-buffer.test.ts
+++ b/apps/server/test/bootstrap/preboot-buffer.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Operational } from "@openomni/protocol";
+import { BusPersistence, Storage } from "@openomni/session";
+import { Bus } from "@openomni/telemetry";
+
+function journalRows(): Array<{ event_type: string; trace_id: string }> {
+  const descriptor = Object.getOwnPropertyDescriptor(Storage.getAdapter(), "db");
+  if (!(descriptor?.value instanceof Database)) throw new Error("expected sqlite adapter");
+  return descriptor.value.query("SELECT event_type, trace_id FROM bus_event").all() as Array<{
+    event_type: string;
+    trace_id: string;
+  }>;
+}
+
+describe("pre-persistence boot window (#606 / #676 review)", () => {
+  beforeEach(() => {
+    Bus.reset();
+    Storage.reset();
+  });
+
+  afterEach(() => {
+    BusPersistence.stop();
+    Storage.reset();
+    Bus.reset();
+  });
+
+  test("a warn published before BusPersistence.start survives into the journal", async () => {
+    // The exact bootstrap sequence: buffer -> config-time publish -> storage
+    // init -> persistence start -> ONE microtask turn (observer delivery is
+    // microtask-queued; without it the buffer is provably empty) -> republish.
+    const preBootEvents: Array<Parameters<typeof Bus.publish>> = [];
+    const stopBuffering = Bus.observe((descriptor, data) => {
+      preBootEvents.push([descriptor, data] as Parameters<typeof Bus.publish>);
+    });
+
+    Bus.publish(Operational.Warn, {
+      traceId: "trace-preboot",
+      time: Date.now(),
+      component: "server",
+      msg: "config invalid, using defaults",
+    });
+
+    Storage.initialize({ dbPath: ":memory:" });
+    BusPersistence.start();
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    stopBuffering();
+    for (const [descriptor, data] of preBootEvents) Bus.publish(descriptor, data);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(journalRows()).toEqual([{ event_type: "operational.warn", trace_id: "trace-preboot" }]);
+  });
+});

--- a/apps/server/test/bootstrap/resident-inbound-wait.test.ts
+++ b/apps/server/test/bootstrap/resident-inbound-wait.test.ts
@@ -194,7 +194,11 @@ describe("resident inbound wait kernel dispatch", () => {
       calls.push(args);
       // The run holds the wait while the Resident answers.
       expect(currentStatus(run)).toBe("waiting_input");
-      return { dispatchId: "resident-ask", status: "completed", output: "Proceed carefully." };
+      return {
+        dispatchId: "resident-ask",
+        status: "completed",
+        output: { output: "Proceed carefully." },
+      };
     });
     const handler = createHandler(submit);
 
@@ -276,7 +280,7 @@ describe("resident inbound wait kernel dispatch", () => {
       async (): Promise<Dispatch.Result> => ({
         dispatchId: "resident-ask-after-cancel",
         status: "completed",
-        output: "Already cancelled.",
+        output: { output: "Already cancelled." },
       }),
     );
 
@@ -296,7 +300,7 @@ describe("resident inbound wait kernel dispatch", () => {
       async (): Promise<Dispatch.Result> => ({
         dispatchId: "resident-ask-after-entry-cancel",
         status: "completed",
-        output: "Already cancelled.",
+        output: { output: "Already cancelled." },
       }),
     );
     WorkItemAttemptRun.beginWait = mock(async (...args: Parameters<typeof originalBeginWait>) => {
@@ -323,7 +327,7 @@ describe("resident inbound wait kernel dispatch", () => {
       async (): Promise<Dispatch.Result> => ({
         dispatchId: "resident-ask-before-restoration-cancel",
         status: "completed",
-        output: "Answer delivered.",
+        output: { output: "Answer delivered." },
       }),
     );
     WorkItemAttemptRun.endWait = mock(async (...args: Parameters<typeof originalEndWait>) => {
@@ -384,7 +388,7 @@ describe("resident inbound wait kernel dispatch", () => {
     expect(waitBlockers(run)).toHaveLength(0);
   });
 
-  it("normalizes resident.ask outputs: nested envelope unwraps, non-string falls to empty", async () => {
+  it("unwraps the kernel envelope and REFUSES any other shape (#606)", async () => {
     const nestedRun = await createActiveRun("run-nested-output");
     const nested = await createHandler(
       mock(
@@ -397,6 +401,9 @@ describe("resident inbound wait kernel dispatch", () => {
     )(waitParams(nestedRun));
     expect(nested).toMatchObject({ accepted: true, output: "nested answer" });
 
+    // Pin: the old lenient parser laundered any unexpected shape into an
+    // empty "answer" reported accepted:true — a worker's question silently
+    // got "" as the resident's reply.
     const numericRun = await createActiveRun("run-numeric-output");
     const numeric = await createHandler(
       mock(
@@ -407,7 +414,10 @@ describe("resident inbound wait kernel dispatch", () => {
         }),
       ),
     )(waitParams(numericRun));
-    expect(numeric).toMatchObject({ accepted: true, output: "" });
+    expect(numeric).toMatchObject({ accepted: false });
+    expect(String((numeric as { error?: unknown }).error)).toContain(
+      "invalid inbound-wait response",
+    );
   });
 
   it("rejects an already-aborted wait without dispatching or changing run state", async () => {


### PR DESCRIPTION
## Summary

apps/server round 2 from the 8-package adversarial audit (#606) — the three semantics-bearing MAJORs deliberately split from #675.

1. **Pre-persistence telemetry black hole closed.** Persistence needs the dbPath FROM config, so `loadConfig` must run first — but everything it published (malformed config.json → silent defaults, rejected grants/MCP entries, missing workspace root) landed in a subscriber-less Bus and vanished. Boot now buffers the pre-persistence window with a temporary observer and republishes once the journal is up — including the ONE awaited microtask turn without which the buffer is provably empty (observer delivery is microtask-queued; the review demonstrated the no-op live). Pinned: preboot-buffer.test.ts drives the exact sequence against the real Bus+journal and asserts the warn lands in bus_event; removing the microtask turn fails it (0/1). The two paths that can die BEFORE any journal exists get the only outlet that always exists: the fatal handler and worker-entry's missing-socket/token exits write to stderr before publishing/exiting (a dead worker no longer leaves zero diagnostic anywhere).

2. **Twin resident.ask parsers unified — refuse, never launder.** `resident-inbound-wait`'s lenient shape (admittedly built for "test doubles returning bare strings") turned ANY unexpected envelope into an empty answer reported `accepted: true` — a worker's question silently got `""` as the resident's reply. It now `safeParse`s the kernel envelope like dispatch-owners' question bridge and returns `accepted: false` with the parse error on any other shape. The test that enshrined the laundering is rewritten as the refusal pin; the bare-string fixtures become the real kernel envelope.

3. **The unexplained 5s shutdown sleep is named.** Archaeology (born in #78) plus the channel teardown contract shows what it is: channel `stop()` is synchronous fire-and-forget, so in-flight I/O (a long-poll response, a close frame, a final reply) has no awaitable handle — the window lets those last publishes land before the telemetry drain. Now a named `CHANNEL_TEARDOWN_GRACE_MS` with the honest tradeoff stated (shortening drops tail events; making stops awaitable would retire it).

## Verification

- `bun test apps/server/test`: **468 pass / 1 pre-existing skip / 0 fail** (incl. the flipped refusal pin + the new journal-survival pin)
- `tsc --noEmit` src+test (server): 0 errors; `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers boot-time telemetry until persistence starts and makes `resident.ask` parsing strict. Previously, pre-persistence events were dropped and invalid shapes were laundered into empty accepted replies; now we republish after one microtask and require `{ output: string }`, rejecting others.

**Review notes**
- Boot buffers all `Bus.publish` events until `BusPersistence.start()`, awaits one microtask, then republishes; a test pins the microtask presence in bootstrap. Fatal pre-journal errors now write to stderr in server and worker entry points.
- `resident.ask` now requires the kernel envelope `{ output: string }` via `zod`; invalid shapes return `accepted: false` with an error.
- Introduces `CHANNEL_TEARDOWN_GRACE_MS = 5000` for channel teardown grace; behavior is unchanged.

**Migration**
- Update test doubles and any `resident.ask` mocks to return `{ output: "<string>" }`.
- If callers relied on `accepted: true` with empty output for malformed responses, handle `accepted: false` and surface the parse error.

<sup>Written for commit 03f4c23537856e61a00420fa9fc932e3ef9895e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup event handling so early events are retained and recorded reliably.
  * Invalid resident responses are now rejected with a clear validation error.
  * Startup and worker configuration failures now print diagnostics before exiting.
  * Shutdown timing behavior is now more consistent.

* **Tests**
  * Added coverage for startup event durability and response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->