### PR TITLE
fix(session,server): flush-barrier before terminal exits

### DIFF
--- a/apps/server/src/bootstrap/fatal.ts
+++ b/apps/server/src/bootstrap/fatal.ts
@@ -1,0 +1,33 @@
+import { Operational } from "@openomni/protocol";
+import { BusPersistence } from "@openomni/session";
+import { Bus, newTraceId } from "@openomni/telemetry";
+
+/**
+ * The terminal path for an unrecoverable error: report, then exit. The
+ * telemetry flush between the two is the point — process.exit() discards
+ * queued microtasks, so a publish immediately followed by exit never reaches
+ * the ledger's observation rows. The barrier must also never block the
+ * exit: a flush failure falls back to the stderr line that already went out.
+ */
+export async function reportFatalAndExit(
+  error: unknown,
+  exit: (code: number) => void = process.exit,
+): Promise<void> {
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  // A boot that dies before BusPersistence.start() publishes into a
+  // subscriber-less Bus — stderr is the only outlet that always exists.
+  process.stderr.write(`openomni fatal: ${message}\n`);
+  Bus.publish(Operational.Error, {
+    traceId: newTraceId(),
+    time: Date.now(),
+    component: "server",
+    msg: "fatal error",
+    context: { err: error instanceof Error ? error.message : String(error) },
+  });
+  try {
+    await BusPersistence.flush();
+  } catch {
+    // The observation row is best-effort on this path; stderr already spoke.
+  }
+  exit(1);
+}

--- a/apps/server/src/bootstrap/fatal.ts
+++ b/apps/server/src/bootstrap/fatal.ts
@@ -13,21 +13,24 @@ export async function reportFatalAndExit(
   error: unknown,
   exit: (code: number) => void = process.exit,
 ): Promise<void> {
-  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  // A boot that dies before BusPersistence.start() publishes into a
-  // subscriber-less Bus — stderr is the only outlet that always exists.
-  process.stderr.write(`openomni fatal: ${message}\n`);
-  Bus.publish(Operational.Error, {
-    traceId: newTraceId(),
-    time: Date.now(),
-    component: "server",
-    msg: "fatal error",
-    context: { err: error instanceof Error ? error.message : String(error) },
-  });
+  // Everything before exit is best-effort: a throw from reporting must never
+  // turn the fatal exit into an unhandled rejection that changes how the
+  // process dies.
   try {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    // A boot that dies before BusPersistence.start() publishes into a
+    // subscriber-less Bus — stderr is the only outlet that always exists.
+    process.stderr.write(`openomni fatal: ${message}\n`);
+    Bus.publish(Operational.Error, {
+      traceId: newTraceId(),
+      time: Date.now(),
+      component: "server",
+      msg: "fatal error",
+      context: { err: error instanceof Error ? error.message : String(error) },
+    });
     await BusPersistence.flush();
   } catch {
-    // The observation row is best-effort on this path; stderr already spoke.
+    // The observation row is best-effort on this path.
   }
   exit(1);
 }

--- a/apps/server/src/bootstrap/shutdown.ts
+++ b/apps/server/src/bootstrap/shutdown.ts
@@ -85,6 +85,15 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
         msg: "server error during shutdown",
         context: { err: String(err) },
       });
+      // The publish above lands after the try-body's flush (or before any
+      // flush ran, when the throw came earlier) — without its own barrier the
+      // exit below discards the queued row. After stop() there is no
+      // subscriber and this is a no-op.
+      try {
+        await BusPersistence.flush();
+      } catch {
+        // Never let the telemetry barrier block shutdown.
+      }
     }
 
     process.exit(0);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,19 +1,4 @@
-import { newTraceId } from "@openomni/telemetry";
-import { Operational } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
 import { main } from "./bootstrap";
+import { reportFatalAndExit } from "./bootstrap/fatal";
 
-main().catch((error) => {
-  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
-  // A boot that dies before BusPersistence.start() publishes into a
-  // subscriber-less Bus — stderr is the only outlet that always exists.
-  process.stderr.write(`openomni fatal: ${message}\n`);
-  Bus.publish(Operational.Error, {
-    traceId: newTraceId(),
-    time: Date.now(),
-    component: "server",
-    msg: "fatal error",
-    context: { err: error instanceof Error ? error.message : String(error) },
-  });
-  process.exit(1);
-});
+main().catch((error) => void reportFatalAndExit(error));

--- a/apps/server/test/bootstrap/fatal.test.ts
+++ b/apps/server/test/bootstrap/fatal.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { BusPersistence, Storage } from "@openomni/session";
+import { Bus } from "@openomni/telemetry";
+import { reportFatalAndExit } from "../../src/bootstrap/fatal";
+
+function busEventRows(): Array<{ event_type: string; data: string }> {
+  const descriptor = Object.getOwnPropertyDescriptor(Storage.getAdapter(), "db");
+  if (!(descriptor?.value instanceof Database)) {
+    throw new Error("Expected SQLite-backed storage adapter");
+  }
+  return descriptor.value
+    .query("SELECT event_type, data FROM bus_event ORDER BY id ASC")
+    .all() as Array<{ event_type: string; data: string }>;
+}
+
+describe("reportFatalAndExit", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    Bus.reset();
+  });
+
+  afterEach(() => {
+    BusPersistence.stop();
+    Bus.reset();
+    Storage.reset();
+  });
+
+  test("the fatal row is committed before exit is invoked", async () => {
+    BusPersistence.start();
+
+    let rowsAtExit: number | undefined;
+    let exitCode: number | undefined;
+    await reportFatalAndExit(new Error("boot exploded"), (code) => {
+      exitCode = code;
+      rowsAtExit = busEventRows().length;
+    });
+
+    // The whole point of the barrier: at the moment process.exit would have
+    // run — discarding every queued microtask — the row is already on disk.
+    expect(exitCode).toBe(1);
+    expect(rowsAtExit).toBe(1);
+    const row = busEventRows()[0];
+    expect(row?.event_type).toBe("operational.error");
+    // Free-text fields are redacted to shape descriptors before persistence;
+    // the pin is the barrier (row committed at exit time), not the prose.
+    const data = JSON.parse(row?.data ?? "{}") as Record<string, unknown>;
+    expect(data.msg).toBeDefined();
+    expect(data.context).toBeDefined();
+  });
+
+  test("exits even when persistence never started", async () => {
+    let exitCode: number | undefined;
+    await reportFatalAndExit("string failure", (code) => {
+      exitCode = code;
+    });
+    expect(exitCode).toBe(1);
+  });
+});

--- a/packages/session/src/bus-persistence/persistence-writer.ts
+++ b/packages/session/src/bus-persistence/persistence-writer.ts
@@ -49,12 +49,16 @@ export function persist(input: PersistInput): Promise<void> {
  * Drains the queued batch synchronously (group commit per connection, FIFO —
  * the per-session hash chain reads its tip inside the same transaction).
  * Exported for the shutdown drain; normally runs as the scheduled microtask.
+ * Returns the number of entries drained so the shutdown barrier can detect
+ * quiescence (a turn that drained nothing).
  */
-export function flushPersistQueue(): void {
+export function flushPersistQueue(): number {
   flushScheduled = false;
+  let drained = 0;
   while (queue.length > 0) {
     const batch = queue;
     queue = [];
+    drained += batch.length;
     let start = 0;
     while (start < batch.length) {
       let end = start;
@@ -63,6 +67,7 @@ export function flushPersistQueue(): void {
       start = end;
     }
   }
+  return drained;
 }
 
 function flushGroup(entries: QueueEntry[]): void {

--- a/packages/session/src/bus-persistence/runtime-state.ts
+++ b/packages/session/src/bus-persistence/runtime-state.ts
@@ -106,11 +106,26 @@ export function stopBusPersistence(): void {
   state = undefined;
 }
 
+/**
+ * Bound on quiescence turns, not a target: each turn advances one microtask
+ * hop of subscriber cascade (publish → observer → enqueue), so the bound
+ * supports cascades several levels deeper than anything in the tree while
+ * guaranteeing a pathological self-publishing subscriber cannot wedge the
+ * exit path this barrier protects.
+ */
+const MAX_FLUSH_TURNS = 16;
+
 export async function flushBusPersistence(): Promise<void> {
-  await new Promise((resolve) => queueMicrotask(resolve));
-  // Drain synchronously (shutdown path): commits every queued row now
-  // instead of waiting for the scheduled microtask.
-  flushPersistQueue();
-  const pending = state ? [...state.pending] : [];
-  await Promise.allSettled(pending);
+  // Pre-exit barrier: when this resolves, every row implied by publishes
+  // that happened before the call — including rows published by subscribers
+  // reacting to those publishes — is committed. One turn per iteration lets
+  // already-queued subscriber microtasks enqueue; the drain commits; a turn
+  // that commits nothing with no writes in flight proves quiescence.
+  for (let turn = 0; turn < MAX_FLUSH_TURNS; turn += 1) {
+    await new Promise((resolve) => queueMicrotask(resolve));
+    const committed = flushPersistQueue();
+    const pending = state ? [...state.pending] : [];
+    if (committed === 0 && pending.length === 0) return;
+    await Promise.allSettled(pending);
+  }
 }

--- a/packages/session/src/bus-persistence/runtime-state.ts
+++ b/packages/session/src/bus-persistence/runtime-state.ts
@@ -120,7 +120,11 @@ export async function flushBusPersistence(): Promise<void> {
   // that happened before the call — including rows published by subscribers
   // reacting to those publishes — is committed. One turn per iteration lets
   // already-queued subscriber microtasks enqueue; the drain commits; a turn
-  // that commits nothing with no writes in flight proves quiescence.
+  // that commits nothing with no writes in flight is treated as quiescent.
+  // Known hole: a cascade whose next hop is carried only by an ephemeral
+  // event (observed, never enqueued) yields such a turn while a subscriber
+  // delivery is still queued — no ephemeral-headed publishing cascade exists
+  // in the tree, and this writer is lossy-tolerant by contract.
   for (let turn = 0; turn < MAX_FLUSH_TURNS; turn += 1) {
     await new Promise((resolve) => queueMicrotask(resolve));
     const committed = flushPersistQueue();

--- a/packages/session/test/bus-persistence/flush-barrier.test.ts
+++ b/packages/session/test/bus-persistence/flush-barrier.test.ts
@@ -77,14 +77,18 @@ describe("BusPersistence.flush as a pre-exit barrier", () => {
 
   test("a multi-level cascade is committed when flush resolves", async () => {
     BusPersistence.start();
-    const chain = [0, 1, 2, 3, 4].map((depth) =>
+    // Depth 8 discriminates the barrier: the old one-turn flush committed
+    // exactly the first 5 rows at ANY depth (its internal await hops granted
+    // ~5 ambient microtask turns), so a shallower chain passes vacuously.
+    const DEPTH = 8;
+    const chain = Array.from({ length: DEPTH + 1 }, (_, depth) =>
       BusEvent.define(
         `test.flush.deep.${depth}`,
         z.object({ traceId: z.string(), time: z.number() }),
       ),
     );
-    const unsubscribes = [0, 1, 2, 3].map((depth) =>
-      Bus.subscribe(chain[depth] as BusEvent.Descriptor<{ traceId: string; time: number }>, () => {
+    const unsubscribes = chain.slice(0, DEPTH).map((event, depth) =>
+      Bus.subscribe(event as BusEvent.Descriptor<{ traceId: string; time: number }>, () => {
         Bus.publish(chain[depth + 1] as BusEvent.Descriptor<{ traceId: string; time: number }>, {
           traceId: `trace-deep-${depth + 1}`,
           time: Date.now(),
@@ -100,7 +104,7 @@ describe("BusPersistence.flush as a pre-exit barrier", () => {
 
       await BusPersistence.flush();
 
-      expect(rowCount()).toBe(5);
+      expect(rowCount()).toBe(DEPTH + 1);
     } finally {
       for (const unsubscribe of unsubscribes) unsubscribe();
     }

--- a/packages/session/test/bus-persistence/flush-barrier.test.ts
+++ b/packages/session/test/bus-persistence/flush-barrier.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { z } from "zod";
+import { Bus, BusEvent } from "@openomni/telemetry";
+import { BusPersistence } from "../../src/bus-persistence/index.js";
+import { Storage } from "../../src/storage/storage.js";
+import "../../src/storage/initialize.js";
+
+function db(): Database {
+  const descriptor = Object.getOwnPropertyDescriptor(Storage.getAdapter(), "db");
+  if (descriptor?.value instanceof Database) return descriptor.value;
+  throw new Error("Expected SQLite-backed storage adapter");
+}
+
+function rowCount(): number {
+  const row = db().query("SELECT COUNT(*) AS n FROM bus_event").get() as { n: number };
+  return row.n;
+}
+
+const first = BusEvent.define(
+  "test.flush.first",
+  z.object({ traceId: z.string(), time: z.number() }),
+);
+const second = BusEvent.define(
+  "test.flush.second",
+  z.object({ traceId: z.string(), time: z.number() }),
+);
+
+/**
+ * flush() is the barrier a terminal path relies on right before
+ * process.exit(): after it resolves, every row implied by publishes that
+ * happened before the call must be committed — process death must not be
+ * able to drop them. No extra microtask turns or timers are allowed here;
+ * the exit path won't grant any.
+ */
+describe("BusPersistence.flush as a pre-exit barrier", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    Bus.reset();
+  });
+
+  afterEach(() => {
+    BusPersistence.stop();
+    Bus.reset();
+    Storage.reset();
+  });
+
+  test("a publish immediately followed by flush() is committed when flush resolves", async () => {
+    BusPersistence.start();
+    Bus.publish(first, { traceId: "trace-barrier-1", time: Date.now() });
+
+    await BusPersistence.flush();
+
+    expect(rowCount()).toBe(1);
+  });
+
+  test("a cascade published by a subscriber is committed when flush resolves", async () => {
+    BusPersistence.start();
+    // A subscriber that reacts to the first event by publishing a second —
+    // the shape of every "on terminal, record a follow-up" hook. Its row is
+    // implied by the pre-flush publish and must be inside the barrier.
+    const unsubscribe = Bus.subscribe(first, () => {
+      Bus.publish(second, { traceId: "trace-barrier-2", time: Date.now() });
+    });
+
+    try {
+      Bus.publish(first, { traceId: "trace-barrier-1", time: Date.now() });
+
+      await BusPersistence.flush();
+
+      expect(rowCount()).toBe(2);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  test("a multi-level cascade is committed when flush resolves", async () => {
+    BusPersistence.start();
+    const chain = [0, 1, 2, 3, 4].map((depth) =>
+      BusEvent.define(
+        `test.flush.deep.${depth}`,
+        z.object({ traceId: z.string(), time: z.number() }),
+      ),
+    );
+    const unsubscribes = [0, 1, 2, 3].map((depth) =>
+      Bus.subscribe(chain[depth] as BusEvent.Descriptor<{ traceId: string; time: number }>, () => {
+        Bus.publish(chain[depth + 1] as BusEvent.Descriptor<{ traceId: string; time: number }>, {
+          traceId: `trace-deep-${depth + 1}`,
+          time: Date.now(),
+        });
+      }),
+    );
+
+    try {
+      Bus.publish(chain[0] as BusEvent.Descriptor<{ traceId: string; time: number }>, {
+        traceId: "trace-deep-0",
+        time: Date.now(),
+      });
+
+      await BusPersistence.flush();
+
+      expect(rowCount()).toBe(5);
+    } finally {
+      for (const unsubscribe of unsubscribes) unsubscribe();
+    }
+  });
+
+  test("flush() before start and after stop resolves without touching storage", async () => {
+    await BusPersistence.flush();
+
+    BusPersistence.start();
+    Bus.publish(first, { traceId: "trace-barrier-3", time: Date.now() });
+    await BusPersistence.flush();
+    BusPersistence.stop();
+
+    await BusPersistence.flush();
+    expect(rowCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Issue and contract

Leaf 2 of #698 (agent-core upstream adoption wave). Source insight: codex-rs flushes the rollout before emitting `TurnAborted` because readers re-read immediately; our analog is `process.exit()` discarding queued telemetry microtasks on terminal paths.

## What changed and why

The authoritative stores (WorkItem/effect/wait) are synchronous SQLite transactions — record-before-act never had this window. The **observation rows** (`bus_event`) did, in three places:

1. **Fatal handler always lost its row**: `apps/server/src/index.ts` published `fatal error` then called `process.exit(1)` synchronously — the publish's microtask never ran. Extracted to `bootstrap/fatal.ts` (`reportFatalAndExit`): stderr → publish → `BusPersistence.flush()` → exit, with the whole reporting body guarded so a throw can never turn the fatal exit into an unhandled rejection.
2. **Shutdown-catch row rode a discarded microtask**: the `catch` in `bootstrap/shutdown.ts` published *after* the try-body's drain; added a guarded flush after the catch publish (no-op after `stop()`).
3. **`BusPersistence.flush()` committed exactly the first 5 implied rows regardless of cascade depth** — its internal await hops granted ~5 ambient microtask turns, so rows published by subscriber cascades deeper than that escaped the barrier. The drain now loops to quiescence (a turn that commits nothing with no writes in flight), bounded at 16 turns so a pathological self-publishing subscriber cannot wedge shutdown. The quiescence comment names its known ephemeral-hop hole rather than overclaiming proof.

No semantic change to normal operation: the scheduled-microtask group-commit path is untouched; only the explicit shutdown/exit barrier is stronger.

## Verification

- Red-first, corrected after the Fable gate refuted the original depth-4 test as vacuous (old code passes it — 5 rows is exactly what one-turn flush commits): the cascade pin is now **depth 8**, red-on-revert re-verified at the review head (`Expected: 9, Received: 5` with the old flush restored).
- Fatal barrier mutation-verified: removing the flush fails the pin with `rowsAtExit: 0` — the exact production loss.
- `bun test packages/session apps/server/test/bootstrap` — 438 pass / 0 fail. `check-types`, biome, `lint-guards`, `lint-tools`, `check-deps` — green.

## Review

- Fable round 1: BLOCKED — vacuous cascade depth (fixed in 4442a244, red-on-revert re-verified), 2 MINORs (ephemeral-hole comment; fatal guard width) both landed. Round 2 requested at 4442a244.

## Residual risk

A subscriber publishing unconditionally on every event could hit the 16-turn bound; rows beyond it fall back to the lossy-tolerant contract that always governed this writer. Ephemeral-headed cascades are outside the quiescence proof (documented in-code); none exist in the tree.
