### PR TITLE
chore: script/ joins the typecheck surface (#606)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bunx turbo run build --filter=@openomni/protocol
       - run: bunx turbo run ${{ matrix.task }}
+      # script/ lives outside turbo's package graph — typecheck it explicitly
+      # (needs the protocol dist built above).
+      - if: matrix.task == 'check-types'
+        run: bunx tsc -p script/tsconfig.json
 
   deps:
     name: Dependency Rules

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:tools": "bun run script/lint-tools.ts",
     "lint:fix": "bunx ultracite fix .",
     "format": "bunx biome format --write .",
-    "check-types": "turbo run check-types",
+    "check-types": "turbo run check-types && tsc -p script/tsconfig.json",
     "test": "turbo run test",
     "bench": "turbo run bench",
     "generate:models-snapshot": "bun run script/generate-models-snapshot.ts"

--- a/script/bench-policy-dispatch.ts
+++ b/script/bench-policy-dispatch.ts
@@ -124,7 +124,16 @@ interface Cell {
   readonly messageCount: number;
 }
 
-function buildContext(cell: Cell): Record<string, unknown> {
+/**
+ * The dispatch parameter shape for `run.turn.pre`, derived from the protocol's
+ * point-input contract so the bench context can never drift from what
+ * `dispatchPoint` actually requires.
+ */
+type RunTurnPreContext = GenericPolicyContext &
+  Policy.PolicyPointInputMap["run.turn.pre"] &
+  Record<string, unknown>;
+
+function buildContext(cell: Cell): RunTurnPreContext {
   const sessionID = "bench-session";
   const base = {
     sessionId: sessionID,

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -335,6 +335,8 @@ async function validateDeepImports(): Promise<string[]> {
     const source = await Bun.file(filePath).text();
     for (const match of source.matchAll(importPattern)) {
       const importPath = match[1];
+      // Unreachable: the capture group requires >=1 char; this narrows
+      // string | undefined from noUncheckedIndexedAccess, nothing more.
       if (!importPath) continue;
       const line = lineNumberForOffset(source, match.index);
       const isKnown = KNOWN_DEEP_IMPORTS.has(`${filePath}:${importPath}`);
@@ -375,6 +377,8 @@ async function validateDeepRelativeImports(): Promise<string[]> {
     const source = await Bun.file(filePath).text();
     for (const match of source.matchAll(importPattern)) {
       const importPath = match[1];
+      // Unreachable: the capture group requires >=1 char; this narrows
+      // string | undefined from noUncheckedIndexedAccess, nothing more.
       if (!importPath) continue;
       const line = lineNumberForOffset(source, match.index);
       const key = `${filePath}:${importPath}`;

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -1,35 +1,4 @@
-declare const Bun: {
-  argv: string[];
-  glob?: (pattern: string) => {
-    scan(options: {
-      cwd: string;
-      absolute: boolean;
-      dot: boolean;
-      onlyFiles: boolean;
-      followSymlinks: boolean;
-    }): AsyncIterable<string>;
-  };
-  file(path: string): {
-    exists(): Promise<boolean>;
-    text(): Promise<string>;
-  };
-  spawn(options: { cmd: string[]; stdout: "pipe"; stderr: "pipe" }): {
-    stdout: ReadableStream;
-    exited: Promise<number>;
-  };
-  Glob: new (
-    pattern: string,
-  ) => {
-    scan(options: {
-      cwd: string;
-      absolute: boolean;
-      dot: boolean;
-      onlyFiles: boolean;
-      followSymlinks: boolean;
-    }): AsyncIterable<string>;
-  };
-  exit(code: number): never;
-};
+import { Glob } from "bun";
 
 type PackageKey =
   | "protocol"
@@ -263,8 +232,8 @@ function lineNumberForOffset(source: string, offset: number): number {
 }
 
 function suggestBarrelImport(importPath: string): string {
-  const match = importPath.match(/^(@openomni\/[^/]+)/);
-  return match ? match[1] : importPath;
+  const packageName = importPath.match(/^(@openomni\/[^/]+)/)?.[1];
+  return packageName ?? importPath;
 }
 
 function parentTraversalDepth(importPath: string): number {
@@ -315,7 +284,7 @@ async function validateSourceImportDirection(): Promise<string[]> {
   }));
   const importPattern =
     /(?:from\s+|import\s+|import\s*\(\s*)["'](@openomni\/[^"'/]+)(?:\/[^"']*)?["']/g;
-  const sourceGlob = Bun.glob ? Bun.glob("**/*.ts") : new Bun.Glob("**/*.ts");
+  const sourceGlob = new Glob("**/*.ts");
 
   for await (const filePath of sourceGlob.scan({
     cwd: ".",
@@ -332,18 +301,14 @@ async function validateSourceImportDirection(): Promise<string[]> {
     if (!owner) continue;
 
     const source = await Bun.file(filePath).text();
-    importPattern.lastIndex = 0;
-
-    let match = importPattern.exec(source);
-    while (match !== null) {
+    for (const match of source.matchAll(importPattern)) {
       const dep = match[1];
-      if (!isAllowedSourceDep(owner.rule, dep)) {
+      if (dep && !isAllowedSourceDep(owner.rule, dep)) {
         const line = lineNumberForOffset(source, match.index);
         violations.push(
           `VIOLATION: ${filePath}:${line} source-imports ${dep} — not allowed by layer order for ${owner.rule.displayName} (manifest check cannot see phantom imports)`,
         );
       }
-      match = importPattern.exec(source);
     }
   }
 
@@ -354,7 +319,7 @@ async function validateDeepImports(): Promise<string[]> {
   const violations: string[] = [];
   // Matches both `from "@openomni/.../src/..."` and side-effect `import "@openomni/.../src/..."`
   const importPattern = /(?:from\s+|import\s+)["'](@openomni\/[^"']+\/src\/[^"']*)["']/g;
-  const sourceGlob = Bun.glob ? Bun.glob("**/*.ts") : new Bun.Glob("**/*.ts");
+  const sourceGlob = new Glob("**/*.ts");
 
   for await (const filePath of sourceGlob.scan({
     cwd: ".",
@@ -368,11 +333,9 @@ async function validateDeepImports(): Promise<string[]> {
     }
 
     const source = await Bun.file(filePath).text();
-    importPattern.lastIndex = 0;
-
-    let match = importPattern.exec(source);
-    while (match !== null) {
+    for (const match of source.matchAll(importPattern)) {
       const importPath = match[1];
+      if (!importPath) continue;
       const line = lineNumberForOffset(source, match.index);
       const isKnown = KNOWN_DEEP_IMPORTS.has(`${filePath}:${importPath}`);
       const prefix = isKnown ? "KNOWN" : "VIOLATION";
@@ -387,7 +350,6 @@ async function validateDeepImports(): Promise<string[]> {
       } else {
         violations.push(base);
       }
-      match = importPattern.exec(source);
     }
   }
 
@@ -397,7 +359,7 @@ async function validateDeepImports(): Promise<string[]> {
 async function validateDeepRelativeImports(): Promise<string[]> {
   const violations: string[] = [];
   const importPattern = /(?:from\s+|import\s*\(\s*)["'](\.{2}\/[^"']*)["']/g;
-  const sourceGlob = Bun.glob ? Bun.glob("**/*.ts") : new Bun.Glob("**/*.ts");
+  const sourceGlob = new Glob("**/*.ts");
 
   for await (const filePath of sourceGlob.scan({
     cwd: ".",
@@ -411,18 +373,15 @@ async function validateDeepRelativeImports(): Promise<string[]> {
     }
 
     const source = await Bun.file(filePath).text();
-    importPattern.lastIndex = 0;
-
-    let match = importPattern.exec(source);
-    while (match !== null) {
+    for (const match of source.matchAll(importPattern)) {
       const importPath = match[1];
+      if (!importPath) continue;
       const line = lineNumberForOffset(source, match.index);
       const key = `${filePath}:${importPath}`;
       const isSelfRootImport = importPath.startsWith("../../src/");
       const isDeepRelativeImport = parentTraversalDepth(importPath) >= 3;
 
       if (!isSelfRootImport && !isDeepRelativeImport) {
-        match = importPattern.exec(source);
         continue;
       }
 
@@ -436,8 +395,6 @@ async function validateDeepRelativeImports(): Promise<string[]> {
       } else {
         violations.push(base);
       }
-
-      match = importPattern.exec(source);
     }
   }
 
@@ -462,7 +419,7 @@ const KNOWN_EMPTY_CATCHES = new Set<string>();
 
 async function validateGoldenPrinciples(): Promise<string[]> {
   const violations: string[] = [];
-  const sourceGlob = Bun.glob ? Bun.glob("**/*.ts") : new Bun.Glob("**/*.ts");
+  const sourceGlob = new Glob("**/*.ts");
 
   for await (const filePath of sourceGlob.scan({
     cwd: ".",
@@ -478,9 +435,8 @@ async function validateGoldenPrinciples(): Promise<string[]> {
     const source = await Bun.file(filePath).text();
     const lines = source.split("\n");
 
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      const lineNum = i + 1;
+    for (const [index, line] of lines.entries()) {
+      const lineNum = index + 1;
 
       // #5: No `as any` (except allowed files)
       if (!ALLOWED_AS_ANY_FILES.has(filePath) && /\bas\s+any\b/.test(line)) {
@@ -561,7 +517,7 @@ async function checkDocFreshness(): Promise<string[]> {
         cmd: ["git", "log", "--oneline", `HEAD`, "--", docPath],
         stdout: "pipe",
         stderr: "pipe",
-      }) as { stdout: ReadableStream; exited: Promise<number> };
+      });
 
       const output = await new Response(proc.stdout).text();
       await proc.exited;
@@ -577,7 +533,7 @@ async function checkDocFreshness(): Promise<string[]> {
         cmd: ["git", "log", "-1", "--format=%H", "--", docPath],
         stdout: "pipe",
         stderr: "pipe",
-      }) as { stdout: ReadableStream; exited: Promise<number> };
+      });
 
       const lastTouchHash = (await new Response(lastTouchProc.stdout).text()).trim();
       await lastTouchProc.exited;
@@ -588,7 +544,7 @@ async function checkDocFreshness(): Promise<string[]> {
         cmd: ["git", "rev-list", "--count", `${lastTouchHash}..HEAD`],
         stdout: "pipe",
         stderr: "pipe",
-      }) as { stdout: ReadableStream; exited: Promise<number> };
+      });
 
       const commitsSince = parseInt((await new Response(sinceProc.stdout).text()).trim(), 10);
       await sinceProc.exited;

--- a/script/conformance/p2-ledger-baseline.test.ts
+++ b/script/conformance/p2-ledger-baseline.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   Communication,
+  type Ingress,
   LedgerAppend,
   PolicyDecision,
   Wait,
@@ -181,8 +182,8 @@ function workHeadOf(hash: string): number | undefined {
 
 describe("p2 ledger baseline — Wait decision-class facts", () => {
   test("append-before-act: every committed transition appends its fact at seq === projected revision", () => {
-    const created = WaitStore.create(buildWaitCreate());
-    const resolved = WaitStore.attachReply("wait-1", buildReplyInput());
+    const created = WaitStore.create(buildWaitCreate(), "trace-test");
+    const resolved = WaitStore.attachReply("wait-1", buildReplyInput(), "trace-test");
     if (resolved.kind !== "resolved") throw new Error(`expected resolved, got ${resolved.kind}`);
 
     const facts = factsOf("wait-1");
@@ -221,7 +222,7 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
   });
 
   test("a failed append leaves no projection change, no extra fact, and no Bus event", async () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-test");
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
 
@@ -229,10 +230,14 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
     // append: the appended cancel fact wins, the outer expire must fail as
     // a typed revision_conflict with nothing written.
     const error = captureStoreError(() =>
-      WaitStore.transition("wait-1", (record) => {
-        WaitStore.cancel("wait-1", 500);
-        return Wait.expire(record, { at: 20_000 });
-      }),
+      WaitStore.transition(
+        "wait-1",
+        (record) => {
+          WaitStore.cancel("wait-1", "trace-test", 500);
+          return Wait.expire(record, { at: 20_000 });
+        },
+        "trace-test",
+      ),
     );
 
     expect(error.data.code).toBe("revision_conflict");
@@ -249,7 +254,7 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
   });
 
   test("a stale expectedHead at the append core is a typed cas_conflict that writes nothing", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-test");
 
     const conflict = Ledger.append(
       inspect,
@@ -263,12 +268,12 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
   });
 
   test("a duplicate create conflicts on the owner stream and projects nothing", async () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-test");
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
 
     const error = captureStoreError(() =>
-      WaitStore.create(buildWaitCreate({ originMessageId: "out-msg-2" })),
+      WaitStore.create(buildWaitCreate({ originMessageId: "out-msg-2" }), "trace-test"),
     );
 
     expect(error.data.code).toBe("duplicate");
@@ -280,7 +285,7 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
   });
 
   test("a pre-cutover wait row (revision >= 1, empty stream) is adopted lazily before its first transition", () => {
-    WaitStore.create(buildWaitCreate());
+    WaitStore.create(buildWaitCreate(), "trace-test");
     // Simulate an old-DB wait: the projection row exists at revision >= 1
     // but its owner stream is empty (every write predates the phase-B
     // cutover). Without adoption this row would brick every transition
@@ -289,7 +294,7 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
     inspect.query("DELETE FROM ledger_head WHERE stream_id = ?").run("wait:wait-1");
     expect(factsOf("wait-1")).toHaveLength(0);
 
-    const outcome = WaitStore.attachReply("wait-1", buildReplyInput());
+    const outcome = WaitStore.attachReply("wait-1", buildReplyInput(), "trace-test");
 
     expect(outcome.kind).toBe("resolved");
     const facts = factsOf("wait-1");
@@ -321,10 +326,10 @@ describe("p2 ledger baseline — Wait decision-class facts", () => {
   });
 
   test("boot tail verification passes after a normal run and detects a tampered row", () => {
-    WaitStore.create(buildWaitCreate());
-    WaitStore.attachReply("wait-1", buildReplyInput());
-    WaitStore.create(buildWaitCreate({ id: "wait-2", originMessageId: "out-msg-2" }));
-    WaitStore.expire("wait-2", 10_001);
+    WaitStore.create(buildWaitCreate(), "trace-test");
+    WaitStore.attachReply("wait-1", buildReplyInput(), "trace-test");
+    WaitStore.create(buildWaitCreate({ id: "wait-2", originMessageId: "out-msg-2" }), "trace-test");
+    WaitStore.expire("wait-2", "trace-test", 10_001);
 
     expect(Ledger.verifyTail(inspect)).toEqual([]);
 
@@ -983,12 +988,22 @@ function configureFailingLedger(): void {
   });
 }
 
+// The routed scenarios pin the EXECUTED arm of the ingress result union —
+// a dropped result would mean the route never acted, so it fails loudly.
+function expectExecuted(result: Ingress.IngressResult): Ingress.ExecutedIngressResult {
+  if (result.kind === "dropped") {
+    throw new Error(`expected an executed ingress result, got dropped: ${result.reason}`);
+  }
+  return result;
+}
+
 describe("p2 ledger baseline — routing decision-class facts (C3)", () => {
   // #549: the engine is an instance — each scenario constructs its own with
   // explicit deps instead of mutating module-global setters.
   test("route.decided is durable before the routed action's effects are observable", async () => {
     grantConformanceChannel();
     const workerSession = Session.create({
+      traceId: "trace-test",
       title: "route conformance",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -1020,15 +1035,18 @@ describe("p2 ledger baseline — routing decision-class facts (C3)", () => {
 
     // The executor saw the durable route.decided fact BEFORE it acted.
     expect(observed).toEqual([{ factTypes: ["route.decided"], parsedOutcome: "route" }]);
-    expect(result.result.output).toBe("routed");
+    expect(expectExecuted(result).result.output).toBe("routed");
     // Single-fact stream discipline: expectedHead 0, seq 1, head 1, on the
     // channel-scoped stream key (review fix F1).
     const facts = factsOfStream(routeStreamOf("inbound-route-1"));
     expect(facts.map((fact) => [fact.seq, fact.type])).toEqual([[1, "route.decided"]]);
     expect(headOfStream(routeStreamOf("inbound-route-1"))).toBe(1);
     // The writer and the protocol stream registry agree on the vocabulary.
+    // Widened to string[]: the DB rows carry plain strings, and membership
+    // in the registry's literal vocabulary is exactly what's being pinned.
+    const routeVocabulary: readonly string[] = LedgerAppend.StreamRegistry.route.factTypes;
     for (const fact of facts) {
-      expect(LedgerAppend.StreamRegistry.route.factTypes).toContain(fact.type);
+      expect(routeVocabulary).toContain(fact.type);
     }
   });
 
@@ -1064,6 +1082,7 @@ describe("p2 ledger baseline — routing decision-class facts (C3)", () => {
   test("an equivalent redelivered inbound replays: no second fact, the owner re-receives the action", async () => {
     grantConformanceChannel();
     const workerSession = Session.create({
+      traceId: "trace-test",
       title: "route replay conformance",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -1097,8 +1116,8 @@ describe("p2 ledger baseline — routing decision-class facts (C3)", () => {
       routedIngressEvent("inbound-route-replay-1", workerSession.id),
     );
 
-    expect(first.result.output).toBe("routed");
-    expect(second.result.output).toBe("routed");
+    expect(expectExecuted(first).result.output).toBe("routed");
+    expect(expectExecuted(second).result.output).toBe("routed");
     expect(dispatches).toBe(2);
     expect(dispatchedSessions).toEqual([workerSession.id, workerSession.id]);
     // Replay appended nothing: the stream still holds exactly the one fact.
@@ -1134,6 +1153,7 @@ describe("p2 ledger baseline — routing decision-class facts (C3)", () => {
     // published.
     grantConformanceChannel();
     const workerSession = Session.create({
+      traceId: "trace-test",
       title: "route divergent replay conformance",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -1215,6 +1235,7 @@ describe("p2 ledger baseline — routing decision-class facts (C3)", () => {
   test("a failing ledger append blocks the routed action: typed error, no publish, no act", async () => {
     grantConformanceChannel();
     const workerSession = Session.create({
+      traceId: "trace-test",
       title: "route fail-closed conformance",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -1313,8 +1334,9 @@ describe("p2 ledger baseline — dispatch authorization decision-class facts (C3
       targetKind: "system",
     });
     expect(headOfStream(`command:${result.dispatchId}`)).toBe(1);
+    const commandVocabulary: readonly string[] = LedgerAppend.StreamRegistry.command.factTypes;
     for (const fact of facts) {
-      expect(LedgerAppend.StreamRegistry.command.factTypes).toContain(fact.type);
+      expect(commandVocabulary).toContain(fact.type);
     }
   });
 
@@ -1557,6 +1579,7 @@ describe("p2 ledger baseline — frozen legacy writers + archive manifest (D2a)"
     const adapter = Storage.getAdapter().pendingInteraction;
     if (!adapter) throw new Error("conformance storage misses the pendingInteraction sub-adapter");
     const session = Session.create({
+      traceId: "trace-test",
       title: `pi-conformance-${id}`,
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -1923,8 +1946,9 @@ describe("p2 ledger baseline — effect decision-class facts (intent/outcome)", 
       [2, "effect.confirmed"],
     ]);
     // The writer and the protocol stream registry agree on the vocabulary.
+    const effectVocabulary: readonly string[] = LedgerAppend.StreamRegistry.effect.factTypes;
     for (const fact of factsOfStream("effect:eff-happy")) {
-      expect(LedgerAppend.StreamRegistry.effect.factTypes).toContain(fact.type);
+      expect(effectVocabulary).toContain(fact.type);
     }
   });
 });
@@ -1956,6 +1980,7 @@ describe("p2 ledger baseline — telemetry and Bus.publish cannot authorize", ()
   test("a forged NORMAL-durability telemetry row is rejected as a routing decision record", async () => {
     grantConformanceChannel();
     const workerSession = Session.create({
+      traceId: "trace-test",
       title: "telemetry forge conformance",
       model: { providerID: "test", modelID: "test-model" },
     });
@@ -2002,7 +2027,7 @@ describe("p2 ledger baseline — telemetry and Bus.publish cannot authorize", ()
     // followed the fresh ledger-recorded resolution (the real worker
     // session), never the forged target.
     expect(dispatchedSessions).toEqual([workerSession.id]);
-    expect(result.result.output).toBe("routed");
+    expect(expectExecuted(result).result.output).toBe("routed");
     const facts = factsOfStream(routeStreamOf("inbound-telemetry-forge"));
     expect(facts.map((fact) => [fact.seq, fact.type])).toEqual([[1, "route.decided"]]);
     const decided = LedgerAppend.RouteDecided.parse(JSON.parse(facts[0]?.data ?? "{}"));
@@ -2170,9 +2195,12 @@ describe("p2 ledger baseline — exact producer manifest", () => {
   });
 
   test("manifest stream classes equal the protocol StreamRegistry; one producer per class", () => {
-    expect(LEDGER_PRODUCER_MANIFEST.streams.map((entry) => entry.streamClass).sort()).toEqual(
-      Object.keys(LedgerAppend.StreamRegistry).sort(),
+    // Widened to string[]: Object.keys erases the registry's literal key
+    // union, and set equality of the two name lists is what's being pinned.
+    const manifestClasses: string[] = LEDGER_PRODUCER_MANIFEST.streams.map(
+      (entry) => entry.streamClass,
     );
+    expect(manifestClasses.sort()).toEqual(Object.keys(LedgerAppend.StreamRegistry).sort());
     const producers = LEDGER_PRODUCER_MANIFEST.streams.map((entry) => entry.producer);
     expect(new Set(producers).size).toBe(producers.length);
   });

--- a/script/generate-models-snapshot.ts
+++ b/script/generate-models-snapshot.ts
@@ -10,6 +10,10 @@
 // downgrades in fresh installs and CI runs where neither the cache nor
 // models.dev is reachable.
 
+// Module scope on purpose: top-level await requires it, and script/ typechecks
+// as one program. This file genuinely imports nothing — it runs on Bun globals.
+export {};
+
 const MODELS_URL = process.env.MODELS_DEV_URL ?? "https://models.dev/api.json";
 const BUNDLED_PROVIDERS = ["anthropic", "openai"] as const;
 const SNAPSHOT_PATH = "packages/llm/src/model/models-snapshot.json";

--- a/script/lint-side-effects.ts
+++ b/script/lint-side-effects.ts
@@ -1,3 +1,9 @@
+// Module scope on purpose: script/ typechecks as one program, so a plain
+// script's top-level declarations (main, lineNumberForOffset, …) would
+// collide with the other scripts'. This file genuinely imports nothing —
+// it runs on Bun globals alone.
+export {};
+
 type SideEffectRuleId =
   | "tool-ledger-before-execute"
   | "mcp-ledger-before-execute"

--- a/script/smoke-dist.ts
+++ b/script/smoke-dist.ts
@@ -7,6 +7,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Subprocess } from "bun";
 
 const root = join(import.meta.dir, "..");
 
@@ -47,7 +48,9 @@ const env = {
   OPENOMNI_DISABLE_MODELS_FETCH: "1",
 };
 
-let serve: ReturnType<typeof Bun.spawn> | undefined;
+// Pinned to the piped shape the spawn below configures: `ReturnType<typeof
+// Bun.spawn>` would erase the stdout/stderr inference back to the full union.
+let serve: Subprocess<"ignore", "pipe", "pipe"> | undefined;
 try {
   const onboard = Bun.spawnSync(
     [process.execPath, cli, "onboard", "--port", String(port), "--host", "127.0.0.1"],

--- a/script/tsconfig.json
+++ b/script/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["."],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

`script/` (every pre-push guard, the benches, and the conformance suite) was typechecked by NO CI tsconfig — surfaced as a pre-existing MINOR in #680's review. An ad-hoc strict run showed 55 real accumulated errors. This PR adds `script/tsconfig.json` (strict, `noUncheckedIndexedAccess`, real `types: ["bun"]`), chains it into the root `check-types` script (which both CI and the lefthook pre-push run), and fixes every error at its cause:

- **`script/check-deps.ts` was the root poison**: it opened with a hand-rolled `declare const Bun` global shim; because the file was a non-module, that narrow fake type replaced bun-types for the entire program — which is also exactly why the file's own `Bun.glob ? ... : new Bun.Glob(...)` fallbacks and `as { stdout: ReadableStream }` spawn casts existed. Shim deleted, `import { Glob } from "bun"` (real API only), fallback arms deleted, `exec()` while-loops → `matchAll` with honest capture-group narrowing.
- **Non-module scripts collided in global scope** (duplicate `main`/`lineNumberForOffset` implementations) — `lint-side-effects.ts` and `generate-models-snapshot.ts` are modules now.
- **`smoke-dist.ts`**: `ReturnType<typeof Bun.spawn>` erased the piped-stdout inference; now `Subprocess<"ignore", "pipe", "pipe">` matching the actual spawn config.
- **`bench-policy-dispatch.ts`**: bench context typed from the protocol's `PolicyPointInputMap["run.turn.pre"]` contract instead of `Record<string, unknown>`.
- **`script/conformance/p2-ledger-baseline.test.ts`**: 28 stale call shapes updated to current signatures — `WaitStore.*`/`Session.create` traceId plumbing (payload-only; no assertion reads those), and the `DroppedIngressResult` union arm now fails loudly via an `expectExecuted()` helper instead of dying on `undefined.output`. No assertion weakened; no vacuous test found.

## Verification

- `bunx tsc -p script/tsconfig.json`: **0 errors** (was 55, or 101 under the poisoned shim).
- `bun test script/conformance`: **53 pass / 0 fail** (305 expects).
- `bun run check-types`: all 14 turbo tasks + the new script step green; lint + biome clean.
- Runtime unchanged: `bun script/check-deps.ts` (incl. `--self-test`), `lint-side-effects.ts`, `lint-guards.ts` all exit 0; bench smoke-run OK.

Closes the #680 review MINOR. Refs #606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typechecks everything in `script/` by adding a strict `script/tsconfig.json` and wiring it into both the root and CI typecheck steps. Previously scripts were unchecked in CI; now type errors in `script/` fail fast without changing runtime behavior.

- Adds `script/tsconfig.json` (strict, `noUncheckedIndexedAccess`, `types: ["bun"]`) and updates `package.json` so `check-types` runs `turbo run check-types && tsc -p script/tsconfig.json`.
- Updates CI: when the matrix task is `check-types`, runs `bunx tsc -p script/tsconfig.json` after building `@openomni/protocol` (since `script/` sits outside Turbo’s graph).
- Replaces a hand-rolled Bun shim in `script/check-deps.ts` with real `bun` types, removes glob/spawn fallbacks and casts, and switches regex loops to `matchAll` with proper narrowing.
- Makes `lint-side-effects.ts` and `generate-models-snapshot.ts` modules (`export {}`); tightens `smoke-dist.ts` to `Subprocess<"ignore","pipe","pipe">`.
- Aligns bench and conformance types: derives the `run.turn.pre` context from the protocol map, threads `traceId` through `WaitStore`/`Session` calls, widens literal vocabularies where necessary for registry comparisons, and adds an `expectExecuted` helper to fail on dropped ingress results.

**Developer impact**
- CI and pre-push now block on types in `script/`. New scripts should be ES modules (add `export {}` if needed) and use real `bun` APIs. Do not add global Bun shims.

<sup>Written for commit f024c6237151363dbd18ffa24bcfa731d15aa6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

