### PR TITLE
refactor(openomni): one delivery semantic for send/resume/reply (#606)

### DIFF
--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -62,7 +62,7 @@ function targetRunId(command: Dispatch.Command): string | undefined {
 async function deliverViaCoordinator(
   coordinatorOwner: CoordinatorLike | undefined,
   command: Dispatch.Command,
-  action: string,
+  action: "worker.send" | "worker.resume" | "actor.reply",
   outputFlag: "delivered" | "resumed",
 ) {
   const coordinator = requireCoordinator(coordinatorOwner);

--- a/packages/openomni/src/dispatch/handlers/worker.ts
+++ b/packages/openomni/src/dispatch/handlers/worker.ts
@@ -57,6 +57,30 @@ function targetRunId(command: Dispatch.Command): string | undefined {
   return command.target.runId ?? command.target.id;
 }
 
+// worker.send / worker.resume / actor.reply are one delivery semantic with
+// different result vocabulary — the coordinator call is identical.
+async function deliverViaCoordinator(
+  coordinatorOwner: CoordinatorLike | undefined,
+  command: Dispatch.Command,
+  action: string,
+  outputFlag: "delivered" | "resumed",
+) {
+  const coordinator = requireCoordinator(coordinatorOwner);
+  if (!coordinator.deliverMessage) {
+    throw new Error(`dispatch ${action} requires coordinator.deliverMessage owner`);
+  }
+  const sessionId = command.target.sessionId ?? command.sessionId;
+  if (!sessionId) throw new Error(`${action} requires target.sessionId`);
+  const runId = targetRunId(command);
+  const result = await coordinator.deliverMessage(
+    sessionId,
+    extractText(command.payload),
+    command.traceId,
+    runId,
+  );
+  return { output: { [outputFlag]: true, sessionId, runId, result } };
+}
+
 function parseWorkerCompletePayload(payload: unknown): WorkerCompletePayload {
   const parsed = WorkerCompletePayload.safeParse(payload);
   if (!parsed.success) {
@@ -328,35 +352,11 @@ export function createWorkerDispatchHandlers(
     },
 
     async [Dispatch.Actions.WorkerSend](command) {
-      const coordinator = requireCoordinator(options.coordinator);
-      if (!coordinator.deliverMessage) {
-        throw new Error("dispatch worker.send requires coordinator.deliverMessage owner");
-      }
-      const sessionId = command.target.sessionId ?? command.sessionId;
-      if (!sessionId) throw new Error("worker.send requires target.sessionId");
-      const result = await coordinator.deliverMessage(
-        sessionId,
-        extractText(command.payload),
-        command.traceId,
-        targetRunId(command),
-      );
-      return { output: { delivered: true, sessionId, runId: targetRunId(command), result } };
+      return deliverViaCoordinator(options.coordinator, command, "worker.send", "delivered");
     },
 
     async [Dispatch.Actions.WorkerResume](command) {
-      const coordinator = requireCoordinator(options.coordinator);
-      if (!coordinator.deliverMessage) {
-        throw new Error("dispatch worker.resume requires coordinator.deliverMessage owner");
-      }
-      const sessionId = command.target.sessionId ?? command.sessionId;
-      if (!sessionId) throw new Error("worker.resume requires target.sessionId");
-      const result = await coordinator.deliverMessage(
-        sessionId,
-        extractText(command.payload),
-        command.traceId,
-        targetRunId(command),
-      );
-      return { output: { resumed: true, sessionId, runId: targetRunId(command), result } };
+      return deliverViaCoordinator(options.coordinator, command, "worker.resume", "resumed");
     },
 
     async [Dispatch.Actions.WorkerCancel](command) {
@@ -371,20 +371,7 @@ export function createWorkerDispatchHandlers(
     },
 
     async "actor.reply"(command) {
-      const coordinator = requireCoordinator(options.coordinator);
-      if (!coordinator.deliverMessage) {
-        throw new Error("dispatch actor.reply requires coordinator.deliverMessage owner");
-      }
-      const sessionId = command.target.sessionId ?? command.sessionId;
-      if (!sessionId) throw new Error("actor.reply requires target.sessionId");
-      const runId = targetRunId(command);
-      const result = await coordinator.deliverMessage(
-        sessionId,
-        extractText(command.payload),
-        command.traceId,
-        runId,
-      );
-      return { output: { delivered: true, sessionId, runId, result } };
+      return deliverViaCoordinator(options.coordinator, command, "actor.reply", "delivered");
     },
   };
 }

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -281,6 +281,51 @@ describe("built-in dispatch handlers", () => {
     });
   });
 
+  test("delivery guards name the action that refused, not a shared label", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch() {
+            throw new Error("delivery guards should not spawn workers");
+          },
+          async deliverMessage() {
+            return { status: "delivered" };
+          },
+        },
+      },
+    });
+
+    // One shared implementation now serves three actions — a mislabeled
+    // interpolation would misattribute every refusal at once.
+    for (const action of ["worker.send", "worker.resume", "actor.reply"] as const) {
+      await expectRejectsWithMessage(
+        () => registry.get(action)?.(command(action, { kind: "worker" }, "text")),
+        `${action} requires target.sessionId`,
+      );
+    }
+
+    const withoutDelivery = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(withoutDelivery, {
+      owners: {
+        coordinator: {
+          async dispatch() {
+            throw new Error("delivery guards should not spawn workers");
+          },
+        },
+      },
+    });
+    for (const action of ["worker.send", "worker.resume", "actor.reply"] as const) {
+      await expectRejectsWithMessage(
+        () =>
+          withoutDelivery.get(action)?.(
+            command(action, { kind: "worker", sessionId: "worker-session" }, "text"),
+          ),
+        `dispatch ${action} requires coordinator.deliverMessage owner`,
+      );
+    }
+  });
+
   test("outbound handlers call the outbound owner", async () => {
     const calls: Array<{ action: string; endpointId?: string; timeoutMs?: number }> = [];
     const registry = new DispatchRegistry();

--- a/packages/openomni/test/dispatch/handlers.test.ts
+++ b/packages/openomni/test/dispatch/handlers.test.ts
@@ -248,6 +248,39 @@ describe("built-in dispatch handlers", () => {
     });
   });
 
+  test("worker.resume answers with the resume vocabulary, not a generic delivery", async () => {
+    const registry = new DispatchRegistry();
+    registerBuiltInDispatchHandlers(registry, {
+      owners: {
+        coordinator: {
+          async dispatch() {
+            throw new Error("worker.resume should not spawn workers");
+          },
+          async deliverMessage() {
+            return { status: "delivered" };
+          },
+        },
+      },
+    });
+
+    const output = await registry.get("worker.resume")?.(
+      command(
+        "worker.resume",
+        { kind: "worker", sessionId: "worker-session", runId: "worker-run" },
+        "resume input",
+      ),
+    );
+
+    expect(output).toEqual({
+      output: {
+        resumed: true,
+        sessionId: "worker-session",
+        runId: "worker-run",
+        result: { status: "delivered" },
+      },
+    });
+  });
+
   test("outbound handlers call the outbound owner", async () => {
     const calls: Array<{ action: string; endpointId?: string; timeoutMs?: number }> = [];
     const registry = new DispatchRegistry();


### PR DESCRIPTION
## What

`worker.send`, `worker.resume`, and `actor.reply` in `packages/openomni/src/dispatch/handlers/worker.ts` were byte-identical delivery bodies — same coordinator-owner guard, same sessionId requirement, same `deliverMessage(sessionId, text, traceId, runId)` call — differing only in the action name inside error strings and the output flag (`delivered` vs `resumed`). They now share `deliverViaCoordinator(owner, command, action, outputFlag)`; each handler is one line. −45/+34 net in the handler file.

Behavior-preserving by construction: error messages interpolate the same action names, output shapes are unchanged (`{ [flag]: true, sessionId, runId, result }` with `runId` from the same `targetRunId` resolution).

## New pin

Only `actor.reply`'s exact output shape was pinned; `worker.resume`'s `resumed: true` vocabulary had no test — the dedup could have silently answered `delivered` and nothing would fail. Added "worker.resume answers with the resume vocabulary, not a generic delivery" to `handlers.test.ts`.

- Mutation: flipping the resume handler's flag argument to `"delivered"` fails exactly this pin (1 fail); restored → green.

## Verification

- openomni **1120 pass / 0 fail** (one new test); tsc test config clean; lint clean.

Refs #606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `worker.send`, `worker.resume`, and `actor.reply` delivery behind a shared `deliverViaCoordinator`, removing duplicate guard logic while preserving behavior and output shapes. The old handlers duplicated the same coordinator checks and message delivery; the new path centralizes them, keeps action-specific error strings, and maintains `resumed: true` for `worker.resume`.

- All three handlers now delegate to `deliverViaCoordinator`; checks for `coordinator.deliverMessage` and `target.sessionId` remain with action-specific messages.
- Outputs are unchanged: `{ delivered|resumed, sessionId, runId, result }` with `runId` from `targetRunId`.
- Tests pin `worker.resume` returns `resumed: true` and that guard errors attribute the refusing action, including when `coordinator.deliverMessage` is missing.

<sup>Written for commit 7903cfb5bc3c50c7d39d733f33978d5a7adf4c8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

