### PR TITLE
feat: tier tool-permission cap (collaborator read-tier approval)

### DIFF
--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -11,7 +11,7 @@ Depends on `@openomni/protocol`, `@openomni/policy`, `@openomni/ledger`, `@openo
 ```
 src/
 ├── index.ts              # Entry — calls bootstrap/main()
-├── config.ts             # loadConfig() — reads env / config files into ServerConfig
+├── config.ts             # loadConfig() — reads env / config files into ServerConfig (incl. permissionProfiles: 고도화 A per-tier deny-label tool caps, fail-closed empty)
 ├── recovery.ts           # Crash-recovery glue (delegates to bootstrap/recovery)
 ├── bootstrap/
 │   ├── index.ts          # main() — wires storage, tool providers, resolveModel() (providers.ts merged here, #476), channels, server, recovery, shutdown

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -102,6 +102,10 @@ export async function main(options: MainOptions = {}): Promise<void> {
   const residentRuntime = ResidentRuntime.create({
     maxActive: 10,
     idleTimeoutMs: Number(process.env.OPENOMNI_RESIDENT_IDLE_TIMEOUT_MS ?? 30_000),
+    // 고도화 A: the Owner-declared tier→deny-overlay table, injected from config
+    // (default empty = no tier relaxation). Per delivery, the run's trust tier
+    // indexes this table for the additive deny-label tool-permission cap.
+    permissionProfiles: config.permissionProfiles,
   });
 
   Bus.publish(

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { Gateway, Operational } from "@openomni/protocol";
+import { Actor, Gateway, Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { z } from "zod";
 import { parseMcpServerConfigs, type McpServerConfig } from "./config/mcp-server-config";
@@ -48,7 +48,24 @@ interface RawConfig {
     personaActorId?: unknown;
     replyGrantRules?: unknown;
   };
+  permissionProfiles?: unknown;
 }
+
+/**
+ * 고도화 A — the Owner-declared tier→tool-set permission cap, expressed as an
+ * additive deny-label overlay (NOT a name enumeration, NOT a permission
+ * replacement). The only knob is `denyLabels`: capability labels
+ * (`capability:write` / `capability:destructive` / `capability:read`, stamped
+ * on every tool by `defineTool`) or risk tiers (`risk:tier-N`). These union
+ * into the resident's effective `Policy.Permission.denyLabels` at composition,
+ * so the deny-wins ordering caps the tier WITHOUT discarding the agent's own
+ * allowlist/denylist. Restricting the shape to `denyLabels` keeps this a cap,
+ * never a way to WIDEN authority. The type is inlined into `ServerConfig`
+ * (not a named export) so the shape stays server-config-local.
+ */
+const TierPermissionProfileSchema = z.object({
+  denyLabels: z.array(z.string().min(1)),
+});
 
 export interface ServerConfig {
   workspace?: { root: string };
@@ -74,6 +91,30 @@ export interface ServerConfig {
     personaActorId?: string;
     replyGrantRules: Gateway.ReplyGrantRule[];
   };
+  /**
+   * 고도화 A — per-tier deny-label overlays keyed by `Actor.TrustTier`. Default
+   * EMPTY: with no profile configured, every tier stays at its base permission
+   * (no relaxation, no extra cap). A malformed entry is dropped per-tier
+   * (fail-closed: that tier gets NO relaxation), never crashing boot.
+   *
+   * The Owner declares the tier→tool-set cap as DATA in `config.json`; a
+   * read/analysis-only collaborator is one config block:
+   *
+   * ```json
+   * {
+   *   "permissionProfiles": {
+   *     "collaborator": { "denyLabels": ["capability:write", "capability:destructive"] },
+   *     "observer": { "denyLabels": ["capability:write", "capability:destructive", "capability:read"] }
+   *   }
+   * }
+   * ```
+   *
+   * `owner` / `co_owner` / `manager` are intentionally omitted → no overlay,
+   * tools unchanged. The overlay composes AFTER the `evidence_only` hard gate
+   * (evidence still wins deny-all) and merges INTO the agent's own permission
+   * (additive deny; the agent's allowlist/denylist survive).
+   */
+  permissionProfiles: Partial<Record<Actor.TrustTier, { denyLabels: string[] }>>;
 }
 
 let _config: ServerConfig | null = null;
@@ -163,6 +204,50 @@ function resolvePersonaActorId(
   return undefined;
 }
 
+function resolvePermissionProfiles(
+  raw: RawConfig,
+  configPath: string,
+  traceId: string,
+): Partial<Record<Actor.TrustTier, { denyLabels: string[] }>> {
+  const value = raw.permissionProfiles;
+  if (value === undefined) return {};
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    // Fail closed: a non-object profiles block caps nothing and relaxes
+    // nothing — every tier stays at its base permission.
+    Bus.publish(
+      Operational.Events.Warn,
+      Operational.envelope({
+        traceId,
+        component: "server",
+        msg: "invalid permissionProfiles config ignored; every tier stays at its base permission",
+        context: { configPath },
+      }),
+    );
+    return {};
+  }
+  const resolved: Partial<Record<Actor.TrustTier, { denyLabels: string[] }>> = {};
+  for (const [tier, profile] of Object.entries(value)) {
+    const tierParsed = Actor.TrustTier.safeParse(tier);
+    const profileParsed = TierPermissionProfileSchema.safeParse(profile);
+    if (tierParsed.success && profileParsed.success) {
+      resolved[tierParsed.data] = profileParsed.data;
+      continue;
+    }
+    // Fail closed per entry: an unknown tier key or a malformed overlay is
+    // dropped, so THAT tier gets no relaxation (and no accidental cap either).
+    Bus.publish(
+      Operational.Events.Warn,
+      Operational.envelope({
+        traceId,
+        component: "server",
+        msg: "invalid permissionProfiles entry ignored; that tier stays at its base permission",
+        context: { configPath, tier },
+      }),
+    );
+  }
+  return resolved;
+}
+
 function resolve(raw: RawConfig, configPath: string, traceId: string): ServerConfig {
   const defaultDbPath = join(homedir(), ".openomni", "storage.db");
   const workspaceRoot = raw.workspace?.root;
@@ -226,6 +311,7 @@ function resolve(raw: RawConfig, configPath: string, traceId: string): ServerCon
       personaActorId: resolvePersonaActorId(raw, configPath, traceId),
       replyGrantRules: resolveReplyGrantRules(raw, configPath, traceId),
     },
+    permissionProfiles: resolvePermissionProfiles(raw, configPath, traceId),
   };
 }
 

--- a/apps/server/test/bootstrap/resident-inbound-wait.test.ts
+++ b/apps/server/test/bootstrap/resident-inbound-wait.test.ts
@@ -40,6 +40,7 @@ const serverConfig: ServerConfig = {
   github: { allowedUsers: [] },
   discord: { allowedUsers: [] },
   messaging: { grants: [], replyGrantRules: [] },
+  permissionProfiles: {},
 };
 
 const originalBeginWait = WorkItemAttemptRun.beginWait;

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -299,6 +299,84 @@ describe("config", () => {
     );
   });
 
+  it("resolves permissionProfiles per tier; defaults empty (고도화 A)", () => {
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        permissionProfiles: {
+          collaborator: { denyLabels: ["capability:write", "capability:destructive"] },
+          observer: {
+            denyLabels: ["capability:write", "capability:destructive", "capability:read"],
+          },
+        },
+      }),
+    );
+
+    const config = loadConfig("trace-test", configPath);
+    expect(config.permissionProfiles.collaborator).toEqual({
+      denyLabels: ["capability:write", "capability:destructive"],
+    });
+    expect(config.permissionProfiles.observer?.denyLabels).toContain("capability:read");
+    // A tier with no entry stays absent → no relaxation, no cap.
+    expect(config.permissionProfiles.owner).toBeUndefined();
+
+    const emptyPath = join(tempDir, "empty-profiles.json");
+    writeFileSync(emptyPath, JSON.stringify({}));
+    expect(loadConfig("trace-test", emptyPath).permissionProfiles).toEqual({});
+  });
+
+  it("drops malformed permissionProfiles entries fail-closed with a warning (고도화 A)", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Events.Warn, (payload) => warnings.push(payload));
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        permissionProfiles: {
+          // Unknown tier key → dropped.
+          overlord: { denyLabels: ["capability:write"] },
+          // Malformed overlay shape → dropped.
+          manager: { denyLabels: "capability:write" },
+          // Valid → kept.
+          collaborator: { denyLabels: ["capability:write"] },
+        },
+      }),
+    );
+
+    const config = loadConfig("trace-test", configPath);
+    await flushBus();
+    unsubscribe();
+
+    expect(config.permissionProfiles.collaborator).toEqual({ denyLabels: ["capability:write"] });
+    expect((config.permissionProfiles as Record<string, unknown>).overlord).toBeUndefined();
+    expect(config.permissionProfiles.manager).toBeUndefined();
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid permissionProfiles entry ignored; that tier stays at its base permission",
+        context: expect.objectContaining({ tier: "overlord" }),
+      }),
+    );
+  });
+
+  it("treats a non-object permissionProfiles block as empty, fail-closed (고도화 A)", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Events.Warn, (payload) => warnings.push(payload));
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(configPath, JSON.stringify({ permissionProfiles: ["capability:write"] }));
+
+    const config = loadConfig("trace-test", configPath);
+    await flushBus();
+    unsubscribe();
+
+    expect(config.permissionProfiles).toEqual({});
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid permissionProfiles config ignored; every tier stays at its base permission",
+      }),
+    );
+  });
+
   it("returns undefined when neither config file nor env var is set", () => {
     delete process.env.TELEGRAM_BOT_TOKEN;
     delete process.env.DISCORD_BOT_TOKEN;

--- a/packages/openomni/src/execution-runtime/middleware-test-fixture.ts
+++ b/packages/openomni/src/execution-runtime/middleware-test-fixture.ts
@@ -19,7 +19,14 @@ export function findRegistration(
   return registrations.find((registration) => registration.name === name);
 }
 
-export function invokeTool(registration: Registration | undefined, toolName: string) {
+export function invokeTool(
+  registration: Registration | undefined,
+  toolName: string,
+  // 고도화 A: capability/risk labels the tier deny-overlay matches on (stamped
+  // by `defineTool` in production; supplied explicitly here). Default empty
+  // preserves every existing name-based caller.
+  toolLabels: readonly string[] = [],
+) {
   if (registration === undefined) return undefined;
 
   const engine = PolicyEngine.create({ audit: false });
@@ -36,9 +43,9 @@ export function invokeTool(registration: Registration | undefined, toolName: str
     toolId: toolName,
     toolName,
     toolCallId: "fixture-tool-call",
-    toolLabels: [],
+    toolLabels: [...toolLabels],
     toolInput: {},
-    resourceDescriptor: { ...fixtureDescriptor, id: `tool:${toolName}` },
+    resourceDescriptor: { ...fixtureDescriptor, id: `tool:${toolName}`, labels: [...toolLabels] },
   } satisfies Parameters<PolicyEngineInstance["dispatchPoint"]>[1];
 
   return engine.dispatchPoint("tool.native.pre", context);

--- a/packages/openomni/src/execution-runtime/middleware.test.ts
+++ b/packages/openomni/src/execution-runtime/middleware.test.ts
@@ -108,6 +108,94 @@ describe("buildWorkerMiddleware S6 evidence_only hard tool-authority gate", () =
     );
     await expect(invokeTool(gated, "tool:read")).resolves.toMatchObject({ verdict: "deny" });
   });
+
+  // 고도화 A — the tier tool-permission cap is an ADDITIVE deny-label overlay
+  // composed AFTER the evidence_only gate and ON TOP OF the agent's base
+  // permission (deny-wins, ruleset preserved). Tools are stamped with
+  // `capability:read|write|destructive` by defineTool; a read-only cap denies
+  // the write/destructive labels while leaving read tools and the agent's own
+  // rules intact.
+  const READ_ONLY_OVERLAY = {
+    denyLabels: ["capability:write", "capability:destructive"],
+  } as const;
+
+  it("regression guard: a tier with NO overlay leaves the agent permission unchanged", async () => {
+    // owner/co_owner/manager have no profile entry → no overlay is threaded.
+    // A default-allow permission (no allow/deny lists) still allows a write.
+    const openPermission = { action: "tool.call" };
+    const registration = findRegistration(
+      buildWorkerMiddleware({ permissions: openPermission, inboundTreatment: "full_access" }),
+      "builtin:tool-permission",
+    );
+    await expect(invokeTool(registration, "fs.write", ["capability:write"])).resolves.toMatchObject(
+      { verdict: "allow" },
+    );
+  });
+
+  it("collaborator full_access + read-only overlay: write DENIED, read ALLOWED", async () => {
+    // Base permission the agent ships with — a denylist the overlay must NOT
+    // discard (proves additive, not replacement).
+    const basePermission = { action: "tool.call", denylist: ["secrets.read"] };
+    const registration = findRegistration(
+      buildWorkerMiddleware({
+        permissions: basePermission,
+        inboundTreatment: "full_access",
+        tierDenyOverlay: READ_ONLY_OVERLAY,
+      }),
+      "builtin:tool-permission",
+    );
+    // A capability:write tool is denied by the merged deny label.
+    await expect(invokeTool(registration, "fs.write", ["capability:write"])).resolves.toMatchObject(
+      { verdict: "deny" },
+    );
+    // A capability:read tool passes (default-allow with no matching deny).
+    await expect(invokeTool(registration, "fs.read", ["capability:read"])).resolves.toMatchObject({
+      verdict: "allow",
+    });
+    // The agent's OWN denylist still bites — the overlay added to it, not over it.
+    await expect(
+      invokeTool(registration, "secrets.read", ["capability:read"]),
+    ).resolves.toMatchObject({ verdict: "deny" });
+  });
+
+  it("evidence_only beats the tier overlay: deny-all even for a read tool", async () => {
+    // The batch-② gate still wins: a read tool the overlay would ALLOW is
+    // denied because evidence_only caps the whole run to deny-all.
+    const registration = findRegistration(
+      buildWorkerMiddleware({
+        permissions: { action: "tool.call" },
+        inboundTreatment: "evidence_only",
+        tierDenyOverlay: READ_ONLY_OVERLAY,
+      }),
+      "builtin:tool-permission",
+    );
+    await expect(invokeTool(registration, "fs.read", ["capability:read"])).resolves.toMatchObject({
+      verdict: "deny",
+    });
+  });
+
+  it("the overlay merges into a policy-plan ruleset too (full_access)", async () => {
+    const plan = {
+      policies: [
+        {
+          id: "builtin:tool-permission",
+          required: true,
+          config: { permission: { action: "tool.call" } },
+        },
+      ],
+      labels: [],
+    };
+    const registration = findRegistration(
+      buildWorkerMiddleware({ policyPlan: plan, tierDenyOverlay: READ_ONLY_OVERLAY }),
+      "builtin:tool-permission",
+    );
+    await expect(invokeTool(registration, "fs.write", ["capability:write"])).resolves.toMatchObject(
+      { verdict: "deny" },
+    );
+    await expect(invokeTool(registration, "fs.read", ["capability:read"])).resolves.toMatchObject({
+      verdict: "allow",
+    });
+  });
 });
 
 describe("buildWorkerMiddleware injection queue persistence", () => {

--- a/packages/openomni/src/execution-runtime/middleware.ts
+++ b/packages/openomni/src/execution-runtime/middleware.ts
@@ -43,9 +43,33 @@ type WorkerCompactionConfig = {
   readonly elideToolOutputs?: { minOutputChars: number; keepHeadChars: number };
 };
 
+/**
+ * 고도화 A — a tier→tool-set permission cap expressed as an ADDITIVE deny-label
+ * overlay (never a name enumeration, never a permission replacement). The
+ * Owner declares, as DATA, that a trust tier's tools are capped by capability
+ * (`capability:write` / `capability:destructive` / `capability:read`, stamped
+ * by `defineTool`); the overlay's `denyLabels` union into the effective
+ * permission's `denyLabels`, so the deny-wins ordering caps the tier WITHOUT
+ * discarding the agent's own allowlist/denylist. Absent overlay → no
+ * relaxation change (base behavior).
+ */
+export interface TierDenyOverlay {
+  readonly denyLabels: readonly string[];
+}
+
 export interface WorkerMiddlewareConfig {
   permissions?: Policy.Permission;
   policyPlan?: Policy.PolicyPlan;
+  /**
+   * 고도화 A — the resolved deny-label overlay for the triggering delivery's
+   * trust tier (looked up from the injected profiles table by the resident
+   * runtime). Composes AFTER the S6 `evidence_only` cap: evidence_only still
+   * short-circuits to deny-all; only a `full_access` turn gets the overlay
+   * merged onto its base permission. Absent for tiers with no profile entry
+   * (owner/co_owner/manager by default) and for runs with no trust tier
+   * (internal / wait-resumption / anonymous).
+   */
+  tierDenyOverlay?: TierDenyOverlay;
   /**
    * The trace of the run these policies are being resolved for. Resolution
    * reports a missing optional policy, and that report is filed under this
@@ -86,6 +110,22 @@ const FAIL_CLOSED_TOOL_PERMISSION: Policy.Permission = { action: "tool.call", de
  */
 function isEvidenceOnly(config: WorkerMiddlewareConfig): boolean {
   return config.inboundTreatment === "evidence_only";
+}
+
+/**
+ * 고도화 A additive-deny merge: union the tier overlay's `denyLabels` into the
+ * effective permission, preserving everything else (allowlist/denylist/rules)
+ * so the cap tightens WITHOUT replacing the agent's own ruleset. A no-op
+ * overlay (absent or empty) returns the permission unchanged by reference, so
+ * callers can cheaply detect "nothing changed".
+ */
+function applyTierDenyOverlay(
+  permission: Policy.Permission,
+  overlay: TierDenyOverlay | undefined,
+): Policy.Permission {
+  if (overlay === undefined || overlay.denyLabels.length === 0) return permission;
+  const merged = [...new Set([...(permission.denyLabels ?? []), ...overlay.denyLabels])];
+  return { ...permission, denyLabels: merged };
 }
 
 export function buildWorkerMiddleware(config: WorkerMiddlewareConfig): PolicyEngineRegistration[] {
@@ -168,10 +208,15 @@ function buildLegacyPermissionMiddleware(
     createToolPermissionPolicy({
       // No plan and no legacy permissions: nothing declared a ruleset for
       // this run, so the guard denies every tool instead of allowing all.
-      // An evidence_only run is capped to deny-all regardless (S6 hard gate).
+      // Composition order: evidence_only cap (deny-all, S6) → tier deny-overlay
+      // → agent base permission. evidence_only short-circuits; only a
+      // full_access turn gets the tier overlay merged onto its base.
       permission: isEvidenceOnly(config)
         ? FAIL_CLOSED_TOOL_PERMISSION
-        : (config.permissions ?? FAIL_CLOSED_TOOL_PERMISSION),
+        : applyTierDenyOverlay(
+            config.permissions ?? FAIL_CLOSED_TOOL_PERMISSION,
+            config.tierDenyOverlay,
+          ),
       events: Bus,
     }),
   ];
@@ -197,13 +242,16 @@ function hydrateToolPermissionConfig(
   workerConfig: WorkerMiddlewareConfig,
 ): Policy.PolicyPlan {
   const evidenceOnly = isEvidenceOnly(workerConfig);
+  const overlay = workerConfig.tierDenyOverlay;
   const fallbackPermission = workerConfig.permissions ?? FAIL_CLOSED_TOOL_PERMISSION;
   let changed = false;
   const policies = plan.policies.map((policy) => {
     if (policy.id !== "builtin:tool-permission") return policy;
     const config = policy.config ?? {};
-    // S6 hard gate: an evidence_only run's tool authority is capped to
-    // deny-all, OVERRIDING whatever ruleset the plan declares.
+    // Composition order: evidence_only cap (deny-all, S6) → tier deny-overlay
+    // → the plan's/legacy ruleset. The S6 hard gate short-circuits FIRST:
+    // an evidence_only run's tool authority is capped to deny-all, OVERRIDING
+    // whatever ruleset the plan declares and skipping the tier overlay.
     if (evidenceOnly) {
       changed = true;
       return { ...policy, config: { ...config, permission: FAIL_CLOSED_TOOL_PERMISSION } };
@@ -213,14 +261,25 @@ function hydrateToolPermissionConfig(
     // either, the absent arm fails CLOSED (deny-all): a plan that selects the
     // guard without a ruleset gets no implicit allow-all.
     // A present-but-invalid permission is treated as explicit and fails closed.
+    // 고도화 A: a full_access turn merges the tier deny-overlay onto the
+    // effective permission (additive deny, deny-wins preserved).
     if ("permission" in config) {
-      if (Policy.Permission.safeParse(config.permission).success) return policy;
+      const parsed = Policy.Permission.safeParse(config.permission);
+      if (parsed.success) {
+        const overlaid = applyTierDenyOverlay(parsed.data, overlay);
+        if (overlaid === parsed.data) return policy;
+        changed = true;
+        return { ...policy, config: { ...config, permission: overlaid } };
+      }
       changed = true;
       return { ...policy, config: { ...config, permission: FAIL_CLOSED_TOOL_PERMISSION } };
     }
 
     changed = true;
-    return { ...policy, config: { ...config, permission: fallbackPermission } };
+    return {
+      ...policy,
+      config: { ...config, permission: applyTierDenyOverlay(fallbackPermission, overlay) },
+    };
   });
 
   return changed ? { ...plan, policies } : plan;

--- a/packages/openomni/src/resident/runtime.ts
+++ b/packages/openomni/src/resident/runtime.ts
@@ -5,7 +5,7 @@ import {
   type TraceContext as TraceContextProtocol,
 } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
-import { buildWorkerMiddleware } from "../execution-runtime/middleware";
+import { buildWorkerMiddleware, type TierDenyOverlay } from "../execution-runtime/middleware";
 import { createAnchorCompletion } from "../execution-runtime/middleware/anchor-completion";
 import { SessionBridge } from "../ingress/session-bridge";
 import { EngagementContext } from "./engagement-context";
@@ -53,6 +53,15 @@ export interface ResidentRuntimeOptions {
   readonly maxActive?: number;
   readonly idleTimeoutMs?: number;
   readonly slotWaitTimeoutMs?: number;
+  /**
+   * 고도화 A — the Owner-declared tier→deny-overlay table, injected at
+   * composition (server bootstrap resolves it from config), NEVER hardcoded.
+   * Per delivery, the run's `actorTrustTier` indexes this table for the
+   * additive deny-label cap. Keyed by `Actor.TrustTier` string; a tier with no
+   * entry gets NO relaxation change (owner/co_owner/manager by default).
+   * Default empty → no tier ever gains an overlay (base behavior).
+   */
+  readonly permissionProfiles?: Readonly<Record<string, TierDenyOverlay>>;
   readonly runAgent?: (
     config: ChatAgentConfig,
     input: ChatAgentInput,
@@ -178,7 +187,11 @@ function resolveResidentToolExecutor(
   return ctx.event.agent.toolExecutor;
 }
 
-function buildResidentAgentConfig(ctx: ResidentRunContext, runId: string): ChatAgentConfig {
+function buildResidentAgentConfig(
+  ctx: ResidentRunContext,
+  runId: string,
+  permissionProfiles: Readonly<Record<string, TierDenyOverlay>>,
+): ChatAgentConfig {
   // The sandbox root / lock key comes from the COMPOSED agent config only.
   // `ctx.event.workspace` is a surface-derived identifier (an inbound event
   // field the perimeter influences) and must never become the workspace root
@@ -187,6 +200,13 @@ function buildResidentAgentConfig(ctx: ResidentRunContext, runId: string): ChatA
   const workspaceRoot = ctx.event.agent.toolConfig?.workspaceRoot;
   const toolExecutor = resolveResidentToolExecutor(ctx, runId, workspaceRoot);
   const agent = ctx.event.agent as RuntimeAgentDef;
+
+  // 고도화 A: the tier deny-overlay is looked up per delivery from the injected
+  // profiles table. A run with no trust tier (internal / wait-resumption /
+  // anonymous) skips the lookup entirely — the overlay stays absent, so the
+  // middleware applies no cap (same guard shape as inboundTreatment).
+  const tierDenyOverlay =
+    ctx.actorTrustTier === undefined ? undefined : permissionProfiles[ctx.actorTrustTier];
 
   return {
     // The kernel is a composition layer: it chooses what observation
@@ -205,6 +225,9 @@ function buildResidentAgentConfig(ctx: ResidentRunContext, runId: string): ChatA
       // S6 hard gate: an evidence_only delivery caps this run's tool authority
       // to deny-all, overriding whatever permissions/plan would allow.
       ...(ctx.inboundTreatment === undefined ? {} : { inboundTreatment: ctx.inboundTreatment }),
+      // 고도화 A tier tool-permission cap: present only for tiers with a
+      // profile entry on a delivery that carries a trust tier.
+      ...(tierDenyOverlay === undefined ? {} : { tierDenyOverlay }),
       ...(ctx.event.agent.policyPlan ? { policyPlan: ctx.event.agent.policyPlan } : {}),
       compaction: {
         summarizeWith: createAnchorCompletion({
@@ -241,12 +264,15 @@ export class ResidentRuntime {
   private readonly slotWaitTimeoutMs: number;
   private activeRuns = 0;
   private readonly runAgent: NonNullable<ResidentRuntimeOptions["runAgent"]>;
+  private readonly permissionProfiles: Readonly<Record<string, TierDenyOverlay>>;
 
   constructor(options: ResidentRuntimeOptions = {}) {
     this.maxActive = options.maxActive ?? 10;
     this.idleTimeoutMs = options.idleTimeoutMs ?? 30_000;
     this.slotWaitTimeoutMs = options.slotWaitTimeoutMs ?? 30_000;
     this.runAgent = options.runAgent ?? defaultRunAgent;
+    // Default empty → no tier ever gains an overlay (fail-closed base posture).
+    this.permissionProfiles = options.permissionProfiles ?? {};
   }
 
   stats(): { activations: number; activeRuns: number; idle: number; maxActive: number } {
@@ -422,7 +448,7 @@ export class ResidentRuntime {
               ...messages,
             ];
       activation.lifecycle = "active";
-      const agentConfig = buildResidentAgentConfig(ctx, runId);
+      const agentConfig = buildResidentAgentConfig(ctx, runId, this.permissionProfiles);
       const result = await this.runAgent(agentConfig, {
         messages: hydrated,
         traceContext,


### PR DESCRIPTION
Feature 고도화 A — a declarative permission-profile surface so an Owner can approve "collaborator may run read/analysis tools but not write/exec/deploy" as **data**, composing with the audit's fail-closed plane + the S6 evidence_only hard gate. 2 commits.

## What
- **Owner declares it in config** (`apps/server/src/config.ts`): `permissionProfiles: Partial<Record<Actor.TrustTier, { denyLabels: string[] }>>`, resolved like `messaging.grants` — **fail-closed** (malformed → dropped → that tier gets no relaxation). Reuses `Actor.TrustTier` keys + `Policy.Permission.denyLabels`; no new expression language.
- **Expression = additive deny-label overlay**, not name enumeration, not permission replacement. Tools are label-stamped (`capability:read|write|destructive`, `risk:tier-N`) by `defineTool`; a read-only cap = `denyLabels: ["capability:write","capability:destructive"]`. Deny-wins ordering caps WITHOUT discarding the agent's own ruleset.
- **Composition order preserved**: `evidence_only` (deny-all, batch ②) → tier deny-overlay → agent base. The overlay is applied after the `isEvidenceOnly` short-circuit in both middleware arms; threaded via the existing #709 trustTier rail (zero new threads).

## Safety invariants (all tested)
1. owner/co_owner/manager, no profile → tools unchanged (regression guard).
2. collaborator full_access + read-only overlay → `capability:write` DENIED, `capability:read` ALLOWED, agent's own denylist still bites.
3. collaborator evidence_only → deny-all (evidence beats tier — S6 gate still wins).
4. absent trustTier (internal/wait-resumption/anonymous) → overlay skipped.
5. delegated workers untouched (no trustTier rail there — authority is the dispatch stamp).
6. malformed config → dropped fail-closed with warn, boot survives.

## Verification
build + check-types + full turbo test 16/16 (openomni 960, server 451), lint suite, check-deps+self-test, import-cycles, dead-exports, coverage-ratchet, p2-ledger-baseline 54, channels standalone. Config example in JSDoc + apps/server/AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Owner-declared per-trust-tier tool-permission cap using an additive deny-label overlay. Previously, tiers had no overlay (only agent rules and the S6 evidence_only gate); now, for tiers with a profile, `denyLabels` merge into effective permissions after evidence_only, enabling read-only collaborators without replacing agent rules.

- Config: `permissionProfiles: Partial<Record<Actor.TrustTier, { denyLabels: string[] }>>` in `apps/server` config. Example for read-only: collaborator → `["capability:write","capability:destructive"]`. Parsed fail-closed with operational warnings; unknown tiers or malformed entries are ignored.
- Composition: evidence_only deny-all → tier deny-overlay → agent base permission. Overlay is additive (deny-wins); agent allow/deny rules remain in effect.
- Scope: Applied only to deliveries with `actorTrustTier` and only to tiers with a profile. Tiers without entries and runs without a trust tier are unchanged. Delegated workers are untouched.
- Runtime/API: `ResidentRuntime` accepts injected `permissionProfiles` (server passes it). `buildWorkerMiddleware` accepts an optional `tierDenyOverlay`; evidence_only still short-circuits to deny-all.
- Tests/docs: New tests cover no-overlay regression, read-only collaborator, evidence_only precedence, and plan-arm merge; `AGENTS.md` updated.
- Migration: No required changes. To enable read-only collaborators, add `permissionProfiles` to `config.json` and restart the server.

<sup>Written for commit 691d479a611b6700bcd0f3e80b08db99294bb2ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable permission profiles based on actor trust tiers.
  * Profiles can apply additional tool restrictions while preserving existing permissions.
  * Resident deliveries now automatically use the configured profile for the actor’s trust tier.

* **Bug Fixes**
  * Invalid or incomplete permission profiles are safely ignored with warnings.
  * Restricted and evidence-only modes continue to fail closed, preventing unauthorized tool access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->