### PR TITLE
chore(reduction): consolidate llm test clusters (p5b)

### DIFF
--- a/packages/llm/test/auth/storage.test.ts
+++ b/packages/llm/test/auth/storage.test.ts
@@ -1,37 +1,33 @@
-import { describe, it, expect } from "bun:test";
-import { Auth } from "../../src/auth";
-import { rmSync, existsSync, mkdtempSync } from "node:fs";
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Auth } from "../../src/auth";
 
 const testAuthRoot = join(tmpdir(), "openomni-auth-storage-");
 
 async function withTestAuthFile<T>(fn: (filepath: string, dir: string) => Promise<T>): Promise<T> {
   const dir = mkdtempSync(testAuthRoot);
   const filepath = join(dir, "auth.json");
-
   try {
     return await Auth.withFile(filepath, () => fn(filepath, dir));
   } finally {
-    if (existsSync(dir)) {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
   }
 }
 
 describe("Auth Storage", () => {
-  it("should write API auth to auth.json", async () => {
+  it.each([
+    { name: "should write API auth to auth.json", provider: "anthropic", key: "sk-ant" },
+    { name: "should work with API key auth type", provider: "openai", key: "sk-xxx" },
+  ])("$name", async ({ provider, key }) => {
     await withTestAuthFile(async () => {
-      await Auth.set("anthropic", {
-        type: "api",
-        key: "sk-ant",
-      });
-
-      const stored = await Auth.get("anthropic");
+      await Auth.set(provider, { type: "api", key });
+      const stored = await Auth.get(provider);
       expect(stored).toBeDefined();
       expect(stored?.type).toBe("api");
       if (stored?.type !== "api") throw new Error("expected API auth");
-      expect(stored?.key).toBe("sk-ant");
+      expect(stored?.key).toBe(key);
     });
   });
 
@@ -42,7 +38,6 @@ describe("Auth Storage", () => {
         baseURL: "http://localhost:8317/v1",
         apiKey: "proxy-key",
       });
-
       const stored = await Auth.get("anthropic");
       expect(stored).toBeDefined();
       expect(stored?.type).toBe("proxy");
@@ -54,23 +49,14 @@ describe("Auth Storage", () => {
 
   it("should return undefined for nonexistent key", async () => {
     await withTestAuthFile(async () => {
-      const stored = await Auth.get("nonexistent");
-      expect(stored).toBeUndefined();
+      expect(await Auth.get("nonexistent")).toBeUndefined();
     });
   });
 
   it("should return all entries", async () => {
     await withTestAuthFile(async () => {
-      await Auth.set("anthropic", {
-        type: "proxy",
-        baseURL: "http://localhost:8317/v1",
-      });
-
-      await Auth.set("openai", {
-        type: "api",
-        key: "sk-xxx",
-      });
-
+      await Auth.set("anthropic", { type: "proxy", baseURL: "http://localhost:8317/v1" });
+      await Auth.set("openai", { type: "api", key: "sk-xxx" });
       const all = await Auth.all();
       expect(Object.keys(all).length).toBe(2);
       expect(all.anthropic).toBeDefined();
@@ -85,17 +71,10 @@ describe("Auth Storage", () => {
       await Bun.write(
         filepath,
         JSON.stringify({
-          valid: {
-            type: "api",
-            key: "sk-valid",
-          },
-          invalid: {
-            type: "unknown",
-            data: "bad",
-          },
+          valid: { type: "api", key: "sk-valid" },
+          invalid: { type: "unknown", data: "bad" },
         }),
       );
-
       const all = await Auth.all();
       expect(Object.keys(all).length).toBe(1);
       expect(all.valid).toBeDefined();
@@ -104,19 +83,13 @@ describe("Auth Storage", () => {
   });
 
   it("fails loudly on a malformed auth file instead of reading it as empty", async () => {
-    // Regression (#audit L4): a parse failure used to become `{}`, and the
-    // next set() would overwrite the file — destroying every credential.
     await withTestAuthFile(async (filepath) => {
       await Bun.write(filepath, "{ this is not json");
-
       await expect(Auth.all()).rejects.toThrow("auth file is not valid JSON");
       await expect(Auth.get("anthropic")).rejects.toThrow("auth file is not valid JSON");
-      // set() must refuse too — writing would destroy the stored credentials.
       await expect(Auth.set("anthropic", { type: "api", key: "sk-new" })).rejects.toThrow(
         "auth file is not valid JSON",
       );
-
-      // The malformed file survives untouched for manual recovery.
       expect(await Bun.file(filepath).text()).toBe("{ this is not json");
     });
   });
@@ -133,15 +106,9 @@ describe("Auth Storage", () => {
       await Bun.write(
         filepath,
         JSON.stringify({
-          legacy: {
-            type: "oauth",
-            refresh: "r",
-            access: "a",
-            expires: 999,
-          },
+          legacy: { type: "oauth", refresh: "r", access: "a", expires: 999 },
         }),
       );
-
       const all = await Auth.all();
       expect(all.legacy).toBeUndefined();
     });
@@ -149,32 +116,9 @@ describe("Auth Storage", () => {
 
   it("should set auth.json file with 0o600 permissions", async () => {
     await withTestAuthFile(async (filepath) => {
-      await Auth.set("anthropic", {
-        type: "api",
-        key: "sk-ant",
-      });
-
-      const file = Bun.file(filepath);
-      const stat = await file.stat();
-      // Check that file has restrictive permissions (0o600 = rw-------)
-      const mode = stat?.mode ?? 0;
-      const permissions = mode & 0o777;
-      expect(permissions).toBe(0o600);
-    });
-  });
-
-  it("should work with API key auth type", async () => {
-    await withTestAuthFile(async () => {
-      await Auth.set("openai", {
-        type: "api",
-        key: "sk-xxx",
-      });
-
-      const stored = await Auth.get("openai");
-      expect(stored).toBeDefined();
-      expect(stored?.type).toBe("api");
-      if (stored?.type !== "api") throw new Error("expected API auth");
-      expect(stored?.key).toBe("sk-xxx");
+      await Auth.set("anthropic", { type: "api", key: "sk-ant" });
+      const mode = (await Bun.file(filepath).stat())?.mode ?? 0;
+      expect(mode & 0o777).toBe(0o600);
     });
   });
 });

--- a/packages/llm/test/message/to-model-messages.test.ts
+++ b/packages/llm/test/message/to-model-messages.test.ts
@@ -3,172 +3,86 @@ import type { Message } from "@openomni/protocol";
 import { toModelMessages } from "../../src/message";
 import type { Provider } from "../../src/provider";
 
+const anthropicModel: Provider.Model = {
+  id: "claude-3-5-sonnet",
+  providerID: "anthropic",
+  name: "Claude 3.5 Sonnet",
+  api: { npm: "@ai-sdk/anthropic" },
+};
+
+function textPart(messageID: string, text: string, id = `part-${messageID}`): Message.TextPart {
+  return { id, sessionID: "session-1", messageID, type: "text", text };
+}
+
+function userMessage(text = "Hello"): Message.WithParts {
+  return {
+    info: {
+      id: "msg-1",
+      sessionID: "session-1",
+      role: "user",
+      time: { created: 1000 },
+      agent: "default",
+      model: { providerID: "anthropic", modelID: "claude-3-5-sonnet" },
+    },
+    parts: [textPart("msg-1", text, "part-1")],
+  };
+}
+
+function assistantMessage(
+  parts: Message.Part[] = [textPart("msg-2", "Response", "part-1")],
+): Message.WithParts {
+  return {
+    info: {
+      id: "msg-2",
+      sessionID: "session-1",
+      role: "assistant",
+      time: { created: 1100 },
+      parentID: "msg-1",
+      modelID: "claude-3-5-sonnet",
+      providerID: "anthropic",
+      agent: "default",
+      path: { cwd: "/home/user", root: "/home/user/project" },
+      cost: 0.001,
+      tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts,
+  };
+}
+
 describe("toModelMessages", () => {
   test("converts empty array", () => {
-    const model: Provider.Model = {
-      id: "claude-3-5-sonnet",
-      providerID: "anthropic",
-      name: "Claude 3.5 Sonnet",
-      api: {
-        npm: "@ai-sdk/anthropic",
-      },
-    };
-
-    const result = toModelMessages([], model);
-    expect(result).toEqual([]);
+    expect(toModelMessages([], anthropicModel)).toEqual([]);
   });
 
   test("converts UserMessage to model message", () => {
-    const model: Provider.Model = {
-      id: "claude-3-5-sonnet",
-      providerID: "anthropic",
-      name: "Claude 3.5 Sonnet",
-      api: {
-        npm: "@ai-sdk/anthropic",
-      },
-    };
-
-    const userMsg: Message.WithParts = {
-      info: {
-        id: "msg-1",
-        sessionID: "session-1",
-        role: "user",
-        time: { created: 1000 },
-        agent: "default",
-        model: {
-          providerID: "anthropic",
-          modelID: "claude-3-5-sonnet",
-        },
-      } as Message.UserMessage,
-      parts: [
-        {
-          id: "part-1",
-          sessionID: "session-1",
-          messageID: "msg-1",
-          type: "text",
-          text: "Hello",
-        } as Message.TextPart,
-      ],
-    };
-
-    const result = toModelMessages([userMsg], model);
+    const result = toModelMessages([userMessage()], anthropicModel);
     expect(result).toHaveLength(1);
     expect(result[0]?.role).toBe("user");
     expect(result[0]?.content).toBe("Hello");
   });
 
   test("converts AssistantMessage to model message", () => {
-    const model: Provider.Model = {
-      id: "claude-3-5-sonnet",
-      providerID: "anthropic",
-      name: "Claude 3.5 Sonnet",
-      api: {
-        npm: "@ai-sdk/anthropic",
-      },
-    };
-
-    const assistantMsg: Message.WithParts = {
-      info: {
-        id: "msg-2",
-        sessionID: "session-1",
-        role: "assistant",
-        time: { created: 1100 },
-        parentID: "msg-1",
-        modelID: "claude-3-5-sonnet",
-        providerID: "anthropic",
-        agent: "default",
-        path: {
-          cwd: "/home/user",
-          root: "/home/user/project",
-        },
-        cost: 0.001,
-        tokens: {
-          input: 100,
-          output: 50,
-          reasoning: 0,
-          cache: {
-            read: 0,
-            write: 0,
-          },
-        },
-      } as Message.AssistantMessage,
-      parts: [
-        {
-          id: "part-1",
-          sessionID: "session-1",
-          messageID: "msg-2",
-          type: "text",
-          text: "Response",
-        } as Message.TextPart,
-      ],
-    };
-
-    const result = toModelMessages([assistantMsg], model);
+    const result = toModelMessages([assistantMessage()], anthropicModel);
     expect(result).toHaveLength(1);
     expect(result[0]?.role).toBe("assistant");
     expect(result[0]?.content).toBe("Response");
   });
 
   test("preserves assistant reasoning parts during conversion", () => {
-    const model: Provider.Model = {
-      id: "claude-3-5-sonnet",
-      providerID: "anthropic",
-      name: "Claude 3.5 Sonnet",
-      api: {
-        npm: "@ai-sdk/anthropic",
-      },
+    const reasoning: Message.ReasoningPart = {
+      id: "part-1",
+      sessionID: "session-1",
+      messageID: "msg-2",
+      type: "reasoning",
+      text: "I should preserve this.",
+      time: { start: 1100, end: 1101 },
     };
-
-    const assistantMsg: Message.WithParts = {
-      info: {
-        id: "msg-2",
-        sessionID: "session-1",
-        role: "assistant",
-        time: { created: 1100 },
-        parentID: "msg-1",
-        modelID: "claude-3-5-sonnet",
-        providerID: "anthropic",
-        agent: "default",
-        path: {
-          cwd: "/home/user",
-          root: "/home/user/project",
-        },
-        cost: 0.001,
-        tokens: {
-          input: 100,
-          output: 50,
-          reasoning: 12,
-          cache: {
-            read: 0,
-            write: 0,
-          },
-        },
-      } as Message.AssistantMessage,
-      parts: [
-        {
-          id: "part-1",
-          sessionID: "session-1",
-          messageID: "msg-2",
-          type: "reasoning",
-          text: "I should preserve this.",
-          time: { start: 1100, end: 1101 },
-        } as Message.ReasoningPart,
-        {
-          id: "part-2",
-          sessionID: "session-1",
-          messageID: "msg-2",
-          type: "text",
-          text: "Final answer",
-        } as Message.TextPart,
-      ],
-    };
-
-    const result = toModelMessages([assistantMsg], model);
-
+    const result = toModelMessages(
+      [assistantMessage([reasoning, textPart("msg-2", "Final answer", "part-2")])],
+      anthropicModel,
+    );
     expect(result).toHaveLength(1);
     expect(result[0]?.role).toBe("assistant");
-    // Reasoning must come first: Anthropic rejects assistant turns where a
-    // thinking block follows other content.
     expect(result[0]?.content).toEqual([
       { type: "reasoning", text: "I should preserve this." },
       { type: "text", text: "Final answer" },
@@ -176,75 +90,7 @@ describe("toModelMessages", () => {
   });
 
   test("converts mixed messages", () => {
-    const model: Provider.Model = {
-      id: "claude-3-5-sonnet",
-      providerID: "anthropic",
-      name: "Claude 3.5 Sonnet",
-      api: {
-        npm: "@ai-sdk/anthropic",
-      },
-    };
-
-    const userMsg: Message.WithParts = {
-      info: {
-        id: "msg-1",
-        sessionID: "session-1",
-        role: "user",
-        time: { created: 1000 },
-        agent: "default",
-        model: {
-          providerID: "anthropic",
-          modelID: "claude-3-5-sonnet",
-        },
-      } as Message.UserMessage,
-      parts: [
-        {
-          id: "part-1",
-          sessionID: "session-1",
-          messageID: "msg-1",
-          type: "text",
-          text: "Hello",
-        } as Message.TextPart,
-      ],
-    };
-
-    const assistantMsg: Message.WithParts = {
-      info: {
-        id: "msg-2",
-        sessionID: "session-1",
-        role: "assistant",
-        time: { created: 1100 },
-        parentID: "msg-1",
-        modelID: "claude-3-5-sonnet",
-        providerID: "anthropic",
-        agent: "default",
-        path: {
-          cwd: "/home/user",
-          root: "/home/user/project",
-        },
-        cost: 0.001,
-        tokens: {
-          input: 100,
-          output: 50,
-          reasoning: 0,
-          cache: {
-            read: 0,
-            write: 0,
-          },
-        },
-      } as Message.AssistantMessage,
-      parts: [
-        {
-          id: "part-2",
-          sessionID: "session-1",
-          messageID: "msg-2",
-          type: "text",
-          text: "Response",
-        } as Message.TextPart,
-      ],
-    };
-
-    const result = toModelMessages([userMsg, assistantMsg], model);
+    const result = toModelMessages([userMessage(), assistantMessage()], anthropicModel);
     expect(result).toHaveLength(2);
     expect(result[0]?.role).toBe("user");
     expect(result[0]?.content).toBe("Hello");
@@ -253,39 +99,7 @@ describe("toModelMessages", () => {
   });
 
   test("calls ProviderTransform.normalizeMessages", () => {
-    const model: Provider.Model = {
-      id: "claude-3-5-sonnet",
-      providerID: "anthropic",
-      name: "Claude 3.5 Sonnet",
-      api: {
-        npm: "@ai-sdk/anthropic",
-      },
-    };
-
-    const userMsg: Message.WithParts = {
-      info: {
-        id: "msg-1",
-        sessionID: "session-1",
-        role: "user",
-        time: { created: 1000 },
-        agent: "default",
-        model: {
-          providerID: "anthropic",
-          modelID: "claude-3-5-sonnet",
-        },
-      } as Message.UserMessage,
-      parts: [
-        {
-          id: "part-1",
-          sessionID: "session-1",
-          messageID: "msg-1",
-          type: "text",
-          text: "Hello",
-        } as Message.TextPart,
-      ],
-    };
-
-    const result = toModelMessages([userMsg], model);
+    const result = toModelMessages([userMessage()], anthropicModel);
     expect(result).toHaveLength(1);
     expect(result[0]?.role).toBe("user");
     expect(result[0]?.content).toBe("Hello");

--- a/packages/llm/test/provider/anthropic.test.ts
+++ b/packages/llm/test/provider/anthropic.test.ts
@@ -1,9 +1,13 @@
-import { describe, test, expect, afterEach } from "bun:test";
-import { getSDK, getLanguage } from "../../src/provider/sdk";
-import type { Provider } from "../../src/provider";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { Auth } from "../../src/auth";
+import type { Provider } from "../../src/provider";
+import { getLanguage, getSDK } from "../../src/provider/sdk";
 
 const originalFetch = globalThis.fetch;
+const authCases: Array<{ name: string; auth: Auth.Info }> = [
+  { name: "api key auth", auth: { type: "api", key: "sk-xxx" } },
+  { name: "proxy auth", auth: { type: "proxy", baseURL: "http://localhost:8317" } },
+];
 
 function makeModel(overrides?: Partial<Provider.Model>): Provider.Model {
   return {
@@ -21,21 +25,7 @@ describe("getSDK (Anthropic)", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("api key auth returns SDK with languageModel", () => {
-    const auth: Auth.Info = { type: "api", key: "sk-xxx" };
-    const sdk = getSDK(makeModel(), auth);
-    expect(sdk).toBeDefined();
-    expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel("claude-sonnet-4-20250514");
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe("claude-sonnet-4-20250514");
-  });
-
-  test("proxy auth returns SDK with languageModel", () => {
-    const auth: Auth.Info = {
-      type: "proxy",
-      baseURL: "http://localhost:8317",
-    };
+  test.each(authCases)("$name returns SDK with languageModel", ({ auth }) => {
     const sdk = getSDK(makeModel(), auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
@@ -46,28 +36,16 @@ describe("getSDK (Anthropic)", () => {
 });
 
 describe("getLanguage (Anthropic)", () => {
-  test("returns a language model for anthropic model with api auth", () => {
-    const auth: Auth.Info = { type: "api", key: "sk-xxx" };
-    const model = getLanguage(makeModel(), auth);
-    expect(model).toBeDefined();
-    expect(model.modelId).toBe("claude-sonnet-4-20250514");
-  });
-
-  test("returns a language model for proxy auth", () => {
-    const auth: Auth.Info = {
-      type: "proxy",
-      baseURL: "http://localhost:8317",
-    };
+  test.each(authCases)("returns a language model with $name", ({ auth }) => {
     const model = getLanguage(makeModel(), auth);
     expect(model).toBeDefined();
     expect(model.modelId).toBe("claude-sonnet-4-20250514");
   });
 
   test("uses api.id when provided", () => {
-    const auth: Auth.Info = { type: "api", key: "sk-xxx" };
     const model = getLanguage(
       makeModel({ api: { npm: "@ai-sdk/anthropic", id: "claude-3-haiku" } }),
-      auth,
+      { type: "api", key: "sk-xxx" },
     );
     expect(model).toBeDefined();
     expect(model.modelId).toBe("claude-3-haiku");

--- a/packages/llm/test/provider/integration.test.ts
+++ b/packages/llm/test/provider/integration.test.ts
@@ -1,145 +1,119 @@
 import { describe, expect, it } from "bun:test";
 import type { Auth } from "../../src/auth";
-import { getSDK, getLanguage } from "../../src/provider/sdk";
 import { Provider } from "../../src/provider";
+import { getLanguage, getSDK } from "../../src/provider/sdk";
 
-function makeAnthropicModel(id?: string): Provider.Model {
+function makeModel(provider: "anthropic" | "openai", id: string): Provider.Model {
   return {
-    id: id ?? "claude-sonnet-4-20250514",
-    providerID: "anthropic",
-    name: "Claude Sonnet 4",
-    api: { npm: "@ai-sdk/anthropic" },
+    id,
+    providerID: provider,
+    name: provider === "anthropic" ? "Claude Sonnet 4" : "GPT-4o",
+    api: { npm: provider === "anthropic" ? "@ai-sdk/anthropic" : "@ai-sdk/openai" },
   };
 }
 
-function makeOpenAIModel(id?: string): Provider.Model {
-  return {
-    id: id ?? "gpt-4o",
-    providerID: "openai",
-    name: "GPT-4o",
-    api: { npm: "@ai-sdk/openai" },
-  };
-}
-
-describe("Provider Integration", () => {
-  it("full flow: getSDK → getLanguage (Anthropic API)", () => {
-    const auth: Auth.Info = { type: "api", key: "test-anthropic-key" };
-    const model = makeAnthropicModel();
-
-    const sdk = getSDK(model, auth);
-    expect(sdk).toBeDefined();
-    expect(typeof sdk.languageModel).toBe("function");
-    const sdkLm = sdk.languageModel(model.id);
-    expect(sdkLm).toBeDefined();
-    expect(sdkLm.modelId).toBe(model.id);
-
-    const lm = getLanguage(model, auth);
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe(model.id);
-  });
-
-  it("full flow: getSDK → getLanguage (Anthropic proxy)", () => {
-    const auth: Auth.Info = {
-      type: "proxy",
-      baseURL: "http://localhost:8317",
-    };
-    const model = makeAnthropicModel("claude-opus-4-20250514");
-
-    const sdk = getSDK(model, auth);
-    expect(sdk).toBeDefined();
-    expect(typeof sdk.languageModel).toBe("function");
-    const sdkLm = sdk.languageModel(model.id);
-    expect(sdkLm).toBeDefined();
-    expect(sdkLm.modelId).toBe(model.id);
-
-    const lm = getLanguage(model, auth);
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe(model.id);
-  });
-
-  it("full flow: getSDK returns valid OpenAI SDK (API)", () => {
-    const auth: Auth.Info = { type: "api", key: "test-openai-key" };
-    const model = makeOpenAIModel();
-
-    const sdk = getSDK(model, auth);
-    expect(sdk).toBeDefined();
-    expect(typeof sdk.languageModel).toBe("function");
-
-    const lm = sdk.languageModel("gpt-4o");
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe("gpt-4o");
-  });
-
-  it("full flow: getSDK returns valid OpenAI SDK (proxy)", () => {
-    const auth: Auth.Info = {
+const sdkCases: Array<{
+  name: string;
+  model: Provider.Model;
+  auth: Auth.Info;
+  checksGetLanguage: boolean;
+}> = [
+  {
+    name: "Anthropic API",
+    model: makeModel("anthropic", "claude-sonnet-4-20250514"),
+    auth: { type: "api", key: "test-anthropic-key" },
+    checksGetLanguage: true,
+  },
+  {
+    name: "Anthropic proxy",
+    model: makeModel("anthropic", "claude-opus-4-20250514"),
+    auth: { type: "proxy", baseURL: "http://localhost:8317" },
+    checksGetLanguage: true,
+  },
+  {
+    name: "OpenAI API",
+    model: makeModel("openai", "gpt-4o"),
+    auth: { type: "api", key: "test-openai-key" },
+    checksGetLanguage: false,
+  },
+  {
+    name: "OpenAI proxy",
+    model: makeModel("openai", "gpt-5.1-codex-max"),
+    auth: {
       type: "proxy",
       baseURL: "http://localhost:8317/v1",
       apiKey: "test-proxy-api-key",
-    };
-    const model = makeOpenAIModel("gpt-5.1-codex-max");
+    },
+    checksGetLanguage: false,
+  },
+];
 
+describe("Provider Integration", () => {
+  it.each(sdkCases)("full flow: getSDK returns valid SDK ($name)", ({
+    model,
+    auth,
+    checksGetLanguage,
+  }) => {
     const sdk = getSDK(model, auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel(model.id);
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe(model.id);
+    const sdkLm = sdk.languageModel(model.id);
+    expect(sdkLm).toBeDefined();
+    expect(sdkLm.modelId).toBe(model.id);
+    if (checksGetLanguage) {
+      const lm = getLanguage(model, auth);
+      expect(lm).toBeDefined();
+      expect(lm.modelId).toBe(model.id);
+    }
   });
 
-  it("should list models for each provider", async () => {
-    const anthropicModels = await Provider.listModels("anthropic");
-    expect(Array.isArray(anthropicModels)).toBe(true);
-    expect(anthropicModels.length).toBeGreaterThan(0);
+  const listCases: Array<{
+    name: string;
+    requests: Array<{ provider: "anthropic" | "openai"; auth?: "proxy" | "api" }>;
+  }> = [
+    {
+      name: "each provider",
+      requests: [{ provider: "anthropic" }, { provider: "openai" }],
+    },
+    {
+      name: "both proxy and api auth types",
+      requests: [
+        { provider: "openai", auth: "proxy" },
+        { provider: "openai", auth: "api" },
+      ],
+    },
+  ];
 
-    const openaiModels = await Provider.listModels("openai");
-    expect(Array.isArray(openaiModels)).toBe(true);
-    expect(openaiModels.length).toBeGreaterThan(0);
-  });
-
-  it("should return all OpenAI models for both proxy and api auth types", async () => {
-    const proxyModels = await Provider.listModels("openai", "proxy");
-    expect(Array.isArray(proxyModels)).toBe(true);
-    expect(proxyModels.length).toBeGreaterThan(0);
-
-    const apiModels = await Provider.listModels("openai", "api");
-    expect(Array.isArray(apiModels)).toBe(true);
-    expect(apiModels.length).toBeGreaterThan(0);
+  it.each(listCases)("should list models for $name", async ({ requests }) => {
+    for (const { provider, auth } of requests) {
+      const models = await Provider.listModels(provider, auth);
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBeGreaterThan(0);
+    }
   });
 
   it("maps custom models without stale removed-provider npm metadata", () => {
-    const provider = {
-      id: "custom",
-      name: "Custom",
-      env: [],
-      api: "http://localhost:8317/v1",
-      models: {},
-    };
-    const model = Provider.fromModelsDevModel(provider, {
-      id: "custom-model",
-      name: "Custom Model",
-    });
-
+    const model = Provider.fromModelsDevModel(
+      { id: "custom", name: "Custom", env: [], api: "http://localhost:8317/v1", models: {} },
+      { id: "custom-model", name: "Custom Model" },
+    );
     expect(model.api?.npm).toBe("@ai-sdk/openai");
     expect(model.api?.url).toBe("http://localhost:8317/v1");
   });
 
   it("maps catalog limit.context through to the model (the run-window input)", () => {
     const provider = { id: "custom", name: "Custom", env: [], models: {} };
-
     const sized = Provider.fromModelsDevModel(provider, {
       id: "m",
       name: "M",
       limit: { context: 200_000 },
     });
     expect(sized.limit?.context).toBe(200_000);
-
     const unsized = Provider.fromModelsDevModel(provider, { id: "m", name: "M" });
     expect(unsized.limit?.context).toBe(0);
   });
 
   it("honors model.api.url for openai models (#audit L5)", () => {
-    // Regression: the old `providerID !== "openai"` gate silently ignored a
-    // configured catalog URL for openai models.
     const auth: Auth.Info = { type: "api", key: "test-openai-key" };
     const model: Provider.Model = {
       id: "gpt-4o-custom-endpoint",
@@ -147,7 +121,6 @@ describe("Provider Integration", () => {
       name: "GPT-4o (custom endpoint)",
       api: { npm: "@ai-sdk/openai", url: "http://localhost:9317/v1" },
     };
-
     const lm = getLanguage(model, auth) as unknown as {
       config: { url: (options: { path: string; modelId: string }) => string };
       provider: string;
@@ -166,10 +139,8 @@ describe("Provider Integration", () => {
       name: "Custom Model",
       api: { npm: "@ai-sdk/openai", url: "http://localhost:8317/v1" },
     };
-
     const sdk = getSDK(model, auth);
     expect(typeof sdk.languageModel).toBe("function");
-
     const lm = getLanguage(model, auth);
     expect(lm.modelId).toBe("custom-model");
     expect(lm.provider).toBe("custom.responses");

--- a/packages/llm/test/provider/openai.test.ts
+++ b/packages/llm/test/provider/openai.test.ts
@@ -1,11 +1,9 @@
-import { describe, test, expect, afterEach } from "bun:test";
-import { getSDK, getLanguage } from "../../src/provider/sdk";
-import type { Provider } from "../../src/provider";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { Auth } from "../../src/auth";
+import type { Provider } from "../../src/provider";
+import { getLanguage, getSDK } from "../../src/provider/sdk";
 
 const originalFetch = globalThis.fetch;
-
-/** `config` is an OpenAI SDK detail, absent from the `LanguageModelV3` interface. */
 type OpenAIModelRef = { readonly config?: { readonly provider?: string } };
 
 function makeModel(overrides?: Partial<Provider.Model>): Provider.Model {
@@ -18,40 +16,21 @@ function makeModel(overrides?: Partial<Provider.Model>): Provider.Model {
   };
 }
 
+const authCases: Array<{ name: string; auth: Auth.Info }> = [
+  { name: "api key auth", auth: { type: "api", key: "sk-xxx" } },
+  { name: "proxy auth", auth: { type: "proxy", baseURL: "http://localhost:8317/v1" } },
+  {
+    name: "proxy auth with apiKey",
+    auth: { type: "proxy", baseURL: "http://localhost:8317/v1", apiKey: "proxy-key" },
+  },
+];
+
 describe("getSDK (OpenAI)", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
   });
 
-  test("api key auth returns SDK with languageModel", () => {
-    const auth: Auth.Info = { type: "api", key: "sk-xxx" };
-    const sdk = getSDK(makeModel(), auth);
-    expect(sdk).toBeDefined();
-    expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel("gpt-4o");
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe("gpt-4o");
-  });
-
-  test("proxy auth returns SDK", () => {
-    const auth: Auth.Info = {
-      type: "proxy",
-      baseURL: "http://localhost:8317/v1",
-    };
-    const sdk = getSDK(makeModel(), auth);
-    expect(sdk).toBeDefined();
-    expect(typeof sdk.languageModel).toBe("function");
-    const lm = sdk.languageModel("gpt-4o");
-    expect(lm).toBeDefined();
-    expect(lm.modelId).toBe("gpt-4o");
-  });
-
-  test("proxy auth with apiKey returns SDK", () => {
-    const auth: Auth.Info = {
-      type: "proxy",
-      baseURL: "http://localhost:8317/v1",
-      apiKey: "proxy-key",
-    };
+  test.each(authCases)("$name returns SDK", ({ auth }) => {
     const sdk = getSDK(makeModel(), auth);
     expect(sdk).toBeDefined();
     expect(typeof sdk.languageModel).toBe("function");
@@ -61,13 +40,7 @@ describe("getSDK (OpenAI)", () => {
   });
 
   test("proxy auth uses Chat Completions language model", () => {
-    const auth: Auth.Info = {
-      type: "proxy",
-      baseURL: "http://localhost:8317/v1",
-      apiKey: "proxy-key",
-    };
-    const lm = getLanguage(makeModel({ id: "gpt-5.4" }), auth);
-
+    const lm = getLanguage(makeModel({ id: "gpt-5.4" }), authCases[2]?.auth as Auth.Info);
     expect(lm.modelId).toBe("gpt-5.4");
     expect((lm as OpenAIModelRef).config?.provider).toBe("openai.chat");
   });

--- a/packages/llm/test/provider/proxy-models.test.ts
+++ b/packages/llm/test/provider/proxy-models.test.ts
@@ -1,120 +1,89 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Provider } from "../../src/provider/index";
 import {
   enrichWithCatalog,
   fetchProxyModels,
   ProxyModelsError,
 } from "../../src/provider/proxy-models";
-import type { Provider } from "../../src/provider/index";
 
 type FetchArgs = Parameters<typeof fetch>;
+const originalFetch = globalThis.fetch;
 
 function stubFetch(
   handler: (input: FetchArgs[0], init?: FetchArgs[1]) => Response | Promise<Response>,
-): { restore: () => void } {
-  const original = globalThis.fetch;
-  // The stub answers calls; it does not carry `fetch.preconnect`, and nothing
-  // under test reaches for it. A single assertion, so the call signature is
-  // still checked — `as unknown as` here would wave through any shape.
+): void {
   globalThis.fetch = handler as typeof fetch;
-  return {
-    restore: () => {
-      globalThis.fetch = original;
-    },
-  };
 }
 
 describe("proxy-models", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   describe("fetchProxyModels", () => {
-    it("sends Authorization header when apiKey is provided", async () => {
+    it.each([
+      {
+        name: "sends Authorization header when apiKey is provided",
+        port: 3100,
+        apiKey: "test-key-123",
+        expected: "Bearer test-key-123",
+      },
+      {
+        name: "omits Authorization header when apiKey is not provided",
+        port: 3101,
+        apiKey: undefined,
+        expected: null,
+      },
+    ])("$name", async ({ port, apiKey, expected }) => {
       let capturedHeaders: Headers | undefined;
-
-      const stub = stubFetch((_input, init) => {
+      stubFetch((_input, init) => {
         capturedHeaders = new Headers(init?.headers);
         return new Response(JSON.stringify({ data: [{ id: "test-model" }] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       });
-
-      try {
-        const result = await fetchProxyModels("http://localhost:3100/v1", "test-key-123");
-        expect(result).toEqual(["test-model"]);
-        expect(capturedHeaders?.get("Authorization")).toBe("Bearer test-key-123");
-      } finally {
-        stub.restore();
-      }
+      const result = await fetchProxyModels(`http://localhost:${port}/v1`, apiKey);
+      expect(result).toEqual(["test-model"]);
+      expect(capturedHeaders?.get("Authorization")).toBe(expected);
     });
 
-    it("omits Authorization header when apiKey is not provided", async () => {
-      let capturedHeaders: Headers | undefined;
-
-      const stub = stubFetch((_input, init) => {
-        capturedHeaders = new Headers(init?.headers);
-        return new Response(JSON.stringify({ data: [{ id: "test-model" }] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      });
-
-      try {
-        const result = await fetchProxyModels("http://localhost:3101/v1");
-        expect(result).toEqual(["test-model"]);
-        expect(capturedHeaders?.get("Authorization")).toBeNull();
-      } finally {
-        stub.restore();
-      }
-    });
-
-    // Regression (#audit M2): listing failures used to return [], and the
-    // caller then fell through to the FULL models.dev catalog — silently
-    // presenting every model as available on the proxy. Behavior change:
-    // failures are now a typed ProxyModelsError the caller must surface.
     it("throws a typed error on auth failure (401) instead of returning []", async () => {
-      const stub = stubFetch(
-        () => new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+      stubFetch(() => new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }));
+      const error = await fetchProxyModels("http://localhost:3102/v1").then(
+        () => {
+          throw new Error("expected fetchProxyModels to reject");
+        },
+        (cause: unknown) => cause,
       );
-
-      try {
-        const error = await fetchProxyModels("http://localhost:3102/v1").then(
-          () => {
-            throw new Error("expected fetchProxyModels to reject");
-          },
-          (cause: unknown) => cause,
-        );
-        expect(ProxyModelsError.isInstance(error)).toBe(true);
-        if (ProxyModelsError.isInstance(error)) {
-          expect(error.data.status).toBe(401);
-          expect(error.data.url).toBe("http://localhost:3102/v1/models");
-        }
-      } finally {
-        stub.restore();
+      expect(ProxyModelsError.isInstance(error)).toBe(true);
+      if (ProxyModelsError.isInstance(error)) {
+        expect(error.data.status).toBe(401);
+        expect(error.data.url).toBe("http://localhost:3102/v1/models");
       }
     });
 
-    it("throws a typed error when the proxy is unreachable", async () => {
-      const stub = stubFetch(() => {
-        throw new Error("ECONNREFUSED");
-      });
-
-      try {
-        await expect(fetchProxyModels("http://localhost:3103/v1")).rejects.toThrow(
-          "proxy model listing unreachable",
-        );
-      } finally {
-        stub.restore();
-      }
-    });
-
-    it("throws a typed error when the proxy returns invalid JSON", async () => {
-      const stub = stubFetch(() => new Response("<html>gateway timeout</html>", { status: 200 }));
-
-      try {
-        await expect(fetchProxyModels("http://localhost:3104/v1")).rejects.toThrow(
-          "proxy model listing returned invalid JSON",
-        );
-      } finally {
-        stub.restore();
-      }
+    it.each([
+      {
+        name: "throws a typed error when the proxy is unreachable",
+        port: 3103,
+        response: () => {
+          throw new Error("ECONNREFUSED");
+        },
+        message: "proxy model listing unreachable",
+      },
+      {
+        name: "throws a typed error when the proxy returns invalid JSON",
+        port: 3104,
+        response: () => new Response("<html>gateway timeout</html>", { status: 200 }),
+        message: "proxy model listing returned invalid JSON",
+      },
+    ])("$name", async ({ port, response, message }) => {
+      stubFetch(response);
+      await expect(fetchProxyModels(`http://localhost:${port}/v1`)).rejects.toThrow(message);
     });
   });
 
@@ -128,9 +97,7 @@ describe("proxy-models", () => {
           status: "active",
         },
       };
-
       const result = enrichWithCatalog(["gpt-5.4", "gpt-5.5"], catalog, "openai");
-
       expect(result).toHaveLength(2);
       expect(result[0]?.name).toBe("GPT 5.4");
       expect(result[1]?.id).toBe("gpt-5.5");

--- a/packages/llm/test/provider/registry.test.ts
+++ b/packages/llm/test/provider/registry.test.ts
@@ -1,16 +1,70 @@
 import { describe, expect, it } from "bun:test";
-import { getSDK } from "../../src/provider/sdk";
-import { Provider } from "../../src/provider";
 import type { Auth } from "../../src/auth";
+import { Provider } from "../../src/provider";
+import { getSDK } from "../../src/provider/sdk";
 
-function makeModel(providerID: string, npm: string, id?: string): Provider.Model {
-  return {
-    id: id ?? "test-model",
-    providerID,
-    name: "Test Model",
-    api: { npm },
-  };
+function makeModel(providerID: string, npm: string, id = "test-model"): Provider.Model {
+  return { id, providerID, name: "Test Model", api: { npm } };
 }
+
+const sdkCases: Array<{
+  name: string;
+  providerID: string;
+  npm: string;
+  id: string;
+  auth: Auth.Info;
+}> = [
+  {
+    name: "Anthropic provider with API auth",
+    providerID: "anthropic",
+    npm: "@ai-sdk/anthropic",
+    id: "claude-sonnet-4-20250514",
+    auth: { type: "api", key: "test-api-key" },
+  },
+  {
+    name: "Anthropic provider with proxy auth",
+    providerID: "anthropic",
+    npm: "@ai-sdk/anthropic",
+    id: "claude-sonnet-4-20250514",
+    auth: { type: "proxy", baseURL: "http://localhost:8317" },
+  },
+  {
+    name: "OpenAI provider with API auth",
+    providerID: "openai",
+    npm: "@ai-sdk/openai",
+    id: "gpt-4o",
+    auth: { type: "api", key: "test-api-key" },
+  },
+  {
+    name: "OpenAI provider with proxy auth",
+    providerID: "openai",
+    npm: "@ai-sdk/openai",
+    id: "gpt-5.1-codex-max",
+    auth: { type: "proxy", baseURL: "http://localhost:8317/v1", apiKey: "test-proxy-key" },
+  },
+];
+
+const modelListCases: Array<{
+  name: string;
+  provider: "anthropic" | "openai";
+  auth?: "proxy" | "api";
+  properties: boolean;
+}> = [
+  { name: "model definitions from ModelsDev", provider: "anthropic", properties: true },
+  { name: "OpenAI model definitions", provider: "openai", properties: false },
+  {
+    name: "OpenAI models for proxy auth type without CODEX filter",
+    provider: "openai",
+    auth: "proxy",
+    properties: false,
+  },
+  {
+    name: "all OpenAI models for API auth type",
+    provider: "openai",
+    auth: "api",
+    properties: false,
+  },
+];
 
 describe("Provider Registry", () => {
   describe("public surface", () => {
@@ -18,7 +72,6 @@ describe("Provider Registry", () => {
       const providerSource = await Bun.file(
         new URL("../../src/provider/index.ts", import.meta.url),
       ).text();
-
       expect(Object.hasOwn(Provider, "BUNDLED_PROVIDERS")).toBe(false);
       expect(providerSource).not.toMatch(/\bexport\s+const\s+BUNDLED_PROVIDERS\b/);
       expect(providerSource).not.toMatch(/\bexport\s+type\s+ProviderID\b/);
@@ -26,93 +79,38 @@ describe("Provider Registry", () => {
   });
 
   describe("getSDK", () => {
-    it("should return configured Anthropic provider with API auth", () => {
-      const auth: Auth.Info = { type: "api", key: "test-api-key" };
-      const model = makeModel("anthropic", "@ai-sdk/anthropic", "claude-sonnet-4-20250514");
-      const provider = getSDK(model, auth);
-      expect(provider).toBeDefined();
-      expect(provider.languageModel).toBeDefined();
-    });
-
-    it("should return configured Anthropic provider with proxy auth", () => {
-      const auth: Auth.Info = {
-        type: "proxy",
-        baseURL: "http://localhost:8317",
-      };
-      const model = makeModel("anthropic", "@ai-sdk/anthropic", "claude-sonnet-4-20250514");
-      const provider = getSDK(model, auth);
-      expect(provider).toBeDefined();
-      expect(provider.languageModel).toBeDefined();
-    });
-
-    it("should return configured OpenAI provider with API auth", () => {
-      const auth: Auth.Info = { type: "api", key: "test-api-key" };
-      const model = makeModel("openai", "@ai-sdk/openai", "gpt-4o");
-      const provider = getSDK(model, auth);
-      expect(provider).toBeDefined();
-      expect(provider.languageModel).toBeDefined();
-    });
-
-    it("should return configured OpenAI provider with proxy auth", () => {
-      const auth: Auth.Info = {
-        type: "proxy",
-        baseURL: "http://localhost:8317/v1",
-        apiKey: "test-proxy-key",
-      };
-      const model = makeModel("openai", "@ai-sdk/openai", "gpt-5.1-codex-max");
-      const provider = getSDK(model, auth);
+    it.each(sdkCases)("should return configured $name", ({ providerID, npm, id, auth }) => {
+      const provider = getSDK(makeModel(providerID, npm, id), auth);
       expect(provider).toBeDefined();
       expect(provider.languageModel).toBeDefined();
     });
 
     it("should throw error for unknown npm package", () => {
-      const auth: Auth.Info = { type: "api", key: "test-api-key" };
-      const model = makeModel("unknown", "unknown-npm-pkg");
-      expect(() => getSDK(model, auth)).toThrow(
-        "No bundled provider for npm package: unknown-npm-pkg",
-      );
+      expect(() =>
+        getSDK(makeModel("unknown", "unknown-npm-pkg"), { type: "api", key: "test-api-key" }),
+      ).toThrow("No bundled provider for npm package: unknown-npm-pkg");
     });
 
     it("treats Object.prototype keys as unknown npm packages", () => {
-      // `in`-style lookups would resolve "toString"/"constructor" to
-      // Object.prototype members and invoke them as SDK factories.
       const auth: Auth.Info = { type: "api", key: "test-api-key" };
       for (const npm of ["toString", "constructor", "valueOf"]) {
-        const model = makeModel("unknown", npm);
-        expect(() => getSDK(model, auth)).toThrow(`No bundled provider for npm package: ${npm}`);
+        expect(() => getSDK(makeModel("unknown", npm), auth)).toThrow(
+          `No bundled provider for npm package: ${npm}`,
+        );
       }
     });
   });
 
   describe("listModels", () => {
-    it("should return model definitions from ModelsDev", async () => {
-      const models = await Provider.listModels("anthropic");
+    it.each(modelListCases)("should return $name", async ({ provider, auth, properties }) => {
+      const models = await Provider.listModels(provider, auth);
       expect(models).toBeDefined();
       expect(Array.isArray(models)).toBe(true);
       expect(models.length).toBeGreaterThan(0);
-      expect(models[0]).toHaveProperty("id");
-      expect(models[0]).toHaveProperty("name");
-    });
-
-    it("should return OpenAI model definitions", async () => {
-      const models = await Provider.listModels("openai");
-      expect(models).toBeDefined();
-      expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBeGreaterThan(0);
-    });
-
-    it("should return OpenAI models for proxy auth type without CODEX filter", async () => {
-      const models = await Provider.listModels("openai", "proxy");
-      expect(models).toBeDefined();
-      expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBeGreaterThan(0);
-    });
-
-    it("should return all OpenAI models for API auth type", async () => {
-      const models = await Provider.listModels("openai", "api");
-      expect(models).toBeDefined();
-      expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBeGreaterThan(0);
+      if (properties) {
+        expect(models[0]).toHaveProperty("id");
+        expect(models[0]).toHaveProperty("name");
+      }
     });
 
     it("should throw error for unknown provider", async () => {

--- a/packages/llm/test/retry/retry.test.ts
+++ b/packages/llm/test/retry/retry.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, test } from "bun:test";
-import { Retry } from "../../src/retry";
 import { APIError } from "../../src/error";
+import { Retry } from "../../src/retry";
+
+type APIErrorInput = ConstructorParameters<typeof APIError>[0];
+const apiError = (input: APIErrorInput) => new APIError(input);
+
+function retryableError(headers?: Record<string, string>) {
+  return apiError({
+    message: "Rate limited",
+    isRetryable: true,
+    ...(headers && { responseHeaders: headers }),
+  });
+}
+
+function rateLimitError(headers?: Record<string, string>) {
+  return apiError({
+    message: "rate limited",
+    isRetryable: true,
+    statusCode: 429,
+    ...(headers && { responseHeaders: headers }),
+  });
+}
+
+function delayOf(attempt: number, error: unknown): number {
+  const decision = Retry.decide(attempt, error);
+  if (!decision.retry) throw new Error(`expected a retry decision, got ${decision.reason}`);
+  return decision.delayMs;
+}
 
 describe("Retry", () => {
   test("does not expose removed agent-level retry namespace members", async () => {
     const retrySource = await Bun.file(new URL("../../src/retry/index.ts", import.meta.url)).text();
-
     expect(Object.hasOwn(Retry, "DEFAULT_AGENT_RETRY_POLICY")).toBe(false);
     expect(Object.hasOwn(Retry, "calculateAgentBackoffMs")).toBe(false);
     expect(Object.hasOwn(Retry, "classifyAgentRetryReason")).toBe(false);
@@ -17,24 +42,21 @@ describe("Retry", () => {
 
   describe("sleep(ms, abortSignal)", () => {
     test("resolves after specified milliseconds", async () => {
-      const controller = new AbortController();
       const start = Date.now();
-      await Retry.sleep(100, controller.signal);
-      const elapsed = Date.now() - start;
-      expect(elapsed).toBeGreaterThanOrEqual(90);
+      await Retry.sleep(100, new AbortController().signal);
+      expect(Date.now() - start).toBeGreaterThanOrEqual(90);
     });
 
     test("respects AbortSignal and throws AbortError", async () => {
       const controller = new AbortController();
       const promise = Retry.sleep(1000, controller.signal);
       setTimeout(() => controller.abort(), 50);
-
       try {
         await promise;
         expect.unreachable("Should have thrown AbortError");
-      } catch (e) {
-        expect(e).toBeInstanceOf(DOMException);
-        expect((e as DOMException).name).toBe("AbortError");
+      } catch (error) {
+        expect(error).toBeInstanceOf(DOMException);
+        expect((error as DOMException).name).toBe("AbortError");
       }
     });
 
@@ -42,81 +64,94 @@ describe("Retry", () => {
       const controller = new AbortController();
       const promise = Retry.sleep(5000, controller.signal);
       controller.abort();
-
       try {
         await promise;
         expect.unreachable("Should have thrown AbortError");
-      } catch (e) {
-        expect((e as DOMException).name).toBe("AbortError");
+      } catch (error) {
+        expect((error as DOMException).name).toBe("AbortError");
       }
     });
 
     test("rejects immediately when signal is already aborted", async () => {
       const controller = new AbortController();
       controller.abort();
-
       const start = Date.now();
-
       try {
         await Retry.sleep(5000, controller.signal);
         expect.unreachable("Should have thrown AbortError");
-      } catch (e) {
-        expect(e).toBeInstanceOf(DOMException);
-        expect((e as DOMException).name).toBe("AbortError");
+      } catch (error) {
+        expect(error).toBeInstanceOf(DOMException);
+        expect((error as DOMException).name).toBe("AbortError");
       }
-
       expect(Date.now() - start).toBeLessThan(100);
     });
 
     test("caps delay at RETRY_MAX_DELAY", async () => {
       const controller = new AbortController();
-      // Request a delay larger than RETRY_MAX_DELAY
       const promise = Retry.sleep(Retry.RETRY_MAX_DELAY + 1000, controller.signal);
-
-      // Should complete within reasonable time (capped at RETRY_MAX_DELAY)
       setTimeout(() => controller.abort(), 100);
-
       try {
         await promise;
       } catch {
-        // Expected to abort
+        // Expected abort proves the requested delay was capped before completion.
       }
     });
   });
 
   describe("decide(attempt, error) delay computation", () => {
-    function retryableError(headers?: Record<string, string>): InstanceType<typeof APIError> {
-      return new APIError({
-        message: "Rate limited",
-        isRetryable: true,
-        ...(headers && { responseHeaders: headers }),
-      });
-    }
-
-    function delayOf(attempt: number, error: unknown): number {
-      const decision = Retry.decide(attempt, error);
-      if (!decision.retry) throw new Error(`expected a retry decision, got ${decision.reason}`);
-      return decision.delayMs;
-    }
-
     test("exponential backoff without headers", () => {
-      expect(delayOf(1, retryableError())).toBe(2000); // 2000 * 2^0
-      expect(delayOf(2, retryableError())).toBe(4000); // 2000 * 2^1
-      expect(delayOf(3, retryableError())).toBe(8000); // 2000 * 2^2
-      expect(delayOf(4, retryableError())).toBe(16000); // 2000 * 2^3
+      expect(delayOf(1, retryableError())).toBe(2000);
+      expect(delayOf(2, retryableError())).toBe(4000);
+      expect(delayOf(3, retryableError())).toBe(8000);
+      expect(delayOf(4, retryableError())).toBe(16000);
     });
 
-    test("caps exponential backoff at RETRY_MAX_DELAY_NO_HEADERS", () => {
-      expect(delayOf(20, retryableError())).toBeLessThanOrEqual(Retry.RETRY_MAX_DELAY_NO_HEADERS);
-    });
-
-    test("uses Retry-After-Ms header if present", () => {
-      expect(delayOf(1, retryableError({ "retry-after-ms": "5000" }))).toBe(5000);
-    });
-
-    test("uses Retry-After header (seconds) if Retry-After-Ms not present", () => {
-      expect(delayOf(1, retryableError({ "retry-after": "10" }))).toBe(10000);
-    });
+    test.each([
+      {
+        name: "caps exponential backoff at RETRY_MAX_DELAY_NO_HEADERS",
+        attempt: 20,
+        headers: undefined,
+        assert: (delay: number) =>
+          expect(delay).toBeLessThanOrEqual(Retry.RETRY_MAX_DELAY_NO_HEADERS),
+      },
+      {
+        name: "uses Retry-After-Ms header if present",
+        attempt: 1,
+        headers: { "retry-after-ms": "5000" },
+        assert: (delay: number) => expect(delay).toBe(5000),
+      },
+      {
+        name: "uses Retry-After header (seconds) if Retry-After-Ms not present",
+        attempt: 1,
+        headers: { "retry-after": "10" },
+        assert: (delay: number) => expect(delay).toBe(10000),
+      },
+      {
+        name: "falls back to exponential backoff if Retry-After is invalid",
+        attempt: 2,
+        headers: { "retry-after": "invalid" },
+        assert: (delay: number) => expect(delay).toBe(4000),
+      },
+      {
+        name: "caps the fallback backoff even when headers are present",
+        attempt: 20,
+        headers: { "retry-after": "invalid" },
+        assert: (delay: number) => expect(delay).toBe(Retry.RETRY_MAX_DELAY_NO_HEADERS),
+      },
+      {
+        name: "prioritizes Retry-After-Ms over Retry-After",
+        attempt: 1,
+        headers: { "retry-after-ms": "3000", "retry-after": "10" },
+        assert: (delay: number) => expect(delay).toBe(3000),
+      },
+      {
+        name: "handles missing headers gracefully",
+        attempt: 2,
+        headers: undefined,
+        assert: (delay: number) => expect(delay).toBe(4000),
+      },
+    ])("$name", ({ attempt, headers, assert }) =>
+      assert(delayOf(attempt, retryableError(headers as Record<string, string> | undefined))));
 
     test("parses Retry-After as HTTP date if not a number", () => {
       const futureDate = new Date(Date.now() + 5000).toUTCString();
@@ -125,41 +160,15 @@ describe("Retry", () => {
       expect(delayMs).toBeLessThanOrEqual(5000);
     });
 
-    test("falls back to exponential backoff if Retry-After is invalid", () => {
-      expect(delayOf(2, retryableError({ "retry-after": "invalid" }))).toBe(4000);
-    });
-
-    test("caps the fallback backoff even when headers are present", () => {
-      expect(delayOf(20, retryableError({ "retry-after": "invalid" }))).toBe(
-        Retry.RETRY_MAX_DELAY_NO_HEADERS,
-      );
-    });
-
     test("does not throw when error payload code fields are not strings", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          type: "error",
-          error: { code: 42, message: 7 },
-        }),
+      const error = apiError({
+        message: JSON.stringify({ type: "error", error: { code: 42, message: 7 } }),
         isRetryable: true,
       });
-
       expect(Retry.decide(1, error)).toMatchObject({ retry: true, reason: "server_error" });
     });
 
-    test("prioritizes Retry-After-Ms over Retry-After", () => {
-      expect(delayOf(1, retryableError({ "retry-after-ms": "3000", "retry-after": "10" }))).toBe(
-        3000,
-      );
-    });
-
-    test("handles missing headers gracefully", () => {
-      expect(delayOf(2, retryableError())).toBe(4000);
-    });
-
     test("does not expose the removed delay dual path", async () => {
-      // decide() is the single retry decision surface; the standalone
-      // uncapped delay() had no src consumer and is gone.
       const retrySource = await Bun.file(
         new URL("../../src/retry/index.ts", import.meta.url),
       ).text();
@@ -169,10 +178,6 @@ describe("Retry", () => {
   });
 
   describe("decide(attempt, error) reason classification", () => {
-    function reasonOf(error: unknown): Retry.Reason {
-      return Retry.decide(1, error).reason;
-    }
-
     test("classifies non-APIError as non_retryable", () => {
       expect(Retry.decide(1, new Error("Retry failed"))).toEqual({
         retry: false,
@@ -180,158 +185,105 @@ describe("Retry", () => {
       });
     });
 
-    test("classifies APIError with isRetryable false as non_retryable", () => {
-      const error = new APIError({
-        message: "Not found",
-        statusCode: 404,
-        isRetryable: false,
-      });
+    const reasonCases: Array<{ name: string; input: APIErrorInput; expected: Retry.Reason }> = [
+      {
+        name: "classifies APIError with isRetryable false as non_retryable",
+        input: { message: "Not found", statusCode: 404, isRetryable: false },
+        expected: "non_retryable",
+      },
+      {
+        name: "falls back to status classification when message is not JSON",
+        input: { message: "Server error", statusCode: 500, isRetryable: true },
+        expected: "server_error",
+      },
+      {
+        name: "classifies 429 by status when payload is opaque",
+        input: { message: "<html>rate limited</html>", statusCode: 429, isRetryable: true },
+        expected: "rate_limit",
+      },
+      {
+        name: "classifies 429 by status when the JSON body has no specific signal",
+        input: {
+          message: JSON.stringify({
+            type: "error",
+            error: { message: "request tokens exceeded your per-minute rate limit" },
+          }),
+          statusCode: 429,
+          isRetryable: true,
+        },
+        expected: "rate_limit",
+      },
+      {
+        name: "classifies from responseBody when message is opaque",
+        input: {
+          message: "Overloaded",
+          isRetryable: true,
+          responseBody: JSON.stringify({ type: "error", error: { type: "too_many_requests" } }),
+        },
+        expected: "rate_limit",
+      },
+      {
+        name: "detects too_many_requests in JSON response",
+        input: {
+          message: JSON.stringify({ type: "error", error: { type: "too_many_requests" } }),
+          isRetryable: true,
+        },
+        expected: "rate_limit",
+      },
+      {
+        name: "detects rate_limit in JSON error code",
+        input: {
+          message: JSON.stringify({ type: "error", error: { code: "rate_limit_exceeded" } }),
+          isRetryable: true,
+        },
+        expected: "rate_limit",
+      },
+      {
+        name: "detects rate_limit in JSON error type (Anthropic rate_limit_error)",
+        input: {
+          message: JSON.stringify({
+            type: "error",
+            error: { type: "rate_limit_error", message: "rate limited" },
+          }),
+          isRetryable: true,
+        },
+        expected: "rate_limit",
+      },
+      {
+        name: "detects server_error in JSON response",
+        input: {
+          message: JSON.stringify({ type: "error", error: { type: "server_error" } }),
+          isRetryable: true,
+        },
+        expected: "server_error",
+      },
+      {
+        name: "detects exhausted in error code",
+        input: { message: JSON.stringify({ code: "quota_exhausted" }), isRetryable: true },
+        expected: "overloaded",
+      },
+      {
+        name: "detects unavailable in error code",
+        input: { message: JSON.stringify({ code: "service_unavailable" }), isRetryable: true },
+        expected: "overloaded",
+      },
+      {
+        name: "detects no_kv_space in error message",
+        input: {
+          message: JSON.stringify({ error: { message: "no_kv_space" } }),
+          isRetryable: true,
+        },
+        expected: "server_error",
+      },
+    ];
 
-      expect(reasonOf(error)).toBe("non_retryable");
-    });
-
-    test("falls back to status classification when message is not JSON", () => {
-      const error = new APIError({
-        message: "Server error",
-        statusCode: 500,
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("server_error");
-    });
-
-    test("classifies 429 by status when payload is opaque", () => {
-      const error = new APIError({
-        message: "<html>rate limited</html>",
-        statusCode: 429,
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("rate_limit");
-    });
-
-    test("classifies 429 by status when the JSON body has no specific signal", () => {
-      // The prose classifier let the generic body.error sniff outrank the 429
-      // status ("Provider Server Error"), so real Anthropic rate limits
-      // ({error:{type:"rate_limit_error"}}) skipped the RateLimited path.
-      const error = new APIError({
-        message: JSON.stringify({
-          type: "error",
-          error: { message: "request tokens exceeded your per-minute rate limit" },
-        }),
-        statusCode: 429,
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("rate_limit");
-    });
-
-    test("classifies from responseBody when message is opaque", () => {
-      const error = new APIError({
-        message: "Overloaded",
-        isRetryable: true,
-        responseBody: JSON.stringify({
-          type: "error",
-          error: { type: "too_many_requests" },
-        }),
-      });
-
-      expect(reasonOf(error)).toBe("rate_limit");
-    });
-
-    test("detects too_many_requests in JSON response", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          type: "error",
-          error: { type: "too_many_requests" },
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("rate_limit");
-    });
-
-    test("detects rate_limit in JSON error code", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          type: "error",
-          error: { code: "rate_limit_exceeded" },
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("rate_limit");
-    });
-
-    test("detects rate_limit in JSON error type (Anthropic rate_limit_error)", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          type: "error",
-          error: { type: "rate_limit_error", message: "rate limited" },
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("rate_limit");
-    });
-
-    test("detects server_error in JSON response", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          type: "error",
-          error: { type: "server_error" },
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("server_error");
-    });
-
-    test("detects exhausted in error code", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          code: "quota_exhausted",
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("overloaded");
-    });
-
-    test("detects unavailable in error code", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          code: "service_unavailable",
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("overloaded");
-    });
-
-    test("detects no_kv_space in error message", () => {
-      const error = new APIError({
-        message: JSON.stringify({
-          error: { message: "no_kv_space" },
-        }),
-        isRetryable: true,
-      });
-
-      expect(reasonOf(error)).toBe("server_error");
+    test.each(reasonCases)("$name", ({ input, expected }) => {
+      expect(Retry.decide(1, apiError(input)).reason).toBe(expected);
     });
 
     test("trusts the provider retryable flag when payload and status are opaque", () => {
-      // The SDK only sets isRetryable for transient failures (408/409/429/5xx,
-      // x-should-retry); an unparseable payload must not veto that signal.
-      const plainText = new APIError({
-        message: "Plain text error",
-        isRetryable: true,
-      });
-      const invalidJson = new APIError({
-        message: "{ invalid json",
-        isRetryable: true,
-      });
-
+      const plainText = apiError({ message: "Plain text error", isRetryable: true });
+      const invalidJson = apiError({ message: "{ invalid json", isRetryable: true });
       expect(Retry.decide(1, plainText)).toMatchObject({ retry: true, reason: "server_error" });
       expect(Retry.decide(1, invalidJson)).toMatchObject({ retry: true, reason: "server_error" });
     });
@@ -341,42 +293,20 @@ describe("Retry", () => {
     });
   });
 
-  describe("removed retry wrapper", () => {
-    test("does not expose withRetry", async () => {
-      const retrySource = await Bun.file(
-        new URL("../../src/retry/index.ts", import.meta.url),
-      ).text();
-
-      expect(Object.hasOwn(Retry, "withRetry")).toBe(false);
-      expect(retrySource).not.toMatch(/\bwithRetry\b/);
-    });
+  test("removed retry wrapper does not expose withRetry", async () => {
+    const retrySource = await Bun.file(new URL("../../src/retry/index.ts", import.meta.url)).text();
+    expect(Object.hasOwn(Retry, "withRetry")).toBe(false);
+    expect(retrySource).not.toMatch(/\bwithRetry\b/);
   });
 });
 
 describe("Retry.decide ratelimit-reset parsing (#532 candidate 3)", () => {
-  function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
-    return new APIError({
-      message: "rate limited",
-      isRetryable: true,
-      statusCode: 429,
-      responseHeaders: headers,
-    });
-  }
-
-  function delayOf(headers: Record<string, string>): number {
-    const decision = Retry.decide(1, apiError(headers));
-    if (!decision.retry) throw new Error(`expected a retry decision, got ${decision.reason}`);
-    return decision.delayMs;
-  }
-
   test("x-ratelimit-reset-requests duration is used when retry-after is absent", () => {
-    expect(delayOf({ "x-ratelimit-reset-requests": "3s" })).toBe(3000);
+    expect(delayOf(1, rateLimitError({ "x-ratelimit-reset-requests": "3s" }))).toBe(3000);
   });
 
   test("x-ratelimit-reset duration with compound units parses", () => {
-    // 1m30s parses to 90s — above the header cap, so the inferred reset
-    // demotes to backoff with the over-cap flag proving the parse happened.
-    expect(Retry.decide(1, apiError({ "x-ratelimit-reset-tokens": "1m30s" }))).toEqual({
+    expect(Retry.decide(1, rateLimitError({ "x-ratelimit-reset-tokens": "1m30s" }))).toEqual({
       retry: true,
       reason: "rate_limit",
       delayMs: Retry.RETRY_INITIAL_DELAY,
@@ -386,34 +316,25 @@ describe("Retry.decide ratelimit-reset parsing (#532 candidate 3)", () => {
 
   test("anthropic-ratelimit reset timestamp is used when retry-after is absent", () => {
     const resetAt = new Date(Date.now() + 5000).toISOString();
-    const ms = delayOf({ "anthropic-ratelimit-requests-reset": resetAt });
+    const ms = delayOf(1, rateLimitError({ "anthropic-ratelimit-requests-reset": resetAt }));
     expect(ms).toBeGreaterThan(3500);
     expect(ms).toBeLessThanOrEqual(5100);
   });
 
   test("retry-after still wins over ratelimit resets", () => {
-    expect(delayOf({ "retry-after": "2", "x-ratelimit-reset-requests": "9s" })).toBe(2000);
+    expect(
+      delayOf(1, rateLimitError({ "retry-after": "2", "x-ratelimit-reset-requests": "9s" })),
+    ).toBe(2000);
   });
 });
 
 describe("Retry.decide (#532 candidate 3)", () => {
-  function apiError(headers?: Record<string, string>): InstanceType<typeof APIError> {
-    return new APIError({
-      message: "rate limited",
-      isRetryable: true,
-      statusCode: 429,
-      ...(headers && { responseHeaders: headers }),
-    });
-  }
-
   test("non-retryable errors decide against retry", () => {
-    const decision = Retry.decide(1, new Error("plain"));
-    expect(decision.retry).toBe(false);
+    expect(Retry.decide(1, new Error("plain")).retry).toBe(false);
   });
 
   test("header delay within the cap is honored", () => {
-    const decision = Retry.decide(1, apiError({ "retry-after": "45" }));
-    expect(decision).toEqual({
+    expect(Retry.decide(1, rateLimitError({ "retry-after": "45" }))).toEqual({
       retry: true,
       reason: "rate_limit",
       delayMs: 45_000,
@@ -421,54 +342,45 @@ describe("Retry.decide (#532 candidate 3)", () => {
   });
 
   test("header delay above the cap fails fast instead of silently stalling", () => {
-    const decision = Retry.decide(1, apiError({ "retry-after": "3600" }));
+    const decision = Retry.decide(1, rateLimitError({ "retry-after": "3600" }));
     expect(decision.retry).toBe(false);
     if (!decision.retry) {
-      // The typed reason stays a branchable literal; prose lives in detail.
       expect(decision.reason).toBe("rate_limit");
       expect(decision.detail).toContain("3600000");
     }
   });
 
   test("headless retry keeps the exponential backoff and its 30s cap", () => {
-    expect(Retry.decide(1, apiError())).toEqual({
+    expect(Retry.decide(1, rateLimitError())).toEqual({
       retry: true,
       reason: "rate_limit",
       delayMs: Retry.RETRY_INITIAL_DELAY,
     });
-    const late = Retry.decide(10, apiError());
-    if (late.retry) {
-      expect(late.delayMs).toBe(Retry.RETRY_MAX_DELAY_NO_HEADERS);
-    }
+    const late = Retry.decide(10, rateLimitError());
+    if (late.retry) expect(late.delayMs).toBe(Retry.RETRY_MAX_DELAY_NO_HEADERS);
   });
 });
 
 describe("Retry.decide cap semantics for inferred resets", () => {
-  function apiError(headers: Record<string, string>): InstanceType<typeof APIError> {
-    return new APIError({
-      message: "rate limited",
-      isRetryable: true,
-      statusCode: 429,
-      responseHeaders: headers,
-    });
-  }
-
-  test("an out-of-range ratelimit reset demotes to backoff instead of failing", () => {
-    const decision = Retry.decide(1, apiError({ "x-ratelimit-reset-requests": "30m" }));
-    expect(decision).toEqual({
-      retry: true,
-      reason: "rate_limit",
-      delayMs: Retry.RETRY_INITIAL_DELAY,
-      retryAfterOverCap: true,
-    });
-  });
-
-  test("bare numbers in reset headers are never parsed as years", () => {
-    const decision = Retry.decide(1, apiError({ "x-ratelimit-reset-requests": "2027" }));
-    expect(decision).toEqual({
-      retry: true,
-      reason: "rate_limit",
-      delayMs: Retry.RETRY_INITIAL_DELAY,
-    });
+  test.each([
+    {
+      name: "an out-of-range ratelimit reset demotes to backoff instead of failing",
+      header: "30m",
+      expected: {
+        retry: true,
+        reason: "rate_limit",
+        delayMs: Retry.RETRY_INITIAL_DELAY,
+        retryAfterOverCap: true,
+      },
+    },
+    {
+      name: "bare numbers in reset headers are never parsed as years",
+      header: "2027",
+      expected: { retry: true, reason: "rate_limit", delayMs: Retry.RETRY_INITIAL_DELAY },
+    },
+  ])("$name", ({ header, expected }) => {
+    expect(Retry.decide(1, rateLimitError({ "x-ratelimit-reset-requests": header }))).toEqual(
+      expected,
+    );
   });
 });

--- a/packages/llm/test/token/token-tracker.test.ts
+++ b/packages/llm/test/token/token-tracker.test.ts
@@ -1,34 +1,27 @@
 import { describe, expect, it } from "bun:test";
 import { TokenTracker } from "../../src/token/index";
 
-describe("TokenTracker.extractUsage", () => {
-  it("extracts AI SDK usage format", () => {
-    const response = {
+const usageCases: Array<{
+  name: string;
+  response: Parameters<typeof TokenTracker.extractUsage>[0];
+  expected: [number, number, number, number, number];
+}> = [
+  {
+    name: "extracts AI SDK usage format",
+    response: {
       usage: {
         inputTokens: 100,
         outputTokens: 50,
-        inputTokenDetails: {
-          noCacheTokens: 90,
-          cacheReadTokens: 7,
-          cacheWriteTokens: 3,
-        },
-        outputTokenDetails: {
-          textTokens: 44,
-          reasoningTokens: 6,
-        },
+        inputTokenDetails: { noCacheTokens: 90, cacheReadTokens: 7, cacheWriteTokens: 3 },
+        outputTokenDetails: { textTokens: 44, reasoningTokens: 6 },
         totalTokens: 150,
       },
-    };
-    const result = TokenTracker.extractUsage(response);
-    expect(result.inputTokens).toBe(100);
-    expect(result.outputTokens).toBe(50);
-    expect(result.reasoningTokens).toBe(6);
-    expect(result.cacheReadTokens).toBe(7);
-    expect(result.cacheWriteTokens).toBe(3);
-  });
-
-  it("extracts Anthropic usage format", () => {
-    const response = {
+    },
+    expected: [100, 50, 6, 7, 3],
+  },
+  {
+    name: "extracts Anthropic usage format",
+    response: {
       usage: {
         input_tokens: 100,
         output_tokens: 50,
@@ -36,34 +29,27 @@ describe("TokenTracker.extractUsage", () => {
         cache_creation_input_tokens: 7,
         cache_read_input_tokens: 3,
       },
-    };
-    const result = TokenTracker.extractUsage(response);
-    expect(result.inputTokens).toBe(100);
-    expect(result.outputTokens).toBe(50);
-    expect(result.reasoningTokens).toBe(12);
-    expect(result.cacheWriteTokens).toBe(7);
-    expect(result.cacheReadTokens).toBe(3);
-  });
-
-  it("extracts OpenAI usage format", () => {
-    const response = {
+    },
+    expected: [100, 50, 12, 3, 7],
+  },
+  {
+    name: "extracts OpenAI usage format",
+    response: {
       usage: { prompt_tokens: 200, completion_tokens: 80 },
       providerMetadata: { openai: { reasoningTokens: 9 } },
-    };
-    const result = TokenTracker.extractUsage(response);
-    expect(result.inputTokens).toBe(200);
-    expect(result.outputTokens).toBe(80);
-    expect(result.reasoningTokens).toBe(9);
-    expect(result.cacheReadTokens).toBe(0);
-    expect(result.cacheWriteTokens).toBe(0);
-  });
+    },
+    expected: [200, 80, 9, 0, 0],
+  },
+  { name: "returns zeros when usage is missing", response: {}, expected: [0, 0, 0, 0, 0] },
+];
 
-  it("returns zeros when usage is missing", () => {
-    const result = TokenTracker.extractUsage({});
-    expect(result.inputTokens).toBe(0);
-    expect(result.outputTokens).toBe(0);
-    expect(result.reasoningTokens).toBe(0);
-    expect(result.cacheReadTokens).toBe(0);
-    expect(result.cacheWriteTokens).toBe(0);
+describe("TokenTracker.extractUsage", () => {
+  it.each(usageCases)("$name", ({ response, expected }) => {
+    const result = TokenTracker.extractUsage(response);
+    expect(result.inputTokens).toBe(expected[0]);
+    expect(result.outputTokens).toBe(expected[1]);
+    expect(result.reasoningTokens).toBe(expected[2]);
+    expect(result.cacheReadTokens).toBe(expected[3]);
+    expect(result.cacheWriteTokens).toBe(expected[4]);
   });
 });


### PR DESCRIPTION
Deslop campaign phase 5b (final phase). Tabularizes duplicated llm test clusters; test-only, no src changes.

- Net: -457 LOC; tests 272->272, files 26->26, expect calls 694->694
- llm lcov hit-set exactly preserved (1914=1914 covered lines)
- Mutation probe kills (TokenTracker extraction mutation -> suite fails)
- Adversarial verification: no matcher weakening or dropped rows; 9 test-name merges from tabularization (allowed); apps/server ratchet wobble shown pre-existing on unchanged main (89.56 both, host-specific vs 90.37 baseline) - not caused by this PR
- Coverage ratchet run WITHOUT --update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates duplicated LLM tests into parameterized/table-driven cases and shared helpers to reduce duplication without changing behavior or coverage. No src changes.

- Net -457 LOC across `packages/llm/test/*`; files/tests/expect counts unchanged (26 files, 272 tests, 694 expects). lcov hit-set preserved exactly (1914 covered lines).
- Introduces `it.each`/`test.each` with small model/auth builders; merges 9 test names from tabularization while keeping assertions equivalent (no matcher weakening).
- Strengthens Retry coverage: header precedence, cap semantics, inferred resets, and opaque payloads; preserves exponential backoff limits. Validates `APIError` parsing and reasons.
- Unifies provider tests (Anthropic/OpenAI, API/proxy) via shared cases; respects `@ai-sdk/anthropic` and `@ai-sdk/openai` `api.id/url` paths in `getLanguage`/`getSDK`.
- Proxy models tests standardize fetch stubbing; assert typed `ProxyModelsError` flows and Authorization header behavior.
- Token and message pipelines use table-driven fixtures (TokenTracker usage extraction; `toModelMessages` ordering and normalization).
- Mutation probe: `TokenTracker` extraction mutation breaks suite, confirming assertion strength.
- Coverage ratchet run without `--update`; observed apps/server coverage wobble is pre-existing on main, not introduced here.

<sup>Written for commit b81261a5667e2d44e3fd08177734699bc5d9e113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for assistant reasoning order, retry behavior, rate-limit handling, authentication, proxy errors, and token usage.
  * Consolidated provider, authentication, model-listing, and conversion tests into clearer data-driven test cases.
  * Preserved existing coverage for malformed files, invalid entries, legacy tokens, permissions, custom models, and API configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->