### PR TITLE
feat(agent,protocol): compaction lock bracket — started/completed

### DIFF
--- a/packages/agent/bench/index.ts
+++ b/packages/agent/bench/index.ts
@@ -6,7 +6,7 @@ import { Compaction } from "../src/compaction/compact.ts";
 import { noopSink } from "@openomni/telemetry";
 
 /** The bench stands in for one run. It measures compaction, not reporting. */
-const BENCH_TRACE = { traceId: "trace-agent-bench" };
+const BENCH_TRACE = { traceId: "trace-agent-bench", sessionId: "session-agent-bench" };
 const BENCH_EVENTS = noopSink();
 
 interface BenchmarkResult {
@@ -32,7 +32,9 @@ for (const size of [20, 100, 500]) {
   bench.add(
     `compaction/${size}-messages`,
     async () => {
-      await Compaction.compact(messages, compactionOptions, BENCH_TRACE, BENCH_EVENTS);
+      await Compaction.compact(messages, compactionOptions, BENCH_TRACE, BENCH_EVENTS, {
+        trigger: "threshold",
+      });
     },
     { async: true },
   );

--- a/packages/agent/src/compaction/compact.ts
+++ b/packages/agent/src/compaction/compact.ts
@@ -1,5 +1,5 @@
 import type { BusEvent } from "@openomni/protocol";
-import { Operational, type Message } from "@openomni/protocol";
+import { AgentExecution, type Message } from "@openomni/protocol";
 import { elideToolOutputs, type ToolOutputElision } from "./reduce";
 
 export interface CompactionOptions {
@@ -53,25 +53,89 @@ export namespace Compaction {
   }
 
   /**
-   * @param trace The run whose history is being rewritten. A separate required
-   * parameter rather than a field on `options`: the trace is a per-call fact,
-   * not configuration, and an optional field validated by a runtime throw
-   * gives the compiler nothing — which is how the caller that supplied none
-   * reached production.
+   * @param identity The run whose history is being rewritten. A separate
+   * required parameter rather than a field on `options`: identity is a
+   * per-call fact, not configuration, and an optional field validated by a
+   * runtime throw gives the compiler nothing — which is how the caller that
+   * supplied none reached production.
    * @param events Where the record of the rewrite goes. Beside the identity,
    * not inside it: a destination is not something the trace says.
+   * @param dispatch What fired the seam and what was measured — per-dispatch
+   * facts the bracket records.
+   *
+   * The lock bracket: exactly one `agent.compaction.started` before any work
+   * and exactly one `agent.compaction.completed` as the last record on every
+   * exit path, a summarizer throw included. A started without a completed
+   * diagnoses a run that died inside compaction.
    */
   export async function compact(
     messages: Message.WithParts[],
     options: ResolvedCompactionOptions,
-    trace: { readonly traceId: string },
+    identity: { readonly traceId: string; readonly sessionId: string; readonly runId?: string },
     events: BusEvent.Sink,
-    measuredContextTokens?: number,
+    dispatch: { readonly trigger: "threshold" | "yield"; readonly measuredTokens?: number },
+  ): Promise<CompactionResult> {
+    const messagesBefore = messages.length;
+    events.publish(AgentExecution.CompactionStarted, {
+      ...identity,
+      time: Date.now(),
+      messagesBefore,
+      ...(dispatch.measuredTokens === undefined ? {} : { contextTokens: dispatch.measuredTokens }),
+      trigger: dispatch.trigger,
+      summarizer: options.onSummarize !== undefined,
+    });
+
+    const finish = (
+      result: CompactionResult,
+      outcome: "cut" | "reduced" | "nothing_reclaimed" | "no_user_boundary",
+      elidedChars: number,
+    ): CompactionResult => {
+      events.publish(AgentExecution.CompactionCompleted, {
+        ...identity,
+        time: Date.now(),
+        outcome,
+        messagesBefore,
+        messagesAfter: result.messages.length,
+        removedCount: result.removedCount,
+        elidedChars,
+      });
+      return result;
+    };
+
+    try {
+      return await compactUnbracketed(messages, options, dispatch.measuredTokens, finish);
+    } catch (error) {
+      // The one exit finish() cannot serve: the summarizer threw. The
+      // bracket still closes — `failed` is this operation's terminal — and
+      // the throw propagates unchanged into the seam's fail-closed contract.
+      events.publish(AgentExecution.CompactionCompleted, {
+        ...identity,
+        time: Date.now(),
+        outcome: "failed",
+        messagesBefore,
+        messagesAfter: messagesBefore,
+        removedCount: 0,
+        elidedChars: 0,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  async function compactUnbracketed(
+    messages: Message.WithParts[],
+    options: ResolvedCompactionOptions,
+    measuredContextTokens: number | undefined,
+    finish: (
+      result: CompactionResult,
+      outcome: "cut" | "reduced" | "nothing_reclaimed" | "no_user_boundary",
+      elidedChars: number,
+    ) => CompactionResult,
   ): Promise<CompactionResult> {
     const protectRecent = options.protectRecentMessages ?? DEFAULT_PROTECT_RECENT;
 
     if (messages.length <= protectRecent) {
-      return { messages, compacted: false, removedCount: 0 };
+      return finish({ messages, compacted: false, removedCount: 0 }, "nothing_reclaimed", 0);
     }
 
     // Reduction before the cut: eliding old tool outputs reclaims window
@@ -91,24 +155,17 @@ export namespace Compaction {
       if (reduction.elidedChars > 0) {
         working = reduction.messages;
         elidedChars = reduction.elidedChars;
-        events.publish(Operational.Info, {
-          traceId: trace.traceId,
-          time: Date.now(),
-          component: "agent.compaction",
-          msg: "compaction reduced tool outputs",
-          context: {
-            elidedChars: reduction.elidedChars,
-            messageCount: messages.length,
-            reason: "context window threshold exceeded",
-          },
-        });
         const overageTokens =
           measuredContextTokens === undefined
             ? undefined
             : measuredContextTokens - resolveThresholdTokens(options);
         const estimatedReclaimTokens = elidedChars / ESTIMATED_CHARS_PER_TOKEN;
         if (overageTokens === undefined || estimatedReclaimTokens >= overageTokens) {
-          return { messages: working, compacted: true, removedCount: 0 };
+          return finish(
+            { messages: working, compacted: true, removedCount: 0 },
+            "reduced",
+            elidedChars,
+          );
         }
       }
     }
@@ -142,13 +199,17 @@ export namespace Compaction {
       // reachable from resumed worker hydration — a throw here would turn a
       // fail-closed run.completion.pre into a mid-conversation kill.
       return elidedChars > 0
-        ? { messages: working, compacted: true, removedCount: 0 }
-        : { messages: working, compacted: false, removedCount: 0, blocked: "no_user_boundary" };
+        ? finish({ messages: working, compacted: true, removedCount: 0 }, "reduced", elidedChars)
+        : finish(
+            { messages: working, compacted: false, removedCount: 0, blocked: "no_user_boundary" },
+            "no_user_boundary",
+            0,
+          );
     }
     if (cutoff === 0) {
       return elidedChars > 0
-        ? { messages: working, compacted: true, removedCount: 0 }
-        : { messages: working, compacted: false, removedCount: 0 };
+        ? finish({ messages: working, compacted: true, removedCount: 0 }, "reduced", elidedChars)
+        : finish({ messages: working, compacted: false, removedCount: 0 }, "nothing_reclaimed", 0);
     }
 
     const toRemove = working.slice(0, cutoff);
@@ -165,24 +226,15 @@ export namespace Compaction {
 
     const compacted = [...summaryMessages, ...toKeep];
 
-    events.publish(Operational.Info, {
-      traceId: trace.traceId,
-      time: Date.now(),
-      component: "agent.compaction",
-      msg: "compaction triggered",
-      context: {
-        messagesBefore: working.length,
-        messagesAfter: compacted.length,
+    return finish(
+      {
+        messages: compacted,
+        compacted: true,
         removedCount: toRemove.length,
-        reason: "context window threshold exceeded",
       },
-    });
-
-    return {
-      messages: compacted,
-      compacted: true,
-      removedCount: toRemove.length,
-    };
+      "cut",
+      elidedChars,
+    );
   }
 }
 

--- a/packages/agent/src/compaction/policy.ts
+++ b/packages/agent/src/compaction/policy.ts
@@ -51,9 +51,9 @@ export function createCompactionPolicy(config: CompactionConfig): CanonicalPolic
 
       // `run.completion.pre` is fail-closed, so throwing here would end the
       // run — the failure mode this guard was added to prevent. The lifecycle
-      // always supplies the trace (`buildLifecyclePolicyContext`); if some
-      // future dispatcher does not, skipping compaction degrades the turn
-      // rather than killing the run, and the skip is itself recorded.
+      // always supplies the trace and session (`buildLifecyclePolicyContext`);
+      // if some future dispatcher does not, skipping compaction degrades the
+      // turn rather than killing the run, and the skip is itself recorded.
       const traceId = ctx.traceContext?.traceId;
       if (traceId === undefined || traceId.length === 0) {
         return PolicyDecision.allow({
@@ -61,12 +61,22 @@ export function createCompactionPolicy(config: CompactionConfig): CanonicalPolic
           reasonCodes: ["compaction_skipped_no_trace"],
         });
       }
+      const sessionId = ctx.sessionId;
+      if (sessionId === undefined || sessionId.length === 0) {
+        return PolicyDecision.allow({
+          policyId: "builtin.compaction",
+          reasonCodes: ["compaction_skipped_no_session"],
+        });
+      }
       const result = await Compaction.compact(
         ctx.messages,
         resolved,
-        { traceId },
+        { traceId, sessionId },
         events,
-        ctx.contextTokens,
+        {
+          trigger: ctx.contextYielded ? "yield" : "threshold",
+          ...(ctx.contextTokens === undefined ? {} : { measuredTokens: ctx.contextTokens }),
+        },
       );
       if (!result.compacted) {
         // The trigger fired and nothing was reclaimed — the one silent path

--- a/packages/agent/test/compaction/bracket.test.ts
+++ b/packages/agent/test/compaction/bracket.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { AgentExecution, type Message } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
+import { Compaction } from "../../src/compaction/compact";
+
+/**
+ * The lock bracket: every compact() call publishes exactly one
+ * `agent.compaction.started` before any work and exactly one
+ * `agent.compaction.completed` as its last record — on every exit path,
+ * including a summarizer throw. A started without a completed therefore
+ * means the run died inside compaction, which is precisely the diagnosis
+ * that was impossible while the only records were success-path ephemerals.
+ */
+
+const IDENTITY = {
+  traceId: "trace-bracket-test",
+  sessionId: "session-bracket-test",
+} as const;
+
+let idCounter = 0;
+function nextId(prefix: string): string {
+  idCounter += 1;
+  return `${prefix}-${idCounter}`;
+}
+
+function makeUserMessage(text: string): Message.WithParts {
+  const id = nextId("user-message");
+  const sessionID = IDENTITY.sessionId;
+  const info: Message.UserMessage = {
+    id,
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test",
+    model: { providerID: "", modelID: "" },
+  };
+  const part: Message.TextPart = {
+    id: nextId("user-part"),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+  return { info, parts: [part] };
+}
+
+function makeAssistantMessage(text: string): Message.WithParts {
+  const id = nextId("assistant-message");
+  const sessionID = IDENTITY.sessionId;
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID: "",
+    modelID: "",
+    providerID: "",
+    agent: "test",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  };
+  const part: Message.TextPart = {
+    id: nextId("assistant-part"),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+  return { info, parts: [part] };
+}
+
+interface StartedEvent {
+  traceId: string;
+  sessionId: string;
+  messagesBefore: number;
+  trigger: string;
+  summarizer: boolean;
+}
+
+interface CompletedEvent {
+  traceId: string;
+  sessionId: string;
+  outcome: string;
+  messagesBefore: number;
+  messagesAfter: number;
+  removedCount: number;
+  elidedChars: number;
+  error?: string;
+}
+
+function captureBracket(): {
+  started: StartedEvent[];
+  completed: CompletedEvent[];
+  order: string[];
+  unsubscribe: () => void;
+} {
+  const started: StartedEvent[] = [];
+  const completed: CompletedEvent[] = [];
+  const order: string[] = [];
+  const unsubStarted = Bus.subscribe(AgentExecution.CompactionStarted, (event) => {
+    started.push(event as unknown as StartedEvent);
+    order.push("started");
+  });
+  const unsubCompleted = Bus.subscribe(AgentExecution.CompactionCompleted, (event) => {
+    completed.push(event as unknown as CompletedEvent);
+    order.push("completed");
+  });
+  return {
+    started,
+    completed,
+    order,
+    unsubscribe: () => {
+      unsubStarted();
+      unsubCompleted();
+    },
+  };
+}
+
+describe("Compaction bracket", () => {
+  afterEach(() => {
+    Bus.reset();
+  });
+
+  it("brackets a cut: one started, one completed(cut), completed last", async () => {
+    const capture = captureBracket();
+    try {
+      const result = await Compaction.compact(
+        Array.from({ length: 12 }, (_unused, index) => makeUserMessage(`message ${index}`)),
+        { contextWindowTokens: 1000, protectRecentMessages: 2 },
+        IDENTITY,
+        Bus,
+        { trigger: "threshold" },
+      );
+      await Bun.sleep(0);
+
+      expect(result.compacted).toBe(true);
+      expect(capture.started).toHaveLength(1);
+      expect(capture.completed).toHaveLength(1);
+      expect(capture.order).toEqual(["started", "completed"]);
+      expect(capture.started[0]).toMatchObject({
+        traceId: IDENTITY.traceId,
+        sessionId: IDENTITY.sessionId,
+        messagesBefore: 12,
+        trigger: "threshold",
+        summarizer: false,
+      });
+      expect(capture.completed[0]).toMatchObject({
+        traceId: IDENTITY.traceId,
+        sessionId: IDENTITY.sessionId,
+        outcome: "cut",
+      });
+      expect(capture.completed[0]?.removedCount).toBeGreaterThan(0);
+    } finally {
+      capture.unsubscribe();
+    }
+  });
+
+  it("a summarizer throw still closes the bracket as failed, then propagates", async () => {
+    const capture = captureBracket();
+    try {
+      const attempt = Compaction.compact(
+        Array.from({ length: 12 }, (_unused, index) => makeUserMessage(`message ${index}`)),
+        {
+          contextWindowTokens: 1000,
+          protectRecentMessages: 2,
+          onSummarize: () => Promise.reject(new Error("summarizer exploded")),
+        },
+        IDENTITY,
+        Bus,
+        { trigger: "threshold" },
+      );
+      await expect(attempt).rejects.toThrow("summarizer exploded");
+      await Bun.sleep(0);
+
+      expect(capture.started).toHaveLength(1);
+      expect(capture.completed).toHaveLength(1);
+      expect(capture.completed[0]?.outcome).toBe("failed");
+      expect(String(capture.completed[0]?.error)).toContain("summarizer exploded");
+      expect(capture.order).toEqual(["started", "completed"]);
+    } finally {
+      capture.unsubscribe();
+    }
+  });
+
+  it("brackets the refused cut: completed(no_user_boundary)", async () => {
+    const capture = captureBracket();
+    try {
+      const result = await Compaction.compact(
+        Array.from({ length: 12 }, (_unused, index) => makeAssistantMessage(`assistant ${index}`)),
+        { contextWindowTokens: 1000, protectRecentMessages: 2 },
+        IDENTITY,
+        Bus,
+        { trigger: "yield" },
+      );
+      await Bun.sleep(0);
+
+      expect(result.compacted).toBe(false);
+      expect(result.blocked).toBe("no_user_boundary");
+      expect(capture.started).toHaveLength(1);
+      expect(capture.started[0]?.trigger).toBe("yield");
+      expect(capture.completed).toHaveLength(1);
+      expect(capture.completed[0]?.outcome).toBe("no_user_boundary");
+    } finally {
+      capture.unsubscribe();
+    }
+  });
+
+  it("brackets the trivial no-op: completed(nothing_reclaimed)", async () => {
+    const capture = captureBracket();
+    try {
+      const result = await Compaction.compact(
+        [makeUserMessage("only one")],
+        { contextWindowTokens: 1000, protectRecentMessages: 6 },
+        IDENTITY,
+        Bus,
+        { trigger: "threshold" },
+      );
+      await Bun.sleep(0);
+
+      expect(result.compacted).toBe(false);
+      expect(capture.started).toHaveLength(1);
+      expect(capture.completed).toHaveLength(1);
+      expect(capture.completed[0]?.outcome).toBe("nothing_reclaimed");
+    } finally {
+      capture.unsubscribe();
+    }
+  });
+});

--- a/packages/agent/test/compaction/compact.test.ts
+++ b/packages/agent/test/compaction/compact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { Operational, type Message } from "@openomni/protocol";
+import { AgentExecution, type Message } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { Compaction } from "../../src/compaction/compact";
 
@@ -88,7 +88,10 @@ describe("Compaction", () => {
    */
   it("files the compaction record under the run's trace", async () => {
     const seen: Array<{ traceId: string }> = [];
-    const unsubscribe = Bus.subscribe(Operational.Info, (event) => {
+    const unsubStarted = Bus.subscribe(AgentExecution.CompactionStarted, (event) => {
+      seen.push(event as unknown as { traceId: string });
+    });
+    const unsubCompleted = Bus.subscribe(AgentExecution.CompactionCompleted, (event) => {
       seen.push(event as unknown as { traceId: string });
     });
 
@@ -96,15 +99,18 @@ describe("Compaction", () => {
       await Compaction.compact(
         Array.from({ length: 12 }, (_unused, index) => makeUserMessage(`message ${index}`)),
         { contextWindowTokens: 1000, protectRecentMessages: 2 },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       await Bun.sleep(0);
     } finally {
-      unsubscribe();
+      unsubStarted();
+      unsubCompleted();
     }
 
-    expect(seen.filter((event) => event.traceId === TEST_TRACE_ID)).toHaveLength(1);
+    // The bracket: started + completed, both filed under the run's trace.
+    expect(seen.filter((event) => event.traceId === TEST_TRACE_ID)).toHaveLength(2);
   });
 
   describe("shouldCompact", () => {
@@ -208,8 +214,9 @@ describe("Compaction", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(false);
       expect(result.removedCount).toBe(0);
@@ -226,8 +233,9 @@ describe("Compaction", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 4,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(true);
       expect(result.removedCount).toBe(6);
@@ -251,8 +259,9 @@ describe("Compaction", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(true);
       expect(result.messages).toHaveLength(6);
@@ -274,8 +283,9 @@ describe("Compaction", () => {
           protectRecentMessages: 4,
           onSummarize: async () => "Summary of removed messages",
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(true);
       const allTexts = result.messages.flatMap((m) =>
@@ -292,8 +302,9 @@ describe("Compaction", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 6,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(false);
     });
@@ -321,8 +332,9 @@ describe("Compaction", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 3,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(true);
       expect(result.messages[0]?.info.role).toBe("user");
@@ -350,8 +362,9 @@ describe("Compaction", () => {
           contextWindowTokens: 1000,
           protectRecentMessages: 3,
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(false);
       expect(result.blocked).toBe("no_user_boundary");
@@ -378,8 +391,9 @@ describe("Compaction", () => {
           protectRecentMessages: 3,
           onSummarize: async () => "anchored",
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       expect(result.compacted).toBe(true);
       expect(result.removedCount).toBe(5);
@@ -398,8 +412,9 @@ describe("Compaction", () => {
           protectRecentMessages: 4,
           onSummarize: async () => "summary",
         },
-        { traceId: TEST_TRACE_ID },
+        { traceId: TEST_TRACE_ID, sessionId: "test" },
         Bus,
+        { trigger: "threshold" },
       );
       const summary = result.messages[0];
       expect(summary?.info.role).toBe("user");

--- a/packages/agent/test/compaction/policy.test.ts
+++ b/packages/agent/test/compaction/policy.test.ts
@@ -13,6 +13,7 @@ function baseCtx(
     timing: "turn.finish",
     pointId: "run.completion.pre",
     traceContext: { traceId: "trace-builtin-test" },
+    sessionId: "session-builtin-test",
     steps: [],
     usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     turnCount: 0,

--- a/packages/agent/test/compaction/reduce.test.ts
+++ b/packages/agent/test/compaction/reduce.test.ts
@@ -109,7 +109,7 @@ describe("elideToolOutputs", () => {
 });
 
 describe("Compaction.compact with elision configured", () => {
-  const trace = { traceId: "trace-reduce" };
+  const trace = { traceId: "trace-reduce", sessionId: "session-reduce" };
 
   it("reduces instead of cutting while there is something to elide", async () => {
     const sink = collector();
@@ -125,6 +125,8 @@ describe("Compaction.compact with elision configured", () => {
       { contextWindowTokens: 100, protectRecentMessages: 2, elideToolOutputs: options },
       trace,
       sink,
+
+      { trigger: "threshold" },
     );
 
     expect(result.compacted).toBe(true);
@@ -147,6 +149,8 @@ describe("Compaction.compact with elision configured", () => {
       { contextWindowTokens: 100, protectRecentMessages: 2, elideToolOutputs: options },
       trace,
       sink,
+
+      { trigger: "threshold" },
     );
 
     expect(result.compacted).toBe(true);
@@ -199,7 +203,8 @@ describe("Compaction.compact with elision configured", () => {
       { contextWindowTokens: 100, protectRecentMessages: 2, elideToolOutputs: options },
       trace,
       sink,
-      10_000, // measured: overage ~9920 tokens; elision nets 439 chars ≈ 110 tokens
+
+      { trigger: "threshold", measuredTokens: 10_000 }, // measured: overage ~9920 tokens; elision nets 439 chars ≈ 110 tokens
     );
 
     expect(result.compacted).toBe(true);
@@ -221,7 +226,8 @@ describe("Compaction.compact with elision configured", () => {
       { contextWindowTokens: 100, protectRecentMessages: 2, elideToolOutputs: options },
       trace,
       sink,
-      100, // measured: overage 20 tokens; elision nets 439 chars ≈ 110 tokens
+
+      { trigger: "threshold", measuredTokens: 100 }, // measured: overage 20 tokens; elision nets 439 chars ≈ 110 tokens
     );
 
     expect(result.compacted).toBe(true);

--- a/packages/agent/test/core/execution/compaction-lifecycle.test.ts
+++ b/packages/agent/test/core/execution/compaction-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { Operational } from "@openomni/protocol";
+import { AgentExecution } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { PolicyEngine } from "../../../src/core/policy";
 import { createCompactionPolicy } from "../../../src/compaction";
@@ -44,7 +44,7 @@ describe("compaction through the lifecycle", () => {
 
   it("files the compaction record under the run's trace, not a minted one", async () => {
     const seen: Array<{ traceId: string }> = [];
-    const unsubscribe = Bus.subscribe(Operational.Info, (event) => {
+    const unsubscribe = Bus.subscribe(AgentExecution.CompactionStarted, (event) => {
       seen.push(event as unknown as { traceId: string });
     });
     const engine = PolicyEngine.create();

--- a/packages/openomni/test/execution-runtime/compaction-policy-plan.test.ts
+++ b/packages/openomni/test/execution-runtime/compaction-policy-plan.test.ts
@@ -81,6 +81,7 @@ function baseCtx(overrides?: Partial<Parameters<PolicyFn>[0]>): Parameters<Polic
     timing: "turn.finish",
     pointId: "run.completion.pre",
     traceContext: { traceId: "trace-builtin-test" },
+    sessionId: "session-builtin-test",
     steps: [],
     usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     turnCount: 0,

--- a/packages/openomni/test/execution-runtime/compaction-registration.test.ts
+++ b/packages/openomni/test/execution-runtime/compaction-registration.test.ts
@@ -96,6 +96,7 @@ describe("registerCompaction", () => {
       timing: "turn.finish",
       pointId: "run.completion.pre",
       traceContext: { traceId: "trace-registry-inject" },
+      sessionId: "session-registry-inject",
       steps: [],
       usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
       turnCount: 0,

--- a/packages/protocol/src/event/agent-execution.ts
+++ b/packages/protocol/src/event/agent-execution.ts
@@ -55,6 +55,42 @@ export namespace AgentExecution {
     { visibility: "llm_reason" },
   );
 
+  /**
+   * The compaction lock bracket. `started` is published before any
+   * compaction work; `completed` is the operation's last record on every
+   * exit path, a summarizer throw included (`outcome: "failed"`). A started
+   * row without a completed row therefore diagnoses a run that died inside
+   * compaction — previously indistinguishable from an unexplained
+   * fail-closed deny. The existing `agent.compaction` event remains the
+   * apply-phase record at the effect seam.
+   */
+  export const CompactionStarted = BusEvent.define(
+    "agent.compaction.started",
+    AgentBase.extend({
+      messagesBefore: z.number(),
+      /** Provider-measured context of the last call; absent when unmeasured. */
+      contextTokens: z.number().optional(),
+      /** What fired the seam: the threshold gate or the loop's window yield. */
+      trigger: z.enum(["threshold", "yield"]),
+      /** Whether a summarizer is configured — the crash-risk half. */
+      summarizer: z.boolean(),
+    }),
+    { visibility: "internal" },
+  );
+
+  export const CompactionCompleted = BusEvent.define(
+    "agent.compaction.completed",
+    AgentBase.extend({
+      outcome: z.enum(["cut", "reduced", "nothing_reclaimed", "no_user_boundary", "failed"]),
+      messagesBefore: z.number(),
+      messagesAfter: z.number(),
+      removedCount: z.number(),
+      elidedChars: z.number(),
+      error: z.string().optional(),
+    }),
+    { visibility: "internal" },
+  );
+
   export const ErrorRetry = BusEvent.define(
     "agent.error.retry",
     AgentBase.extend({

--- a/packages/protocol/test/agent-execution.test.ts
+++ b/packages/protocol/test/agent-execution.test.ts
@@ -63,6 +63,68 @@ describe("AgentExecution BusEvents", () => {
     ).not.toThrow();
   });
 
+  test("CompactionStarted parses, with and without measurement", () => {
+    expect(() =>
+      AgentExecution.CompactionStarted.schema.parse({
+        ...base,
+        messagesBefore: 20,
+        contextTokens: 180_000,
+        trigger: "threshold",
+        summarizer: false,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      AgentExecution.CompactionStarted.schema.parse({
+        ...base,
+        messagesBefore: 20,
+        trigger: "yield",
+        summarizer: true,
+      }),
+    ).not.toThrow();
+  });
+
+  test("CompactionStarted rejects an unknown trigger", () => {
+    expect(() =>
+      AgentExecution.CompactionStarted.schema.parse({
+        ...base,
+        messagesBefore: 20,
+        trigger: "manual",
+        summarizer: false,
+      }),
+    ).toThrow();
+  });
+
+  test("CompactionCompleted parses every outcome; rejects unknown ones", () => {
+    for (const outcome of [
+      "cut",
+      "reduced",
+      "nothing_reclaimed",
+      "no_user_boundary",
+      "failed",
+    ] as const) {
+      expect(() =>
+        AgentExecution.CompactionCompleted.schema.parse({
+          ...base,
+          outcome,
+          messagesBefore: 20,
+          messagesAfter: 5,
+          removedCount: 15,
+          elidedChars: 0,
+        }),
+      ).not.toThrow();
+    }
+    expect(() =>
+      AgentExecution.CompactionCompleted.schema.parse({
+        ...base,
+        outcome: "partial",
+        messagesBefore: 20,
+        messagesAfter: 5,
+        removedCount: 15,
+        elidedChars: 0,
+      }),
+    ).toThrow();
+  });
+
   /** One field at a time, or relaxing either alone still throws on the other. */
   test.each(["reason", "backoffMs"] as const)("ErrorRetry requires %s", (field) => {
     const payload: Record<string, unknown> = {


### PR DESCRIPTION
## Issue and contract

Leaf 3 of #698 (agent-core upstream adoption wave). Source insight: deepseek-harness brackets every compaction in log-only start/end events with the end released last, so a crash mid-compaction is a detectable orphaned lock rather than silent loss.

## What changed and why

Compaction's compute phase — where the summarizer (an LLM call) can hang or throw — had **zero persisted trace**: its two `Operational.Info` publishes are ephemeral by visibility, and the only persisted record (`agent.compaction`, apply-phase, unchanged by this PR) fires after the effect applies. A run that died inside compaction was indistinguishable from an unexplained fail-closed deny at `run.completion.pre`.

New vocabulary (2 additive members in `AgentExecution`, both `internal` visibility — no existing schema touched):

- **`agent.compaction.started`** — published before any work: messagesBefore, measured contextTokens, trigger (`threshold`|`yield`), whether a summarizer is configured (the crash-risk half).
- **`agent.compaction.completed`** — the operation's last record on **every** exit path, closed outcome vocabulary: `cut` / `reduced` (elision sufficed) / `nothing_reclaimed` / `no_user_boundary` / `failed`. A summarizer throw closes the bracket as `failed` (error message attached) and propagates unchanged into the fail-closed contract.

Diagnostics this buys: started-without-completed = died inside compute (summarizer); completed(cut)-without-`agent.compaction` = died/denied between compute and apply. Leaf 4 (replacement history) extends the apply-phase record next.

Also: `compact()` now takes the run identity (`traceId` + `sessionId`, required by type — same rationale as the trace parameter's original extraction) and per-dispatch facts (`trigger`, `measuredTokens`); the policy guards a missing sessionId exactly like a missing trace (skip + `compaction_skipped_no_session`, never a run kill); the two ephemeral Infos are deleted with their data absorbed into the bracket (an ephemeral→persisted upgrade, not a loss).

## Verification

- Red-first: the four bracket pins (cut, summarizer-throw→failed, no_user_boundary, nothing_reclaimed) failed 4/4 before the implementation.
- `bun test packages/agent packages/protocol` — 1022 pass / 0 fail (all pre-existing compaction/lifecycle/bench call sites updated to the new signature).
- `check-types` (all 14), biome clean, `lint-guards`, `lint-tools` (vocab ratchet + schema snapshot pass — additive event members do not touch the tool snapshot; the #698 Owner authorization covers the vocabulary widening regardless), `check-deps`, `check-ledger-schema-drift` — green.

## Residual risk

The bracket lives on the observation plane (bus_event) — a hard process kill between publish and persistence flush can still drop it; leaf 2's flush-barrier narrows that to abrupt SIGKILL. Authoritative stores are unaffected by design.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists compaction’s compute phase with a lock bracket: emits `agent.compaction.started` before work and `agent.compaction.completed` on every exit. Previously only the apply-phase `agent.compaction` persisted, making mid-compaction crashes indistinguishable from fail-closed denies; summarizer throws now close the bracket as failed and still propagate.

- Compaction now publishes `AgentExecution.CompactionStarted`/`CompactionCompleted` from `@openomni/protocol` and removes prior `Operational.Info` emits during compaction.
- `Compaction.compact` requires identity `{ traceId, sessionId }` and dispatch `{ trigger: 'threshold' | 'yield', measuredTokens? }`.

**Migration**
- Update all calls to `Compaction.compact(messages, options, identity, events, dispatch)` to pass `sessionId` and `dispatch.trigger`; `dispatch.measuredTokens` is optional.
- Dispatchers/policies must provide `sessionId`; when `traceId` or `sessionId` is missing, compaction is skipped with `compaction_skipped_no_trace` or `compaction_skipped_no_session` (tests in `openomni` now include `sessionId`).
- Subscribe to `AgentExecution.CompactionStarted` and `AgentExecution.CompactionCompleted`; stop relying on compaction `Operational.Info`.

**Event details**
- `CompactionStarted`: records `messagesBefore`, optional `contextTokens`, `trigger`, and whether a summarizer is configured.
- `CompactionCompleted`: outcome is one of `cut`, `reduced`, `nothing_reclaimed`, `no_user_boundary`, `failed`; includes `messagesBefore/After`, `removedCount`, and `elidedChars`. Summarizer errors emit `failed` and rethrow.

<sup>Written for commit 3f6f2f100a74f939719593a7840278613b637cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed compaction lifecycle events for start and completion.
  * Compaction events now include trigger source, context measurements, outcomes, message counts, reclaimed content, and errors.
  * Benchmark traces now include session identification.

* **Bug Fixes**
  * Improved compaction handling when session or trace information is unavailable.
  * Preserved summarization errors while reporting completion status.

* **Tests**
  * Expanded coverage for successful, skipped, refused, no-op, and failed compaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->