### PR TITLE
fix(llm): sanitize tool names to provider pattern (wire-only)

### DIFF
--- a/packages/llm/src/message/index.ts
+++ b/packages/llm/src/message/index.ts
@@ -51,7 +51,10 @@ function buildToolCallBlock(call: {
   return {
     type: "tool-call",
     toolCallId: call.id,
-    toolName: call.tool,
+    // Wire name: prior turns must re-serialize the same provider-pattern-safe
+    // name the tools array advertised, or the request is rejected on replay.
+    // Runs for every provider (this builder is provider-agnostic).
+    toolName: ProviderTransform.sanitizeToolName(call.tool),
     input: call.input,
     providerExecuted: false,
   };
@@ -69,7 +72,8 @@ function buildToolResultBlock(result: {
   return {
     type: "tool-result",
     toolCallId: result.id,
-    toolName: result.tool,
+    // Wire name, matching the tool-call block above (all providers).
+    toolName: ProviderTransform.sanitizeToolName(result.tool),
     output: { type: "text", value: result.output },
   };
 }

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -49,6 +49,14 @@ export namespace Processor {
     events: BusEvent.Sink;
     createStream: (input: StreamInput) => Promise<Stream>;
     /**
+     * Wire tool name → internal dotted name. The provider echoes the sanitized
+     * wire name (`message_send`) on tool-call/result stream events, so the
+     * transcript would otherwise record the drifted name; this reverse map
+     * restores the dotted internal name (`message.send`) on the recorded part.
+     * Absent = record the name verbatim.
+     */
+    toolNames?: ReadonlyMap<string, string>;
+    /**
      * The call's identity. Required: `run()` always has it, and making it
      * optional is what justified filing records under `traceId ?? sessionID`
      * — a session id in the field every reader treats as a trace.
@@ -85,6 +93,7 @@ export namespace Processor {
       sink: configuredSink = createNoopSink(),
       events,
       createStream,
+      toolNames,
       maxRetryAttempts = DEFAULT_MAX_RETRY_ATTEMPTS,
       trace,
     } = options;
@@ -162,6 +171,7 @@ export namespace Processor {
               sink,
               record,
               note: debugNote,
+              ...(toolNames !== undefined && { toolNames }),
             };
 
             function finishAttempt(finish: Transcript.FinishReason): void {

--- a/packages/llm/src/processor/stream-events.ts
+++ b/packages/llm/src/processor/stream-events.ts
@@ -20,7 +20,19 @@ export type StreamEventContext = {
   readonly record: (fact: Transcript.Fact) => void;
   /** Debug note for normalized-away provider anomalies (#532-6). */
   readonly note: (msg: string, data?: Record<string, unknown>) => void;
+  /**
+   * Wire tool name → internal dotted name. The provider echoes the sanitized
+   * wire name on stream events; this restores the dotted internal name on the
+   * recorded part so the transcript keeps the native vocabulary. Absent =
+   * record the name verbatim.
+   */
+  readonly toolNames?: ReadonlyMap<string, string>;
 };
+
+/** Map a wire tool name back to its internal dotted name, if known. */
+function resolveToolName(wireName: string, context: StreamEventContext): string {
+  return context.toolNames?.get(wireName) ?? wireName;
+}
 
 type OpenBlock = {
   partId: string;
@@ -327,7 +339,7 @@ function handleToolCall(
     messageID: context.messageID,
     type: "tool",
     callID,
-    tool: String(event.toolName),
+    tool: resolveToolName(String(event.toolName), context),
     state: { status: "pending", input },
   };
   appendPart(part, context);
@@ -363,7 +375,8 @@ function handleToolResult(
       messageID: context.messageID,
       type: "tool",
       callID: toolCallId,
-      tool: String(event.toolName ?? "unknown"),
+      tool:
+        event.toolName !== undefined ? resolveToolName(String(event.toolName), context) : "unknown",
       state: { status: "pending", input: {} },
     };
     const at = Date.now();
@@ -386,7 +399,9 @@ function handleToolResult(
           to: "completed",
           at: Date.now(),
           output: outputPayload.output,
-          ...(event.toolName !== undefined ? { title: String(event.toolName) } : {}),
+          ...(event.toolName !== undefined
+            ? { title: resolveToolName(String(event.toolName), context) }
+            : {}),
         },
     context,
   );

--- a/packages/llm/src/provider/transform.ts
+++ b/packages/llm/src/provider/transform.ts
@@ -147,6 +147,20 @@ export namespace ProviderTransform {
     return toolCallID.replace(/[^a-zA-Z0-9_-]/g, "_");
   }
 
+  /**
+   * Coerce a tool name to the provider-agnostic wire pattern
+   * `^[a-zA-Z0-9_-]{1,128}$`. Native tools are dotted (`message.send`) and MCP
+   * tools are `${server}.${name}` with arbitrary segments, but every provider
+   * SDK (the failure surfaced on an OpenAI-pattern proxy) rejects a name with a
+   * dot. This runs for ALL providers — it is NOT the Anthropic-only
+   * name-touching branch above. The internal dotted vocabulary is unchanged;
+   * only the name that crosses to the SDK is sanitized, and the SDK's
+   * key-match dispatch makes the reverse map free at execution time.
+   */
+  export function sanitizeToolName(name: string): string {
+    return name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 128);
+  }
+
   function buildMessageWithContent(
     msg: Extract<SDKMessage, { role: "assistant" | "tool" }>,
     content: NormalizableContentPart[],

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -75,6 +75,39 @@ export namespace Run {
   export type Outcome = z.infer<typeof Outcome>;
 }
 
+/**
+ * Assign each tool spec its wire name — the provider-pattern-safe key it takes
+ * in the `tools` object crossing to the SDK — and the reverse map back to the
+ * internal dotted name.
+ *
+ * The native catalog (`message.send`, `engagement.open`, …) is collision-free
+ * under plain `.`→`_`, but MCP tool names are `${server}.${name}` with
+ * arbitrary segments, so two distinct originals can sanitize to the same key.
+ * A silent overwrite of one tool's `execute` closure by another is a
+ * correctness bug, so a taken key is disambiguated with a deterministic
+ * `_2`/`_3`/… suffix (truncated to keep the 128-char bound). The reverse map
+ * lets the transcript record the dotted internal name instead of the wire name.
+ */
+function assignWireToolNames(tools: Tool.Spec[]): {
+  wireNames: string[];
+  originalByWire: Map<string, string>;
+} {
+  const wireNames: string[] = [];
+  const originalByWire = new Map<string, string>();
+  for (const spec of tools) {
+    const base = ProviderTransform.sanitizeToolName(spec.name);
+    let wire = base;
+    let suffix = 2;
+    while (originalByWire.has(wire)) {
+      const tail = `_${suffix++}`;
+      wire = base.slice(0, 128 - tail.length) + tail;
+    }
+    originalByWire.set(wire, spec.name);
+    wireNames.push(wire);
+  }
+  return { wireNames, originalByWire };
+}
+
 export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   const { messages, system = "", signal, model } = input;
 
@@ -89,6 +122,12 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
   }
   const messageID = `msg-${crypto.randomUUID()}`;
   const parentID = messages[messages.length - 1]?.info.id || "";
+
+  // The tool set is fixed across retries, so the wire-name assignment (and its
+  // reverse map for transcript fidelity) is computed once here and captured by
+  // createStream. The reverse map keeps the recorded ToolPart.tool dotted even
+  // though the stream reports the wire name the provider echoed back.
+  const { wireNames, originalByWire } = assignWireToolNames(input.tools);
 
   const assistantMessage: Message.AssistantMessage = {
     id: messageID,
@@ -138,10 +177,15 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
         ]
       : [];
 
+    // Tools are keyed by their wire name (provider-pattern-safe), but the
+    // execute closure sets `tool: spec.name` (internal dotted) so execution
+    // and policy always see the dotted vocabulary. The SDK dispatches execute
+    // by the same key it advertised, so the wire→dotted reverse is free here.
     const sdkTools: Record<string, unknown> = {};
-    for (const spec of input.tools) {
+    input.tools.forEach((spec, index) => {
+      const wireName = wireNames[index] as string;
       const executor = input.toolExecutor;
-      sdkTools[spec.name] = {
+      sdkTools[wireName] = {
         type: "function" as const,
         description: spec.description,
         inputSchema: ai.jsonSchema(spec.inputSchema),
@@ -170,8 +214,8 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
           },
         }),
       };
-    }
-    const lastToolName = input.tools[input.tools.length - 1]?.name;
+    });
+    const lastToolName = wireNames[wireNames.length - 1];
     if (cacheOptions && lastToolName !== undefined) {
       (sdkTools[lastToolName] as Record<string, unknown>).providerOptions = cacheOptions;
     }
@@ -246,6 +290,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
     abort: abortSignal,
     sink,
     createStream,
+    toolNames: originalByWire,
     trace: {
       traceId,
       sessionId: sessionID,

--- a/packages/llm/test/message/to-model-messages.test.ts
+++ b/packages/llm/test/message/to-model-messages.test.ts
@@ -360,6 +360,71 @@ describe("toModelMessages error-turn exclusion (#545 T2)", () => {
   });
 });
 
+describe("toModelMessages tool-name wire sanitization (all providers)", () => {
+  // A non-claude provider: the sanitize must run here too — the live-LLM
+  // failure was an OpenAI-pattern proxy, and the claude-only normalize branch
+  // never touches this model.
+  const openaiModel: Provider.Model = {
+    id: "gpt-4o",
+    providerID: "openai-proxy",
+    name: "Proxied",
+    api: { npm: "@ai-sdk/openai" },
+  };
+
+  function assistantWithDottedToolCall(): Message.WithParts {
+    return {
+      info: {
+        id: "msg-a",
+        sessionID: "session-1",
+        role: "assistant",
+        time: { created: 1100, completed: 1200 },
+        parentID: "msg-u",
+        modelID: "gpt-4o",
+        providerID: "openai-proxy",
+        agent: "default",
+        path: { cwd: "/", root: "/" },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "stop",
+      } as Message.AssistantMessage,
+      parts: [
+        {
+          id: "part-tool",
+          sessionID: "session-1",
+          messageID: "msg-a",
+          type: "tool",
+          callID: "call-1",
+          tool: "message.send",
+          state: {
+            status: "completed",
+            input: { text: "hi" },
+            output: "sent",
+            time: { start: 1100, end: 1150 },
+            title: "message.send",
+            metadata: {},
+          },
+        } as Message.ToolPart,
+      ],
+    };
+  }
+
+  test("sanitizes tool-call and tool-result block names for a non-claude provider", () => {
+    const result = toModelMessages([assistantWithDottedToolCall()], openaiModel);
+
+    const assistant = result.find((m) => m.role === "assistant");
+    const toolMsg = result.find((m) => m.role === "tool");
+    if (!assistant || !Array.isArray(assistant.content))
+      throw new Error("expected tool-call block");
+    if (!toolMsg || !Array.isArray(toolMsg.content)) throw new Error("expected tool-result block");
+
+    const toolCall = assistant.content.find((b) => b.type === "tool-call");
+    const toolResult = toolMsg.content.find((b) => b.type === "tool-result");
+    // The dotted internal name must not leak into the re-serialized history.
+    expect((toolCall as { toolName?: string }).toolName).toBe("message_send");
+    expect((toolResult as { toolName?: string }).toolName).toBe("message_send");
+  });
+});
+
 describe("toModelMessages reasoning signature resend gate (#532 candidate 10)", () => {
   const outgoing: Provider.Model = {
     id: "claude-3-5-sonnet",

--- a/packages/llm/test/processor/tool-result.test.ts
+++ b/packages/llm/test/processor/tool-result.test.ts
@@ -104,6 +104,58 @@ describe("Processor tool result projection", () => {
     expect(runningSnapshot).toBeDefined();
   });
 
+  test("restores the dotted internal name on the recorded part via the reverse map", async () => {
+    // W4: the provider echoes the sanitized WIRE name on stream events, so
+    // without the reverse map the recorded ToolPart.tool would drift to
+    // "message_send". The map keeps the transcript on the native vocabulary.
+    const toolCalls: Tool.Call[] = [];
+    const toolResults: Tool.Result[] = [];
+    const messages: Message.WithParts[] = [];
+    const sink: Sink = {
+      onMessage: (message) => messages.push(message),
+      onToolCall: (call) => toolCalls.push(call),
+      onToolResult: (result) => toolResults.push(result),
+    };
+
+    const processor = Processor.create({
+      assistantMessage: assistantMessage(),
+      sessionID: "session-tool-result",
+      model,
+      abort: new AbortController().signal,
+      sink,
+      events: Bus,
+      toolNames: new Map([["message_send", "message.send"]]),
+      trace: { traceId: "trace-processor-test", sessionId: "session-tool-result" },
+      createStream: async () => ({
+        fullStream: (async function* () {
+          yield {
+            type: "tool-call",
+            toolCallId: "call-send",
+            toolName: "message_send",
+            input: { text: "hi" },
+          };
+          yield {
+            type: "tool-result",
+            toolCallId: "call-send",
+            toolName: "message_send",
+            output: "sent",
+          };
+          yield { type: "finish" };
+        })(),
+      }),
+    });
+
+    await processor.process({ system: "" });
+
+    expect(toolCalls[0]?.tool).toBe("message.send");
+    const toolPart = messages.at(-1)?.parts.find((part) => part.type === "tool");
+    expect(toolPart).toMatchObject({
+      callID: "call-send",
+      tool: "message.send",
+      state: { status: "completed", title: "message.send" },
+    });
+  });
+
   test("synthesizes an error part for unmatched AI SDK tool-result stream parts", async () => {
     const toolCalls: Tool.Call[] = [];
     const toolResults: Tool.Result[] = [];

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -212,6 +212,59 @@ describe("run() streamText arguments", () => {
     expect(Object.keys(streamArgs.tools ?? {})).toEqual(["lookup"]);
   });
 
+  // The real native tool catalog: dotted names a provider SDK rejects
+  // (`^[a-zA-Z0-9_-]{1,128}$`). Kept as literals so this llm-package test does
+  // not depend on @openomni/openomni (the catalog's home).
+  const NATIVE_TOOL_NAMES = [
+    "message.send",
+    "engagement.open",
+    "engagement.transition",
+    "engagement.list",
+    "grep.search",
+    "recall.output",
+  ];
+
+  test("serializes native dotted tool names to the provider wire pattern", async () => {
+    await run(
+      {
+        trace: TEST_TRACE,
+        events: Bus,
+        messages: [],
+        tools: NATIVE_TOOL_NAMES.map((name) => ({
+          name,
+          description: name,
+          inputSchema: { type: "object" as const },
+        })),
+        auth: { type: "api", key: "test-key-run" },
+        model: {
+          id: "gpt-4o",
+          providerID: TEST_PROVIDER_ID,
+          name: "OpenAI-pattern proxy",
+          api: { npm: "@ai-sdk/openai" },
+        },
+      },
+      mockSink,
+    );
+
+    const streamArgs = aiCapture.__openomniAiStreamArgs as { tools?: Record<string, unknown> };
+    const keys = Object.keys(streamArgs.tools ?? {});
+    expect(keys).toHaveLength(NATIVE_TOOL_NAMES.length);
+    // The invariant the live-LLM E2E surfaced: every serialized tool name must
+    // match the provider pattern, on ALL providers (the failure was OpenAI).
+    for (const key of keys) {
+      expect(key).toMatch(/^[a-zA-Z0-9_-]{1,128}$/);
+    }
+    // Plain `.`→`_` on the collision-free native catalog.
+    expect(keys).toEqual([
+      "message_send",
+      "engagement_open",
+      "engagement_transition",
+      "engagement_list",
+      "grep_search",
+      "recall_output",
+    ]);
+  });
+
   test("omits the providerOptions key entirely when none are configured", async () => {
     await run(
       {

--- a/packages/llm/test/run-tool-execution.test.ts
+++ b/packages/llm/test/run-tool-execution.test.ts
@@ -166,6 +166,88 @@ describe("run() tool execution ownership", () => {
     expect(output).toEqual({ output: "tool-error", isError: true });
   });
 
+  test("SDK invoking the sanitized wire key routes the dotted internal name to the executor", async () => {
+    const toolExecutor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      return { id: "result-1", toolCallId: call.id, output: "sent" };
+    });
+
+    await run(
+      {
+        trace: TEST_TRACE,
+        events: Bus,
+        messages: [],
+        tools: [
+          {
+            name: "message.send",
+            description: "the native dotted tool",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+        model: testModel,
+        auth: { type: "api", key: "test-key-run-tool" },
+        toolExecutor,
+      },
+      mockSink,
+    );
+
+    const streamArgs = aiCapture.__openomniAiStreamArgs;
+    const tools = streamArgs?.tools as Record<
+      string,
+      { execute?: (a: Record<string, unknown>, o?: { toolCallId?: string }) => Promise<unknown> }
+    >;
+    // The SDK sees only the wire key; the dotted name would be rejected.
+    expect(tools.message_send).toBeDefined();
+    expect(tools["message.send"]).toBeUndefined();
+
+    await tools.message_send?.execute?.({ text: "hi" }, { toolCallId: "call-1" });
+
+    // The execute closure restores the dotted internal name for execution/policy.
+    expect(toolExecutor).toHaveBeenCalledWith(
+      { id: "call-1", tool: "message.send", input: { text: "hi" } },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  test("distinct MCP originals that sanitize to one key get distinct reachable wire names", async () => {
+    const seen: string[] = [];
+    const toolExecutor = mock(async (call: Tool.Call): Promise<Tool.Result> => {
+      seen.push(call.tool);
+      return { id: `r-${call.id}`, toolCallId: call.id, output: "ok" };
+    });
+
+    await run(
+      {
+        trace: TEST_TRACE,
+        events: Bus,
+        messages: [],
+        // Two distinct arbitrary MCP names both sanitize to "srv_x_y".
+        tools: [
+          { name: "srv.x.y", description: "a", inputSchema: { type: "object" } },
+          { name: "srv_x_y", description: "b", inputSchema: { type: "object" } },
+        ],
+        model: testModel,
+        auth: { type: "api", key: "test-key-run-tool" },
+        toolExecutor,
+      },
+      mockSink,
+    );
+
+    const streamArgs = aiCapture.__openomniAiStreamArgs;
+    const tools = streamArgs?.tools as Record<
+      string,
+      { execute?: (a: Record<string, unknown>, o?: { toolCallId?: string }) => Promise<unknown> }
+    >;
+    const keys = Object.keys(tools);
+    // No silent overwrite: two keys, one disambiguated deterministically.
+    expect(keys).toEqual(["srv_x_y", "srv_x_y_2"]);
+
+    await tools.srv_x_y?.execute?.({}, { toolCallId: "c1" });
+    await tools.srv_x_y_2?.execute?.({}, { toolCallId: "c2" });
+
+    // Both closures are reachable and each routes to its own dotted original.
+    expect(seen).toEqual(["srv.x.y", "srv_x_y"]);
+  });
+
   test("normalizes missing tool execution results to structured output", async () => {
     const toolExecutor = mock(
       async (): Promise<Tool.Result> => undefined as unknown as Tool.Result,


### PR DESCRIPTION
A live-LLM E2E harness run surfaced a duplicated sanitize + harness gap (NOT a prod leak — both prod paths, bridge.ts:60 and worker-runtime.ts:71, already sanitize before the provider; the harness fed dotted specs straight to run()): a proxy model rejected the request with `tools.1.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'` — native tool names carry dots (`message.send`, `engagement.open/transition/list`, `grep.search`, `recall.output`) and MCP names are arbitrary. Fixed as a **wire-only** sanitize in `@openomni/llm`. 2 commits.

## What
- `sanitizeToolName` in provider/transform.ts (`[^a-zA-Z0-9_-]→_`, ≤128), **provider-agnostic** (not folded into the claude-only branch).
- **tools array** (run.ts): `sdkTools` keyed by the wire name; the `execute` closure still sets `tool: spec.name` (dotted) so execution/policy see the internal dotted name. MCP collision disambiguation: a `Map<wire,original>` with deterministic `_2/_3` suffixing so distinct MCP originals can't overwrite each other's closure.
- **message history** (message/index.ts): tool-call + tool-result block `toolName` sanitized — the single all-provider choke point (covers the multi-turn/replay leak that transform.ts's claude-only branch would miss).
- **transcript fidelity** (stream-events via Processor.create): wire→dotted reverse map so recorded `Message.ToolPart.tool` stays `message.send`, not `message_send`.

## Wire-only invariant
Internal dotted names are UNCHANGED end to end — no tool renames, no Tool.Spec/protocol change, no policy-pattern change, no prompt/doc change. Policy keeps matching `engagement.*` and `resource: toolName` on the dotted form (proven by the round-trip test: SDK key `message_send` → executor sees `call.tool === "message.send"`).

## Note (for review)
A pre-existing server-side sanitize exists (bridge.ts:26/60, worker-runtime.ts:71, reverse-mapped in turn.ts) that also does `.`→`_`. The new llm-level sanitize is idempotent over already-underscored names. Whether the live failure was a genuine prod-path gap vs a harness that didn't mirror the server sanitize — and whether the two layers should be reconciled — is called out for the reviewer.

## Verification
build + check-types 16/16 + full turbo test 16/16 (llm 278, +5 tests: serialized-name invariant, non-claude message-history sanitize, round-trip name mapping, MCP collision, transcript reverse-map), llm coverage 94.04→96.75, all lint/dep/cycle/dead-export gates, p2-ledger-baseline 54, channels standalone 217, E2E harness 458 pass / 2 live-skip (stub green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes tool names to the provider wire pattern without changing internal dotted names. Previously we sent dotted names (e.g., message.send) that some SDKs reject; now we send sanitized keys (e.g., message_send) on the wire and map them back so execution, policy, and transcripts continue to use the dotted names.

• Applies a provider-agnostic sanitize (replace non [A-Za-z0-9_-] with “_”, max 128) in `@openomni/llm` when building the tools object and when re-serializing prior tool_call/tool_result history to prevent replay rejections.  
• Keys SDK tools by sanitized wire names; the execute closure still passes the original dotted name to the tool executor. The wire→dotted reverse map keeps recorded ToolPart.tool and titles in the native dotted form; mapping is computed once per run and reused across retries.  
• Disambiguates wire-name collisions (e.g., arbitrary MCP tool names) with deterministic “_2/_3/…” suffixing to avoid silent overwrites.  
• No changes to Tool.Spec, prompts, or policy matching; existing server-side sanitize remains compatible and this client-side step is idempotent. If any tests or harnesses assert on raw SDK tool keys, update expectations to the sanitized form.

<sup>Written for commit 4b797a657bde672b81a7e6999d5db591e91dbdad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->