### PR TITLE
refactor(protocol): move newTraceId mint to protocol trace domain

### DIFF
--- a/apps/server/src/channel/authn/websocket.ts
+++ b/apps/server/src/channel/authn/websocket.ts
@@ -1,6 +1,6 @@
 import { Operational } from "@openomni/protocol";
 import type { Policy } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import { WebSocketToken } from "./definitions";
 import { evaluateChannelPermission, recordDecision } from "./decision";
 import type { ChannelAuthnDecisionObserver, WebSocketAuthResult } from "./types";

--- a/apps/server/src/channel/discord/gateway.ts
+++ b/apps/server/src/channel/discord/gateway.ts
@@ -1,5 +1,5 @@
 import { Operational } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import { sleep } from "../support/fetch-retry";
 import type { PublishPort } from "../types";
 import { GatewayOp, Intents, type DiscordUser, type GatewayPayload } from "./types";

--- a/apps/server/src/channel/discord/surface.ts
+++ b/apps/server/src/channel/discord/surface.ts
@@ -1,5 +1,5 @@
 import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import { Dedupe } from "../support/dedupe";
 import { DiscordClient } from "./client";
 import { DiscordGateway } from "./gateway";

--- a/apps/server/src/channel/github/surface.ts
+++ b/apps/server/src/channel/github/surface.ts
@@ -1,5 +1,5 @@
 import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import { Dedupe } from "../support/dedupe";
 import { GitHubClient } from "./client";
 import { GitHubNormalizer } from "./normalizer";

--- a/apps/server/src/channel/telegram/poller.ts
+++ b/apps/server/src/channel/telegram/poller.ts
@@ -1,4 +1,4 @@
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
 import { sleep } from "../support/fetch-retry";
 import type { PublishPort } from "../types";

--- a/apps/server/src/channel/telegram/surface.ts
+++ b/apps/server/src/channel/telegram/surface.ts
@@ -1,5 +1,5 @@
 import { Adapter, Operational, PolicyDecision } from "@openomni/protocol";
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import { Dedupe } from "../support/dedupe";
 import { splitText } from "../support/chunk-text";
 import { TelegramClient } from "./client";

--- a/apps/server/src/channel/websocket.ts
+++ b/apps/server/src/channel/websocket.ts
@@ -1,4 +1,4 @@
-import { newTraceId } from "@openomni/telemetry";
+import { newTraceId } from "@openomni/protocol";
 import type { Adapter } from "@openomni/protocol";
 import { Operational } from "@openomni/protocol";
 import { ChannelAuthnMiddleware, type ChannelAuthnDecisionObserver } from "./channel-authn";

--- a/packages/protocol/src/trace/index.ts
+++ b/packages/protocol/src/trace/index.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 export type TraceId = string;
 
 /**
- * Pure trace-id mint (W3C shape): `crypto.randomUUID()` is already 32 hex
+ * Side-effect-free trace-id mint (W3C shape, nondeterministic by nature): `crypto.randomUUID()` is already 32 hex
  * once the dashes go. Lives in protocol so channel drivers can mint at the
  * first frame (D11 origin) without a telemetry import — gateway stage-1 seam
  * prep (#551); `@openomni/telemetry` re-exports it for its own consumers.

--- a/packages/protocol/src/trace/index.ts
+++ b/packages/protocol/src/trace/index.ts
@@ -1,5 +1,18 @@
 import { z } from "zod";
 
+/** 32 lowercase hex characters (W3C trace id). */
+export type TraceId = string;
+
+/**
+ * Pure trace-id mint (W3C shape): `crypto.randomUUID()` is already 32 hex
+ * once the dashes go. Lives in protocol so channel drivers can mint at the
+ * first frame (D11 origin) without a telemetry import — gateway stage-1 seam
+ * prep (#551); `@openomni/telemetry` re-exports it for its own consumers.
+ */
+export function newTraceId(): TraceId {
+  return crypto.randomUUID().split("-").join("");
+}
+
 export namespace TraceContext {
   const Schema = z.object({
     traceId: z.string(),

--- a/packages/telemetry/src/trace.ts
+++ b/packages/telemetry/src/trace.ts
@@ -37,10 +37,9 @@ const INVALID_SPAN_ID = "0".repeat(16);
 const TRACEPARENT_PATTERN = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(-.*)?$/;
 const FORBIDDEN_TRACEPARENT_VERSION = "ff";
 
-/** A W3C trace id. `crypto.randomUUID()` is already 32 hex once the dashes go. */
-export function newTraceId(): TraceId {
-  return crypto.randomUUID().split("-").join("");
-}
+/** A W3C trace id — the mint moved to protocol (gateway stage-1 seam prep, #551); re-exported here unchanged. */
+import { newTraceId } from "@openomni/protocol";
+export { newTraceId };
 
 export function newSpanId(): SpanId {
   for (;;) {


### PR DESCRIPTION
Gateway stage-1 seam prep for #551 ("Bus/telemetry seam" precursor family; the Bus→PublishPort injection already landed earlier).

- `newTraceId` (pure W3C 32-hex mint) moves to `protocol/src/trace/` — allowed there as pure ID formatting; channel drivers mint the D11 origin trace at the first frame and must not import telemetry once extracted to `packages/channels` (whitelist {protocol, ipc, policy, ledger}).
- `@openomni/telemetry` re-exports it unchanged (19 other consumers untouched).
- The 7 channel files switch to the protocol import → **channel code now imports telemetry zero times**.

Verified: build, check-types, conformance lint, telemetry suite (55), server channel suite (37) all green. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the side-effect-free W3C `newTraceId()` mint from `@openomni/telemetry` to the protocol trace domain so channel drivers can mint at the first frame without a telemetry import. Previously channels imported from telemetry; now they import from `@openomni/protocol`. No runtime behavior change.

- Adds `newTraceId()` and `TraceId` to `packages/protocol/src/trace`; `@openomni/telemetry` re-exports it unchanged.
- Updates seven channel drivers to import from `@openomni/protocol`; channel code now has zero `@openomni/telemetry` imports.
- Migration for channels: replace `newTraceId` imports from `@openomni/telemetry` with `@openomni/protocol`. Other packages may continue using the telemetry re-export.

<sup>Written for commit 4b631e0eae9e9b3ae2e1d83b41807ddfad060bb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

