### PR TITLE
feat(protocol): gateway stage 0 contracts

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -151,7 +151,7 @@ Flow: external message → ingress resolves the actor → the Resident judges *d
 
 **Tier 1 (philosophy, exactly ten):** Actor, Gate, Ledger, Evidence, Stakes, Owner, Resident, Worker, Jester, Governor.
 
-**Tier 2 (specification):** authority profile and its fields (TrustTier, Grant, SocialBudget, voice register, Blacklist), ActorIdentity, Endpoint, Channel, Surface, Command, Lane, Subagent, Policy and policy points, Wait, Session, Transcript, WorkItem, CompletionReport, Receipt, Memory, Outcome, Voice.
+**Tier 2 (specification):** authority profile and its fields (TrustTier, Grant, SocialBudget, voice register, Blacklist), ActorIdentity, Endpoint, Channel, Surface, Gateway (the perimeter seam — Owner addition 2026-08-19, [gateway-design.md](gateway-design.md)), Command, Lane, Subagent, Policy and policy points, Wait, Session, Transcript, WorkItem, CompletionReport, Receipt, Memory, Outcome, Voice.
 
 **Tier 3 (implementation):** packages and modules — see [Architecture](architecture.md). `IngressEngine`, `DispatchRuntime`, `DispatchHandler`, `ActorRegistry`, `EventProjector`, `Connector` are module names, never concepts.
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -42,8 +42,8 @@ only in protocol contracts, wired by apps/server through injected ports.**
 ```
 {
   sessionId: string,            // opaque routing label to the gateway (S1)
-  message: {                    // Gateway.InboundMessage — "envelope" is a
-    messageId, traceId,         //   banned identifier (#465 demotions)
+  message: {                    // Gateway.InboundMessage — "Envelope" is demoted
+    messageId, traceId,         //   to a wire-format word, not a concept (#465)
     surfaceKey,                 // e.g. telegram:bot:chat:123 — origin identity
     text, media?, threadId?, replyToId?,
   },
@@ -121,7 +121,7 @@ delivery effect), platform-id re-key after delivery.
 - **Reply-scoped grant** (case-discovered 2026-08-19): `SenderTargetGrant`
   requires a known `targetActorId`, which cannot be pre-written for unknown
   initiators (marketplace inquiries). Provenance stays Owner: the Owner
-  writes a *reply-grant rule row* (channel-scoped, part of a standing
+  writes a *reply-grant rule row* (surface- or channel-scoped, part of a standing
   delegation); the gateway then materializes grant **instances** from it
   mechanically when it admits a first-contact actor on the covered channel.
   Instances are scoped by **perimeter facts only** — initiator actorId +

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -42,8 +42,8 @@ only in protocol contracts, wired by apps/server through injected ports.**
 ```
 {
   sessionId: string,            // opaque routing label to the gateway (S1)
-  envelope: {
-    messageId, traceId,         // trace minted at the driver's first frame (D11)
+  message: {                    // Gateway.InboundMessage — "envelope" is a
+    messageId, traceId,         //   banned identifier (#465 demotions)
     surfaceKey,                 // e.g. telegram:bot:chat:123 — origin identity
     text, media?, threadId?, replyToId?,
   },

--- a/packages/openomni/src/messaging/schema.ts
+++ b/packages/openomni/src/messaging/schema.ts
@@ -1,159 +1,34 @@
-import type { Wait } from "@openomni/protocol";
-import { Wait as WaitSchemas } from "@openomni/protocol";
-import { z } from "zod";
+import { Gateway } from "@openomni/protocol";
 
 /**
- * Existing-agent messaging definitions (#215): the policy-plane sender-target
- * grant, the explicit-target send input, and the deterministic send receipt.
+ * Existing-agent messaging definitions (#215). The schema vocabulary was
+ * re-homed to `protocol` as the `Gateway.Send` contract (gateway stage 0,
+ * #706 — docs/gateway-design.md §2b); this module re-exports it unchanged
+ * for the kernel's consumers until stage 2 moves the kernel itself into
+ * `@openomni/channels`.
  *
- * The vocabulary is deliberately non-allocating: a grant bounds exactly one
- * sender to one existing target actor plus an operation set, and cannot
- * express Worker creation, delegation, WorkItem/executor assignment, budget,
- * or authority transfer — those capabilities simply do not exist here.
- * Kernel-local by design: messaging has a single kernel consumer, and the
- * blueprint's 13 protocol domains do not include messaging.
+ * `resolveSenderTargetGrant` stays here on purpose: grant EVALUATION is
+ * forbidden in protocol (contract boundary — schemas and pure folds only,
+ * never authority evaluation). It moves to the gateway router at stage 2.
  */
 
-export const MessageOperation = z.enum(["fire_and_forget", "awaited"]);
-export type MessageOperation = z.infer<typeof MessageOperation>;
+export const MessageOperation = Gateway.MessageOperation;
+export type MessageOperation = Gateway.MessageOperation;
 
-/**
- * Explicit target: always one existing actor; an optional endpoint pin
- * disambiguates actors reachable at more than one endpoint. There is no
- * broadcast or wildcard form — resolution yields exactly one delivery
- * address or a typed denial.
- */
-export const MessageTarget = z
-  .object({
-    actorId: z.string().min(1),
-    endpointId: z.string().min(1).optional(),
-  })
-  .strict();
-export type MessageTarget = z.infer<typeof MessageTarget>;
+export const MessageTarget = Gateway.MessageTarget;
+export type MessageTarget = Gateway.MessageTarget;
 
-export const SenderTargetGrant = z
-  .object({
-    id: z.string().min(1),
-    senderId: z.string().min(1),
-    targetActorId: z.string().min(1),
-    operations: z.array(MessageOperation).min(1),
-    expiresAt: z.number().optional(),
-  })
-  .strict();
-export type SenderTargetGrant = z.infer<typeof SenderTargetGrant>;
+export const SenderTargetGrant = Gateway.SenderTargetGrant;
+export type SenderTargetGrant = Gateway.SenderTargetGrant;
 
-/**
- * Typed denial taxonomy — callers branch on `code`, never message text.
- * Ungranted, missing, stale, and ambiguous targets all fail closed with an
- * unchanged allocation/authority surface (nothing is created or guessed).
- * `wait_duplicate` is the awaited-delivery exactly-once rule surfacing as a
- * denial: a Wait already exists for the message (or wait id), so nothing is
- * delivered and nothing changes.
- */
-export const MessageDenialCode = z.enum([
-  "ungranted",
-  "target_missing",
-  "target_stale",
-  "target_ambiguous",
-  "wait_duplicate",
-]);
-export type MessageDenialCode = z.infer<typeof MessageDenialCode>;
+export const MessageDenialCode = Gateway.MessageDenialCode;
+export type MessageDenialCode = Gateway.MessageDenialCode;
 
-/**
- * The Wait an awaited delivery opens. Quorum/resolution-policy coherence is
- * NOT re-refined here — `Wait.Record.parse` at WaitStore.create is the one
- * enforcement layer for that invariant (#215 rule 4).
- */
-const AwaitSpec = z
-  .object({
-    waitId: z.string().min(1),
-    ownerRef: WaitSchemas.OwnerRef,
-    allowedActions: z.array(WaitSchemas.AllowedAction).min(1),
-    expectedResponders: z.array(z.string().min(1)).min(1),
-    resolutionPolicy: WaitSchemas.ResolutionPolicy,
-    quorum: WaitSchemas.Quorum.optional(),
-    expiresAt: z.number(),
-    followUpWindow: z.number().int().nonnegative(),
-    /** Extra correlation fields (threadId, channelId, …); endpointId and replyToMessageId are derived from the delivery itself. */
-    correlation: WaitSchemas.Correlation.optional(),
-  })
-  .strict();
+export const SendInput = Gateway.SendInput;
+export type SendInput = Gateway.SendInput;
 
-const SendInputBase = z
-  .object({
-    /** Outbound message identity: doubles as the Wait's originMessageId, whose UNIQUE column pins "exactly one Wait per awaited message". */
-    messageId: z.string().min(1),
-    /** The sender flow's trace: every event this send leaves files under it. */
-    traceId: z.string().min(1),
-    senderId: z.string().min(1),
-    target: MessageTarget,
-    operation: MessageOperation,
-    body: z.string().min(1),
-    /** Injected timestamp — messaging never reads the wall clock. */
-    at: z.number(),
-    waitSpec: AwaitSpec.optional(),
-  })
-  .strict();
-
-export const SendInput = SendInputBase.superRefine((input, ctx) => {
-  if (input.operation === "awaited" && input.waitSpec === undefined) {
-    ctx.addIssue({
-      code: "custom",
-      message: "awaited operation requires a waitSpec",
-      path: ["waitSpec"],
-    });
-  }
-  if (input.operation === "fire_and_forget" && input.waitSpec !== undefined) {
-    ctx.addIssue({
-      code: "custom",
-      message: "fire_and_forget never opens a Wait — waitSpec is not allowed",
-      path: ["waitSpec"],
-    });
-  }
-});
-export type SendInput = z.infer<typeof SendInput>;
-
-/** The one allocated delivery address a target resolves to. */
-export type DeliveryTarget = Readonly<{
-  actorId: string;
-  endpointId: string;
-  channel: string;
-  externalId: string;
-}>;
-
-/**
- * Deterministic send receipt. `sent`/`denied` and the denial code are the
- * audit facts; a `wait` is present exactly when the operation was awaited.
- */
-export type SendReceipt =
-  | Readonly<{
-      kind: "sent";
-      operation: "fire_and_forget";
-      messageId: string;
-      senderId: string;
-      grantId: string;
-      target: DeliveryTarget;
-      at: number;
-    }>
-  | Readonly<{
-      kind: "sent";
-      operation: "awaited";
-      messageId: string;
-      senderId: string;
-      grantId: string;
-      target: DeliveryTarget;
-      wait: Wait.Record;
-      at: number;
-    }>
-  | Readonly<{
-      kind: "denied";
-      code: MessageDenialCode;
-      messageId: string;
-      senderId: string;
-      targetActorId: string;
-      reason: string;
-      at: number;
-    }>;
+export type DeliveryTarget = Gateway.DeliveryTarget;
+export type SendReceipt = Gateway.SendReceipt;
 
 /**
  * Pure policy-plane grant evaluation: returns the first (id-ordered) active

--- a/packages/openomni/src/messaging/schema.ts
+++ b/packages/openomni/src/messaging/schema.ts
@@ -49,6 +49,12 @@ export function resolveSenderTargetGrant(
     .sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0))
     .find(
       (grant) =>
+        // Fail-closed containment guard: this evaluator has no surface
+        // context, so it CANNOT check replyScope — a scope-carrying
+        // (rule-materialized) instance is resolvable only by the scope-aware
+        // gateway evaluator (stage 2). Honoring it here would silently void
+        // the containment the instance was created with.
+        grant.replyScope === undefined &&
         grant.senderId === claim.senderId &&
         grant.targetActorId === claim.targetActorId &&
         grant.operations.includes(claim.operation) &&

--- a/packages/openomni/test/messaging/reply-scope-guard.test.ts
+++ b/packages/openomni/test/messaging/reply-scope-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSenderTargetGrant } from "../../src/messaging/schema.js";
+
+const claim = {
+  senderId: "persona-1",
+  targetActorId: "seller-1",
+  operation: "awaited",
+  at: 1_000,
+} as const;
+
+describe("resolveSenderTargetGrant — replyScope containment guard", () => {
+  test("a scope-carrying (rule-materialized) instance is NOT resolvable here", () => {
+    // This evaluator has no surface context, so it cannot check replyScope
+    // containment — honoring the grant would silently void it (fail-closed;
+    // the scope-aware gateway evaluator owns these from stage 2).
+    const scoped = {
+      id: "g-1",
+      senderId: "persona-1",
+      targetActorId: "seller-1",
+      operations: ["awaited" as const],
+      expiresAt: 2_000,
+      ruleId: "r-1",
+      replyScope: { surfaceKey: "junggonara:chat:777" },
+    };
+    expect(resolveSenderTargetGrant([scoped], claim)).toBeUndefined();
+  });
+
+  test("a standing grant without replyScope still resolves", () => {
+    const standing = {
+      id: "g-2",
+      senderId: "persona-1",
+      targetActorId: "seller-1",
+      operations: ["awaited" as const],
+    };
+    expect(resolveSenderTargetGrant([standing], claim)?.id).toBe("g-2");
+  });
+});

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -20,6 +20,7 @@ src/
 ├── dispatch/             # Dispatch.Command / Actions / ActorContext / target schemas
 ├── error/                # NamedError factory + built-in error classes (incl. WorkerDeliveryError, #478)
 ├── event/                # Typed event descriptors: agent-execution, ingress, llm, mcp, operational, policy, tool
+├── gateway/              # Gateway.Deliver / Send / WaitControl contracts + ReplyGrantRule (gateway stage 0, #706 — the channels↔openomni seam)
 ├── execution/            # Execution.Request / Result contracts + Execution.Driver command face (#478)
 ├── ingress/              # InboundEvent discriminated union (DirectEvent | InternalEvent), AgentDef, IngressResult, ResolvedInboundEvent
 ├── ipc/                  # IPC request/response schemas and worker transport contracts
@@ -114,4 +115,4 @@ Future WorkItem-attempt and Jester-evaluation shapes are contracts only: they ad
 
 _Edited 2026-08-10 per Owner-approved clean-room corpus (local docs/corpus, session record)._
 
-_2026-08-19: gateway stage 0 (docs/gateway-design.md §2) will add `Gateway.Deliver` / `Gateway.Send` contract schemas and the perimeter/conduct trust vocabulary here; perimeter store row schemas migrate here under the SSOT directive. Target only — not yet wired._
+_2026-08-19: gateway stage 0 (#706) landed `gateway/` — `Gateway.Deliver`/`Send`/`WaitControl` contracts, `ReplyGrantRule`, perimeter/conduct trust vocabulary (docs/gateway-design.md §2–§3). `openomni/messaging/schema.ts` re-exports the Send vocabulary from here; grant EVALUATION stays above protocol (contract boundary). Wiring lands at gateway stage 2+._

--- a/packages/protocol/src/gateway/index.ts
+++ b/packages/protocol/src/gateway/index.ts
@@ -1,0 +1,1 @@
+export { Gateway } from "./schema.js";

--- a/packages/protocol/src/gateway/schema.ts
+++ b/packages/protocol/src/gateway/schema.ts
@@ -31,11 +31,18 @@ const OriginSchema = z
  * `trustTier`/`inboundTreatment` verbatim (perimeter output = conduct input)
  * and frames `evidence_only` turns as evidence, never as user commands.
  */
+const DeliveredTreatmentSchema = z.enum(["full_access", "evidence_only"]);
+
 const ActorContextSchema = z
   .object({
     actorId: z.string().min(1).optional(),
     trustTier: Actor.TrustTier,
-    inboundTreatment: Actor.InboundTreatment,
+    /**
+     * Narrower than Actor.InboundTreatment on purpose: "drop" means the
+     * message was never delivered, so a Deliver stamped drop must be
+     * unrepresentable at this seam.
+     */
+    inboundTreatment: DeliveredTreatmentSchema,
     origin: OriginSchema,
   })
   .strict();
@@ -48,7 +55,10 @@ const MediaSchema = z
     mimeType: z.string().min(1).optional(),
     filename: z.string().min(1).optional(),
   })
-  .strict();
+  .strict()
+  .refine((media) => media.url !== undefined || media.filename !== undefined, {
+    message: "a media reference needs at least a url or a filename",
+  });
 
 /** The normalized message a channel driver produced from a platform payload. */
 const InboundMessageSchema = z
@@ -117,8 +127,41 @@ const SenderTargetGrantSchema = z
     targetActorId: z.string().min(1),
     operations: z.array(MessageOperationSchema).min(1),
     expiresAt: z.number().optional(),
+    /** Present iff this grant was materialized from a ReplyGrantRule — the provenance link that makes `maxLiveInstances` countable. */
+    ruleId: z.string().min(1).optional(),
+    /** Perimeter-fact scope of a materialized instance: replies stay inside the initiating container. */
+    replyScope: z
+      .object({ surfaceKey: z.string().min(1) })
+      .strict()
+      .optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((grant, ctx) => {
+    // A rule-materialized instance is always bounded: containment + expiry
+    // are what distinguish it from an Owner-written standing grant.
+    if (grant.ruleId !== undefined) {
+      if (grant.replyScope === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: "a rule-materialized grant requires replyScope (perimeter containment)",
+          path: ["replyScope"],
+        });
+      }
+      if (grant.expiresAt === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: "a rule-materialized grant requires expiresAt (instanceTtlMs bound)",
+          path: ["expiresAt"],
+        });
+      }
+    } else if (grant.replyScope !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: "replyScope without ruleId — reply containment has no owning rule",
+        path: ["ruleId"],
+      });
+    }
+  });
 
 /**
  * Owner-written rule row from which the gateway mechanically materializes

--- a/packages/protocol/src/gateway/schema.ts
+++ b/packages/protocol/src/gateway/schema.ts
@@ -1,0 +1,326 @@
+import { z } from "zod";
+import { Actor } from "../actor/index.js";
+import { Wait } from "../wait/index.js";
+
+/**
+ * Gateway contracts (docs/gateway-design.md §2, stage 0 — #706).
+ *
+ * The gateway (`@openomni/channels` after stage 2) and the brain
+ * (`@openomni/openomni`) never import each other; these schemas are the only
+ * seam, wired by apps/server through injected ports.
+ *
+ * Trust vocabulary (§3): *perimeter trust* — who may reach us / whom we may
+ * reach (admission, grants, wait correlation, egress budget) — is
+ * gateway-owned and arrives in `ActorContext` as a verdict the brain consumes
+ * verbatim. *Conduct trust* — what the agent may do once running (tool
+ * policy, completion admission, evidence) — is brain-owned and never crosses
+ * this seam. Schemas only: evaluation of either plane lives above protocol.
+ */
+
+/** Taint root for injection defense: where the content physically entered. */
+const OriginSchema = z
+  .object({
+    surface: z.string().min(1),
+    externalId: z.string().min(1),
+  })
+  .strict();
+
+/**
+ * The perimeter verdict attached to every delivery. `actorId` is absent for
+ * anonymous senders admitted via a channel defaultTier. The brain consumes
+ * `trustTier`/`inboundTreatment` verbatim (perimeter output = conduct input)
+ * and frames `evidence_only` turns as evidence, never as user commands.
+ */
+const ActorContextSchema = z
+  .object({
+    actorId: z.string().min(1).optional(),
+    trustTier: Actor.TrustTier,
+    inboundTreatment: Actor.InboundTreatment,
+    origin: OriginSchema,
+  })
+  .strict();
+
+/** Wire-shape media reference (no raw bytes at this seam). */
+const MediaSchema = z
+  .object({
+    kind: z.enum(["image", "file", "audio", "video"]),
+    url: z.string().min(1).optional(),
+    mimeType: z.string().min(1).optional(),
+    filename: z.string().min(1).optional(),
+  })
+  .strict();
+
+/** The normalized message a channel driver produced from a platform payload. */
+const InboundMessageSchema = z
+  .object({
+    messageId: z.string().min(1),
+    /** Minted at the driver's first frame (D11 origin), carried unchanged. */
+    traceId: z.string().min(1),
+    surfaceKey: z.string().min(1),
+    text: z.string(),
+    media: z.array(MediaSchema).optional(),
+    threadId: z.string().min(1).optional(),
+    replyToId: z.string().min(1).optional(),
+  })
+  .strict();
+
+/**
+ * Present iff this delivery resumed an open Wait. The expected-responder
+ * gate (§2a-1) has already run perimeter-side: a correlated message from a
+ * non-responder is delivered WITHOUT waitContext — attachment is itself the
+ * perimeter's assertion that the sender may resume this wait.
+ */
+const WaitContextSchema = z
+  .object({
+    waitId: z.string().min(1),
+    allowedAction: Wait.AllowedAction,
+    engagementId: z.string().min(1).optional(),
+  })
+  .strict();
+
+/** Inbound contract: gateway → brain. The brain needs nothing else to run. */
+const DeliverSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    message: InboundMessageSchema,
+    actorContext: ActorContextSchema,
+    waitContext: WaitContextSchema.optional(),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Outbound vocabulary — re-homed from the #215 messaging kernel verbatim
+// (openomni/messaging re-exports these until stage 2 moves the kernel).
+// Grant *evaluation* stays above protocol (grant evaluation is forbidden
+// here per the contract boundary); only the shapes live at the seam.
+// ---------------------------------------------------------------------------
+
+const MessageOperationSchema = z.enum(["fire_and_forget", "awaited"]);
+
+/**
+ * Explicit target: always one existing actor; an optional endpoint pin
+ * disambiguates actors reachable at more than one endpoint. No broadcast or
+ * wildcard form — resolution yields exactly one delivery address or a typed
+ * denial.
+ */
+const MessageTargetSchema = z
+  .object({
+    actorId: z.string().min(1),
+    endpointId: z.string().min(1).optional(),
+  })
+  .strict();
+
+const SenderTargetGrantSchema = z
+  .object({
+    id: z.string().min(1),
+    senderId: z.string().min(1),
+    targetActorId: z.string().min(1),
+    operations: z.array(MessageOperationSchema).min(1),
+    expiresAt: z.number().optional(),
+  })
+  .strict();
+
+/**
+ * Owner-written rule row from which the gateway mechanically materializes
+ * reply-scoped SenderTargetGrant instances for first-contact initiators on
+ * the covered channel (§2b). Instances are scoped by perimeter facts only
+ * (initiator actorId + originating thread/surfaceKey + `instanceTtlMs`);
+ * `maxLiveInstances` bounds grant farming by mass first contact.
+ */
+const ReplyGrantRuleSchema = z
+  .object({
+    id: z.string().min(1),
+    senderId: z.string().min(1),
+    surface: z.string().min(1),
+    workspace: z.string().min(1).optional(),
+    channel: z.string().min(1).optional(),
+    operations: z.array(MessageOperationSchema).min(1),
+    instanceTtlMs: z.number().int().positive(),
+    maxLiveInstances: z.number().int().positive(),
+    createdBy: z.string().min(1),
+    createdAt: z.number().optional(),
+    updatedAt: z.number().optional(),
+  })
+  .strict();
+
+/**
+ * Typed denial taxonomy — callers branch on `code`, never message text.
+ * Ungranted, missing, stale, and ambiguous targets all fail closed with an
+ * unchanged allocation/authority surface. `wait_duplicate` is the
+ * awaited-delivery exactly-once rule surfacing as a denial.
+ */
+const MessageDenialCodeSchema = z.enum([
+  "ungranted",
+  "target_missing",
+  "target_stale",
+  "target_ambiguous",
+  "wait_duplicate",
+]);
+
+/**
+ * The Wait an awaited delivery opens. Quorum/resolution-policy coherence is
+ * NOT re-refined here — `Wait.Record.parse` at WaitStore.create is the one
+ * enforcement layer for that invariant (#215 rule 4).
+ */
+const AwaitSpecSchema = z
+  .object({
+    waitId: z.string().min(1),
+    ownerRef: Wait.OwnerRef,
+    allowedActions: z.array(Wait.AllowedAction).min(1),
+    expectedResponders: z.array(z.string().min(1)).min(1),
+    resolutionPolicy: Wait.ResolutionPolicy,
+    quorum: Wait.Quorum.optional(),
+    expiresAt: z.number(),
+    followUpWindow: z.number().int().nonnegative(),
+    /** Extra correlation fields (threadId, channelId, …); endpointId and replyToMessageId are derived from the delivery itself. */
+    correlation: Wait.Correlation.optional(),
+  })
+  .strict();
+
+const SendInputBase = z
+  .object({
+    /** Outbound message identity: doubles as the Wait's originMessageId, whose UNIQUE column pins "exactly one Wait per awaited message". */
+    messageId: z.string().min(1),
+    /** The sender flow's trace: every event this send leaves files under it. */
+    traceId: z.string().min(1),
+    senderId: z.string().min(1),
+    target: MessageTargetSchema,
+    operation: MessageOperationSchema,
+    body: z.string().min(1),
+    /** Injected timestamp — messaging never reads the wall clock. */
+    at: z.number(),
+    waitSpec: AwaitSpecSchema.optional(),
+  })
+  .strict();
+
+const SendInputSchema = SendInputBase.superRefine((input, ctx) => {
+  if (input.operation === "awaited" && input.waitSpec === undefined) {
+    ctx.addIssue({
+      code: "custom",
+      message: "awaited operation requires a waitSpec",
+      path: ["waitSpec"],
+    });
+  }
+  if (input.operation === "fire_and_forget" && input.waitSpec !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      message: "fire_and_forget never opens a Wait — waitSpec is not allowed",
+      path: ["waitSpec"],
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Wait control — brain → gateway (§2b-1): the brain owns WHEN a wait should
+// stop mattering; the gateway owns the rows and executes the write.
+// ---------------------------------------------------------------------------
+
+const WaitControlActionSchema = z.enum(["cancel", "expire_now"]);
+
+const WaitControlSchema = z
+  .object({
+    waitId: z.string().min(1),
+    action: WaitControlActionSchema,
+    reason: z.string().min(1),
+  })
+  .strict();
+
+export namespace Gateway {
+  export const Origin = OriginSchema;
+  export type Origin = z.infer<typeof OriginSchema>;
+
+  export const ActorContext = ActorContextSchema;
+  export type ActorContext = z.infer<typeof ActorContextSchema>;
+
+  export const Media = MediaSchema;
+  export type Media = z.infer<typeof MediaSchema>;
+
+  export const InboundMessage = InboundMessageSchema;
+  export type InboundMessage = z.infer<typeof InboundMessageSchema>;
+
+  export const WaitContext = WaitContextSchema;
+  export type WaitContext = z.infer<typeof WaitContextSchema>;
+
+  export const Deliver = DeliverSchema;
+  export type Deliver = z.infer<typeof DeliverSchema>;
+
+  export const MessageOperation = MessageOperationSchema;
+  export type MessageOperation = z.infer<typeof MessageOperationSchema>;
+
+  export const MessageTarget = MessageTargetSchema;
+  export type MessageTarget = z.infer<typeof MessageTargetSchema>;
+
+  export const SenderTargetGrant = SenderTargetGrantSchema;
+  export type SenderTargetGrant = z.infer<typeof SenderTargetGrantSchema>;
+
+  export const ReplyGrantRule = ReplyGrantRuleSchema;
+  export type ReplyGrantRule = z.infer<typeof ReplyGrantRuleSchema>;
+
+  export const MessageDenialCode = MessageDenialCodeSchema;
+  export type MessageDenialCode = z.infer<typeof MessageDenialCodeSchema>;
+
+  export const AwaitSpec = AwaitSpecSchema;
+  export type AwaitSpec = z.infer<typeof AwaitSpecSchema>;
+
+  export const SendInput = SendInputSchema;
+  export type SendInput = z.infer<typeof SendInputSchema>;
+
+  /** The one allocated delivery address a target resolves to. */
+  export type DeliveryTarget = Readonly<{
+    actorId: string;
+    endpointId: string;
+    channel: string;
+    externalId: string;
+  }>;
+
+  /**
+   * Deterministic send receipt. `sent`/`denied` and the denial code are the
+   * audit facts; a `wait` is present exactly when the operation was awaited.
+   */
+  export type SendReceipt =
+    | Readonly<{
+        kind: "sent";
+        operation: "fire_and_forget";
+        messageId: string;
+        senderId: string;
+        grantId: string;
+        target: DeliveryTarget;
+        at: number;
+      }>
+    | Readonly<{
+        kind: "sent";
+        operation: "awaited";
+        messageId: string;
+        senderId: string;
+        grantId: string;
+        target: DeliveryTarget;
+        wait: Wait.Record;
+        at: number;
+      }>
+    | Readonly<{
+        kind: "denied";
+        code: MessageDenialCode;
+        messageId: string;
+        senderId: string;
+        targetActorId: string;
+        reason: string;
+        at: number;
+      }>;
+
+  export const WaitControlAction = WaitControlActionSchema;
+  export type WaitControlAction = z.infer<typeof WaitControlActionSchema>;
+
+  export const WaitControl = WaitControlSchema;
+  export type WaitControl = z.infer<typeof WaitControlSchema>;
+
+  /** Writes stay gateway-side; rejection is typed, never message text. */
+  export type WaitControlReceipt =
+    | Readonly<{ kind: "cancelled" | "expired"; waitId: string; at: number }>
+    | Readonly<{
+        kind: "rejected";
+        waitId: string;
+        code: "not_found" | "already_terminal";
+        reason: string;
+        at: number;
+      }>;
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -18,6 +18,7 @@ export * from "./mcp/index.js";
 export * from "./adapter/index.js";
 export * from "./actor/index.js";
 export * from "./communication/index.js";
+export * from "./gateway/index.js";
 export * from "./ingress/index.js";
 export * from "./policy/index.js";
 export * from "./agent/index.js";

--- a/packages/protocol/test/gateway.test.ts
+++ b/packages/protocol/test/gateway.test.ts
@@ -53,6 +53,50 @@ describe("Gateway.Deliver", () => {
     ).toThrow();
   });
 
+  test("rejects 'drop' across the seam — a dropped message is never delivered", () => {
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message,
+        actorContext: { ...actorContext, inboundTreatment: "drop" },
+      }),
+    ).toThrow();
+  });
+
+  test("nested strictness: message and waitContext reject unknown fields", () => {
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message: { ...message, rawPlatformPayload: {} },
+        actorContext,
+      }),
+    ).toThrow();
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message,
+        actorContext,
+        waitContext: { waitId: "w-1", allowedAction: "report_result", sessionPeek: true },
+      }),
+    ).toThrow();
+  });
+
+  test("media reference needs a url or filename; kind alone is not addressable", () => {
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message: { ...message, media: [{ kind: "image" }] },
+        actorContext,
+      }),
+    ).toThrow();
+    const ok = Gateway.Deliver.parse({
+      sessionId: "s-1",
+      message: { ...message, media: [{ kind: "image", url: "https://x/y.png" }] },
+      actorContext,
+    });
+    expect(ok.message.media?.length).toBe(1);
+  });
+
   test("rejects an out-of-enum treatment or trust tier", () => {
     expect(() =>
       Gateway.Deliver.parse({
@@ -125,6 +169,62 @@ describe("Gateway.SendInput (re-homed #215 vocabulary)", () => {
       },
     });
     expect(parsed.waitSpec?.waitId).toBe("w-1");
+  });
+});
+
+describe("Gateway.SenderTargetGrant (instances)", () => {
+  const standing = {
+    id: "g-1",
+    senderId: "persona-1",
+    targetActorId: "seller-1",
+    operations: ["awaited"],
+  };
+
+  test("an Owner-written standing grant parses without rule fields", () => {
+    expect(Gateway.SenderTargetGrant.parse(standing).ruleId).toBeUndefined();
+  });
+
+  test("a rule-materialized instance requires replyScope AND expiresAt", () => {
+    expect(() => Gateway.SenderTargetGrant.parse({ ...standing, ruleId: "r-1" })).toThrow();
+    expect(() =>
+      Gateway.SenderTargetGrant.parse({
+        ...standing,
+        ruleId: "r-1",
+        replyScope: { surfaceKey: "junggonara:chat:777" },
+      }),
+    ).toThrow();
+    const instance = Gateway.SenderTargetGrant.parse({
+      ...standing,
+      ruleId: "r-1",
+      replyScope: { surfaceKey: "junggonara:chat:777" },
+      expiresAt: 2_000,
+    });
+    expect(instance.replyScope?.surfaceKey).toBe("junggonara:chat:777");
+  });
+
+  test("replyScope without a ruleId is orphaned containment — rejected", () => {
+    expect(() =>
+      Gateway.SenderTargetGrant.parse({
+        ...standing,
+        replyScope: { surfaceKey: "junggonara:chat:777" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Gateway.AwaitSpec — quorum coherence is deliberately NOT refined here", () => {
+  test("quorum without resolutionPolicy 'quorum' still parses at spec level (#215 rule 4: Wait.Record.parse at WaitStore.create is the one enforcement layer)", () => {
+    const spec = Gateway.AwaitSpec.parse({
+      waitId: "w-1",
+      ownerRef: { kind: "session", id: "s-1" },
+      allowedActions: ["report_result"],
+      expectedResponders: ["a", "b"],
+      resolutionPolicy: "first_reply",
+      quorum: { expected: 2, threshold: 1 },
+      expiresAt: 2_000,
+      followUpWindow: 0,
+    });
+    expect(spec.quorum?.expected).toBe(2);
   });
 });
 

--- a/packages/protocol/test/gateway.test.ts
+++ b/packages/protocol/test/gateway.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { Gateway } from "../src/gateway/index.js";
+
+const message = {
+  messageId: "m-1",
+  traceId: "t-1",
+  surfaceKey: "telegram:bot:chat:123",
+  text: "hello",
+};
+
+const actorContext = {
+  trustTier: "observer",
+  inboundTreatment: "evidence_only",
+  origin: { surface: "telegram", externalId: "u-9" },
+} as const;
+
+describe("Gateway.Deliver", () => {
+  test("parses a minimal anonymous delivery (no actorId, no waitContext)", () => {
+    const parsed = Gateway.Deliver.parse({
+      sessionId: "s-1",
+      message,
+      actorContext,
+    });
+    expect(parsed.actorContext.actorId).toBeUndefined();
+    expect(parsed.waitContext).toBeUndefined();
+  });
+
+  test("parses a wait resumption with waitContext", () => {
+    const parsed = Gateway.Deliver.parse({
+      sessionId: "s-1",
+      message: { ...message, replyToId: "m-0", threadId: "th-1" },
+      actorContext: { ...actorContext, actorId: "a-7", trustTier: "collaborator" },
+      waitContext: { waitId: "w-1", allowedAction: "report_result", engagementId: "e-1" },
+    });
+    expect(parsed.waitContext?.waitId).toBe("w-1");
+  });
+
+  test("rejects unknown fields (strict at every level)", () => {
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message,
+        actorContext,
+        smuggled: true,
+      }),
+    ).toThrow();
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message,
+        actorContext: { ...actorContext, conductOverride: "admin" },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects an out-of-enum treatment or trust tier", () => {
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message,
+        actorContext: { ...actorContext, inboundTreatment: "root_access" },
+      }),
+    ).toThrow();
+    expect(() =>
+      Gateway.Deliver.parse({
+        sessionId: "s-1",
+        message,
+        actorContext: { ...actorContext, trustTier: "manager_i_swear" },
+      }),
+    ).toThrow();
+  });
+
+  test("origin is mandatory — a delivery without a taint root is invalid", () => {
+    const { origin: _origin, ...withoutOrigin } = actorContext;
+    expect(() =>
+      Gateway.Deliver.parse({ sessionId: "s-1", message, actorContext: withoutOrigin }),
+    ).toThrow();
+  });
+});
+
+describe("Gateway.SendInput (re-homed #215 vocabulary)", () => {
+  const base = {
+    messageId: "m-1",
+    traceId: "t-1",
+    senderId: "persona-1",
+    target: { actorId: "seller-1" },
+    body: "still available?",
+    at: 1_000,
+  };
+
+  test("awaited requires a waitSpec", () => {
+    expect(() => Gateway.SendInput.parse({ ...base, operation: "awaited" })).toThrow();
+  });
+
+  test("fire_and_forget forbids a waitSpec", () => {
+    expect(() =>
+      Gateway.SendInput.parse({
+        ...base,
+        operation: "fire_and_forget",
+        waitSpec: {
+          waitId: "w-1",
+          ownerRef: { kind: "session", id: "s-1" },
+          allowedActions: ["report_result"],
+          expectedResponders: ["seller-1"],
+          resolutionPolicy: "first_reply",
+          expiresAt: 2_000,
+          followUpWindow: 0,
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("awaited with a coherent waitSpec parses", () => {
+    const parsed = Gateway.SendInput.parse({
+      ...base,
+      operation: "awaited",
+      waitSpec: {
+        waitId: "w-1",
+        ownerRef: { kind: "session", id: "s-1" },
+        allowedActions: ["report_result"],
+        expectedResponders: ["seller-1"],
+        resolutionPolicy: "first_reply",
+        expiresAt: 2_000,
+        followUpWindow: 0,
+      },
+    });
+    expect(parsed.waitSpec?.waitId).toBe("w-1");
+  });
+});
+
+describe("Gateway.ReplyGrantRule", () => {
+  const rule = {
+    id: "r-1",
+    senderId: "persona-1",
+    surface: "junggonara",
+    operations: ["awaited"],
+    instanceTtlMs: 86_400_000,
+    maxLiveInstances: 5,
+    createdBy: "owner",
+  };
+
+  test("parses an Owner-written rule row", () => {
+    expect(Gateway.ReplyGrantRule.parse(rule).maxLiveInstances).toBe(5);
+  });
+
+  test("rejects a zero or negative live-instance cap (farming bound)", () => {
+    expect(() => Gateway.ReplyGrantRule.parse({ ...rule, maxLiveInstances: 0 })).toThrow();
+    expect(() => Gateway.ReplyGrantRule.parse({ ...rule, instanceTtlMs: -1 })).toThrow();
+  });
+});
+
+describe("Gateway.WaitControl", () => {
+  test("parses cancel and expire_now, rejects other verbs", () => {
+    expect(
+      Gateway.WaitControl.parse({ waitId: "w-1", action: "cancel", reason: "engagement aborted" })
+        .action,
+    ).toBe("cancel");
+    expect(
+      Gateway.WaitControl.parse({ waitId: "w-1", action: "expire_now", reason: "term crossed" })
+        .action,
+    ).toBe("expire_now");
+    expect(() =>
+      Gateway.WaitControl.parse({ waitId: "w-1", action: "extend", reason: "nope" }),
+    ).toThrow();
+  });
+
+  test("requires a reason (auditability)", () => {
+    expect(() => Gateway.WaitControl.parse({ waitId: "w-1", action: "cancel" })).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #706. Design: docs/gateway-design.md §2–§3 (PR #705).

## What

- `packages/protocol/src/gateway/` — the channels↔openomni seam, schemas only:
  - **`Gateway.Deliver`**: `(sessionId, message: InboundMessage, actorContext, waitContext?)` — actorContext carries the perimeter verdict (`trustTier`, `inboundTreatment`, `origin` taint root, all strict/enum-gated); waitContext presence is the perimeter's assertion that the sender passed the expected-responder gate. (`InboundMessage`, not `Envelope` — banned identifier per #465 demotions.)
  - **`Gateway.Send` vocabulary re-homed from #215**: SendInput (with awaited⇄waitSpec refinements), SenderTargetGrant, MessageTarget/Operation/DenialCode, DeliveryTarget/SendReceipt types — byte-compatible with the kernel's shapes.
  - **`Gateway.ReplyGrantRule`**: Owner-written rule rows from which the gateway materializes reply-scoped grant instances (perimeter-fact scoping, `maxLiveInstances` farming bound).
  - **`Gateway.WaitControl`**: `cancel | expire_now` + mandatory reason; typed receipt.
- `openomni/messaging/schema.ts` now re-exports the moved schemas; `resolveSenderTargetGrant` stays kernel-side — grant **evaluation** is forbidden in protocol (contract boundary).
- `docs/core-model.md`: **Gateway** added to Tier 2 (Owner addition, receipt → gateway-design.md); vocab-ratchet and naming lints pass clean.
- AGENTS.md (protocol) structure + stage-0 note updated; design doc field name synced.

## Behavior change

None. No wiring, no consumers beyond the re-export. Messaging tests (21) pass unchanged; protocol suite 618 tests incl. 12 new gateway tests; check-types + conformance lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Gateway stage 0 protocol contracts and moves the messaging send vocabulary to `@openomni/protocol` as `Gateway.*`, establishing the channels↔openomni seam without wiring. Adds a fail-closed guard in the kernel’s `resolveSenderTargetGrant` to reject reply‑scoped (rule‑materialized) grants so scope is enforced only by the gateway.

- Adds `protocol/src/gateway/schema.ts` and exports via `Gateway`: Deliver (InboundMessage with media requiring url|filename, ActorContext with `trustTier`, `origin`, and `inboundTreatment` limited to `full_access`|`evidence_only` so “drop” cannot cross the seam), optional WaitContext.
- Re-homes `Gateway.Send`: `SendInput`/`SendReceipt`, `MessageTarget`/`MessageOperation`/`MessageDenialCode`, `DeliveryTarget`, and `SenderTargetGrant` extended with `ruleId` and `replyScope` (when `ruleId` is set, `replyScope` and `expiresAt` are required). Adds `Gateway.ReplyGrantRule` and `Gateway.WaitControl` (`cancel`|`expire_now`) with typed receipts.
- `packages/openomni/src/messaging/schema.ts` re-exports `Gateway.Send`; keeps grant evaluation kernel-side and now refuses scope-carrying instances (fail-closed guard) to reserve scoped resolution for the gateway; tests added.
- Docs: core-model adds Gateway to Tier 2; gateway design switches inbound field to `message` and clarifies reply-grant rules are surface- or channel-scoped.
- Migration: none. Existing `openomni/messaging/schema` imports continue to work; new code may import `Gateway` from `@openomni/protocol`.

<sup>Written for commit abddf9a91ded875d0031f30e286f398e0f6691e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

