### PR TITLE
feat(protocol,openomni,server): effect intents carry a replay tag

### DIFF
--- a/apps/server/src/bootstrap/effects.ts
+++ b/apps/server/src/bootstrap/effects.ts
@@ -27,6 +27,8 @@ import { Bus } from "@openomni/telemetry";
  */
 const crashAfterIntent: EffectDriver = {
   kind: "crash-after-intent",
+  // Models the crash window itself — re-execution would falsify the scenario.
+  replay: "never",
   execute: () => ({ kind: "unknown", reason: "simulated crash between intent and outcome" }),
   reconcile: () => ({
     kind: "confirmed",
@@ -37,6 +39,7 @@ const crashAfterIntent: EffectDriver = {
 /** Definite failure — observably distinct from `unknown`: a terminal fact IS recorded. */
 const definiteFailure: EffectDriver = {
   kind: "definite-failure",
+  replay: "never",
   execute: () => ({ kind: "failed", reason: "definite failure (scenario)" }),
   reconcile: () => ({ kind: "failed", reason: "definite failure (scenario)" }),
 };
@@ -44,6 +47,7 @@ const definiteFailure: EffectDriver = {
 /** Unprovable outcome — stays outcome-less and reconcilable across sweeps, never terminalized. */
 const unknownResult: EffectDriver = {
   kind: "unknown-result",
+  replay: "never",
   execute: () => ({ kind: "unknown", reason: "outcome unprovable (scenario)" }),
   reconcile: () => ({ kind: "unknown", reason: "outcome unprovable (scenario)" }),
 };
@@ -51,6 +55,8 @@ const unknownResult: EffectDriver = {
 /** Owner-driven manual effect: confirms immediately; input is boundary-checked below. */
 const manualDriver: EffectDriver = {
   kind: "manual",
+  // In-process idempotent confirm — the one live "safe" row for Manual QA.
+  replay: "safe",
   execute: () => ({ kind: "confirmed", receipt: "manual effect confirmed" }),
   reconcile: () => ({ kind: "confirmed", receipt: "manual effect confirmed (reconciled)" }),
 };
@@ -63,6 +69,7 @@ const manualDriver: EffectDriver = {
  */
 const exhaustingProbe: EffectDriver = {
   kind: "exhausting-probe",
+  replay: "never",
   execute: () => ({ kind: "unknown", reason: "outcome unprovable (scenario)" }),
   reconcile: () => ({
     kind: "unknown",

--- a/packages/openomni/src/effect/driver.ts
+++ b/packages/openomni/src/effect/driver.ts
@@ -29,6 +29,14 @@ export type EffectExecution =
 
 export interface EffectDriver {
   readonly kind: string;
+  /**
+   * The driver's replay declaration, stamped into the intent fact at record
+   * time (senpi's per-record replay tag, adopted via #698): "safe" means a
+   * replay/recovery consumer may re-execute this effect under its
+   * idempotency key; "never" means recorded outcomes are read back only.
+   * Required by type — every driver decides, none defaults.
+   */
+  readonly replay: "never" | "safe";
   execute(intent: EffectIntent, input: unknown): Promise<EffectExecution> | EffectExecution;
   reconcile(intent: EffectIntent): Promise<EffectExecution> | EffectExecution;
 }

--- a/packages/openomni/src/effect/lifecycle.ts
+++ b/packages/openomni/src/effect/lifecycle.ts
@@ -51,6 +51,9 @@ export class EffectService {
     const intended = EffectStore.intend({
       effectId: request.effectId,
       kind: request.kind,
+      // The driver's replay declaration rides the intent fact so replay and
+      // recovery read the judgment from the ledger, never re-derive it.
+      replay: driver.replay,
       ...(request.target === undefined ? {} : { target: request.target }),
       ...(request.workItemHash === undefined ? {} : { workItemHash: request.workItemHash }),
       ...(request.attemptId === undefined ? {} : { attemptId: request.attemptId }),

--- a/packages/openomni/test/effect/replay-tag.test.ts
+++ b/packages/openomni/test/effect/replay-tag.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EffectStore, SqliteStorageAdapter, Storage } from "@openomni/session";
+import {
+  EffectManifest,
+  EffectService,
+  type EffectDriver,
+  type EffectExecution,
+  type EffectIntent,
+} from "../../src/effect/index.js";
+
+let adapter: SqliteStorageAdapter | undefined;
+
+beforeEach(() => {
+  adapter = new SqliteStorageAdapter(":memory:");
+  Storage.configure(adapter);
+});
+
+afterEach(() => {
+  Storage.reset();
+  adapter?.close();
+  adapter = undefined;
+});
+
+function driverWith(replay: "never" | "safe"): EffectDriver {
+  return {
+    kind: `tagged.${replay}`,
+    replay,
+    execute: (): EffectExecution => ({ kind: "confirmed", receipt: "ok" }),
+    reconcile: (_intent: EffectIntent): EffectExecution => ({ kind: "confirmed", receipt: "ok" }),
+  };
+}
+
+/**
+ * The replay tag is written at record time, by the one party that knows the
+ * effect's nature — the driver. A replay or recovery consumer reads the
+ * ledger, never re-derives the judgment; a row recorded before the
+ * vocabulary existed has no tag and MUST be treated as "never".
+ */
+describe("effect replay tag", () => {
+  test("the intent row carries the driver's declared replay tag", async () => {
+    for (const replay of ["never", "safe"] as const) {
+      const driver = driverWith(replay);
+      const manifest = new EffectManifest();
+      manifest.register(driver);
+      const service = new EffectService(manifest);
+
+      await service.run({ effectId: `effect-${replay}`, kind: driver.kind });
+
+      const recorded = EffectStore.terminalIntents().find(
+        (terminal) => terminal.intent.effectId === `effect-${replay}`,
+      );
+      expect(recorded?.intent.replay).toBe(replay);
+    }
+  });
+
+  test("a replayed idempotency hit does not rewrite the recorded tag", async () => {
+    const driver = driverWith("safe");
+    const manifest = new EffectManifest();
+    manifest.register(driver);
+    const service = new EffectService(manifest);
+
+    await service.run({ effectId: "effect-stable", kind: driver.kind });
+    await service.run({ effectId: "effect-stable", kind: driver.kind });
+
+    const recorded = EffectStore.terminalIntents().find(
+      (terminal) => terminal.intent.effectId === "effect-stable",
+    );
+    expect(recorded?.intent.replay).toBe("safe");
+  });
+});

--- a/packages/openomni/test/effect/service.test.ts
+++ b/packages/openomni/test/effect/service.test.ts
@@ -27,6 +27,7 @@ afterEach(() => {
 
 /** A programmable driver: `execute`/`reconcile` return whatever is queued, recording calls. */
 class ScriptedDriver implements EffectDriver {
+  readonly replay = "never" as const;
   executeCalls = 0;
   reconcileCalls = 0;
   constructor(

--- a/packages/protocol/src/ledger-append/streams.ts
+++ b/packages/protocol/src/ledger-append/streams.ts
@@ -150,6 +150,15 @@ export const EffectIntended = z
     target: z.string().min(1).optional(),
     workItemHash: z.string().min(1).optional(),
     attemptId: z.string().min(1).optional(),
+    /**
+     * Whether a replay/recovery consumer may re-execute this effect ("safe")
+     * or must only read back its recorded outcome ("never"). Written at
+     * record time by the effect service from the driver's declaration — the
+     * one party that knows the effect's nature. Optional ONLY as a
+     * persisted-data boundary: rows recorded before this vocabulary existed
+     * carry no tag, and every consumer must treat absence as "never".
+     */
+    replay: z.enum(["never", "safe"]).optional(),
   })
   .strict();
 export type EffectIntended = z.infer<typeof EffectIntended>;

--- a/script/conformance/p2-effects-reconciliation.test.ts
+++ b/script/conformance/p2-effects-reconciliation.test.ts
@@ -99,6 +99,7 @@ describe("p2 effects conformance (#492)", () => {
     const manifest = new EffectManifest();
     manifest.register({
       kind: "observed",
+      replay: "never",
       execute: (intent) => {
         // Record-before-act: at the moment the driver runs, the intent fact
         // is already durable on the stream.
@@ -168,6 +169,7 @@ describe("p2 effects conformance (#492)", () => {
     const manifest = new EffectManifest();
     manifest.register({
       kind: "count-executions",
+      replay: "never",
       execute: () => {
         executions += 1;
         return { kind: "confirmed", receipt: "first" };

--- a/script/conformance/p2-ledger-baseline.test.ts
+++ b/script/conformance/p2-ledger-baseline.test.ts
@@ -1889,6 +1889,7 @@ describe("p2 ledger baseline — effect decision-class facts (intent/outcome)", 
     const manifest = new EffectManifest();
     manifest.register({
       kind: driver.kind,
+      replay: "never",
       execute: driver.execute,
       reconcile: () => ({ kind: "unknown" }),
     });


### PR DESCRIPTION
## Issue and contract

Leaf 5 of #698 (agent-core upstream adoption wave). Source insight: senpi's `ToolStartedRecord.replay: "never" | "safe"` — per-record replayability written at record time, so replay/recovery consumers read the judgment from the ledger instead of re-deriving it.

## What changed and why

- **`EffectDriver.replay: "never" | "safe"`** — required by type; every driver decides, none defaults. The driver is the one party that knows the effect's nature.
- **`EffectService.run` stamps `replay: driver.replay` into the intent fact** at record time, beside the identity. A replayed idempotency hit never rewrites the recorded tag (the CAS append writes nothing on conflict — the ledger row is the authority; note the in-memory IntendResult.intent on a conflict carries the caller input, and the named future consumers read via outstandingIntents/terminalIntents which parse the ledger row).
- **`LedgerAppend.EffectIntended` gains `replay` as an optional field** — optional strictly as a persisted-data boundary: rows recorded before this vocabulary carry no tag, and the schema documents that every consumer must treat absence as "never" (conservative reading stated at the boundary, never defaulted in silently).
- Production drivers declared: `manual` → `safe` (in-process idempotent confirm — gives Manual QA a live "safe" row); the four crash/failure/unknown scenario drivers → `never` (re-execution would falsify the scenarios they model).

Named future consumers (recorded, not yet consumed — same forward-hygiene precedent as #659's PendingAsk traceId): the #493 replay engine, the effect reconciler ("safe" pending intents could re-execute instead of probing), durable Wait resume (#215).

## Verification

- Red-first: both replay-tag pins failed (2/2) before the implementation.
- Full repo suite: 3569 pass / 0 fail. Types clean including the `script/` surface (the pre-push hook caught two conformance driver literals turbo's package scope missed — fixed and covered).
- biome, `lint-tools` (schema snapshot untouched — ledger stream payloads are not the tool snapshot surface), `lint-guards`, `check-deps`, `check-ledger-schema-drift` (payload field, no DDL) — green.
- Vocabulary widening is Owner-authorized via the #698 batch instruction.

## Residual risk

The tag is declared per driver-kind, not per call. If a future driver's replayability depends on the input (same kind, sometimes safe), the declaration moves to a per-request override at that point — today no such driver exists and the narrower surface is the safer default.
