### PR TITLE
refactor(server): drop duplicate tool-name sanitize, llm owns it

### DIFF
--- a/apps/server/src/execution/worker-runtime.ts
+++ b/apps/server/src/execution/worker-runtime.ts
@@ -66,9 +66,14 @@ export function createExecutionToolContext(
     return {};
   }
   return {
+    // Keep the DOTTED spec name: the worker's agent loop runs through
+    // `@openomni/llm` run() (ChatAgent.run → runAgent → llmRun), whose
+    // `assignWireToolNames` (#749) owns the provider-wire `.`→`_` coercion and
+    // records the dotted name back. Underscoring here would be a redundant
+    // second sanitize that also drifted the recorded transcript off the native
+    // vocabulary.
     tools: selectedTools.map((tool) => ({
       ...tool.spec,
-      name: tool.spec.name.replace(/\./g, "_"),
       ...(tool.descriptor !== undefined && { descriptor: tool.descriptor }),
     })),
     toolExecutor: createToolExecutor({

--- a/apps/server/src/ingress/bridge.ts
+++ b/apps/server/src/ingress/bridge.ts
@@ -23,10 +23,6 @@ export interface BridgeDeps {
 
 type ToolListProvider = Pick<McpToolProvider, "listTools">;
 
-function sanitizeToolName(name: string): string {
-  return name.replace(/\./g, "_");
-}
-
 /**
  * The server's explicit tool-permission ruleset for composed agents (audit
  * batch A): the execution runtime fails CLOSED on an absent permission, so
@@ -55,10 +51,13 @@ function buildAgentDefFromEntries(
   deps: BridgeDeps,
   selectedEntries: ReturnType<typeof selectToolEntries>,
 ): Ingress.AgentDef {
-  const specs = selectedEntries.map((entry) => ({
-    ...entry.tool.spec,
-    name: sanitizeToolName(entry.tool.spec.name),
-  }));
+  // AgentDef entries keep the DOTTED spec name end-to-end (`message.send`,
+  // `grep.search`, …). The provider-wire constraint (`^[a-zA-Z0-9_-]{1,128}$`)
+  // is owned solely by the `@openomni/llm` boundary (`assignWireToolNames` in
+  // run.ts, #749), which sanitizes only the name crossing to the SDK and
+  // records the dotted name back — so policy, dispatch, and the transcript all
+  // stay on the native dotted vocabulary.
+  const specs = selectedEntries.map((entry) => ({ ...entry.tool.spec }));
   const nativeTools = selectedEntries.map((entry) => entry.tool);
 
   return {

--- a/apps/server/test/e2e/harness.ts
+++ b/apps/server/test/e2e/harness.ts
@@ -159,6 +159,15 @@ export function composeHarness(config: ComposeConfig): Harness {
   // = `createToolExecutor({ tools, config })`, and `permissions` allow-by-default
   // (the execution runtime fails closed on an absent permission). The S6 gate
   // overrides this to deny-all for an evidence_only delivery.
+  //
+  // TOOL NAMES: `tools` carries the tools' DOTTED spec names verbatim
+  // (`message.send`, `engagement.open`, …) — exactly as the production
+  // `buildAgentDefFromEntries` now does. There is NO name sanitize here (and
+  // none in the bridge): the provider-wire coercion `^[a-zA-Z0-9_-]{1,128}$`
+  // is owned SOLELY by the `@openomni/llm` boundary (`assignWireToolNames`,
+  // #749), which sanitizes only the name crossing to the SDK and records the
+  // dotted name back. So this harness feeding dotted specs straight to run()
+  // mirrors prod — it is not a bug to "fix" by underscoring here.
   const agentDef: Ingress.AgentDef = {
     model: config.model.model,
     systemPrompt: SYSTEM_PROMPT,

--- a/apps/server/test/execution/worker-runner-descriptor.test.ts
+++ b/apps/server/test/execution/worker-runner-descriptor.test.ts
@@ -8,7 +8,7 @@ import { createSpawnOptions, createValidRequest, successfulResult } from "./work
 type AgentTool = NonNullable<ChatAgentConfig["tools"]>[number];
 
 describe("WorkerRunner tool descriptors", () => {
-  it("preserves the listed MCP descriptor when exposing a renamed tool to ChatAgent", async () => {
+  it("preserves the listed MCP descriptor and keeps the dotted name when exposing a tool to ChatAgent", async () => {
     // Given
     const descriptor: Policy.Resource.Descriptor = {
       id: "tool:mcp:filesystem:write_file",
@@ -53,7 +53,10 @@ describe("WorkerRunner tool descriptors", () => {
           getBootstrap: () => bootstrap,
           createAgent: (config) => ({
             async run() {
-              exposedTool = config.tools?.find((tool) => tool.name === "mcp_filesystem_write_file");
+              // The exposed spec keeps its DOTTED internal name: the worker no
+              // longer underscores here — the `@openomni/llm` wire boundary
+              // (#749) owns the provider-pattern coercion on the worker path.
+              exposedTool = config.tools?.find((tool) => tool.name === "mcp.filesystem.write_file");
               return successfulResult;
             },
           }),
@@ -68,7 +71,7 @@ describe("WorkerRunner tool descriptors", () => {
 
     // Then
     expect(exposedTool).toEqual({
-      name: "mcp_filesystem_write_file",
+      name: "mcp.filesystem.write_file",
       description: "Write a file",
       inputSchema: { type: "object" },
       safe: false,

--- a/apps/server/test/execution/worker-runtime.test.ts
+++ b/apps/server/test/execution/worker-runtime.test.ts
@@ -69,9 +69,14 @@ describe("worker-runtime", () => {
     }
   });
 
-  it("selects requested tools by sanitized protocol names", () => {
+  it("matches an underscored request but keeps the dotted internal name", () => {
     const availableTools = new SystemToolProvider("/workspace/openomni").listTools();
 
+    // A request may still name a tool in the underscored wire form
+    // (`grep_search`); `expandRequestedToolNames` matches it tolerantly against
+    // the dotted catalog entry. But the exposed spec keeps the DOTTED internal
+    // name — the `@openomni/llm` wire boundary (#749) is the only place that
+    // coerces to the provider pattern, on the worker path too.
     const context = createExecutionToolContext(
       {
         tools: [
@@ -83,7 +88,7 @@ describe("worker-runtime", () => {
       availableTools,
     );
 
-    expect(context.tools?.map((tool) => tool.name)).toEqual(["bash", "grep_search"]);
+    expect(context.tools?.map((tool) => tool.name)).toEqual(["bash", "grep.search"]);
     expect(context.toolExecutor).toBeDefined();
   });
 

--- a/apps/server/test/ingress-bridge.test.ts
+++ b/apps/server/test/ingress-bridge.test.ts
@@ -165,6 +165,21 @@ describe("ingress bridge transport boundary", () => {
     ]);
   });
 
+  it("keeps DOTTED spec names in the AgentDef — the llm wire boundary owns sanitize", () => {
+    // A dotted native/MCP name (`grep.search`) must survive into the AgentDef
+    // unchanged: the provider-pattern coercion belongs solely to the
+    // `@openomni/llm` wire boundary (#749), so policy/dispatch/transcript keep
+    // the native dotted vocabulary. Pre-reconcile the bridge underscored here.
+    const dottedDeps = {
+      ...deps,
+      systemProvider: makeProvider([makeTool("read"), makeTool("grep.search")]),
+    };
+    const agent = buildResidentAgentDef(dottedDeps);
+    const names = agent.tools?.map((tool) => tool.name) ?? [];
+    expect(names).toContain("grep.search");
+    expect(names).not.toContain("grep_search");
+  });
+
   it("keeps full agent tool selection available for spawned workers", () => {
     const { customProvider: _customProvider, ...workerDeps } = deps;
     const workerAgent = buildAgentDef("dev", workerDeps);

--- a/packages/agent/src/core/execution/turn.ts
+++ b/packages/agent/src/core/execution/turn.ts
@@ -123,18 +123,15 @@ function resolvePolicyToolName(
   toolName: string,
   metadata: Map<string, ToolPolicyMetadata>,
 ): string {
-  // The resolved name must be a key the metadata map answers: an MCP tool
-  // registered "server.tool" and called with the underscore-mangled name has
-  // no `tool:` canonical label, and returning the mangled name unresolved
-  // sent its labels lookup into the void — downgrading the call from the
-  // fail-closed tool.mcp.pre to tool.native.pre (#606 audit).
-  const direct = metadata.get(toolName);
-  const dotted = toolName.replace(/_/g, ".");
-  const viaDotted = direct === undefined ? metadata.get(dotted) : undefined;
-  const toolMetadata = direct ?? viaDotted;
-  const canonical = toolMetadata?.labels?.find((label) => label.startsWith("tool:"));
-  if (canonical) return canonical.slice(5);
-  return viaDotted !== undefined ? dotted : toolName;
+  // Tool names are DOTTED end-to-end now: the `@openomni/llm` wire boundary
+  // (#749) sanitizes only the name crossing to the provider SDK and sets the
+  // executed `call.tool` to the internal dotted spec name, so the name
+  // reaching here is always that dotted name — never an underscore-mangled
+  // wire name. The former `_`→`.` recovery leg is therefore dead. A `tool:`
+  // canonical label still redirects to the policy-canonical name for a tool
+  // whose spec name is not itself the canonical (kept for MCP/aliased tools).
+  const canonical = metadata.get(toolName)?.labels?.find((label) => label.startsWith("tool:"));
+  return canonical ? canonical.slice(5) : toolName;
 }
 
 export async function buildTurn(

--- a/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
@@ -279,11 +279,17 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     ]);
   });
 
-  it("routes an underscore-mangled MCP call to tool.mcp.pre — never native (#606)", async () => {
+  it("routes a dotted MCP call (mcp labels, no tool: canonical) to tool.mcp.pre — never native (#606)", async () => {
     // The tool registers under its dotted name with mcp labels and NO tool:
-    // canonical label; an executor calling the underscore-mangled alias must
-    // still resolve the labels — the old resolver returned the mangled name
-    // unresolved, downgrading the call to the fail-open tool.native.pre.
+    // canonical label. The executor must resolve its labels so the call routes
+    // to the fail-closed tool.mcp.pre — not the fail-open tool.native.pre
+    // (#606). Post-#749 the name reaching the executor is the internal DOTTED
+    // spec name: the llm wire boundary confines the provider-pattern coercion
+    // to the SDK edge and records the dotted name back, so a mangled name never
+    // re-enters the internal vocabulary. The former `_`→`.` recovery leg in
+    // resolvePolicyToolName is therefore dead and was removed; this pins the
+    // live invariant — an mcp-labelled tool routes fail-closed by its dotted
+    // name.
     const seen: string[] = [];
     const engine = PolicyEngine.create();
     engine.register({
@@ -325,7 +331,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     );
     if (result.type !== "ready") throw new Error("expected a prepared turn");
 
-    await result.turn.runInput.toolExecutor?.({ id: "call", tool: "server_tool", input: {} });
+    await result.turn.runInput.toolExecutor?.({ id: "call", tool: "server.tool", input: {} });
 
     expect(seen).toEqual(["tool.mcp.pre", "tool.mcp.post"]);
   });

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -265,6 +265,79 @@ describe("run() streamText arguments", () => {
     ]);
   });
 
+  test("records the DOTTED internal name even though the provider echoes the wire name", async () => {
+    // The resident/prod path end to end: the AgentDef now carries the dotted
+    // spec name (`message.send`) straight into run() — the server-side
+    // sanitizes were removed, so the llm wire boundary is the ONLY coercion.
+    // The provider advertises + echoes the sanitized wire name (`message_send`),
+    // and the reverse map restores the dotted name on the recorded ToolPart so
+    // the transcript stays on the native vocabulary (the prior audit-tier
+    // wrinkle where a pre-underscored spec recorded `message_send`).
+    mock.module("ai", () => ({
+      streamText: () => ({
+        fullStream: (async function* () {
+          yield {
+            type: "tool-call",
+            toolCallId: "call-send",
+            toolName: "message_send",
+            input: { body: "hi" },
+          };
+          yield {
+            type: "tool-result",
+            toolCallId: "call-send",
+            toolName: "message_send",
+            output: "sent",
+          };
+          yield { type: "finish" };
+        })(),
+      }),
+      jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+      stepCountIs: () => () => false,
+    }));
+
+    const recordedCalls: Array<{ tool: string }> = [];
+    const recordedParts: Array<{ type: string; tool?: string }> = [];
+    const capturingSink: Sink = {
+      onMessage: (message) => {
+        for (const part of message.parts) {
+          recordedParts.push(part as { type: string; tool?: string });
+        }
+      },
+      onToolCall: (call) => recordedCalls.push(call),
+      onToolResult: () => undefined,
+    };
+
+    await run(
+      {
+        trace: TEST_TRACE,
+        events: Bus,
+        messages: [],
+        tools: [
+          { name: "message.send", description: "message.send", inputSchema: { type: "object" } },
+        ],
+        toolExecutor: async (call) => ({
+          id: "result-send",
+          toolCallId: call.id,
+          output: "sent",
+          isError: false,
+        }),
+        auth: { type: "api", key: "test-key-run" },
+        model: {
+          id: "gpt-4o",
+          providerID: TEST_PROVIDER_ID,
+          name: "OpenAI-pattern proxy",
+          api: { npm: "@ai-sdk/openai" },
+        },
+      },
+      capturingSink,
+    );
+
+    // Dispatched + recorded on the native dotted vocabulary, not the wire name.
+    expect(recordedCalls.map((call) => call.tool)).toEqual(["message.send"]);
+    const toolPart = recordedParts.find((part) => part.type === "tool");
+    expect(toolPart?.tool).toBe("message.send");
+  });
+
   test("omits the providerOptions key entirely when none are configured", async () => {
     await run(
       {


### PR DESCRIPTION
Follow-up to #749 (recommended by its review): collapse the triple-duplicated tool-name `.`→`_` sanitize to the SINGLE correct boundary — the `@openomni/llm` wire (where the provider constraint actually lives). Internal + AgentDef names now stay dotted end-to-end; only the provider wire coerces them.

## Preconditions verified (both hold)
1. **Worker path routes through llm run()** — worker-runner → ChatAgent.create → agent.run → runAgent → llm `run()`, where `assignWireToolNames` (#749) sanitizes on the wire. So worker-runtime.ts:71 was a redundant second sanitize.
2. **Nothing dispatches/authorizes by the underscored spec name** — executor's `call.tool` is the dotted `spec.name`; policy sees dotted; no production consumer keys on `message_send`/`engagement_open`/`grep_search` (grep-confirmed absent); `web_search`/`child_agent` have no dots so are unaffected.

## Removed / kept
- **Removed** `bridge.ts` sanitizeToolName (26-28) + use (:60) — AgentDef keeps dotted spec names.
- **Removed** `worker-runtime.ts:71` `.replace(/\./g,"_")` — exposed specs stay dotted (kept `expandRequestedToolNames`, the tolerant request matcher).
- **Simplified** `turn.ts resolvePolicyToolName` — dropped the now-dead `_`→`.` recovery leg; kept the `tool:` canonical-label redirect (still needed for MCP/aliased tools).

## Wins
- **Single sanitize boundary** — the exact over-lapping-mechanism slop this campaign has been killing, resolved.
- **Transcript consistency** — recorded `Message.ToolPart.tool` is now `message.send` on the prod path too (the pre-existing audit-tier wrinkle where a pre-underscored spec recorded `message_send` is fixed).
- **Harness honesty** — added a comment in the E2E harness that it feeds dotted specs exactly as prod's `buildAgentDefFromEntries` now does, sanitize point = the llm wire — so the earlier harness-gap misdiagnosis can't recur.

## Verification
build + check-types 16/16 + full turbo test 16/16, all lint/dep/cycle/dead-export/coverage gates + self-tests, p2-ledger-baseline, channels standalone, E2E harness stub (live cleanly skipped). Adjusted tests: worker-runtime/worker-runner-descriptor assert dotted exposed names; lifecycle-turn-pre retargeted to the dotted name the boundary actually dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates tool-name sanitization to the `@openomni/llm` wire boundary. Previously server code also underscored names; now internal and `AgentDef` tool names remain dotted end-to-end, and only the provider wire coerces `.`→`_` and maps back. This removes drift and makes transcripts, policy, and dispatch consistent.

- Removed server-side sanitization in `bridge.ts` and `worker-runtime.ts`; exposed tools and `AgentDef` keep dotted names.
- Kept tolerant requests: `expandRequestedToolNames` matches underscored requests to dotted catalog entries, but exposed names stay dotted.
- Simplified `resolvePolicyToolName` in `turn.ts`: dropped `_`→`.` recovery; still honors `tool:` canonical labels for MCP/aliased tools.
- Updated tests and added an `@openomni/llm` run-path test to assert recorded tool calls use dotted names even when the provider echoes wire-safe names.

- Rollout: No migration required. If any downstream code keyed on underscored names, switch to dotted names; provider SDKs still receive sanitized names via `@openomni/llm`.

<sup>Written for commit 4f5beb5aa126136362726a44cdf2938f17c6f9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

