### PR TITLE
test: swappable-model E2E harness (stub now, proxy-ready)

### DIFF
--- a/apps/server/test/e2e/harness.ts
+++ b/apps/server/test/e2e/harness.ts
@@ -1,0 +1,205 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createGatewayRouter,
+  type ChannelDeliveryRoute,
+  type GatewayRouter,
+} from "@openomni/channels";
+import {
+  createBrainEngine,
+  createEngagementTools,
+  createMessageSendTool,
+  createToolExecutor,
+  ResidentRuntime,
+  type NativeTool,
+} from "@openomni/openomni";
+import { EngagementStore } from "@openomni/ledger";
+import type { Gateway, Ingress, Tool } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
+import type { SeamModel } from "./model-seam";
+
+/**
+ * The E2E harness: the REAL gateway router + REAL brain deliver consumer +
+ * REAL tool executor (the production `toolExecutorFactory` = `createToolExecutor`),
+ * composed exactly as `apps/server/src/bootstrap` wires them. The ONLY fakes
+ * are the two legitimate ones the existing composed-pipeline E2E tests use:
+ *
+ *   1. the OUTBOUND platform delivery route (capturing, no real Telegram/Discord);
+ *   2. the model, behind the swappable `SeamModel` seam (stub now, proxy later).
+ *
+ * Everything authority-bearing — perimeter admission/treatment, session
+ * materialization, engagement hydration, the S6 deny-all gate, the send
+ * kernel, wait correlation — is the production code path.
+ */
+
+const PERSONA = "actor-persona";
+const WORKSPACE_ROOT = "/tmp/openomni-e2e-workspace";
+const SYSTEM_PROMPT = "You are the resident assistant (E2E harness).";
+
+/**
+ * A deterministic, side-effect-free native tool. Read-only tier 0 so it is
+ * allowed under a normal (full_access) run and denied fail-closed under an
+ * evidence_only run — the S6 gate is the only thing that changes the verdict.
+ */
+export function probeTool(output: Record<string, unknown> = { probe: "ok" }): NativeTool {
+  return {
+    spec: {
+      name: "probe",
+      description: "Deterministic read-only probe used by the E2E harness.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    },
+    riskTier: 0,
+    isReadOnly: true,
+    isDestructive: false,
+    isConcurrencySafe: true,
+    category: "custom",
+    async execute(call: Tool.Call): Promise<Tool.Result> {
+      return {
+        id: crypto.randomUUID(),
+        toolCallId: call.id,
+        toolName: call.tool,
+        output: JSON.stringify(output),
+        isError: false,
+      };
+    },
+  };
+}
+
+export interface ComposeConfig {
+  readonly model: SeamModel;
+  /** Send grants for the as-me `message.send` tool (case 4). */
+  readonly grants?: readonly Gateway.SenderTargetGrant[];
+  /** Fixed tool clock; defaults to a real-future constant. */
+  readonly now?: () => number;
+  /** Extra native tools to register alongside the bootstrap-shaped set. */
+  readonly extraTools?: readonly NativeTool[];
+}
+
+export interface Harness {
+  readonly router: GatewayRouter;
+  /** Captured outbound platform sends (the legitimate delivery fake). */
+  readonly outbound: Array<{ externalId: string; body: string }>;
+  /** Every `Gateway.Deliver` the router handed the brain, in order. */
+  readonly deliveries: Gateway.Deliver[];
+  /** Per-run implicit-input context the production factory received. */
+  readonly factoryContexts: Array<{ engagementId?: string; actorTrustTier?: string }>;
+  readonly personaActorId: string;
+}
+
+// A fixed injected clock, safely in the future of the wall clock the wait fold
+// reads (expiry is evaluated against Date.now() at reply time).
+const DEFAULT_NOW = 5_000_000_000_000;
+
+/**
+ * Live-mode wiring: when the proxy model carries a baseURL but no auth file is
+ * configured, materialize a proxy auth file and point `OPENOMNI_AUTH_FILE` at
+ * it so the real `@openomni/llm` path resolves a proxy credential. A no-op for
+ * the stub model, and a no-op when the operator already set an auth file.
+ */
+function ensureLiveAuth(model: SeamModel): void {
+  if (model.kind !== "proxy") return;
+  if (process.env.OPENOMNI_AUTH_FILE) return;
+  const baseURL = process.env.OPENOMNI_E2E_PROXY_URL;
+  if (!baseURL) return;
+  const dir = mkdtempSync(join(tmpdir(), "openomni-e2e-auth-"));
+  const file = join(dir, "auth.json");
+  const apiKey = process.env.OPENOMNI_E2E_PROXY_KEY;
+  writeFileSync(
+    file,
+    JSON.stringify({
+      [model.model.provider]: {
+        type: "proxy",
+        baseURL,
+        ...(apiKey === undefined ? {} : { apiKey }),
+      },
+    }),
+    { mode: 0o600 },
+  );
+  process.env.OPENOMNI_AUTH_FILE = file;
+}
+
+/**
+ * Composes the production seams around a swappable model. The caller drives it
+ * with `router.ingest(...)` and asserts on the capture surfaces.
+ */
+export function composeHarness(config: ComposeConfig): Harness {
+  ensureLiveAuth(config.model);
+
+  const outbound: Array<{ externalId: string; body: string }> = [];
+  const deliveries: Gateway.Deliver[] = [];
+  const factoryContexts: Array<{ engagementId?: string; actorTrustTier?: string }> = [];
+  const now = config.now ?? (() => DEFAULT_NOW);
+
+  // Late-bound so the send tool can reach the router's messaging seam, exactly
+  // as bootstrap defers the send port until the router composes.
+  let router: GatewayRouter;
+
+  const buildTools = (): NativeTool[] => [
+    probeTool(),
+    createMessageSendTool({
+      send: (input) => router.messaging.send(input),
+      personaActorId: PERSONA,
+      now,
+      activeEngagementId: (sessionId) => {
+        const active = EngagementStore.list({
+          ownerSessionId: sessionId,
+          states: [...EngagementStore.activeStates],
+        });
+        const [sole, ...rest] = active;
+        return rest.length === 0 ? sole?.id : undefined;
+      },
+    }),
+    ...createEngagementTools({ engagements: EngagementStore, now }),
+    ...(config.extraTools ?? []),
+  ];
+
+  // The production AgentDef shape (mirrors bootstrap's buildResidentAgentDef →
+  // buildAgentDefFromEntries): the authority-bearing seam is `toolExecutorFactory`
+  // = `createToolExecutor({ tools, config })`, and `permissions` allow-by-default
+  // (the execution runtime fails closed on an absent permission). The S6 gate
+  // overrides this to deny-all for an evidence_only delivery.
+  const agentDef: Ingress.AgentDef = {
+    model: config.model.model,
+    systemPrompt: SYSTEM_PROMPT,
+    tools: buildTools().map((tool) => tool.spec),
+    permissions: { action: "tool.call" },
+    toolConfig: { workspaceRoot: WORKSPACE_ROOT },
+    toolExecutorFactory: (ctx) => {
+      factoryContexts.push({
+        ...(ctx.engagementId === undefined ? {} : { engagementId: ctx.engagementId }),
+        ...(ctx.actorTrustTier === undefined ? {} : { actorTrustTier: ctx.actorTrustTier }),
+      });
+      return createToolExecutor({ tools: buildTools(), config: { runtime: ctx } });
+    },
+  };
+
+  const brain = createBrainEngine({
+    residentRuntime: ResidentRuntime.create(config.model.residentOptions()),
+    externalAgentResolver: async () => agentDef,
+  });
+
+  const deliveryRoutes = new Map<string, ChannelDeliveryRoute>([
+    [
+      "telegram",
+      async (externalId, body) => {
+        outbound.push({ externalId, body });
+        return { externalMessageId: `platform:${outbound.length}` };
+      },
+    ],
+  ]);
+
+  router = createGatewayRouter({
+    sink: Bus.publish,
+    deliver: async (delivery) => {
+      deliveries.push(delivery);
+      return brain.deliver(delivery);
+    },
+    messaging: {
+      deliveryRoutes,
+      grants: () => config.grants ?? [],
+    },
+  });
+
+  return { router, outbound, deliveries, factoryContexts, personaActorId: PERSONA };
+}

--- a/apps/server/test/e2e/llm-round-trip.test.ts
+++ b/apps/server/test/e2e/llm-round-trip.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  ActorRegistry,
+  ChannelGrantStore,
+  EngagementStore,
+  Storage,
+  WaitStore,
+} from "@openomni/ledger";
+import type { Gateway } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
+import { composeHarness } from "./harness";
+import { proxyModel, stubModel } from "./model-seam";
+
+/**
+ * Swappable-model E2E: one inbound event travels the REAL router →
+ * Gateway.Deliver → REAL brain deliver → REAL resident run (production
+ * toolExecutorFactory) → reply, with the model behind a seam. The stub proves
+ * the wiring deterministically; the same harness becomes a live test the
+ * moment a proxy baseURL/auth is present.
+ *
+ * The only fakes: the outbound platform delivery route (capturing) and the
+ * model (stub, one-line swap to `proxyModel()`).
+ */
+
+const OWNER = "actor-owner";
+const OWNER_ENDPOINT = "telegram:owner-1";
+const OWNER_CHANNEL = "telegram:owner-dm";
+const COLLAB = "actor-collab";
+const COLLAB_ENDPOINT = "telegram:collab-1";
+const COLLAB_CHANNEL = "telegram:collab-dm";
+const SELLER = "actor-seller";
+const SELLER_ENDPOINT = "telegram:seller-1";
+const PERSONA = "actor-persona";
+
+function registerActors(): void {
+  ActorRegistry.registerIdentity({ id: PERSONA, kind: "ai_agent", trustTier: "owner" });
+  ActorRegistry.registerIdentity({ id: OWNER, kind: "human", trustTier: "owner" });
+  ActorRegistry.registerEndpoint({
+    id: OWNER_ENDPOINT,
+    actorId: OWNER,
+    channel: "telegram",
+    externalId: "owner-1",
+  });
+  // A collaborator on the evidence tier: admitted enough to be heard, never to
+  // drive tool use.
+  ActorRegistry.registerIdentity({ id: COLLAB, kind: "human", trustTier: "collaborator" });
+  ActorRegistry.registerEndpoint({
+    id: COLLAB_ENDPOINT,
+    actorId: COLLAB,
+    channel: "telegram",
+    externalId: "collab-1",
+  });
+  ActorRegistry.registerIdentity({ id: SELLER, kind: "human", trustTier: "collaborator" });
+  ActorRegistry.registerEndpoint({
+    id: SELLER_ENDPOINT,
+    actorId: SELLER,
+    channel: "telegram",
+    externalId: "seller-1",
+  });
+  // The Owner's DM is a trusted channel (full access); the collaborator's DM is
+  // trusted-but-evidence-only (§2a) — the S6 gate reads its treatment.
+  ChannelGrantStore.put({
+    id: "grant-owner-dm",
+    surface: "telegram",
+    channel: OWNER_CHANNEL,
+    kind: "trusted_channel",
+    inboundTreatment: "full_access",
+    createdBy: OWNER,
+  });
+  ChannelGrantStore.put({
+    id: "grant-collab-dm",
+    surface: "telegram",
+    channel: COLLAB_CHANNEL,
+    kind: "trusted_channel",
+    inboundTreatment: "evidence_only",
+    createdBy: OWNER,
+  });
+}
+
+function ownerInbound(id: string, text: string): Gateway.DeliveredEvent {
+  return {
+    id,
+    traceId: `trace-${id}`,
+    surface: "telegram",
+    channel: OWNER_CHANNEL,
+    userId: "owner-1",
+    mode: "direct",
+    payload: text,
+    meta: {},
+  };
+}
+
+function collabInbound(id: string, text: string): Gateway.DeliveredEvent {
+  return {
+    id,
+    traceId: `trace-${id}`,
+    surface: "telegram",
+    channel: COLLAB_CHANNEL,
+    userId: "collab-1",
+    mode: "direct",
+    payload: text,
+    meta: {},
+  };
+}
+
+function sellerReply(id: string, replyToMessageId: string, output: string): Gateway.DeliveredEvent {
+  return {
+    id,
+    traceId: `trace-${id}`,
+    surface: "telegram",
+    channel: "telegram:dm",
+    userId: "seller-1",
+    mode: "direct",
+    payload: { action: "report_result", output },
+    meta: {
+      correlation: {
+        endpointId: SELLER_ENDPOINT,
+        channelId: "telegram:dm",
+        replyToMessageId,
+      },
+    },
+  };
+}
+
+function probeCall(): { id: string; tool: string; input: Record<string, unknown> } {
+  return { id: crypto.randomUUID(), tool: "probe", input: {} };
+}
+
+describe("swappable-model E2E round trip (stub mode)", () => {
+  beforeEach(() => {
+    Storage.reset();
+    Bus.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    registerActors();
+  });
+
+  // ---- Case 1: reactive reply -------------------------------------------
+  test("owner DM → full_access → resident run → assistant text on the same surface", async () => {
+    const model = stubModel();
+    model.scripts.push({ text: "현재 상태: 정상 가동 중입니다." });
+    const harness = composeHarness({ model });
+
+    const result = await harness.router.ingest(ownerInbound("inbound-status", "현재 상태 알려줘"));
+
+    if (result.kind === "dropped") throw new Error("owner DM was dropped");
+    // The round trip returned the resident's reply on the owner's surface.
+    expect(result.result.output).toBe("현재 상태: 정상 가동 중입니다.");
+    // The perimeter admitted the owner at full access and threaded the verdict.
+    expect(harness.deliveries[0]?.actorContext?.trustTier).toBe("owner");
+    expect(harness.deliveries[0]?.actorContext?.inboundTreatment).toBe("full_access");
+    expect(harness.factoryContexts[0]).toEqual({ actorTrustTier: "owner" });
+  });
+
+  // ---- Case 2: evidence_only deny vs owner allow ------------------------
+  test("evidence_only run denies a scripted tool call that the owner run allows (S6 gate)", async () => {
+    const model = stubModel();
+    // Turn 1 (owner, full_access): the probe is allowed and executes for real.
+    model.scripts.push({ text: "probe done", toolCalls: [probeCall()] });
+    // Turn 2 (collaborator, evidence_only): the SAME probe is denied fail-closed.
+    model.scripts.push({ text: "noted (evidence only)", toolCalls: [probeCall()] });
+    const harness = composeHarness({ model });
+
+    const owner = await harness.router.ingest(ownerInbound("inbound-owner-probe", "probe please"));
+    if (owner.kind === "dropped") throw new Error("owner probe was dropped");
+    const evidence = await harness.router.ingest(
+      collabInbound("inbound-collab-probe", "run the probe"),
+    );
+    if (evidence.kind === "dropped") throw new Error("collaborator inbound was dropped");
+
+    // Perimeter treatments reached the runs verbatim.
+    expect(harness.deliveries[0]?.actorContext?.inboundTreatment).toBe("full_access");
+    expect(harness.deliveries[1]?.actorContext?.inboundTreatment).toBe("evidence_only");
+
+    // Owner turn: the real gated executor allowed the call → production probe ran.
+    const ownerResult = model.llmCaptures[0]?.toolResults[0];
+    expect(ownerResult?.isError).toBeFalsy();
+    expect(ownerResult?.output).toContain('"probe":"ok"');
+
+    // Evidence turn: deny-all overrode the allow permission → typed denial,
+    // the production tool never ran.
+    const evidenceResult = model.llmCaptures[1]?.toolResults[0];
+    expect(evidenceResult?.isError).toBe(true);
+    expect(evidenceResult?.output).toContain("Denied");
+    expect(evidenceResult?.output).not.toContain('"probe":"ok"');
+  });
+
+  // ---- Case 3: engagement state hydrated into the run context -----------
+  test("an owner query hydrates the session's engagement slice into the prompt the model sees", async () => {
+    const model = stubModel();
+    model.scripts.push({ text: "안녕하세요" }); // Run 1 materializes the session.
+    model.scripts.push({ text: "협상 진행 중입니다" }); // Run 2 sees the engagement slice.
+    const harness = composeHarness({ model });
+
+    const first = await harness.router.ingest(ownerInbound("inbound-open", "안녕"));
+    if (first.kind === "dropped") throw new Error("first owner DM was dropped");
+    const ownerSessionId = first.sessionId;
+    if (ownerSessionId === undefined) throw new Error("owner session was not materialized");
+
+    const deadline = Date.now() + 3_600_000;
+    EngagementStore.open(
+      {
+        id: "eng-negotiation",
+        ownerSessionId,
+        title: "중고 거래 협상",
+        terms: { deadline },
+      },
+      "trace-seed-engagement",
+    );
+
+    const second = await harness.router.ingest(ownerInbound("inbound-query", "협상 상태 알려줘"));
+    if (second.kind === "dropped") throw new Error("owner query was dropped");
+
+    // The engagement slice prepends as a machine-side context block the model saw.
+    const hydrated = model.runInputs[1]?.messages[0];
+    expect(hydrated?.role).toBe("user");
+    expect(hydrated?.partMetadata).toEqual({ engagementContext: true });
+    expect(hydrated?.content).toContain("[engagement context");
+    expect(hydrated?.content).toContain("중고 거래 협상");
+    expect(hydrated?.content).toContain(new Date(deadline).toISOString());
+    // The first run — before any engagement existed — saw no slice.
+    expect(
+      model.runInputs[0]?.messages.some((m) => m.content.includes("[engagement context")),
+    ).toBe(false);
+  });
+
+  // ---- Case 4: awaited as-me send → reply resumes the calling session ----
+  test("an awaited as-me send opens a Wait and the responder's reply resumes the run with waitContext", async () => {
+    const model = stubModel();
+    // Run 1 (owner): the resident sends an awaited as-me message to the seller.
+    model.scripts.push({
+      text: "판매자에게 문의를 보냈습니다.",
+      toolCalls: [
+        {
+          id: crypto.randomUUID(),
+          tool: "message.send",
+          input: {
+            target: { actorId: SELLER },
+            body: "still available? 5만원에 가능할까요?",
+            operation: "awaited",
+            expectReply: { expiresInMs: 3_600_000 },
+          },
+        },
+      ],
+    });
+    // Run 2 (wait resumption): the reply comes back and the resident acknowledges.
+    model.scripts.push({ text: "판매자가 확인해줬습니다." });
+
+    const harness = composeHarness({
+      model,
+      grants: [
+        {
+          id: "grant-persona-seller",
+          senderId: PERSONA,
+          targetActorId: SELLER,
+          operations: ["awaited", "fire_and_forget"],
+        },
+      ],
+    });
+
+    const opened = await harness.router.ingest(ownerInbound("inbound-send", "판매자한테 물어봐줘"));
+    if (opened.kind === "dropped") throw new Error("owner send request was dropped");
+
+    // The as-me send was delivered to the platform and opened a durable wait.
+    const sent = JSON.parse(model.llmCaptures[0]?.toolResults[0]?.output ?? "{}") as {
+      kind?: string;
+      waitId?: string;
+    };
+    expect(sent.kind).toBe("sent");
+    const waitId = sent.waitId;
+    if (waitId === undefined) throw new Error("send did not open a wait");
+    expect(harness.outbound).toEqual([
+      { externalId: "seller-1", body: "still available? 5만원에 가능할까요?" },
+    ]);
+    expect(WaitStore.get(waitId)).toMatchObject({
+      status: "open",
+      ownerRef: { kind: "session", id: opened.sessionId },
+      expectedResponders: [SELLER],
+    });
+
+    // The responder's reply correlates through the router and resumes the run.
+    const resumed = await harness.router.ingest(
+      sellerReply("inbound-seller-reply", "platform:1", "네, 가능합니다"),
+    );
+    if (resumed.kind === "dropped") throw new Error("seller reply was dropped");
+    expect(resumed.sessionId).toBe(opened.sessionId);
+    expect(resumed.result.output).toBe("판매자가 확인해줬습니다.");
+    expect(WaitStore.get(waitId)).toMatchObject({ status: "resolved" });
+    const resumeDelivery = harness.deliveries.at(-1);
+    expect(resumeDelivery?.waitContext).toMatchObject({ waitId, allowedAction: "report_result" });
+    expect(resumeDelivery?.sessionId).toBe(opened.sessionId);
+  });
+});
+
+// ---- Live mode: skipped cleanly unless a proxy is configured -------------
+describe("live proxy mode", () => {
+  const proxy = proxyModel();
+
+  test.skipIf(!proxy.configured)("owner DM round trips through the real proxy model", async () => {
+    Storage.reset();
+    Bus.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    registerActors();
+    const harness = composeHarness({ model: proxy });
+    const result = await harness.router.ingest(
+      ownerInbound("inbound-live", "Say the single word: online."),
+    );
+    if (result.kind === "dropped") throw new Error("live owner DM was dropped");
+    expect(result.result.output.length).toBeGreaterThan(0);
+  });
+
+  test("proxy seam contract: no injection, and it reports whether live mode is enabled", () => {
+    if (!proxy.configured) {
+      // Never a fake pass: the live round trip above is genuinely skipped.
+      // Print exactly how to enable it.
+      console.log(
+        "[e2e] live LLM not configured — skipping the proxy round trip. To run it live, set " +
+          "OPENOMNI_E2E_PROXY_URL (+ optional OPENOMNI_E2E_PROXY_KEY / OPENOMNI_E2E_PROXY_PROVIDER / " +
+          "OPENOMNI_E2E_PROXY_MODEL), or point OPENOMNI_AUTH_FILE at a proxy auth.json. Would run: " +
+          `${proxy.model.provider}/${proxy.model.id}.`,
+      );
+    }
+    // The proxy model injects NOTHING — it uses the runtime's real default path.
+    expect(proxy.residentOptions().runAgent).toBeUndefined();
+    expect(proxy.model.provider).toBeTruthy();
+    expect(proxy.model.id).toBeTruthy();
+  });
+});

--- a/apps/server/test/e2e/model-seam.ts
+++ b/apps/server/test/e2e/model-seam.ts
@@ -1,0 +1,223 @@
+import { ChatAgent, type ChatAgentConfig, type ChatAgentInput } from "@openomni/agent";
+import type { Provider, Run, RunInput, Sink } from "@openomni/llm";
+import type { Message, Model, Tool } from "@openomni/protocol";
+import type { ResidentRuntimeOptions } from "@openomni/openomni";
+
+/**
+ * The swappable model at the E2E seam.
+ *
+ * Two implementations flip a SINGLE lever — `ResidentRuntime`'s `runAgent`
+ * option — and nothing else in the composition changes:
+ *
+ *   - `stubModel()` injects a `runAgent` that runs the REAL `ChatAgent` loop
+ *     (real middleware, real tool executor, real S6 deny-all gate) but swaps
+ *     ONLY the LLM call (`ChatAgentConfig.llm.run`) for a deterministic,
+ *     scripted stream. This proves the whole router→deliver→run→reply path
+ *     including the tool-authority gate WITHOUT a live model.
+ *
+ *   - `proxyModel()` injects NOTHING (`runAgent` stays the runtime default,
+ *     `defaultRunAgent` = `ChatAgent.create(config).run(input)`), so the run
+ *     resolves the real `@openomni/llm` provider against an `OPENOMNI_AUTH_FILE`
+ *     proxy. It becomes a live test the moment a proxy baseURL/auth is present;
+ *     until then the harness SKIPS it (never a failure, never a fake pass).
+ *
+ * The seam is `ChatAgentConfig.llm.run`: in production `buildResidentAgentConfig`
+ * leaves `llm` undefined, so the loop uses the real `@openomni/llm` run(); the
+ * stub wraps `defaultRunAgent` and threads a scripted run through the SAME
+ * loop, so the loop the stub exercises is byte-for-byte the production loop
+ * minus the network round trip.
+ */
+
+/** A single turn's script for the stub model. */
+export interface StubScript {
+  /** The deterministic assistant reply text this turn returns. */
+  readonly text: string;
+  /**
+   * Tool calls the model "makes" this turn. Each is dispatched through the
+   * REAL policy-gated executor (`RunInput.toolExecutor`, i.e. the agent-core
+   * hooked executor that applies the run's middleware — the S6 deny-all gate
+   * included), so the captured result reflects the genuine authority verdict.
+   */
+  readonly toolCalls?: readonly Tool.Call[];
+}
+
+/** What the stub model observed for one turn — the prompt it "saw" and results. */
+export interface LlmCapture {
+  readonly system?: string;
+  readonly messages: RunInput["messages"];
+  readonly toolResults: Tool.Result[];
+}
+
+/** The uniform shape the harness consumes; both models satisfy it. */
+export interface SeamModel {
+  readonly kind: "stub" | "proxy";
+  /** The AgentDef model ref this model wants the resident composed with. */
+  readonly model: Model.Ref;
+  /** The `ResidentRuntime.create` options — the one lever that flips. */
+  residentOptions(): Pick<ResidentRuntimeOptions, "runAgent">;
+}
+
+/** The stub model plus its capture surfaces (asserted by the cases). */
+export interface StubModel extends SeamModel {
+  readonly kind: "stub";
+  /** FIFO queue of per-turn scripts; one is consumed per resident run. */
+  readonly scripts: StubScript[];
+  /** The `ChatAgentInput` each run received — hydrated messages included. */
+  readonly runInputs: ChatAgentInput[];
+  /** What the scripted LLM saw + tool results, one entry per run. */
+  readonly llmCaptures: LlmCapture[];
+}
+
+const STUB_PROVIDER_LIMIT_CONTEXT = 200_000;
+
+function fakeProviderModel(model: Model.Ref): Provider.Model {
+  // A healthy context window so the loop never arms a spurious window-yield
+  // (a resolved limit of 0 would floor the yield point to 0 tokens).
+  return {
+    id: model.id,
+    providerID: model.provider,
+    name: model.id,
+    limit: { context: STUB_PROVIDER_LIMIT_CONTEXT },
+  };
+}
+
+/**
+ * A valid assistant boundary snapshot, hand-built to the `Message.WithParts`
+ * shape the agent's tracking sink folds. No `step-finish` part: `turnYield`
+ * reads the last step-finish reason, and its absence means "the model's own
+ * stop", so the turn ends cleanly with this text as the result.
+ */
+function assistantSnapshot(text: string, input: RunInput): Message.WithParts {
+  const sessionID = input.trace.sessionId;
+  const id = `msg-${crypto.randomUUID()}`;
+  const parentID = input.messages.at(-1)?.info.id ?? "";
+  const info: Message.AssistantMessage = {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: Date.now() },
+    parentID,
+    modelID: input.model.id,
+    providerID: input.model.providerID,
+    agent: "default",
+    path: { cwd: process.cwd(), root: process.cwd() },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  };
+  const textPart: Message.TextPart = {
+    id: crypto.randomUUID(),
+    sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  };
+  return { info, parts: [textPart] };
+}
+
+function scriptedRun(
+  script: StubScript,
+  captures: LlmCapture[],
+): (input: RunInput, sink: Sink) => Promise<Run.Outcome> {
+  return async (input, sink) => {
+    const toolResults: Tool.Result[] = [];
+    for (const call of script.toolCalls ?? []) {
+      // The REAL gated executor: policy pre-dispatch runs here, so an
+      // evidence_only run's deny-all gate returns a typed denial result while
+      // a full_access run reaches the production tool.
+      const result = await input.toolExecutor?.(call, {
+        signal: input.signal,
+        traceContext: {
+          traceId: input.trace.traceId,
+          sessionId: input.trace.sessionId,
+          runId: input.trace.runId,
+        },
+      });
+      if (result !== undefined) {
+        sink.onToolCall(call);
+        sink.onToolResult(result);
+        toolResults.push(result);
+      }
+    }
+    captures.push({
+      ...(input.system === undefined ? {} : { system: input.system }),
+      messages: input.messages,
+      toolResults,
+    });
+    sink.onMessage(assistantSnapshot(script.text, input));
+    return { type: "stop" };
+  };
+}
+
+/**
+ * The deterministic stub model. The injected `runAgent` runs the production
+ * `ChatAgent` loop with the LLM call swapped for a scripted stream — so the
+ * middleware, tool executor, and S6 gate are the real ones.
+ */
+export function stubModel(model: Model.Ref = { provider: "stub", id: "stub-model" }): StubModel {
+  const scripts: StubScript[] = [];
+  const runInputs: ChatAgentInput[] = [];
+  const llmCaptures: LlmCapture[] = [];
+
+  const runAgent = async (config: ChatAgentConfig, input: ChatAgentInput) => {
+    runInputs.push(input);
+    const script = scripts.shift() ?? { text: "" };
+    const result = await ChatAgent.create({
+      ...config,
+      llm: {
+        resolveProviderModel: async (ref) => fakeProviderModel(ref),
+        run: scriptedRun(script, llmCaptures),
+      },
+    }).run(input);
+    return { text: result.text, finishReason: result.finishReason };
+  };
+
+  return {
+    kind: "stub",
+    model,
+    scripts,
+    runInputs,
+    llmCaptures,
+    residentOptions: () => ({ runAgent }),
+  };
+}
+
+/** Configuration that flips the proxy model from "skip" to "live". */
+export interface ProxyModelConfig {
+  /** Proxy baseURL; defaults to `OPENOMNI_E2E_PROXY_URL`. */
+  readonly baseURL?: string;
+  /** Provider/model ids; default to the `OPENOMNI_E2E_PROXY_*` env vars. */
+  readonly model?: Model.Ref;
+}
+
+export interface ProxyModel extends SeamModel {
+  readonly kind: "proxy";
+  /** True iff a proxy URL or a pre-provisioned auth file is available. */
+  readonly configured: boolean;
+  /** The resolved baseURL (if any) — for the "would run" skip message. */
+  readonly baseURL?: string;
+  /** Provider id whose credential the auth file must carry. */
+  readonly providerId: string;
+}
+
+/**
+ * The live model. Uses the runtime default `runAgent` (the real `@openomni/llm`
+ * path) and reads credentials from `OPENOMNI_AUTH_FILE`. `configured` is false
+ * — and the case is skipped — unless a proxy URL or an existing auth file is
+ * present. When a baseURL is given but no auth file exists, the harness writes
+ * a proxy auth file and points `OPENOMNI_AUTH_FILE` at it (see harness).
+ */
+export function proxyModel(config: ProxyModelConfig = {}): ProxyModel {
+  const baseURL = config.baseURL ?? process.env.OPENOMNI_E2E_PROXY_URL;
+  const providerId = config.model?.provider ?? process.env.OPENOMNI_E2E_PROXY_PROVIDER ?? "openai";
+  const modelId = config.model?.id ?? process.env.OPENOMNI_E2E_PROXY_MODEL ?? "gpt-4o-mini";
+  const configured = Boolean(baseURL) || Boolean(process.env.OPENOMNI_AUTH_FILE);
+  return {
+    kind: "proxy",
+    configured,
+    ...(baseURL === undefined ? {} : { baseURL }),
+    providerId,
+    model: { provider: providerId, id: modelId },
+    // No injection: the resident runtime's default runAgent is the real path.
+    residentOptions: () => ({}),
+  };
+}


### PR DESCRIPTION
End-to-end harness driving the full inbound→brain→LLM→reply round trip, over the REAL production composition (createGatewayRouter + createBrainEngine + real tool executor). The model is the one swappable seam: a deterministic **stub** now, a **token-hub proxy** model the moment a baseURL is provided — a one-env-var flip, no code change.

## Design
- `model-seam.ts`: `StubModel` (deterministic canned assistant text + scriptable tool call) vs `proxyModel` (real `@openomni/llm` provider against an OPENOMNI_AUTH_FILE proxy). Live mode activates on `OPENOMNI_E2E_PROXY_URL` (or an existing auth file); otherwise it **skips cleanly** — never a failure, never a fake pass.
- `harness.ts`: boots in-memory Storage + real router + real brain + production toolExecutorFactory; the only fakes are the capturing outbound delivery (like the existing gateway-pipeline E2E) and the model.

## Cases (5 pass under stub, 1 live-skip)
1. **Reactive reply** — owner DM → routed → brain deliver (full_access) → resident run → assistant text back on the same surface.
2. **evidence_only downgrade** — collaborator/broadcast inbound → evidence_only → a scripted tool call is DENIED on that turn (S6 hard gate) but ALLOWED on the owner turn.
3. **engagement state answer** — open engagement, then owner query → the engagement slice is hydrated into the messages the model sees (asserted on the stub's received prompt).
4. **wait round trip** — awaited as-me send opens a Wait; expected-responder reply correlates → brain deliver with waitContext.
5. **live** — skipped with a "would run" message until a proxy is configured.

## Run it live
`OPENOMNI_E2E_PROXY_URL=<token-hub baseURL> bun test apps/server/test/e2e/` — the skipped case flips to a real model over the same production path.

## Verification
build + check-types + full turbo test 16/16, harness 5 pass / 1 skip, lint/dep/cycle/dead-export/coverage gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a production-composed E2E harness for inbound → brain → tools → reply with a swappable LLM model seam. Default runs a deterministic stub; setting a proxy env enables a live model. No runtime behavior changes.

- Uses real `createGatewayRouter`, `createBrainEngine`, `createToolExecutor`, `createMessageSendTool`, and `createEngagementTools`; only the outbound delivery route and the model are faked.
- `stubModel`: runs the real `ChatAgent` loop with only `@openomni/llm` execution scripted; captures prompts and tool results as gated by the S6 deny-all policy.
- `proxyModel`: injects nothing (runtime default path to `@openomni/llm`); credentials resolve via `OPENOMNI_AUTH_FILE` or `OPENOMNI_E2E_PROXY_URL`/`OPENOMNI_E2E_PROXY_KEY` (harness writes a temp auth file when only a base URL is set). Provider/model can be set via `OPENOMNI_E2E_PROXY_PROVIDER`/`OPENOMNI_E2E_PROXY_MODEL`.
- Focused cases: reactive reply; evidence_only deny vs owner allow; engagement-context hydration; awaited as-me `message.send` with wait resumption and delivery capture; live round trip that skips unless a proxy is configured.

<sup>Written for commit 6ebb308d56d0c8519586709074b0052caa7c6835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

