### PR TITLE
fix(session): session writes commit as one unit or fail loudly (#606)

### DIFF
--- a/packages/openomni/test/dispatch/runtime-worker-authority.test.ts
+++ b/packages/openomni/test/dispatch/runtime-worker-authority.test.ts
@@ -267,6 +267,9 @@ describe("DispatchRuntime", () => {
       if (!adapter.workerGrant) throw new Error("workerGrant adapter missing in test setup");
       Storage.configure({
         ...adapter,
+        // Spreading a class instance loses prototype methods — rebind the
+        // required transaction so only the grant list is broken.
+        transaction: adapter.transaction.bind(adapter),
         workerGrant: {
           ...adapter.workerGrant,
           list: () => {

--- a/packages/openomni/test/ingress/actor-resolver-sanitization.test.ts
+++ b/packages/openomni/test/ingress/actor-resolver-sanitization.test.ts
@@ -143,8 +143,11 @@ describe("Ingress actor resolver sanitization", () => {
 
   it("keeps ingest working with storage adapters that do not implement actorRegistry", async () => {
     // Given
-    const { actorRegistry: _actorRegistry, ...legacyAdapter } = Storage.get();
-    Storage.configure(legacyAdapter);
+    const base = Storage.get();
+    const { actorRegistry: _actorRegistry, ...legacyAdapter } = base;
+    // Spreading a class instance loses prototype methods — rebind the
+    // required transaction so only actorRegistry is absent.
+    Storage.configure({ ...legacyAdapter, transaction: base.transaction.bind(base) });
     let capturedActor: Ingress.Actor | undefined;
     const engine = getIngressEngine();
     const unobserve = observeResolvedActor("event-user-1", (actor) => {

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -106,7 +106,8 @@ export namespace Storage {
     create(record: Communication.WorkerGrant.Record): void;
     get(id: string): Communication.WorkerGrant.Record | undefined;
     list(workerRunId?: string): Communication.WorkerGrant.Record[];
-    set(record: Communication.WorkerGrant.Record): void;
+    /** Version-guarded upsert: false = a newer version already persisted (lost race). */
+    set(record: Communication.WorkerGrant.Record): boolean;
     remove(id: string): boolean;
   }
 

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -106,7 +106,7 @@ export namespace Storage {
     create(record: Communication.WorkerGrant.Record): void;
     get(id: string): Communication.WorkerGrant.Record | undefined;
     list(workerRunId?: string): Communication.WorkerGrant.Record[];
-    /** Version-guarded upsert: false = a newer version already persisted (lost race). */
+    /** Version-guarded upsert: false = an equal-or-newer version already persisted (lost race). */
     set(record: Communication.WorkerGrant.Record): boolean;
     remove(id: string): boolean;
   }

--- a/packages/session/src/session/lifecycle.ts
+++ b/packages/session/src/session/lifecycle.ts
@@ -147,15 +147,18 @@ export function remove(id: string, traceId: string): boolean {
   const adapter = Storage.getAdapter();
   const exists = adapter.session.get(id) !== undefined;
   if (exists) {
-    const msgs = adapter.message.list(id);
-    for (const msg of msgs) {
-      const parts = adapter.part.list(msg.id);
-      for (const part of parts) {
-        adapter.part.remove(msg.id, part.id);
+    // One transaction: a crash mid-cascade must not leave a half-deleted
+    // session. The manual loop stays — it is the only cascade for adapters
+    // without FK enforcement.
+    adapter.transaction(() => {
+      for (const msg of adapter.message.list(id)) {
+        for (const part of adapter.part.list(msg.id)) {
+          adapter.part.remove(msg.id, part.id);
+        }
+        adapter.message.remove(id, msg.id);
       }
-      adapter.message.remove(id, msg.id);
-    }
-    adapter.session.remove(id);
+      adapter.session.remove(id);
+    });
     Bus.publish(Event.Deleted, { traceId, id });
   }
   return exists;

--- a/packages/session/src/session/messages.ts
+++ b/packages/session/src/session/messages.ts
@@ -19,12 +19,12 @@ export function addMessage(
 
   const status = options?.status ?? "completed";
 
-  adapter.message.set(sessionID, message);
-
-  if (status !== "completed" && adapter.message.setStatus) {
-    adapter.message.setStatus(message.id, status);
-  }
-
+  // The counter update below is get→mutate→set without a CAS. It is safe
+  // because session rows have exactly one writer process (server ingress +
+  // dispatch); worker processes write only message/part/transcript_fact.
+  // A second session-row writer requires a revision column + CAS, per the
+  // wait/work-item precedent. The transaction makes the three writes one
+  // fsync unit and (BEGIN IMMEDIATE) serializes the read against them.
   const updated = {
     ...session,
     messageCount: (session.messageCount ?? 0) + 1,
@@ -41,10 +41,18 @@ export function addMessage(
     }),
   };
 
-  adapter.session.set(sessionID, updated);
+  adapter.transaction(() => {
+    adapter.message.set(sessionID, message);
+    if (status !== "completed" && adapter.message.setStatus) {
+      adapter.message.setStatus(message.id, status);
+    }
+    adapter.session.set(sessionID, updated);
+  });
   Bus.publish(Event.Updated, { info: updated });
 }
 
+// Publishes nothing: status flips are recovery bookkeeping, not the
+// ingress-tier "session content changed" notification Event.Updated carries.
 export function updateMessageStatus(
   messageID: string,
   status: "received" | "processing" | "completed",
@@ -61,11 +69,14 @@ export function getMessages(sessionID: string): Message.Info[] {
 
 export function addPart(messageID: string, part: Message.Part): void {
   const adapter = Storage.getAdapter();
-  adapter.part.set(messageID, part);
   const session = adapter.session.get(part.sessionID);
-  if (session) {
-    Bus.publish(Event.Updated, { info: session });
+  if (!session) {
+    // Fail closed like addMessage: a part for a missing session is a defect
+    // upstream, not a condition to absorb silently.
+    throw new Error(`addPart: session not found: ${part.sessionID}`);
   }
+  adapter.part.set(messageID, part);
+  Bus.publish(Event.Updated, { info: session });
 }
 
 export function getParts(messageID: string): Message.Part[] {

--- a/packages/session/src/session/messages.ts
+++ b/packages/session/src/session/messages.ts
@@ -19,12 +19,13 @@ export function addMessage(
 
   const status = options?.status ?? "completed";
 
-  // The counter update below is get→mutate→set without a CAS. It is safe
-  // because session rows have exactly one writer process (server ingress +
-  // dispatch); worker processes write only message/part/transcript_fact.
-  // A second session-row writer requires a revision column + CAS, per the
+  // The counter update below is get→mutate→set without a CAS, and the read
+  // above runs BEFORE the transaction — its safety rests entirely on session
+  // rows having exactly one writer process (server ingress + dispatch;
+  // worker processes write only message/part/transcript_fact). A second
+  // session-row writer requires a revision column + CAS, per the
   // wait/work-item precedent. The transaction makes the three writes one
-  // fsync unit and (BEGIN IMMEDIATE) serializes the read against them.
+  // fsync unit; it does not protect the read.
   const updated = {
     ...session,
     messageCount: (session.messageCount ?? 0) + 1,
@@ -48,6 +49,9 @@ export function addMessage(
     }
     adapter.session.set(sessionID, updated);
   });
+  // Published after the top-level commit. Do not wrap addMessage in an outer
+  // transaction: this publish would fire at savepoint release, announcing a
+  // write the outer transaction can still roll back.
   Bus.publish(Event.Updated, { info: updated });
 }
 

--- a/packages/session/src/session/transcript.ts
+++ b/packages/session/src/session/transcript.ts
@@ -48,6 +48,11 @@ import { Storage } from "../storage/storage";
  * replay() is the fold's read-back — it reconstructs Message.WithParts from
  * the recorded stream and pins the live record() path (worker-runner
  * transcript and transcript-store tests fold what production wrote).
+ *
+ * This path deliberately publishes no Session.Event.Updated: it is a
+ * recording-tier write; Event.Updated is the ingress-tier notification
+ * (Session.addMessage/addPart). A subscriber that wants worker-produced
+ * turns must gate on message.finished facts, not on Event.Updated.
  */
 export class TranscriptRecordingError extends Error {
   readonly name = "TranscriptRecordingError";

--- a/packages/session/src/storage/sqlite-actor-registry-adapter.ts
+++ b/packages/session/src/storage/sqlite-actor-registry-adapter.ts
@@ -1,9 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { Actor, type Storage as ProtocolStorage } from "@openomni/protocol";
-import { z } from "zod";
-
-const DataRow = z.object({ data: z.string() });
-const DataRows = z.array(DataRow);
+import { SqliteJsonDataRowSchema, SqliteJsonDataRowsSchema } from "./sqlite-json-data";
 
 function workspaceKey(workspace: string | undefined): string {
   return workspace ?? "";
@@ -14,7 +11,7 @@ export function createSqliteActorRegistryAdapter(
 ): ProtocolStorage.ActorRegistrySubAdapter {
   return {
     getIdentity(id) {
-      const row = DataRow.nullable().parse(
+      const row = SqliteJsonDataRowSchema.nullable().parse(
         db.query("SELECT data FROM actor_identity WHERE id = ?").get(id),
       );
       return row ? Actor.Identity.parse(JSON.parse(row.data)) : undefined;
@@ -42,7 +39,7 @@ export function createSqliteActorRegistryAdapter(
       );
     },
     listIdentities() {
-      const rows = DataRows.parse(
+      const rows = SqliteJsonDataRowsSchema.parse(
         db.query("SELECT data FROM actor_identity ORDER BY time_created ASC, id ASC").all(),
       );
       return rows.map((row) => Actor.Identity.parse(JSON.parse(row.data)));
@@ -51,7 +48,7 @@ export function createSqliteActorRegistryAdapter(
       return db.query("DELETE FROM actor_identity WHERE id = ?").run(id).changes > 0;
     },
     getEndpoint(id) {
-      const row = DataRow.nullable().parse(
+      const row = SqliteJsonDataRowSchema.nullable().parse(
         db.query("SELECT data FROM actor_endpoint WHERE id = ?").get(id),
       );
       return row ? Actor.Endpoint.parse(JSON.parse(row.data)) : undefined;
@@ -81,7 +78,7 @@ export function createSqliteActorRegistryAdapter(
       );
     },
     findEndpoint(channel, externalId, workspace) {
-      const row = DataRow.nullable().parse(
+      const row = SqliteJsonDataRowSchema.nullable().parse(
         db
           .query(
             `SELECT data FROM actor_endpoint
@@ -93,7 +90,7 @@ export function createSqliteActorRegistryAdapter(
     },
     listEndpoints(actorId, workspace) {
       const workspaceFilter = workspaceKey(workspace);
-      const rows = DataRows.parse(
+      const rows = SqliteJsonDataRowsSchema.parse(
         actorId === undefined && workspace === undefined
           ? db.query("SELECT data FROM actor_endpoint ORDER BY time_created ASC, id ASC").all()
           : actorId === undefined

--- a/packages/session/src/storage/sqlite-app-connector-installation-adapter.ts
+++ b/packages/session/src/storage/sqlite-app-connector-installation-adapter.ts
@@ -1,16 +1,13 @@
 import { AppConnector, type Storage as ProtocolStorage } from "@openomni/protocol";
 import type { Database } from "bun:sqlite";
-import { z } from "zod";
-
-const DataRow = z.object({ data: z.string() });
-const DataRows = z.array(DataRow);
+import { SqliteJsonDataRowSchema, SqliteJsonDataRowsSchema } from "./sqlite-json-data";
 
 export function createSqliteAppConnectorInstallationAdapter(
   db: Database,
 ): ProtocolStorage.AppConnectorInstallationSubAdapter {
   return {
     get(id) {
-      const row = DataRow.nullable().parse(
+      const row = SqliteJsonDataRowSchema.nullable().parse(
         db.query("SELECT data FROM app_connector_installation WHERE id = ?").get(id),
       );
       return row ? AppConnector.Installation.parse(JSON.parse(row.data)) : undefined;
@@ -36,7 +33,7 @@ export function createSqliteAppConnectorInstallationAdapter(
       );
     },
     list() {
-      const rows = DataRows.parse(
+      const rows = SqliteJsonDataRowsSchema.parse(
         db
           .query("SELECT data FROM app_connector_installation ORDER BY time_created ASC, id ASC")
           .all(),

--- a/packages/session/src/storage/sqlite-blacklist-adapter.ts
+++ b/packages/session/src/storage/sqlite-blacklist-adapter.ts
@@ -1,14 +1,11 @@
 import type { Database } from "bun:sqlite";
 import { Actor, type Storage as ProtocolStorage } from "@openomni/protocol";
-import { z } from "zod";
-
-const DataRow = z.object({ data: z.string() });
-const DataRows = z.array(DataRow);
+import { SqliteJsonDataRowSchema, SqliteJsonDataRowsSchema } from "./sqlite-json-data";
 
 export function createSqliteBlacklistAdapter(db: Database): ProtocolStorage.BlacklistSubAdapter {
   return {
     get(id) {
-      const row = DataRow.nullable().parse(
+      const row = SqliteJsonDataRowSchema.nullable().parse(
         db.query("SELECT data FROM blacklist WHERE id = ?").get(id),
       );
       return row ? Actor.BlacklistEntry.parse(JSON.parse(row.data)) : undefined;
@@ -36,7 +33,7 @@ export function createSqliteBlacklistAdapter(db: Database): ProtocolStorage.Blac
       );
     },
     list() {
-      const rows = DataRows.parse(
+      const rows = SqliteJsonDataRowsSchema.parse(
         db.query("SELECT data FROM blacklist ORDER BY time_created ASC, id ASC").all(),
       );
       return rows.map((row) => Actor.BlacklistEntry.parse(JSON.parse(row.data)));

--- a/packages/session/src/storage/sqlite-channel-grant-adapter.ts
+++ b/packages/session/src/storage/sqlite-channel-grant-adapter.ts
@@ -1,16 +1,13 @@
 import type { Database } from "bun:sqlite";
 import { Actor, type Storage as ProtocolStorage } from "@openomni/protocol";
-import { z } from "zod";
-
-const DataRow = z.object({ data: z.string() });
-const DataRows = z.array(DataRow);
+import { SqliteJsonDataRowSchema, SqliteJsonDataRowsSchema } from "./sqlite-json-data";
 
 export function createSqliteChannelGrantAdapter(
   db: Database,
 ): ProtocolStorage.ChannelGrantSubAdapter {
   return {
     get(id) {
-      const row = DataRow.nullable().parse(
+      const row = SqliteJsonDataRowSchema.nullable().parse(
         db.query("SELECT data FROM channel_grant WHERE id = ?").get(id),
       );
       return row ? Actor.ChannelGrant.parse(JSON.parse(row.data)) : undefined;
@@ -40,7 +37,7 @@ export function createSqliteChannelGrantAdapter(
       );
     },
     list() {
-      const rows = DataRows.parse(
+      const rows = SqliteJsonDataRowsSchema.parse(
         db.query("SELECT data FROM channel_grant ORDER BY time_created ASC, id ASC").all(),
       );
       return rows.map((row) => Actor.ChannelGrant.parse(JSON.parse(row.data)));

--- a/packages/session/src/storage/sqlite-json-data.ts
+++ b/packages/session/src/storage/sqlite-json-data.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite";
+import { z } from "zod";
 
 export type SqliteJsonDataTable = "pending_ask" | "pending_interaction" | "wait";
 
@@ -14,6 +15,12 @@ export type SqliteStringEqualityColumn =
 export type SqliteJsonDataRow = {
   readonly data: string;
 };
+
+// The one `SELECT data` row envelope, for adapters that zod-validate the
+// envelope before decoding (low-volume registry/config tables — the
+// streaming projection adapters deliberately cast instead).
+export const SqliteJsonDataRowSchema = z.object({ data: z.string() });
+export const SqliteJsonDataRowsSchema = z.array(SqliteJsonDataRowSchema);
 
 // Parse-don't-cast on read: every caller passes a `decode` that re-validates
 // the row's JSON across the persistence boundary (schema `.parse`), so a

--- a/packages/session/src/storage/sqlite-worker-grant-adapter.ts
+++ b/packages/session/src/storage/sqlite-worker-grant-adapter.ts
@@ -34,7 +34,7 @@ export function createSqliteWorkerGrantAdapter(
       return rows.map((row) => decodeGrant(row.data));
     },
     set(record) {
-      insertOrReplace(db, record, true);
+      return insertOrReplace(db, record, true).changes === 1;
     },
     remove(id) {
       return db.query("DELETE FROM worker_grant WHERE id = ?").run(id).changes > 0;
@@ -42,11 +42,7 @@ export function createSqliteWorkerGrantAdapter(
   };
 }
 
-function insertOrReplace(
-  db: Database,
-  record: Communication.WorkerGrant.Record,
-  replace: boolean,
-): void {
+function insertOrReplace(db: Database, record: Communication.WorkerGrant.Record, replace: boolean) {
   const sql = replace
     ? `INSERT INTO worker_grant (
          id, worker_run_id, data, status, version, time_created, time_updated, expires_at
@@ -62,14 +58,16 @@ function insertOrReplace(
     : `INSERT INTO worker_grant (
          id, worker_run_id, data, status, version, time_created, time_updated, expires_at
        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
-  db.query(sql).run(
-    record.id,
-    record.workerRunId,
-    JSON.stringify(record),
-    record.status,
-    record.version,
-    record.createdAt,
-    record.updatedAt,
-    record.expiresAt ?? null,
-  );
+  return db
+    .query(sql)
+    .run(
+      record.id,
+      record.workerRunId,
+      JSON.stringify(record),
+      record.status,
+      record.version,
+      record.createdAt,
+      record.updatedAt,
+      record.expiresAt ?? null,
+    );
 }

--- a/packages/session/src/worker-grant/index.ts
+++ b/packages/session/src/worker-grant/index.ts
@@ -116,7 +116,14 @@ export namespace WorkerGrantStore {
       version: current.version + 1,
       updatedAt: Date.now(),
     });
-    adapter.set(updated);
+    if (!adapter.set(updated)) {
+      // The version guard dropped this write: a newer version persisted
+      // concurrently. Publishing or returning `updated` here would report a
+      // write that never happened — authz state must fail loudly instead.
+      throw new Error(
+        `WorkerGrant ${event} lost a version race on ${id} (v${updated.version}); re-read and retry`,
+      );
+    }
     const descriptor =
       event === "updated"
         ? Communication.WorkerGrant.Events.Updated

--- a/packages/session/src/worker-grant/index.ts
+++ b/packages/session/src/worker-grant/index.ts
@@ -146,10 +146,23 @@ export namespace WorkerGrantStore {
     traceId: string,
     workerRunId?: string,
   ): Communication.WorkerGrant.Record[] {
-    return requireAdapter()
-      .list(workerRunId)
-      .filter((grant) => isPastExpiry(grant))
-      .map((grant) => expire(grant.id, traceId));
+    const expired: Communication.WorkerGrant.Record[] = [];
+    const failures: string[] = [];
+    for (const grant of requireAdapter().list(workerRunId)) {
+      if (!isPastExpiry(grant)) continue;
+      try {
+        expired.push(expire(grant.id, traceId));
+      } catch (error) {
+        // One lost race must not abandon the rest of the sweep.
+        failures.push(`${grant.id}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        `worker grant sweep: ${failures.length} expiry write(s) failed — ${failures.join("; ")}`,
+      );
+    }
+    return expired;
   }
 
   export function evaluate(

--- a/packages/session/test/session/write-discipline.test.ts
+++ b/packages/session/test/session/write-discipline.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Message } from "@openomni/protocol";
+import { Session } from "../../src/session";
+import { Storage } from "../../src/storage/storage";
+import "../../src/storage/initialize";
+
+/**
+ * Session write discipline (#606 audit follow-up):
+ *   1. addMessage's three writes (message row, status, session counters) are
+ *      one transaction — a failing session write rolls the message back;
+ *   2. addPart fails closed on a missing session, exactly like addMessage;
+ *   3. remove()'s manual cascade is one transaction — a failure mid-cascade
+ *      leaves the session fully intact, never half-deleted.
+ */
+
+function userMessage(sessionID: string, id: string): Message.Info {
+  return {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test-agent",
+    model: { providerID: "test", modelID: "test-model" },
+  };
+}
+
+function textPart(sessionID: string, messageID: string, id: string): Message.TextPart {
+  return { id, sessionID, messageID, type: "text", text: "content", time: { start: 1 } };
+}
+
+beforeEach(() => {
+  Storage.reset();
+  Storage.initialize({ dbPath: ":memory:" });
+});
+
+afterEach(() => {
+  Storage.reset();
+});
+
+function createSession(title: string) {
+  return Session.create({
+    traceId: "trace-write-discipline",
+    title,
+    model: { providerID: "test", modelID: "test-model" },
+  });
+}
+
+describe("session write discipline", () => {
+  test("addMessage is atomic: a failing session write rolls the message back", () => {
+    const session = createSession("atomic-add");
+    const adapter = Storage.getAdapter();
+    const realSessionSet = adapter.session.set.bind(adapter.session);
+    Storage.configure({
+      ...adapter,
+      transaction: adapter.transaction.bind(adapter),
+      session: {
+        ...adapter.session,
+        set: (id, info) => {
+          if (info.messageCount === 1) throw new Error("session write refused");
+          realSessionSet(id, info);
+        },
+      },
+    });
+
+    expect(() => Session.addMessage(session.id, userMessage(session.id, "msg-atomic"))).toThrow(
+      "session write refused",
+    );
+    // The message row committed BEFORE the session write — the transaction
+    // must have rolled it back with the failure.
+    expect(Session.getMessages(session.id)).toEqual([]);
+  });
+
+  test("addPart refuses a part for a missing session", () => {
+    expect(() => textPartInsert("no-such-session")).toThrow(
+      "addPart: session not found: no-such-session",
+    );
+
+    function textPartInsert(sessionID: string): void {
+      Session.addPart("msg-none", textPart(sessionID, "msg-none", "part-none"));
+    }
+  });
+
+  test("remove() is atomic: a failure mid-cascade leaves the session intact", () => {
+    const session = createSession("atomic-remove");
+    Session.addMessage(session.id, userMessage(session.id, "msg-1"));
+    Session.addPart("msg-1", textPart(session.id, "msg-1", "part-1"));
+    Session.addPart("msg-1", textPart(session.id, "msg-1", "part-2"));
+
+    const adapter = Storage.getAdapter();
+    const realPartRemove = adapter.part.remove.bind(adapter.part);
+    let removals = 0;
+    Storage.configure({
+      ...adapter,
+      transaction: adapter.transaction.bind(adapter),
+      part: {
+        ...adapter.part,
+        remove: (messageID, partID) => {
+          removals += 1;
+          if (removals === 2) throw new Error("cascade interrupted");
+          return realPartRemove(messageID, partID);
+        },
+      },
+    });
+
+    expect(() => Session.remove(session.id, "trace-write-discipline")).toThrow(
+      "cascade interrupted",
+    );
+    // Nothing half-deleted: the first part's removal rolled back with the rest.
+    expect(Session.get(session.id)?.id).toBe(session.id);
+    expect(Session.getMessages(session.id)).toHaveLength(1);
+    expect(Session.getParts("msg-1")).toHaveLength(2);
+  });
+});

--- a/packages/session/test/worker-grant/store.test.ts
+++ b/packages/session/test/worker-grant/store.test.ts
@@ -270,11 +270,57 @@ describe("WorkerGrantStore", () => {
     };
 
     WorkerGrantStore.revoke("grant-stale", "trace-grant-test");
-    Storage.get().workerGrant?.set(staleConcurrentUpdate);
+    // The version guard reports the drop — a silent false would let a caller
+    // believe a stale write persisted.
+    expect(Storage.get().workerGrant?.set(staleConcurrentUpdate)).toBe(false);
 
     expect(WorkerGrantStore.get("grant-stale")).toMatchObject({
       status: "revoked",
       version: created.version + 1,
     });
+  });
+
+  test("a lost version race fails loudly and publishes nothing", async () => {
+    await createWorkerRun("run-race");
+    const created = WorkerGrantStore.create(
+      {
+        id: "grant-race",
+        workerRunId: "run-race",
+        allowedActions: ["worker.send"],
+        canCreateExternalTasks: false,
+      },
+      "trace-grant-test",
+    );
+
+    // Simulate a concurrent writer landing between the store's read and its
+    // write: the store sees a stale copy while a newer version is persisted.
+    const adapter = Storage.getAdapter();
+    const grantAdapter = adapter.workerGrant;
+    if (!grantAdapter) throw new Error("workerGrant sub-adapter missing");
+    const newerConcurrent = {
+      ...created,
+      version: created.version + 2,
+      updatedAt: Date.now() + 1,
+    };
+    expect(grantAdapter.set(newerConcurrent)).toBe(true);
+    Storage.configure({
+      ...adapter,
+      transaction: adapter.transaction.bind(adapter),
+      workerGrant: {
+        ...grantAdapter,
+        get: () => created,
+      },
+    });
+
+    const events: string[] = [];
+    Bus.observe((descriptor) => {
+      events.push(descriptor.name);
+    });
+
+    expect(() => WorkerGrantStore.revoke("grant-race", "trace-grant-test")).toThrow(
+      "lost a version race on grant-race",
+    );
+    await new Promise((resolve) => queueMicrotask(resolve));
+    expect(events).not.toContain("worker_grant.revoked");
   });
 });

--- a/packages/session/test/worker-grant/store.test.ts
+++ b/packages/session/test/worker-grant/store.test.ts
@@ -323,4 +323,40 @@ describe("WorkerGrantStore", () => {
     await new Promise((resolve) => queueMicrotask(resolve));
     expect(events).not.toContain("worker_grant.revoked");
   });
+
+  test("the expiry sweep continues past a lost race and names it at the end", async () => {
+    await createWorkerRun("run-sweep");
+    const past = Date.now() - 60_000;
+    for (const id of ["grant-sweep-ok", "grant-sweep-fail"]) {
+      WorkerGrantStore.create(
+        {
+          id,
+          workerRunId: "run-sweep",
+          allowedActions: ["worker.send"],
+          canCreateExternalTasks: false,
+          expiresAt: past,
+        },
+        "trace-grant-test",
+      );
+    }
+
+    const adapter = Storage.getAdapter();
+    const grantAdapter = adapter.workerGrant;
+    if (!grantAdapter) throw new Error("workerGrant sub-adapter missing");
+    Storage.configure({
+      ...adapter,
+      transaction: adapter.transaction.bind(adapter),
+      workerGrant: {
+        ...grantAdapter,
+        set: (record) => (record.id === "grant-sweep-fail" ? false : grantAdapter.set(record)),
+      },
+    });
+
+    expect(() => WorkerGrantStore.cleanupExpired("trace-grant-test")).toThrow(
+      "1 expiry write(s) failed — grant-sweep-fail",
+    );
+    // The healthy grant was swept BEFORE the aggregate throw.
+    expect(WorkerGrantStore.get("grant-sweep-ok")?.status).toBe("expired");
+    expect(WorkerGrantStore.get("grant-sweep-fail")?.status).toBe("active");
+  });
 });


### PR DESCRIPTION
## What

Audit follow-up on `packages/session` write discipline (investigated by a dedicated census agent; report drove the scope):

1. **Atomicity.** `addMessage`'s three statements (message row, status flip, session counter/token update) and `remove()`'s 2+2N manual cascade were independent autocommits — a crash midway left a message without its counter bump, or a half-deleted session with some messages gone and the row present. Both now run inside `adapter.transaction` (nested calls degrade to savepoints, so ingress's own transactions still compose); `Bus.publish` stays outside the write unit. The manual cascade loop stays — it is the only cascade for adapters without FK enforcement.
2. **Stated invariant instead of unwritten luck.** The counter update is get→mutate→set without CAS; it is safe only because session rows have exactly one writer process (server ingress + dispatch — workers write only message/part/transcript_fact). That property was asserted nowhere; it is now a comment at the RMW site naming the wait/work-item CAS precedent a second writer would require.
3. **`addPart` fail-open asymmetry closed.** Same file: `addMessage` throws on a missing session, `addPart` silently skipped its publish. `addPart` now fails closed identically.
4. **WorkerGrant lost race was silent.** The adapter's version-guarded upsert (`WHERE excluded.version > worker_grant.version`) dropped stale writes but returned `void`, so `persistUpdate` published Updated/Revoked/Expired and returned the record as if persisted. The adapter now returns the write receipt (`changes === 1`) and the store **throws before publishing** on a lost race — authz state never reports a write that did not happen.
5. **Envelope dedup.** The verbatim `z.object({ data: z.string() })` row envelope duplicated across four registry adapters moves to `sqlite-json-data.ts`, which already owned the concept. The streaming adapters' raw casts are deliberately untouched (hot-path cost split).
6. Transcript header now states the recording-tier path deliberately publishes no `Session.Event.Updated` (a future subscriber must gate on `message.finished` facts); `updateMessageStatus`'s non-publication documented likewise.

## Pins (each mutation-verified)

- addMessage atomicity: failing session write → message row rolled back (unwrapping the transaction fails exactly this pin).
- remove atomicity: failure mid-cascade → session, message, and both parts intact (unwrapping fails it).
- addPart fail-closed: missing session throws (restoring the silent branch fails it).
- Grant race: store-level lost race throws `lost a version race` and publishes nothing; adapter-level stale write returns `false` (restoring the swallowed receipt fails it).

## Verification

- session **417 / 0**, openomni **1121 / 0**, apps/server **470 / 0** (one openomni fixture rebinds the class-method `transaction` its adapter spread was silently dropping); `turbo check-types --force` 14/14; lint/biome clean.
- Governance: no disposition-ledger row names `WorkerGrantSubAdapter`; the `set` change is a receipt tightening, not a concept change.

Refs #606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commits session writes as one unit and fails loudly on lost worker‑grant races to prevent partial state and false authz events. Previously `addMessage`/`remove` autocommitted and the grant store published after dropped writes; now session writes are transactional, `addPart` matches `addMessage` by throwing on missing sessions, and the expiry sweep continues past failures and reports them.

- Session: `addMessage` wraps message insert, optional status flip, and counter update in `adapter.transaction`; publish after commit. `remove` runs the manual cascade in one `transaction`. `addPart` throws on missing sessions; publish on success. `updateMessageStatus` and transcript recording do not emit `Session.Event.Updated`.
- WorkerGrant: adapter `workerGrant.set(record)` returns `boolean`; the store throws and publishes nothing on a `false` receipt. `cleanupExpired` continues past per‑grant failures and throws a summarized error.
- Storage: deduplicates the zod `SELECT data` envelope into `packages/session/src/storage/sqlite-json-data.ts`. Tests rebind `transaction` when spreading adapter instances to preserve method binding. Protocol interface updated in `@openomni/protocol`: `Storage.WorkerGrantSubAdapter.set` now returns `boolean`.

**Migration**
- Update `Storage.WorkerGrantSubAdapter.set(record)` to return `boolean` and propagate the receipt (true = persisted, false = version guard dropped the write).

<sup>Written for commit 53f1a43bf01694f9c77948e2bd1b0a20fea02f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session message, part, and deletion operations now complete atomically, preventing partial updates after failures.
  - Missing sessions are reported when adding parts.
  - Concurrent worker-grant updates are detected, preventing stale changes and incorrect event publication.
  - Version-guarded writes now report whether they were accepted.

- **Tests**
  - Added coverage for transaction rollbacks, write consistency, and concurrent update handling.

- **Documentation**
  - Clarified transcript replay and event-recording behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->