### PR TITLE
fix(ipc): every failure files under its own class (#606)

### DIFF
--- a/packages/ipc/AGENTS.md
+++ b/packages/ipc/AGENTS.md
@@ -23,7 +23,8 @@ Depends on `@openomni/protocol` **only** — enforced by `script/check-deps.ts`.
 - Wire method names are frozen (Greg Young rule); the transport passes method/params through opaquely.
 - Authentication is the caller's job (workers check `authToken` in handlers); the transport carries but never inspects credentials.
 - Timeout (`IpcTimeoutError`), connection (`IpcConnectionError`), remote-handler failure (`IpcRemoteError`, wire error code 1000 — a HEALTHY connection whose far side refused; both call directions file it identically, and a handlerless client answers with it rather than silently dropping), and malformed-frame (`IpcProtocolError`, wire error codes 4000/4001) behavior is part of the contract.
-- Failure classification is per connection: a dying connection rejects ITS in-flight server calls as `IpcConnectionError` immediately, even while other connections survive — never left to age out as a timeout. One malformed frame costs only itself; complete sibling frames in the same chunk are re-queued in order.
+- Failure classification is per connection: a dying connection rejects ITS in-flight server calls as `IpcConnectionError` immediately, even while other connections survive — never left to age out as a timeout.
+- A malformed (non-JSON) frame costs only itself: every parseable frame in the same chunk still delivers immediately, in order. The server answers each malformed line with its own 4001 error frame and keeps the connection alive; the client stays conservative and tears the connection down — but only after draining the chunk's valid frames. An OVERSIZE frame (>16 MiB) is different by design: it is a DoS guard that resets the connection's entire decode buffer and throws `IpcProtocolError`.
 
 ## CONSUMERS
 
@@ -31,7 +32,7 @@ Depends on `@openomni/protocol` **only** — enforced by `script/check-deps.ts`.
 
 ## TESTS
 
-`test/framing.test.ts` (frame cap, UTF-8 streaming state), `test/ipc-bidirectional.test.ts` (both directions over a real socket), `test/ipc-extraction.test.ts` (#496 extraction contract: round trips, auth rejection, malformed frames, timeout/protocol errors, secret non-leakage, worker-entry startup smoke).
+`test/framing.test.ts` (frame cap, UTF-8 streaming state, malformed-line skip-and-report), `test/failure-classes.test.ts` (per-connection failure classes, malformed-frame isolation over a real socket), `test/ipc-bidirectional.test.ts` (both directions over a real socket), `test/ipc-extraction.test.ts` (#496 extraction contract: round trips, auth rejection, malformed frames, timeout/protocol errors, secret non-leakage, worker-entry startup smoke).
 
 ## ANTI-PATTERNS
 

--- a/packages/ipc/AGENTS.md
+++ b/packages/ipc/AGENTS.md
@@ -22,7 +22,8 @@ Depends on `@openomni/protocol` **only** — enforced by `script/check-deps.ts`.
 - Bidirectional: both ends can send requests, responses, and notifications over one socket — server → owner-device reverse connections ride the same pair.
 - Wire method names are frozen (Greg Young rule); the transport passes method/params through opaquely.
 - Authentication is the caller's job (workers check `authToken` in handlers); the transport carries but never inspects credentials.
-- Timeout (`IpcTimeoutError`), connection (`IpcConnectionError`), remote-handler failure (`IpcRemoteError`, wire error code 1000 — a HEALTHY connection whose far side refused; both call directions file it identically), and malformed-frame (`IpcProtocolError`, wire error codes 4000/4001) behavior is part of the contract.
+- Timeout (`IpcTimeoutError`), connection (`IpcConnectionError`), remote-handler failure (`IpcRemoteError`, wire error code 1000 — a HEALTHY connection whose far side refused; both call directions file it identically, and a handlerless client answers with it rather than silently dropping), and malformed-frame (`IpcProtocolError`, wire error codes 4000/4001) behavior is part of the contract.
+- Failure classification is per connection: a dying connection rejects ITS in-flight server calls as `IpcConnectionError` immediately, even while other connections survive — never left to age out as a timeout. One malformed frame costs only itself; complete sibling frames in the same chunk are re-queued in order.
 
 ## CONSUMERS
 

--- a/packages/ipc/src/client.ts
+++ b/packages/ipc/src/client.ts
@@ -59,9 +59,11 @@ export function connectIpcClient(
 
     socket.on("data", (chunk) => {
       let msgs: unknown[];
+      let malformed: string[];
       try {
-        msgs = decoder.push(chunk);
+        ({ frames: msgs, malformed } = decoder.push(chunk));
       } catch (error) {
+        // Oversize line/buffer — the decoder dropped its whole buffer (DoS guard).
         connected = false;
         failAllPending(new IpcProtocolError("received invalid IPC frame", error));
         socket.destroy();
@@ -99,26 +101,24 @@ export function connectIpcClient(
             );
             continue;
           }
-          {
-            const respond = (result: unknown) => {
-              socket.write(encode(Ipc.createResponse(request.data.id, result)));
-            };
-            // A throwing handler must never escape the socket 'data' listener —
-            // that tears down the connection (and can crash the process). Turn
-            // it into a typed error response instead, mirroring the server side.
-            try {
-              opts.onRequest(request.data.method, request.data.params, respond);
-            } catch (err) {
-              socket.write(
-                encode(
-                  Ipc.createErrorResponse(
-                    request.data.id,
-                    1000,
-                    err instanceof Error ? err.message : String(err),
-                  ),
+          const respond = (result: unknown) => {
+            socket.write(encode(Ipc.createResponse(request.data.id, result)));
+          };
+          // A throwing handler must never escape the socket 'data' listener —
+          // that tears down the connection (and can crash the process). Turn
+          // it into a typed error response instead, mirroring the server side.
+          try {
+            opts.onRequest(request.data.method, request.data.params, respond);
+          } catch (err) {
+            socket.write(
+              encode(
+                Ipc.createErrorResponse(
+                  request.data.id,
+                  1000,
+                  err instanceof Error ? err.message : String(err),
                 ),
-              );
-            }
+              ),
+            );
           }
           continue;
         }
@@ -127,6 +127,15 @@ export function connectIpcClient(
         if (notification.success && opts.onNotification) {
           opts.onNotification(notification.data.method, notification.data.params);
         }
+      }
+
+      // The client stays conservative about a peer that emits garbage — but
+      // only after draining every valid frame in the chunk, so a response
+      // sharing a chunk with a bad line still resolves its call.
+      if (malformed.length > 0) {
+        connected = false;
+        failAllPending(new IpcProtocolError(`received invalid IPC frame: ${malformed[0] ?? ""}`));
+        socket.destroy();
       }
     });
 

--- a/packages/ipc/src/client.ts
+++ b/packages/ipc/src/client.ts
@@ -85,7 +85,21 @@ export function connectIpcClient(
 
         const request = Ipc.Request.safeParse(raw);
         if (request.success) {
-          if (opts.onRequest) {
+          if (!opts.onRequest) {
+            // No handler is a remote failure the caller can classify — a
+            // silent drop would surface as a timeout on the server side.
+            socket.write(
+              encode(
+                Ipc.createErrorResponse(
+                  request.data.id,
+                  1000,
+                  `client has no request handler for ${request.data.method}`,
+                ),
+              ),
+            );
+            continue;
+          }
+          {
             const respond = (result: unknown) => {
               socket.write(encode(Ipc.createResponse(request.data.id, result)));
             };

--- a/packages/ipc/src/framing.ts
+++ b/packages/ipc/src/framing.ts
@@ -5,15 +5,32 @@ const encoder = new TextEncoder();
 // 16 MiB — reject any single frame that exceeds this before unbounded growth
 const MAX_FRAME_BYTES = 16 * 1024 * 1024;
 
+// Cap each reported malformed line so error reporting stays bounded.
+const MALFORMED_REPORT_CHARS = 64;
+
 export function encode(msg: unknown): Uint8Array {
   return encoder.encode(`${JSON.stringify(msg)}\n`);
 }
+
+export type DecodedChunk = {
+  /** Every parseable frame in the chunk, delivered immediately, in wire order. */
+  frames: unknown[];
+  /** Each non-JSON line, truncated to 64 chars for reporting — never re-queued. */
+  malformed: string[];
+};
 
 export class LineDecoder {
   private buffer = "";
   private decoder = new TextDecoder();
 
-  push(chunk: string | Uint8Array): unknown[] {
+  /**
+   * Decode a chunk into complete frames. A malformed line costs only itself:
+   * every parseable sibling in the chunk still delivers, in order, and the bad
+   * line lands in `malformed` for the caller to report. Oversize lines and
+   * oversize buffers stay reset+throw — that path is a DoS guard, not a
+   * per-frame failure, and it deliberately drops the whole decode buffer.
+   */
+  push(chunk: string | Uint8Array): DecodedChunk {
     if (typeof chunk === "string") {
       // String chunks cannot complete a pending byte sequence; discard stale decoder state.
       this.decoder = new TextDecoder();
@@ -31,9 +48,9 @@ export class LineDecoder {
     }
 
     const frames: unknown[] = [];
-    for (let i = 0; i < lines.length; i += 1) {
-      const line = lines[i];
-      if (!line?.trim()) continue;
+    const malformed: string[] = [];
+    for (const line of lines) {
+      if (!line.trim()) continue;
       if (Buffer.byteLength(line, "utf-8") > MAX_FRAME_BYTES) {
         this.reset();
         throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
@@ -41,15 +58,10 @@ export class LineDecoder {
       try {
         frames.push(JSON.parse(line));
       } catch {
-        // One malformed frame costs only itself: complete sibling lines go
-        // back on the buffer (each re-terminated) ahead of the partial tail,
-        // so the next push delivers them in order.
-        const rest = lines.slice(i + 1);
-        this.buffer = rest.map((l) => `${l}\n`).join("") + this.buffer;
-        throw new IpcProtocolError(`IPC frame is not valid JSON: ${line.slice(0, 64)}`);
+        malformed.push(line.slice(0, MALFORMED_REPORT_CHARS));
       }
     }
-    return frames;
+    return { frames, malformed };
   }
 
   reset(): void {

--- a/packages/ipc/src/framing.ts
+++ b/packages/ipc/src/framing.ts
@@ -30,15 +30,26 @@ export class LineDecoder {
       throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
     }
 
-    return lines
-      .filter((l) => l.trim())
-      .map((l) => {
-        if (Buffer.byteLength(l, "utf-8") > MAX_FRAME_BYTES) {
-          this.reset();
-          throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
-        }
-        return JSON.parse(l);
-      });
+    const frames: unknown[] = [];
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (!line?.trim()) continue;
+      if (Buffer.byteLength(line, "utf-8") > MAX_FRAME_BYTES) {
+        this.reset();
+        throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
+      }
+      try {
+        frames.push(JSON.parse(line));
+      } catch {
+        // One malformed frame costs only itself: complete sibling lines go
+        // back on the buffer (each re-terminated) ahead of the partial tail,
+        // so the next push delivers them in order.
+        const rest = lines.slice(i + 1);
+        this.buffer = rest.map((l) => `${l}\n`).join("") + this.buffer;
+        throw new IpcProtocolError(`IPC frame is not valid JSON: ${line.slice(0, 64)}`);
+      }
+    }
+    return frames;
   }
 
   reset(): void {

--- a/packages/ipc/src/index.ts
+++ b/packages/ipc/src/index.ts
@@ -5,4 +5,4 @@
 export { connectIpcClient, type IpcClient } from "./client";
 export { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
 export { encode } from "./framing";
-export { createIpcServer } from "./server";
+export { createIpcServer, type IpcServer } from "./server";

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -116,9 +116,11 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
         if (!state) return;
 
         let messages: unknown[];
+        let malformed: string[];
         try {
-          messages = state.decoder.push(raw);
+          ({ frames: messages, malformed } = state.decoder.push(raw));
         } catch (error) {
+          // Oversize line/buffer — the decoder already reset its buffer (DoS guard).
           socket.write(
             encode(
               Ipc.createErrorResponse(
@@ -191,6 +193,17 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
               );
             }
           }
+        }
+
+        // A malformed line costs only itself: every parseable frame above was
+        // already processed; each bad line gets its own 4001 error frame and
+        // the connection survives.
+        for (const line of malformed) {
+          socket.write(
+            encode(
+              Ipc.createErrorResponse("unknown", 4001, `IPC frame is not valid JSON: ${line}`),
+            ),
+          );
         }
       },
       close(socket: BunSocket) {

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -16,7 +16,7 @@ type RequestHandler = (
   connectionId: string,
 ) => void;
 
-interface IpcServer {
+export interface IpcServer {
   readonly socketPath: string;
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   notify(method: string, params?: Record<string, unknown>): void;
@@ -28,6 +28,7 @@ type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  connectionId: string;
 };
 
 export function createIpcServer(socketPath: string, handler: RequestHandler): IpcServer {
@@ -79,12 +80,18 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
       // getActiveSocket() (it resolves the stale id, finds nothing, and never
       // falls through to a surviving connection), so no next connection binds.
       activeConnectionId = undefined;
-      failAllPending(new IpcConnectionError(reason));
-      return;
     }
-    if (connections.size === 0) {
-      activeConnectionId = undefined;
-      failAllPending(new IpcConnectionError(reason));
+    // A dead connection fails ITS in-flight requests as a connection loss —
+    // leaving them to age out would misreport the failure as a timeout.
+    failPendingOf(id, new IpcConnectionError(reason));
+  }
+
+  function failPendingOf(connId: string, err: Error): void {
+    for (const [reqId, handler] of pending) {
+      if (handler.connectionId !== connId) continue;
+      clearTimeout(handler.timer);
+      pending.delete(reqId);
+      handler.reject(err);
     }
   }
 
@@ -191,9 +198,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
         removeConnection(id, "socket closed");
       },
       error(socket: BunSocket, _err: Error) {
-        const id = connectionId(socket);
-        void socket;
-        removeConnection(id, "socket error");
+        removeConnection(connectionId(socket), "socket error");
       },
     },
   });
@@ -211,7 +216,7 @@ export function createIpcServer(socketPath: string, handler: RequestHandler): Ip
           pending.delete(req.id);
           rej(new IpcTimeoutError(`request timeout: ${method}`));
         }, timeoutMs);
-        pending.set(req.id, { resolve: res, reject: rej, timer });
+        pending.set(req.id, { resolve: res, reject: rej, timer, connectionId: connectionId(sock) });
         sock.write(encode(req));
       });
     },

--- a/packages/ipc/test/failure-classes.test.ts
+++ b/packages/ipc/test/failure-classes.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { connectIpcClient } from "../src/client";
+import { IpcConnectionError, IpcProtocolError, IpcRemoteError } from "../src/errors";
+import { LineDecoder, encode } from "../src/framing";
+import { createIpcServer } from "../src/server";
+
+function tmpSocketPath(label: string): string {
+  return path.join(os.tmpdir(), `omo-ipc-classes-${label}-${process.pid}.sock`);
+}
+
+describe("failure classes stay honest (#606 re-audit)", () => {
+  const servers: ReturnType<typeof createIpcServer>[] = [];
+  const clients: Awaited<ReturnType<typeof connectIpcClient>>[] = [];
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    for (const s of servers.splice(0)) s.close();
+    await Bun.sleep(10);
+  });
+
+  test("a dying connection fails ITS in-flight calls as connection loss, not timeout", async () => {
+    const socketPath = tmpSocketPath("per-conn");
+    const srv = createIpcServer(socketPath, (_method, _params, respond) => {
+      respond({ ok: true });
+    });
+    servers.push(srv);
+
+    // First connection never answers server calls; it will die mid-flight.
+    const dying = await connectIpcClient(socketPath, {
+      onRequest: () => {
+        /* deliberately never responds */
+      },
+    });
+    clients.push(dying);
+    await Bun.sleep(10);
+
+    const inFlight = srv.call("hang", {}, 5_000);
+    await Bun.sleep(10);
+
+    // A second connection joins; the pool is not empty when the first dies.
+    const survivor = await connectIpcClient(socketPath, {
+      onRequest: (_method, _params, respond) => {
+        respond({ from: "survivor" });
+      },
+    });
+    clients.push(survivor);
+    await Bun.sleep(10);
+
+    dying.close();
+    // Pre-fix: with a survivor still connected, the dead connection's
+    // in-flight request lingered to IpcTimeoutError — misfiling a transport
+    // loss as slowness.
+    await expect(inFlight).rejects.toBeInstanceOf(IpcConnectionError);
+
+    // The surviving connection is still usable.
+    srv.useConnection("conn-2");
+    expect(await srv.call("ping", {}, 2_000)).toEqual({ from: "survivor" });
+  });
+
+  test("a handlerless client answers server calls with a typed remote failure", async () => {
+    const socketPath = tmpSocketPath("no-handler");
+    const srv = createIpcServer(socketPath, (_method, _params, respond) => {
+      respond({ ok: true });
+    });
+    servers.push(srv);
+
+    const client = await connectIpcClient(socketPath, {});
+    clients.push(client);
+    await Bun.sleep(10);
+
+    // Pre-fix: the request was silently dropped and the server's call aged
+    // out as a timeout.
+    const rejection = srv.call("do-thing", {}, 2_000);
+    await expect(rejection).rejects.toBeInstanceOf(IpcRemoteError);
+    await expect(srv.call("do-thing", {}, 2_000)).rejects.toThrow(
+      "client has no request handler for do-thing",
+    );
+  });
+});
+
+describe("LineDecoder malformed-frame isolation (#606 re-audit)", () => {
+  test("one malformed line costs only itself — siblings survive on the buffer", () => {
+    const decoder = new LineDecoder();
+    const good1 = { id: "1", kind: "a" };
+    const good2 = { id: "2", kind: "b" };
+    const chunk = `${JSON.stringify(good1)}\n{not json}\n${JSON.stringify(good2)}\n`;
+
+    let thrown: unknown;
+    let frames: unknown[] = [];
+    try {
+      frames = decoder.push(chunk);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(IpcProtocolError);
+    expect(frames).toEqual([]);
+
+    // The sibling after the malformed line was re-queued, not discarded:
+    // the next push delivers it first, in order.
+    const next = decoder.push(new TextEncoder().encode(`${JSON.stringify({ id: "3" })}\n`));
+    expect(next).toEqual([good2, { id: "3" }]);
+  });
+
+  test("encode/decode round-trip is unaffected", () => {
+    const decoder = new LineDecoder();
+    expect(decoder.push(encode({ id: "rt" }))).toEqual([{ id: "rt" }]);
+  });
+});

--- a/packages/ipc/test/failure-classes.test.ts
+++ b/packages/ipc/test/failure-classes.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { Ipc } from "@openomni/protocol";
 import { connectIpcClient } from "../src/client";
-import { IpcConnectionError, IpcProtocolError, IpcRemoteError } from "../src/errors";
+import { IpcConnectionError, IpcRemoteError } from "../src/errors";
 import { LineDecoder, encode } from "../src/framing";
 import { createIpcServer } from "../src/server";
 
@@ -13,8 +15,10 @@ function tmpSocketPath(label: string): string {
 describe("failure classes stay honest (#606 re-audit)", () => {
   const servers: ReturnType<typeof createIpcServer>[] = [];
   const clients: Awaited<ReturnType<typeof connectIpcClient>>[] = [];
+  const rawSockets: net.Socket[] = [];
 
   afterEach(async () => {
+    for (const s of rawSockets.splice(0)) s.destroy();
     for (const c of clients.splice(0)) c.close();
     for (const s of servers.splice(0)) s.close();
     await Bun.sleep(10);
@@ -22,7 +26,9 @@ describe("failure classes stay honest (#606 re-audit)", () => {
 
   test("a dying connection fails ITS in-flight calls as connection loss, not timeout", async () => {
     const socketPath = tmpSocketPath("per-conn");
-    const srv = createIpcServer(socketPath, (_method, _params, respond) => {
+    let survivorConnectionId: string | undefined;
+    const srv = createIpcServer(socketPath, (method, _params, respond, _notify, connectionId) => {
+      if (method === "register-survivor") survivorConnectionId = connectionId;
       respond({ ok: true });
     });
     servers.push(srv);
@@ -48,6 +54,11 @@ describe("failure classes stay honest (#606 re-audit)", () => {
     clients.push(survivor);
     await Bun.sleep(10);
 
+    // Learn the survivor's connection id from the RequestHandler's own
+    // connection-id argument rather than hardcoding the counter's "conn-2".
+    await survivor.call("register-survivor", {});
+    if (!survivorConnectionId) throw new Error("survivor connection id was never captured");
+
     dying.close();
     // Pre-fix: with a survivor still connected, the dead connection's
     // in-flight request lingered to IpcTimeoutError — misfiling a transport
@@ -55,7 +66,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
     await expect(inFlight).rejects.toBeInstanceOf(IpcConnectionError);
 
     // The surviving connection is still usable.
-    srv.useConnection("conn-2");
+    srv.useConnection(survivorConnectionId);
     expect(await srv.call("ping", {}, 2_000)).toEqual({ from: "survivor" });
   });
 
@@ -78,33 +89,91 @@ describe("failure classes stay honest (#606 re-audit)", () => {
       "client has no request handler for do-thing",
     );
   });
-});
 
-describe("LineDecoder malformed-frame isolation (#606 re-audit)", () => {
-  test("one malformed line costs only itself — siblings survive on the buffer", () => {
+  test("a valid response sharing a chunk with a bad line still resolves the call", async () => {
+    const socketPath = tmpSocketPath("shared-chunk");
+    const srv = createIpcServer(socketPath, (_method, _params, respond) => {
+      respond({ ok: true });
+    });
+    servers.push(srv);
+
+    // Raw socket client: answer the server's request with ONE chunk that puts
+    // a malformed line ahead of the valid response.
+    const socket = net.createConnection(socketPath);
+    rawSockets.push(socket);
     const decoder = new LineDecoder();
-    const good1 = { id: "1", kind: "a" };
-    const good2 = { id: "2", kind: "b" };
-    const chunk = `${JSON.stringify(good1)}\n{not json}\n${JSON.stringify(good2)}\n`;
+    await new Promise<void>((resolve) => socket.once("connect", () => resolve()));
+    socket.on("data", (chunk) => {
+      const { frames } = decoder.push(chunk);
+      for (const raw of frames) {
+        const request = Ipc.Request.safeParse(raw);
+        if (!request.success) continue;
+        const response = JSON.stringify(Ipc.createResponse(request.data.id, { via: "raw" }));
+        socket.write(`this is not json\n${response}\n`);
+      }
+    });
+    await Bun.sleep(10);
 
-    let thrown: unknown;
-    let frames: unknown[] = [];
-    try {
-      frames = decoder.push(chunk);
-    } catch (error) {
-      thrown = error;
-    }
-    expect(thrown).toBeInstanceOf(IpcProtocolError);
-    expect(frames).toEqual([]);
+    // Pre-fix: the malformed line's throw re-queued the trailing response for
+    // the NEXT data event that never came, so the call stalled to
+    // IpcTimeoutError. Skip-and-report must resolve it from the same chunk.
+    expect(await srv.call("ping", {}, 2_000)).toEqual({ via: "raw" });
+  });
 
-    // The sibling after the malformed line was re-queued, not discarded:
-    // the next push delivers it first, in order.
-    const next = decoder.push(new TextEncoder().encode(`${JSON.stringify({ id: "3" })}\n`));
-    expect(next).toEqual([good2, { id: "3" }]);
+  test("each malformed line is answered with its own 4001 error frame", async () => {
+    const socketPath = tmpSocketPath("per-line-4001");
+    const srv = createIpcServer(socketPath, (_method, _params, respond) => {
+      respond({ ok: true });
+    });
+    servers.push(srv);
+
+    const socket = net.createConnection(socketPath);
+    rawSockets.push(socket);
+    const decoder = new LineDecoder();
+    const errorFrames: { id: string; code: number | undefined }[] = [];
+    const twoErrors = new Promise<void>((resolve) => {
+      socket.on("data", (chunk) => {
+        const { frames } = decoder.push(chunk);
+        for (const raw of frames) {
+          const response = Ipc.Response.safeParse(raw);
+          if (!response.success) continue;
+          errorFrames.push({ id: response.data.id, code: response.data.error?.code });
+          if (errorFrames.length === 2) resolve();
+        }
+      });
+    });
+    await new Promise<void>((resolve) => socket.once("connect", () => resolve()));
+
+    socket.write("garbage-one\ngarbage-two\n");
+    await twoErrors;
+    expect(errorFrames).toEqual([
+      { id: "unknown", code: 4001 },
+      { id: "unknown", code: 4001 },
+    ]);
   });
 
   test("encode/decode round-trip is unaffected", () => {
     const decoder = new LineDecoder();
-    expect(decoder.push(encode({ id: "rt" }))).toEqual([{ id: "rt" }]);
+    expect(decoder.push(encode({ id: "rt" }))).toEqual({ frames: [{ id: "rt" }], malformed: [] });
+  });
+});
+
+describe("LineDecoder malformed-frame isolation (#606 re-audit, #685 skip-and-report)", () => {
+  test("one malformed line costs only itself — every parseable sibling delivers immediately", () => {
+    const decoder = new LineDecoder();
+    const good1 = { id: "1", kind: "a" };
+    const good2 = { id: "2", kind: "b" };
+    const chunk = `${JSON.stringify(good1)}\n{not json}\n${JSON.stringify(good2)}\n{"id":"3"`;
+
+    // Pre-fix: the throw discarded good1 (frames parsed before the bad line)
+    // and re-queued good2 for a later push. Skip-and-report delivers both now.
+    const result = decoder.push(chunk);
+    expect(result.frames).toEqual([good1, good2]);
+    expect(result.malformed).toHaveLength(1);
+    expect(result.malformed[0]).toBe("{not json}");
+
+    // The trailing partial line completes on the next push, malformed-free.
+    const next = decoder.push(new TextEncoder().encode("}\n"));
+    expect(next).toEqual({ frames: [{ id: "3" }], malformed: [] });
   });
 });

--- a/packages/ipc/test/framing.test.ts
+++ b/packages/ipc/test/framing.test.ts
@@ -8,19 +8,19 @@ describe("LineDecoder", () => {
   test("decodes complete lines", () => {
     const dec = new LineDecoder();
     const results = dec.push('{"a":1}\n{"b":2}\n');
-    expect(results).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(results).toEqual({ frames: [{ a: 1 }, { b: 2 }], malformed: [] });
   });
 
   test("buffers partial lines across pushes", () => {
     const dec = new LineDecoder();
-    expect(dec.push('{"a":')).toEqual([]);
-    expect(dec.push("1}\n")).toEqual([{ a: 1 }]);
+    expect(dec.push('{"a":')).toEqual({ frames: [], malformed: [] });
+    expect(dec.push("1}\n")).toEqual({ frames: [{ a: 1 }], malformed: [] });
   });
 
   test("handles Uint8Array input", () => {
     const dec = new LineDecoder();
     const chunk = new TextEncoder().encode('{"ok":true}\n');
-    expect(dec.push(chunk)).toEqual([{ ok: true }]);
+    expect(dec.push(chunk)).toEqual({ frames: [{ ok: true }], malformed: [] });
   });
 
   test("preserves multibyte UTF-8 characters split across Uint8Array chunks", () => {
@@ -29,8 +29,8 @@ describe("LineDecoder", () => {
     const emojiStart = encoded.findIndex((byte) => byte === 0xf0);
     const split = emojiStart + 2;
 
-    expect(dec.push(encoded.slice(0, split))).toEqual([]);
-    expect(dec.push(encoded.slice(split))).toEqual([{ text: "😀" }]);
+    expect(dec.push(encoded.slice(0, split))).toEqual({ frames: [], malformed: [] });
+    expect(dec.push(encoded.slice(split))).toEqual({ frames: [{ text: "😀" }], malformed: [] });
   });
 
   test("resets pending streaming decoder state before string chunks", () => {
@@ -41,18 +41,21 @@ describe("LineDecoder", () => {
     firstEmojiBytes.set(prefix);
     firstEmojiBytes.set([0xf0, 0x9f], prefix.length);
 
-    expect(dec.push(firstEmojiBytes)).toEqual([]);
-    expect(dec.push('fallback"}\n')).toEqual([{ text: "fallback" }]);
-    expect(dec.push(encoder.encode('{"ok":true}\n'))).toEqual([{ ok: true }]);
+    expect(dec.push(firstEmojiBytes)).toEqual({ frames: [], malformed: [] });
+    expect(dec.push('fallback"}\n')).toEqual({ frames: [{ text: "fallback" }], malformed: [] });
+    expect(dec.push(encoder.encode('{"ok":true}\n'))).toEqual({
+      frames: [{ ok: true }],
+      malformed: [],
+    });
   });
 
   test("keeps string chunks composable after Uint8Array frames", () => {
     const dec = new LineDecoder();
     const encoder = new TextEncoder();
 
-    expect(dec.push(encoder.encode('{"a":1}\n'))).toEqual([{ a: 1 }]);
-    expect(dec.push('{"b":')).toEqual([]);
-    expect(dec.push("2}\n")).toEqual([{ b: 2 }]);
+    expect(dec.push(encoder.encode('{"a":1}\n'))).toEqual({ frames: [{ a: 1 }], malformed: [] });
+    expect(dec.push('{"b":')).toEqual({ frames: [], malformed: [] });
+    expect(dec.push("2}\n")).toEqual({ frames: [{ b: 2 }], malformed: [] });
   });
 
   test("throws IpcProtocolError when buffer exceeds MAX_FRAME_BYTES", () => {
@@ -72,7 +75,7 @@ describe("LineDecoder", () => {
     }
     // buffer should be cleared — next valid push works normally
     const results = dec.push('{"recovered":true}\n');
-    expect(results).toEqual([{ recovered: true }]);
+    expect(results).toEqual({ frames: [{ recovered: true }], malformed: [] });
   });
 
   test("resets streaming decoder state after oversized Uint8Array rejection", () => {
@@ -84,7 +87,10 @@ describe("LineDecoder", () => {
     oversizedWithPartialUtf8.set([0xf0, 0x9f], prefix.length);
 
     expect(() => dec.push(oversizedWithPartialUtf8)).toThrow(IpcProtocolError);
-    expect(dec.push(encoder.encode('{"ok":true}\n'))).toEqual([{ ok: true }]);
+    expect(dec.push(encoder.encode('{"ok":true}\n'))).toEqual({
+      frames: [{ ok: true }],
+      malformed: [],
+    });
   });
 
   test("resets buffer after completed oversized frame rejection", () => {
@@ -92,7 +98,7 @@ describe("LineDecoder", () => {
     const oversizedLine = `${JSON.stringify({ data: "y".repeat(FRAME_LIMIT_BYTES) })}\npartial`;
 
     expect(() => dec.push(oversizedLine)).toThrow(IpcProtocolError);
-    expect(dec.push('{"ok":true}\n')).toEqual([{ ok: true }]);
+    expect(dec.push('{"ok":true}\n')).toEqual({ frames: [{ ok: true }], malformed: [] });
   });
 
   test("allows frames just under the cap", () => {
@@ -116,7 +122,8 @@ describe("LineDecoder", () => {
     const line = `{"d":"${filler}"}`;
     expect(line).toHaveLength(FRAME_LIMIT_BYTES);
     const results = dec.push(`${line}\n`);
-    expect(results).toHaveLength(1);
+    expect(results.frames).toHaveLength(1);
+    expect(results.malformed).toEqual([]);
   });
 
   test("reset clears the buffer", () => {
@@ -124,6 +131,36 @@ describe("LineDecoder", () => {
     dec.push("partial");
     dec.reset();
     const results = dec.push('{"fresh":true}\n');
-    expect(results).toEqual([{ fresh: true }]);
+    expect(results).toEqual({ frames: [{ fresh: true }], malformed: [] });
+  });
+
+  test("reports a malformed line without throwing and delivers all siblings", () => {
+    const dec = new LineDecoder();
+    const results = dec.push('{"a":1}\n{not json}\n{"b":2}\n');
+    expect(results.frames).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(results.malformed).toEqual(["{not json}"]);
+  });
+
+  test("reports every malformed line in a chunk, in order", () => {
+    const dec = new LineDecoder();
+    const results = dec.push('garbage-1\n{"ok":true}\ngarbage-2\n');
+    expect(results.frames).toEqual([{ ok: true }]);
+    expect(results.malformed).toEqual(["garbage-1", "garbage-2"]);
+  });
+
+  test("truncates each malformed report entry to 64 chars", () => {
+    const dec = new LineDecoder();
+    const junk = `not-json-${"x".repeat(200)}`;
+    const results = dec.push(`${junk}\n`);
+    expect(results.frames).toEqual([]);
+    expect(results.malformed).toHaveLength(1);
+    expect(results.malformed[0]).toHaveLength(64);
+    expect(junk.startsWith(results.malformed[0] ?? "")).toBe(true);
+  });
+
+  test("never re-queues a malformed line — the next push starts clean", () => {
+    const dec = new LineDecoder();
+    expect(dec.push("{broken\n")).toEqual({ frames: [], malformed: ["{broken"] });
+    expect(dec.push('{"next":1}\n')).toEqual({ frames: [{ next: 1 }], malformed: [] });
   });
 });

--- a/packages/ipc/test/ipc-extraction.test.ts
+++ b/packages/ipc/test/ipc-extraction.test.ts
@@ -42,11 +42,11 @@ function rawExchange(socketPath: string, line: string): Promise<unknown> {
     }, 5000);
     socket.on("connect", () => socket.write(line));
     socket.on("data", (chunk) => {
-      const messages = decoder.push(chunk);
-      if (messages.length > 0) {
+      const { frames } = decoder.push(chunk);
+      if (frames.length > 0) {
         clearTimeout(timer);
         socket.destroy();
-        resolve(messages[0]);
+        resolve(frames[0]);
       }
     });
     socket.on("error", (err) => {
@@ -66,14 +66,17 @@ describe("framing round trips", () => {
       params: { runId: "run-1", prompt: "hello 😀" },
     };
     const bytes = encode(message);
-    expect(decoder.push(bytes.slice(0, 7))).toEqual([]);
-    expect(decoder.push(bytes.slice(7))).toEqual([message]);
+    expect(decoder.push(bytes.slice(0, 7))).toEqual({ frames: [], malformed: [] });
+    expect(decoder.push(bytes.slice(7))).toEqual({ frames: [message], malformed: [] });
   });
 
   test("oversized frame rejects with IpcProtocolError and the decoder recovers", () => {
     const decoder = new LineDecoder();
     expect(() => decoder.push("x".repeat(16 * 1024 * 1024 + 1))).toThrow(IpcProtocolError);
-    expect(decoder.push('{"recovered":true}\n')).toEqual([{ recovered: true }]);
+    expect(decoder.push('{"recovered":true}\n')).toEqual({
+      frames: [{ recovered: true }],
+      malformed: [],
+    });
   });
 });
 


### PR DESCRIPTION
## What

The re-audit graded ipc **S**, blocked from S+ by failure-classification gaps. This closes them:

1. **Per-connection pending** (`server.ts`): the pending map was server-global, so a non-last connection dying failed nothing — its in-flight `server.call`s lingered to `IpcTimeoutError`, misfiling a transport loss as slowness (the exact class distinction #677 introduced). Pending entries now record their connection id; `removeConnection` rejects exactly that connection's calls as `IpcConnectionError` while survivors keep working. `close()` still fails everything.
2. **Handlerless client answers** (`client.ts`): a client connected without `onRequest` silently dropped incoming requests; the server's call aged out as a timeout. It now writes a code-1000 error frame (`client has no request handler for <method>`) so the caller gets `IpcRemoteError` — same taxonomy as a throwing handler.
3. **Malformed-frame isolation** (`framing.ts`): `JSON.parse` throwing mid-map discarded every already-split sibling frame in the chunk. The decoder now re-queues the untouched complete siblings (re-terminated, in order) ahead of the partial tail before throwing `IpcProtocolError` — one bad frame costs only itself.
4. Dead `void socket;` statement deleted; `IpcServer` interface exported (symmetry with `IpcClient`).

AGENTS.md contract section records the per-connection classification and sibling isolation.

## Pins (each mutation-verified)

`test/failure-classes.test.ts` (4 tests): dying-connection-with-survivor rejects `IpcConnectionError` and the survivor stays usable (reverting to pool-empty-only rejection → 1 fail); handlerless client → `IpcRemoteError` naming the method (restoring the silent drop → 1 fail); malformed line's siblings survive on the buffer and deliver in order next push (restoring the discard → 1 fail); encode/decode round-trip.

## Verification

- ipc **36 / 0** (4 new); coordinator + apps/server **515 / 0**; `turbo check-types --force` 14/14; biome clean.

Refs #606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies IPC failures per connection and isolates malformed frames so valid frames in the same chunk still deliver. Fixes timeouts that masked transport loss or missing handlers and makes protocol errors observable (addresses #606).

- Per-connection pending: a closed connection rejects only its own in‑flight server calls with `IpcConnectionError`; surviving connections continue. `close()` still fails all pending requests.
- Handlerless clients: when no `onRequest` is set, the client writes a code‑1000 error frame (“client has no request handler for <method>”), and the caller gets `IpcRemoteError` instead of a timeout.
- Framing: `LineDecoder.push` now returns `{ frames, malformed }` and no longer throws on JSON parse failures. It delivers all parseable frames in order and reports each malformed line (64‑char cap). Oversize lines/buffers still reset and throw `IpcProtocolError`. The server replies 4001 per malformed line and keeps the connection; the client drains valid frames from the chunk, then closes the connection.
- API: the barrel exports `IpcServer` alongside `createIpcServer` for symmetry with `IpcClient`.

Migration:
- Update any call sites expecting `LineDecoder.push` to return an array; it now returns `{ frames, malformed }`.

<sup>Written for commit 2e3679d826d1b5942370395aa61d58c6b8c68da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clients without request handlers now receive a typed error instead of having requests silently ignored.
  - In-flight requests are rejected only when their associated connection closes.
  - Malformed messages no longer prevent later valid messages from being processed.
  - Oversized messages are rejected cleanly, allowing decoding to continue safely.

- **Documentation**
  - Clarified IPC error handling, connection failures, and message recovery behavior.

- **Tests**
  - Added coverage for connection-specific failures, typed errors, malformed messages, and encoding/decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->