### PR TITLE
feat(machines): body-machine driver band — localhost attach + capability negotiation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Last verified against `origin/main`: 2026-08-19 (paths, dependency graph, and sh
 
 OpenOmni — a single-Owner Agent OS. Agents earn autonomy through evidence, not self-report. See [Design Philosophy](docs/design-philosophy.md) (one page: three kernel primitives, two laws and a dial, four roles).
 
-The Owner talks to one Resident (a judgment partner that executes nothing), which delegates to Workers (internal agents, external AI, humans — uniformly) through one gate and isolated sessions; everything lands on one ledger. TypeScript monorepo (Bun + Turborepo) with 11 packages and 1 app (Server).
+The Owner talks to one Resident (a judgment partner that executes nothing), which delegates to Workers (internal agents, external AI, humans — uniformly) through one gate and isolated sessions; everything lands on one ledger. TypeScript monorepo (Bun + Turborepo) with 12 packages and 1 app (Server).
 
 The specification lives in [`docs/core-model.md`](docs/core-model.md) (actors/gate/ledger, roles incl. Governor and Jester, policy hook layer, three-tier vocabulary) and [`docs/architecture.md`](docs/architecture.md) (three communication verbs and package rings). Normative contract detail (guarantee split, authority evaluation, work-item/evidence contracts, Governor rules, memory port) lives in [`docs/kernel-contract.md`](docs/kernel-contract.md). The Owner-directed gateway pivot (channels = perimeter gateway, openomni = brain, SSOT single-ledger storage, engagement machine) is specified in [`docs/gateway-design.md`](docs/gateway-design.md) — stages 0–2 are wired (#718 contracts, #730 driver extraction, #736 router promotion): `packages/channels` IS the perimeter gateway, `packages/openomni` is the brain, and the two meet only in the protocol `Gateway.Deliver` contract plus ports injected by `apps/server`. ADRs are retired — absorbed into these docs; git history preserves the originals. **Design docs describe targets; `docs/implementation-status.md` is the single source of truth for what is actually wired.**
 
@@ -34,6 +34,7 @@ openomni/
 │   ├── openomni/        # Product kernel: messaging, access, orchestration, ledger/evidence gates, tools runtime
 │   ├── ipc/             # Worker-process IPC transport contract: NDJSON framing, bidirectional Unix-socket client/server, protocol errors — protocol-only deps (#496)
 │   ├── coordinator/     # Multiprocess worker driver: on-demand worker pool, supervision — protocol+ipc deps only, ports injected by the composition root
+│   ├── machines/        # Body-machine driver band: machine daemon + host accept endpoint (`machine.attach` handshake, enrollment∩offer effective fold) — protocol+ipc deps only, enrollment/event ports injected
 │   └── channels/        # Gateway (stage 2, #551/#707): Discord/Telegram/GitHub/WebSocket drivers + channel authn + perimeter router (resolve-route, wait service, #215 send kernel) — {protocol, ipc, policy, ledger} deps, S8 judgment-band confinement, observation sinks injected
 ├── turbo.json           # Build pipeline config
 └── package.json         # Workspace root (bun@1.3.6)
@@ -44,7 +45,7 @@ openomni/
 ```
 protocol  ←  policy, telemetry, ipc, placement (ring 0 → 1)
 telemetry ←  ledger, llm                      ledger adds durability
-ipc       ←  coordinator                      process driver, ledger-free
+ipc       ←  coordinator, machines            process/machine drivers, ledger-free
 protocol, ipc, policy, ledger    ←  channels  gateway drivers + router/authn (#707)
 policy, placement, llm, telemetry  ←  agent   the loop
 everything                       ←  openomni  ←  server
@@ -66,6 +67,7 @@ package's tests may reach further than its runtime code, and the gate holds
 | `ledger` | protocol, telemetry |
 | `llm` | protocol, telemetry — `src/` protocol only |
 | `coordinator` | protocol, ipc |
+| `machines` | protocol, ipc |
 | `channels` | protocol, ipc, policy, ledger — policy/ledger confined to the judgment band `src/router/` + `src/authn/` (S8 banding); the router may name only the perimeter ledger surfaces; tests may add telemetry |
 | `agent` | protocol, policy, placement, llm, telemetry — `src/` protocol, policy, placement, llm |
 | `openomni` | any except itself |
@@ -89,6 +91,7 @@ The package boundary rule is strict: product meaning belongs in `packages/openom
 | `packages/agent` | Stateless ChatAgent loop, agent policy built-ins/facade, tool invocation protocol, generic runtime primitives | OpenOmni session-backed worker lifecycle, external actor authority, channel routing, durable background/pending interaction semantics |
 | `packages/openomni` | Product kernel: messaging/routing, access control, Resident/Worker orchestration, worker lifecycle backed by session, ledger/evidence gates, tools runtime | Provider SDK behavior, raw channel transport, process supervision internals, storage adapter implementation |
 | `packages/ipc` | Worker-process IPC transport: NDJSON framing, bidirectional Unix-socket client/server (reverse server → owner-device connections included), typed transport errors | Kernel/ledger/policy imports, authorization decisions, run semantics, serializable message schemas (those stay in `protocol`) |
+| `packages/machines` | Machine daemon (offer + hold connection) and host accept endpoint: `machine.attach` wire handshake, live attachment table, attach/detach event emission through an injected sink | Enrollment storage (lookup is an injected port), capability execution semantics, kernel/ledger/policy imports |
 | `packages/coordinator` | Isolated worker process execution: spawn/slot/idle/restart/cancel, primitive run delivery, crash recovery | Actor authority, pending interactions, channel/session routing, worker grant policy, IPC transport internals (moved to `packages/ipc` in #496) |
 | `packages/channels` | Perimeter gateway (stage 2, #707): Discord/Telegram/GitHub/WebSocket drivers, envelope normalization, channel authn/trigger judgment, delivery clients, and the router band — external route resolution + `route.decided` recording, wait correlation/lifecycle (sole wait-store writer), blacklist/channel-grant/actor admission, routed pre-run authority, surface↔session map claims, #215 existing-agent send kernel (reply-grant instances, #219 egress-budget gate) | Session content, brain (`@openomni/openomni`) imports, storage engines, telemetry imports (observation sinks are injected), work placement / dispatch execution semantics (brain judgment behind the `Gateway.Deliver` seam) |
 | `apps/server` | Runtime host: config/bootstrap, channel registration, webhook/WebSocket/gateway transport wiring, connector process drivers and stored-installation wiring, server-owned MCP/custom tool wiring | PendingAsk/PendingInteraction lookup, agent/session routing, access decisions, tool selection policy, orchestration semantics, channel adapter implementations (moved to `packages/channels` in #551) |
@@ -148,6 +151,7 @@ raw channel event
 | Principal / actor identity | `packages/protocol/src/actor/` + `packages/ledger/src/actor/` + `packages/channels/src/router/actor-resolver.ts` | Schemas/storage are lower-level; inbound principal resolution is perimeter judgment in the gateway router since #707; dispatch-side actor semantics stay in `openomni` |
 | ChannelAccessRule / Blocklist | `packages/protocol/src/actor/` + `packages/ledger/src/{channel-grant,blacklist}/` | Storage lives in `ledger`; evaluation and precedence belong in `openomni` access |
 | PendingInteraction | `packages/protocol/src/communication/pending-interaction.ts` + `packages/ledger/src/pending-interaction/` + `packages/openomni/src/dispatch/pending-interaction-routing.ts` | Frozen legacy external-response correlation (#548): the store is read-only (writes throw the typed FrozenError), kernel owns match precedence via the upcast-on-read Wait view, and lifecycle transitions belong to the durable Wait primitive |
+| Machine attach (daemon + host) | `packages/machines/src/` | `attachMachineDaemon` / `createMachineHost` — `machine.attach` handshake over `@openomni/ipc`; enrollment lookup + event sink injected |
 | Coordinator (on-demand workers) | `packages/coordinator/src/worker-manager/worker-pool.ts` | `createWorkerManager(config, ports)` — spawn on demand, idle shutdown, max-active cap; verbs are `deliver`/`send`/`cancel`/`stats` (never `dispatch`), typed failures via `WorkerDeliveryError` codes |
 | Coordinator supervision | `packages/coordinator/src/worker-supervision/` | Process supervisor (`WorkerSupervisorOptions` config object; `events` sink required) |
 | Worker IPC transport | `packages/ipc/src/` | Unix socket transport, request/response framing — wire method names are frozen (Greg Young rule); standalone `@openomni/ipc` since #496, driver-band consumable |

--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,18 @@
         "@types/bun": "latest",
       },
     },
+    "packages/machines": {
+      "name": "@openomni/machines",
+      "version": "0.0.1",
+      "dependencies": {
+        "@openomni/ipc": "workspace:*",
+        "@openomni/protocol": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
     "packages/openomni": {
       "name": "@openomni/openomni",
       "version": "0.1.0",
@@ -377,6 +389,8 @@
     "@openomni/ledger": ["@openomni/ledger@workspace:packages/ledger"],
 
     "@openomni/llm": ["@openomni/llm@workspace:packages/llm"],
+
+    "@openomni/machines": ["@openomni/machines@workspace:packages/machines"],
 
     "@openomni/openomni": ["@openomni/openomni@workspace:packages/openomni"],
 
@@ -1030,11 +1044,13 @@
 
     "@openomni/coordinator/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@openomni/ipc/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@openomni/ipc/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@openomni/ledger/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@openomni/llm/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@openomni/machines/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@openomni/openomni/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -1126,11 +1142,13 @@
 
     "@openomni/coordinator/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "@openomni/ipc/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "@openomni/ipc/@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "@openomni/ledger/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@openomni/llm/@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "@openomni/machines/@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "@openomni/openomni/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -128,7 +128,8 @@ Role-specific judgment remains partly userland: Resident delegation choices, ses
 
 | Component | Status | Code | Notes |
 | --- | --- | --- | --- |
-| Machine contracts (`Machine.Enrollment`/`Offer`, `effectiveCapabilities` fold, capability grammar, attach events) | 🔌 | `packages/protocol/src/machine/` | Contracts only — no producer or consumer. The daemon (driver-band `packages/machines`), enrollment storage, and attach admission are planned |
+| Machine contracts (`Machine.Enrollment`/`Offer`/`AttachResult`, `effectiveCapabilities` fold, capability grammar, attach events, `machine.attach` wire method) | ✅ | `packages/protocol/src/machine/`, `packages/protocol/src/ipc/` | Produced and consumed by `packages/machines` |
+| Machines driver band (daemon + host accept endpoint, localhost Unix-socket attach, live attachment table, attach/detach events) | ✅ | `packages/machines/` | Enrollment lookup and event sink are injected ports; enrollment STORAGE and server-side wiring (composition root) are planned, as is capability execution over the held connection |
 | Delegation contracts (`WorkerAddress`, `Request`/`Handle`/`Settled`, `delivery_failed`≠`no_response` terminals, events) | 🔌 | `packages/protocol/src/delegation/` | Contracts only — the DelegationKernel, its transport drivers, and the agent-loop `DelegationPort` are planned. Existing worker.spawn/child_agent/resident.ask lanes are untouched |
 | Tool placement axis (`Tool.Placement`, `Spec.placement`/`Spec.requires`) | 🔌 | `packages/protocol/src/tool/index.ts` | Additive-optional; no catalog resolver reads them yet (placement machine axis is planned). Mutation axis stays the existing `safe` field |
 

--- a/packages/ipc/AGENTS.md
+++ b/packages/ipc/AGENTS.md
@@ -29,11 +29,12 @@ Depends on `@openomni/protocol` **only** — enforced by `script/check-deps.ts`.
 - Failure classification is per connection: a dying connection rejects ITS in-flight server calls as `IpcConnectionError` immediately, even while other connections survive — never left to age out as a timeout. Response matching is scoped the same way: a response id is only honored on the connection its request was written to.
 - A malformed (non-JSON) frame costs only itself: every parseable frame in the same chunk still delivers immediately, in order. The server answers each malformed line with its own 4001 error frame and keeps the connection alive; the client stays conservative and tears the connection down — but only after draining the chunk's valid frames. An OVERSIZE frame (>16 MiB) is different by design: it is a DoS guard that resets the connection's entire decode buffer mid-frame, so after answering 4001 the server CLOSES the desynced connection (the client tears down on the FIN, failing its pendings as `IpcConnectionError` instead of burning timeouts).
 - Server writes are backpressure-safe: Bun sockets do not buffer partial writes, so every server write goes through a per-connection queue flushed on `drain`; frames arrive intact and in order regardless of frame size or reader speed. Requests whose bytes die queued fail as `IpcConnectionError` with their connection.
+- `createIpcServer` accepts an optional `onDisconnect(connectionId)` observer, fired exactly once per torn-down connection (close or error) after its in-flight requests were failed — the hook driver-band hosts (e.g. `packages/machines`) use to observe detach.
 - `createIpcServer` is async and never steals a live server's socket: an existing socket file is probed first and only unlinked when provably dead (`IpcConnectionError` otherwise). `notify()` returns `false` when it dropped the notification because no client is connected.
 
 ## CONSUMERS
 
-`packages/coordinator` (worker supervision client side; bootstrap uses `typedCall`), `apps/server/src/execution/worker-entry.ts` (worker-side server), test harnesses (`packages/openomni/test/harness/policy-echo-worker.ts`, coordinator fixtures), and the manual QA driver `apps/server/src/manual/ipc-worker-driver.ts`.
+`packages/coordinator` (worker supervision client side; bootstrap uses `typedCall`), `packages/machines` (daemon client + host server for `machine.attach`), `apps/server/src/execution/worker-entry.ts` (worker-side server), test harnesses (`packages/openomni/test/harness/policy-echo-worker.ts`, coordinator fixtures), and the manual QA driver `apps/server/src/manual/ipc-worker-driver.ts`.
 
 ## TESTS
 

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -9,6 +9,14 @@ function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
+export interface IpcServerOptions {
+  /**
+   * Fires once per connection after it is torn down (close or error). The
+   * connection's in-flight requests have already been failed when this runs.
+   */
+  readonly onDisconnect?: (connectionId: string) => void;
+}
+
 type RequestHandler = (
   method: string,
   params: Record<string, unknown> | undefined,
@@ -62,6 +70,7 @@ function probeSocketLive(socketPath: string): Promise<boolean> {
 export async function createIpcServer(
   socketPath: string,
   handler: RequestHandler,
+  options: IpcServerOptions = {},
 ): Promise<IpcServer> {
   // A leftover socket file blocks Bun.listen with EADDRINUSE — but blindly
   // unlinking would steal a LIVE server's socket (new connections silently
@@ -183,6 +192,9 @@ export async function createIpcServer(
     // leaving them to age out would misreport the failure as a timeout. This
     // includes requests whose bytes were still sitting in the write queue.
     failPendingOf(id, new IpcConnectionError(reason));
+    // `state` guards double delivery: close always follows error, and the
+    // second call finds the connection already deleted.
+    if (state) options.onDisconnect?.(id);
   }
 
   function failPendingOf(connId: string, err: Error): void {

--- a/packages/ipc/test/disconnect.test.ts
+++ b/packages/ipc/test/disconnect.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { connectIpcClient } from "../src/client";
+import { createIpcServer } from "../src/server";
+
+test("onDisconnect fires exactly once per torn-down connection", async () => {
+  const socketPath = `/tmp/omo-ipc-disc-${process.pid}.sock`;
+  const disconnects: string[] = [];
+  let notifyDisconnect: (() => void) | undefined;
+  const server = await createIpcServer(
+    socketPath,
+    (_method, _params, respond) => {
+      respond({ ok: true });
+    },
+    {
+      onDisconnect: (connectionId) => {
+        disconnects.push(connectionId);
+        notifyDisconnect?.();
+      },
+    },
+  );
+  try {
+    const first = await connectIpcClient(socketPath);
+    await first.call("ping", {});
+    const second = await connectIpcClient(socketPath);
+    await second.call("ping", {});
+
+    const firstClosed = new Promise<void>((resolve) => {
+      notifyDisconnect = resolve;
+    });
+    first.close();
+    await firstClosed;
+    expect(disconnects).toHaveLength(1);
+
+    const secondClosed = new Promise<void>((resolve) => {
+      notifyDisconnect = resolve;
+    });
+    second.close();
+    await secondClosed;
+    expect(disconnects).toHaveLength(2);
+    expect(disconnects[0]).not.toBe(disconnects[1]);
+  } finally {
+    server.close();
+  }
+});

--- a/packages/ipc/test/disconnect.test.ts
+++ b/packages/ipc/test/disconnect.test.ts
@@ -42,3 +42,34 @@ test("onDisconnect fires exactly once per torn-down connection", async () => {
     server.close();
   }
 });
+
+test("onDisconnect fires exactly once on abrupt socket destruction", async () => {
+  const socketPath = `/tmp/omo-ipc-abrupt-${process.pid}.sock`;
+  const disconnects: string[] = [];
+  let notifyDisconnect: (() => void) | undefined;
+  const server = await createIpcServer(
+    socketPath,
+    (_method, _params, respond) => {
+      respond({ ok: true });
+    },
+    {
+      onDisconnect: (connectionId) => {
+        disconnects.push(connectionId);
+        notifyDisconnect?.();
+      },
+    },
+  );
+  try {
+    const { connect } = await import("node:net");
+    const raw = connect(socketPath);
+    await new Promise<void>((resolve) => raw.once("connect", () => resolve()));
+    const torn = new Promise<void>((resolve) => {
+      notifyDisconnect = resolve;
+    });
+    raw.destroy();
+    await torn;
+    expect(disconnects).toHaveLength(1);
+  } finally {
+    server.close();
+  }
+});

--- a/packages/machines/package.json
+++ b/packages/machines/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@openomni/machines",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "lint": "bunx biome check ./src",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@openomni/ipc": "workspace:*",
+    "@openomni/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
+}

--- a/packages/machines/src/daemon.ts
+++ b/packages/machines/src/daemon.ts
@@ -1,0 +1,41 @@
+import { type IpcClient, connectIpcClient, typedCall } from "@openomni/ipc";
+import type { Machine } from "@openomni/protocol";
+
+export interface MachineDaemonOptions {
+  readonly socketPath: string;
+  readonly offer: Machine.Offer;
+  readonly attachTimeoutMs?: number;
+}
+
+export interface MachineDaemon {
+  /** The host's verdict — a refusal is a typed outcome, not a thrown error. */
+  readonly attachment: Machine.AttachResult;
+  close(): void;
+}
+
+/**
+ * Machine-side daemon for the localhost slice: connect to the host socket,
+ * offer the capability set, and hold the connection open — the live
+ * connection IS the attachment. Capability execution arrives in a later
+ * slice over this same connection.
+ */
+export async function attachMachineDaemon(options: MachineDaemonOptions): Promise<MachineDaemon> {
+  const client: IpcClient = await connectIpcClient(options.socketPath);
+  try {
+    const attachment = await typedCall(
+      client,
+      "machine.attach",
+      options.offer,
+      options.attachTimeoutMs,
+    );
+    return {
+      attachment,
+      close() {
+        client.close();
+      },
+    };
+  } catch (error) {
+    client.close();
+    throw error;
+  }
+}

--- a/packages/machines/src/daemon.ts
+++ b/packages/machines/src/daemon.ts
@@ -1,5 +1,5 @@
 import { type IpcClient, connectIpcClient, typedCall } from "@openomni/ipc";
-import type { Machine } from "@openomni/protocol";
+import { Machine } from "@openomni/protocol";
 
 export interface MachineDaemonOptions {
   readonly socketPath: string;
@@ -22,11 +22,10 @@ export interface MachineDaemon {
 export async function attachMachineDaemon(options: MachineDaemonOptions): Promise<MachineDaemon> {
   const client: IpcClient = await connectIpcClient(options.socketPath);
   try {
-    const attachment = await typedCall(
-      client,
-      "machine.attach",
-      options.offer,
-      options.attachTimeoutMs,
+    // typedCall types the wire result but does not validate it; the host is
+    // across a trust boundary, so parse before believing it.
+    const attachment = Machine.AttachResult.parse(
+      await typedCall(client, "machine.attach", options.offer, options.attachTimeoutMs),
     );
     return {
       attachment,

--- a/packages/machines/src/host.ts
+++ b/packages/machines/src/host.ts
@@ -1,0 +1,107 @@
+import { type IpcServer, createIpcServer } from "@openomni/ipc";
+import { type BusEvent, Machine } from "@openomni/protocol";
+
+export interface MachineHostOptions {
+  readonly socketPath: string;
+  /**
+   * Owner enrollment lookup, injected by the composition root. The host is
+   * ledger-free by the driver-band rule; whoever wires it decides where
+   * enrollments persist.
+   */
+  readonly enrollment: (machineId: Machine.MachineId) => Machine.Enrollment | undefined;
+  readonly events: BusEvent.Sink;
+  readonly now: () => number;
+}
+
+export interface MachineHost {
+  /** Effective capability set of a currently attached machine. */
+  attached(machineId: Machine.MachineId): readonly Machine.CapabilityId[] | undefined;
+  close(): void;
+}
+
+interface Attachment {
+  readonly machineId: Machine.MachineId;
+  readonly capabilities: readonly Machine.CapabilityId[];
+}
+
+/**
+ * Brain-side accept endpoint for machine daemons (docs/machines-and-delegation.md §2).
+ * Owns the `machine.attach` wire method: parse the Offer, fold it against the
+ * injected enrollment, answer attached|refused, and keep the live attachment
+ * table so detach (connection loss or re-attach supersession) is observable
+ * through the injected event sink.
+ */
+export async function createMachineHost(options: MachineHostOptions): Promise<MachineHost> {
+  // Keyed by connectionId: one attachment per connection, and a machine
+  // re-attaching over a NEW connection supersedes the stale one (daemon
+  // restart is the normal path, not an error).
+  const attachments = new Map<string, Attachment>();
+  const connectionByMachine = new Map<Machine.MachineId, string>();
+
+  function detach(connectionId: string, reason: string): void {
+    const attachment = attachments.get(connectionId);
+    if (!attachment) return;
+    attachments.delete(connectionId);
+    if (connectionByMachine.get(attachment.machineId) === connectionId) {
+      connectionByMachine.delete(attachment.machineId);
+    }
+    options.events.publish(Machine.Events.Detached, {
+      machineId: attachment.machineId,
+      time: options.now(),
+      reason,
+    });
+  }
+
+  const server: IpcServer = await createIpcServer(
+    options.socketPath,
+    (method, params, respond, _notify, connectionId) => {
+      if (method !== "machine.attach") {
+        throw new Error(`unknown method: ${method}`);
+      }
+      const offer = Machine.Offer.parse(params);
+      const enrollment = options.enrollment(offer.machineId);
+      if (enrollment === undefined) {
+        respond({ status: "refused", reason: "machine_not_enrolled" } satisfies Machine.AttachResult);
+        return;
+      }
+      const outcome = Machine.effectiveCapabilities(enrollment, offer);
+      if (outcome.kind === "machine_mismatch") {
+        respond({ status: "refused", reason: "machine_mismatch" } satisfies Machine.AttachResult);
+        return;
+      }
+      const stale = connectionByMachine.get(outcome.machineId);
+      if (stale !== undefined && stale !== connectionId) {
+        detach(stale, "superseded_by_reattach");
+      }
+      detach(connectionId, "superseded_by_reattach");
+      attachments.set(connectionId, {
+        machineId: outcome.machineId,
+        capabilities: outcome.capabilities,
+      });
+      connectionByMachine.set(outcome.machineId, connectionId);
+      options.events.publish(Machine.Events.Attached, {
+        machineId: outcome.machineId,
+        time: options.now(),
+        effectiveCapabilities: [...outcome.capabilities],
+      });
+      respond({
+        status: "attached",
+        effectiveCapabilities: [...outcome.capabilities],
+      } satisfies Machine.AttachResult);
+    },
+    {
+      onDisconnect: (connectionId) => detach(connectionId, "connection_closed"),
+    },
+  );
+
+  return {
+    attached(machineId) {
+      const connectionId = connectionByMachine.get(machineId);
+      if (connectionId === undefined) return undefined;
+      return attachments.get(connectionId)?.capabilities;
+    },
+    close() {
+      server.close();
+    },
+  };
+}

--- a/packages/machines/src/host.ts
+++ b/packages/machines/src/host.ts
@@ -1,3 +1,4 @@
+import { chmodSync } from "node:fs";
 import { type IpcServer, createIpcServer } from "@openomni/ipc";
 import { type BusEvent, Machine } from "@openomni/protocol";
 
@@ -93,6 +94,9 @@ export async function createMachineHost(options: MachineHostOptions): Promise<Ma
       onDisconnect: (connectionId) => detach(connectionId, "connection_closed"),
     },
   );
+  // The localhost slice carries no auth token: the socket itself is the
+  // trust boundary, so it must not be connectable by other local users.
+  chmodSync(options.socketPath, 0o600);
 
   return {
     attached(machineId) {

--- a/packages/machines/src/index.ts
+++ b/packages/machines/src/index.ts
@@ -1,0 +1,2 @@
+export { attachMachineDaemon, type MachineDaemon, type MachineDaemonOptions } from "./daemon";
+export { createMachineHost, type MachineHost, type MachineHostOptions } from "./host";

--- a/packages/machines/test/attach.test.ts
+++ b/packages/machines/test/attach.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { IpcRemoteError, connectIpcClient } from "@openomni/ipc";
+import { statSync } from "node:fs";
+import { IpcRemoteError, connectIpcClient, createIpcServer } from "@openomni/ipc";
 import type { BusEvent, Machine } from "@openomni/protocol";
 import { attachMachineDaemon } from "../src/daemon";
 import { type MachineHost, createMachineHost } from "../src/host";
@@ -140,6 +141,10 @@ describe("machine attach handshake", () => {
           await expect(
             client.call("machine.attach", { machineId: "mac-studio" }),
           ).rejects.toBeInstanceOf(IpcRemoteError);
+          expect(await client.call("machine.attach", offer())).toEqual({
+            status: "attached",
+            effectiveCapabilities: ["fs.read"],
+          });
         } finally {
           client.close();
         }
@@ -188,5 +193,28 @@ describe("machine attach handshake", () => {
         first.close();
       },
     );
+  });
+
+  test("host socket is owner-only — the localhost trust boundary is real", async () => {
+    await withHost(
+      () => enrollment,
+      async ({ path }) => {
+        expect(statSync(path).mode & 0o777).toBe(0o600);
+      },
+    );
+  });
+
+  test("daemon refuses a host reply that violates Machine.AttachResult", async () => {
+    const path = socketPath();
+    const rogue = await createIpcServer(path, (_method, _params, respond) => {
+      respond({ status: "bogus" });
+    });
+    try {
+      await expect(attachMachineDaemon({ socketPath: path, offer: offer() })).rejects.toMatchObject(
+        { name: "ZodError" },
+      );
+    } finally {
+      rogue.close();
+    }
   });
 });

--- a/packages/machines/test/attach.test.ts
+++ b/packages/machines/test/attach.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { IpcRemoteError, connectIpcClient } from "@openomni/ipc";
+import type { BusEvent, Machine } from "@openomni/protocol";
+import { attachMachineDaemon } from "../src/daemon";
+import { type MachineHost, createMachineHost } from "../src/host";
+
+let socketCounter = 0;
+function socketPath(): string {
+  socketCounter += 1;
+  return `/tmp/omo-machines-${process.pid}-${socketCounter}.sock`;
+}
+
+interface RecordedEvent {
+  readonly name: string;
+  readonly payload: Record<string, unknown>;
+}
+
+function eventCollector() {
+  const events: RecordedEvent[] = [];
+  const waiters: Array<{ name: string; resolve: (event: RecordedEvent) => void }> = [];
+  const sink: BusEvent.Sink = {
+    publish(descriptor, payload) {
+      const event = { name: descriptor.name, payload: payload as Record<string, unknown> };
+      events.push(event);
+      for (let i = waiters.length - 1; i >= 0; i -= 1) {
+        const waiter = waiters[i];
+        if (waiter && waiter.name === event.name) {
+          waiters.splice(i, 1);
+          waiter.resolve(event);
+        }
+      }
+    },
+  };
+  return {
+    sink,
+    events,
+    /** Resolves on the NEXT event of this name (bounded by bun's test timeout). */
+    next(name: string): Promise<RecordedEvent> {
+      return new Promise((resolve) => {
+        waiters.push({ name, resolve });
+      });
+    },
+  };
+}
+
+const enrollment: Machine.Enrollment = {
+  name: "studio",
+  machineId: "mac-studio",
+  allowedCapabilities: ["fs.read", "shell.exec"],
+  enrolledAt: 1000,
+};
+
+function offer(overrides: Partial<Machine.Offer> = {}): Machine.Offer {
+  return {
+    machineId: "mac-studio",
+    daemonVersion: "0.0.1",
+    platform: "darwin-arm64",
+    offeredCapabilities: ["fs.read", "browser.control"],
+    offeredAt: 2000,
+    ...overrides,
+  };
+}
+
+async function withHost(
+  resolve: (machineId: Machine.MachineId) => Machine.Enrollment | undefined,
+  run: (context: {
+    host: MachineHost;
+    path: string;
+    collector: ReturnType<typeof eventCollector>;
+  }) => Promise<void>,
+): Promise<void> {
+  const collector = eventCollector();
+  const path = socketPath();
+  const host = await createMachineHost({
+    socketPath: path,
+    enrollment: resolve,
+    events: collector.sink,
+    now: () => 5000,
+  });
+  try {
+    await run({ host, path, collector });
+  } finally {
+    host.close();
+  }
+}
+
+describe("machine attach handshake", () => {
+  test("enrolled daemon attaches with the enrollment∩offer effective set and the attached event", async () => {
+    await withHost(
+      () => enrollment,
+      async ({ host, path, collector }) => {
+        const daemon = await attachMachineDaemon({ socketPath: path, offer: offer() });
+        expect(daemon.attachment).toEqual({
+          status: "attached",
+          effectiveCapabilities: ["fs.read"],
+        });
+        expect(host.attached("mac-studio")).toEqual(["fs.read"]);
+        expect(collector.events).toEqual([
+          {
+            name: "machine.attached",
+            payload: { machineId: "mac-studio", time: 5000, effectiveCapabilities: ["fs.read"] },
+          },
+        ]);
+        daemon.close();
+      },
+    );
+  });
+
+  test("unknown machine is refused machine_not_enrolled and never attaches", async () => {
+    await withHost(
+      () => undefined,
+      async ({ host, path, collector }) => {
+        const daemon = await attachMachineDaemon({ socketPath: path, offer: offer() });
+        expect(daemon.attachment).toEqual({ status: "refused", reason: "machine_not_enrolled" });
+        expect(host.attached("mac-studio")).toBeUndefined();
+        expect(collector.events).toEqual([]);
+        daemon.close();
+      },
+    );
+  });
+
+  test("a resolver answering with another machine's enrollment is refused machine_mismatch", async () => {
+    await withHost(
+      () => ({ ...enrollment, machineId: "other-box" }),
+      async ({ path, collector }) => {
+        const daemon = await attachMachineDaemon({ socketPath: path, offer: offer() });
+        expect(daemon.attachment).toEqual({ status: "refused", reason: "machine_mismatch" });
+        expect(collector.events).toEqual([]);
+        daemon.close();
+      },
+    );
+  });
+
+  test("a malformed offer is a remote protocol error, not a refusal", async () => {
+    await withHost(
+      () => enrollment,
+      async ({ path }) => {
+        const client = await connectIpcClient(path);
+        try {
+          await expect(
+            client.call("machine.attach", { machineId: "mac-studio" }),
+          ).rejects.toBeInstanceOf(IpcRemoteError);
+        } finally {
+          client.close();
+        }
+      },
+    );
+  });
+
+  test("daemon disconnect publishes machine.detached with connection_closed", async () => {
+    await withHost(
+      () => enrollment,
+      async ({ host, path, collector }) => {
+        const daemon = await attachMachineDaemon({ socketPath: path, offer: offer() });
+        const detached = collector.next("machine.detached");
+        daemon.close();
+        expect((await detached).payload).toEqual({
+          machineId: "mac-studio",
+          time: 5000,
+          reason: "connection_closed",
+        });
+        expect(host.attached("mac-studio")).toBeUndefined();
+      },
+    );
+  });
+
+  test("re-attach over a new connection supersedes the stale attachment", async () => {
+    await withHost(
+      () => enrollment,
+      async ({ host, path, collector }) => {
+        const first = await attachMachineDaemon({ socketPath: path, offer: offer() });
+        const superseded = collector.next("machine.detached");
+        const second = await attachMachineDaemon({
+          socketPath: path,
+          offer: offer({ offeredCapabilities: ["shell.exec"] }),
+        });
+        expect((await superseded).payload).toEqual({
+          machineId: "mac-studio",
+          time: 5000,
+          reason: "superseded_by_reattach",
+        });
+        expect(second.attachment).toEqual({
+          status: "attached",
+          effectiveCapabilities: ["shell.exec"],
+        });
+        expect(host.attached("mac-studio")).toEqual(["shell.exec"]);
+        second.close();
+        first.close();
+      },
+    );
+  });
+});

--- a/packages/machines/tsconfig.json
+++ b/packages/machines/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@openomni/machines": ["./src/index.ts"]
+    }
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Execution } from "../execution/index.js";
+import { Machine } from "../machine/index.js";
 import { Tool } from "../tool/index.js";
 import { WorkerBootstrap } from "../worker-bootstrap/index.js";
 
@@ -42,6 +43,17 @@ const notificationSchema = baseMessage.extend({
  * workers/coordinators.
  */
 const methods = {
+  /**
+   * Machine daemon → machine host (docs/machines-and-delegation.md §2):
+   * the daemon offers its capability set, the host answers with the
+   * enrollment∩offer effective set or a typed refusal. The localhost slice
+   * carries no auth token — the Unix socket is the trust boundary; remote
+   * transports add authentication as an additive field when they land.
+   */
+  "machine.attach": {
+    params: Machine.Offer,
+    result: Machine.AttachResult,
+  },
   "coordinator.spawn_run": {
     /**
      * #500 B1: the params ARE the canonical spawn config — Execution.Request

--- a/packages/protocol/src/machine/index.ts
+++ b/packages/protocol/src/machine/index.ts
@@ -16,6 +16,8 @@ export namespace Machine {
   export type Enrollment = Schema.Enrollment;
   export const Offer = Schema.Offer;
   export type Offer = Schema.Offer;
+  export const AttachResult = Schema.AttachResult;
+  export type AttachResult = Schema.AttachResult;
 
   export const effectiveCapabilities = Fold.effectiveCapabilities;
   export type EffectiveOutcome = Fold.EffectiveOutcome;

--- a/packages/protocol/src/machine/schema.ts
+++ b/packages/protocol/src/machine/schema.ts
@@ -57,3 +57,24 @@ export const Offer = z
   })
   .strict();
 export type Offer = z.infer<typeof Offer>;
+
+/**
+ * Host reply to a daemon's `machine.attach` wire call. `refused` is a typed
+ * outcome, not a transport error: the connection stays open and the daemon
+ * may re-offer after the Owner fixes the enrollment.
+ */
+export const AttachResult = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("attached"),
+      effectiveCapabilities: z.array(CapabilityId).superRefine(uniqueCapabilities),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("refused"),
+      reason: z.enum(["machine_not_enrolled", "machine_mismatch"]),
+    })
+    .strict(),
+]);
+export type AttachResult = z.infer<typeof AttachResult>;

--- a/packages/protocol/test/machine/machine.test.ts
+++ b/packages/protocol/test/machine/machine.test.ts
@@ -143,3 +143,42 @@ describe("machine.attached event payload", () => {
     }
   });
 });
+
+describe("Machine.AttachResult", () => {
+  test("attached refuses a duplicated effective set", () => {
+    const result = Machine.AttachResult.safeParse({
+      status: "attached",
+      effectiveCapabilities: ["fs.read", "fs.read"],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("capabilities must be unique");
+      expect(result.error.issues[0]?.path.join(".")).toBe("effectiveCapabilities");
+    }
+  });
+
+  test("refused accepts only the enrollment refusal vocabulary", () => {
+    const result = Machine.AttachResult.safeParse({ status: "refused", reason: "bad_weather" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.code).toBe("invalid_enum_value");
+      expect(result.error.issues[0]?.path.join(".")).toBe("reason");
+    }
+  });
+
+  test("refused carries no capability set", () => {
+    const result = Machine.AttachResult.safeParse({
+      status: "refused",
+      reason: "machine_not_enrolled",
+      effectiveCapabilities: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.code).toBe("unrecognized_keys");
+      expect(result.error.issues[0]?.message).toBe(
+        "Unrecognized key(s) in object: 'effectiveCapabilities'",
+      );
+      expect(result.error.issues[0]?.path).toEqual([]);
+    }
+  });
+});

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -11,6 +11,7 @@ type PackageKey =
   | "agent"
   | "openomni"
   | "coordinator"
+  | "machines"
   | "channels"
   | "server";
 
@@ -138,6 +139,15 @@ const RULES: Record<PackageKey, PackageRule> = {
     // Ring-2 process driver: protocol + ipc only (#462 step 1 made it
     // ledger-free; #496 moved the IPC transport into @openomni/ipc; this
     // ratchet keeps it that way — widening requires Owner sign-off).
+    allowedDeps: new Set(["@openomni/protocol", "@openomni/ipc"]),
+  },
+  machines: {
+    displayName: "machines",
+    packageJsonPath: "packages/machines/package.json",
+    packageName: "@openomni/machines",
+    // Driver band (docs/machines-and-delegation.md §2): daemon + host accept
+    // endpoint for body machines. Enrollment lookup and event sink are
+    // injected ports — no ledger, no telemetry, repo-extractable.
     allowedDeps: new Set(["@openomni/protocol", "@openomni/ipc"]),
   },
   channels: {


### PR DESCRIPTION
Closes #770. Stage 2 of docs/machines-and-delegation.md §5 — contracts landed in #769; this PR gives them their first producer and consumer.

## What

- **`packages/machines`** (new driver-band package, deps `{protocol, ipc}` only):
  - `attachMachineDaemon` — connects to the host socket, sends `Machine.Offer` over the frozen `machine.attach` wire method, holds the connection open (the live connection IS the attachment). Refusal is a typed outcome, not a throw.
  - `createMachineHost` — accept endpoint: parses the Offer, looks up the enrollment through an **injected port** (ledger-free), applies the `Machine.effectiveCapabilities` fold, answers `attached|refused`, maintains the live attachment table, and publishes `machine.attached`/`machine.detached` through an injected `BusEvent.Sink`. A machine re-attaching over a new connection supersedes the stale one (`superseded_by_reattach`); connection loss publishes `connection_closed`.
- **protocol**: `Machine.AttachResult` (attached effective set | refused `machine_not_enrolled`/`machine_mismatch`) + `machine.attach` registered in the Ipc methods map. Localhost slice carries no auth token — the Unix socket is the trust boundary; remote transports add authentication as an additive field.
- **ipc**: additive `IpcServerOptions.onDisconnect(connectionId)` — fired exactly once per torn-down connection after in-flight requests are failed. Wire format untouched.
- **Gates/docs**: check-deps `machines` allowlist row; AGENTS.md (structure, dep graph, ownership, where-to-look), packages/ipc/AGENTS.md, docs/implementation-status.md (machine contracts 🔌→✅, machines driver band ✅) all move in this PR.

## Not in this PR (deliberate)

Enrollment storage, composition-root wiring in apps/server, remote (non-localhost) transport, and capability execution over the held connection — later slices per §5.

## Conformance / baselines

No baseline growth: lint:tools, check-deps, check-dead-exports all pass unchanged. New wire method `machine.attach` is additive to the methods map (Greg Young rule: name frozen from here).

## Verification

- `bun test --timeout 15000`: 3898 pass / 2 skip / 0 fail (12 new tests: 6 machines socket round-trips, 3 AttachResult contract, 1 ipc onDisconnect exactly-once, plus existing)
- `bun run check-types`, `bun run lint:tools`, `bun run script/check-deps.ts`, `bun run script/check-dead-exports.ts`: all exit 0
- Machines tests run real Unix-socket handshakes (daemon↔host), event-driven awaits, no sleeps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the localhost machine attach driver band with capability negotiation and a strict trust boundary. Previously machine contracts had no producer/consumer; now a daemon attaches over IPC, the live connection is the attachment, the host enforces enrollment∩offer, returns typed refusals, restricts its socket to owner-only, and the daemon validates host replies.

- `@openomni/machines`: `attachMachineDaemon` offers `Machine.Offer`, validates the `Machine.AttachResult` reply, and holds the connection; `createMachineHost` parses offers, looks up enrollment via an injected port, folds `effectiveCapabilities`, replies attached|refused, tracks live attachments, emits `machine.attached`/`machine.detached`, supersedes stale connections on re-attach, and chmods the socket 0600 to make the Unix socket the trust boundary.
- Protocol: adds `Machine.AttachResult` and registers `machine.attach` in the IPC methods map; localhost slice has no auth token (remote transports add auth later).
- `@openomni/ipc`: adds optional `IpcServerOptions.onDisconnect(connectionId)`, fired exactly once per torn-down connection after failing in-flight requests.
- Rollout: additive only — no migrations; `@openomni/machines` depends on `@openomni/protocol` and `@openomni/ipc`; enrollment storage and composition-root wiring land later.

<sup>Written for commit d6a62d9bf59c855a6a167d53e1af6edd11d21018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added machine host and daemon support for secure local attachment over IPC.
  - Machines can submit capability offers, receive accepted or refused attachment results, and track attach/detach events.
  - Added the `machine.attach` protocol and structured attachment outcomes.
  - IPC servers can now notify applications when connections disconnect.

- **Documentation**
  - Updated implementation status and package documentation for machine support.

- **Tests**
  - Added coverage for enrollment, capabilities, refusals, reconnections, detachments, permissions, and disconnect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->