### PR TITLE
test(openomni): pin the conflicting-head dispatch record guard (#606)

### DIFF
--- a/script/conformance/p2-ledger-baseline.test.ts
+++ b/script/conformance/p2-ledger-baseline.test.ts
@@ -1384,6 +1384,53 @@ describe("p2 ledger baseline — dispatch authorization decision-class facts (C3
     // The observe-only Authorized projection fires strictly AFTER the append.
     expect(events).not.toContain("dispatch.authorized");
   });
+
+  test("a conflicting verdict-stream head blocks the dispatch: fresh dispatchIds have no replay semantics", async () => {
+    const runtime = new DispatchRuntime({ includeDefaultPolicies: false });
+    let handlerCalls = 0;
+    runtime.register("conformance.act", () => {
+      handlerCalls += 1;
+      return { output: "acted" };
+    });
+    // The append itself succeeds at the adapter level but reports an occupied
+    // head: for a per-submit-minted dispatchId that can only mean id collision
+    // or a corrupted stream head — a record failure, never a detected replay.
+    const adapter = Storage.getAdapter();
+    const ledger = adapter.ledger;
+    if (!ledger) throw new Error("conformance storage misses the ledger sub-adapter");
+    Storage.configure({
+      ...adapter,
+      transaction: adapter.transaction.bind(adapter),
+      ledger: {
+        ...ledger,
+        append: () => ({ kind: "cas_conflict", currentHead: 1 }),
+      },
+    });
+    const events: string[] = [];
+    Bus.observe((event) => events.push(event.name));
+
+    let thrown: unknown;
+    try {
+      await runtime.submit(
+        { action: "conformance.act", target: { kind: "system" }, payload: "go" },
+        {
+          traceId: "trace-conformance",
+          actorKind: "resident",
+          actorId: "resident:main",
+          policies: [allowPolicy],
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(CommandRecordError);
+    expect((thrown as CommandRecordError).code).toBe("command_record_failed");
+    expect((thrown as CommandRecordError).message).toContain("already has a head");
+    expect(handlerCalls).toBe(0);
+    await flushBus();
+    expect(events).not.toContain("dispatch.authorized");
+  });
 });
 
 describe("p2 ledger baseline — frozen legacy writers + archive manifest (D2a)", () => {


### PR DESCRIPTION
## What

One new conformance test. The `appendCommandVerdict` guard in `packages/openomni/src/dispatch/runtime.ts` has three fail-closed arms — missing ledger sub-adapter, throwing append, and a `cas_conflict` head on the fresh `command:<dispatchId>` stream. The first two were pinned by `p2-ledger-baseline.test.ts`; the third (the arm encoding "fresh dispatchIds have NO replay semantics — an occupied head is id collision or corruption, never a detected duplicate", #672's ruling) was unpinned.

The new test stubs `ledger.append` to report `{ kind: "cas_conflict", currentHead: 1 }` and asserts: typed `CommandRecordError` with `command_record_failed` and the "already has a head" message, handler never invoked, and no observe-only `dispatch.authorized` projection.

## Verification

- Suite: 46 pass / 0 fail.
- Mutation: replacing the `cas_conflict` arm with `void appended;` fails exactly this test (45/1); restored → green.

Refs #606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the “conflicting head” guard in `appendCommandVerdict` for dispatch recording so fresh `dispatchId`s have no replay semantics. This codifies that a CAS conflict on `command:<dispatchId>` is a record failure, not a duplicate detection.

**What it verifies**
- Stubs ledger `append` to return `{ kind: 'cas_conflict', currentHead: 1 }` on the verdict stream.
- Expects a thrown `CommandRecordError` with code `command_record_failed` and a message containing “already has a head”.
- Ensures the handler is never called and no observe-only `dispatch.authorized` event is emitted.
- Backstops #606’s requirement: an occupied verdict-stream head implies ID collision or corruption, not replay.

<sup>Written for commit 00140872933c0f2dbe334d016c6bbce4f0e2a195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

