### PR TITLE
refactor(openomni): recorded verifier input moves to evidence (#606)

### DIFF
--- a/packages/openomni/AGENTS.md
+++ b/packages/openomni/AGENTS.md
@@ -64,7 +64,7 @@ Use these ownership boundaries when adding or moving code:
 agents/             → @openomni/protocol (Model.Ref only)
 resident/           → @openomni/session + @openomni/agent + @openomni/protocol
 policy/             → @openomni/protocol (pure label→plan resolution; consumed by dispatch)
-evidence/           → @openomni/session + @openomni/protocol (read-back → WorkItem evidence)
+evidence/           → @openomni/session + @openomni/protocol (read-back → WorkItem evidence), work-item/ (type-only: the admission port contract verifier-recorded-input implements)
 ledger/             → evidence/ (canonical JSON snapshot boundary only); no orchestration deps
 execution-runtime/  → no orchestration deps (tool system, workspace, middleware)
 ingress/            → dispatch/ (DEFAULT_DISPATCH_MODEL), resident/ (type-only)

--- a/packages/openomni/src/dispatch/handlers/worker-completion.ts
+++ b/packages/openomni/src/dispatch/handlers/worker-completion.ts
@@ -5,11 +5,11 @@ import { z } from "zod";
 import { ReadBackExecutor } from "../../evidence/read-back-executor.js";
 import { settleBeforeDeadline } from "../../evidence/read-back-http.js";
 import { canonicalJson as canonicalEvidenceJson } from "../../evidence/verifier-conformance-canonical.js";
+import { durableVerifierInput } from "../../evidence/verifier-recorded-input.js";
 import { VerifierRegistry } from "../../evidence/verifier-registry.js";
 import {
   CompletionAdmissionError,
   completionBlockerDescription,
-  durableVerifierInput,
   type CompletionAdmissionService,
   type CompletionBoundaryOutcome,
   type CompletionRequestCallOptions,

--- a/packages/openomni/src/evidence/verifier-recorded-input.ts
+++ b/packages/openomni/src/evidence/verifier-recorded-input.ts
@@ -1,0 +1,125 @@
+import type { WorkItem } from "@openomni/protocol";
+import { WorkItemStore } from "@openomni/session";
+import { z } from "zod";
+import type {
+  CompletionResultAuthorityCandidate,
+  CompletionResultAuthorityPort,
+} from "../work-item/completion-admission.js";
+import { VerifierRegistry } from "./verifier-registry.js";
+
+/**
+ * Recorded verifier input: the durable evidence → verifier-input projection
+ * and the result-authority port built on it. This evolves with the
+ * VerifierRegistry obligation/read-back vocabulary, not with the admission
+ * transaction protocol — which is why it lives in evidence/, one type-only
+ * import away from the admission port contract it implements.
+ */
+
+const PersistedVerifierInput = z
+  .object({
+    type: z.literal("verifier_recorded_inputs"),
+    version: z.literal(1),
+    workItemHash: z.string().min(1),
+    basisRef: z.string().min(1),
+    criterionId: z.string().min(1),
+    verifierKind: VerifierRegistry.ObligationKind,
+    recordedInputs: z.record(VerifierRegistry.JsonValue),
+  })
+  .strict();
+
+export function createDurableCompletionResultAuthorityPort(): CompletionResultAuthorityPort {
+  const verifierRegistry = VerifierRegistry.create();
+  return Object.freeze({
+    validate(candidate: CompletionResultAuthorityCandidate) {
+      const item = WorkItemStore.get(candidate.workItemHash);
+      if (!item) return { ok: false };
+      if (candidate.result.observationIds.length !== 1 || candidate.observations.length !== 1) {
+        return { ok: false };
+      }
+      const observation = candidate.observations[0];
+      if (!observation) return { ok: false };
+      if (
+        observation.id !== candidate.result.observationIds[0] ||
+        observation.basisRef !== candidate.basisRef ||
+        observation.subjectRef !== candidate.workItemHash
+      ) {
+        return { ok: false };
+      }
+      const evidenceId = observation?.artifactRefs[0];
+      const evidence = evidenceId ? item.evidence.find(({ id }) => id === evidenceId) : undefined;
+      const verifierInput =
+        evidence === undefined
+          ? undefined
+          : durableVerifierInput(item, candidate.criterion, evidence);
+      if (!observation || !verifierInput) return { ok: false };
+
+      const verification = verifierRegistry.verify({
+        obligationId: candidate.criterion.id,
+        kind: verifierInput.kind,
+        claim: candidate.criterion.statement,
+        recordedInputs: verifierInput.recordedInputs,
+      });
+      if (verification.type !== "verification_result") return { ok: false };
+      return {
+        ok:
+          verification.status === candidate.result.value &&
+          verification.verifierId === candidate.result.verifierRef &&
+          (candidate.result.value === "asserted" ||
+            verification.checkedPredicate === candidate.result.checkedPredicate) &&
+          (verifierInput.kind === "citation_support" ||
+            candidate.result.value === "asserted" ||
+            candidate.result.checkedPredicate === candidate.criterion.statement) &&
+          observation.producer === verification.verifierId &&
+          observation.artifactRefs.length === 1 &&
+          observation.provenanceRef === evidenceId,
+      };
+    },
+  });
+}
+
+export function durableVerifierInput(
+  item: WorkItem.Info,
+  criterion: WorkItem.Criterion,
+  evidence: WorkItem.Evidence,
+):
+  | Readonly<{
+      kind: VerifierRegistry.ObligationKind;
+      recordedInputs: Record<string, VerifierRegistry.JsonValue>;
+    }>
+  | undefined {
+  if (evidence.attempt !== item.attempt || evidence.basisRef !== item.completionContract.basisRef) {
+    return undefined;
+  }
+  if (evidence.readBack?.kind === "citation_match") {
+    if (evidence.criterionId !== criterion.id) return undefined;
+    return {
+      kind: "archived_quote_match",
+      recordedInputs: {
+        archivedText: evidence.readBack.matchedText ?? "",
+        quotedText: evidence.readBack.quotedText,
+      },
+    };
+  }
+  if (evidence.detail === undefined) return undefined;
+  const persisted = PersistedVerifierInput.safeParse(parseJson(evidence.detail));
+  if (
+    !persisted.success ||
+    persisted.data.workItemHash !== item.hash ||
+    persisted.data.basisRef !== item.completionContract.basisRef ||
+    persisted.data.criterionId !== criterion.id
+  ) {
+    return undefined;
+  }
+  return {
+    kind: persisted.data.verifierKind,
+    recordedInputs: persisted.data.recordedInputs,
+  };
+}
+
+function parseJson(input: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/openomni/src/work-item/completion-admission.ts
+++ b/packages/openomni/src/work-item/completion-admission.ts
@@ -1,9 +1,8 @@
 import type { PolicyEngine } from "@openomni/policy";
 import { WorkItem, type Policy } from "@openomni/protocol";
+import { createDurableCompletionResultAuthorityPort } from "../evidence/verifier-recorded-input.js";
 import { Storage, WorkItemStore } from "@openomni/session";
 import { Bus } from "@openomni/telemetry";
-import { z } from "zod";
-import { VerifierRegistry } from "../evidence/verifier-registry.js";
 import type { CompletionStakesInjection } from "../ledger/index.js";
 import {
   evaluateCompletion as foldCompletion,
@@ -2110,115 +2109,6 @@ export function completionBlockerDescription(
 ): string | undefined {
   if (admission.decision === "admit" || admission.decision === "owner_override") return undefined;
   return `completion admission ${admission.decision}: ${admission.reasonCodes.join(", ")}`;
-}
-
-const PersistedVerifierInput = z
-  .object({
-    type: z.literal("verifier_recorded_inputs"),
-    version: z.literal(1),
-    workItemHash: z.string().min(1),
-    basisRef: z.string().min(1),
-    criterionId: z.string().min(1),
-    verifierKind: VerifierRegistry.ObligationKind,
-    recordedInputs: z.record(VerifierRegistry.JsonValue),
-  })
-  .strict();
-
-export function createDurableCompletionResultAuthorityPort(): CompletionResultAuthorityPort {
-  const verifierRegistry = VerifierRegistry.create();
-  return Object.freeze({
-    validate(candidate: CompletionResultAuthorityCandidate) {
-      const item = WorkItemStore.get(candidate.workItemHash);
-      if (!item) return { ok: false };
-      if (candidate.result.observationIds.length !== 1 || candidate.observations.length !== 1) {
-        return { ok: false };
-      }
-      const observation = candidate.observations[0];
-      if (!observation) return { ok: false };
-      if (
-        observation.id !== candidate.result.observationIds[0] ||
-        observation.basisRef !== candidate.basisRef ||
-        observation.subjectRef !== candidate.workItemHash
-      ) {
-        return { ok: false };
-      }
-      const evidenceId = observation?.artifactRefs[0];
-      const evidence = evidenceId ? item.evidence.find(({ id }) => id === evidenceId) : undefined;
-      const verifierInput =
-        evidence === undefined
-          ? undefined
-          : durableVerifierInput(item, candidate.criterion, evidence);
-      if (!observation || !verifierInput) return { ok: false };
-
-      const verification = verifierRegistry.verify({
-        obligationId: candidate.criterion.id,
-        kind: verifierInput.kind,
-        claim: candidate.criterion.statement,
-        recordedInputs: verifierInput.recordedInputs,
-      });
-      if (verification.type !== "verification_result") return { ok: false };
-      return {
-        ok:
-          verification.status === candidate.result.value &&
-          verification.verifierId === candidate.result.verifierRef &&
-          (candidate.result.value === "asserted" ||
-            verification.checkedPredicate === candidate.result.checkedPredicate) &&
-          (verifierInput.kind === "citation_support" ||
-            candidate.result.value === "asserted" ||
-            candidate.result.checkedPredicate === candidate.criterion.statement) &&
-          observation.producer === verification.verifierId &&
-          observation.artifactRefs.length === 1 &&
-          observation.provenanceRef === evidenceId,
-      };
-    },
-  });
-}
-
-export function durableVerifierInput(
-  item: WorkItem.Info,
-  criterion: WorkItem.Criterion,
-  evidence: WorkItem.Evidence,
-):
-  | Readonly<{
-      kind: VerifierRegistry.ObligationKind;
-      recordedInputs: Record<string, VerifierRegistry.JsonValue>;
-    }>
-  | undefined {
-  if (evidence.attempt !== item.attempt || evidence.basisRef !== item.completionContract.basisRef) {
-    return undefined;
-  }
-  if (evidence.readBack?.kind === "citation_match") {
-    if (evidence.criterionId !== criterion.id) return undefined;
-    return {
-      kind: "archived_quote_match",
-      recordedInputs: {
-        archivedText: evidence.readBack.matchedText ?? "",
-        quotedText: evidence.readBack.quotedText,
-      },
-    };
-  }
-  if (evidence.detail === undefined) return undefined;
-  const persisted = PersistedVerifierInput.safeParse(parseJson(evidence.detail));
-  if (
-    !persisted.success ||
-    persisted.data.workItemHash !== item.hash ||
-    persisted.data.basisRef !== item.completionContract.basisRef ||
-    persisted.data.criterionId !== criterion.id
-  ) {
-    return undefined;
-  }
-  return {
-    kind: persisted.data.verifierKind,
-    recordedInputs: persisted.data.recordedInputs,
-  };
-}
-
-function parseJson(input: string): unknown {
-  try {
-    return JSON.parse(input);
-  } catch {
-    return undefined;
-  }
 }
 
 type WorkItemCompletionRecoveryReceipt = Readonly<{

--- a/packages/openomni/test/dispatch/worker-completion-admission.test.ts
+++ b/packages/openomni/test/dispatch/worker-completion-admission.test.ts
@@ -16,9 +16,9 @@ import {
   workerCompletionReservationRoot,
   workerCompletionRequestRoot,
 } from "../../src/dispatch/handlers/worker-completion.js";
+import { createDurableCompletionResultAuthorityPort } from "../../src/evidence/verifier-recorded-input.js";
 import {
   createCompletionAdmissionService,
-  createDurableCompletionResultAuthorityPort,
   reserveCompletionRequest,
   type CompletionAdmissionService,
   type CompletionStakesResolver,

--- a/packages/openomni/test/evidence/verifier-recorded-input.test.ts
+++ b/packages/openomni/test/evidence/verifier-recorded-input.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { WorkItem } from "@openomni/protocol";
+import { Storage, WorkItemStore, initialize } from "@openomni/session";
+import { durableVerifierInput } from "../../src/evidence/verifier-recorded-input";
+
+/**
+ * Owning-layer pins for the recorded-verifier-input projection (#606):
+ * every refusal branch returns undefined — scope mismatches and malformed
+ * durable detail must never produce a verifiable input.
+ */
+
+beforeEach(() => {
+  Storage.reset();
+  initialize({ dbPath: ":memory:" });
+});
+
+afterEach(() => {
+  Storage.reset();
+});
+
+async function storedItem(): Promise<WorkItem.Info> {
+  const created = await WorkItemStore.create(
+    {
+      name: "Recorded verifier input",
+      sourceMessageId: "evidence:verifier-recorded-input",
+      sourceChannel: "dispatch",
+      intent: "worker.spawn",
+      goal: "pin the durable verifier-input projection",
+      executorKind: "internal_chat_agent",
+      acceptanceCriteria: ["archived source contains the recorded quote exactly"],
+    },
+    "trace-test",
+  );
+  const item = await WorkItemStore.start(created.hash, "trace-test");
+  if (!item) throw new Error("missing started fixture item");
+  return item;
+}
+
+function criterionOf(item: WorkItem.Info): WorkItem.Criterion {
+  const criterion = item.completionFacts.criteria[0];
+  if (!criterion) throw new Error("missing fixture criterion");
+  return criterion;
+}
+
+function citationEvidence(
+  item: WorkItem.Info,
+  criterion: WorkItem.Criterion,
+  overrides: Partial<WorkItem.Evidence> = {},
+): WorkItem.Evidence {
+  return WorkItem.Evidence.parse({
+    id: "evidence:citation",
+    kind: "verification",
+    description: "read-back citation",
+    passed: true,
+    createdAt: 1_000,
+    readBack: {
+      kind: "citation_match",
+      target: "https://example.com/source",
+      quotedText: "the recorded quote",
+      matchedText: "the recorded quote",
+      passed: true,
+      observedAt: 1_000,
+      statusCode: 200,
+    },
+    attempt: item.attempt,
+    basisRef: item.completionContract.basisRef,
+    criterionId: criterion.id,
+    ...overrides,
+  });
+}
+
+function detailEvidence(item: WorkItem.Info, detail: string): WorkItem.Evidence {
+  return WorkItem.Evidence.parse({
+    id: "evidence:detail",
+    kind: "verification",
+    description: "persisted verifier inputs",
+    passed: true,
+    createdAt: 1_000,
+    detail,
+    attempt: item.attempt,
+    basisRef: item.completionContract.basisRef,
+  });
+}
+
+function persistedDetail(item: WorkItem.Info, criterion: WorkItem.Criterion): string {
+  return JSON.stringify({
+    type: "verifier_recorded_inputs",
+    version: 1,
+    workItemHash: item.hash,
+    basisRef: item.completionContract.basisRef,
+    criterionId: criterion.id,
+    verifierKind: "archived_quote_match",
+    recordedInputs: { archivedText: "quote", quotedText: "quote" },
+  });
+}
+
+describe("durableVerifierInput", () => {
+  test("projects a criterion-bound citation read-back", async () => {
+    const item = await storedItem();
+    const criterion = criterionOf(item);
+
+    expect(durableVerifierInput(item, criterion, citationEvidence(item, criterion))).toEqual({
+      kind: "archived_quote_match",
+      recordedInputs: {
+        archivedText: "the recorded quote",
+        quotedText: "the recorded quote",
+      },
+    });
+  });
+
+  test("projects persisted verifier inputs from durable detail", async () => {
+    const item = await storedItem();
+    const criterion = criterionOf(item);
+
+    expect(
+      durableVerifierInput(item, criterion, detailEvidence(item, persistedDetail(item, criterion))),
+    ).toEqual({
+      kind: "archived_quote_match",
+      recordedInputs: { archivedText: "quote", quotedText: "quote" },
+    });
+  });
+
+  test("refuses evidence from another attempt or basis", async () => {
+    const item = await storedItem();
+    const criterion = criterionOf(item);
+
+    const staleAttempt = citationEvidence(item, criterion, { attempt: item.attempt + 1 });
+    expect(durableVerifierInput(item, criterion, staleAttempt)).toBeUndefined();
+
+    const foreignBasis = citationEvidence(item, criterion, { basisRef: "basis:foreign" });
+    expect(durableVerifierInput(item, criterion, foreignBasis)).toBeUndefined();
+  });
+
+  test("refuses a citation read-back bound to a different criterion", async () => {
+    const item = await storedItem();
+    const criterion = criterionOf(item);
+
+    const foreignCriterion = citationEvidence(item, criterion, {
+      criterionId: "criterion:other",
+    });
+    expect(durableVerifierInput(item, criterion, foreignCriterion)).toBeUndefined();
+  });
+
+  test("refuses unparseable, mis-scoped, and non-strict durable detail", async () => {
+    const item = await storedItem();
+    const criterion = criterionOf(item);
+
+    expect(
+      durableVerifierInput(item, criterion, detailEvidence(item, "not json at all")),
+    ).toBeUndefined();
+
+    const parsed = JSON.parse(persistedDetail(item, criterion)) as Record<string, unknown>;
+    for (const tamper of [
+      { workItemHash: "hash:foreign" },
+      { basisRef: "basis:foreign" },
+      { criterionId: "criterion:other" },
+      { smuggled: "extra keys fail the strict schema" },
+    ]) {
+      const detail = JSON.stringify({ ...parsed, ...tamper });
+      expect(durableVerifierInput(item, criterion, detailEvidence(item, detail))).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## What

The audit asked for a semantic split of `work-item/completion-admission.ts` (2,487 lines). A dedicated scoping pass ruled **NO-GO on the split** and this PR executes the one extraction the repo's own rules permit.

### Why the split is NO-GO (recorded so it isn't re-litigated)

- AGENTS.md module rules: line count is never a split criterion; a split needs a second consumer, a trust boundary, or an independent lifecycle. The file has exactly **two production consumers** (`dispatch/setup.ts`, `dispatch/handlers/worker-completion.ts`) and both pull across every internal section — there is no consumer-cluster boundary to follow.
- The names a split would need (`-authority`/`-service`/`-boundary`/`-gateway`/`-helpers`) are the exact role-noun suffixes AGENTS.md bans, and the shared-primitive matrix (errors, canonicalization, adapter accessors, head/lease asserts) would force either a banned `-helpers` module or ~30 new exports of deliberately-private internals against a near-empty dead-export baseline.
- The file is one transaction protocol — reserve → guard → resolve authority → fold → append-by-CAS → verify report → commit terminal → recover — whose re-assertion of the same head/basis/lease invariants at every step IS the product. The genuinely independent part (the pure fold) was already a separate file at birth, with a machine-checked purity pin.

### The earned extraction

`durableVerifierInput` + `createDurableCompletionResultAuthorityPort` (~110 LOC) move to **`evidence/verifier-recorded-input.ts`**: they evolve with the `VerifierRegistry` obligation/read-back vocabulary rather than the admission protocol (independent lifecycle), and have a second consumer today (`worker-completion.ts:645` read-back verification, uninvolved with the admission machinery). The move also removes the `work-item/ → evidence/` value edge from `completion-admission.ts`; the admission port contract stays put, referenced by a **type-only** back-edge (`check-import-cycles`: 505 modules, 0 value cycles).

Pure move: bodies verbatim (only `WorkItem` import narrowed to type-only by biome), both consumers repointed, no re-export residue, dead-export ratchet clean.

## New coverage (second commit)

§F previously had no owning-layer test — only indirect coverage through admission suites. `test/evidence/verifier-recorded-input.test.ts` pins the projection's refusal branches: attempt/basis scope mismatches, citation read-back bound to a different criterion, unparseable durable detail, mis-scoped persisted inputs (hash/basis/criterion tamper), and strict-schema rejection of smuggled keys — plus both happy paths.

## Verification (the scoper's pure-move recipe)

- openomni **1126 / 0** (5 new tests), apps/server + script/conformance green; `check-import-cycles` 0; `check-deps` OK; `check-dead-exports` no new entries; biome clean.
- Completion-admission driver `--self-test`: deterministic, 12/12 scenario runs OK.
- Deep-import canary: the four out-of-package imports of `work-item/completion-admission` (`createCompletionAdmissionService`) are untouched and resolve unchanged.

Refs #606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the recorded-verifier-input projection and result-authority port from `work-item/completion-admission.ts` to `evidence/verifier-recorded-input.ts` to align with the `VerifierRegistry` lifecycle and its second consumer. Behavior is unchanged; consumers are repointed and docs now note the new type-only dependency.

- Extracts `durableVerifierInput` and `createDurableCompletionResultAuthorityPort` verbatim; narrows `WorkItem` import to type-only; no re-exports.
- Repoints `worker-completion.ts` and admission tests to `evidence/verifier-recorded-input.ts`.
- Adds `test/evidence/verifier-recorded-input.test.ts` to pin refusal branches and happy paths.
- Updates `AGENTS.md` to document the `evidence/ → work-item/` type-only edge; admission port contract remains via a type-only back-edge; no value cycles.

<sup>Written for commit a8968fa83a0899c42b9cff07183000d751560653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

