### PR TITLE
fix(ipc): remote failures reject as their own class (#606)

### DIFF
--- a/packages/ipc/AGENTS.md
+++ b/packages/ipc/AGENTS.md
@@ -10,7 +10,7 @@ src/
 ├── framing.ts    # encode() + LineDecoder (NDJSON, 16 MiB cap, streaming TextDecoder state)
 ├── client.ts     # connectIpcClient — outbound connection; onRequest/onNotification make it bidirectional
 ├── server.ts     # createIpcServer — Bun.listen Unix socket server, per-connection decoders, call/notify
-└── errors.ts     # IpcConnectionError / IpcTimeoutError / IpcProtocolError
+└── errors.ts     # IpcConnectionError / IpcTimeoutError / IpcProtocolError / IpcRemoteError
 ```
 
 ## DEPENDENCIES
@@ -22,7 +22,7 @@ Depends on `@openomni/protocol` **only** — enforced by `script/check-deps.ts`.
 - Bidirectional: both ends can send requests, responses, and notifications over one socket — server → owner-device reverse connections ride the same pair.
 - Wire method names are frozen (Greg Young rule); the transport passes method/params through opaquely.
 - Authentication is the caller's job (workers check `authToken` in handlers); the transport carries but never inspects credentials.
-- Timeout (`IpcTimeoutError`), connection (`IpcConnectionError`), and malformed-frame (`IpcProtocolError`, wire error codes 4000/4001) behavior is part of the contract.
+- Timeout (`IpcTimeoutError`), connection (`IpcConnectionError`), remote-handler failure (`IpcRemoteError`, wire error code 1000 — a HEALTHY connection whose far side refused; both call directions file it identically), and malformed-frame (`IpcProtocolError`, wire error codes 4000/4001) behavior is part of the contract.
 
 ## CONSUMERS
 

--- a/packages/ipc/src/client.ts
+++ b/packages/ipc/src/client.ts
@@ -1,7 +1,7 @@
 import net from "node:net";
 import { Ipc } from "@openomni/protocol";
 import { LineDecoder, encode } from "./framing";
-import { IpcConnectionError, IpcProtocolError, IpcTimeoutError } from "./errors";
+import { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
 
 export interface IpcClient {
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
@@ -25,19 +25,11 @@ export type ConnectIpcClientOptions = {
   onNotification?: (method: string, params: Record<string, unknown> | undefined) => void;
 };
 
-export function connectIpcClient(socketPath: string, connectTimeoutMs?: number): Promise<IpcClient>;
 export function connectIpcClient(
   socketPath: string,
   options?: ConnectIpcClientOptions,
-): Promise<IpcClient>;
-export function connectIpcClient(
-  socketPath: string,
-  optionsOrTimeout?: ConnectIpcClientOptions | number,
 ): Promise<IpcClient> {
-  const opts: ConnectIpcClientOptions =
-    typeof optionsOrTimeout === "number"
-      ? { connectTimeoutMs: optionsOrTimeout }
-      : (optionsOrTimeout ?? {});
+  const opts: ConnectIpcClientOptions = options ?? {};
   const connectTimeoutMs = opts.connectTimeoutMs ?? 5000;
 
   return new Promise((resolve, reject) => {
@@ -84,7 +76,7 @@ export function connectIpcClient(
           clearTimeout(handler.timer);
           pending.delete(id);
           if (error) {
-            handler.reject(new IpcConnectionError(`IPC error ${error.code}: ${error.message}`));
+            handler.reject(new IpcRemoteError(error.code, error.message));
           } else {
             handler.resolve(result);
           }

--- a/packages/ipc/src/errors.ts
+++ b/packages/ipc/src/errors.ts
@@ -17,3 +17,19 @@ export class IpcProtocolError extends Error {
     if (cause !== undefined) this.cause = cause;
   }
 }
+
+/**
+ * The REMOTE handler failed (an error frame came back over a healthy
+ * connection). Distinct from IpcConnectionError on purpose: a supervisor
+ * deciding between "reconnect" and "the remote refused" must be able to
+ * tell them apart by class (#606 audit).
+ */
+export class IpcRemoteError extends Error {
+  override name = "IpcRemoteError";
+  readonly code: number;
+
+  constructor(code: number, message: string) {
+    super(`IPC error ${code}: ${message}`);
+    this.code = code;
+  }
+}

--- a/packages/ipc/src/index.ts
+++ b/packages/ipc/src/index.ts
@@ -3,6 +3,6 @@
 // Driver-band packages (channels, remote, browser, machines, …) consume this
 // barrel as a published contract; it never grows a kernel/ledger/policy import.
 export { connectIpcClient, type IpcClient } from "./client";
-export { IpcConnectionError, IpcProtocolError, IpcTimeoutError } from "./errors";
+export { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
 export { encode } from "./framing";
 export { createIpcServer } from "./server";

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -1,7 +1,7 @@
 import { Ipc } from "@openomni/protocol";
 import fs from "node:fs";
 
-import { IpcConnectionError, IpcProtocolError, IpcTimeoutError } from "./errors";
+import { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
 import { LineDecoder, encode } from "./framing";
 
 function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
@@ -142,9 +142,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
               clearTimeout(handler.timer);
               pending.delete(parsed.id);
               if (parsed.error) {
-                handler.reject(
-                  new IpcConnectionError(`IPC error ${parsed.error.code}: ${parsed.error.message}`),
-                );
+                handler.reject(new IpcRemoteError(parsed.error.code, parsed.error.message));
               } else {
                 handler.resolve(parsed.result);
               }

--- a/packages/ipc/test/remote-error.test.ts
+++ b/packages/ipc/test/remote-error.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { connectIpcClient } from "../src/client";
+import { IpcConnectionError, IpcRemoteError } from "../src/errors";
+import { createIpcServer } from "../src/server";
+
+function tmpSocketPath(label: string): string {
+  return path.join(os.tmpdir(), `omo-ipc-remote-${label}-${process.pid}.sock`);
+}
+
+describe("client remote-error path (#606 audit)", () => {
+  const servers: ReturnType<typeof createIpcServer>[] = [];
+  const clients: Awaited<ReturnType<typeof connectIpcClient>>[] = [];
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    for (const s of servers.splice(0)) s.close();
+    await Bun.sleep(10);
+  });
+
+  test("an error frame REJECTS the call as IpcRemoteError — never resolves undefined", async () => {
+    const socketPath = tmpSocketPath("reject");
+    const srv = createIpcServer(socketPath, (method, _params, _respond) => {
+      // A throwing handler produces the server's typed error frame (code 1000).
+      throw new Error(`remote refused ${method}`);
+    });
+    servers.push(srv);
+    const client = await connectIpcClient(socketPath, {});
+    clients.push(client);
+
+    // Pin: pre-fix this path was untested repo-wide (deleting the mapping
+    // made remote failures resolve `undefined` with every suite green), and
+    // the rejection class was IpcConnectionError — misfiling a healthy
+    // connection's remote failure as a transport problem.
+    const rejection = client.call("do-thing", {}, 2_000);
+    await expect(rejection).rejects.toBeInstanceOf(IpcRemoteError);
+    await expect(client.call("do-thing", {}, 2_000)).rejects.toThrow("remote refused do-thing");
+    const error = await client.call("do-thing", {}, 2_000).catch((e: unknown) => e);
+    expect(error).not.toBeInstanceOf(IpcConnectionError);
+    expect((error as IpcRemoteError).code).toBe(1000);
+  });
+});

--- a/packages/ipc/test/remote-error.test.ts
+++ b/packages/ipc/test/remote-error.test.ts
@@ -40,4 +40,23 @@ describe("client remote-error path (#606 audit)", () => {
     expect(error).not.toBeInstanceOf(IpcConnectionError);
     expect((error as IpcRemoteError).code).toBe(1000);
   });
+
+  test("the SERVER side of the socket files remote failures the same way (#677 review)", async () => {
+    const socketPath = tmpSocketPath("server-side");
+    const srv = createIpcServer(socketPath, () => undefined);
+    servers.push(srv);
+    const client = await connectIpcClient(socketPath, {
+      onRequest: () => {
+        // A throwing client-side handler becomes the code-1000 error frame
+        // the server.call path receives.
+        throw new Error("client handler refused");
+      },
+    });
+    clients.push(client);
+
+    const error = await srv.call("do-thing", {}, 2_000).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(IpcRemoteError);
+    expect(error).not.toBeInstanceOf(IpcConnectionError);
+    expect(String((error as Error).message)).toContain("client handler refused");
+  });
 });

--- a/packages/ipc/test/transport-resilience.test.ts
+++ b/packages/ipc/test/transport-resilience.test.ts
@@ -31,8 +31,8 @@ describe("IPC transport resilience (#QB1)", () => {
     });
     clients.push(client);
 
-    // Today the throw escapes the socket 'data' listener and crashes the
-    // process; fixed, it comes back as a typed error response.
+    // Pre-fix the throw escaped the socket 'data' listener and crashed the
+    // process; it now comes back as a typed error response.
     await expect(srv.call("boom", { x: 1 })).rejects.toThrow("handler blew up");
 
     // Process + socket survived: a normal request still round-trips.
@@ -64,8 +64,8 @@ describe("IPC transport resilience (#QB1)", () => {
     c1.close();
     await Bun.sleep(40);
 
-    // Fixed: activeConnectionId is cleared, so the surviving connection binds.
-    // Today it stays pinned to the dead conn-1 and this call finds no socket.
+    // activeConnectionId is cleared on close, so the surviving connection
+    // binds (pre-fix it stayed pinned to the dead conn-1 and found no socket).
     expect(await srv.call("ping")).toEqual({ from: "c2" });
   });
 });

--- a/packages/telemetry/src/bus.ts
+++ b/packages/telemetry/src/bus.ts
@@ -107,7 +107,7 @@ export namespace Bus {
     state.observers.clear();
   }
 
-  /** Diagnostic counters for tests and runtime observability; not control-flow state. */
+  /** Diagnostic counters for tests; no runtime consumer exists today. Not control-flow state. */
   export function stats(): {
     readonly subscriberEventCount: number;
     readonly subscriberCount: number;

--- a/packages/telemetry/src/span.ts
+++ b/packages/telemetry/src/span.ts
@@ -6,8 +6,10 @@ import type { EmitPayload } from "./trace";
  *
  * `guard_denied` and `budget_exhausted` are first-class because they are how a
  * run most often stops: without them a policy block looks like a normal return
- * and emits no terminal event at all. Before spans, twelve of the agent's
- * fifteen run-terminating paths did exactly that.
+ * and emits no terminal event at all — at the time this vocabulary was cut,
+ * twelve of the agent's fifteen run-terminating paths did exactly that.
+ * NOTE: `Emitter.span` has no production caller yet (D11 roadmap surface);
+ * the vocabulary is ahead of its adoption.
  */
 export type SpanOutcome =
   | { readonly kind: "completed" }

--- a/packages/telemetry/test/bus/observe-delivery.test.ts
+++ b/packages/telemetry/test/bus/observe-delivery.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { Bus, BusEvent } from "../../src/index";
+
+const TestEvent = BusEvent.define(
+  "test.observe.delivery",
+  z.object({ traceId: z.string(), n: z.number() }),
+);
+
+describe("Bus.observe delivery (#606 audit M1)", () => {
+  afterEach(() => {
+    Bus.reset();
+  });
+
+  test("observers receive every publish — the journal rides this path", async () => {
+    // The durable WAL journal is a wildcard observer: losing this delivery
+    // silently kills persistence while every subscriber-based test stays
+    // green (the audit's surviving mutant).
+    const seen: Array<{ name: string; n: number }> = [];
+    const unsubscribe = Bus.observe((descriptor, data) => {
+      seen.push({ name: descriptor.name, n: (data as { n: number }).n });
+    });
+
+    Bus.publish(TestEvent, { traceId: "trace-observe", n: 1 });
+    Bus.publish(TestEvent, { traceId: "trace-observe", n: 2 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(seen).toEqual([
+      { name: "test.observe.delivery", n: 1 },
+      { name: "test.observe.delivery", n: 2 },
+    ]);
+
+    unsubscribe();
+    Bus.publish(TestEvent, { traceId: "trace-observe", n: 3 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(seen).toHaveLength(2);
+  });
+
+  test("a throwing observer never breaks delivery to the others", async () => {
+    const survived: number[] = [];
+    Bus.observe(() => {
+      throw new Error("hostile observer");
+    });
+    Bus.observe((_descriptor, data) => {
+      survived.push((data as { n: number }).n);
+    });
+
+    Bus.publish(TestEvent, { traceId: "trace-observe", n: 7 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(survived).toEqual([7]);
+  });
+});


### PR DESCRIPTION
## Summary

ipc + telemetry test-honesty batch from the 8-package adversarial audit (#606).

**ipc:**
- **Remote-error path pinned in-package (audit MAJOR — M4 survived TWO packages' suites).** Deleting the client's error-frame→rejection mapping made remote failures resolve `undefined` with everything green. New `remote-error.test.ts` drives a throwing server handler over a real socket and asserts the call REJECTS; mutation-verified (deleting the mapping fails it 0/1).
- **Remote failure gets its own class.** A healthy connection's remote handler error was thrown as `IpcConnectionError` — a supervisor deciding between "reconnect" and "the remote refused" could not tell them apart (it only special-cases `IpcTimeoutError`). New `IpcRemoteError(code, message)`, exported; the pin also asserts the class split.
- **Dead legacy overload deleted.** `connectIpcClient(path, number)` had zero callers anywhere.
- **Stale test narration fixed.** Two "Today ..." comments described pre-fix behavior as present tense.

**telemetry:**
- **`Bus.observe` delivery pinned in-package (audit MAJOR — M1: disabling observer dispatch left 53/53 green while the WAL journal rides exactly this path).** New `observe-delivery.test.ts`: every publish reaches observers, unsubscribe stops delivery, a hostile observer never breaks the others. Mutation-verified: disabling dispatch now fails in-package (53/2).
- `stats()` comment stops claiming a runtime consumer; `span.ts` states its vocabulary is ahead of adoption (`Emitter.span` has no production caller yet) instead of implying it shipped the fix.

## Verification

- `bun test packages/telemetry packages/ipc`: **87 pass / 0 fail** (4 new tests: remote-error both socket sides + observe delivery ×2)
- Review round 2: the SERVER side of the socket (`server.call`, live via worker-runner-ipc) now files remote failures as `IpcRemoteError` too — the taxonomy was half-applied; mirrored pin added; AGENTS.md contract line names the new class with its real domain (code 1000; 4000/4001 frames carry id "unknown" and surface as timeouts — pre-existing).; coordinator + session bus-persistence downstream: 90 pass / 0 fail
- `tsc --noEmit` (telemetry, ipc): 0 errors; `bun run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remote handler failures over a healthy IPC connection now reject as `IpcRemoteError(code, message)` instead of `IpcConnectionError`. This applies to both `client.call` and `server.call`, so supervisors can distinguish “remote refused” from transport issues.

- `packages/ipc`: Map error frames to `IpcRemoteError` on both socket sides (wire code 1000); export from the barrel. Add `remote-error.test.ts` and tighten resilience tests. Remove legacy `connectIpcClient(path, number)` overload. Update `AGENTS.md` to include the new class.
- `packages/telemetry`: Add `observe-delivery.test.ts` to pin `Bus.observe` delivery and resilience to throwing observers. Clarify comments in `stats()` and `span.ts`; no runtime changes.

**Migration**
- Catch and handle `IpcRemoteError` for remote handler failures; update code that only checked `IpcConnectionError` if it needs to distinguish remote vs transport errors.
- Replace `connectIpcClient("/path", 5000)` with `connectIpcClient("/path", { connectTimeoutMs: 5000 })`.

<sup>Written for commit cb220380defb57e48b77893a5701a3a7f8f95f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

