### PR TITLE
feat(protocol,policy,agent): model.override policy effect — per-point model routing

### DIFF
--- a/packages/agent/src/core/execution/lifecycle-dispatch.ts
+++ b/packages/agent/src/core/execution/lifecycle-dispatch.ts
@@ -1,4 +1,5 @@
 import type { Run } from "@openomni/llm";
+import type { Model } from "@openomni/protocol";
 import { PolicyDecision } from "@openomni/protocol";
 import { effectOf, PolicyEffectApplier } from "./effects";
 import { publishBudgetTelemetry } from "../budget";
@@ -77,6 +78,18 @@ type ModelResponseFacts = {
   readonly responseTokens: number;
 };
 
+/**
+ * The connection gate's verdict: `blocked` carries a terminal result when the
+ * policy denied the connection; `overrideModel` carries a `model.override`
+ * effect (#753) — the model THIS connection must call instead of the
+ * per-attempt selection. Connection-scoped by the effect's definition: the
+ * next connection re-resolves normally.
+ */
+export type ModelRequestGate = {
+  readonly blocked: AgentResult | null;
+  readonly overrideModel?: Model.Ref;
+};
+
 export async function dispatchModelRequest(
   state: RunState,
   engine: PolicyEngineInstance,
@@ -86,15 +99,21 @@ export async function dispatchModelRequest(
   // fallback switch, `config.model.id` names the primary, and a per-model
   // policy would judge the wrong model.
   modelId: string,
-): Promise<AgentResult | null> {
+): Promise<ModelRequestGate> {
   const decision = await engine.dispatchPoint(
     "connection.llm.pre",
     buildLifecyclePolicyContext(state, config, agentBase, { modelId }),
   );
 
-  if (PolicyDecision.isBlocking(decision)) return guardAbortedResult(state);
+  if (PolicyDecision.isBlocking(decision)) return { blocked: guardAbortedResult(state) };
   PolicyEffectApplier.applyPromptMessageEffects(state, decision);
-  return null;
+  const override = effectOf(decision, "model.override");
+  return {
+    blocked: null,
+    ...(override === undefined
+      ? {}
+      : { overrideModel: { provider: override.provider, id: override.id } }),
+  };
 }
 
 export async function dispatchModelResponse(

--- a/packages/agent/src/core/execution/run.ts
+++ b/packages/agent/src/core/execution/run.ts
@@ -10,6 +10,7 @@ import {
 import { ModelsDev, Provider, run as llmRun } from "@openomni/llm";
 import type { Sink } from "@openomni/llm";
 import { Placement } from "@openomni/placement";
+import { DEFAULT_THRESHOLD_RATIO } from "../../compaction/compact";
 import type { AgentResult, ChatAgentConfig, ChatAgentInput } from "../types";
 import * as Retry from "../retry";
 import { PolicyEngine, type PolicyEngineInstance } from "../policy";
@@ -172,15 +173,46 @@ export async function runAgent(
           if (turnResult.type === "complete") return finish(turnResult.result);
 
           const runLlm = config.llm?.run ?? llmRun;
-          const modelRequestResult = await dispatchModelRequest(
+          const gate = await dispatchModelRequest(
             state,
             engine,
             config,
             agentBase,
             providerModel.id,
           );
-          if (modelRequestResult) return finish(modelRequestResult);
-          const outcome = await runLlm(turnResult.turn.runInput, turnResult.turn.trackingSink);
+          if (gate.blocked) return finish(gate.blocked);
+          // model.override (#753): a connection.llm.pre policy reroutes THIS
+          // connection to a different model — connection-scoped: the next
+          // call re-resolves from the per-attempt selection. The window-yield
+          // arm point is recomputed from the OVERRIDE's window locally; run
+          // state keeps the attempt model's window fact (the next connection
+          // reverts to it), so nothing is re-recorded.
+          let callModel = providerModel;
+          let callRunInput = turnResult.turn.runInput;
+          if (
+            gate.overrideModel !== undefined &&
+            (gate.overrideModel.provider !== attemptModel.provider ||
+              gate.overrideModel.id !== attemptModel.id)
+          ) {
+            callModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
+              gate.overrideModel,
+            );
+            const overrideWindow = callModel.limit?.context ?? 0;
+            const yieldAt =
+              overrideWindow > 0 && state.windowYieldDisarmed !== true
+                ? Math.floor(overrideWindow * DEFAULT_THRESHOLD_RATIO)
+                : undefined;
+            const { yieldAtInputTokens: _priorYield, ...restInput } = turnResult.turn.runInput;
+            callRunInput = {
+              ...restInput,
+              model: callModel,
+              ...(yieldAt === undefined ? {} : { yieldAtInputTokens: yieldAt }),
+            };
+            // turnYield reads this to classify the stop — it must describe
+            // the call that actually ran, not the one buildTurn planned.
+            turnResult.turn.windowYieldArmed = yieldAt !== undefined;
+          }
+          const outcome = await runLlm(callRunInput, turnResult.turn.trackingSink);
           const modelResponseResult = await dispatchModelResponse(
             state,
             engine,
@@ -190,7 +222,7 @@ export async function runAgent(
               responseTokens: turnResult.turn.turnUsage.outputTokens,
             },
             agentBase,
-            providerModel.id,
+            callModel.id,
           );
           if (modelResponseResult) return finish(modelResponseResult);
 

--- a/packages/agent/src/core/execution/state.ts
+++ b/packages/agent/src/core/execution/state.ts
@@ -156,8 +156,13 @@ export interface TurnArtifacts {
   readonly toolPolicyDecisions: Array<{ readonly decision: Policy.PolicyDecision }>;
   /** The step budget this turn was given — a turn that used all of it ended on the cap, not a window yield. */
   readonly stepCap: number;
-  /** Whether the window-yield knob was armed (a known window existed). */
-  readonly windowYieldArmed: boolean;
+  /**
+   * Whether the window-yield knob was armed for the call that actually ran.
+   * Mutable on purpose: a `model.override` (#753) reroutes the connection
+   * after buildTurn planned it, and turnYield must classify the stop against
+   * the call's real arm state, not the plan's.
+   */
+  windowYieldArmed: boolean;
   /**
    * Set when the host steering check fired at a step boundary (#751) — the
    * yield disambiguator: a tool-calls stop below the step cap with this set

--- a/packages/agent/test/core/execution/execution-verdicts-model.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts-model.test.ts
@@ -30,8 +30,8 @@ describe("model execution deny verdicts", () => {
 
     const result = await dispatchModelRequest(makeState(), engine, makeConfig(), makeAgentBase(), "test-model");
 
-    expect(result).not.toBeNull();
-    expect(result?.guardAborted).toBe(true);
+    expect(result.blocked).not.toBeNull();
+    expect(result.blocked?.guardAborted).toBe(true);
     expect(fn).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/agent/test/core/execution/execution-verdicts-model.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts-model.test.ts
@@ -28,7 +28,13 @@ describe("model execution deny verdicts", () => {
       fn,
     });
 
-    const result = await dispatchModelRequest(makeState(), engine, makeConfig(), makeAgentBase(), "test-model");
+    const result = await dispatchModelRequest(
+      makeState(),
+      engine,
+      makeConfig(),
+      makeAgentBase(),
+      "test-model",
+    );
 
     expect(result.blocked).not.toBeNull();
     expect(result.blocked?.guardAborted).toBe(true);

--- a/packages/agent/test/core/execution/lifecycle-model.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-model.test.ts
@@ -26,7 +26,7 @@ describe("model dispatch points", () => {
     const state = makeState();
     const result = await dispatchModelRequest(state, engine, makeConfig(), makeAgentBase(), "test-model");
 
-    expect(result).toBeNull();
+    expect(result.blocked).toBeNull();
     expect(fn).toHaveBeenCalledTimes(1);
     const ctx = fn.mock.calls[0]?.[0] as PolicyContext | undefined;
     expect(ctx?.timing).toBe("model.request");
@@ -79,7 +79,7 @@ describe("model dispatch points", () => {
     const state = makeState();
     const result = await dispatchModelRequest(state, engine, makeConfig(), makeAgentBase(), "test-model");
 
-    expect(result).toBeNull();
+    expect(result.blocked).toBeNull();
     const lastMessage = state.messages[state.messages.length - 1];
     const hasInjection = lastMessage?.parts.some(
       (part) => part.type === "text" && part.text === "pre-llm context",

--- a/packages/agent/test/core/execution/lifecycle-model.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-model.test.ts
@@ -24,7 +24,13 @@ describe("model dispatch points", () => {
     });
 
     const state = makeState();
-    const result = await dispatchModelRequest(state, engine, makeConfig(), makeAgentBase(), "test-model");
+    const result = await dispatchModelRequest(
+      state,
+      engine,
+      makeConfig(),
+      makeAgentBase(),
+      "test-model",
+    );
 
     expect(result.blocked).toBeNull();
     expect(fn).toHaveBeenCalledTimes(1);
@@ -77,7 +83,13 @@ describe("model dispatch points", () => {
     });
 
     const state = makeState();
-    const result = await dispatchModelRequest(state, engine, makeConfig(), makeAgentBase(), "test-model");
+    const result = await dispatchModelRequest(
+      state,
+      engine,
+      makeConfig(),
+      makeAgentBase(),
+      "test-model",
+    );
 
     expect(result.blocked).toBeNull();
     const lastMessage = state.messages[state.messages.length - 1];

--- a/packages/agent/test/core/model-fallback.test.ts
+++ b/packages/agent/test/core/model-fallback.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import type { Sink } from "@openomni/llm";
-import type { Message, Model } from "@openomni/protocol";
+import type { Model } from "@openomni/protocol";
 import { createStopOutcome, type MockLlmFn } from "../helpers/mock-llm";
 import { runInput } from "../helpers/run-input";
+import { assistantSnapshot } from "../helpers/assistant-snapshot";
 import { allow } from "../helpers/policy-decision";
 import { Bus } from "@openomni/telemetry";
 
@@ -14,36 +15,6 @@ beforeAll(async () => {
 
 const primary = { provider: "anthropic", id: "primary-model" };
 const fallback = { provider: "openai", id: "fallback-model" };
-
-function snapshot(id: string, text: string): Message.WithParts {
-  return {
-    info: {
-      id,
-      sessionID: "test",
-      role: "assistant",
-      time: { created: Date.now() },
-      parentID: "",
-      modelID: "m",
-      providerID: "p",
-      agent: "test",
-      path: { cwd: "", root: "" },
-      cost: 0,
-      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-    },
-    parts: [
-      { id: `${id}-t`, sessionID: "test", messageID: id, type: "text", text },
-      {
-        id: `${id}-s`,
-        sessionID: "test",
-        messageID: id,
-        type: "step-finish",
-        reason: "stop",
-        cost: 0,
-        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-      },
-    ],
-  };
-}
 
 /** Zero-backoff retry so the tests pin selection, not the schedule. */
 const zeroBackoff = {
@@ -63,7 +34,7 @@ function fallbackHarness(errorMessage: string) {
     if (calls === 1) {
       return { type: "error", error: { message: errorMessage, name: "Error" } };
     }
-    sink.onMessage(snapshot(`msg-${calls}`, "recovered"));
+    sink.onMessage(assistantSnapshot(`msg-${calls}`, "recovered"));
     return createStopOutcome();
   };
   const llm = {
@@ -176,10 +147,7 @@ describe("model fallback via placement (#752)", () => {
           // Primary turn 1: end mid tool-loop so the WINDOW yield fires; no
           // compaction seam is registered, so the seam reclaims nothing and
           // the loop DISARMS the yield.
-          const message = snapshot("msg-w1", "working");
-          const stepPart = message.parts[1] as { reason: string };
-          stepPart.reason = "tool-calls";
-          sink.onMessage(message);
+          sink.onMessage(assistantSnapshot("msg-w1", "working", "tool-calls"));
           return createStopOutcome();
         }
         if (calls === 2) {
@@ -187,7 +155,7 @@ describe("model fallback via placement (#752)", () => {
           // to the fallback model.
           return { type: "error", error: { message: "transient blip", name: "Error" } };
         }
-        sink.onMessage(snapshot(`msg-w${calls}`, "recovered"));
+        sink.onMessage(assistantSnapshot(`msg-w${calls}`, "recovered"));
         return createStopOutcome();
       }) as MockLlmFn,
       resolveProviderModel: async (model: Model.Ref) => ({

--- a/packages/agent/test/core/model-override.test.ts
+++ b/packages/agent/test/core/model-override.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import type { Sink } from "@openomni/llm";
-import type { Message, Model } from "@openomni/protocol";
+import type { Model } from "@openomni/protocol";
 import { createStopOutcome, type MockLlmFn } from "../helpers/mock-llm";
 import { runInput } from "../helpers/run-input";
+import { assistantSnapshot } from "../helpers/assistant-snapshot";
 import { allow, inject } from "../helpers/policy-decision";
 import { Bus } from "@openomni/telemetry";
 
@@ -14,36 +15,6 @@ beforeAll(async () => {
 
 const primary = { provider: "anthropic", id: "primary-model" };
 const override = { provider: "openai", id: "override-model" };
-
-function snapshot(id: string, text: string): Message.WithParts {
-  return {
-    info: {
-      id,
-      sessionID: "test",
-      role: "assistant",
-      time: { created: Date.now() },
-      parentID: "",
-      modelID: "m",
-      providerID: "p",
-      agent: "test",
-      path: { cwd: "", root: "" },
-      cost: 0,
-      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-    },
-    parts: [
-      { id: `${id}-t`, sessionID: "test", messageID: id, type: "text", text },
-      {
-        id: `${id}-s`,
-        sessionID: "test",
-        messageID: id,
-        type: "step-finish",
-        reason: "stop",
-        cost: 0,
-        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-      },
-    ],
-  };
-}
 
 function overrideOnce() {
   let fired = false;
@@ -84,7 +55,7 @@ function harness(windows: Record<string, number | undefined>) {
   const resolved: Model.Ref[] = [];
   const run: MockLlmFn = async (input, sink: Sink) => {
     calls.push({ modelId: input.model?.id, yieldAt: input.yieldAtInputTokens });
-    sink.onMessage(snapshot(`msg-${calls.length}`, `turn ${calls.length}`));
+    sink.onMessage(assistantSnapshot(`msg-${calls.length}`, `turn ${calls.length}`));
     return createStopOutcome();
   };
   const llm = {

--- a/packages/agent/test/core/model-override.test.ts
+++ b/packages/agent/test/core/model-override.test.ts
@@ -189,6 +189,65 @@ describe("model.override at connection.llm.pre (#753)", () => {
     ]);
   });
 
+  it("fails honestly on an override to a nonexistent model — bounded retries, zero llm calls", async () => {
+    const resolved: string[] = [];
+    let llmCalls = 0;
+    const llm = {
+      run: (async () => {
+        llmCalls += 1;
+        return createStopOutcome();
+      }) as MockLlmFn,
+      resolveProviderModel: async (model: Model.Ref) => {
+        resolved.push(model.id);
+        if (model.id === override.id) {
+          throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
+        }
+        return { id: model.id, name: model.id, providerID: model.provider };
+      },
+    };
+    const persistentOverride = {
+      kind: "point" as const,
+      name: "test-ghost-override",
+      pointIds: ["connection.llm.pre" as const],
+      effectCapabilities: { "connection.llm.pre": ["model.override" as const] },
+      priority: 100,
+      fn: () =>
+        allow("test.ghost-override", undefined, [
+          { type: "model.override", provider: override.provider, id: override.id },
+        ]),
+    };
+    const zeroBackoff = {
+      kind: "point" as const,
+      name: "test-zero-backoff",
+      pointIds: ["run.error.error" as const],
+      effectCapabilities: { "run.error.error": ["run.retry_after" as const] },
+      priority: 100,
+      fn: () => allow("test.zero-backoff", undefined, [{ type: "run.retry_after", delayMs: 0 }]),
+    };
+
+    await expect(
+      ChatAgent.create({
+        events: Bus,
+        model: primary,
+        llm,
+        middleware: [persistentOverride, zeroBackoff],
+      }).run(runInput([{ role: "user", content: "go" }])),
+    ).rejects.toThrow("Model not found");
+
+    // Three attempts (default ceiling), each: attempt model resolves, the
+    // ghost override throws — the model is never called, and with no
+    // fallbacks configured the attempt selection stays the primary (a
+    // policy-caused fault must not silently walk a chain).
+    expect(llmCalls).toBe(0);
+    expect(resolved).toEqual([
+      primary.id,
+      override.id,
+      primary.id,
+      override.id,
+      primary.id,
+      override.id,
+    ]);
+  });
   it("drops the arm point entirely when the override model's window is unknown", async () => {
     const { calls, llm } = harness({ [primary.id]: 1000 });
 

--- a/packages/agent/test/core/model-override.test.ts
+++ b/packages/agent/test/core/model-override.test.ts
@@ -1,0 +1,205 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { Sink } from "@openomni/llm";
+import type { Message, Model } from "@openomni/protocol";
+import { createStopOutcome, type MockLlmFn } from "../helpers/mock-llm";
+import { runInput } from "../helpers/run-input";
+import { allow, inject } from "../helpers/policy-decision";
+import { Bus } from "@openomni/telemetry";
+
+let ChatAgent: typeof import("../../src/core/chat-agent").ChatAgent;
+
+beforeAll(async () => {
+  ({ ChatAgent } = await import("../../src/core/chat-agent"));
+});
+
+const primary = { provider: "anthropic", id: "primary-model" };
+const override = { provider: "openai", id: "override-model" };
+
+function snapshot(id: string, text: string): Message.WithParts {
+  return {
+    info: {
+      id,
+      sessionID: "test",
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: "m",
+      providerID: "p",
+      agent: "test",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      { id: `${id}-t`, sessionID: "test", messageID: id, type: "text", text },
+      {
+        id: `${id}-s`,
+        sessionID: "test",
+        messageID: id,
+        type: "step-finish",
+        reason: "stop",
+        cost: 0,
+        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+    ],
+  };
+}
+
+function overrideOnce() {
+  let fired = false;
+  return {
+    kind: "point" as const,
+    name: "test-model-override",
+    pointIds: ["connection.llm.pre" as const],
+    effectCapabilities: { "connection.llm.pre": ["model.override" as const] },
+    priority: 100,
+    fn: () => {
+      if (fired) return allow("test.model-override");
+      fired = true;
+      return allow("test.model-override", undefined, [
+        { type: "model.override", provider: override.provider, id: override.id },
+      ]);
+    },
+  };
+}
+
+function continueOnce() {
+  let injected = false;
+  return {
+    kind: "point" as const,
+    name: "test-continue-once",
+    pointIds: ["run.turn.post" as const],
+    effectCapabilities: { "run.turn.post": ["prompt.inject_message" as const] },
+    priority: 100,
+    fn: () => {
+      if (injected) return allow("test.continue-once");
+      injected = true;
+      return inject("keep going");
+    },
+  };
+}
+
+function harness(windows: Record<string, number | undefined>) {
+  const calls: Array<{ modelId: string | undefined; yieldAt: number | undefined }> = [];
+  const resolved: Model.Ref[] = [];
+  const run: MockLlmFn = async (input, sink: Sink) => {
+    calls.push({ modelId: input.model?.id, yieldAt: input.yieldAtInputTokens });
+    sink.onMessage(snapshot(`msg-${calls.length}`, `turn ${calls.length}`));
+    return createStopOutcome();
+  };
+  const llm = {
+    run,
+    resolveProviderModel: async (model: Model.Ref) => {
+      resolved.push(model);
+      const context = windows[model.id];
+      return {
+        id: model.id,
+        name: model.id,
+        providerID: model.provider,
+        ...(context === undefined ? {} : { limit: { context, output: 1000 } }),
+      };
+    },
+  };
+  return { calls, resolved, llm };
+}
+
+describe("model.override at connection.llm.pre (#753)", () => {
+  it("reroutes exactly one connection and reverts on the next — connection scope", async () => {
+    const { calls, resolved, llm } = harness({});
+    const observedPostIds: unknown[] = [];
+
+    const result = await ChatAgent.create({
+      events: Bus,
+      model: primary,
+      llm,
+      middleware: [
+        overrideOnce(),
+        continueOnce(),
+        {
+          kind: "point",
+          name: "test-post-capture",
+          pointIds: ["connection.llm.post"],
+          effectCapabilities: { "connection.llm.post": ["audit.annotate"] },
+          priority: 90,
+          fn: (ctx) => {
+            observedPostIds.push(ctx.modelId);
+            return allow("test.post-capture");
+          },
+        },
+      ],
+    }).run(runInput([{ role: "user", content: "go" }]));
+
+    expect(result.finishReason).toBe("stop");
+    // Call 1 ran the override; call 2 (continuation turn) reverted to the
+    // per-attempt selection — the effect is connection-scoped.
+    expect(calls.map((c) => c.modelId)).toEqual([override.id, primary.id]);
+    // connection.llm.post reports the model ACTUALLY called, both times.
+    expect(observedPostIds).toEqual([override.id, primary.id]);
+    // The override resolved through the same seam the attempt resolution uses.
+    expect(resolved).toEqual([primary, override]);
+  });
+
+  it("skips re-resolution when the override names the model already selected", async () => {
+    const { calls, resolved, llm } = harness({});
+    let fired = false;
+
+    const result = await ChatAgent.create({
+      events: Bus,
+      model: primary,
+      llm,
+      middleware: [
+        {
+          kind: "point",
+          name: "test-noop-override",
+          pointIds: ["connection.llm.pre"],
+          effectCapabilities: { "connection.llm.pre": ["model.override"] },
+          priority: 100,
+          fn: () => {
+            if (fired) return allow("test.noop-override");
+            fired = true;
+            return allow("test.noop-override", undefined, [
+              { type: "model.override", provider: primary.provider, id: primary.id },
+            ]);
+          },
+        },
+      ],
+    }).run(runInput([{ role: "user", content: "go" }]));
+
+    expect(result.finishReason).toBe("stop");
+    expect(calls.map((c) => c.modelId)).toEqual([primary.id]);
+    expect(resolved).toEqual([primary]);
+  });
+
+  it("recomputes the window-yield arm point from the override model's window", async () => {
+    const { calls, llm } = harness({ [primary.id]: 1000, [override.id]: 500 });
+
+    const result = await ChatAgent.create({
+      events: Bus,
+      model: primary,
+      llm,
+      middleware: [overrideOnce(), continueOnce()],
+    }).run(runInput([{ role: "user", content: "go" }]));
+
+    expect(result.finishReason).toBe("stop");
+    // Call 1: the override's 500-token window arms at 400 (0.8), not the
+    // primary's 800. Call 2 reverts to the primary's plan.
+    expect(calls).toEqual([
+      { modelId: override.id, yieldAt: 400 },
+      { modelId: primary.id, yieldAt: 800 },
+    ]);
+  });
+
+  it("drops the arm point entirely when the override model's window is unknown", async () => {
+    const { calls, llm } = harness({ [primary.id]: 1000 });
+
+    const result = await ChatAgent.create({
+      events: Bus,
+      model: primary,
+      llm,
+      middleware: [overrideOnce()],
+    }).run(runInput([{ role: "user", content: "go" }]));
+
+    expect(result.finishReason).toBe("stop");
+    expect(calls).toEqual([{ modelId: override.id, yieldAt: undefined }]);
+  });
+});

--- a/packages/agent/test/core/placement-vocabulary.test.ts
+++ b/packages/agent/test/core/placement-vocabulary.test.ts
@@ -19,9 +19,7 @@ const ALL_RETRY_REASONS = [
   "validation_error",
   "context_overflow",
 ] as const satisfies readonly RetryReason[];
-const _everyReasonListed: [Exclude<RetryReason, (typeof ALL_RETRY_REASONS)[number]>] extends [
-  never,
-]
+const _everyReasonListed: [Exclude<RetryReason, (typeof ALL_RETRY_REASONS)[number]>] extends [never]
   ? true
   : never = true;
 void _everyReasonListed;

--- a/packages/agent/test/core/steering.test.ts
+++ b/packages/agent/test/core/steering.test.ts
@@ -9,6 +9,7 @@ import {
   type MockLlmFn,
 } from "../helpers/mock-llm";
 import { runInput } from "../helpers/run-input";
+import { assistantSnapshot } from "../helpers/assistant-snapshot";
 import { allow, inject } from "../helpers/policy-decision";
 import { Bus } from "@openomni/telemetry";
 
@@ -31,40 +32,6 @@ const baseConfig = {
   model: { provider: "anthropic", id: "claude-3-haiku-20240307" },
   llm: mockLlm,
 };
-
-function assistantSnapshot(
-  id: string,
-  text: string,
-  stepReason: "tool-calls" | "stop",
-): Message.WithParts {
-  return {
-    info: {
-      id,
-      sessionID: "test",
-      role: "assistant",
-      time: { created: Date.now() },
-      parentID: "",
-      modelID: "claude-3-haiku-20240307",
-      providerID: "anthropic",
-      agent: "test",
-      path: { cwd: "", root: "" },
-      cost: 0,
-      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-    },
-    parts: [
-      { id: `${id}-t`, sessionID: "test", messageID: id, type: "text", text },
-      {
-        id: `${id}-s`,
-        sessionID: "test",
-        messageID: id,
-        type: "step-finish",
-        reason: stepReason,
-        cost: 0,
-        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-      },
-    ],
-  };
-}
 
 function textsOf(messages: readonly unknown[]): string[] {
   return (messages as Message.WithParts[]).flatMap((message) =>

--- a/packages/agent/test/helpers/assistant-snapshot.ts
+++ b/packages/agent/test/helpers/assistant-snapshot.ts
@@ -1,0 +1,41 @@
+import type { Message } from "@openomni/protocol";
+
+/**
+ * The llm fold's assistant boundary snapshot, minimally shaped for loop
+ * tests: one text part plus one step-finish part. `stepReason` decides how
+ * `turnYield` classifies the turn end ("stop" = the model's own stop,
+ * "tool-calls" = the loop stopped it mid tool-loop).
+ */
+export function assistantSnapshot(
+  id: string,
+  text: string,
+  stepReason: "tool-calls" | "stop" = "stop",
+): Message.WithParts {
+  return {
+    info: {
+      id,
+      sessionID: "test",
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: "m",
+      providerID: "p",
+      agent: "test",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      { id: `${id}-t`, sessionID: "test", messageID: id, type: "text", text },
+      {
+        id: `${id}-s`,
+        sessionID: "test",
+        messageID: id,
+        type: "step-finish",
+        reason: stepReason,
+        cost: 0,
+        tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+    ],
+  };
+}

--- a/packages/agent/test/helpers/mock-llm.ts
+++ b/packages/agent/test/helpers/mock-llm.ts
@@ -10,6 +10,8 @@ type MockLlmInput = {
   readonly shouldYield?: () => boolean;
   /** The window-yield arm point — undefined when the yield is disarmed or the window unknown. */
   readonly yieldAtInputTokens?: number;
+  /** The resolved model this call runs — reflects a model.override (#753) when one fired. */
+  readonly model?: { readonly id: string; readonly providerID: string };
 };
 
 export type MockLlmFn = (input: MockLlmInput, sink: Sink) => Promise<Run.Outcome>;

--- a/packages/policy/src/effects/conflicts.ts
+++ b/packages/policy/src/effects/conflicts.ts
@@ -21,6 +21,7 @@ export function collectPreConflicts(entries: EffectEntry[]): Conflict[] {
       "run.replace_messages",
     ),
     ...collectSingleValueConflicts(entries, "writeback.rewrite", "output", "writeback.rewrite"),
+    ...collectSingleValueConflicts(entries, "model.override", "model", "model.override"),
     ...collectWritebackSuppressConflicts(entries),
     ...collectFilterApprovalConflicts(entries),
   ];
@@ -89,8 +90,9 @@ function collectSingleValueConflicts(
     | "tool.rewrite_output"
     | "run.continue_with_prompt"
     | "run.replace_messages"
-    | "writeback.rewrite",
-  field: "prompt" | "output" | "messages",
+    | "writeback.rewrite"
+    | "model.override",
+  field: "prompt" | "output" | "messages" | "model",
   label: string,
 ): Conflict[] {
   const conflicts: Conflict[] = [];
@@ -125,7 +127,8 @@ function singleValueForEffect(
     | "tool.rewrite_output"
     | "run.continue_with_prompt"
     | "run.replace_messages"
-    | "writeback.rewrite",
+    | "writeback.rewrite"
+    | "model.override",
 ): unknown {
   if (effectType === "prompt.replace" && effect.type === "prompt.replace") return effect.prompt;
   if (effectType === "tool.rewrite_output" && effect.type === "tool.rewrite_output") {
@@ -139,6 +142,12 @@ function singleValueForEffect(
   }
   if (effectType === "writeback.rewrite" && effect.type === "writeback.rewrite") {
     return effect.output;
+  }
+  // Two same-priority policies routing ONE connection to different models is
+  // divergent intent, not composition — the same fail-closed family as
+  // prompt.replace (#757 adversarial review F1). Provider+id hash as one value.
+  if (effectType === "model.override" && effect.type === "model.override") {
+    return { provider: effect.provider, id: effect.id };
   }
   return undefined;
 }

--- a/packages/policy/src/effects/merge/output.ts
+++ b/packages/policy/src/effects/merge/output.ts
@@ -8,6 +8,8 @@ import { approvalEffect, retryEffect } from "./accumulators";
 
 export interface EffectAccumulatorSet {
   readonly promptReplace?: MergedEffect;
+  /** Single-winner model.override (#753) — the priority-selected reroute for the gated connection. */
+  readonly modelOverride?: MergedEffect;
   readonly toolFilters: ReadonlyMap<string, number>;
   readonly toolRewrite?: { readonly input: Record<string, unknown>; readonly order: number };
   readonly toolOutputRewrite?: MergedEffect;
@@ -33,6 +35,7 @@ export function appendMergedEffects(
   accumulators: EffectAccumulatorSet,
 ): void {
   if (accumulators.promptReplace) merged.push(accumulators.promptReplace);
+  if (accumulators.modelOverride) merged.push(accumulators.modelOverride);
   for (const [toolPattern, order] of accumulators.toolFilters) {
     merged.push({ effect: { type: "tool.filter", toolPattern }, order, priority: 0 });
   }

--- a/packages/policy/src/effects/merge/rules.ts
+++ b/packages/policy/src/effects/merge/rules.ts
@@ -31,6 +31,9 @@ export function mergeEntries(entries: readonly EffectEntry[]): MergeResult {
     | undefined;
   let delegationApproval: ApprovalAccumulator | undefined;
   let promptReplace: MergedEffect | undefined;
+  // Single-winner like prompt.replace: two policies overriding the same
+  // connection's model cannot compose — the higher-priority one wins (#753).
+  let modelOverride: MergedEffect | undefined;
   let writebackRewrite: MergedEffect | undefined;
   let writebackSuppress: PriorityApprovalAccumulator | undefined;
   let timeout: { readonly timeoutMs: number; readonly order: number } | undefined;
@@ -50,6 +53,9 @@ export function mergeEntries(entries: readonly EffectEntry[]): MergeResult {
         break;
       case "prompt.replace":
         promptReplace = selectPriorityEffect(promptReplace, entry);
+        break;
+      case "model.override":
+        modelOverride = selectPriorityEffect(modelOverride, entry);
         break;
       case "tool.filter":
         if (!toolFilters.has(effect.toolPattern)) toolFilters.set(effect.toolPattern, entry.order);
@@ -143,6 +149,7 @@ export function mergeEntries(entries: readonly EffectEntry[]): MergeResult {
 
   appendMergedEffects(merged, {
     promptReplace,
+    modelOverride,
     toolFilters,
     toolRewrite,
     toolOutputRewrite,

--- a/packages/policy/test/point-dispatch.test.ts
+++ b/packages/policy/test/point-dispatch.test.ts
@@ -307,3 +307,68 @@ describe("WorkItem policy effect composition", () => {
     ]);
   });
 });
+
+describe("model.override conflict rule (#757 review F1)", () => {
+  test("same-priority divergent overrides fail closed — never an alphabetical winner", () => {
+    const composed = composeEffects([
+      PolicyDecision.allow({
+        policyId: "aa-budget",
+        priority: 50,
+        effects: [{ type: "model.override", provider: "cheap", id: "model-a" }],
+      }),
+      PolicyDecision.allow({
+        policyId: "zz-residency",
+        priority: 50,
+        effects: [{ type: "model.override", provider: "eu", id: "model-b" }],
+      }),
+    ]);
+
+    expect(composed.verdict).toBe("deny");
+    expect(
+      composed.mergedEffects.some(
+        (effect) =>
+          effect.type === "audit.annotate" &&
+          effect.annotation.includes("policy.effect_conflict.fail_closed") &&
+          effect.annotation.includes("model.override.model"),
+      ),
+    ).toBe(true);
+  });
+
+  test("same-priority IDENTICAL overrides compose — one intent, no conflict", () => {
+    const composed = composeEffects([
+      PolicyDecision.allow({
+        policyId: "aa-budget",
+        priority: 50,
+        effects: [{ type: "model.override", provider: "cheap", id: "model-a" }],
+      }),
+      PolicyDecision.allow({
+        policyId: "zz-mirror",
+        priority: 50,
+        effects: [{ type: "model.override", provider: "cheap", id: "model-a" }],
+      }),
+    ]);
+
+    expect(composed.verdict).toBe("allow");
+    const overrides = composed.mergedEffects.filter((effect) => effect.type === "model.override");
+    expect(overrides).toEqual([{ type: "model.override", provider: "cheap", id: "model-a" }]);
+  });
+
+  test("a higher-priority override wins regardless of policy name order", () => {
+    const composed = composeEffects([
+      PolicyDecision.allow({
+        policyId: "zz-low",
+        priority: 10,
+        effects: [{ type: "model.override", provider: "p", id: "low-model" }],
+      }),
+      PolicyDecision.allow({
+        policyId: "aa-high",
+        priority: 90,
+        effects: [{ type: "model.override", provider: "p", id: "high-model" }],
+      }),
+    ]);
+
+    expect(composed.verdict).toBe("allow");
+    const overrides = composed.mergedEffects.filter((effect) => effect.type === "model.override");
+    expect(overrides).toEqual([{ type: "model.override", provider: "p", id: "high-model" }]);
+  });
+});

--- a/packages/protocol/src/policy/effects.ts
+++ b/packages/protocol/src/policy/effects.ts
@@ -22,6 +22,7 @@ export namespace PolicyEffects {
     "runtime.set_timeout",
     "runtime.workspace_lock",
     "work.allow_asserted",
+    "model.override",
   ]);
   export type PolicyEffectType = z.infer<typeof PolicyEffectType>;
 
@@ -108,6 +109,17 @@ export namespace PolicyEffects {
     z.object({
       type: z.literal("work.allow_asserted"),
       criterionIds: z.array(z.string().min(1)),
+    }),
+    // Per-point model routing (#753): reroutes the CONNECTION being gated at
+    // `connection.llm.pre` to a different model — connection-scoped by
+    // definition (the next connection re-resolves normally; a policy that
+    // wants the whole run re-issues the effect per connection, which per-run
+    // factory registrations make trivial). A run-scoped variant is deferred
+    // to #753 follow-up scope.
+    z.object({
+      type: z.literal("model.override"),
+      provider: z.string().min(1),
+      id: z.string().min(1),
     }),
   ]);
   export type PolicyEffect = z.infer<typeof PolicyEffect>;

--- a/packages/protocol/src/policy/point-registry.ts
+++ b/packages/protocol/src/policy/point-registry.ts
@@ -68,7 +68,13 @@ export namespace PolicyPointRegistryModule {
       "pre",
       ["connection"],
       ["sessionId", "runId", "modelId"],
-      ["prompt.append_context", "prompt.inject_message", "run.abort", "audit.annotate"],
+      [
+        "prompt.append_context",
+        "prompt.inject_message",
+        "run.abort",
+        "audit.annotate",
+        "model.override",
+      ],
       ...preBoundary,
     ),
     "connection.llm.post": contract(

--- a/packages/protocol/test/policy.test.ts
+++ b/packages/protocol/test/policy.test.ts
@@ -350,13 +350,28 @@ describe("Policy schemas", () => {
       });
     });
 
-    it("refuses a model.override with empty coordinates", () => {
-      expect(() =>
-        Policy.PolicyEffect.parse({ type: "model.override", provider: "", id: "m" }),
-      ).toThrow();
-      expect(() =>
-        Policy.PolicyEffect.parse({ type: "model.override", provider: "p", id: "" }),
-      ).toThrow();
+    it("refuses a model.override with empty coordinates, naming the offending field", () => {
+      const emptyProvider = Policy.PolicyEffect.safeParse({
+        type: "model.override",
+        provider: "",
+        id: "m",
+      });
+      expect(emptyProvider.success).toBe(false);
+      if (!emptyProvider.success) {
+        expect(emptyProvider.error.issues.map((issue) => issue.path.join("."))).toContain(
+          "provider",
+        );
+        expect(emptyProvider.error.issues.every((issue) => issue.code === "too_small")).toBe(true);
+      }
+      const emptyId = Policy.PolicyEffect.safeParse({
+        type: "model.override",
+        provider: "p",
+        id: "",
+      });
+      expect(emptyId.success).toBe(false);
+      if (!emptyId.success) {
+        expect(emptyId.error.issues.map((issue) => issue.path.join("."))).toContain("id");
+      }
     });
 
     it("parses tool.require_approval effect", () => {

--- a/packages/protocol/test/policy.test.ts
+++ b/packages/protocol/test/policy.test.ts
@@ -337,6 +337,28 @@ describe("Policy schemas", () => {
       });
     });
 
+    it("parses model.override effect (#753) — connection-scoped model routing", () => {
+      const result = Policy.PolicyEffect.parse({
+        type: "model.override",
+        provider: "anthropic",
+        id: "claude-3-haiku-20240307",
+      });
+      expect(result).toMatchObject({
+        type: "model.override",
+        provider: "anthropic",
+        id: "claude-3-haiku-20240307",
+      });
+    });
+
+    it("refuses a model.override with empty coordinates", () => {
+      expect(() =>
+        Policy.PolicyEffect.parse({ type: "model.override", provider: "", id: "m" }),
+      ).toThrow();
+      expect(() =>
+        Policy.PolicyEffect.parse({ type: "model.override", provider: "p", id: "" }),
+      ).toThrow();
+    });
+
     it("parses tool.require_approval effect", () => {
       const result = Policy.PolicyEffect.parse({
         type: "tool.require_approval",

--- a/packages/protocol/test/policy/point-registry.test.ts
+++ b/packages/protocol/test/policy/point-registry.test.ts
@@ -180,3 +180,16 @@ describe("PolicyPoint registry", () => {
     expect(Policy.PolicyPoint.Registry["run.error.error"].phase).toBe("error");
   });
 });
+
+describe("model.override point admission (#753)", () => {
+  test("connection.llm.pre allows model.override; every other point refuses it", () => {
+    for (const pointId of expectedPointIds) {
+      const contract = Policy.PolicyPoint.Registry[pointId];
+      const allowed = contract.allowedEffects.includes("model.override");
+      expect({ pointId, allowed }).toEqual({
+        pointId,
+        allowed: pointId === "connection.llm.pre",
+      });
+    }
+  });
+});

--- a/packages/protocol/test/policy/point-registry.test.ts
+++ b/packages/protocol/test/policy/point-registry.test.ts
@@ -140,7 +140,13 @@ describe("PolicyPoint registry", () => {
     );
     expect(roundTripped).toEqual(Policy.PolicyPoint.Registry);
 
-    for (const pointId of expectedPointIds) {
+    // Derived from the registry itself, not the expected list — a NEW point
+    // cannot dodge this assertion by not being enumerated here.
+    const pointIds = Object.keys(Policy.PolicyPoint.Registry) as Array<
+      keyof typeof Policy.PolicyPoint.Registry
+    >;
+    expect(pointIds.length).toBeGreaterThan(0);
+    for (const pointId of pointIds) {
       const contract = Policy.PolicyPoint.Registry[pointId];
       expect(contract).toBeDefined();
       if (contract === undefined) continue;
@@ -151,7 +157,13 @@ describe("PolicyPoint registry", () => {
   });
 
   test("preserves every v1 input schema identifier", () => {
-    for (const pointId of expectedPointIds) {
+    // Derived from the registry itself, not the expected list — a NEW point
+    // cannot dodge this assertion by not being enumerated here.
+    const pointIds = Object.keys(Policy.PolicyPoint.Registry) as Array<
+      keyof typeof Policy.PolicyPoint.Registry
+    >;
+    expect(pointIds.length).toBeGreaterThan(0);
+    for (const pointId of pointIds) {
       const contract = Policy.PolicyPoint.Registry[pointId];
       expect(contract).toBeDefined();
       if (contract === undefined) continue;
@@ -183,7 +195,13 @@ describe("PolicyPoint registry", () => {
 
 describe("model.override point admission (#753)", () => {
   test("connection.llm.pre allows model.override; every other point refuses it", () => {
-    for (const pointId of expectedPointIds) {
+    // Derived from the registry itself, not the expected list — a NEW point
+    // cannot dodge this assertion by not being enumerated here.
+    const pointIds = Object.keys(Policy.PolicyPoint.Registry) as Array<
+      keyof typeof Policy.PolicyPoint.Registry
+    >;
+    expect(pointIds.length).toBeGreaterThan(0);
+    for (const pointId of pointIds) {
       const contract = Policy.PolicyPoint.Registry[pointId];
       const allowed = contract.allowedEffects.includes("model.override");
       expect({ pointId, allowed }).toEqual({


### PR DESCRIPTION
Closes #753. Loop-only per the issue scope: **no `packages/openomni` / `apps/server` change**; production registrations stay #609 scope.

## What

Policies can route the connection being gated at `connection.llm.pre` to a different model — "this point / this kind of work → this model" becomes expressible without loop special cases.

- **protocol** — `model.override` joins the policy effect union (`{provider, id}`, both non-empty) and `connection.llm.pre`'s allowed-effect list. **Connection-scoped by definition**: the next connection re-resolves normally; a policy wanting the whole run re-issues per connection (per-run factory registrations make that trivial). A run-scoped variant is deferred (noted on #753).
- **policy** — the effect-merge fold gains the single-winner rule (mirrors `prompt.replace`): two overrides for one connection cannot compose — higher priority wins.
- **agent** — `dispatchModelRequest` returns a gate (`{blocked, overrideModel}`); the loop re-resolves the override through the same seam as the attempt selection, swaps the call's `runInput.model`, recomputes the window-yield arm point from the OVERRIDE's window locally (run state keeps the attempt model's window fact — the next connection reverts), updates `turn.windowYieldArmed` so `turnYield` classifies the stop against the call that actually ran, and reports the override id to `connection.llm.post` (keeps #752 F4 truthfulness). An override naming the already-selected model skips re-resolution.

Precedent for in-run model divergence: the compaction anchor summarizer already runs as a separate one-shot model call under the run's trace (D7).

## Tests

- protocol: effect parse + empty-coordinate refusal.
- agent e2e: connection scope (override one call → revert next; `connection.llm.post` truthful both times), noop-override skips resolution, **yield recompute** (500-window override arms 400 vs primary 800), unknown-window override drops the arm point.

## Gates

`bun run test` 17/17 tasks, root `check-types` 17/17, lint, `check-deps`, `lint:guards`, `check-dead-exports`, `check-import-cycles`, `lint:tools` (schema snapshot clean) — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables per-point model routing: policies can reroute a single LLM connection at `connection.llm.pre` via `model.override`. Previously the attempt’s model was fixed; now one call can switch models, the next re-resolves normally, and telemetry/yield reflect the actual call.

- `@openomni/protocol`: adds `model.override` to the effect union; validates non-empty `{provider,id}`; allows it only at `connection.llm.pre` (all other points refuse). Tests pin zod issue paths and verify registry-derived admission. Connects to Linear #753.
- `@openomni/policy`: merge is single-winner; same-priority divergent overrides deny with `policy.effect_conflict.fail_closed`; identical overrides compose; higher priority wins.
- `@openomni/agent`: `dispatchModelRequest` returns a gate `{blocked, overrideModel?}`; the loop resolves overrides through the model seam, swaps `runInput.model`, recomputes `yieldAtInputTokens` from the override’s window, mutates `turn.windowYieldArmed`, and reports the actual model id to `connection.llm.post`. Noop overrides skip resolution. Overrides to nonexistent models fail honestly with bounded retries, zero LLM calls, and no fallback walking.
- Tests: e2e cover connection scope (override one call, revert next), noop override, yield recompute, unknown-window drops arm point. Shared `assistantSnapshot` fixture deduplicates boundary snapshots across tests.
- Rollout: loop-only; no changes to `packages/openomni` or `apps/server`. To route an entire run, re-issue `model.override` at each `connection.llm.pre`.

<sup>Written for commit 528d9dabcc47526277e9d579683ebe07e18148e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added policy-based model overrides for language model connections.
  * Policies can reroute a connection to a specified provider and model.
  * Higher-priority overrides take precedence, while conflicting same-priority overrides fail safely.
  * Context-window thresholds and response metadata now reflect the model actually used.
* **Bug Fixes**
  * Improved handling when override models cannot be resolved or have unknown context limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->