### PR TITLE
feat(llm): fail fast on instant transport-failure streaks

### DIFF
--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -139,6 +139,10 @@ export namespace Processor {
         publishStatus(events, sessionID, trace.traceId, "busy");
         let attempt = 0;
         let attemptSeq = 0;
+        // Consecutive instant transport failures (no HTTP status, dead under
+        // the window). Reset by any attempt that reaches the endpoint or
+        // fails slowly — only an unbroken streak declines the retry.
+        let instantFailureStreak = 0;
 
         try {
           while (true) {
@@ -176,6 +180,7 @@ export namespace Processor {
               });
             }
 
+            const attemptStartedAt = Date.now();
             try {
               const stream = await createStream(streamInput);
 
@@ -220,7 +225,13 @@ export namespace Processor {
               return;
             } catch (e: unknown) {
               const apiError = coerceApiError(e);
-              const decision = Retry.decide(attempt + 1, apiError ?? e);
+              instantFailureStreak = Retry.isInstantTransportFailure(
+                apiError ?? e,
+                Date.now() - attemptStartedAt,
+              )
+                ? instantFailureStreak + 1
+                : 0;
+              const decision = Retry.decide(attempt + 1, apiError ?? e, instantFailureStreak);
 
               if (!decision.retry || ++attempt > retryAttemptLimit) {
                 if (!decision.retry && decision.reason !== "non_retryable") {

--- a/packages/llm/src/retry/index.ts
+++ b/packages/llm/src/retry/index.ts
@@ -36,6 +36,30 @@ export namespace Retry {
   export const RETRY_HEADER_DELAY_CAP = 60_000;
 
   /**
+   * Backoff exists to relieve an overloaded endpoint; it cannot help one
+   * refusing connections outright. A retryable failure that carries no HTTP
+   * status and dies under this window is the signature of the latter, so a
+   * streak of them retries on the short probe delay and then declines,
+   * instead of burning the exponential ladder in silence. A failure at or
+   * above the window (a slow timeout) keeps the full backoff budget.
+   */
+  export const INSTANT_FAILURE_WINDOW_MS = 2000;
+  export const INSTANT_FAILURE_PROBE_DELAY_MS = 250;
+  export const INSTANT_FAILURE_STREAK_LIMIT = 3;
+
+  export function isInstantTransportFailure(error: unknown, elapsedMs: number): boolean {
+    if (elapsedMs >= INSTANT_FAILURE_WINDOW_MS) return false;
+    if (!APIError.isInstance(error)) return false;
+    // A status code or response headers prove the endpoint answered — that is
+    // an HTTP failure, not a transport one, whatever the timing.
+    return (
+      error.data.isRetryable &&
+      error.data.statusCode === undefined &&
+      error.data.responseHeaders === undefined
+    );
+  }
+
+  /**
    * The retry vocabulary (#532 candidate 3). Every member has a producing
    * branch in classify() and a consuming case in the processor's typed
    * switch — reasons are branched on as literals, never as prose. Human
@@ -58,10 +82,20 @@ export namespace Retry {
    * Typed retry decision (#532 candidate 3): classification + delay in one
    * call, failing fast when the server asks for a wait above the cap.
    */
-  export function decide(attempt: number, error: unknown): Decision {
+  export function decide(attempt: number, error: unknown, instantFailureStreak = 0): Decision {
     const reason = classify(error);
     if (reason === "non_retryable") {
       return { retry: false, reason };
+    }
+    if (instantFailureStreak >= INSTANT_FAILURE_STREAK_LIMIT) {
+      return {
+        retry: false,
+        reason,
+        detail: `${instantFailureStreak} consecutive transport failures under ${INSTANT_FAILURE_WINDOW_MS}ms — the endpoint is refusing connections, retrying cannot help`,
+      };
+    }
+    if (instantFailureStreak > 0) {
+      return { retry: true, reason, delayMs: INSTANT_FAILURE_PROBE_DELAY_MS };
     }
     const apiError = APIError.isInstance(error) ? error : undefined;
     const header = headerDelay(apiError);

--- a/packages/llm/test/processor/instant-failure-streak.test.ts
+++ b/packages/llm/test/processor/instant-failure-streak.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Operational, type Message } from "@openomni/protocol";
+import { collector } from "@openomni/telemetry";
+import { APIError } from "../../src/error";
+import { Processor } from "../../src/processor";
+import type { Provider } from "../../src/provider";
+
+function assistantMessage(): Message.AssistantMessage {
+  return {
+    id: "msg-instant-streak",
+    sessionID: "session-instant-streak",
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "parent-instant-streak",
+    modelID: "claude-3-5-sonnet",
+    providerID: "anthropic",
+    agent: "test-agent",
+    path: { cwd: "/test", root: "/" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+const model: Provider.Model = {
+  id: "claude-3-5-sonnet",
+  providerID: "anthropic",
+  name: "Claude 3.5 Sonnet",
+  api: { npm: "@ai-sdk/anthropic" },
+};
+
+function transportError() {
+  // Connection refused: retryable per the SDK, but no HTTP response — no
+  // status code, no headers. Dies the moment the stream is consumed.
+  return new APIError({ message: "fetch failed", isRetryable: true });
+}
+
+describe("Processor instant transport-failure streak", () => {
+  const events = collector();
+
+  afterEach(() => {
+    events.reset();
+  });
+
+  test("three instant connection failures end the run instead of burning the backoff budget", async () => {
+    let attemptCount = 0;
+    const processor = Processor.create({
+      assistantMessage: assistantMessage(),
+      sessionID: "session-instant-streak",
+      model,
+      abort: new AbortController().signal,
+      maxRetryAttempts: 10,
+      trace: { traceId: "trace-instant-streak", sessionId: "session-instant-streak" },
+      events,
+      createStream: async () => ({
+        fullStream: (async function* () {
+          attemptCount++;
+          const error: unknown = transportError();
+          if (error !== undefined) throw error;
+          yield { type: "finish" };
+        })(),
+      }),
+    });
+
+    const startedAt = Date.now();
+    await expect(processor.process({ system: "" })).rejects.toBeDefined();
+    const elapsed = Date.now() - startedAt;
+
+    // The streak declines on the third instant failure: exactly three
+    // attempts, and the two waits between them are probe delays, not the
+    // 2s/4s exponential ladder (which alone would exceed 6s here).
+    expect(attemptCount).toBe(3);
+    expect(elapsed).toBeLessThan(2000);
+
+    // A retryable error declined for a non-"non_retryable" reason must say
+    // why, through the port.
+    const declined = events
+      .named(Operational.Error.name)
+      .map((event) => event as { component?: string; msg?: string; error?: string });
+    const fromRetry = declined.filter((event) => event.component === "llm.retry");
+    expect(fromRetry).toHaveLength(1);
+    expect(fromRetry[0]?.msg).toBe("retry declined");
+    expect(String(fromRetry[0]?.error)).toContain("transport");
+  });
+});

--- a/packages/llm/test/retry/instant-transport-failure.test.ts
+++ b/packages/llm/test/retry/instant-transport-failure.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { APIError } from "../../src/error";
+import { Retry } from "../../src/retry";
+
+function transportError(): InstanceType<typeof APIError> {
+  // A connection-level failure: retryable, but no HTTP response ever arrived,
+  // so there is no status code and there are no response headers.
+  return new APIError({ message: "fetch failed", isRetryable: true });
+}
+
+function httpError(statusCode: number): InstanceType<typeof APIError> {
+  return new APIError({ message: "boom", isRetryable: true, statusCode });
+}
+
+describe("Retry.isInstantTransportFailure", () => {
+  test("true for a retryable no-status failure under the window", () => {
+    expect(Retry.isInstantTransportFailure(transportError(), 100)).toBe(true);
+    expect(
+      Retry.isInstantTransportFailure(transportError(), Retry.INSTANT_FAILURE_WINDOW_MS - 1),
+    ).toBe(true);
+  });
+
+  test("false at or above the window — slow failures keep the backoff budget", () => {
+    expect(Retry.isInstantTransportFailure(transportError(), Retry.INSTANT_FAILURE_WINDOW_MS)).toBe(
+      false,
+    );
+    expect(Retry.isInstantTransportFailure(transportError(), 30_000)).toBe(false);
+  });
+
+  test("false when an HTTP response arrived — the endpoint is up", () => {
+    expect(Retry.isInstantTransportFailure(httpError(429), 100)).toBe(false);
+    expect(Retry.isInstantTransportFailure(httpError(500), 100)).toBe(false);
+  });
+
+  test("false when response headers arrived without a status — the endpoint answered", () => {
+    const headerOnly = new APIError({
+      message: "rate limited",
+      isRetryable: true,
+      responseHeaders: { "retry-after-ms": "1" },
+    });
+    expect(Retry.isInstantTransportFailure(headerOnly, 100)).toBe(false);
+  });
+
+  test("false for non-APIError values", () => {
+    expect(Retry.isInstantTransportFailure(new Error("nope"), 100)).toBe(false);
+    expect(Retry.isInstantTransportFailure(undefined, 100)).toBe(false);
+  });
+});
+
+describe("Retry.decide with an instant-failure streak", () => {
+  test("below the limit: retries on the short probe delay, not the backoff ladder", () => {
+    const decision = Retry.decide(2, transportError(), 2);
+    expect(decision.retry).toBe(true);
+    if (decision.retry) {
+      expect(decision.delayMs).toBe(Retry.INSTANT_FAILURE_PROBE_DELAY_MS);
+      expect(decision.delayMs).toBeLessThan(Retry.RETRY_INITIAL_DELAY);
+    }
+  });
+
+  test("at the limit: declines with a detail naming the transport streak", () => {
+    const decision = Retry.decide(3, transportError(), Retry.INSTANT_FAILURE_STREAK_LIMIT);
+    expect(decision.retry).toBe(false);
+    if (!decision.retry) {
+      expect(decision.reason).toBe("server_error");
+      expect(decision.detail).toContain("transport");
+    }
+  });
+
+  test("a zero streak keeps the existing backoff behavior byte-identical", () => {
+    const decision = Retry.decide(1, transportError(), 0);
+    expect(decision.retry).toBe(true);
+    if (decision.retry) {
+      expect(decision.delayMs).toBe(Retry.RETRY_INITIAL_DELAY);
+    }
+  });
+
+  test("the streak never overrides non_retryable classification", () => {
+    const decision = Retry.decide(1, new Error("not api"), Retry.INSTANT_FAILURE_STREAK_LIMIT);
+    expect(decision.retry).toBe(false);
+    if (!decision.retry) {
+      expect(decision.reason).toBe("non_retryable");
+    }
+  });
+});


### PR DESCRIPTION
## Issue and contract

Leaf 1 of #698 (agent-core upstream adoption wave). Source insight: hermes-agent production fork — a dead endpoint (connection refused) burned 13 retries / ~250s of user-visible silence because instant connection failures paid the same exponential backoff as overloaded-server errors.

## What changed and why

Backoff exists to relieve an overloaded endpoint; it cannot help one refusing connections outright. The retry seam now distinguishes the two:

- `Retry.isInstantTransportFailure(error, elapsedMs)` — a retryable `APIError` with **no HTTP status and no response headers** (the endpoint never answered) that died under `INSTANT_FAILURE_WINDOW_MS` (2s). A status or headers prove the endpoint is up; a slow failure keeps the full backoff budget.
- `Retry.decide(attempt, error, instantFailureStreak)` — streak 1–2 retries on a 250ms probe delay (a refused connection has no server to relieve); streak 3 declines through the existing retry-declined path with a detail naming the streak. A zero streak is byte-identical to prior behavior, pinned by test.
- The processor tracks the streak per `process()` call, measuring elapsed time per attempt; any attempt that reaches the endpoint or fails slowly resets it.

No legacy path, no fallback: the decline reuses the existing `retry declined` Operational.Error publish (reason + detail), and the exhaustive `RetryableReason` switch is untouched (no vocabulary change).

## Verification

- Red-first: unit tests failed 6/8 before implementation (the 2 passing were the behavior-preservation pins); the processor test hung on the exponential ladder before the fix — that hang is the bug.
- `bun test packages/llm` — 260 pass / 0 fail (the new scenario completes in ~0.5s instead of ~3min).
- `bun run check-types`, `bun run lint` (biome clean on changed files), `bun script/lint-guards.ts`, `bun script/lint-tools.ts`, `bun script/check-deps.ts` — all green.

## Residual risk

A genuinely transient sub-second network blip now surfaces after 3 probes (~500ms) instead of being absorbed by minutes of backoff. The run-level retry policy in `packages/agent` still classifies and may retry the whole run above this seam, so the blip case keeps a second net.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on instant transport-failure streaks in `packages/llm` so we do not burn exponential backoff against dead endpoints. Previously, connection-refused failures were treated like HTTP 5xx/429 and retried for minutes; now sub-2s failures with no status or headers probe twice at 250ms and decline on the third.

**Behavior details**
- Instant transport failure = retryable error with no HTTP status or response headers and duration < 2s; slow timeouts keep full backoff.
- The processor tracks a streak per `process()` call; any response (status or headers) or a slow failure resets it.
- Streak 1–2: retry after 250ms; streak 3: decline via existing “retry declined” path with a detail naming the streak. A zero streak preserves prior behavior (tests pin).
- Constants: 2s window, 250ms probe delay, 3-attempt limit. No change to retry vocabulary or event schema.

**Review notes**
- Scope: `packages/llm` only; adds two tests to cover streak classification and processor behavior.
- No migration or config changes. External callers and `RetryableReason` remain unchanged.
- Risk: brief sub-second blips may surface after ~500ms instead of minutes; higher-level run retry policy can still reattempt.

<sup>Written for commit cb83fa8dd5d8c1ebe22e919326ecb9a036d8784d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

