### PR TITLE
feat: message.send over the gateway — as-me outbound goes live

### DIFF
--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -9,6 +9,7 @@ import {
   AgentToolProvider,
   createBrainEngine,
   createDefaultDispatchRuntime,
+  createMessageSendTool,
   CronAdapter,
   CronJobRunner,
   ResidentRuntime,
@@ -16,7 +17,11 @@ import {
   type BrainEngine,
   type DispatchRuntime,
 } from "@openomni/openomni";
-import { createGatewayRouter, type ChannelDeliveryRoute } from "@openomni/channels";
+import {
+  createGatewayRouter,
+  type ChannelDeliveryRoute,
+  type GatewayRouter,
+} from "@openomni/channels";
 import { loadConfig } from "../config";
 import { McpConfigLoader } from "../context/mcp-config";
 import { createMessageHandler } from "../handler/conversation";
@@ -29,7 +34,7 @@ import { CustomToolProvider } from "../tool/custom";
 import { createChannelAdapters } from "./channels";
 import { assembleEffectRuntime } from "./effects";
 import { createServerDispatchOwners } from "./dispatch-owners";
-import { registerServerMessaging } from "./messaging";
+import { registerServerMessaging, serverMessaging } from "./messaging";
 import { connectMcpServers } from "./mcp";
 import { runRecovery, startInboundSurfacesAfterRecovery } from "./recovery";
 import { createResidentInboundWaitHandler } from "./resident-inbound-wait";
@@ -174,6 +179,21 @@ export async function main(options: MainOptions = {}): Promise<void> {
   agentProviderRef.current = new AgentToolProvider({
     dispatchRuntime: sharedDispatchRuntime,
   });
+  // #708: the brain's as-me outbound trigger. The send port is the server's
+  // registered messaging seam (lazy: registration happens after the router
+  // composes below; a call before that keeps the typed fail-closed error).
+  // Default posture: the tool is cataloged (delegation category — the depth
+  // gate keeps it resident-only), but authority stays with the Owner: no
+  // `messaging.personaActorId` → typed "persona not configured" result, and
+  // grants default empty → every send denied `ungranted`.
+  agentProviderRef.current.register(
+    createMessageSendTool({
+      send: (input) => serverMessaging().send(input),
+      ...(config.messaging.personaActorId === undefined
+        ? {}
+        : { personaActorId: config.messaging.personaActorId }),
+    }),
+  );
   dispatchRuntimeRef.current = sharedDispatchRuntime;
   // #707: the brain's Deliver consumer resolves the resident AgentDef itself —
   // the SAME construction the channel bridge used to embed per message
@@ -195,12 +215,22 @@ export async function main(options: MainOptions = {}): Promise<void> {
         return agentDef;
       }
     : undefined;
+  // The engine claims internal (cron-stickiness) surface sessions through
+  // the gateway router's port (#708); the router is composed just below, so
+  // the claim crosses the same fail-closed ref seam as the other cycles.
+  const gatewayRouterRef: { current?: GatewayRouter } = {};
   const ingressEngine = createBrainEngine({
     coordinator,
     residentRuntime,
     agentResolver: residentAgentResolver,
     dispatchRuntime: sharedDispatchRuntime,
     ...(externalAgentResolver === undefined ? {} : { externalAgentResolver }),
+    claimSurface: (surfaceKey, sessionId, expectedSessionId) => {
+      if (!gatewayRouterRef.current) {
+        throw new Error("gateway router is not configured — surface claims fail closed");
+      }
+      return gatewayRouterRef.current.claimSurface(surfaceKey, sessionId, expectedSessionId);
+    },
   });
   ingressEngineRef.current = ingressEngine;
 
@@ -216,8 +246,10 @@ export async function main(options: MainOptions = {}): Promise<void> {
     messaging: {
       deliveryRoutes,
       grants: () => config.messaging.grants,
+      replyGrantRules: () => config.messaging.replyGrantRules,
     },
   });
+  gatewayRouterRef.current = gatewayRouter;
 
   const routingHandler = model ? createMessageHandler({ ingress: gatewayRouter }) : undefined;
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -45,6 +45,8 @@ interface RawConfig {
   };
   messaging?: {
     grants?: unknown;
+    personaActorId?: unknown;
+    replyGrantRules?: unknown;
   };
 }
 
@@ -58,8 +60,20 @@ export interface ServerConfig {
   telegram: { token?: string; allowedUsers: string[] };
   github: { secret?: string; token?: string; botUsername?: string; allowedUsers: string[] };
   discord: { token?: string; allowedUsers: string[] };
-  /** Existing-agent messaging grants: default EMPTY — every send is denied `ungranted` until a grant is explicitly configured. */
-  messaging: { grants: Gateway.SenderTargetGrant[] };
+  /**
+   * Existing-agent messaging (#215/#708): `grants` default EMPTY — every send
+   * is denied `ungranted` until a grant is explicitly configured.
+   * `personaActorId` is the Owner-owned resident persona actor every as-me
+   * send is attributed to; unset → the message.send tool fails closed with a
+   * typed "persona not configured" result. `replyGrantRules` are the
+   * Owner-written stage-0 rules the gateway materializes bounded reply-scoped
+   * grant instances from (design §2b); default EMPTY.
+   */
+  messaging: {
+    grants: Gateway.SenderTargetGrant[];
+    personaActorId?: string;
+    replyGrantRules: Gateway.ReplyGrantRule[];
+  };
 }
 
 let _config: ServerConfig | null = null;
@@ -98,6 +112,47 @@ function resolveMessagingGrants(
     context: { configPath, error: parsed.error.message },
   });
   return [];
+}
+
+function resolveReplyGrantRules(
+  raw: RawConfig,
+  configPath: string,
+  traceId: string,
+): Gateway.ReplyGrantRule[] {
+  if (raw.messaging?.replyGrantRules === undefined) return [];
+  const parsed = z.array(Gateway.ReplyGrantRule).safeParse(raw.messaging.replyGrantRules);
+  if (parsed.success) return parsed.data;
+  // Fail closed: a malformed rule list materializes nothing.
+  Bus.publish(Operational.Events.Warn, {
+    traceId,
+    time: Date.now(),
+    component: "server",
+    msg: "invalid messaging.replyGrantRules config ignored; no reply-grant instances materialize",
+    context: { configPath, error: parsed.error.message },
+  });
+  return [];
+}
+
+function resolvePersonaActorId(
+  raw: RawConfig,
+  configPath: string,
+  traceId: string,
+): string | undefined {
+  const value = raw.messaging?.personaActorId;
+  if (value === undefined) return undefined;
+  const parsed = z.string().min(1).safeParse(value);
+  if (parsed.success) return parsed.data;
+  // Fail closed: a malformed persona id configures no persona — the
+  // message.send tool keeps returning its typed "persona not configured"
+  // result instead of sending under a garbage identity.
+  Bus.publish(Operational.Events.Warn, {
+    traceId,
+    time: Date.now(),
+    component: "server",
+    msg: "invalid messaging.personaActorId config ignored; as-me sends stay fail-closed",
+    context: { configPath },
+  });
+  return undefined;
 }
 
 function resolve(raw: RawConfig, configPath: string, traceId: string): ServerConfig {
@@ -158,6 +213,8 @@ function resolve(raw: RawConfig, configPath: string, traceId: string): ServerCon
     },
     messaging: {
       grants: resolveMessagingGrants(raw, configPath, traceId),
+      personaActorId: resolvePersonaActorId(raw, configPath, traceId),
+      replyGrantRules: resolveReplyGrantRules(raw, configPath, traceId),
     },
   };
 }

--- a/apps/server/test/bootstrap/resident-inbound-wait.test.ts
+++ b/apps/server/test/bootstrap/resident-inbound-wait.test.ts
@@ -39,7 +39,7 @@ const serverConfig: ServerConfig = {
   telegram: { allowedUsers: [] },
   github: { allowedUsers: [] },
   discord: { allowedUsers: [] },
-  messaging: { grants: [] },
+  messaging: { grants: [], replyGrantRules: [] },
 };
 
 const originalBeginWait = WorkItemAttemptRun.beginWait;

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -232,6 +232,73 @@ describe("config", () => {
     expect(config.server.wsToken).toBe("env-ws-token");
   });
 
+  it("parses messaging.personaActorId and replyGrantRules; defaults stay fail-closed empty (#708)", () => {
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        messaging: {
+          personaActorId: "actor:persona",
+          replyGrantRules: [
+            {
+              id: "rule-1",
+              senderId: "actor:persona",
+              surface: "telegram",
+              operations: ["awaited"],
+              instanceTtlMs: 60_000,
+              maxLiveInstances: 3,
+              createdBy: "owner",
+            },
+          ],
+        },
+      }),
+    );
+
+    const config = loadConfig("trace-test", configPath);
+    expect(config.messaging.personaActorId).toBe("actor:persona");
+    expect(config.messaging.replyGrantRules).toHaveLength(1);
+    expect(config.messaging.replyGrantRules[0]).toMatchObject({ id: "rule-1" });
+
+    const emptyPath = join(tempDir, "empty.json");
+    writeFileSync(emptyPath, JSON.stringify({}));
+    const empty = loadConfig("trace-test", emptyPath);
+    expect(empty.messaging.personaActorId).toBeUndefined();
+    expect(empty.messaging.replyGrantRules).toEqual([]);
+    expect(empty.messaging.grants).toEqual([]);
+  });
+
+  it("drops malformed persona/reply-grant config fail-closed with a warning (#708)", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Events.Warn, (payload) => warnings.push(payload));
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        messaging: {
+          personaActorId: "",
+          replyGrantRules: [{ id: "rule-broken" }],
+        },
+      }),
+    );
+
+    const config = loadConfig("trace-test", configPath);
+    await flushBus();
+    unsubscribe();
+
+    expect(config.messaging.personaActorId).toBeUndefined();
+    expect(config.messaging.replyGrantRules).toEqual([]);
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid messaging.personaActorId config ignored; as-me sends stay fail-closed",
+      }),
+    );
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid messaging.replyGrantRules config ignored; no reply-grant instances materialize",
+      }),
+    );
+  });
+
   it("returns undefined when neither config file nor env var is set", () => {
     delete process.env.TELEGRAM_BOT_TOKEN;
     delete process.env.DISCORD_BOT_TOKEN;

--- a/apps/server/test/ingress/message-send-pipeline.test.ts
+++ b/apps/server/test/ingress/message-send-pipeline.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { Gateway, Tool } from "@openomni/protocol";
+import { createGatewayRouter, type ChannelDeliveryRoute } from "@openomni/channels";
+import {
+  createBrainEngine,
+  createMessageSendTool,
+  createToolExecutor,
+  ResidentRuntime,
+} from "@openomni/openomni";
+import { ActorRegistry, ChannelGrantStore, Session, Storage, WaitStore } from "@openomni/ledger";
+import { Bus } from "@openomni/telemetry";
+
+/**
+ * #708 E2E — the as-me outbound trigger, composed exactly as bootstrap wires
+ * it: resident agent invokes `message.send` (through the real tool executor,
+ * so the calling session rides the implicit-input seam) → the gateway send
+ * kernel grants/resolves/records → SendReceipt `sent` + durable Wait open →
+ * a driver-shaped inbound reply from the expected responder correlates
+ * through the router → brain deliver fires with waitContext → the calling
+ * session is resumed. This closes the product-thesis "outbound as-me trigger
+ * unwired" gap: the persona actor now has a live, grant-gated, ledgered path
+ * from a resident run to an external counterpart and back.
+ */
+
+const PERSONA = "actor-persona";
+const SELLER = "actor-seller";
+const SELLER_ENDPOINT = "telegram:seller-1";
+// Fixed injected clock, safely in the future of the real wall clock the wait
+// fold reads (expiry is evaluated against Date.now() at reply time).
+const NOW = 5_000_000_000_000;
+
+function registerActors(): void {
+  ActorRegistry.registerIdentity({ id: PERSONA, kind: "ai_agent", trustTier: "owner" });
+  // A marketplace counterpart: admitted on the evidence tier (§2a) — enough
+  // to correlate replies and to be a reply-grant initiator, never top-level
+  // command authority.
+  ActorRegistry.registerIdentity({ id: SELLER, kind: "human", trustTier: "collaborator" });
+  ActorRegistry.registerEndpoint({
+    id: SELLER_ENDPOINT,
+    actorId: SELLER,
+    channel: "telegram",
+    externalId: "seller-1",
+  });
+}
+
+function sellerReply(id: string, replyToMessageId: string): Gateway.DeliveredEvent {
+  return {
+    id,
+    traceId: "trace-reply",
+    surface: "telegram",
+    channel: "telegram:dm",
+    userId: "seller-1",
+    mode: "direct",
+    payload: { action: "report_result", output: "yes, still available" },
+    meta: {
+      correlation: {
+        endpointId: SELLER_ENDPOINT,
+        channelId: "telegram:dm",
+        replyToMessageId,
+      },
+    },
+  };
+}
+
+function firstContactInbound(id: string): Gateway.DeliveredEvent {
+  return {
+    id,
+    traceId: "trace-first-contact",
+    surface: "telegram",
+    channel: "telegram:dm",
+    userId: "seller-1",
+    mode: "direct",
+    payload: "is the item still available?",
+    meta: {},
+  };
+}
+
+type Harness = ReturnType<typeof composeHarness>;
+
+function composeHarness(config: {
+  grants?: readonly Gateway.SenderTargetGrant[];
+  replyGrantRules?: readonly Gateway.ReplyGrantRule[];
+  personaActorId?: string | undefined;
+  /**
+   * Tool clock. Reply-grant tests use the real clock: instance materialization
+   * stamps expiry with the router's wall clock at admission (Date.now at the
+   * seam), and the evaluator compares it against the SEND's `at`.
+   */
+  now?: () => number;
+}) {
+  const outbound: Array<{ externalId: string; body: string }> = [];
+  const deliveries: Gateway.Deliver[] = [];
+  const residentRuns: string[] = [];
+
+  const brain = createBrainEngine({
+    residentRuntime: ResidentRuntime.create({
+      runAgent: async () => {
+        residentRuns.push("executed");
+        return { text: "resident resumed", finishReason: "stop" };
+      },
+    }),
+    externalAgentResolver: async () => ({ model: { provider: "test", id: "test-model" } }),
+  });
+
+  const deliveryRoutes = new Map<string, ChannelDeliveryRoute>([
+    [
+      "telegram",
+      async (externalId, body) => {
+        outbound.push({ externalId, body });
+        return { externalMessageId: `platform:${outbound.length}` };
+      },
+    ],
+  ]);
+
+  const router = createGatewayRouter({
+    sink: Bus.publish,
+    deliver: async (delivery) => {
+      deliveries.push(delivery);
+      return brain.deliver(delivery);
+    },
+    messaging: {
+      deliveryRoutes,
+      grants: () => config.grants ?? [],
+      ...(config.replyGrantRules === undefined
+        ? {}
+        : { replyGrantRules: () => config.replyGrantRules ?? [] }),
+    },
+  });
+
+  // The exact bootstrap construction: the tool holds the send seam and the
+  // configured persona; the executor injects the calling session.
+  const ownerSession = Session.create({
+    traceId: "trace-e2e",
+    title: "resident window",
+    model: { providerID: "test", modelID: "test-model" },
+  });
+  const tool = createMessageSendTool({
+    send: (input) => router.messaging.send(input),
+    ...(config.personaActorId === undefined ? {} : { personaActorId: config.personaActorId }),
+    now: config.now ?? (() => NOW),
+  });
+  const execute = createToolExecutor({
+    tools: [tool],
+    config: {
+      runtime: { sessionId: ownerSession.id, runId: "run-resident-1", agentName: "resident" },
+    },
+  });
+
+  async function invokeMessageSend(input: Record<string, unknown>): Promise<Tool.Result> {
+    return execute(
+      { id: crypto.randomUUID(), tool: "message.send", input },
+      {
+        traceContext: { traceId: "trace-e2e", sessionId: ownerSession.id, runId: "run-resident-1" },
+      },
+    );
+  }
+
+  return { router, ownerSession, outbound, deliveries, residentRuns, invokeMessageSend };
+}
+
+function outputOf(result: Tool.Result): Record<string, unknown> {
+  return JSON.parse(result.output) as Record<string, unknown>;
+}
+
+describe("message.send → gateway → reply resumption (composed, #708)", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Bus.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    registerActors();
+  });
+
+  test("awaited as-me send with an Owner grant opens a Wait and the responder's reply resumes the calling session", async () => {
+    const harness: Harness = composeHarness({
+      personaActorId: PERSONA,
+      grants: [
+        {
+          id: "grant-persona-seller",
+          senderId: PERSONA,
+          targetActorId: SELLER,
+          operations: ["awaited", "fire_and_forget"],
+        },
+      ],
+    });
+
+    const result = await harness.invokeMessageSend({
+      target: { actorId: SELLER },
+      body: "Is the listing still available? I can pick it up today.",
+      operation: "awaited",
+      expectReply: { expiresInMs: 3_600_000 },
+    });
+
+    // 1) SendReceipt sent + Wait open, owned by the calling session.
+    expect(result.isError).toBeUndefined();
+    const output = outputOf(result);
+    expect(output).toMatchObject({ kind: "sent", operation: "awaited" });
+    const waitId = output.waitId as string;
+    expect(harness.outbound).toEqual([
+      { externalId: "seller-1", body: "Is the listing still available? I can pick it up today." },
+    ]);
+    const openWait = WaitStore.get(waitId);
+    expect(openWait).toMatchObject({
+      status: "open",
+      ownerRef: { kind: "session", id: harness.ownerSession.id },
+      expectedResponders: [SELLER],
+      resolutionPolicy: "first_reply",
+      expiresAt: NOW + 3_600_000,
+      // Delivery receipt re-keyed correlation to the platform message id.
+      correlation: { endpointId: SELLER_ENDPOINT, replyToMessageId: "platform:1" },
+    });
+
+    // 2) Driver-shaped reply from the expected responder correlates through
+    //    the router and resumes the owner session with waitContext attached.
+    const ingest = await harness.router.ingest(sellerReply("reply-1", "platform:1"));
+
+    if (ingest.kind === "dropped") throw new Error("reply was dropped");
+    expect(ingest.sessionId).toBe(harness.ownerSession.id);
+    expect(ingest.result.output).toBe("resident resumed");
+    expect(harness.residentRuns).toEqual(["executed"]);
+    expect(WaitStore.get(waitId)).toMatchObject({ status: "resolved" });
+    const resumed = harness.deliveries.at(-1);
+    expect(resumed?.waitContext).toMatchObject({ waitId, allowedAction: "report_result" });
+    expect(resumed?.sessionId).toBe(harness.ownerSession.id);
+  });
+
+  test("ungranted target: the agent sees the typed denial as a result and nothing is delivered or awaited", async () => {
+    const harness = composeHarness({ personaActorId: PERSONA, grants: [] });
+
+    const result = await harness.invokeMessageSend({
+      target: { actorId: SELLER },
+      body: "hello",
+      operation: "awaited",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(outputOf(result)).toMatchObject({ kind: "denied", code: "ungranted" });
+    expect(harness.outbound).toHaveLength(0);
+    expect(WaitStore.list()).toHaveLength(0);
+  });
+
+  test("persona unset: the tool fails closed with a typed error result — no identity, no send", async () => {
+    const harness = composeHarness({ personaActorId: undefined, grants: [] });
+
+    const result = await harness.invokeMessageSend({
+      target: { actorId: SELLER },
+      body: "hello",
+      operation: "fire_and_forget",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("persona not configured");
+    expect(harness.outbound).toHaveLength(0);
+  });
+
+  test("reply-grant rule: a first-contact admission materializes a scoped instance that grants the reply and refuses cross-surface use", async () => {
+    const harness = composeHarness({
+      personaActorId: PERSONA,
+      grants: [],
+      now: Date.now,
+      replyGrantRules: [
+        {
+          id: "rule-telegram-replies",
+          senderId: PERSONA,
+          surface: "telegram",
+          operations: ["fire_and_forget", "awaited"],
+          instanceTtlMs: 24 * 60 * 60 * 1000,
+          maxLiveInstances: 5,
+          createdBy: "actor-owner",
+        },
+      ],
+    });
+    // Surface-default admission requires an Owner channel grant (§2a); a
+    // stranger-facing channel admits on the EVIDENCE tier, never full access.
+    ChannelGrantStore.put({
+      id: "grant-telegram-dm",
+      surface: "telegram",
+      channel: "telegram:dm",
+      kind: "trusted_channel",
+      inboundTreatment: "evidence_only",
+      createdBy: "actor-owner",
+    });
+
+    // Before first contact: nothing materialized, the send is ungranted.
+    const beforeContact = await harness.invokeMessageSend({
+      target: { actorId: SELLER },
+      body: "cold outreach",
+      operation: "fire_and_forget",
+    });
+    expect(outputOf(beforeContact)).toMatchObject({ kind: "denied", code: "ungranted" });
+
+    // First-contact inbound from the seller is admitted through the router →
+    // the rule materializes ONE reply-scoped instance from perimeter facts.
+    const admitted = await harness.router.ingest(firstContactInbound("inbound-first-contact"));
+    if (admitted.kind === "dropped") throw new Error("first contact was dropped");
+
+    // The reply INTO the initiating container is now granted…
+    const reply = await harness.invokeMessageSend({
+      target: { actorId: SELLER, endpointId: SELLER_ENDPOINT },
+      body: "Yes — it is available. When suits you?",
+      operation: "fire_and_forget",
+    });
+    expect(outputOf(reply)).toMatchObject({ kind: "sent", operation: "fire_and_forget" });
+    expect(harness.outbound).toEqual([
+      { externalId: "seller-1", body: "Yes — it is available. When suits you?" },
+    ]);
+
+    // …while the SAME instance is refused cross-surface (pinned containment).
+    ActorRegistry.registerEndpoint({
+      id: "discord:seller-9",
+      actorId: SELLER,
+      channel: "discord",
+      externalId: "seller-9",
+    });
+    const crossSurface = await harness.invokeMessageSend({
+      target: { actorId: SELLER, endpointId: "discord:seller-9" },
+      body: "moving to discord",
+      operation: "fire_and_forget",
+    });
+    const denied = outputOf(crossSurface);
+    expect(denied).toMatchObject({ kind: "denied", code: "ungranted" });
+    expect(String(denied.reason)).toContain("replies stay inside the initiating container");
+    expect(harness.outbound).toHaveLength(1);
+  });
+});

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -70,10 +70,13 @@ Brain-side consumption rules (normative, closes the known gap):
 Grant-write validation (perimeter): a channel grant whose `defaultTier`
 materializes strangers may never carry `inboundTreatment: "full_access"` —
 rejected at grant write, not at delivery time. Deferred to the first
-Owner-write surface (#708): measured at cut, zero production writers exist
+Owner-write surface: measured at cut, zero production writers exist
 for actor/blacklist/channel-grant rows — the sole-writer property is vacuous
 today (recorded), and the rejection has no write seam to attach to until
-that surface lands. Accepted residual: the
+that surface lands. Re-measured at #708: still true — #708's Owner surfaces
+(send grants, reply-grant rules) are config-parsed, not channel-grant row
+writes, so the validation rides to the durable grant/actor store follow-up
+(#709/SSOT). Accepted residual: the
 unconditional recency window (§5) means admitted external text enters run
 context regardless of engagement match; the mitigation is taint framing plus
 the evidence tier, not exclusion.
@@ -323,7 +326,12 @@ inventory above:
   `require()` alike (the static named clause is the only road).
 - The brain-side internal `SurfaceKey.claim` residue rides to #708 (a
   gateway port for internal claims) — Owner-ruled, no concrete breakage,
-  CAS-converged.
+  CAS-converged. **Resolved at #708**: the router exposes
+  `claimSurface(surfaceKey, sessionId, expectedSessionId?)` (CAS receipt =
+  the owner after the attempt), apps/server injects it into the brain
+  engine, and the brain's session resolver fails closed without it — the
+  gateway is now the literal sole WRITER of the surface↔session map
+  (brain-side reads stay recorded residue).
 
 Perimeter stores do NOT move to channels (§4 SSOT): `actor/`, `blacklist/`,
 `channel-grant/`, `wait/` store, `surface-key/`, `pending-ask/`,

--- a/packages/channels/src/router/index.ts
+++ b/packages/channels/src/router/index.ts
@@ -10,6 +10,7 @@ import {
 import { SurfaceKey } from "@openomni/ledger";
 import { resolveIngressActor } from "./actor-resolver.js";
 import { IngressAuthorityMiddleware } from "./authority.js";
+import { createReplyGrantInstances, type ReplyGrantInstances } from "./messaging/reply-grant.js";
 import { createExistingAgentMessaging, type DeliveryReceipt } from "./messaging/send.js";
 import type { ExistingAgentMessaging } from "./messaging/send.js";
 import {
@@ -78,6 +79,13 @@ export interface GatewayRouterPorts {
   readonly messaging?: Readonly<{
     deliveryRoutes: ReadonlyMap<string, ChannelDeliveryRoute>;
     grants: () => readonly Gateway.SenderTargetGrant[];
+    /**
+     * Owner-written reply-grant rules (#708, design §2b stage-0 rule): the
+     * router materializes bounded, reply-scoped grant INSTANCES from them
+     * when it admits a first-contact actor on a covered channel. Instances
+     * live in router memory (recorded ruling — durable store is #709).
+     */
+    replyGrantRules?: () => readonly Gateway.ReplyGrantRule[];
   }>;
 }
 
@@ -86,6 +94,16 @@ export interface GatewayRouter {
   ingest(event: unknown): Promise<Ingress.IngressResult>;
   /** The existing-agent send kernel (#215); fail-closed when unconfigured. */
   readonly messaging: ExistingAgentMessaging;
+  /**
+   * Gateway port for the brain's INTERNAL-mode surface↔session stickiness
+   * claims (#708, closing the #707 residue): the brain injects this at
+   * composition instead of writing the perimeter surface directly, making
+   * the gateway the literal sole writer of the surface↔session map. CAS
+   * semantics: with `expectedSessionId` the claim replaces only that owner;
+   * without it, it inserts only when absent. The returned session id is the
+   * owner AFTER the attempt — the CAS receipt.
+   */
+  claimSurface(surfaceKey: string, sessionId: string, expectedSessionId?: string): string;
 }
 
 /**
@@ -172,12 +190,18 @@ function waitContextOf(resolution: KernelRouteResolution): Gateway.WaitContext |
 }
 
 export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
+  const replyGrantRules = ports.messaging?.replyGrantRules;
+  const replyGrants: ReplyGrantInstances | undefined =
+    replyGrantRules === undefined
+      ? undefined
+      : createReplyGrantInstances({ rules: replyGrantRules, publish: ports.sink });
+  const messagingPorts = ports.messaging;
   const messaging =
-    ports.messaging === undefined
+    messagingPorts === undefined
       ? undefined
       : createExistingAgentMessaging({
           deliver: async (message) => {
-            const route = ports.messaging?.deliveryRoutes.get(message.target.channel);
+            const route = messagingPorts.deliveryRoutes.get(message.target.channel);
             if (route === undefined) {
               throw new Error(
                 `no registered channel surface delivers ${message.target.channel} ` +
@@ -186,7 +210,11 @@ export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
             }
             return route(message.target.externalId, message.body);
           },
-          grants: ports.messaging.grants,
+          // One grant source per send: Owner-written standing grants plus the
+          // live rule-materialized instances. The scope-less base evaluator
+          // still refuses the instances; only the scope-aware arm honors one
+          // whose replyScope matches the resolved delivery endpoint.
+          grants: () => [...messagingPorts.grants(), ...(replyGrants?.list() ?? [])],
           publish: ports.sink,
         });
 
@@ -202,6 +230,32 @@ export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
       const trace = { traceId: externalEvent.traceId };
       const route = resolveAndRecordRoute(resolvedActorEvent, trace.traceId, ports.sink);
       const decision = requireRoutedDecision(route.decision);
+
+      // Reply-grant materialization (#708, §2b stage-0 rule): a ROUTED
+      // admission of a resolved, registered actor on a rule-covered channel
+      // materializes a bounded reply-scoped grant instance — perimeter facts
+      // only (initiator actorId + resolved endpoint + rule TTL). Anonymous
+      // senders (no ActorRegistry endpoint) and dropped/blocked events
+      // materialize nothing.
+      if (replyGrants !== undefined && decision.outcome === "route") {
+        const actor = resolvedActorEvent.meta?.actor;
+        const actorId = typeof actor?.actorId === "string" ? actor.actorId : undefined;
+        const endpoint = actor?.endpoint;
+        if (actorId !== undefined && endpoint !== undefined) {
+          replyGrants.admit({
+            actorId,
+            endpoint: { channel: endpoint.channel, externalId: endpoint.externalId },
+            surface: externalEvent.surface,
+            ...(externalEvent.workspace === undefined
+              ? {}
+              : { workspace: externalEvent.workspace }),
+            ...(externalEvent.channel === undefined ? {} : { channel: externalEvent.channel }),
+            traceId: trace.traceId,
+            at: Date.now(),
+          });
+        }
+      }
+
       const waitExecution = await executeWaitRoute(trace, route, decision);
       if (waitExecution.kind === "handled") return waitExecution.result;
 
@@ -243,6 +297,14 @@ export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
         throw new Error("existing-agent messaging is not registered — sends fail closed");
       }
       return messaging;
+    },
+
+    // #708 residue closure: internal-mode (cron stickiness) claims cross this
+    // port instead of a brain-side SurfaceKey write — the gateway is now the
+    // literal sole writer of the surface↔session map. Same CAS semantics as
+    // the router's own resident claim above.
+    claimSurface(surfaceKey: string, sessionId: string, expectedSessionId?: string): string {
+      return SurfaceKey.claim(surfaceKey, sessionId, expectedSessionId);
     },
   };
 }

--- a/packages/channels/src/router/messaging/grant.ts
+++ b/packages/channels/src/router/messaging/grant.ts
@@ -7,6 +7,53 @@ import type { Gateway } from "@openomni/protocol";
  * (contract boundary — schemas and pure folds only, never authority
  * evaluation), so the evaluator lives here on the perimeter.
  *
+ * Two evaluators, one fail-closed split (#708 stage 3):
+ * - `resolveSenderTargetGrant` — the scope-LESS base evaluator. It has no
+ *   surface context, so it refuses replyScope-carrying (rule-materialized)
+ *   instances outright; honoring one here would silently void its
+ *   containment.
+ * - `resolveScopedSenderTargetGrant` — the scope-AWARE evaluator. The send
+ *   kernel calls it with the surface key derived from the RESOLVED delivery
+ *   endpoint, so a materialized instance is honored exactly inside the
+ *   container it was created for and refused everywhere else.
+ */
+
+type GrantClaim = Readonly<{
+  senderId: string;
+  targetActorId: string;
+  operation: Gateway.MessageOperation;
+  at: number;
+}>;
+
+function matchesClaim(grant: Gateway.SenderTargetGrant, claim: GrantClaim): boolean {
+  return (
+    grant.senderId === claim.senderId &&
+    grant.targetActorId === claim.targetActorId &&
+    grant.operations.includes(claim.operation) &&
+    (grant.expiresAt === undefined || claim.at <= grant.expiresAt)
+  );
+}
+
+function idOrdered(
+  grants: readonly Gateway.SenderTargetGrant[],
+): readonly Gateway.SenderTargetGrant[] {
+  return [...grants].sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+}
+
+/**
+ * The perimeter surface key of a resolved delivery endpoint: channel +
+ * externalId — the two facts a `Gateway.DeliveryTarget` and a resolved
+ * inbound actor endpoint share, so materialization (inbound admission) and
+ * evaluation (outbound send) derive the SAME key from the SAME endpoint.
+ * Thread-level narrowing awaits the durable grant-instance store (#709).
+ */
+export function deliverySurfaceKey(
+  endpoint: Readonly<{ channel: string; externalId: string }>,
+): string {
+  return `${endpoint.channel}:${endpoint.externalId}`;
+}
+
+/**
  * Pure policy-plane grant evaluation: returns the first (id-ordered) active
  * grant binding this sender to this target for this operation, or undefined —
  * the caller fails closed as `ungranted`. Time is an input; an expired grant
@@ -14,26 +61,46 @@ import type { Gateway } from "@openomni/protocol";
  */
 export function resolveSenderTargetGrant(
   grants: readonly Gateway.SenderTargetGrant[],
-  claim: Readonly<{
-    senderId: string;
-    targetActorId: string;
-    operation: Gateway.MessageOperation;
-    at: number;
-  }>,
+  claim: GrantClaim,
 ): Gateway.SenderTargetGrant | undefined {
-  return [...grants]
-    .sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0))
-    .find(
-      (grant) =>
-        // Fail-closed containment guard: this evaluator has no surface
-        // context, so it CANNOT check replyScope — a scope-carrying
-        // (rule-materialized) instance is resolvable only by a scope-aware
-        // evaluator (stage 3). Honoring it here would silently void the
-        // containment the instance was created with.
-        grant.replyScope === undefined &&
-        grant.senderId === claim.senderId &&
-        grant.targetActorId === claim.targetActorId &&
-        grant.operations.includes(claim.operation) &&
-        (grant.expiresAt === undefined || claim.at <= grant.expiresAt),
-    );
+  return idOrdered(grants).find(
+    (grant) =>
+      // Fail-closed containment guard: no surface context here — a
+      // scope-carrying (rule-materialized) instance is resolvable only by
+      // the scope-aware evaluator below.
+      grant.replyScope === undefined && matchesClaim(grant, claim),
+  );
+}
+
+/**
+ * True when at least one reply-scoped instance covers sender→target for this
+ * operation at this time, scope UNCHECKED. The send kernel uses it to decide
+ * whether target resolution may run at all: with no candidate the denial is
+ * `ungranted` BEFORE any registry lookup (an ungranted sender learns nothing
+ * from the registry); with a candidate the endpoint must resolve first,
+ * because only the resolved endpoint yields the outbound surface key.
+ */
+export function hasScopedSenderTargetCandidate(
+  grants: readonly Gateway.SenderTargetGrant[],
+  claim: GrantClaim,
+): boolean {
+  return grants.some((grant) => grant.replyScope !== undefined && matchesClaim(grant, claim));
+}
+
+/**
+ * Scope-aware evaluation of rule-materialized instances (#708): the first
+ * (id-ordered) active reply-scoped instance whose `replyScope.surfaceKey`
+ * equals the outbound delivery surface key. Cross-surface use fails closed —
+ * the instance authorizes replies INTO the initiating container only.
+ */
+export function resolveScopedSenderTargetGrant(
+  grants: readonly Gateway.SenderTargetGrant[],
+  claim: GrantClaim & Readonly<{ surfaceKey: string }>,
+): Gateway.SenderTargetGrant | undefined {
+  return idOrdered(grants).find(
+    (grant) =>
+      grant.replyScope !== undefined &&
+      grant.replyScope.surfaceKey === claim.surfaceKey &&
+      matchesClaim(grant, claim),
+  );
 }

--- a/packages/channels/src/router/messaging/reply-grant.ts
+++ b/packages/channels/src/router/messaging/reply-grant.ts
@@ -1,0 +1,126 @@
+import { Gateway, Operational, type BusEvent } from "@openomni/protocol";
+import { deliverySurfaceKey } from "./grant.js";
+
+/**
+ * Reply-grant materialization (#708, stage-0 rule of docs/gateway-design.md
+ * §2b): the Owner writes a *rule* row (surface/channel-scoped standing
+ * delegation); the gateway materializes bounded `SenderTargetGrant`
+ * INSTANCES from it mechanically when it admits a first-contact actor on the
+ * covered channel. Instances are scoped by perimeter facts only — initiator
+ * actorId + originating endpoint surface key + `instanceTtlMs` expiry —
+ * never by engagement id, and `maxLiveInstances` caps grant farming by mass
+ * first contact.
+ *
+ * RULING (#708): instances are IN-MEMORY on the router for this stage. A
+ * restart forgets them and the initiator's next admitted message
+ * re-materializes an instance under the same rule — no new persisted surface
+ * lands here; the durable grant-instance store is the #709/SSOT follow-up.
+ */
+
+export type ReplyGrantAdmission = Readonly<{
+  /** Resolved registered initiator (perimeter fact — anonymous senders materialize nothing). */
+  actorId: string;
+  /** The initiator's resolved endpoint — the same facts the send kernel re-derives at evaluation. */
+  endpoint: Readonly<{ channel: string; externalId: string }>;
+  surface: string;
+  workspace?: string;
+  channel?: string;
+  traceId: string;
+  at: number;
+}>;
+
+export type ReplyGrantInstances = Readonly<{
+  /** Live view for the send kernel's grant source; expiry is re-checked per-send by the evaluator (`at` is the send's clock). */
+  list(): readonly Gateway.SenderTargetGrant[];
+  /** Materializes instances for an admitted inbound; capacity/first-contact rules applied per rule. */
+  admit(admission: ReplyGrantAdmission): void;
+}>;
+
+function ruleCovers(rule: Gateway.ReplyGrantRule, admission: ReplyGrantAdmission): boolean {
+  return (
+    rule.surface === admission.surface &&
+    (rule.workspace === undefined || rule.workspace === admission.workspace) &&
+    (rule.channel === undefined || rule.channel === admission.channel)
+  );
+}
+
+export function createReplyGrantInstances(ports: {
+  readonly rules: () => readonly Gateway.ReplyGrantRule[];
+  /** Injected observation sink — materialization and capacity refusals are audited, never silent. */
+  readonly publish: BusEvent.Sink["publish"];
+}): ReplyGrantInstances {
+  let instances: Gateway.SenderTargetGrant[] = [];
+
+  /** Memory hygiene only — authority-expiry is the evaluator's per-send check. */
+  function prune(at: number): void {
+    instances = instances.filter(
+      (instance) => instance.expiresAt === undefined || at <= instance.expiresAt,
+    );
+  }
+
+  return {
+    list() {
+      return [...instances];
+    },
+
+    admit(admission: ReplyGrantAdmission): void {
+      prune(admission.at);
+      for (const rule of ports.rules()) {
+        if (!ruleCovers(rule, admission)) continue;
+        // The persona never needs a grant to be replied to by itself.
+        if (rule.senderId === admission.actorId) continue;
+        const surfaceKey = deliverySurfaceKey(admission.endpoint);
+        const liveForRule = instances.filter((instance) => instance.ruleId === rule.id);
+        const alreadyLive = liveForRule.some(
+          (instance) =>
+            instance.targetActorId === admission.actorId &&
+            instance.replyScope?.surfaceKey === surfaceKey,
+        );
+        // First contact only: a live instance for this initiator+container
+        // keeps its ORIGINAL expiry — repeat messages never refresh it.
+        if (alreadyLive) continue;
+        if (liveForRule.length >= rule.maxLiveInstances) {
+          ports.publish(Operational.Events.Warn, {
+            traceId: admission.traceId,
+            time: admission.at,
+            component: "gateway",
+            msg: "reply-grant rule at capacity; no instance materialized",
+            context: {
+              ruleId: rule.id,
+              targetActorId: admission.actorId,
+              surfaceKey,
+              maxLiveInstances: rule.maxLiveInstances,
+            },
+          });
+          continue;
+        }
+        // Parse pins the schema invariants (rule-materialized ⇒ replyScope +
+        // expiresAt) — a drifting materializer fails loudly, not silently.
+        const instance = Gateway.SenderTargetGrant.parse({
+          id: crypto.randomUUID(),
+          senderId: rule.senderId,
+          targetActorId: admission.actorId,
+          operations: [...rule.operations],
+          expiresAt: admission.at + rule.instanceTtlMs,
+          ruleId: rule.id,
+          replyScope: { surfaceKey },
+        } satisfies Gateway.SenderTargetGrant);
+        instances.push(instance);
+        ports.publish(Operational.Events.Info, {
+          traceId: admission.traceId,
+          time: admission.at,
+          component: "gateway",
+          msg: "reply-grant instance materialized",
+          context: {
+            ruleId: rule.id,
+            instanceId: instance.id,
+            senderId: rule.senderId,
+            targetActorId: admission.actorId,
+            surfaceKey,
+            expiresAt: instance.expiresAt,
+          },
+        });
+      }
+    },
+  };
+}

--- a/packages/channels/src/router/messaging/send.ts
+++ b/packages/channels/src/router/messaging/send.ts
@@ -8,7 +8,12 @@ import {
 import { ActorRegistry } from "@openomni/ledger";
 import { WaitService } from "../wait/index.js";
 import { Events } from "./events.js";
-import { resolveSenderTargetGrant } from "./grant.js";
+import {
+  deliverySurfaceKey,
+  hasScopedSenderTargetCandidate,
+  resolveScopedSenderTargetGrant,
+  resolveSenderTargetGrant,
+} from "./grant.js";
 
 type DeliveryTarget = Gateway.DeliveryTarget;
 type MessageDenialCode = Gateway.MessageDenialCode;
@@ -159,13 +164,21 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
 
   async function send(rawInput: SendInput): Promise<SendReceipt> {
     const input = SendInput.parse(rawInput);
-    const grant = resolveSenderTargetGrant(ports.grants(), {
+    const grants = ports.grants();
+    const claim = {
       senderId: input.senderId,
       targetActorId: input.target.actorId,
       operation: input.operation,
       at: input.at,
-    });
-    if (grant === undefined) {
+    };
+    // Scope-aware arm (#708): a rule-materialized instance carries a
+    // replyScope that can only be checked against the RESOLVED delivery
+    // endpoint, so with a candidate present the target resolves first and
+    // the scope check follows. With no candidate the denial stays
+    // `ungranted` BEFORE any registry lookup — an ungranted sender learns
+    // nothing from the registry (pinned by the send suite).
+    let grant = resolveSenderTargetGrant(grants, claim);
+    if (grant === undefined && !hasScopedSenderTargetCandidate(grants, claim)) {
       return deny(
         input,
         "ungranted",
@@ -176,6 +189,23 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
     if (!resolution.ok) {
       return deny(input, resolution.code, resolution.reason);
     }
+    if (grant === undefined) {
+      const surfaceKey = deliverySurfaceKey(resolution.target);
+      grant = resolveScopedSenderTargetGrant(grants, { ...claim, surfaceKey });
+      if (grant === undefined) {
+        // Cross-surface use of a reply-scoped instance fails closed: the
+        // instance authorizes replies INTO the initiating container only.
+        return deny(
+          input,
+          "ungranted",
+          `reply-scoped grant does not cover surface ${surfaceKey} — replies stay inside the initiating container`,
+        );
+      }
+    }
+
+    // #219 seam: egress semantics (social budget, notify|converse class
+    // split, 봉수 escalation counting) evaluate HERE — after grant, before
+    // the wait record and the delivery effect. Own leaf, not this PR.
 
     let wait: Wait.Record | undefined;
     if (input.operation === "awaited") {

--- a/packages/channels/test/router/messaging/reply-grant.test.ts
+++ b/packages/channels/test/router/messaging/reply-grant.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import type { BusEvent, Gateway } from "@openomni/protocol";
+import {
+  createReplyGrantInstances,
+  type ReplyGrantAdmission,
+} from "../../../src/router/messaging/reply-grant.js";
+
+/**
+ * #708 reply-grant materialization mechanics (design §2b stage-0 rule):
+ * Owner-written RULES materialize bounded, reply-scoped grant INSTANCES for
+ * first-contact admitted actors — perimeter facts only, capped per rule,
+ * in-memory for this stage (recorded ruling; durable store is #709).
+ */
+
+const NOW = 1_700_000_000_000;
+
+function rule(overrides: Partial<Gateway.ReplyGrantRule> = {}): Gateway.ReplyGrantRule {
+  return {
+    id: "rule-1",
+    senderId: "actor:persona",
+    surface: "telegram",
+    operations: ["awaited", "fire_and_forget"],
+    instanceTtlMs: 60_000,
+    maxLiveInstances: 2,
+    createdBy: "owner",
+    ...overrides,
+  };
+}
+
+function admission(overrides: Partial<ReplyGrantAdmission> = {}): ReplyGrantAdmission {
+  return {
+    actorId: "actor:stranger-1",
+    endpoint: { channel: "telegram", externalId: "chat-1" },
+    surface: "telegram",
+    traceId: "trace-reply-grant",
+    at: NOW,
+    ...overrides,
+  };
+}
+
+function harness(rules: readonly Gateway.ReplyGrantRule[]) {
+  const published: Array<{ name: string; data: Record<string, unknown> }> = [];
+  const publish: BusEvent.Sink["publish"] = (descriptor, data) => {
+    published.push({ name: descriptor.name, data: data as Record<string, unknown> });
+  };
+  const instances = createReplyGrantInstances({ rules: () => rules, publish });
+  return { instances, published };
+}
+
+describe("reply-grant instance materialization", () => {
+  test("an admitted first-contact actor on a covered surface materializes one bounded instance", () => {
+    const { instances, published } = harness([rule()]);
+
+    instances.admit(admission());
+
+    const live = instances.list();
+    expect(live).toHaveLength(1);
+    expect(live[0]).toMatchObject({
+      senderId: "actor:persona",
+      targetActorId: "actor:stranger-1",
+      operations: ["awaited", "fire_and_forget"],
+      expiresAt: NOW + 60_000,
+      ruleId: "rule-1",
+      replyScope: { surfaceKey: "telegram:chat-1" },
+    });
+    expect(published.map((event) => event.name)).toEqual(["operational.info"]);
+    expect(published[0]?.data).toMatchObject({
+      msg: "reply-grant instance materialized",
+      traceId: "trace-reply-grant",
+    });
+  });
+
+  test("repeat contact is NOT first contact: no second instance, no expiry refresh", () => {
+    const { instances } = harness([rule()]);
+
+    instances.admit(admission());
+    instances.admit(admission({ at: NOW + 10_000 }));
+
+    const live = instances.list();
+    expect(live).toHaveLength(1);
+    expect(live[0]?.expiresAt).toBe(NOW + 60_000);
+  });
+
+  test("maxLiveInstances caps grant farming: at capacity no instance lands and the refusal is audited", () => {
+    const { instances, published } = harness([rule({ maxLiveInstances: 1 })]);
+
+    instances.admit(admission());
+    instances.admit(
+      admission({
+        actorId: "actor:stranger-2",
+        endpoint: { channel: "telegram", externalId: "chat-2" },
+      }),
+    );
+
+    expect(instances.list()).toHaveLength(1);
+    const warn = published.find((event) => event.name === "operational.warn");
+    expect(warn?.data).toMatchObject({
+      msg: "reply-grant rule at capacity; no instance materialized",
+      context: {
+        ruleId: "rule-1",
+        targetActorId: "actor:stranger-2",
+        maxLiveInstances: 1,
+      },
+    });
+  });
+
+  test("expired instances free capacity — the cap counts LIVE instances", () => {
+    const { instances } = harness([rule({ maxLiveInstances: 1 })]);
+
+    instances.admit(admission());
+    instances.admit(
+      admission({
+        actorId: "actor:stranger-2",
+        endpoint: { channel: "telegram", externalId: "chat-2" },
+        at: NOW + 60_001,
+      }),
+    );
+
+    const live = instances.list();
+    expect(live).toHaveLength(1);
+    expect(live[0]?.targetActorId).toBe("actor:stranger-2");
+  });
+
+  test("rule scope pins: wrong surface, wrong workspace, and the persona itself materialize nothing", () => {
+    const { instances } = harness([rule({ workspace: "bot-a" })]);
+
+    instances.admit(admission({ surface: "discord", workspace: "bot-a" }));
+    instances.admit(admission({ workspace: "bot-b" }));
+    instances.admit(admission({ workspace: "bot-a", actorId: "actor:persona" }));
+
+    expect(instances.list()).toHaveLength(0);
+
+    instances.admit(admission({ workspace: "bot-a" }));
+    expect(instances.list()).toHaveLength(1);
+  });
+
+  test("the same actor in a second container is a new first contact (per-container scope)", () => {
+    const { instances } = harness([rule()]);
+
+    instances.admit(admission());
+    instances.admit(admission({ endpoint: { channel: "telegram", externalId: "chat-9" } }));
+
+    const scopes = instances.list().map((instance) => instance.replyScope?.surfaceKey);
+    expect(scopes.sort()).toEqual(["telegram:chat-1", "telegram:chat-9"]);
+  });
+});

--- a/packages/channels/test/router/messaging/scoped-grant.test.ts
+++ b/packages/channels/test/router/messaging/scoped-grant.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Gateway } from "@openomni/protocol";
+import { ActorRegistry, Storage } from "@openomni/ledger";
+import { Bus } from "@openomni/telemetry";
+import {
+  deliverySurfaceKey,
+  hasScopedSenderTargetCandidate,
+  resolveScopedSenderTargetGrant,
+} from "../../../src/router/messaging/grant.js";
+import { createExistingAgentMessaging } from "../../../src/router/messaging/send.js";
+import { buildSendInput, messagingNow, registerAgentFixture } from "../../helpers/messaging.js";
+
+/**
+ * #708 scope-aware grant arm: a rule-materialized (reply-scoped) instance is
+ * honored exactly inside the container it was created for — evaluated against
+ * the surface key derived from the RESOLVED delivery endpoint — and refused
+ * everywhere else. The scope-less base evaluator keeps failing closed on
+ * these instances (reply-scope-guard.test.ts pins that half).
+ */
+
+const scopedInstance = (overrides: Partial<Gateway.SenderTargetGrant> = {}) =>
+  ({
+    id: "instance-1",
+    senderId: "actor:sender",
+    targetActorId: "actor:target",
+    operations: ["fire_and_forget", "awaited"],
+    expiresAt: messagingNow + 60_000,
+    ruleId: "rule-1",
+    replyScope: { surfaceKey: "qa:target-1" },
+    ...overrides,
+  }) as Gateway.SenderTargetGrant;
+
+const claim = {
+  senderId: "actor:sender",
+  targetActorId: "actor:target",
+  operation: "fire_and_forget",
+  at: messagingNow,
+} as const;
+
+describe("scope-aware grant evaluation (pure)", () => {
+  test("deliverySurfaceKey derives channel:externalId — the facts both sides share", () => {
+    expect(deliverySurfaceKey({ channel: "qa", externalId: "target-1" })).toBe("qa:target-1");
+  });
+
+  test("a scoped instance resolves only for its own surface key", () => {
+    const grants = [scopedInstance()];
+    expect(
+      resolveScopedSenderTargetGrant(grants, { ...claim, surfaceKey: "qa:target-1" })?.id,
+    ).toBe("instance-1");
+    expect(
+      resolveScopedSenderTargetGrant(grants, { ...claim, surfaceKey: "discord:target-9" }),
+    ).toBeUndefined();
+  });
+
+  test("a scope-less standing grant is never resolved by the scoped arm", () => {
+    const standing = scopedInstance({
+      id: "standing-1",
+      ruleId: undefined,
+      replyScope: undefined,
+      expiresAt: undefined,
+    });
+    expect(
+      resolveScopedSenderTargetGrant([standing], { ...claim, surfaceKey: "qa:target-1" }),
+    ).toBeUndefined();
+  });
+
+  test("expiry and operation bounds hold on the scoped arm too", () => {
+    const expired = scopedInstance({ expiresAt: messagingNow - 1 });
+    const awaitedOnly = scopedInstance({ id: "instance-2", operations: ["awaited"] });
+    expect(
+      resolveScopedSenderTargetGrant([expired], { ...claim, surfaceKey: "qa:target-1" }),
+    ).toBeUndefined();
+    expect(
+      resolveScopedSenderTargetGrant([awaitedOnly], { ...claim, surfaceKey: "qa:target-1" }),
+    ).toBeUndefined();
+  });
+
+  test("candidate check matches scope-carrying instances only, scope unchecked", () => {
+    expect(hasScopedSenderTargetCandidate([scopedInstance()], claim)).toBe(true);
+    expect(
+      hasScopedSenderTargetCandidate(
+        [scopedInstance({ replyScope: undefined, ruleId: undefined, expiresAt: undefined })],
+        claim,
+      ),
+    ).toBe(false);
+    expect(
+      hasScopedSenderTargetCandidate([scopedInstance({ expiresAt: messagingNow - 1 })], claim),
+    ).toBe(false);
+  });
+});
+
+describe("send kernel over reply-scoped instances", () => {
+  let grants: Gateway.SenderTargetGrant[];
+  let delivered: string[];
+
+  function messaging() {
+    return createExistingAgentMessaging({
+      deliver: (message) => {
+        delivered.push(message.target.endpointId);
+      },
+      grants: () => grants,
+      publish: Bus.publish,
+    });
+  }
+
+  beforeEach(() => {
+    Bus.reset();
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    delivered = [];
+    grants = [scopedInstance()];
+    registerAgentFixture("actor:sender");
+    // channel "qa", externalId "target-1" → surface key "qa:target-1".
+    registerAgentFixture("actor:target", [{ id: "endpoint:target", externalId: "target-1" }]);
+  });
+
+  afterEach(() => {
+    Storage.reset();
+    Bus.reset();
+  });
+
+  test("a send into the initiating container is granted by the scoped instance", async () => {
+    const receipt = await messaging().send(buildSendInput());
+
+    expect(receipt.kind).toBe("sent");
+    if (receipt.kind !== "sent") throw new Error("expected sent");
+    expect(receipt.grantId).toBe("instance-1");
+    expect(delivered).toEqual(["endpoint:target"]);
+  });
+
+  test("cross-surface use of the instance is refused ungranted — containment is pinned", async () => {
+    ActorRegistry.registerEndpoint({
+      id: "endpoint:target-discord",
+      actorId: "actor:target",
+      channel: "discord",
+      externalId: "target-9",
+      createdAt: messagingNow,
+      updatedAt: messagingNow,
+    });
+
+    const receipt = await messaging().send(
+      buildSendInput({
+        target: { actorId: "actor:target", endpointId: "endpoint:target-discord" },
+      }),
+    );
+
+    expect(receipt.kind).toBe("denied");
+    if (receipt.kind !== "denied") throw new Error("expected denial");
+    expect(receipt.code).toBe("ungranted");
+    expect(receipt.reason).toContain("replies stay inside the initiating container");
+    expect(delivered).toHaveLength(0);
+  });
+
+  test("with only a scoped candidate, an unresolvable target still yields its typed target denial", async () => {
+    grants = [scopedInstance({ targetActorId: "actor:ghost" })];
+
+    const receipt = await messaging().send(buildSendInput({ target: { actorId: "actor:ghost" } }));
+
+    expect(receipt.kind).toBe("denied");
+    if (receipt.kind !== "denied") throw new Error("expected denial");
+    expect(receipt.code).toBe("target_missing");
+  });
+
+  test("no candidate at all keeps the ungranted denial ahead of any registry lookup", async () => {
+    grants = [];
+
+    const receipt = await messaging().send(buildSendInput({ target: { actorId: "actor:ghost" } }));
+
+    expect(receipt.kind).toBe("denied");
+    if (receipt.kind !== "denied") throw new Error("expected denial");
+    expect(receipt.code).toBe("ungranted");
+  });
+});

--- a/packages/openomni/src/execution-runtime/index.ts
+++ b/packages/openomni/src/execution-runtime/index.ts
@@ -21,6 +21,7 @@ export {
   buildToolCatalog,
   createChildAgentTool,
   createDispatchTool,
+  createMessageSendTool,
   createToolExecutor,
   resolveMeta,
   resolveCategory,
@@ -38,4 +39,6 @@ export type {
   ToolRiskTier,
   ToolSource,
   DispatchToolRuntime,
+  MessageSendPort,
+  MessageSendToolOptions,
 } from "./tool/index.js";

--- a/packages/openomni/src/execution-runtime/tool/agent/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/index.ts
@@ -2,3 +2,5 @@ export { AgentToolProvider } from "./provider.js";
 export { createChildAgentTool } from "./tools/child-agent.js";
 export { createDispatchTool } from "./tools/dispatch.js";
 export type { DispatchToolRuntime } from "./tools/dispatch.js";
+export { createMessageSendTool } from "./tools/message-send.js";
+export type { MessageSendPort, MessageSendToolOptions } from "./tools/message-send.js";

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/message-send.test.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/message-send.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import type { Gateway, Tool } from "@openomni/protocol";
+import {
+  createMessageSendTool,
+  DEFAULT_EXPECT_REPLY_EXPIRES_IN_MS,
+  type MessageSendToolOptions,
+} from "./message-send.js";
+
+const NOW = 1_700_000_000_000;
+
+const sentReceipt = (input: Gateway.SendInput): Gateway.SendReceipt => ({
+  kind: "sent",
+  operation: "fire_and_forget",
+  messageId: input.messageId,
+  senderId: input.senderId,
+  grantId: "grant-1",
+  target: {
+    actorId: input.target.actorId,
+    endpointId: "qa:target-1",
+    channel: "qa",
+    externalId: "target-1",
+  },
+  at: input.at,
+});
+
+function makeCall(input: Record<string, unknown>): Tool.Call {
+  return { id: "call-1", tool: "message.send", input };
+}
+
+const context = {
+  traceContext: { traceId: "trace-message-send", sessionId: "session-caller", runId: "run-1" },
+} as const;
+
+function makeTool(overrides: Partial<MessageSendToolOptions> = {}) {
+  const sends: Gateway.SendInput[] = [];
+  const tool = createMessageSendTool({
+    send: async (input) => {
+      sends.push(input);
+      return sentReceipt(input);
+    },
+    personaActorId: "actor:persona",
+    now: () => NOW,
+    ...overrides,
+  });
+  return { tool, sends };
+}
+
+describe("message.send tool", () => {
+  test("declares the conservative posture: agent source, tier 2, delegation category, implicit sessionId", () => {
+    const { tool } = makeTool();
+    expect(tool.spec.name).toBe("message.send");
+    expect(tool.riskTier).toBe(2);
+    expect(tool.category).toBe("delegation");
+    expect(tool.implicitInputs).toEqual({ sessionId: "sessionId" });
+    // The implicit slot is stripped from the public schema — the model never
+    // sees (or spoofs) the session identity field.
+    const properties = (tool.spec.inputSchema as { properties: Record<string, unknown> })
+      .properties;
+    expect(properties.sessionId).toBeUndefined();
+  });
+
+  test("fire_and_forget builds a persona-sender SendInput without a waitSpec", async () => {
+    const { tool, sends } = makeTool();
+
+    const result = await tool.execute(
+      makeCall({
+        target: { actorId: "actor:target" },
+        body: "hello",
+        operation: "fire_and_forget",
+      }),
+      context,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toMatchObject({
+      senderId: "actor:persona",
+      target: { actorId: "actor:target" },
+      operation: "fire_and_forget",
+      body: "hello",
+      at: NOW,
+      traceId: "trace-message-send",
+    });
+    expect(sends[0]?.waitSpec).toBeUndefined();
+    expect(JSON.parse(result.output)).toMatchObject({ kind: "sent", operation: "fire_and_forget" });
+  });
+
+  test("awaited expands expectReply to a full waitSpec owned by the calling session", async () => {
+    const sends2: Gateway.SendInput[] = [];
+    const { tool } = makeTool({
+      send: async (input) => {
+        sends2.push(input);
+        const spec = input.waitSpec;
+        if (spec === undefined) throw new Error("awaited send lost its waitSpec");
+        return {
+          kind: "sent",
+          operation: "awaited",
+          messageId: input.messageId,
+          senderId: input.senderId,
+          grantId: "grant-1",
+          target: {
+            actorId: input.target.actorId,
+            endpointId: "qa:target-1",
+            channel: "qa",
+            externalId: "target-1",
+          },
+          wait: {
+            id: spec.waitId,
+            ownerRef: spec.ownerRef,
+            originMessageId: input.messageId,
+            correlation: { endpointId: "qa:target-1", replyToMessageId: input.messageId },
+            allowedActions: [...spec.allowedActions],
+            expectedResponders: [...spec.expectedResponders],
+            resolutionPolicy: spec.resolutionPolicy,
+            status: "open",
+            partial: false,
+            replies: [],
+            revision: 1,
+            expiresAt: spec.expiresAt,
+            followUpWindow: spec.followUpWindow,
+            createdAt: input.at,
+            updatedAt: input.at,
+          },
+          at: input.at,
+        };
+      },
+    });
+
+    const result = await tool.execute(
+      makeCall({
+        target: { actorId: "actor:target", endpointId: "qa:target-1" },
+        body: "deal?",
+        operation: "awaited",
+        expectReply: { expiresInMs: 60_000, followUpWindow: 5_000 },
+        // Model-supplied sessionId is executor-stripped in production; here we
+        // emulate the executor's injection of the calling session.
+        sessionId: "session-caller",
+      }),
+      context,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(sends2).toHaveLength(1);
+    const spec = sends2[0]?.waitSpec;
+    expect(spec).toMatchObject({
+      ownerRef: { kind: "session", id: "session-caller" },
+      allowedActions: ["report_result"],
+      expectedResponders: ["actor:target"],
+      resolutionPolicy: "first_reply",
+      expiresAt: NOW + 60_000,
+      followUpWindow: 5_000,
+    });
+    const output = JSON.parse(result.output);
+    expect(output).toMatchObject({ kind: "sent", operation: "awaited", waitId: spec?.waitId });
+  });
+
+  test("awaited without expectReply uses the declared defaults (24h deadline, report_result, window 0)", async () => {
+    const sends: Gateway.SendInput[] = [];
+    const { tool } = makeTool({
+      send: async (input) => {
+        sends.push(input);
+        return { ...sentReceipt(input), operation: "fire_and_forget" };
+      },
+    });
+
+    await tool.execute(
+      makeCall({
+        target: { actorId: "actor:target" },
+        body: "ping",
+        operation: "awaited",
+        sessionId: "session-caller",
+      }),
+      context,
+    );
+
+    expect(sends[0]?.waitSpec).toMatchObject({
+      allowedActions: ["report_result"],
+      expiresAt: NOW + DEFAULT_EXPECT_REPLY_EXPIRES_IN_MS,
+      followUpWindow: 0,
+    });
+  });
+
+  test("a denial receipt is a RESULT the agent can reason about, not an error", async () => {
+    const { tool } = makeTool({
+      send: async (input) => ({
+        kind: "denied",
+        code: "ungranted",
+        messageId: input.messageId,
+        senderId: input.senderId,
+        targetActorId: input.target.actorId,
+        reason: "no active sender-target grant",
+        at: input.at,
+      }),
+    });
+
+    const result = await tool.execute(
+      makeCall({ target: { actorId: "actor:target" }, body: "hi", operation: "fire_and_forget" }),
+      context,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.output)).toEqual({
+      kind: "denied",
+      code: "ungranted",
+      reason: "no active sender-target grant",
+      messageId: expect.any(String),
+      targetActorId: "actor:target",
+    });
+  });
+
+  test("persona unset fails closed with a typed error result — never a throw", async () => {
+    const { tool, sends } = makeTool({ personaActorId: undefined });
+
+    const result = await tool.execute(
+      makeCall({ target: { actorId: "actor:target" }, body: "hi", operation: "fire_and_forget" }),
+      context,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("persona not configured");
+    expect(sends).toHaveLength(0);
+  });
+
+  test("awaited without a calling session is refused (ownerRef needs the session)", async () => {
+    const { tool, sends } = makeTool();
+
+    const result = await tool.execute(
+      makeCall({ target: { actorId: "actor:target" }, body: "hi", operation: "awaited" }),
+      context,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("calling session context");
+    expect(sends).toHaveLength(0);
+  });
+
+  test("expectReply with fire_and_forget is an input error", async () => {
+    const { tool, sends } = makeTool();
+
+    const result = await tool.execute(
+      makeCall({
+        target: { actorId: "actor:target" },
+        body: "hi",
+        operation: "fire_and_forget",
+        expectReply: { expiresInMs: 1_000 },
+      }),
+      context,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain('expectReply requires operation "awaited"');
+    expect(sends).toHaveLength(0);
+  });
+
+  test("a traceless direct call is refused", async () => {
+    const { tool, sends } = makeTool();
+
+    const result = await tool.execute(
+      makeCall({ target: { actorId: "actor:target" }, body: "hi", operation: "fire_and_forget" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("run trace context");
+    expect(sends).toHaveLength(0);
+  });
+
+  test("a throwing send port surfaces as an error result, not an unhandled rejection", async () => {
+    const { tool } = makeTool({
+      send: async () => {
+        throw new Error("existing-agent messaging is not registered — sends fail closed");
+      },
+    });
+
+    const result = await tool.execute(
+      makeCall({ target: { actorId: "actor:target" }, body: "hi", operation: "fire_and_forget" }),
+      context,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.output).toContain("sends fail closed");
+  });
+});

--- a/packages/openomni/src/execution-runtime/tool/agent/tools/message-send.ts
+++ b/packages/openomni/src/execution-runtime/tool/agent/tools/message-send.ts
@@ -1,0 +1,255 @@
+import { Gateway, Wait } from "@openomni/protocol";
+import { z } from "zod";
+import { defineTool, errorResult, fromError, successResult } from "../../define.js";
+import type { NativeTool, ToolExecutionContext } from "../../types.js";
+
+/**
+ * `message.send` — the brain's as-me outbound trigger (#708, gateway stage 3;
+ * docs/gateway-design.md §2b).
+ *
+ * The tool calls an INJECTED send port (`Gateway.SendInput → SendReceipt`):
+ * the brain receives the port at composition and never imports the gateway
+ * (openomni↔channels stays 0/0 — check-deps enforced). senderId is always the
+ * Owner-owned resident persona actor; the model never chooses who it speaks
+ * as. Authority is the gateway's: grants are Owner-written and default-empty,
+ * so every send is denied `ungranted` until the Owner configures one — a
+ * denial is a RESULT the agent sees and reasons about, never a thrown error.
+ *
+ * `expectReply` expands to a full waitSpec whose ownerRef is the CALLING
+ * session (`{kind: "session", id: <executor-injected sessionId>}`) — the
+ * engagement ownerRef arrives with #709.
+ */
+
+/** Default reply deadline for awaited sends: 24 hours. */
+export const DEFAULT_EXPECT_REPLY_EXPIRES_IN_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_ALLOWED_ACTIONS: readonly Wait.AllowedAction[] = ["report_result"];
+const DEFAULT_FOLLOW_UP_WINDOW_MS = 0;
+
+export type MessageSendPort = (input: Gateway.SendInput) => Promise<Gateway.SendReceipt>;
+
+export type MessageSendToolOptions = Readonly<{
+  /** The gateway send kernel, injected by the composition root (apps/server). */
+  send: MessageSendPort;
+  /**
+   * The Owner-owned resident persona actor (ActorRegistry identity) every
+   * as-me send is attributed to. Unset → the tool fails closed with a typed
+   * error result ("persona not configured"); it never throws into the run.
+   */
+  personaActorId?: string;
+  /** Injected clock — messaging never reads the wall clock internally. */
+  now?: () => number;
+}>;
+
+const ExpectReplySchema = z
+  .object({
+    allowedActions: z.array(Wait.AllowedAction).min(1).optional(),
+    expiresInMs: z.number().int().positive().optional(),
+    followUpWindow: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+const MessageSendInputSchema = z
+  .object({
+    target: z
+      .object({
+        actorId: z.string().min(1),
+        endpointId: z.string().min(1).optional(),
+      })
+      .strict(),
+    body: z.string().min(1),
+    operation: Gateway.MessageOperation,
+    expectReply: ExpectReplySchema.optional(),
+    /** Executor-injected calling session (implicit input — never model-supplied). */
+    sessionId: z.string().min(1).optional(),
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    if (input.operation === "fire_and_forget" && input.expectReply !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: 'expectReply requires operation "awaited" — fire_and_forget never opens a Wait',
+        path: ["expectReply"],
+      });
+    }
+  });
+
+type MessageSendInput = z.infer<typeof MessageSendInputSchema>;
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    target: {
+      type: "object",
+      properties: {
+        actorId: { type: "string", description: "Registered actor to reach." },
+        endpointId: {
+          type: "string",
+          description: "Endpoint pin — required when the actor is reachable at several endpoints.",
+        },
+      },
+      required: ["actorId"],
+      additionalProperties: false,
+    },
+    body: { type: "string", description: "Message text, already rendered in persona voice." },
+    operation: {
+      enum: ["fire_and_forget", "awaited"],
+      description:
+        '"awaited" opens a durable reply Wait owned by the calling session; "fire_and_forget" delivers without awaiting.',
+    },
+    expectReply: {
+      type: "object",
+      description:
+        'Awaited-reply shaping (operation "awaited" only). Defaults: allowedActions ["report_result"], expiresInMs 86400000 (24h), followUpWindow 0.',
+      properties: {
+        allowedActions: {
+          type: "array",
+          items: {
+            enum: ["report_result", "ask_clarification", "attach_artifact", "decline_task"],
+          },
+          minItems: 1,
+        },
+        expiresInMs: { type: "number", description: "Reply deadline from now (default 24h)." },
+        followUpWindow: {
+          type: "number",
+          description: "ms after resolution during which follow-ups still correlate (default 0).",
+        },
+      },
+      additionalProperties: false,
+    },
+    sessionId: { type: "string" },
+  },
+  required: ["target", "body", "operation"],
+  additionalProperties: false,
+};
+
+/**
+ * The receipt rendered honestly for the model: `sent` carries the messageId
+ * (+ waitId/deadline when awaited); `denied` carries the typed code + reason.
+ * Denials are results, not errors — the agent must see `ungranted` and reason
+ * about it.
+ */
+function renderReceipt(receipt: Gateway.SendReceipt): Record<string, unknown> {
+  if (receipt.kind === "denied") {
+    return {
+      kind: "denied",
+      code: receipt.code,
+      reason: receipt.reason,
+      messageId: receipt.messageId,
+      targetActorId: receipt.targetActorId,
+    };
+  }
+  const base = {
+    kind: "sent",
+    operation: receipt.operation,
+    messageId: receipt.messageId,
+    target: receipt.target,
+  };
+  if (receipt.operation === "awaited") {
+    return { ...base, waitId: receipt.wait.id, replyExpiresAt: receipt.wait.expiresAt };
+  }
+  return base;
+}
+
+function buildSendInput(
+  input: MessageSendInput,
+  personaActorId: string,
+  traceId: string,
+  sessionId: string | undefined,
+  at: number,
+): Gateway.SendInput | { error: string } {
+  const base = {
+    messageId: crypto.randomUUID(),
+    traceId,
+    senderId: personaActorId,
+    target: input.target,
+    operation: input.operation,
+    body: input.body,
+    at,
+  };
+  if (input.operation === "fire_and_forget") return Gateway.SendInput.parse(base);
+  if (sessionId === undefined) {
+    return {
+      error:
+        "awaited send requires the calling session context — the executor injects it; " +
+        "message.send cannot be called outside a session run",
+    };
+  }
+  return Gateway.SendInput.parse({
+    ...base,
+    waitSpec: {
+      waitId: crypto.randomUUID(),
+      // #709 will carry the engagement ownerRef; until then the calling
+      // session owns the Wait.
+      ownerRef: { kind: "session", id: sessionId },
+      allowedActions: [...(input.expectReply?.allowedActions ?? DEFAULT_ALLOWED_ACTIONS)],
+      expectedResponders: [input.target.actorId],
+      resolutionPolicy: "first_reply",
+      expiresAt: at + (input.expectReply?.expiresInMs ?? DEFAULT_EXPECT_REPLY_EXPIRES_IN_MS),
+      followUpWindow: input.expectReply?.followUpWindow ?? DEFAULT_FOLLOW_UP_WINDOW_MS,
+    },
+  });
+}
+
+export function createMessageSendTool(options: MessageSendToolOptions): NativeTool {
+  const now = options.now ?? Date.now;
+  const tool = defineTool<MessageSendInput>({
+    name: "message.send",
+    description:
+      "Send an outbound message AS the resident persona to an existing, registered actor " +
+      "through the gateway send kernel. Every send is Owner-grant-gated: without an active " +
+      "sender-target grant the receipt is a denial (code `ungranted`) — denials are normal " +
+      'results to reason about, not execution errors. operation "awaited" opens a durable ' +
+      "reply Wait owned by the calling session (expectReply defaults: allowedActions " +
+      '["report_result"], expiresInMs 86400000 = 24h, followUpWindow 0); reply correlation ' +
+      "resumes this session when the target answers.",
+    inputSchema,
+    source: "agent",
+    riskTier: 2,
+    isReadOnly: false,
+    isDestructive: false,
+    isConcurrencySafe: false,
+    implicitInputs: { sessionId: "sessionId" },
+    async execute(call, context?: ToolExecutionContext) {
+      const parsed = MessageSendInputSchema.safeParse(call.input);
+      if (!parsed.success) {
+        return errorResult(
+          call,
+          `Invalid input: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
+        );
+      }
+      // A send belongs to the run that asked for it (the executor refuses
+      // traceless calls; this refuses direct traceless invocation too).
+      const traceId = context?.traceContext?.traceId;
+      if (traceId === undefined || traceId.length === 0) {
+        return errorResult(call, "message.send requires the run trace context");
+      }
+      // Fail closed, in-band: no persona means no as-me identity to send
+      // under. A typed error result — never a throw that kills the run.
+      if (options.personaActorId === undefined) {
+        return errorResult(
+          call,
+          "persona not configured: message.send needs the Owner-owned resident persona actor " +
+            "(server config `messaging.personaActorId`) — as-me sends fail closed",
+        );
+      }
+      const sendInput = buildSendInput(
+        parsed.data,
+        options.personaActorId,
+        traceId,
+        parsed.data.sessionId,
+        now(),
+      );
+      if ("error" in sendInput) return errorResult(call, sendInput.error);
+      try {
+        const receipt = await options.send(sendInput);
+        return successResult(call, JSON.stringify(renderReceipt(receipt)));
+      } catch (error) {
+        return fromError(call, error);
+      }
+    },
+  });
+  // Delegation category: the depth gate strips delegation tools from child
+  // agents (catalog step 4), so only the depth-0 resident can speak as-me —
+  // workers ask the Resident instead of borrowing the persona.
+  return { ...tool, category: "delegation" };
+}

--- a/packages/openomni/src/execution-runtime/tool/index.ts
+++ b/packages/openomni/src/execution-runtime/tool/index.ts
@@ -2,8 +2,13 @@ export {
   AgentToolProvider,
   createChildAgentTool,
   createDispatchTool,
+  createMessageSendTool,
 } from "./agent/index.js";
-export type { DispatchToolRuntime } from "./agent/index.js";
+export type {
+  DispatchToolRuntime,
+  MessageSendPort,
+  MessageSendToolOptions,
+} from "./agent/index.js";
 export { buildToolCatalog, resolveCategory, resolveToolSelection } from "./catalog.js";
 export { Tool, resolveMeta } from "./define.js";
 export { createToolExecutor } from "./executor.js";

--- a/packages/openomni/src/index.ts
+++ b/packages/openomni/src/index.ts
@@ -63,6 +63,7 @@ export {
   createChildAgentRuntime,
   createChildAgentTool,
   createDispatchTool,
+  createMessageSendTool,
   createToolExecutor,
   resolveMeta,
   resolveCategory,
@@ -86,6 +87,8 @@ export type {
   ChildAgentSpawnInput,
   DelegationPolicyRegistration,
   DispatchToolRuntime,
+  MessageSendPort,
+  MessageSendToolOptions,
 } from "./execution-runtime";
 
 // Evidence conformance vocabulary (#493-owned dormant replay types ride this

--- a/packages/openomni/src/ingress/engine.ts
+++ b/packages/openomni/src/ingress/engine.ts
@@ -11,7 +11,7 @@ import type { DispatchRuntime } from "../dispatch/runtime";
 import type { ResidentRuntime } from "../resident/runtime";
 import { IngressEventProjector } from "./event-projector";
 import { IngressHandlers } from "./handlers";
-import { IngressSessionResolver } from "./session-resolver";
+import { IngressSessionResolver, type SurfaceSessionClaim } from "./session-resolver";
 import { executePendingInteractionDelivery } from "./pending-interaction-delivery";
 import { requireRoutedInternalDecision, resolveAndRecordInternalRoute } from "./internal-route";
 
@@ -40,6 +40,13 @@ export interface BrainEngineDeps {
    * tool catalog, same runtime model resolution) — same behavior, new home.
    */
   readonly externalAgentResolver?: (event: Gateway.DeliveredEvent) => Promise<Ingress.AgentDef>;
+  /**
+   * Gateway port for internal-mode surface↔session stickiness claims (#708,
+   * closing the #707 residue): the composition root binds the router's
+   * `claimSurface`; the brain writes no perimeter surface directly. Absent →
+   * internal resident surface sessions fail closed at claim time.
+   */
+  readonly claimSurface?: SurfaceSessionClaim;
 }
 
 /**
@@ -206,7 +213,8 @@ export function createBrainEngine(deps: BrainEngineDeps = {}): BrainEngine {
         // Worker placement stays brain judgment: the delivered event carries
         // the pinned activation/target facts and the resolver selects or
         // creates the worker session exactly as before the flip.
-        sessionId = IngressSessionResolver.resolve(resolvedEvent, trace, model).session.id;
+        sessionId = IngressSessionResolver.resolve(resolvedEvent, trace, model, deps.claimSurface)
+          .session.id;
       }
 
       return executeResolved(
@@ -250,10 +258,15 @@ export function createBrainEngine(deps: BrainEngineDeps = {}): BrainEngine {
       );
       publishReceived(resolvedEvent, trace);
       const agentModel = resolvedEvent.agent.model;
-      const { session } = IngressSessionResolver.resolve(resolvedEvent, trace, {
-        providerID: agentModel.provider,
-        modelID: agentModel.id,
-      });
+      const { session } = IngressSessionResolver.resolve(
+        resolvedEvent,
+        trace,
+        {
+          providerID: agentModel.provider,
+          modelID: agentModel.id,
+        },
+        deps.claimSurface,
+      );
       return executeResolved(
         resolvedEvent,
         route.selectedTarget,

--- a/packages/openomni/src/ingress/session-resolver.ts
+++ b/packages/openomni/src/ingress/session-resolver.ts
@@ -31,6 +31,20 @@ interface ResolveResult extends ResolvedSession {
   trace: TraceContextProtocol.Type;
 }
 
+/**
+ * Gateway port for surface↔session stickiness claims (#708): CAS semantics —
+ * with `expectedSessionId` the claim replaces only that owner; without it, it
+ * inserts only when absent; the returned id is the owner AFTER the attempt.
+ * The brain holds no direct SurfaceKey WRITE since #708 — the composition
+ * root injects the gateway router's `claimSurface`, making the gateway the
+ * literal sole writer of the perimeter surface (reads stay recorded residue).
+ */
+export type SurfaceSessionClaim = (
+  surfaceKey: string,
+  sessionId: string,
+  expectedSessionId?: string,
+) => string;
+
 export namespace IngressSessionResolver {
   /**
    * Lazy materialization of a router-claimed resident session (#707 stage 2):
@@ -72,8 +86,8 @@ export namespace IngressSessionResolver {
    * The internal-path + worker-placement resolver. The EXTERNAL resident
    * surface-map ops moved to the gateway router at #707 stage 2; the
    * resident claim loop below now serves only internal events (cron surface
-   * sessions) — a recorded brain-side write residue on a perimeter surface,
-   * scoped to internal mode which never crosses the perimeter.
+   * sessions) and claims through the injected gateway port (#708) — the
+   * brain writes no perimeter surface directly.
    */
   export function resolve(
     event: ResolvableEvent,
@@ -82,6 +96,7 @@ export namespace IngressSessionResolver {
       providerID: DEFAULT_DISPATCH_MODEL.provider,
       modelID: DEFAULT_DISPATCH_MODEL.id,
     },
+    claimSurface?: SurfaceSessionClaim,
   ): ResolveResult {
     const target = resolveTarget(event);
     let session: Session.Info;
@@ -134,6 +149,7 @@ export namespace IngressSessionResolver {
           event.surface,
           defaultModel,
           traceContext.traceId,
+          claimSurface,
         );
         session = resolved.session;
         isNew = resolved.isNew;
@@ -155,7 +171,17 @@ export namespace IngressSessionResolver {
     surface: string,
     defaultModel: ModelConfig,
     traceId: string,
+    claimSurface: SurfaceSessionClaim | undefined,
   ): ResolvedSession {
+    // Fail closed (#708): without the gateway port there is no legal way to
+    // write the surface↔session map — the brain never falls back to a direct
+    // ledger write.
+    if (claimSurface === undefined) {
+      throw new Error(
+        "surface claim port not configured — resident surface sessions fail closed " +
+          "(#708: internal claims route through the gateway claimSurface port)",
+      );
+    }
     let staleSessionId: string | undefined;
     let lastOwnerSessionId: string | undefined;
 
@@ -178,7 +204,7 @@ export namespace IngressSessionResolver {
       });
       let ownerSessionId: string;
       try {
-        ownerSessionId = SurfaceKey.claim(surfaceKey, candidate.id, staleSessionId);
+        ownerSessionId = claimSurface(surfaceKey, candidate.id, staleSessionId);
       } catch (err) {
         Session.remove(candidate.id, traceId);
         throw err;

--- a/packages/openomni/test/execution-runtime/cron-job-runner.test.ts
+++ b/packages/openomni/test/execution-runtime/cron-job-runner.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Ingress, type CronJob, type Command } from "@openomni/protocol";
-import { Storage } from "@openomni/ledger";
+import { Storage, SurfaceKey } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
 import { DispatchRegistry, registerBuiltInDispatchHandlers } from "../../src/dispatch";
 import { CronJobRegistry, CronJobRunner } from "../../src/execution-runtime";
@@ -353,6 +353,10 @@ describe("CronJobRunner", () => {
           return { text: "cron-result", finishReason: "stop" };
         },
       }),
+      // #708: cron stickiness claims cross the injected gateway port; the
+      // test binds the same ledger CAS the router wraps.
+      claimSurface: (surfaceKey, sessionId, expectedSessionId) =>
+        SurfaceKey.claim(surfaceKey, sessionId, expectedSessionId),
     });
 
     try {

--- a/packages/openomni/test/ingress/engine-internal.test.ts
+++ b/packages/openomni/test/ingress/engine-internal.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Ingress } from "@openomni/protocol";
-import { Storage } from "@openomni/ledger";
+import { Storage, SurfaceKey } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
 import {
   defaultRunFn,
@@ -34,6 +34,10 @@ function makeEngine(overrides: BrainEngineDeps = {}): BrainEngine {
         return { text: testState.responseQueue.shift() ?? "{}", finishReason: "stop" };
       },
     }),
+    // The composition root injects the gateway router's claimSurface (#708);
+    // the test binds the same ledger CAS the router wraps.
+    claimSurface: (surfaceKey, sessionId, expectedSessionId) =>
+      SurfaceKey.claim(surfaceKey, sessionId, expectedSessionId),
     ...overrides,
   });
 }

--- a/packages/openomni/test/ingress/session-resolver.test.ts
+++ b/packages/openomni/test/ingress/session-resolver.test.ts
@@ -4,12 +4,23 @@ import { SurfaceKey, Storage, Session } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
 import { IngressSessionResolver } from "../../src/ingress";
 
-/** resolve() with the test trace context; model stays on the resolver default unless given. */
+/**
+ * resolve() with the test trace context; model stays on the resolver default
+ * unless given. The claim port mirrors the composition root (#708): the
+ * gateway router's claimSurface is SurfaceKey.claim — the brain src itself no
+ * longer holds the write.
+ */
 function resolveWithTrace(
   event: Parameters<typeof IngressSessionResolver.resolve>[0],
   model?: Parameters<typeof IngressSessionResolver.resolve>[2],
 ) {
-  return IngressSessionResolver.resolve(event, { traceId: "trace-resolver-test" }, model);
+  return IngressSessionResolver.resolve(
+    event,
+    { traceId: "trace-resolver-test" },
+    model,
+    (surfaceKey, sessionId, expectedSessionId) =>
+      SurfaceKey.claim(surfaceKey, sessionId, expectedSessionId),
+  );
 }
 
 describe("IngressSessionResolver", () => {
@@ -243,6 +254,32 @@ describe("IngressSessionResolver", () => {
 
       expect(result2.isNew).toBe(true);
       expect(sessionId1).not.toBe(sessionId2);
+    });
+
+    it("fails closed when the claim port is absent — the brain never writes the surface map directly (#708)", () => {
+      expect(() =>
+        IngressSessionResolver.resolve(
+          { surface: "slack", workspace: "team-a", channel: "C123" },
+          { traceId: "trace-resolver-test" },
+        ),
+      ).toThrow("surface claim port not configured");
+      // Fail-closed means no side effects either: no orphan candidate session.
+      expect(Session.list()).toEqual([]);
+    });
+
+    it("worker placement needs no claim port — only resident surface stickiness claims", () => {
+      const parent = Session.create({
+        traceId: "trace-resolver-test",
+        title: "parent",
+        model: { providerID: "test", modelID: "fixture" },
+      });
+
+      const result = IngressSessionResolver.resolve(
+        { surface: "resident-worker-tool", target: { kind: "worker", parentSessionId: parent.id } },
+        { traceId: "trace-resolver-test" },
+      );
+
+      expect(result.session.parentSessionId).toBe(parent.id);
     });
 
     it("fails closed when worker target session is missing", () => {


### PR DESCRIPTION
Closes #708 — **gateway stage 3**. The product-thesis 'outbound as-me trigger unwired' gap closes: the resident can now send as the Owner's persona, grant-gated and ledgered, and replies resume the session through the perimeter. 4 commits.

## What

- **`message.send` native tool** (resident-only: `delegation` category strips it from all child agents/workers; riskTier 2): calls the injected `Gateway.Send` port; senderId is always the composed persona actor; ownerRef = the calling session via executor-injected sessionId (**unspoofable — stripped from the public input schema**). Denials (`ungranted`…) are results the agent reasons about, not errors. Authority = the Owner grant table, default empty (all sends denied); persona unset = typed error.
- **Scope-aware grant evaluation** (router): two-phase — scope-unchecked candidacy first (preserves the existing `ungranted`-before-registry pin), then the resolved endpoint's `channel:externalId` key must equal `replyScope.surfaceKey`; cross-surface use refused with tests. Base evaluator stays fail-closed for scope-less callers.
- **Reply-grant materialization**: Owner rule rows → in-memory instances (durable store = #709, receipt comment) on routed first-contact admission of a resolved actor; `maxLiveInstances` capacity enforced with an audit warn; instances schema-pinned (ruleId ⇒ replyScope+expiresAt).
- **#707 residue resolved**: internal surface claims now cross a gateway `claimSurface` CAS port — brain drops its direct perimeter write, session-resolver **throws without the port** (no silent fallback); sole-writer is literal.
- **E2E proof** (composed, real tool executor): awaited as-me send → Wait open → platform-id re-key → expected-responder reply through `router.ingest` → brain deliver with waitContext → calling session resumed, Wait resolved. Plus ungranted / cross-surface / persona-unset denial paths.

## Non-goals (receipts in-code)
#219 egress semantics (seam comment after grant, before delivery); #709 engagement ownerRef + durable instance store + thread-level scope narrowing.

## Verification
All gates green ×4 commits: build/check-types 16/16, check-deps+self-test, lint suite, import-cycles 0, dead-exports none new, coverage ratchet, full turbo test 16/16 (server 443), p2-ledger-baseline 54, both verifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables outbound “as-me” messaging through the gateway and resumes the calling session on replies. Previously the resident had no safe send path and internal surface claims wrote the ledger directly; now the resident uses `message.send`, grant-gated, with awaited sends opening a Wait and replies resuming the session, and internal claims go through the gateway port.

- Adds `message.send` native tool in `@openomni/openomni` (resident-only via “delegation” category, riskTier 2). Sender is always the configured persona; denials like `ungranted` are results the agent sees, not errors. Awaited sends expand `expectReply` into a waitSpec owned by the calling session (defaults: 24h deadline, allowedActions ["report_result"], followUpWindow 0).
- Adds scope-aware grant evaluation in `@openomni/channels`: two-phase check honors reply-scoped instances only on the initiating container’s surface key; cross-surface use is refused. Base evaluator continues to skip scoped instances and deny ungranted sends before any registry lookup.
- Materializes reply-scoped grant instances in memory from Owner rules on first-contact admission (bounded by TTL and `maxLiveInstances`, audited on capacity). Durable store remains out of scope.
- Introduces `GatewayRouter.claimSurface(surfaceKey, sessionId, expectedSessionId?)`. The brain injects this port and no longer writes surface keys directly; missing the port fails closed at claim time.

- Server config adds `messaging.personaActorId` and `messaging.replyGrantRules` (both parsed fail-closed with warnings). Standing `messaging.grants` remains default-empty, so sends are denied until explicitly granted.

- E2E: granted awaited send -> delivery + Wait open -> expected responder reply -> `router.ingest` -> brain deliver with waitContext -> session resumed. Ungranted, cross-surface, and persona-unset paths are covered.

- Non-goals: egress semantics evaluation and durable grant-instance store.

Bolded section title per requirements? The bullets are already provided. But the requirements allow minimal sections. We didn't include section headers. The output is acceptable.

<sup>Written for commit 892006466c6768986e1d98df776ba57090871dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

