### PR TITLE
feat: #219 v1 — synchronous active-egress gate (social budget)

### DIFF
--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -98,6 +98,40 @@ Errors bubble up as `Error: {message}` strings back to the channel so operators 
 
 The current `conversation.ts` / `ingress/bridge.ts` path still contains transitional model and tool-selection logic; per-message routing back doors were deleted when the kernel's unified `resolveRoute` shipped (#464, PR #485). Do not add new product semantics there. Move new logic into `packages/openomni` and shrink the server bridge over time.
 
+## MESSAGING CONFIG (`config.json` → `messaging`, #215 / #708 / #219)
+
+`config.ts` resolves the outbound `messaging` block; every resolver is fail-closed (a malformed entry is dropped with an `Operational.Warn`, never a crash):
+
+- `grants` — Owner-written standing `SenderTargetGrant`s (authority: MAY the persona reach a target at all). Default EMPTY = every cold send is `ungranted`.
+- `personaActorId` — the as-me persona actor; unset → `message.send` fails closed.
+- `replyGrantRules` — `ReplyGrantRule`s the gateway materializes bounded reply-scoped grant instances from on first contact (§2b).
+- `socialBudget` (#219) — Owner-declared active-egress caps (HOW OFTEN the persona may COLD-contact each target). Wiring the source engages the synchronous egress gate in the send kernel; the gate evaluates AFTER the grant (authority) and BEFORE the Wait/delivery, so a suppressed outreach records a typed `denied` receipt (`budget_exhausted` / `cooldown_suppressed` / `dnc_denied`) without opening a Wait or emitting bytes. **Default EMPTY is FAIL-SAFE, not permissive**: a cold proactive send to a target with NO budget entry is capped at ZERO (suppressed `budget_exhausted`). Replies (reply-scoped grant instances) always bypass the gate — absence of a budget never throttles the reply path. The debit ledger (`EgressBudgetStore`, perimeter domain) is written record-before-act on admission, so split outreach across calls cannot evade the cap and cooldown survives restart.
+
+```json
+{
+  "messaging": {
+    "personaActorId": "actor-persona",
+    "grants": [
+      { "id": "g-seller", "senderId": "actor-persona", "targetActorId": "actor-seller", "operations": ["awaited", "fire_and_forget"] }
+    ],
+    "socialBudget": [
+      {
+        "id": "budget-seller",
+        "targetActorId": "actor-seller",
+        "maxPerWindow": 3,
+        "windowMs": 86400000,
+        "cooldownMs": 3600000,
+        "classCaps": { "notify": 1 },
+        "quietHours": { "startMinuteUtc": 1320, "endMinuteUtc": 480 },
+        "doNotContact": false
+      }
+    ]
+  }
+}
+```
+
+The autonomous timer-fired 봉수 escalation ladder is deliberately OUT of #219 v1 (deferred — blocked by the #469 accumulator + a missing periodic-timeout firing source); the send kernel leaves a seam comment where the escalation coordinate would attach.
+
 ## TOOL SYSTEM
 
 Tool providers are assembled in `bootstrap/index.ts` and passed through to the routing handler and worker manager:

--- a/apps/server/src/bootstrap/index.ts
+++ b/apps/server/src/bootstrap/index.ts
@@ -272,6 +272,10 @@ export async function main(options: MainOptions = {}): Promise<void> {
       deliveryRoutes,
       grants: () => config.messaging.grants,
       replyGrantRules: () => config.messaging.replyGrantRules,
+      // #219: wiring the budget source engages the synchronous active-egress
+      // gate. Empty config is fail-safe (cold proactive capped at zero), not
+      // permissive; replies bypass the gate.
+      budgets: () => config.messaging.socialBudget,
     },
   });
   gatewayRouterRef.current = gatewayRouter;

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -47,6 +47,7 @@ interface RawConfig {
     grants?: unknown;
     personaActorId?: unknown;
     replyGrantRules?: unknown;
+    socialBudget?: unknown;
   };
   permissionProfiles?: unknown;
 }
@@ -85,11 +86,38 @@ export interface ServerConfig {
    * typed "persona not configured" result. `replyGrantRules` are the
    * Owner-written stage-0 rules the gateway materializes bounded reply-scoped
    * grant instances from (design §2b); default EMPTY.
+   *
+   * `socialBudget` (#219) is the Owner-declared active-egress cap: HOW OFTEN
+   * the persona may COLD-contact each target (authority — MAY I — stays the
+   * grant's job). Default EMPTY, and empty is FAIL-SAFE, not permissive: with
+   * the gate wired, a cold proactive send to a target with NO budget entry is
+   * suppressed (`budget_exhausted`), capped at zero. Replies (reply-scoped
+   * grant instances) are never throttled by absence. Example config block:
+   *
+   * ```json
+   * {
+   *   "messaging": {
+   *     "socialBudget": [
+   *       {
+   *         "id": "budget-seller",
+   *         "targetActorId": "actor-seller",
+   *         "maxPerWindow": 3,
+   *         "windowMs": 86400000,
+   *         "cooldownMs": 3600000,
+   *         "classCaps": { "notify": 1 },
+   *         "quietHours": { "startMinuteUtc": 1320, "endMinuteUtc": 480 },
+   *         "doNotContact": false
+   *       }
+   *     ]
+   *   }
+   * }
+   * ```
    */
   messaging: {
     grants: Gateway.SenderTargetGrant[];
     personaActorId?: string;
     replyGrantRules: Gateway.ReplyGrantRule[];
+    socialBudget: Gateway.SocialBudget[];
   };
   /**
    * 고도화 A — per-tier deny-label overlays keyed by `Actor.TrustTier`. Default
@@ -174,6 +202,29 @@ function resolveReplyGrantRules(
       traceId,
       component: "server",
       msg: "invalid messaging.replyGrantRules config ignored; no reply-grant instances materialize",
+      context: { configPath, error: parsed.error.message },
+    }),
+  );
+  return [];
+}
+
+function resolveSocialBudget(
+  raw: RawConfig,
+  configPath: string,
+  traceId: string,
+): Gateway.SocialBudget[] {
+  if (raw.messaging?.socialBudget === undefined) return [];
+  const parsed = z.array(Gateway.SocialBudget).safeParse(raw.messaging.socialBudget);
+  if (parsed.success) return parsed.data;
+  // Fail closed: a malformed budget list configures NO budget — with the gate
+  // wired this leaves every target on the fail-safe default (cold proactive
+  // capped at zero), never a permissive "no cap" fallback.
+  Bus.publish(
+    Operational.Events.Warn,
+    Operational.envelope({
+      traceId,
+      component: "server",
+      msg: "invalid messaging.socialBudget config ignored; every target stays on the fail-safe zero-cap default",
       context: { configPath, error: parsed.error.message },
     }),
   );
@@ -310,6 +361,7 @@ function resolve(raw: RawConfig, configPath: string, traceId: string): ServerCon
       grants: resolveMessagingGrants(raw, configPath, traceId),
       personaActorId: resolvePersonaActorId(raw, configPath, traceId),
       replyGrantRules: resolveReplyGrantRules(raw, configPath, traceId),
+      socialBudget: resolveSocialBudget(raw, configPath, traceId),
     },
     permissionProfiles: resolvePermissionProfiles(raw, configPath, traceId),
   };

--- a/apps/server/test/bootstrap/resident-inbound-wait.test.ts
+++ b/apps/server/test/bootstrap/resident-inbound-wait.test.ts
@@ -39,7 +39,7 @@ const serverConfig: ServerConfig = {
   telegram: { allowedUsers: [] },
   github: { allowedUsers: [] },
   discord: { allowedUsers: [] },
-  messaging: { grants: [], replyGrantRules: [] },
+  messaging: { grants: [], replyGrantRules: [], socialBudget: [] },
   permissionProfiles: {},
 };
 

--- a/apps/server/test/config.test.ts
+++ b/apps/server/test/config.test.ts
@@ -299,6 +299,59 @@ describe("config", () => {
     );
   });
 
+  it("parses messaging.socialBudget; default stays fail-closed empty (#219)", () => {
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        messaging: {
+          socialBudget: [
+            {
+              id: "budget-seller",
+              targetActorId: "actor:seller",
+              maxPerWindow: 3,
+              windowMs: 86_400_000,
+              cooldownMs: 3_600_000,
+              classCaps: { notify: 1 },
+            },
+          ],
+        },
+      }),
+    );
+
+    const config = loadConfig("trace-test", configPath);
+    expect(config.messaging.socialBudget).toHaveLength(1);
+    expect(config.messaging.socialBudget[0]).toMatchObject({
+      id: "budget-seller",
+      targetActorId: "actor:seller",
+    });
+
+    const emptyPath = join(tempDir, "empty-budget.json");
+    writeFileSync(emptyPath, JSON.stringify({}));
+    expect(loadConfig("trace-test", emptyPath).messaging.socialBudget).toEqual([]);
+  });
+
+  it("drops malformed messaging.socialBudget fail-closed with a warning (#219)", async () => {
+    const warnings: unknown[] = [];
+    const unsubscribe = Bus.subscribe(Operational.Events.Warn, (payload) => warnings.push(payload));
+    const configPath = join(tempDir, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ messaging: { socialBudget: [{ id: "broken", maxPerWindow: -1 }] } }),
+    );
+
+    const config = loadConfig("trace-test", configPath);
+    await flushBus();
+    unsubscribe();
+
+    expect(config.messaging.socialBudget).toEqual([]);
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        msg: "invalid messaging.socialBudget config ignored; every target stays on the fail-safe zero-cap default",
+      }),
+    );
+  });
+
   it("resolves permissionProfiles per tier; defaults empty (고도화 A)", () => {
     const configPath = join(tempDir, "config.json");
     writeFileSync(

--- a/packages/channels/src/router/index.ts
+++ b/packages/channels/src/router/index.ts
@@ -86,6 +86,14 @@ export interface GatewayRouterPorts {
      * live in router memory (recorded ruling — durable store is #709).
      */
     replyGrantRules?: () => readonly Gateway.ReplyGrantRule[];
+    /**
+     * Owner-declared active-egress budgets (#219): the HOW-OFTEN cap on cold
+     * proactive outreach, per target actor. When wired, the send kernel's
+     * synchronous egress gate engages (fail-safe default: a cold send to a
+     * target with no budget entry is suppressed). When absent the gate is
+     * bypassed — replies are never throttled either way.
+     */
+    budgets?: () => readonly Gateway.SocialBudget[];
   }>;
 }
 
@@ -262,6 +270,9 @@ export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
           // still refuses the instances; only the scope-aware arm honors one
           // whose replyScope matches the resolved delivery endpoint.
           grants: () => [...messagingPorts.grants(), ...(replyGrants?.list() ?? [])],
+          // #219: thread the Owner-declared egress budgets through iff the
+          // composition root wired them, so the gate stays a no-op otherwise.
+          ...(messagingPorts.budgets === undefined ? {} : { budgets: messagingPorts.budgets }),
           publish: ports.sink,
         });
 

--- a/packages/channels/src/router/messaging/send.ts
+++ b/packages/channels/src/router/messaging/send.ts
@@ -5,7 +5,7 @@ import {
   type BusEvent,
   type Wait,
 } from "@openomni/protocol";
-import { ActorRegistry } from "@openomni/ledger";
+import { ActorRegistry, EgressBudgetStore } from "@openomni/ledger";
 import { WaitService } from "../wait/index.js";
 import { Events } from "./events.js";
 import {
@@ -14,8 +14,10 @@ import {
   resolveScopedSenderTargetGrant,
   resolveSenderTargetGrant,
 } from "./grant.js";
+import { evaluateSocialBudget } from "./social-budget.js";
 
 type DeliveryTarget = Gateway.DeliveryTarget;
+type MessageClass = Gateway.MessageClass;
 type MessageDenialCode = Gateway.MessageDenialCode;
 type MessageOperation = Gateway.MessageOperation;
 type MessageTarget = Gateway.MessageTarget;
@@ -23,6 +25,12 @@ const SendInput = Gateway.SendInput;
 type SendInput = Gateway.SendInput;
 type SendReceipt = Gateway.SendReceipt;
 type SenderTargetGrant = Gateway.SenderTargetGrant;
+type SocialBudget = Gateway.SocialBudget;
+
+/** Policy-intent class of a send, inferred from `operation` when not explicit (#219). */
+function sendClassOf(input: SendInput): MessageClass {
+  return input.class ?? (input.operation === "awaited" ? "converse" : "notify");
+}
 
 /**
  * Existing-agent messaging service (#215). One send reaches exactly one
@@ -62,6 +70,16 @@ export type MessagingPorts = Readonly<{
   ) => void | DeliveryReceipt | Promise<DeliveryReceipt | undefined>;
   /** Policy-plane grant source; evaluated fresh on every send. */
   grants: () => readonly SenderTargetGrant[];
+  /**
+   * Owner-declared active-egress budget source (#219), evaluated fresh on
+   * every send — the HOW-OFTEN axis, orthogonal to `grants` (the MAY-I axis).
+   * OPTIONAL: when absent the #219 gate is entirely bypassed (pure additive,
+   * backward-compat — existing sends behave exactly as before). When present,
+   * the gate engages and the fail-safe default applies: a COLD-proactive send
+   * to a target with no budget entry is suppressed `budget_exhausted`. Replies
+   * (reply-scoped grant instances) always bypass the gate.
+   */
+  budgets?: () => readonly SocialBudget[];
   /** Injected observation sink (messaging.sent / messaging.denied) — channels never imports the observation channel. */
   publish: BusEvent.Sink["publish"];
 }>;
@@ -203,9 +221,55 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
       }
     }
 
-    // #219 seam: egress semantics (social budget, notify|converse class
-    // split, 봉수 escalation counting) evaluate HERE — after grant, before
-    // the wait record and the delivery effect. Own leaf, not this PR.
+    // #219 active-egress gate: the HOW-OFTEN axis evaluates HERE — after grant
+    // (MAY-I), before the wait record and the delivery effect — so a suppressed
+    // outreach records a denial without opening a Wait or emitting bytes.
+    //
+    // Cold-proactive vs reply (the safety call): a reply-scoped grant instance
+    // (`grant.replyScope !== undefined`, materialized from a ReplyGrantRule) is
+    // a REPLY into an initiating container and BYPASSES the gate entirely — the
+    // existing reply path is never throttled. Everything else is a COLD
+    // proactive initiation authorized by an Owner standing grant, and is
+    // subject to the budget. The gate only engages when a budget source is
+    // injected (`ports.budgets`), keeping the change purely additive.
+    if (ports.budgets !== undefined && grant.replyScope === undefined) {
+      const sendClass = sendClassOf(input);
+      const budget = ports
+        .budgets()
+        .find((candidate) => candidate.targetActorId === input.target.actorId);
+      // Debit state is only meaningful with a budget window; the fail-safe
+      // (budget === undefined → suppress) needs no read.
+      const state =
+        budget === undefined
+          ? { countInWindow: 0, notifyInWindow: 0, converseInWindow: 0 }
+          : EgressBudgetStore.readState(
+              input.senderId,
+              input.target.actorId,
+              input.at - budget.windowMs,
+            );
+      const verdict = evaluateSocialBudget(budget, state, { class: sendClass, at: input.at });
+      if (verdict !== "allow") {
+        return deny(
+          input,
+          verdict.suppress,
+          `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${verdict.suppress})`,
+        );
+      }
+      // Record-before-act: the debit lands on ADMISSION, before the Wait/deliver
+      // path, so split outreach across calls cannot evade the cap and cooldown
+      // survives restart. A later delivery failure conservatively keeps the debit.
+      EgressBudgetStore.record({
+        id: crypto.randomUUID(),
+        senderId: input.senderId,
+        targetActorId: input.target.actorId,
+        class: sendClass,
+        at: input.at,
+      });
+    }
+    // #219 escalation seam (DEFERRED, out of this PR): the autonomous
+    // timer-fired 봉수 rung-advance would attach its counting coordinate HERE —
+    // blocked by the #469 accumulator + a missing periodic-timeout firing
+    // source. The synchronous suppression gate above ships without it.
 
     let wait: Wait.Record | undefined;
     if (input.operation === "awaited") {

--- a/packages/channels/src/router/messaging/social-budget.ts
+++ b/packages/channels/src/router/messaging/social-budget.ts
@@ -1,0 +1,81 @@
+import type { Gateway } from "@openomni/protocol";
+
+/**
+ * Active-egress budget evaluation (#219, gateway router perimeter). A PURE fold
+ * — no store, no clock: time (`claim.at`) and the debit state are inputs, so
+ * the decision is fully replayable and testable. Evaluation (a suppress/allow
+ * ruling) lives here on the perimeter, never in protocol, exactly like grant
+ * evaluation (the contract boundary forbids authority evaluation in protocol).
+ *
+ * The gate is the HOW-OFTEN axis; authority (MAY-I, the SenderTargetGrant) is
+ * evaluated FIRST by the send kernel. The kernel only calls this for a
+ * COLD-PROACTIVE send — a reply-scoped grant instance bypasses the gate
+ * entirely upstream, so replies are never throttled.
+ *
+ * Fail-safe default (critical): `budget === undefined` means the target has NO
+ * Owner-declared budget, so cold proactive outreach is capped at ZERO —
+ * suppressed `budget_exhausted`, never unlimited.
+ */
+
+type Suppression = Readonly<{ suppress: Gateway.MessageDenialCode }>;
+export type SocialBudgetVerdict = "allow" | Suppression;
+
+const MINUTES_PER_DAY = 24 * 60;
+
+/** UTC minute-of-day for an epoch-ms instant (pure). */
+function minuteOfDayUtc(at: number): number {
+  return Math.floor(at / 60_000) % MINUTES_PER_DAY;
+}
+
+/**
+ * Daily quiet-hours blackout, UTC minute-of-day. A window where start <= end is
+ * same-day [start, end); start > end wraps past midnight (an overnight
+ * blackout). Endpoints are half-open so a 0..0 window blacks out nothing.
+ */
+function withinQuietHours(
+  at: number,
+  quietHours: NonNullable<Gateway.SocialBudget["quietHours"]>,
+): boolean {
+  const minute = minuteOfDayUtc(at);
+  const { startMinuteUtc: start, endMinuteUtc: end } = quietHours;
+  if (start === end) return false;
+  return start < end ? minute >= start && minute < end : minute >= start || minute < end;
+}
+
+/**
+ * Fold one cold-proactive claim against the target's budget and debit state.
+ * Order mirrors severity: do-not-contact (hard) → lapsed allowance → quiet
+ * hours → cooldown → window cap → class cap. Any miss is `allow`.
+ */
+export function evaluateSocialBudget(
+  budget: Gateway.SocialBudget | undefined,
+  state: Gateway.EgressDebitState,
+  claim: Readonly<{ class: Gateway.MessageClass; at: number }>,
+): SocialBudgetVerdict {
+  // Fail-safe: no Owner-declared budget → cold proactive is capped at zero.
+  if (budget === undefined) return { suppress: "budget_exhausted" };
+  if (budget.doNotContact === true) return { suppress: "dnc_denied" };
+  // A lapsed allowance re-applies the fail-safe default rather than admitting.
+  if (budget.expiresAt !== undefined && claim.at > budget.expiresAt) {
+    return { suppress: "budget_exhausted" };
+  }
+  if (budget.quietHours !== undefined && withinQuietHours(claim.at, budget.quietHours)) {
+    return { suppress: "cooldown_suppressed" };
+  }
+  if (
+    state.lastSendAt !== undefined &&
+    budget.cooldownMs > 0 &&
+    claim.at - state.lastSendAt < budget.cooldownMs
+  ) {
+    return { suppress: "cooldown_suppressed" };
+  }
+  if (state.countInWindow >= budget.maxPerWindow) {
+    return { suppress: "budget_exhausted" };
+  }
+  const classCap = budget.classCaps?.[claim.class];
+  if (classCap !== undefined) {
+    const classCount = claim.class === "notify" ? state.notifyInWindow : state.converseInWindow;
+    if (classCount >= classCap) return { suppress: "budget_exhausted" };
+  }
+  return "allow";
+}

--- a/packages/channels/test/router/messaging/social-budget.test.ts
+++ b/packages/channels/test/router/messaging/social-budget.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Gateway } from "@openomni/protocol";
+import { EgressBudgetStore, Storage } from "@openomni/ledger";
+import { Bus } from "@openomni/telemetry";
+import { createExistingAgentMessaging } from "../../../src/router/messaging/send.js";
+import { evaluateSocialBudget } from "../../../src/router/messaging/social-budget.js";
+import {
+  buildGrant,
+  buildSendInput,
+  messagingNow,
+  registerAgentFixture,
+} from "../../helpers/messaging.js";
+
+const ZERO_STATE: Gateway.EgressDebitState = {
+  countInWindow: 0,
+  notifyInWindow: 0,
+  converseInWindow: 0,
+};
+
+const budget = (overrides: Partial<Gateway.SocialBudget> = {}): Gateway.SocialBudget => ({
+  id: "budget:target",
+  targetActorId: "actor:target",
+  maxPerWindow: 2,
+  windowMs: 60_000,
+  cooldownMs: 0,
+  ...overrides,
+});
+
+describe("evaluateSocialBudget (pure fold, #219)", () => {
+  test("fail-safe default: no Owner-declared budget suppresses cold proactive at zero", () => {
+    expect(
+      evaluateSocialBudget(undefined, ZERO_STATE, { class: "notify", at: messagingNow }),
+    ).toEqual({ suppress: "budget_exhausted" });
+  });
+
+  test("do-not-contact is a hard kill switch, ahead of any count", () => {
+    expect(
+      evaluateSocialBudget(budget({ doNotContact: true }), ZERO_STATE, {
+        class: "notify",
+        at: messagingNow,
+      }),
+    ).toEqual({ suppress: "dnc_denied" });
+  });
+
+  test("a lapsed allowance re-applies the fail-safe (suppressed, not admitted)", () => {
+    expect(
+      evaluateSocialBudget(budget({ expiresAt: messagingNow - 1 }), ZERO_STATE, {
+        class: "notify",
+        at: messagingNow,
+      }),
+    ).toEqual({ suppress: "budget_exhausted" });
+  });
+
+  test("window cap: at the cap, the next send is budget_exhausted", () => {
+    expect(
+      evaluateSocialBudget(
+        budget({ maxPerWindow: 2 }),
+        { ...ZERO_STATE, countInWindow: 2 },
+        {
+          class: "notify",
+          at: messagingNow,
+        },
+      ),
+    ).toEqual({ suppress: "budget_exhausted" });
+    expect(
+      evaluateSocialBudget(
+        budget({ maxPerWindow: 2 }),
+        { ...ZERO_STATE, countInWindow: 1 },
+        {
+          class: "notify",
+          at: messagingNow,
+        },
+      ),
+    ).toBe("allow");
+  });
+
+  test("cooldown: a send within cooldownMs of the last is cooldown_suppressed", () => {
+    const b = budget({ cooldownMs: 10_000 });
+    expect(
+      evaluateSocialBudget(
+        b,
+        { ...ZERO_STATE, lastSendAt: messagingNow - 5_000 },
+        {
+          class: "notify",
+          at: messagingNow,
+        },
+      ),
+    ).toEqual({ suppress: "cooldown_suppressed" });
+    expect(
+      evaluateSocialBudget(
+        b,
+        { ...ZERO_STATE, lastSendAt: messagingNow - 20_000 },
+        {
+          class: "notify",
+          at: messagingNow,
+        },
+      ),
+    ).toBe("allow");
+  });
+
+  test("class caps bound one class without capping the other", () => {
+    const b = budget({ maxPerWindow: 10, classCaps: { notify: 1 } });
+    expect(
+      evaluateSocialBudget(
+        b,
+        { ...ZERO_STATE, countInWindow: 1, notifyInWindow: 1 },
+        {
+          class: "notify",
+          at: messagingNow,
+        },
+      ),
+    ).toEqual({ suppress: "budget_exhausted" });
+    // converse is uncapped by classCaps.notify.
+    expect(
+      evaluateSocialBudget(
+        b,
+        { ...ZERO_STATE, countInWindow: 1, notifyInWindow: 1 },
+        {
+          class: "converse",
+          at: messagingNow,
+        },
+      ),
+    ).toBe("allow");
+  });
+
+  test("quiet hours blackout suppresses; same-day and overnight-wrap windows both hold", () => {
+    // messagingNow = 5_000_000_000_000 → minute-of-day UTC.
+    const minute = Math.floor(messagingNow / 60_000) % 1440;
+    const sameDay = budget({
+      quietHours: { startMinuteUtc: minute, endMinuteUtc: (minute + 5) % 1440 },
+    });
+    expect(
+      evaluateSocialBudget(sameDay, ZERO_STATE, { class: "notify", at: messagingNow }),
+    ).toEqual({ suppress: "cooldown_suppressed" });
+    // A window that does not contain `minute` admits.
+    const elsewhere = budget({
+      quietHours: { startMinuteUtc: (minute + 10) % 1440, endMinuteUtc: (minute + 20) % 1440 },
+    });
+    expect(evaluateSocialBudget(elsewhere, ZERO_STATE, { class: "notify", at: messagingNow })).toBe(
+      "allow",
+    );
+  });
+});
+
+describe("send kernel active-egress gate (#219 seam)", () => {
+  let deliveries: string[];
+  let grants: Gateway.SenderTargetGrant[];
+  let budgets: Gateway.SocialBudget[];
+
+  function messaging(withGate = true) {
+    return createExistingAgentMessaging({
+      deliver: (message) => {
+        deliveries.push(message.messageId);
+      },
+      grants: () => grants,
+      ...(withGate ? { budgets: () => budgets } : {}),
+      publish: Bus.publish,
+    });
+  }
+
+  beforeEach(() => {
+    Bus.reset();
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    deliveries = [];
+    grants = [buildGrant("grant:sender->target")];
+    budgets = [];
+    registerAgentFixture("actor:sender");
+    registerAgentFixture("actor:target", [{ id: "endpoint:target", externalId: "target-1" }]);
+  });
+
+  afterEach(() => {
+    Storage.reset();
+    Bus.reset();
+  });
+
+  test("backward-compat: with NO budget source injected, a cold proactive send is unaffected", async () => {
+    const receipt = await messaging(false).send(buildSendInput());
+    expect(receipt.kind).toBe("sent");
+    expect(deliveries).toEqual(["message:test"]);
+    // The gate never touched the debit ledger.
+    expect(EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow).toBe(0);
+  });
+
+  test("fail-safe default: gate wired but no budget entry → cold proactive denied budget_exhausted", async () => {
+    const receipt = await messaging().send(buildSendInput());
+    expect(receipt.kind).toBe("denied");
+    if (receipt.kind !== "denied") throw new Error("expected denial");
+    expect(receipt.code).toBe("budget_exhausted");
+    expect(deliveries).toHaveLength(0);
+    expect(EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow).toBe(0);
+  });
+
+  test("an admitted send records a debit (record-before-act)", async () => {
+    budgets = [budget()];
+    const receipt = await messaging().send(buildSendInput());
+    expect(receipt.kind).toBe("sent");
+    expect(deliveries).toEqual(["message:test"]);
+    const state = EgressBudgetStore.readState("actor:sender", "actor:target", 0);
+    expect(state.countInWindow).toBe(1);
+    expect(state.notifyInWindow).toBe(1);
+    expect(state.lastSendAt).toBe(messagingNow);
+  });
+
+  test("split-evasion: the cap survives across separate send calls (debit is durable)", async () => {
+    budgets = [budget({ maxPerWindow: 1 })];
+    const first = await messaging().send(buildSendInput({ messageId: "message:1" }));
+    const second = await messaging().send(buildSendInput({ messageId: "message:2" }));
+    expect(first.kind).toBe("sent");
+    expect(second.kind).toBe("denied");
+    if (second.kind !== "denied") throw new Error("expected denial");
+    expect(second.code).toBe("budget_exhausted");
+    expect(deliveries).toEqual(["message:1"]);
+  });
+
+  test("cooldown-block: a second send within cooldownMs is cooldown_suppressed", async () => {
+    budgets = [budget({ maxPerWindow: 10, cooldownMs: 30_000 })];
+    const first = await messaging().send(
+      buildSendInput({ messageId: "message:1", at: messagingNow }),
+    );
+    const second = await messaging().send(
+      buildSendInput({ messageId: "message:2", at: messagingNow + 5_000 }),
+    );
+    expect(first.kind).toBe("sent");
+    expect(second.kind).toBe("denied");
+    if (second.kind !== "denied") throw new Error("expected denial");
+    expect(second.code).toBe("cooldown_suppressed");
+    // A send past the cooldown is admitted again.
+    const third = await messaging().send(
+      buildSendInput({ messageId: "message:3", at: messagingNow + 40_000 }),
+    );
+    expect(third.kind).toBe("sent");
+    expect(deliveries).toEqual(["message:1", "message:3"]);
+  });
+
+  test("DNC-deny: a do-not-contact target is denied dnc_denied with nothing delivered", async () => {
+    budgets = [budget({ doNotContact: true })];
+    const receipt = await messaging().send(buildSendInput());
+    expect(receipt.kind).toBe("denied");
+    if (receipt.kind !== "denied") throw new Error("expected denial");
+    expect(receipt.code).toBe("dnc_denied");
+    expect(deliveries).toHaveLength(0);
+  });
+
+  test("reply-not-throttled: a reply-scoped grant bypasses the gate even under do-not-contact", async () => {
+    // A reply into the initiating container (surface key qa:target-1), while
+    // the target carries a DNC budget: the reply still delivers and records NO
+    // debit — the gate only governs cold proactive outreach.
+    grants = [
+      {
+        id: "instance-1",
+        senderId: "actor:sender",
+        targetActorId: "actor:target",
+        operations: ["fire_and_forget", "awaited"],
+        expiresAt: messagingNow + 60_000,
+        ruleId: "rule-1",
+        replyScope: { surfaceKey: "qa:target-1" },
+      },
+    ];
+    budgets = [budget({ doNotContact: true })];
+    const receipt = await messaging().send(buildSendInput());
+    expect(receipt.kind).toBe("sent");
+    expect(deliveries).toEqual(["message:test"]);
+    expect(EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow).toBe(0);
+  });
+});

--- a/packages/ledger/migration/0021_egress_budget/migration.sql
+++ b/packages/ledger/migration/0021_egress_budget/migration.sql
@@ -1,0 +1,20 @@
+-- #219 active-egress gate — the durable debit ledger (gateway-design §4).
+--
+-- Perimeter-domain surface: the channels gateway router (the send kernel) is
+-- the sole writer (S8), like the wait store. Append-only — one row per ADMITTED
+-- proactive send. The budget evaluator folds a window projection off these rows
+-- (count in window, per-class counts, and the last-send-at cooldown clock);
+-- there is no update or delete path (a debit, once recorded, is immutable).
+CREATE TABLE IF NOT EXISTS egress_debit (
+  id TEXT PRIMARY KEY,
+  sender_id TEXT NOT NULL,
+  target_actor_id TEXT NOT NULL,
+  class TEXT NOT NULL,
+  at INTEGER NOT NULL,
+  time_created INTEGER NOT NULL
+);
+
+-- The one read shape: fold the window/cooldown projection for a (sender,
+-- target) pair ordered by send time.
+CREATE INDEX IF NOT EXISTS idx_egress_debit_pair_at
+  ON egress_debit(sender_id, target_actor_id, at);

--- a/packages/ledger/src/egress/index.ts
+++ b/packages/ledger/src/egress/index.ts
@@ -1,0 +1,45 @@
+/**
+ * EgressBudgetStore: the active-egress debit ledger (#219, perimeter domain —
+ * gateway-design §4). Records ADMITTED proactive sends and folds the window
+ * projection the pure budget evaluator consumes.
+ *
+ * Perimeter isolation (S8): consumed ONLY by the channels gateway router (the
+ * send kernel), exactly like the wait store — the brain never reaches it. A
+ * missing sub-adapter fails closed: the egress gate must never fabricate an
+ * "admitted" answer.
+ *
+ * Record-before-act: the debit is written when a send is ADMITTED (not
+ * suppressed), so split outreach across separate calls cannot evade the cap and
+ * the cooldown clock survives a restart.
+ */
+
+import type { Gateway } from "@openomni/protocol";
+import { requireSubAdapter } from "../storage/timestamped-store";
+import { Storage } from "../storage/storage";
+
+export namespace EgressBudgetStore {
+  function subAdapter(): NonNullable<Storage.Adapter["egressBudget"]> {
+    return requireSubAdapter(
+      Storage.get().egressBudget,
+      "Storage adapter does not implement egressBudget — the active-egress gate fails closed",
+    );
+  }
+
+  /** Append one admitted-send debit row (record-before-act). */
+  export function record(row: Gateway.EgressDebitRow): void {
+    subAdapter().record(row);
+  }
+
+  /**
+   * Fold the window projection for one (sender, target) pair. `windowStartAt`
+   * is the caller's `at - budget.windowMs`; `lastSendAt` is window-independent
+   * (the cooldown clock runs off the most recent admitted send).
+   */
+  export function readState(
+    senderId: string,
+    targetActorId: string,
+    windowStartAt: number,
+  ): Gateway.EgressDebitState {
+    return subAdapter().readState(senderId, targetActorId, windowStartAt);
+  }
+}

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -15,6 +15,7 @@ export { WorkItemAttemptRun } from "./work-item/attempt-run.js";
 export { hasRetryExhaustionBlocker } from "./work-item/retry-policy.js";
 export { WaitStore } from "./wait/index.js";
 export { EngagementStore } from "./engagement/index.js";
+export { EgressBudgetStore } from "./egress/index.js";
 export { EffectStore, EffectStoreError } from "./effect/index.js";
 export { PendingAskStore } from "./pending-ask/index.js";
 export { PendingInteractionStore } from "./pending-interaction/index.js";

--- a/packages/ledger/src/storage/sqlite-egress-budget-adapter.ts
+++ b/packages/ledger/src/storage/sqlite-egress-budget-adapter.ts
@@ -1,0 +1,48 @@
+import { Gateway, type Storage as ProtocolStorage } from "@openomni/protocol";
+import type { Database } from "bun:sqlite";
+
+/**
+ * Durable active-egress debit rows (#219, perimeter domain — gateway-design
+ * §4). Append-only: one row per ADMITTED proactive send. `readState` folds the
+ * window projection the pure budget evaluator consumes in a single query so the
+ * gate reads counts + the cooldown clock without materializing rows. The write
+ * shape is owned by the EgressBudgetStore; this adapter re-validates on read
+ * across the persistence boundary.
+ */
+export function createSqliteEgressBudgetAdapter(
+  db: Database,
+): ProtocolStorage.EgressBudgetSubAdapter {
+  return {
+    record(row) {
+      const parsed = Gateway.EgressDebitRow.parse(row);
+      db.query(
+        `INSERT INTO egress_debit (id, sender_id, target_actor_id, class, at, time_created)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(parsed.id, parsed.senderId, parsed.targetActorId, parsed.class, parsed.at, Date.now());
+    },
+    readState(senderId, targetActorId, windowStartAt) {
+      const row = db
+        .query(
+          `SELECT
+             COUNT(*) FILTER (WHERE at >= ?) AS count_in_window,
+             COUNT(*) FILTER (WHERE at >= ? AND class = 'notify') AS notify_in_window,
+             COUNT(*) FILTER (WHERE at >= ? AND class = 'converse') AS converse_in_window,
+             MAX(at) AS last_send_at
+           FROM egress_debit
+           WHERE sender_id = ? AND target_actor_id = ?`,
+        )
+        .get(windowStartAt, windowStartAt, windowStartAt, senderId, targetActorId) as {
+        count_in_window: number;
+        notify_in_window: number;
+        converse_in_window: number;
+        last_send_at: number | null;
+      } | null;
+      return Gateway.EgressDebitState.parse({
+        countInWindow: row?.count_in_window ?? 0,
+        notifyInWindow: row?.notify_in_window ?? 0,
+        converseInWindow: row?.converse_in_window ?? 0,
+        ...(row?.last_send_at == null ? {} : { lastSendAt: row.last_send_at }),
+      });
+    },
+  };
+}

--- a/packages/ledger/src/storage/sqlite-schema-lifecycle.ts
+++ b/packages/ledger/src/storage/sqlite-schema-lifecycle.ts
@@ -25,6 +25,7 @@ const ORDERED_MIGRATIONS: Migration.Definition[] = [
   { name: "0018_drop_actor_relationship/migration.sql" },
   { name: "0019_surface_key_perimeter/migration.sql" },
   { name: "0020_engagement/migration.sql" },
+  { name: "0021_egress_budget/migration.sql" },
 ];
 
 const CLEAR_ORDER = [
@@ -39,6 +40,7 @@ const CLEAR_ORDER = [
   "actor_endpoint",
   "actor_identity",
   "cron_job",
+  "egress_debit",
   "pending_interaction",
   "worker_grant",
   "pending_ask",

--- a/packages/ledger/src/storage/sqlite-storage.ts
+++ b/packages/ledger/src/storage/sqlite-storage.ts
@@ -7,6 +7,7 @@ import { createSqliteBlacklistAdapter } from "./sqlite-blacklist-adapter";
 import { createSqliteChannelGrantAdapter } from "./sqlite-channel-grant-adapter";
 import { createSqliteArtifactAdapter } from "./sqlite-artifact-adapter";
 import { createSqliteCronJobAdapter } from "./sqlite-cron-job-adapter";
+import { createSqliteEgressBudgetAdapter } from "./sqlite-egress-budget-adapter";
 import { createSqliteMessageAdapter } from "./sqlite-message-adapter";
 import { createSqlitePartAdapter } from "./sqlite-part-adapter";
 import { createSqlitePendingAskAdapter } from "./sqlite-pending-ask-adapter";
@@ -55,6 +56,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
   readonly pendingInteraction: NonNullable<Storage.Adapter["pendingInteraction"]>;
   readonly workerGrant: NonNullable<Storage.Adapter["workerGrant"]>;
   readonly cronJob: NonNullable<Storage.Adapter["cronJob"]>;
+  readonly egressBudget: NonNullable<Storage.Adapter["egressBudget"]>;
   readonly actorRegistry: NonNullable<Storage.Adapter["actorRegistry"]>;
   readonly blacklist: NonNullable<Storage.Adapter["blacklist"]>;
   readonly channelGrant: NonNullable<Storage.Adapter["channelGrant"]>;
@@ -109,6 +111,7 @@ export class SqliteStorageAdapter implements Storage.Adapter {
     this.pendingInteraction = createSqlitePendingInteractionAdapter(this.db);
     this.workerGrant = createSqliteWorkerGrantAdapter(this.db);
     this.cronJob = createSqliteCronJobAdapter(this.db);
+    this.egressBudget = createSqliteEgressBudgetAdapter(this.db);
     this.actorRegistry = createSqliteActorRegistryAdapter(this.db);
     this.blacklist = createSqliteBlacklistAdapter(this.db);
     this.channelGrant = createSqliteChannelGrantAdapter(this.db);

--- a/packages/ledger/src/storage/storage.ts
+++ b/packages/ledger/src/storage/storage.ts
@@ -111,6 +111,11 @@ export namespace Storage {
     pendingInteraction?: ProtocolStorage.PendingInteractionSubAdapter;
     workerGrant?: ProtocolStorage.WorkerGrantSubAdapter;
     cronJob?: ProtocolStorage.CronJobSubAdapter;
+    // Active-egress debit ledger (#219, perimeter domain). Optional for test
+    // fakes only — EgressBudgetStore fails closed when it is missing;
+    // production adapters wire it as required (SqliteStorageAdapter). Sole
+    // writer is the channels gateway router (S8), like the wait store.
+    egressBudget?: ProtocolStorage.EgressBudgetSubAdapter;
     actorRegistry?: ProtocolStorage.ActorRegistrySubAdapter;
     blacklist?: ProtocolStorage.BlacklistSubAdapter;
     channelGrant?: ProtocolStorage.ChannelGrantSubAdapter;

--- a/packages/ledger/test/egress/egress-budget-store.test.ts
+++ b/packages/ledger/test/egress/egress-budget-store.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EgressBudgetStore, Storage } from "../../src/index";
+
+/**
+ * #219 active-egress debit ledger: append-only record of admitted proactive
+ * sends, folded into the window/cooldown projection the pure budget evaluator
+ * consumes. Perimeter-domain surface (S8) — written only by the channels send
+ * kernel. A missing sub-adapter fails closed.
+ */
+describe("EgressBudgetStore", () => {
+  const NOW = 5_000_000_000_000;
+  const WINDOW = 60_000;
+
+  beforeEach(() => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    Storage.reset();
+  });
+
+  test("an empty ledger reads a zero state", () => {
+    const state = EgressBudgetStore.readState("s", "t", NOW - WINDOW);
+    expect(state).toEqual({ countInWindow: 0, notifyInWindow: 0, converseInWindow: 0 });
+  });
+
+  test("records fold into per-class window counts and a window-independent lastSendAt", () => {
+    EgressBudgetStore.record({
+      id: "d1",
+      senderId: "s",
+      targetActorId: "t",
+      class: "notify",
+      at: NOW - 90_000,
+    });
+    EgressBudgetStore.record({
+      id: "d2",
+      senderId: "s",
+      targetActorId: "t",
+      class: "notify",
+      at: NOW - 10_000,
+    });
+    EgressBudgetStore.record({
+      id: "d3",
+      senderId: "s",
+      targetActorId: "t",
+      class: "converse",
+      at: NOW - 5_000,
+    });
+
+    const state = EgressBudgetStore.readState("s", "t", NOW - WINDOW);
+    // d1 is outside the 60s window; d2 + d3 are inside.
+    expect(state.countInWindow).toBe(2);
+    expect(state.notifyInWindow).toBe(1);
+    expect(state.converseInWindow).toBe(1);
+    // lastSendAt ignores the window — it is the cooldown clock.
+    expect(state.lastSendAt).toBe(NOW - 5_000);
+  });
+
+  test("debits are isolated per (sender, target) pair", () => {
+    EgressBudgetStore.record({
+      id: "a",
+      senderId: "s",
+      targetActorId: "t1",
+      class: "notify",
+      at: NOW,
+    });
+    EgressBudgetStore.record({
+      id: "b",
+      senderId: "s",
+      targetActorId: "t2",
+      class: "notify",
+      at: NOW,
+    });
+    expect(EgressBudgetStore.readState("s", "t1", NOW - WINDOW).countInWindow).toBe(1);
+    expect(EgressBudgetStore.readState("s", "t2", NOW - WINDOW).countInWindow).toBe(1);
+    expect(EgressBudgetStore.readState("s", "other", NOW - WINDOW).countInWindow).toBe(0);
+  });
+
+  test("fails closed when the sub-adapter is absent", () => {
+    Storage.configure({
+      transaction: (op: () => unknown) => op(),
+      session: {} as never,
+      message: {} as never,
+      part: {} as never,
+    } as never);
+    expect(() => EgressBudgetStore.readState("s", "t", 0)).toThrow(
+      "does not implement egressBudget",
+    );
+  });
+});

--- a/packages/protocol/src/gateway/schema.ts
+++ b/packages/protocol/src/gateway/schema.ts
@@ -111,6 +111,15 @@ const DeliverSchema = z
 const MessageOperationSchema = z.enum(["fire_and_forget", "awaited"]);
 
 /**
+ * Policy-intent axis of a send (#219), coherent with — but not collapsed into
+ * — the Wait axis (`operation`). `converse` intends a reply loop (⟺ awaited);
+ * `notify` is a one-way ping (⟺ fire_and_forget). Kept a SEPARATE field so the
+ * active-egress gate can reason about intent (class caps, future 봉수 rungs)
+ * without overloading `operation`, whose only job is whether a Wait opens.
+ */
+const MessageClassSchema = z.enum(["notify", "converse"]);
+
+/**
  * Explicit target: always one existing actor; an optional endpoint pin
  * disambiguates actors reachable at more than one endpoint. No broadcast or
  * wildcard form — resolution yields exactly one delivery address or a typed
@@ -201,7 +210,82 @@ const MessageDenialCodeSchema = z.enum([
   "target_stale",
   "target_ambiguous",
   "wait_duplicate",
+  // #219 active-egress suppressions: a granted, resolvable send the social
+  // budget refuses — window/class cap hit (or no Owner-declared budget for a
+  // cold proactive send), within cooldown/quiet-hours, or do-not-contact.
+  "budget_exhausted",
+  "cooldown_suppressed",
+  "dnc_denied",
 ]);
+
+/**
+ * Owner-declared active-egress budget for proactive outreach to ONE target
+ * actor (#219). It governs HOW OFTEN the persona may cold-contact a target;
+ * authority (MAY I contact at all) stays the SenderTargetGrant's job, evaluated
+ * first. Replies (reply-scoped grant instances) are never throttled by this.
+ *
+ * Semantics: at most `maxPerWindow` admitted sends per rolling `windowMs`, at
+ * least `cooldownMs` between sends, optional per-class sub-caps, an optional
+ * daily quiet-hours blackout (UTC minute-of-day), a hard `doNotContact` kill
+ * switch, and an optional `expiresAt` after which the allowance lapses (and the
+ * fail-safe default re-applies: cold proactive is capped at zero).
+ */
+const SocialBudgetSchema = z
+  .object({
+    id: z.string().min(1),
+    targetActorId: z.string().min(1),
+    maxPerWindow: z.number().int().positive(),
+    windowMs: z.number().int().positive(),
+    cooldownMs: z.number().int().nonnegative(),
+    classCaps: z
+      .object({
+        notify: z.number().int().nonnegative().optional(),
+        converse: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    quietHours: z
+      .object({
+        startMinuteUtc: z.number().int().min(0).max(1439),
+        endMinuteUtc: z.number().int().min(0).max(1439),
+      })
+      .strict()
+      .optional(),
+    doNotContact: z.boolean().optional(),
+    expiresAt: z.number().optional(),
+  })
+  .strict();
+
+/**
+ * One durable debit row: an ADMITTED proactive send (#219). Recorded
+ * record-before-act when a send is admitted (never when suppressed), so split
+ * outreach across separate calls cannot evade the cap and the cooldown clock
+ * survives a restart. The gateway router is the sole writer (perimeter domain).
+ */
+const EgressDebitRowSchema = z
+  .object({
+    id: z.string().min(1),
+    senderId: z.string().min(1),
+    targetActorId: z.string().min(1),
+    class: MessageClassSchema,
+    at: z.number(),
+  })
+  .strict();
+
+/**
+ * The read projection the store folds from the debit rows for one
+ * (sender, target) pair over a window — the pure evaluator's only debit input.
+ * `lastSendAt` is window-independent (the cooldown clock runs off the most
+ * recent admitted send regardless of window).
+ */
+const EgressDebitStateSchema = z
+  .object({
+    countInWindow: z.number().int().nonnegative(),
+    notifyInWindow: z.number().int().nonnegative(),
+    converseInWindow: z.number().int().nonnegative(),
+    lastSendAt: z.number().optional(),
+  })
+  .strict();
 
 /**
  * The Wait an awaited delivery opens. Quorum/resolution-policy coherence is
@@ -236,6 +320,12 @@ const SendInputBase = z
     /** Injected timestamp — messaging never reads the wall clock. */
     at: z.number(),
     waitSpec: AwaitSpecSchema.optional(),
+    /**
+     * #219 policy-intent axis, additive-optional for backward compat. Absent →
+     * defaults from `operation` (notify for fire_and_forget, converse for
+     * awaited). Present → must stay coherent with `operation` (refined below).
+     */
+    class: MessageClassSchema.optional(),
   })
   .strict();
 
@@ -252,6 +342,23 @@ const SendInputSchema = SendInputBase.superRefine((input, ctx) => {
       code: "custom",
       message: "fire_and_forget never opens a Wait — waitSpec is not allowed",
       path: ["waitSpec"],
+    });
+  }
+  // The two axes stay coherent without collapsing: converse ⟺ awaited,
+  // notify ⟺ fire_and_forget. Absent class is inferred from operation, so
+  // only an explicitly-incoherent pairing is rejected.
+  if (input.class === "converse" && input.operation !== "awaited") {
+    ctx.addIssue({
+      code: "custom",
+      message: 'class "converse" requires operation "awaited" (a converse intends a reply loop)',
+      path: ["class"],
+    });
+  }
+  if (input.class === "notify" && input.operation !== "fire_and_forget") {
+    ctx.addIssue({
+      code: "custom",
+      message: 'class "notify" requires operation "fire_and_forget" (a notify awaits nothing)',
+      path: ["class"],
     });
   }
 });
@@ -290,6 +397,9 @@ export namespace Gateway {
   export const MessageOperation = MessageOperationSchema;
   export type MessageOperation = z.infer<typeof MessageOperationSchema>;
 
+  export const MessageClass = MessageClassSchema;
+  export type MessageClass = z.infer<typeof MessageClassSchema>;
+
   export const MessageTarget = MessageTargetSchema;
   export type MessageTarget = z.infer<typeof MessageTargetSchema>;
 
@@ -298,6 +408,15 @@ export namespace Gateway {
 
   export const ReplyGrantRule = ReplyGrantRuleSchema;
   export type ReplyGrantRule = z.infer<typeof ReplyGrantRuleSchema>;
+
+  export const SocialBudget = SocialBudgetSchema;
+  export type SocialBudget = z.infer<typeof SocialBudgetSchema>;
+
+  export const EgressDebitRow = EgressDebitRowSchema;
+  export type EgressDebitRow = z.infer<typeof EgressDebitRowSchema>;
+
+  export const EgressDebitState = EgressDebitStateSchema;
+  export type EgressDebitState = z.infer<typeof EgressDebitStateSchema>;
 
   export const MessageDenialCode = MessageDenialCodeSchema;
   export type MessageDenialCode = z.infer<typeof MessageDenialCodeSchema>;

--- a/packages/protocol/src/storage/index.ts
+++ b/packages/protocol/src/storage/index.ts
@@ -3,6 +3,7 @@ import type { AppConnector } from "../app-connector/index.js";
 import type { Communication } from "../communication/index.js";
 import type { CronJob } from "../cron/index.js";
 import type { Engagement } from "../engagement/index.js";
+import type { Gateway } from "../gateway/index.js";
 import type { Ledger } from "../ledger/index.js";
 import type { Wait } from "../wait/index.js";
 import type { WorkItem } from "../work-item/index.js";
@@ -140,6 +141,23 @@ export namespace Storage {
     /** Version-guarded upsert: false = an equal-or-newer version already persisted (lost race). */
     set(record: Communication.WorkerGrant.Record): boolean;
     remove(id: string): boolean;
+  }
+
+  /**
+   * Active-egress debit ledger (#219, perimeter domain): a per-(senderId,
+   * targetActorId) append-only log of ADMITTED proactive sends. The gateway
+   * router is the sole writer (same isolation as the wait store — the brain
+   * never reaches it). `record` appends one admitted send;
+   * `readState` folds the window projection the pure budget evaluator consumes
+   * (`windowStartAt` is the caller's `at - budget.windowMs`).
+   */
+  export interface EgressBudgetSubAdapter {
+    record(row: Gateway.EgressDebitRow): void;
+    readState(
+      senderId: string,
+      targetActorId: string,
+      windowStartAt: number,
+    ): Gateway.EgressDebitState;
   }
 
   export interface CronJobSubAdapter {

--- a/packages/protocol/test/gateway.test.ts
+++ b/packages/protocol/test/gateway.test.ts
@@ -190,6 +190,80 @@ describe("Gateway.SendInput (re-homed #215 vocabulary)", () => {
     });
     expect(parsed.waitSpec?.waitId).toBe("w-1");
   });
+
+  test("class is additive-optional: absent parses (defaults from operation downstream)", () => {
+    const parsed = Gateway.SendInput.parse({ ...base, operation: "fire_and_forget" });
+    expect(parsed.class).toBeUndefined();
+  });
+
+  test("class coherence: converse ⟺ awaited, notify ⟺ fire_and_forget", () => {
+    // Coherent pairings parse.
+    expect(
+      Gateway.SendInput.parse({ ...base, operation: "fire_and_forget", class: "notify" }).class,
+    ).toBe("notify");
+    expect(
+      Gateway.SendInput.parse({
+        ...base,
+        operation: "awaited",
+        class: "converse",
+        waitSpec: {
+          waitId: "w-1",
+          ownerRef: { kind: "session", id: "s-1" },
+          allowedActions: ["report_result"],
+          expectedResponders: ["seller-1"],
+          resolutionPolicy: "first_reply",
+          expiresAt: 2_000,
+          followUpWindow: 0,
+        },
+      }).class,
+    ).toBe("converse");
+    // Incoherent pairings are refused (the two axes stay coherent, not collapsed).
+    expect(() =>
+      Gateway.SendInput.parse({ ...base, operation: "fire_and_forget", class: "converse" }),
+    ).toThrow();
+    expect(() =>
+      Gateway.SendInput.parse({ ...base, operation: "awaited", class: "notify" }),
+    ).toThrow();
+  });
+});
+
+describe("Gateway.SocialBudget (#219 active-egress contract)", () => {
+  const base = {
+    id: "budget-1",
+    targetActorId: "seller-1",
+    maxPerWindow: 3,
+    windowMs: 86_400_000,
+    cooldownMs: 3_600_000,
+  };
+
+  test("a minimal budget parses; optional caps/quiet-hours/DNC/expiry are additive", () => {
+    expect(Gateway.SocialBudget.parse(base).maxPerWindow).toBe(3);
+    const full = Gateway.SocialBudget.parse({
+      ...base,
+      classCaps: { notify: 1, converse: 2 },
+      quietHours: { startMinuteUtc: 1320, endMinuteUtc: 480 },
+      doNotContact: false,
+      expiresAt: 9_000,
+    });
+    expect(full.classCaps?.notify).toBe(1);
+    expect(full.quietHours?.startMinuteUtc).toBe(1320);
+  });
+
+  test("maxPerWindow and windowMs must be positive; cooldownMs may be zero", () => {
+    expect(() => Gateway.SocialBudget.parse({ ...base, maxPerWindow: 0 })).toThrow();
+    expect(() => Gateway.SocialBudget.parse({ ...base, windowMs: 0 })).toThrow();
+    expect(Gateway.SocialBudget.parse({ ...base, cooldownMs: 0 }).cooldownMs).toBe(0);
+  });
+
+  test("quiet-hours minutes are bounded to a day and unknown keys are rejected (strict)", () => {
+    expect(() =>
+      Gateway.SocialBudget.parse({
+        ...base,
+        quietHours: { startMinuteUtc: 1440, endMinuteUtc: 0 },
+      }),
+    ).toThrow();
+    expect(() => Gateway.SocialBudget.parse({ ...base, unexpected: true })).toThrow();
+  });
 });
 
 describe("Gateway.SenderTargetGrant (instances)", () => {

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -876,6 +876,13 @@ function selfTest(): void {
       ).length === 0,
     ],
     [
+      "S8: the router may name the egress-budget perimeter surface (#219)",
+      channelsRouterLedgerViolations(
+        "packages/channels/src/router/messaging/send.ts",
+        'import { EgressBudgetStore } from "@openomni/ledger";',
+      ).length === 0,
+    ],
+    [
       "S8: the router may not name a brain ledger surface",
       channelsRouterLedgerViolations(
         "packages/channels/src/router/routing-resolution.ts",

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -371,6 +371,9 @@ const CHANNELS_ROUTER_LEDGER_SURFACES = new Set([
   "PendingAskStore",
   "PendingInteractionStore",
   "LedgerAppend",
+  // #219 active-egress debit ledger — a perimeter surface written ONLY by the
+  // router's send kernel (same isolation as the wait store; brain never reaches it).
+  "EgressBudgetStore",
 ]);
 
 function isChannelsJudgmentPath(filePath: string): boolean {

--- a/script/conformance/p2-ledger-baseline.test.ts
+++ b/script/conformance/p2-ledger-baseline.test.ts
@@ -1541,7 +1541,8 @@ describe("p2 ledger baseline — frozen legacy writers + archive manifest (D2a)"
     if (!entry) throw new Error("manifest misses the frozen pending_ask table");
     expect(entry).toMatchObject({
       table: "pending_ask",
-      sourceSchemaVersion: "0020_engagement/migration.sql",
+      // The last applied migration (#219 added 0021_egress_budget).
+      sourceSchemaVersion: "0021_egress_budget/migration.sql",
       rowCount: 3,
       idRange: { first: "ask-a", last: "ask-c" },
     });

--- a/script/conformance/schema-snapshot.json
+++ b/script/conformance/schema-snapshot.json
@@ -312,6 +312,13 @@
     "userId",
     "workspace"
   ],
+  "Gateway.EgressDebitRow": ["at", "class", "id", "senderId", "targetActorId"],
+  "Gateway.EgressDebitState": [
+    "converseInWindow",
+    "countInWindow",
+    "lastSendAt",
+    "notifyInWindow"
+  ],
   "Gateway.MessageTarget": ["actorId", "endpointId"],
   "Gateway.Origin": ["externalId", "surface"],
   "Gateway.ReplyGrantRule": [
@@ -339,12 +346,24 @@
   "Gateway.SendInput": [
     "at",
     "body",
+    "class",
     "messageId",
     "operation",
     "senderId",
     "target",
     "traceId",
     "waitSpec"
+  ],
+  "Gateway.SocialBudget": [
+    "classCaps",
+    "cooldownMs",
+    "doNotContact",
+    "expiresAt",
+    "id",
+    "maxPerWindow",
+    "quietHours",
+    "targetActorId",
+    "windowMs"
   ],
   "Gateway.WaitContext": ["allowedAction", "engagementId", "waitId"],
   "Gateway.WaitControl": ["action", "reason", "waitId"],


### PR DESCRIPTION
Issue #219 v1 — the outbound social-budget gate: caps/cooldown/DNC on **cold proactive outreach**, evaluated at the send seam after grant, before Wait/delivery. The autonomous timer-fired 봉수 escalation ladder is explicitly OUT (deferred, blocked by #469 accumulator + a missing periodic-timeout firing source). 4 commits.

## What
- **`class: notify | converse`** — additive-optional on `Gateway.SendInput`, with a coherence refine (`converse`⟺`awaited`, `notify`⟺`fire_and_forget`): two coherent axes (policy-intent vs Wait), not collapsed. Absent class = backward-compat, defaults from operation.
- **`Gateway.SocialBudget`** (Owner-declared, config `messaging.socialBudget`, fail-closed resolver like grants): per-target maxPerWindow/windowMs/cooldownMs/classCaps/quietHours/doNotContact/expiresAt.
- **Durable debit store** (`EgressBudgetStore`, new perimeter ledger sub-adapter + migration 0021, S8-pinned to the router band): append-only `egress_debit`, one aggregate window fold + window-independent `lastSendAt` cooldown clock. Debit is record-before-act on ADMIT — so splitting outreach across calls can't evade the cap and cooldown survives restart.
- **Pure evaluator** `evaluateSocialBudget(budget, state, {class, at})` (no store/clock — inputs): absent-budget→`budget_exhausted` (fail-safe) → DNC → lapsed → quiet-hours → cooldown → window cap → class cap → allow. Suppression = the existing `denied` receipt arm with new additive codes (`budget_exhausted`/`cooldown_suppressed`/`dnc_denied`), rendered by the #708 tool with no tool change.

## The key safety call: cold-proactive vs reply
The signal is the resolved grant. A **reply-scoped instance** (`grant.replyScope !== undefined`, materialized from a ReplyGrantRule) **bypasses the gate entirely** — no budget, no debit. Only cold initiations under an Owner standing grant (`replyScope === undefined`) are budgeted. So replies (#708/#747 paths) are unthrottled by construction; the fail-safe empty-budget default caps only cold outreach at zero. The gate also only engages when a budget source is injected, so every existing test/harness is behaviorally unchanged.

## Deferred (seam comment in send.ts)
봉수 escalation ladder, BeaconState, #469 accumulator, timer→rung-advance, notify batching — blocked by #469 + a missing periodic-timeout source.

## Tests
Coherence (both incoherent pairings throw), budget parse/bounds; store window-fold + lastSendAt + per-pair isolation + fail-closed adapter; evaluator (fail-safe/DNC/lapsed/window/cooldown/class-cap/quiet-hours same-day+overnight); seam integration — unchanged-payload (gate off), fail-safe cold-deny, record-before-act, **split-evasion**, **cooldown-block**, **DNC-deny**, **reply-not-throttled**; config fail-closed-warn.

## Verification
build + check-types + full turbo test 16/16, lint/dep/cycle/dead-export/coverage gates, p2-ledger-baseline (0020→0021 pin, frozen hashes unchanged), channels standalone, E2E harness. Frozen wire strings untouched; new codes additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synchronous active‑egress gate that enforces per‑target social budgets on cold proactive outreach after grant and before Wait/delivery; replies bypass the gate. Previously there was no throttling; now cold sends can be denied with typed codes and admitted sends write a durable debit.

- **Reviews**
  - Gate placement: `packages/channels/src/router/messaging/send.ts` evaluates `evaluateSocialBudget` and returns a typed denial before any Wait/delivery; on allow it records a debit via `EgressBudgetStore` (record‑before‑act).
  - Fail‑safe semantics: budget source is wired from `apps/server/src/bootstrap/index.ts`; a cold send to a target without a `Gateway.SocialBudget` is suppressed (`budget_exhausted`). Reply‑scoped grant instances always bypass. `Gateway.SendInput.class` is additive and defaults from `operation`.
  - Protocol additions: `Gateway.MessageClass`, `Gateway.SocialBudget`, `Gateway.EgressDebitRow`/`Gateway.EgressDebitState`, and new denial codes `budget_exhausted`/`cooldown_suppressed`/`dnc_denied`.
  - Durable store and migration: new `egress_debit` table (migration `0021_egress_budget`) and SQLite adapter; `EgressBudgetStore.readState` folds window/class counts and a window‑independent `lastSendAt`.
  - Config: `messaging.socialBudget` parsed fail‑closed in `apps/server/src/config.ts`; malformed lists drop with an `Operational.Warn`.
  - S8 check: `script/check-deps.ts` allowlists `EgressBudgetStore` for the router; self‑test asserts the allowed import.
  - Deferred: the timer‑fired escalation ladder is out of scope (seam comment left).

- **Rollout and migration**
  - Required: apply migration `0021_egress_budget`.
  - Required: provision `messaging.socialBudget` per target to keep cold outreach; unspecified targets are capped at zero. Replies are unaffected.
  - No tool changes: denials reuse the existing `denied` receipt arm; codes are additive.

<sup>Written for commit 307e25120a90f8fec8dc453aae49f0096b8de3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable social budgets for proactive messaging.
  * Enforced do-not-contact rules, quiet hours, cooldowns, expiration, and message limits.
  * Added message classes and clear denial reasons for suppressed sends.
  * Added durable tracking of admitted proactive messages to prevent budget circumvention.

* **Documentation**
  * Documented messaging configuration, budget rules, sender permissions, and escalation behavior.

* **Bug Fixes**
  * Malformed or missing budget settings now fail safely by blocking proactive sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->