### PR TITLE
chore: add shared tsconfig base without behavior drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
         working-directory: apps/server
       - name: Test (conformance)
         run: bun test --timeout 15000 script/conformance
+      - name: Test (tsconfig inheritance verifier)
+        run: bun test --timeout 15000 script/verify-tsconfig-inheritance.test.ts
       - name: Coverage ratchet
         run: bun run script/check-coverage-ratchet.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -181,6 +183,7 @@ jobs:
           bun run script/check-deps.ts --self-test
       - run: bun run script/check-dead-exports.ts
       - run: bun run script/check-import-cycles.ts
+      - run: bun run script/verify-tsconfig-inheritance.ts
       - run: bun run script/check-ledger-schema-drift.ts
       - run: bun run script/report-source-metrics.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,21 +1,11 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["bun"]
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/channels/tsconfig.json
+++ b/packages/channels/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -18,8 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@openomni/channels": ["./src/index.ts"]
-    },
-    "types": ["bun"]
+    }
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/packages/coordinator/tsconfig.json
+++ b/packages/coordinator/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -18,8 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@openomni/coordinator": ["./src/index.ts"]
-    },
-    "types": ["bun"]
+    }
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/packages/ipc/tsconfig.json
+++ b/packages/ipc/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -18,8 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@openomni/ipc": ["./src/index.ts"]
-    },
-    "types": ["bun"]
+    }
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/packages/llm/tsconfig.json
+++ b/packages/llm/tsconfig.json
@@ -1,22 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "noEmit": true,
-    "types": ["bun"]
+    "noEmit": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/openomni/tsconfig.json
+++ b/packages/openomni/tsconfig.json
@@ -1,21 +1,11 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["bun"]
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/policy/tsconfig.json
+++ b/packages/policy/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -18,8 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@openomni/policy": ["./src/index.ts"]
-    },
-    "types": ["bun"]
+    }
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/packages/protocol/test/module-surface.test.ts
+++ b/packages/protocol/test/module-surface.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import ts from "typescript";
+
+// #501 preservation constraints, pinned as tests: protocol keeps declaration
+// emission (non-composite, reference-free, exactly the captured baseline) and
+// the published module surface stays the declaration-backed dist barrel.
+
+const packageRoot = resolve(import.meta.dir, "..");
+
+function parseProject(configName: string): ts.ParsedCommandLine {
+  const host: ts.ParseConfigFileHost = {
+    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+    getCurrentDirectory: ts.sys.getCurrentDirectory,
+    onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+      throw new Error(ts.flattenDiagnosticMessageText(diagnostic.messageText, " "));
+    },
+  };
+  const parsed = ts.getParsedCommandLineOfConfigFile(join(packageRoot, configName), {}, host);
+  if (!parsed) {
+    throw new Error(`${configName} did not parse`);
+  }
+  const errors = parsed.errors.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (errors.length > 0) {
+    throw new Error(
+      errors
+        .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, " "))
+        .join("; "),
+    );
+  }
+  return parsed;
+}
+
+describe("protocol module surface", () => {
+  test("package entry points at the declaration-backed dist barrel", () => {
+    const manifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as {
+      main?: string;
+      types?: string;
+      exports?: Record<string, { import?: string; types?: string }>;
+    };
+    expect(manifest.main).toBe("./dist/index.js");
+    expect(manifest.types).toBe("./dist/index.d.ts");
+    expect(manifest.exports?.["."]?.import).toBe("./dist/index.js");
+    expect(manifest.exports?.["."]?.types).toBe("./dist/index.d.ts");
+  });
+
+  test("resolved configs preserve declaration emission without composite/reference drift", () => {
+    for (const configName of ["tsconfig.json", "tsconfig.build.json"]) {
+      const parsed = parseProject(configName);
+      expect(parsed.options.declaration).toBe(true);
+      expect(parsed.options.noEmit ?? false).toBe(false);
+      expect(parsed.options.composite).toBeUndefined();
+      expect(parsed.projectReferences ?? []).toHaveLength(0);
+      expect(parsed.options.outDir).toBe(join(packageRoot, "dist"));
+      expect(parsed.options.rootDir).toBe(join(packageRoot, "src"));
+    }
+  });
+
+  test("build project compiles the barrel plus src modules only, tests excluded", () => {
+    const parsed = parseProject("tsconfig.build.json");
+    const files = parsed.fileNames.map((file) => resolve(file));
+    expect(files).toContain(join(packageRoot, "src", "index.ts"));
+    const srcPrefix = `${join(packageRoot, "src")}/`;
+    for (const file of files) {
+      expect(file.startsWith(srcPrefix)).toBe(true);
+      expect(file.endsWith(".test.ts")).toBe(false);
+    }
+  });
+
+  test("built dist carries a declaration for every build input (when dist exists)", () => {
+    const distDir = join(packageRoot, "dist");
+    if (!existsSync(distDir)) {
+      // Pre-build tree (e.g. clean worktree before `bun run build`) — the
+      // derivation-only check lives in script/verify-tsconfig-inheritance.ts.
+      return;
+    }
+    const parsed = parseProject("tsconfig.build.json");
+    for (const input of parsed.fileNames) {
+      if (input.endsWith(".d.ts")) continue;
+      const declarations = ts
+        .getOutputFileNames(parsed, input, !ts.sys.useCaseSensitiveFileNames)
+        .filter((output) => output.endsWith(".d.ts"));
+      expect(declarations.length).toBeGreaterThan(0);
+      for (const declaration of declarations) {
+        expect(existsSync(declaration)).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,21 +1,11 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["bun"]
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/session/tsconfig.json
+++ b/packages/session/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -19,8 +10,7 @@
     "paths": {
       "@openomni/protocol": ["../protocol/src/index.ts"],
       "@openomni/session": ["./src/index.ts"]
-    },
-    "types": ["bun"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "lib": ["ES2020"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -18,8 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@openomni/telemetry": ["./src/index.ts"]
-    },
-    "types": ["bun"]
+    }
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/script/fixtures/tsconfig-inheritance/declaration-mutation.json
+++ b/script/fixtures/tsconfig-inheritance/declaration-mutation.json
@@ -1,0 +1,13 @@
+{
+  "root": "declaration-mutation",
+  "base": "tsconfig.base.json",
+  "projects": ["tsconfig.json"],
+  "emitPolicy": {
+    "tsconfig.json": {
+      "declaration": true,
+      "noEmit": false,
+      "forbidComposite": true,
+      "forbidProjectReferences": true
+    }
+  }
+}

--- a/script/fixtures/tsconfig-inheritance/declaration-mutation/src/entry.ts
+++ b/script/fixtures/tsconfig-inheritance/declaration-mutation/src/entry.ts
@@ -1,0 +1,5 @@
+// Fixture input for verify-tsconfig-inheritance — intentionally trivial. The
+// project config mutates emit policy (declaration dropped, noEmit introduced);
+// the verifier must fail its emit-policy comparison.
+const entryMarker = "declaration-mutation fixture";
+void entryMarker;

--- a/script/fixtures/tsconfig-inheritance/declaration-mutation/tsconfig.base.json
+++ b/script/fixtures/tsconfig-inheritance/declaration-mutation/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/script/fixtures/tsconfig-inheritance/declaration-mutation/tsconfig.json
+++ b/script/fixtures/tsconfig-inheritance/declaration-mutation/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/script/fixtures/tsconfig-inheritance/missing-base.json
+++ b/script/fixtures/tsconfig-inheritance/missing-base.json
@@ -1,0 +1,5 @@
+{
+  "root": "missing-base",
+  "base": "tsconfig.base.json",
+  "projects": ["tsconfig.json"]
+}

--- a/script/fixtures/tsconfig-inheritance/missing-base/src/main.ts
+++ b/script/fixtures/tsconfig-inheritance/missing-base/src/main.ts
@@ -1,0 +1,3 @@
+// Fixture input for verify-tsconfig-inheritance — intentionally trivial.
+const mainMarker = "missing-base fixture";
+void mainMarker;

--- a/script/fixtures/tsconfig-inheritance/missing-base/tsconfig.json
+++ b/script/fixtures/tsconfig-inheritance/missing-base/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["src"]
+}

--- a/script/fixtures/tsconfig-inheritance/omitted-input.json
+++ b/script/fixtures/tsconfig-inheritance/omitted-input.json
@@ -1,0 +1,6 @@
+{
+  "root": "omitted-input",
+  "base": "tsconfig.base.json",
+  "projects": ["tsconfig.json"],
+  "sourceRoots": ["src", "lib"]
+}

--- a/script/fixtures/tsconfig-inheritance/omitted-input/lib/orphan.ts
+++ b/script/fixtures/tsconfig-inheritance/omitted-input/lib/orphan.ts
@@ -1,0 +1,4 @@
+// Fixture input for verify-tsconfig-inheritance — deliberately outside the
+// project's include set: the verifier must flag it as an omitted input.
+const orphanMarker = "omitted-input fixture: claimed by no project";
+void orphanMarker;

--- a/script/fixtures/tsconfig-inheritance/omitted-input/src/included.ts
+++ b/script/fixtures/tsconfig-inheritance/omitted-input/src/included.ts
@@ -1,0 +1,3 @@
+// Fixture input for verify-tsconfig-inheritance — intentionally trivial.
+const includedMarker = "omitted-input fixture: claimed by the project";
+void includedMarker;

--- a/script/fixtures/tsconfig-inheritance/omitted-input/tsconfig.base.json
+++ b/script/fixtures/tsconfig-inheritance/omitted-input/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/script/fixtures/tsconfig-inheritance/omitted-input/tsconfig.json
+++ b/script/fixtures/tsconfig-inheritance/omitted-input/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/script/fixtures/tsconfig-inheritance/valid.json
+++ b/script/fixtures/tsconfig-inheritance/valid.json
@@ -1,0 +1,15 @@
+{
+  "root": "valid",
+  "base": "tsconfig.base.json",
+  "projects": ["tsconfig.json"],
+  "emitPolicy": {
+    "tsconfig.json": {
+      "declaration": true,
+      "noEmit": false,
+      "forbidComposite": true,
+      "forbidProjectReferences": true
+    }
+  },
+  "sourceRoots": ["src"],
+  "declarationProject": "tsconfig.json"
+}

--- a/script/fixtures/tsconfig-inheritance/valid/src/entry.ts
+++ b/script/fixtures/tsconfig-inheritance/valid/src/entry.ts
@@ -1,0 +1,3 @@
+// Fixture input for verify-tsconfig-inheritance — intentionally trivial.
+const validMarker = "valid fixture";
+void validMarker;

--- a/script/fixtures/tsconfig-inheritance/valid/tsconfig.base.json
+++ b/script/fixtures/tsconfig-inheritance/valid/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/script/fixtures/tsconfig-inheritance/valid/tsconfig.json
+++ b/script/fixtures/tsconfig-inheritance/valid/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }

--- a/script/tsconfig.json
+++ b/script/tsconfig.json
@@ -1,17 +1,9 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
     "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "noEmit": true,
-    "types": ["bun"]
+    "noEmit": true
   },
   "include": ["."],
   "exclude": ["node_modules"]

--- a/script/verify-tsconfig-inheritance.test.ts
+++ b/script/verify-tsconfig-inheritance.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { loadFixtureManifest, repoManifest, verifyManifest } from "./verify-tsconfig-inheritance";
+
+const fixturesDir = join(import.meta.dir, "fixtures", "tsconfig-inheritance");
+const verifierPath = join(import.meta.dir, "verify-tsconfig-inheritance.ts");
+
+function verifyFixture(name: string) {
+  return verifyManifest(loadFixtureManifest(join(fixturesDir, `${name}.json`)));
+}
+
+describe("verify-tsconfig-inheritance", () => {
+  test("repo: every project extends the shared base with intact emit policy and membership", () => {
+    const result = verifyManifest(repoManifest());
+    expect(result.problems).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.code).toBeNull();
+    // 29 tsconfig projects existed at the #501 baseline; discovery may only grow.
+    expect(result.projectCount).toBeGreaterThanOrEqual(29);
+    expect(result.claimedFileCount).toBeGreaterThan(0);
+  });
+
+  test("known-bad fixture: a missing base config fails closed", () => {
+    const result = verifyFixture("missing-base");
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("missing_base_config");
+  });
+
+  test("known-bad fixture: an omitted input fails the source-membership comparison", () => {
+    const result = verifyFixture("omitted-input");
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("omitted_input");
+    expect(result.problems[0]?.message).toContain("orphan.ts");
+  });
+
+  test("known-bad fixture: an emit/declaration mutation fails the emit-policy comparison", () => {
+    const result = verifyFixture("declaration-mutation");
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("emit_policy_drift");
+    const rendered = result.problems.map((problem) => problem.message).join("\n");
+    expect(rendered).toContain("declaration resolved to false, expected true");
+    expect(rendered).toContain("noEmit resolved to true, expected false");
+  });
+
+  test("valid fixture passes, including declaration-output derivation", () => {
+    const result = verifyFixture("valid");
+    expect(result.problems).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.code).toBeNull();
+  });
+
+  test("CLI --fixture --json exits nonzero with a machine-readable code", async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", verifierPath, "--fixture", join(fixturesDir, "missing-base.json"), "--json"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+    const parsed = JSON.parse(stdout) as { ok: boolean; code: string };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("missing_base_config");
+  });
+});

--- a/script/verify-tsconfig-inheritance.ts
+++ b/script/verify-tsconfig-inheritance.ts
@@ -1,0 +1,447 @@
+/**
+ * Shared tsconfig-base inheritance verifier (#501).
+ *
+ * Every TypeScript project in the workspace must extend the root
+ * `tsconfig.base.json` (directly or through its package `tsconfig.json`), and
+ * inheritance must not drift the effective configuration:
+ *
+ * - base + chain must resolve (a missing extends target fails closed),
+ * - the issue-named emit constraints hold — protocol keeps declaration
+ *   emission (and stays non-composite, reference-free), llm stays no-emit,
+ * - no intended input silently leaves compilation: every source file under
+ *   the claimed source roots belongs to at least one project,
+ * - the protocol build project derives one `.d.ts` per input, and when
+ *   `dist/` exists the emitted declaration set matches exactly.
+ *
+ * `packages/openomni/bench` and `packages/session/bench` are intentionally
+ * absent from the source roots: no tsconfig project claimed them before the
+ * shared base existed, and changing compilation membership is a #501 non-goal.
+ *
+ * Modes:
+ *   bun run script/verify-tsconfig-inheritance.ts                     verify the repo
+ *   bun run script/verify-tsconfig-inheritance.ts --json              machine-readable result
+ *   bun run script/verify-tsconfig-inheritance.ts --fixture <path>    verify a fixture manifest
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import ts from "typescript";
+
+export type ProblemCode =
+  | "missing_base_config"
+  | "not_extending_base"
+  | "config_parse_error"
+  | "emit_policy_drift"
+  | "missing_source_root"
+  | "omitted_input"
+  | "declaration_output_drift";
+
+export interface Problem {
+  readonly code: ProblemCode;
+  readonly message: string;
+}
+
+export interface EmitExpectation {
+  readonly declaration?: boolean;
+  readonly noEmit?: boolean;
+  readonly forbidComposite?: boolean;
+  readonly forbidProjectReferences?: boolean;
+}
+
+export interface Manifest {
+  /** Absolute path to the tree the manifest describes. */
+  readonly root: string;
+  /** Shared base config, relative to root. */
+  readonly base: string;
+  /** Project configs, relative to root; each must extend the base. */
+  readonly projects: readonly string[];
+  /** Per-project emit constraints (key = entry of `projects`). */
+  readonly emitPolicy?: Readonly<Record<string, EmitExpectation>>;
+  /** Directories whose .ts/.tsx files must all belong to some project. */
+  readonly sourceRoots?: readonly string[];
+  /** Project whose every input must derive a declaration output. */
+  readonly declarationProject?: string;
+}
+
+export interface VerifyResult {
+  readonly ok: boolean;
+  readonly code: ProblemCode | null;
+  readonly problems: readonly Problem[];
+  readonly projectCount: number;
+  readonly claimedFileCount: number;
+}
+
+const parseHost: ts.ParseConfigFileHost = {
+  useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+  fileExists: ts.sys.fileExists,
+  readFile: ts.sys.readFile,
+  readDirectory: ts.sys.readDirectory,
+  getCurrentDirectory: ts.sys.getCurrentDirectory,
+  onUnRecoverableConfigFileDiagnostic: () => {
+    // Diagnostics are collected from parsed.errors below.
+  },
+};
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+}
+
+/** Resolve a relative `extends` reference the way tsc does (± `.json`). */
+function resolveExtendsRef(fromConfigPath: string, ref: string): string | null {
+  const candidate = resolve(dirname(fromConfigPath), ref);
+  if (existsSync(candidate)) return candidate;
+  if (existsSync(`${candidate}.json`)) return `${candidate}.json`;
+  return null;
+}
+
+interface ChainResult {
+  readonly chain: readonly string[];
+  readonly problem: Problem | null;
+}
+
+/** Walk the raw extends chain of one config without resolving options. */
+export function extendsChainOf(configPath: string, projectLabel: string): ChainResult {
+  const chain: string[] = [];
+  let current = configPath;
+  const seen = new Set<string>([current]);
+  for (;;) {
+    const read = ts.readConfigFile(current, ts.sys.readFile);
+    if (read.error) {
+      return {
+        chain,
+        problem: {
+          code: "config_parse_error",
+          message: `${projectLabel}: cannot read ${current}: ${formatDiagnostic(read.error)}`,
+        },
+      };
+    }
+    const extendsValue = (read.config as { extends?: unknown }).extends;
+    if (extendsValue === undefined) return { chain, problem: null };
+    if (typeof extendsValue !== "string" || !extendsValue.startsWith(".")) {
+      return {
+        chain,
+        problem: {
+          code: "config_parse_error",
+          message: `${projectLabel}: unsupported extends value ${JSON.stringify(extendsValue)} in ${current} — this workspace uses single relative extends references only`,
+        },
+      };
+    }
+    const target = resolveExtendsRef(current, extendsValue);
+    if (target === null) {
+      return {
+        chain,
+        problem: {
+          code: "missing_base_config",
+          message: `${projectLabel}: extends target "${extendsValue}" of ${current} does not exist`,
+        },
+      };
+    }
+    if (seen.has(target)) {
+      return {
+        chain,
+        problem: {
+          code: "config_parse_error",
+          message: `${projectLabel}: circular extends chain through ${target}`,
+        },
+      };
+    }
+    seen.add(target);
+    chain.push(target);
+    current = target;
+  }
+}
+
+function parseProject(configPath: string, projectLabel: string): ts.ParsedCommandLine | Problem {
+  const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, parseHost);
+  if (!parsed) {
+    return { code: "config_parse_error", message: `${projectLabel}: config did not parse` };
+  }
+  const errors = parsed.errors.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (errors.length > 0) {
+    const rendered = errors.map(formatDiagnostic).join("; ");
+    return { code: "config_parse_error", message: `${projectLabel}: ${rendered}` };
+  }
+  return parsed;
+}
+
+function checkEmitPolicy(
+  projectLabel: string,
+  parsed: ts.ParsedCommandLine,
+  expectation: EmitExpectation,
+): Problem[] {
+  const problems: Problem[] = [];
+  const drift = (message: string): void => {
+    problems.push({ code: "emit_policy_drift", message: `${projectLabel}: ${message}` });
+  };
+  const actualDeclaration = parsed.options.declaration === true;
+  if (expectation.declaration !== undefined && actualDeclaration !== expectation.declaration) {
+    drift(`declaration resolved to ${actualDeclaration}, expected ${expectation.declaration}`);
+  }
+  const actualNoEmit = parsed.options.noEmit === true;
+  if (expectation.noEmit !== undefined && actualNoEmit !== expectation.noEmit) {
+    drift(`noEmit resolved to ${actualNoEmit}, expected ${expectation.noEmit}`);
+  }
+  if (expectation.forbidComposite && parsed.options.composite !== undefined) {
+    drift(`composite resolved to ${parsed.options.composite}, expected it unset`);
+  }
+  if (expectation.forbidProjectReferences && (parsed.projectReferences?.length ?? 0) > 0) {
+    drift(`${parsed.projectReferences?.length} project reference(s) resolved, expected none`);
+  }
+  return problems;
+}
+
+const SKIP_SEGMENTS = new Set(["node_modules", "dist", "coverage"]);
+
+function listSourceFiles(rootDir: string): string[] {
+  const glob = new Bun.Glob("**/*.{ts,tsx}");
+  const files: string[] = [];
+  for (const match of glob.scanSync({ cwd: rootDir, onlyFiles: true })) {
+    if (match.split("/").some((segment) => SKIP_SEGMENTS.has(segment))) continue;
+    files.push(resolve(rootDir, match));
+  }
+  return files.sort();
+}
+
+function checkSourceCoverage(manifest: Manifest, claimed: ReadonlySet<string>): Problem[] {
+  const problems: Problem[] = [];
+  const orphans: string[] = [];
+  for (const sourceRoot of manifest.sourceRoots ?? []) {
+    const rootDir = resolve(manifest.root, sourceRoot);
+    if (!existsSync(rootDir)) {
+      problems.push({
+        code: "missing_source_root",
+        message: `source root ${sourceRoot} does not exist under ${manifest.root}`,
+      });
+      continue;
+    }
+    for (const file of listSourceFiles(rootDir)) {
+      if (!claimed.has(file)) orphans.push(file);
+    }
+  }
+  if (orphans.length > 0) {
+    const shown = orphans.slice(0, 20).join(", ");
+    const suffix = orphans.length > 20 ? ` (+${orphans.length - 20} more)` : "";
+    problems.push({
+      code: "omitted_input",
+      message: `${orphans.length} source file(s) belong to no tsconfig project: ${shown}${suffix}`,
+    });
+  }
+  return problems;
+}
+
+function checkDeclarationOutputs(manifest: Manifest, projectLabel: string): Problem[] {
+  const configPath = resolve(manifest.root, projectLabel);
+  const parsed = parseProject(configPath, projectLabel);
+  if (!("options" in parsed)) return [parsed];
+  const problems: Problem[] = [];
+  const expected = new Set<string>();
+  for (const input of parsed.fileNames) {
+    if (input.endsWith(".d.ts")) continue;
+    const declarations = ts
+      .getOutputFileNames(parsed, input, !ts.sys.useCaseSensitiveFileNames)
+      .filter((output) => output.endsWith(".d.ts"));
+    if (declarations.length === 0) {
+      problems.push({
+        code: "declaration_output_drift",
+        message: `${projectLabel}: input ${input} derives no .d.ts output`,
+      });
+      continue;
+    }
+    for (const declaration of declarations) expected.add(resolve(declaration));
+  }
+  const outDir = parsed.options.outDir;
+  if (outDir !== undefined && existsSync(outDir)) {
+    const actual = new Set(
+      [...new Bun.Glob("**/*.d.ts").scanSync({ cwd: outDir, onlyFiles: true })].map((match) =>
+        resolve(outDir, match),
+      ),
+    );
+    for (const declaration of expected) {
+      if (!actual.has(declaration)) {
+        problems.push({
+          code: "declaration_output_drift",
+          message: `${projectLabel}: built output is missing declaration ${declaration}`,
+        });
+      }
+    }
+    for (const declaration of actual) {
+      if (!expected.has(declaration)) {
+        problems.push({
+          code: "declaration_output_drift",
+          message: `${projectLabel}: built output has unexpected declaration ${declaration}`,
+        });
+      }
+    }
+  }
+  return problems;
+}
+
+export function verifyManifest(manifest: Manifest): VerifyResult {
+  const problems: Problem[] = [];
+  const claimed = new Set<string>();
+  let projectCount = 0;
+
+  const basePath = resolve(manifest.root, manifest.base);
+  if (!existsSync(basePath)) {
+    problems.push({
+      code: "missing_base_config",
+      message: `shared base ${manifest.base} does not exist under ${manifest.root}`,
+    });
+  } else {
+    for (const project of manifest.projects) {
+      projectCount += 1;
+      const configPath = resolve(manifest.root, project);
+      if (!existsSync(configPath)) {
+        problems.push({
+          code: "config_parse_error",
+          message: `${project}: config does not exist`,
+        });
+        continue;
+      }
+      const { chain, problem } = extendsChainOf(configPath, project);
+      if (problem) {
+        problems.push(problem);
+        continue;
+      }
+      if (!chain.includes(basePath)) {
+        problems.push({
+          code: "not_extending_base",
+          message: `${project}: extends chain never reaches ${manifest.base}`,
+        });
+        continue;
+      }
+      const parsed = parseProject(configPath, project);
+      if (!("options" in parsed)) {
+        problems.push(parsed);
+        continue;
+      }
+      for (const file of parsed.fileNames) claimed.add(resolve(file));
+      const expectation = manifest.emitPolicy?.[project];
+      if (expectation) problems.push(...checkEmitPolicy(project, parsed, expectation));
+    }
+
+    problems.push(...checkSourceCoverage(manifest, claimed));
+
+    if (manifest.declarationProject !== undefined && problems.length === 0) {
+      problems.push(...checkDeclarationOutputs(manifest, manifest.declarationProject));
+    }
+  }
+
+  return {
+    ok: problems.length === 0,
+    code: problems[0]?.code ?? null,
+    problems,
+    projectCount,
+    claimedFileCount: claimed.size,
+  };
+}
+
+const repoRoot = join(import.meta.dir, "..");
+
+/** Discover every workspace tsconfig project (fixture trees excluded). */
+export function discoverRepoProjects(): string[] {
+  const glob = new Bun.Glob("{apps,packages,script}/**/tsconfig*.json");
+  const projects: string[] = [];
+  for (const match of glob.scanSync({ cwd: repoRoot, onlyFiles: true })) {
+    if (match.split("/").some((segment) => SKIP_SEGMENTS.has(segment))) continue;
+    if (match.startsWith("script/fixtures/")) continue;
+    projects.push(match);
+  }
+  return projects.sort();
+}
+
+export function repoManifest(): Manifest {
+  return {
+    root: repoRoot,
+    base: "tsconfig.base.json",
+    projects: discoverRepoProjects(),
+    emitPolicy: {
+      // #501 preservation constraints: protocol keeps declaration emission
+      // (non-composite, reference-free per the captured baseline), llm stays
+      // no-emit.
+      "packages/protocol/tsconfig.json": {
+        declaration: true,
+        noEmit: false,
+        forbidComposite: true,
+        forbidProjectReferences: true,
+      },
+      "packages/protocol/tsconfig.build.json": {
+        declaration: true,
+        noEmit: false,
+        forbidComposite: true,
+        forbidProjectReferences: true,
+      },
+      "packages/llm/tsconfig.json": { noEmit: true },
+      "packages/llm/tsconfig.test.json": { noEmit: true },
+    },
+    sourceRoots: [
+      "apps/server/src",
+      "apps/server/test",
+      "packages/agent/bench",
+      "packages/agent/src",
+      "packages/agent/test",
+      "packages/channels/src",
+      "packages/channels/test",
+      "packages/coordinator/src",
+      "packages/coordinator/test",
+      "packages/ipc/src",
+      "packages/ipc/test",
+      "packages/llm/src",
+      "packages/llm/test",
+      "packages/openomni/src",
+      "packages/openomni/test",
+      "packages/policy/src",
+      "packages/policy/test",
+      "packages/protocol/src",
+      "packages/protocol/test",
+      "packages/session/src",
+      "packages/session/test",
+      "packages/telemetry/src",
+      "packages/telemetry/test",
+      "script",
+    ],
+    declarationProject: "packages/protocol/tsconfig.build.json",
+  };
+}
+
+export function loadFixtureManifest(manifestPath: string): Manifest {
+  const raw = JSON.parse(readFileSync(manifestPath, "utf8")) as Omit<Manifest, "root"> & {
+    root: string;
+  };
+  return { ...raw, root: resolve(dirname(manifestPath), raw.root) };
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const json = args.includes("--json");
+  const fixtureIndex = args.indexOf("--fixture");
+  const fixturePath = fixtureIndex >= 0 ? args[fixtureIndex + 1] : undefined;
+  if (fixtureIndex >= 0 && fixturePath === undefined) {
+    console.error("--fixture requires a manifest path");
+    process.exit(2);
+  }
+
+  const manifest =
+    fixturePath === undefined ? repoManifest() : loadFixtureManifest(resolve(fixturePath));
+  const result = verifyManifest(manifest);
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.ok) {
+    console.log(
+      `OK: tsconfig inheritance — ${result.projectCount} project(s) extend ${manifest.base}, ${result.claimedFileCount} claimed input file(s), emit policy and declaration outputs intact`,
+    );
+  } else {
+    for (const problem of result.problems) {
+      console.error(`${problem.code}: ${problem.message}`);
+    }
+    console.error(`\n${result.problems.length} tsconfig inheritance problem(s) found`);
+  }
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["bun"]
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
-  "globalDependencies": ["script/**"],
+  "globalDependencies": ["script/**", "tsconfig.base.json"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
Closes #501 (P3-03).

## The proof (the issue's core demand: measured, zero effective-config drift)

- **29/29 tsconfig projects**: `tsc --showConfig` before/after normalized-identical AND `--listFilesOnly` byte-identical per project.
- **protocol dist byte-identical**: forced rebuild sha256 over all 256 emitted files (incl. .d.ts/.d.ts.map) matches pre-change build; **llm no-emit preserved** (`--listEmittedFiles` = 0 bytes). Both named preservation constraints held.
- Design boundaries kept per-project on purpose (hoisting = drift): path-relative options (`extends` rebases them) and emit options (absent→explicit-false deltas).

## Durable enforcement (beyond the one-shot proof)

- `script/verify-tsconfig-inheritance.ts`: every project must extend the base; pins protocol declaration emission + llm no-emit; fails on orphan source files; `--json`/`--fixture` modes with known-bad fixtures (missing base / omitted input / emit mutation all exit 1).
- `turbo.json` `globalDependencies` gains the base (cache invalidation).
- New `packages/protocol/test/module-surface.test.ts` pins the declaration-backed dist barrel.

Deviation: subject uses `chore:` — repo commitlint type-enum has no `build:`.

## Verification

Forced build 6/6, check-types 16/16, full turbo test 16/16, all lint/dep/cycle/dead-export gates, p2-ledger-baseline 46, channels standalone 40, verifier suite 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `tsconfig.base.json` and moves workspace projects to extend it without changing resolved configs, file membership, or build outputs. CI now gates this with a tsconfig inheritance verifier.

- Satisfies #501: 29/29 projects resolve identical configs and file sets; `packages/protocol` dist is byte-identical; `packages/llm` remains no-emit.
- Adds `script/verify-tsconfig-inheritance.ts` with fixtures/tests to enforce: every project extends the base; protocol keeps declaration emission (non-composite, no project refs); `packages/llm` stays no-emit; no orphaned sources; derived vs built protocol declarations match.
- Wires the verifier into CI: runs `bun test script/verify-tsconfig-inheritance.test.ts` and `bun run script/verify-tsconfig-inheritance.ts`.
- Adds `packages/protocol/test/module-surface.test.ts` to pin the declaration-backed dist barrel.
- Updates `turbo.json` to add `tsconfig.base.json` to `globalDependencies` for cache invalidation.

**Required actions**
- When adding a new TS project, extend the root `tsconfig.base.json`. Do not hoist path-relative options (`rootDir`, `outDir`, `baseUrl`, `paths`) or emit policy (`declaration`, `declarationMap`, `sourceMap`, `noEmit`) into the base; the verifier will fail on drift.

<sup>Written for commit 3d15cf936352be164bf5f87afb5fa1b5512fd03a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized TypeScript configuration across projects using a shared base configuration.
  * Preserved package-specific build, declaration, source-map, and output settings.

* **Tests**
  * Added validation for configuration inheritance, source coverage, emit policies, and protocol declaration outputs.
  * Added fixtures covering valid and invalid configuration scenarios.

* **Chores**
  * Added repository-wide configuration verification with human-readable and JSON results.
  * Updated build tooling to track changes to the shared TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->