### PR TITLE
feat(agent,llm): mid-turn steering — injection-pending yield at step boundaries

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -68,6 +68,7 @@ adds the one-line re-export in the same PR that imports it.
 | `budget?`        | `AgentBudget`                            | Max turns / tool calls / wall time / tool runtime (use `-1` for unlimited)  |
 | `toolExecutor?`  | `(call: Tool.Call, context?: Tool.ExecutionContext) => Promise<Tool.Result>` | Custom tool executor; wrapped by `createToolExecutor` |
 | `signal?`        | `AbortSignal`                            | External cancellation                                                       |
+| `steeringPending?` | `() => boolean`                        | Mid-turn steering signal (#751): loop-native stop-condition port in the same class as `signal` and the window yield — a wake-up check the step loop reads at step boundaries, NEVER a judgment surface. The behavioral decision (what to inject, whether to continue) flows exclusively through the `run.turn.post` policy point; the policy plane cannot evaluate inside the llm step loop by ring design (llm imports no policy engine), so a signal port is the only honest shape |
 | `middleware?`    | `PolicyEngineRegistration[]`             | Caller-owned canonical point registrations; legacy timing shapes are REJECTED fail-closed at registration (#530, typed `legacy_timing_registration`) |
 | `providerOptions?` | `Record<string, unknown>`              | Forwarded to the underlying provider SDK                                    |
 

--- a/packages/agent/src/core/execution/run.ts
+++ b/packages/agent/src/core/execution/run.ts
@@ -21,6 +21,7 @@ import {
 } from "./lifecycle-dispatch";
 import {
   createRunState,
+  recordRunAttempt,
   recordRunWindow,
   nonEmptyString,
   requireTrace,
@@ -102,6 +103,10 @@ export async function runAgent(
   try {
     for (;;) {
       try {
+        // Attempt identity for lifecycle policies (#694 observation material):
+        // stamped before any dispatch of this attempt, so run.turn.pre can
+        // pair it with turnIndex to tell a retry re-entry from progress.
+        recordRunAttempt(state, attempt);
         const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
           config.model,
         );

--- a/packages/agent/src/core/execution/state.ts
+++ b/packages/agent/src/core/execution/state.ts
@@ -132,6 +132,13 @@ export interface RunState {
   turnIndex: number;
   /** The last `turnIndex` charged to the budget; -1 before the first turn. */
   chargedTurnIndex: number;
+  /**
+   * The current retry attempt (1-based), stamped by the runner at each
+   * attempt's start. Together with `turnIndex` it gives lifecycle policies an
+   * attempt-scoped identity: the same turnIndex under a higher attempt is a
+   * retry re-entry, never progress (#694 observation material).
+   */
+  attempt: number;
   readonly startTime: number;
 }
 
@@ -151,6 +158,12 @@ export interface TurnArtifacts {
   readonly stepCap: number;
   /** Whether the window-yield knob was armed (a known window existed). */
   readonly windowYieldArmed: boolean;
+  /**
+   * Set when the host steering check fired at a step boundary (#751) — the
+   * yield disambiguator: a tool-calls stop below the step cap with this set
+   * is a steering yield, not a cap end or a window yield.
+   */
+  readonly steering: { requested: boolean };
 }
 
 export type BuildTurnResult =
@@ -193,8 +206,14 @@ export function createRunState(input: ChatAgentInput & { traceContext: RunTrace 
     compactionCount: 0,
     turnIndex: 0,
     chargedTurnIndex: -1,
+    attempt: 1,
     startTime: Date.now(),
   };
+}
+
+/** Stamps the runner's current retry attempt onto the run state (1-based). */
+export function recordRunAttempt(state: RunState, attempt: number): void {
+  state.attempt = attempt;
 }
 
 export function getCompactionCount(state: RunState): number | undefined {
@@ -303,6 +322,7 @@ export function buildLifecyclePolicyContext<
     steps: state.steps,
     usage: state.totalUsage,
     turnCount: state.budgetState.turns,
+    attempt: state.attempt,
     isCompletion: false,
     continuationCount: state.continuationCount,
     elapsedMs,

--- a/packages/agent/src/core/execution/turn.ts
+++ b/packages/agent/src/core/execution/turn.ts
@@ -259,6 +259,11 @@ export async function buildTurn(
       : Math.floor(state.contextWindowTokens * DEFAULT_THRESHOLD_RATIO);
   const turnAssistant: TurnArtifacts["turnAssistant"] = {};
   const trackingSink = createTrackingSink(state, sink, turnUsage, turnAssistant);
+  // Steering (#751): the host check is wrapped so the turn records WHY the
+  // loop stopped — without the flag, a steering yield below the step cap is
+  // indistinguishable from a cap end and would terminate as "max-steps".
+  const steering: TurnArtifacts["steering"] = { requested: false };
+  const steeringPending = config.steeringPending;
 
   return {
     type: "ready",
@@ -287,6 +292,15 @@ export async function buildTurn(
         // below gets its chance on every path — Resident and tool loops
         // included, not just injected continuations (#649 reachability map).
         ...(yieldAtInputTokens === undefined ? {} : { yieldAtInputTokens }),
+        ...(steeringPending === undefined
+          ? {}
+          : {
+              shouldYield: () => {
+                if (!steeringPending()) return false;
+                steering.requested = true;
+                return true;
+              },
+            }),
         providerOptions: config.providerOptions,
         trace: { traceId: trace.traceId, sessionId: trace.sessionId, runId: trace.runId },
       },
@@ -295,6 +309,7 @@ export async function buildTurn(
       turnUsage,
       stepCap,
       windowYieldArmed: yieldAtInputTokens !== undefined,
+      steering,
       toolPolicyDecisions,
     },
   };
@@ -392,7 +407,7 @@ export type StopOutcome = AgentResult | "continue";
 function turnYield(
   turn: TurnArtifacts,
   assistantMessage: Message.WithParts,
-): "window" | "steps" | null {
+): "window" | "steps" | "steer" | null {
   let steps = 0;
   let lastReason: string | undefined;
   for (const part of assistantMessage.parts) {
@@ -403,6 +418,11 @@ function turnYield(
   }
   if (lastReason !== "tool-calls") return null;
   if (steps >= turn.stepCap) return "steps";
+  // The cap outranks steering: a turn that spent its whole step budget ended
+  // on the cap even if the steering check also fired — "max-steps" stays the
+  // honest terminal. Steering outranks the window: the pending message should
+  // reach the model next turn; a still-full window re-arms and yields again.
+  if (turn.steering.requested) return "steer";
   return turn.windowYieldArmed ? "window" : "steps";
 }
 
@@ -490,6 +510,16 @@ export async function handleStop(
   // the drained messages (#651 review BLOCKER — a child finishing during a
   // long parent tool loop enqueues exactly there).
   const yielded = turnYield(turn, assistantMessage);
+  if (yielded === "steer") {
+    // A steering yield whose pending injection already drained took the
+    // continuation branch above. Reaching here means nothing arrived (the
+    // host check outpaced the queue, or the message drained elsewhere): the
+    // turn ended early on purpose, so the only honest move is another turn —
+    // ending as "max-steps" would report a cap that never applied. A host
+    // that never clears its pending signal is bounded by the budget check.
+    advanceRunTurn(state);
+    return "continue";
+  }
   if (yielded === "window") {
     const compactionsBefore = state.compactionCount;
     const blocked = await applyPostCompaction(state, engine, config, agentBase, false, true);

--- a/packages/agent/src/core/policy/types.ts
+++ b/packages/agent/src/core/policy/types.ts
@@ -28,7 +28,8 @@ export interface PolicyContext extends GenericPolicyContext {
   attempt?: number;
   /**
    * The run's turn index, stable across retries of the same turn (charging
-   * is idempotent per index). Supplied on run.turn.pre / prompt.context.pre.
+   * is idempotent per index). Supplied on run.turn.pre / run.turn.post /
+   * prompt.context.pre.
    */
   turnIndex?: number;
   isCompletion: boolean;

--- a/packages/agent/src/core/policy/types.ts
+++ b/packages/agent/src/core/policy/types.ts
@@ -18,6 +18,19 @@ export interface PolicyContext extends GenericPolicyContext {
   steps: AgentStep[];
   usage: TokenUsage;
   turnCount: number;
+  /**
+   * The runner's current retry attempt (1-based). With `turnIndex` this is
+   * the attempt-scoped progress identity #694 asked for: the same turnIndex
+   * under a higher attempt is a retry re-entry of the same turn, never
+   * progress — `turnCount` alone cannot distinguish the two because the
+   * charge lands after the run.turn.pre dispatch.
+   */
+  attempt?: number;
+  /**
+   * The run's turn index, stable across retries of the same turn (charging
+   * is idempotent per index). Supplied on run.turn.pre / prompt.context.pre.
+   */
+  turnIndex?: number;
   isCompletion: boolean;
   continuationCount: number;
   elapsedMs: number;

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -28,6 +28,16 @@ export interface ChatAgentConfig {
   auth?: RunInput["auth"];
   allowAuthFallback?: RunInput["allowAuthFallback"];
   toolChoice?: "auto" | "required" | "none";
+  /**
+   * Mid-turn steering port (#751): returns true while a host-side injection
+   * is pending for this run. The loop checks it at step boundaries; when it
+   * fires, the turn ends early so the pending message can enter history
+   * through the existing `run.turn.post` continuation drain — the same seam
+   * the injection queue already uses. Absent = turns never yield for
+   * steering. A host that never clears its pending signal costs one model
+   * step per turn until a budget bound ends the run — never an infinite loop.
+   */
+  steeringPending?: () => boolean;
   middleware?: PolicyEngineRegistration[];
   llm?: {
     run?: (input: RunInput, sink: Sink) => Promise<import("@openomni/llm").Run.Outcome>;

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -63,6 +63,7 @@ function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtifacts {
     toolPolicyDecisions: [],
     stepCap: 24,
     windowYieldArmed: false,
+    steering: { requested: false },
     ...overrides,
   };
 }

--- a/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
+++ b/packages/agent/test/core/execution/lifecycle-dispatch-fixture.ts
@@ -55,6 +55,7 @@ export function makeTurnArtifacts(overrides?: Partial<TurnArtifacts>): TurnArtif
     toolPolicyDecisions: [],
     stepCap: 24,
     windowYieldArmed: false,
+    steering: { requested: false },
     ...overrides,
   };
 }

--- a/packages/agent/test/core/execution/turn-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-provenance.test.ts
@@ -40,6 +40,7 @@ function makeTurnArtifacts(): TurnArtifacts {
     toolPolicyDecisions: [],
     stepCap: 24,
     windowYieldArmed: false,
+    steering: { requested: false },
   };
 }
 

--- a/packages/agent/test/core/execution/turn-yield.test.ts
+++ b/packages/agent/test/core/execution/turn-yield.test.ts
@@ -186,6 +186,89 @@ describe("window yield (#649 reachability fix)", () => {
     expect(state.compactionCount).toBe(1);
   });
 
+  it("continues on a steering yield with no drained continuation — never max-steps (#751)", async () => {
+    const state = makeState();
+    state.messages = [userMessage("u0")];
+    const engine = PolicyEngine.create();
+    const turn = makeTurnArtifacts({
+      windowYieldArmed: false,
+      stepCap: 24,
+      steering: { requested: true },
+      turnAssistant: { message: assistantWithSteps(["tool-calls"]) },
+    });
+    const turnBefore = state.turnIndex;
+
+    const outcome = await handleStop(state, makeConfig(), engine, makeAgentBase(), turn);
+
+    expect(outcome).toBe("continue");
+    expect(state.turnIndex).toBe(turnBefore + 1);
+    expect(state.compactionCount).toBe(0);
+  });
+
+  it("routes a steering yield's drained injection through the continuation path (#751)", async () => {
+    const state = makeState();
+    state.messages = [userMessage("u0")];
+    const engine = PolicyEngine.create();
+    engine.register({
+      kind: "point",
+      name: "test-steer-drain",
+      pointIds: ["run.turn.post"],
+      effectCapabilities: { "run.turn.post": ["prompt.inject_message"] },
+      priority: 100,
+      fn: () => inject("steer me"),
+    });
+    const turn = makeTurnArtifacts({
+      windowYieldArmed: false,
+      stepCap: 24,
+      steering: { requested: true },
+      turnAssistant: { message: assistantWithSteps(["tool-calls"]) },
+    });
+
+    const outcome = await handleStop(state, makeConfig(), engine, makeAgentBase(), turn);
+
+    expect(outcome).toBe("continue");
+    const texts = state.messages.flatMap((message) =>
+      message.parts.filter((part) => part.type === "text").map((part) => part.text),
+    );
+    expect(texts).toContain("steer me");
+  });
+
+  it("keeps the step cap's honest terminal even when steering also fired (#751)", async () => {
+    const state = makeState();
+    state.messages = [userMessage("u0")];
+    const engine = PolicyEngine.create();
+    const turn = makeTurnArtifacts({
+      windowYieldArmed: false,
+      stepCap: 2,
+      steering: { requested: true },
+      turnAssistant: { message: assistantWithSteps(["tool-calls", "tool-calls"]) },
+    });
+
+    const outcome = await handleStop(state, makeConfig(), engine, makeAgentBase(), turn);
+
+    if (outcome === "continue") throw new Error("expected a terminal result");
+    expect(outcome.finishReason).toBe("max-steps");
+  });
+
+  it("prefers steering over the window yield — the pending message reaches the model next turn (#751)", async () => {
+    const state = makeState();
+    state.messages = [userMessage("u0")];
+    // A registered compaction seam would record a compaction on the window
+    // path; the steer path must skip it (compactionCount stays 0).
+    const engine = seamEngine(() => replaceMessages([userMessage("compacted")]));
+    const turn = makeTurnArtifacts({
+      windowYieldArmed: true,
+      stepCap: 24,
+      steering: { requested: true },
+      turnAssistant: { message: assistantWithSteps(["tool-calls"]) },
+    });
+
+    const outcome = await handleStop(state, makeConfig(), engine, makeAgentBase(), turn);
+
+    expect(outcome).toBe("continue");
+    expect(state.compactionCount).toBe(0);
+  });
+
   it("still terminates on an abort-carrying deny before the yield gets a say", async () => {
     // Re-review observation: the reordering lets a plain (non-abort) deny on a
     // yielded turn fall through to the yield's continue. Abort-denies must

--- a/packages/agent/test/core/steering.test.ts
+++ b/packages/agent/test/core/steering.test.ts
@@ -1,0 +1,226 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+import type { Sink } from "@openomni/llm";
+import type { Message } from "@openomni/protocol";
+import {
+  createMockLlmConfig,
+  createStopOutcome,
+  mockProviderData,
+  mockProviderModel,
+  type MockLlmFn,
+} from "../helpers/mock-llm";
+import { runInput } from "../helpers/run-input";
+import { allow, inject } from "../helpers/policy-decision";
+import { Bus } from "@openomni/telemetry";
+
+let mockRunFn: MockLlmFn = async () => createStopOutcome();
+
+const mockLlm = createMockLlmConfig({
+  getModels: mock(async () => mockProviderData),
+  fromModelsDevModel: mock(() => mockProviderModel),
+  run: (input, sink: Sink) => mockRunFn(input, sink),
+});
+
+let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+
+beforeAll(async () => {
+  ({ ChatAgent } = await import("../../src/core/chat-agent"));
+});
+
+const baseConfig = {
+  events: Bus,
+  model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
+  llm: mockLlm,
+};
+
+function assistantSnapshot(
+  id: string,
+  text: string,
+  stepReason: "tool-calls" | "stop",
+): Message.WithParts {
+  return {
+    info: {
+      id,
+      sessionID: "test",
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: "claude-3-haiku-20240307",
+      providerID: "anthropic",
+      agent: "test",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      { id: `${id}-t`, sessionID: "test", messageID: id, type: "text", text },
+      {
+        id: `${id}-s`,
+        sessionID: "test",
+        messageID: id,
+        type: "step-finish",
+        reason: stepReason,
+        cost: 0,
+        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+    ],
+  };
+}
+
+function textsOf(messages: readonly unknown[]): string[] {
+  return (messages as Message.WithParts[]).flatMap((message) =>
+    message.parts
+      .filter((part): part is Message.TextPart => part.type === "text")
+      .map((part) => part.text),
+  );
+}
+
+describe("mid-turn steering (#751)", () => {
+  it("yields at the step boundary and the drained injection reaches the next model call", async () => {
+    // The host side of the seam, simulated: a pending mid-turn message that
+    // the run.turn.post drain converts into a continuation (the same shape
+    // the production injection queue uses) and then clears.
+    let pending = true;
+    const llmCalls: Array<{ sawYield: boolean | undefined; texts: string[] }> = [];
+
+    mockRunFn = async (input, sink) => {
+      const call = llmCalls.length;
+      if (call === 0) {
+        // Mid tool-loop: the SDK evaluates the stop conditions at the step
+        // boundary — the mock mimics exactly that one evaluation.
+        const sawYield = input.shouldYield?.();
+        llmCalls.push({ sawYield, texts: textsOf(input.messages ?? []) });
+        sink.onMessage(assistantSnapshot("msg-steer-1", "working on it", "tool-calls"));
+        return createStopOutcome();
+      }
+      llmCalls.push({ sawYield: input.shouldYield?.(), texts: textsOf(input.messages ?? []) });
+      sink.onMessage(assistantSnapshot("msg-steer-2", "done", "stop"));
+      return createStopOutcome();
+    };
+
+    const result = await ChatAgent.create({
+      ...baseConfig,
+      steeringPending: () => pending,
+      middleware: [
+        {
+          kind: "point",
+          name: "test-steering-drain",
+          pointIds: ["run.turn.post"],
+          effectCapabilities: { "run.turn.post": ["prompt.inject_message"] },
+          priority: 100,
+          fn: () => {
+            if (!pending) return allow("test.steering-drain");
+            pending = false;
+            return inject("urgent user note");
+          },
+        },
+      ],
+    }).run(runInput([{ role: "user", content: "start" }]));
+
+    expect(result.finishReason).toBe("stop");
+    expect(result.text).toBe("done");
+    expect(llmCalls).toHaveLength(2);
+    expect(llmCalls[0]?.sawYield).toBe(true);
+    // The steered-in message is model input on the very next call.
+    expect(llmCalls[1]?.texts).toContain("urgent user note");
+    // Cleared pending: the second turn's check must not re-fire.
+    expect(llmCalls[1]?.sawYield).toBe(false);
+  });
+
+  it("continues past a steering yield even when nothing drains — never max-steps", async () => {
+    let pending = true;
+    let calls = 0;
+
+    mockRunFn = async (input, sink) => {
+      calls += 1;
+      if (calls === 1) {
+        input.shouldYield?.();
+        // The "pending" signal clears without producing a continuation (the
+        // message drained elsewhere) — the race the steer arm exists for.
+        pending = false;
+        sink.onMessage(assistantSnapshot("msg-race-1", "mid work", "tool-calls"));
+        return createStopOutcome();
+      }
+      sink.onMessage(assistantSnapshot("msg-race-2", "finished", "stop"));
+      return createStopOutcome();
+    };
+
+    const result = await ChatAgent.create({
+      ...baseConfig,
+      steeringPending: () => pending,
+    }).run(runInput([{ role: "user", content: "start" }]));
+
+    expect(result.finishReason).toBe("stop");
+    expect(result.text).toBe("finished");
+    expect(calls).toBe(2);
+  });
+
+  it("passes no shouldYield to the llm when steering is not configured", async () => {
+    let sawShouldYield: unknown = "unset";
+    mockRunFn = async (input, sink) => {
+      sawShouldYield = input.shouldYield;
+      sink.onMessage(assistantSnapshot("msg-none", "plain", "stop"));
+      return createStopOutcome();
+    };
+
+    const result = await ChatAgent.create(baseConfig).run(
+      runInput([{ role: "user", content: "start" }]),
+    );
+
+    expect(result.finishReason).toBe("stop");
+    expect(sawShouldYield).toBeUndefined();
+  });
+});
+
+describe("attempt identity in lifecycle policy context (#694 material)", () => {
+  it("run.turn.pre observes the same turnIndex under an advancing attempt on retry", async () => {
+    const observed: Array<{ attempt: unknown; turnIndex: unknown }> = [];
+    let calls = 0;
+
+    mockRunFn = async (_input, sink) => {
+      calls += 1;
+      if (calls === 1) {
+        // A retryable transient failure: the runner re-enters the SAME turn.
+        return { type: "error", error: { message: "transient blip", name: "Error" } };
+      }
+      sink.onMessage(assistantSnapshot("msg-retry", "recovered", "stop"));
+      return createStopOutcome();
+    };
+
+    const result = await ChatAgent.create({
+      ...baseConfig,
+      middleware: [
+        {
+          kind: "point",
+          name: "test-attempt-capture",
+          pointIds: ["run.turn.pre"],
+          // Observe-only: the engine refuses empty capability maps, so the
+          // narrowest declarable effect stands in.
+          effectCapabilities: { "run.turn.pre": ["audit.annotate"] },
+          priority: 100,
+          fn: (ctx) => {
+            observed.push({ attempt: ctx.attempt, turnIndex: ctx.turnIndex });
+            return allow("test.attempt-capture");
+          },
+        },
+        {
+          // Zero backoff so the retry is immediate — the test pins identity,
+          // not the schedule.
+          kind: "point",
+          name: "test-zero-backoff",
+          pointIds: ["run.error.error"],
+          effectCapabilities: { "run.error.error": ["run.retry_after"] },
+          priority: 100,
+          fn: () =>
+            allow("test.zero-backoff", undefined, [{ type: "run.retry_after", delayMs: 0 }]),
+        },
+      ],
+    }).run(runInput([{ role: "user", content: "start" }]));
+
+    expect(result.finishReason).toBe("stop");
+    expect(observed).toHaveLength(2);
+    expect(observed[0]).toEqual({ attempt: 1, turnIndex: 0 });
+    // Retry re-entry of the SAME turn: turnIndex holds, attempt advances —
+    // the pair a stall guard needs to stop misreading retries as progress.
+    expect(observed[1]).toEqual({ attempt: 2, turnIndex: 0 });
+  });
+});

--- a/packages/agent/test/helpers/mock-llm.ts
+++ b/packages/agent/test/helpers/mock-llm.ts
@@ -6,6 +6,8 @@ type MockLlmInput = {
   readonly maxSteps?: number;
   readonly signal?: ChatAgentConfig["signal"];
   readonly toolExecutor?: ChatAgentConfig["toolExecutor"];
+  /** The steering stop condition the loop passes when config.steeringPending is set (#751). */
+  readonly shouldYield?: () => boolean;
 };
 
 export type MockLlmFn = (input: MockLlmInput, sink: Sink) => Promise<Run.Outcome>;

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -35,6 +35,14 @@ export interface RunInput {
    * compact history at its deterministic seam and re-enter. Absent = never.
    */
   yieldAtInputTokens?: number;
+  /**
+   * Step-boundary steering yield (#751): stop the step loop at the next step
+   * boundary while this host-injected check returns true — e.g. a mid-turn
+   * injection is pending for the run. Evaluated beside the step cap and the
+   * window yield, so the loop still ends gracefully: tool pairs complete and
+   * the message finishes with the model's own finishReason. Absent = never.
+   */
+  shouldYield?: () => boolean;
   providerOptions?: Record<string, unknown>;
   /**
    * The run this call belongs to. Required, and not defaulted: a model round
@@ -220,6 +228,8 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
       (sdkTools[lastToolName] as Record<string, unknown>).providerOptions = cacheOptions;
     }
 
+    // Narrowed once so the stopWhen closure below carries a stable reference.
+    const shouldYield = input.shouldYield;
     const streamArgs = {
       model: languageModel,
       messages: [...systemMessages, ...normalizedMessages],
@@ -235,6 +245,7 @@ export async function run(input: RunInput, sink: Sink): Promise<Run.Outcome> {
                 (steps[steps.length - 1]?.usage?.inputTokens ?? 0) >=
                 (input.yieldAtInputTokens as number),
             ]),
+        ...(shouldYield === undefined ? [] : [() => shouldYield()]),
       ],
       onError: ({ error }: { error: unknown }) => {
         input.events.publish(Operational.Events.Error, {

--- a/packages/llm/test/run-stream-args.test.ts
+++ b/packages/llm/test/run-stream-args.test.ts
@@ -164,6 +164,67 @@ describe("run() streamText arguments", () => {
     expect(windowYield({ steps: [] })).toBe(false);
   });
 
+  test("arms a steering condition only when shouldYield is set (#751)", async () => {
+    let pending = false;
+    await run(
+      {
+        trace: TEST_TRACE,
+        events: Bus,
+        messages: [],
+        tools: [],
+        maxSteps: 24,
+        shouldYield: () => pending,
+        model: {
+          id: "claude-3-haiku",
+          providerID: TEST_PROVIDER_ID,
+          name: "Claude 3 Haiku Test",
+          api: { npm: "@ai-sdk/anthropic" },
+        },
+        auth: { type: "api", key: "test-key-run" },
+      },
+      mockSink,
+    );
+
+    const streamArgs = aiCapture.__openomniAiStreamArgs as { stopWhen?: unknown };
+    const conditions = streamArgs.stopWhen as Array<(input: { steps: unknown[] }) => boolean>;
+    expect(conditions).toBeArrayOfSize(2);
+    const steering = conditions[1] as () => boolean;
+    // Live check, not a construction-time snapshot: the host flips it while
+    // the step loop runs, and the next step boundary must see the flip.
+    expect(steering()).toBe(false);
+    pending = true;
+    expect(steering()).toBe(true);
+    pending = false;
+    expect(steering()).toBe(false);
+  });
+
+  test("orders steering after the window yield when both are set", async () => {
+    await run(
+      {
+        trace: TEST_TRACE,
+        events: Bus,
+        messages: [],
+        tools: [],
+        maxSteps: 24,
+        yieldAtInputTokens: 800,
+        shouldYield: () => true,
+        model: {
+          id: "claude-3-haiku",
+          providerID: TEST_PROVIDER_ID,
+          name: "Claude 3 Haiku Test",
+          api: { npm: "@ai-sdk/anthropic" },
+        },
+        auth: { type: "api", key: "test-key-run" },
+      },
+      mockSink,
+    );
+
+    const streamArgs = aiCapture.__openomniAiStreamArgs as { stopWhen?: unknown };
+    const conditions = streamArgs.stopWhen as Array<(input: { steps: unknown[] }) => boolean>;
+    expect(conditions).toBeArrayOfSize(3);
+    expect((conditions[2] as () => boolean)()).toBe(true);
+  });
+
   test("passes providerOptions as the nested streamText key, never a top-level spread", async () => {
     // Regression (#audit M1): providerOptions used to be spread into the
     // top-level streamText args. The AI SDK reads provider namespaces from


### PR DESCRIPTION
Closes #751. Loop-only per the issue scope: **no `packages/openomni` / `apps/server` change** — production wiring is one optional port the host passes later.

## What

A user message that arrives while a turn's tool loop is still running now reaches the model at the **next step boundary** instead of waiting for the whole turn to settle.

- **llm** — `RunInput.shouldYield?: () => boolean`: a host-injected LIVE check evaluated as the third `stopWhen` member beside the step cap and the window yield. The loop still ends gracefully (tool pairs complete; the message finishes with the model's own finishReason).
- **agent** — `ChatAgentConfig.steeringPending` port. `buildTurn` wraps it so the turn records WHY the loop stopped (`TurnArtifacts.steering`); `turnYield` grows a `"steer"` arm.
  - Precedence: **step cap > steering > window** — the cap's `max-steps` terminal stays honest, and a steering yield below the cap can no longer be misread as a cap end (today that shape terminates the run).
  - A steer-yield whose injection already drained rides the EXISTING `run.turn.post` continuation path (same seam the injection queue uses). One whose signal cleared without draining continues to the next turn.
  - A host that never clears its pending signal costs one model step per turn until a budget bound ends the run — never an infinite loop.
- **#694 observation material** — `RunState.attempt` (stamped per retry attempt) joins `turnIndex` in the lifecycle policy context: `run.turn.pre` observers can now tell a retry re-entry of the same turn from progress (same `turnIndex`, higher `attempt`). Consumption stays #694 scope.

## Tests

- llm `run-stream-args`: steering condition armed only when set; LIVE check (flips mid-loop are seen); ordering with the window yield.
- agent `turn-yield`: steer-continue with no continuation (never `max-steps`), drained-injection routing, cap precedence over steering, steering-over-window skips the compaction seam.
- agent `steering` (end-to-end `ChatAgent.run`): yield → `run.turn.post` drain → injected text is model input on the very next call; race variant; `shouldYield` absent when unconfigured; attempt/turnIndex identity across a zero-backoff retry.

## Gates

`bun run test` (16/16 tasks), `check-types` (incl. test tsconfigs), `lint`, `check-deps`, `lint:guards`, `check-dead-exports`, `check-import-cycles`, `lint:tools` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers mid-turn steering so a user message arriving during a tool loop reaches the model at the next step boundary instead of waiting for the turn to finish. Previously the loop ran to completion; now the loop can yield early without breaking tool pairs or finish reasons.

- `packages/llm`: adds `RunInput.shouldYield?: () => boolean` as a live stop condition, ordered after the window yield and alongside the step cap.
- `packages/agent`: adds `ChatAgentConfig.steeringPending?: () => boolean` (documented as a stop-condition signal, not an extension surface). `buildTurn` records `TurnArtifacts.steering.requested`; `turnYield` adds a "steer" outcome. Precedence: step cap > steering > window. A steer yield with a drained injection uses the existing `run.turn.post` continuation path; if nothing drains, the run advances to the next turn.
- Lifecycle: the runner stamps `RunState.attempt` per retry and exposes `attempt` and `turnIndex` on `run.turn.pre`, `run.turn.post`, and `prompt.context.pre` so policies can distinguish retry re-entry from progress.

Adoption
- Default behavior is unchanged. To enable steering, provide `steeringPending`, drain pending injections in `run.turn.post`, and clear the pending signal; otherwise the run yields one step per turn until budget bounds end it.

<sup>Written for commit a701837bb8851d02635774e759ca090acdadcbbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mid-turn steering, allowing queued host messages to be processed promptly without waiting for the entire turn to finish.
  - Steering continues cleanly on a new turn while preserving pending messages.
  - Added optional controls for detecting pending steering and stopping generation at safe step boundaries.
  - Retry attempts and turn progress are now tracked more consistently for lifecycle and policy handling.

- **Tests**
  - Added coverage for steering, retry tracking, message delivery, and stop-condition priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->