### PR TITLE
feat: channel delegation driver — delegate to external actors over ws

### DIFF
--- a/apps/openomni/src/config.ts
+++ b/apps/openomni/src/config.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { Machine } from "@openomni/protocol";
+import { Actor, Machine } from "@openomni/protocol";
 import { z } from "zod";
 
 export interface OpenOmniConfig {
@@ -23,6 +23,21 @@ export interface OpenOmniConfig {
     readonly socketPath: string;
     readonly enrolled: readonly Machine.Enrollment[];
   };
+  /**
+   * External actors the Owner has admitted as delegation targets. Absent
+   * means the channel transport has nobody to reach: sends are denied
+   * ungranted rather than the driver being unwired.
+   */
+  readonly actors?: readonly RegisteredActor[];
+}
+
+export interface RegisteredActor {
+  readonly actorId: string;
+  /** The identity the actor's connection declares (`?actor=<externalId>`). */
+  readonly externalId: string;
+  readonly trustTier: Actor.TrustTier;
+  readonly kind: Actor.Kind;
+  readonly displayName?: string;
 }
 
 function required(name: string): string {
@@ -57,6 +72,34 @@ export function assertWsExposure(config: Pick<OpenOmniConfig, "host" | "wsToken"
 
 const Enrollments = z.array(Machine.Enrollment).min(1);
 
+const Actors = z
+  .array(
+    z
+      .object({
+        actorId: z.string().min(1),
+        externalId: z.string().min(1),
+        trustTier: Actor.TrustTier,
+        kind: Actor.Kind.default("human"),
+        displayName: z.string().min(1).optional(),
+      })
+      .strict(),
+  )
+  .min(1);
+
+/**
+ * Like enrollment, actor admission is the Owner's decision read from config:
+ * who may be delegated to is never inferred from whoever connects.
+ */
+function actorsFromEnv(): OpenOmniConfig["actors"] {
+  const raw = process.env.OPENOMNI_ACTORS?.trim();
+  if (raw === undefined || raw.length === 0) return undefined;
+  const parsed = Actors.safeParse(JSON.parse(raw));
+  if (!parsed.success) {
+    throw new Error(`OPENOMNI_ACTORS is invalid: ${parsed.error.issues[0]?.message}`);
+  }
+  return parsed.data;
+}
+
 /**
  * Enrollment is the Owner's admission decision, so it is read from config
  * rather than inferred from whoever connects. Ledger-backed enrollment is a
@@ -81,6 +124,7 @@ export function loadConfig(): OpenOmniConfig {
   const host = process.env.OPENOMNI_WS_HOST?.trim() || "127.0.0.1";
   const wsToken = process.env.OPENOMNI_WS_TOKEN?.trim();
   const machines = machinesFromEnv();
+  const actors = actorsFromEnv();
   return {
     dbPath: process.env.OPENOMNI_DB_PATH?.trim() || join(homedir(), ".openomni", "storage.db"),
     host,
@@ -92,5 +136,6 @@ export function loadConfig(): OpenOmniConfig {
       apiKey: required("OPENOMNI_MODEL_API_KEY"),
     },
     ...(machines === undefined ? {} : { machines }),
+    ...(actors === undefined ? {} : { actors }),
   };
 }

--- a/apps/openomni/src/delegation/admission.ts
+++ b/apps/openomni/src/delegation/admission.ts
@@ -13,6 +13,12 @@ import { Delegation } from "@openomni/protocol";
 export interface DelegationOrigin {
   readonly role: "resident" | "worker";
   readonly depth: number;
+  /**
+   * The durable session this delegation chain originates from — the owner of
+   * any Wait a transport opens on its behalf. Inherited unchanged down the
+   * chain: a child works FOR that session, it does not get its own claim.
+   */
+  readonly sessionId: string;
 }
 
 export interface Admitted {
@@ -88,6 +94,6 @@ export function admit(
     ok: true,
     request,
     transport,
-    childOrigin: { role: "worker", depth: origin.depth + 1 },
+    childOrigin: { role: "worker", depth: origin.depth + 1, sessionId: origin.sessionId },
   };
 }

--- a/apps/openomni/src/delegation/channel-driver.ts
+++ b/apps/openomni/src/delegation/channel-driver.ts
@@ -1,0 +1,121 @@
+import type { ExistingAgentMessaging } from "@openomni/channels";
+import type { Delegation } from "@openomni/protocol";
+import type { Admitted } from "./admission";
+import { renderInstruction } from "./instruction";
+import type { DelegationDriver, DriverOutcome } from "./kernel";
+
+export interface ChannelDriverPorts {
+  /**
+   * The gateway's #215 send kernel, resolved late because the driver is
+   * composed before the gateway that owns it. Every grant/target/budget
+   * judgment lives behind this port — the driver only carries the request.
+   */
+  readonly send: ExistingAgentMessaging["send"];
+  readonly now: () => number;
+  readonly newWaitId: () => string;
+}
+
+/**
+ * The channel transport plus its resume half: `run` sends the instruction to
+ * an external actor as an awaited message, `resume` is called by the ingress
+ * bridge when the perimeter correlates that actor's reply back to the Wait.
+ */
+export interface ChannelDelegationDriver extends DelegationDriver {
+  /** True when the waitId belonged to a delegation still awaiting its reply. */
+  resume(waitId: string, text: string): boolean;
+}
+
+/**
+ * The channel transport: delegation to an actor who lives OUTSIDE this
+ * process — a human or an external agent on a channel. The send kernel owns
+ * every authority judgment (grants, target resolution, budgets) and the
+ * durable Wait; this driver owns only the mapping between that machinery and
+ * the delegation contract's settlement vocabulary.
+ */
+export function createChannelDriver(ports: ChannelDriverPorts): ChannelDelegationDriver {
+  const pending = new Map<string, (text: string | undefined) => void>();
+
+  return {
+    resume(waitId, text) {
+      const settle = pending.get(waitId);
+      if (settle === undefined) return false;
+      pending.delete(waitId);
+      settle(text);
+      return true;
+    },
+
+    async run(admitted: Admitted, handle: Delegation.Handle, signal: AbortSignal): Promise<DriverOutcome> {
+      const address = admitted.request.address;
+      if (address.kind !== "actor") {
+        // Admission maps only actor addresses onto this transport; reaching
+        // here with anything else is a composition fault, not a worker answer.
+        throw new Error("channel transport carries actor addresses only");
+      }
+
+      const waitId = ports.newWaitId();
+      // Registered BEFORE the send: the reply can race the send's own return,
+      // and a reply that finds no pending entry would fall through to the
+      // Resident as an ordinary message instead of settling this delegation.
+      const reply = new Promise<string | undefined>((resolve) => {
+        pending.set(waitId, resolve);
+      });
+      const abort = () => {
+        const settle = pending.get(waitId);
+        if (settle !== undefined) {
+          pending.delete(waitId);
+          settle(undefined);
+        }
+      };
+      signal.addEventListener("abort", abort, { once: true });
+
+      let receipt: Awaited<ReturnType<ExistingAgentMessaging["send"]>>;
+      try {
+        receipt = await ports.send({
+          messageId: handle.delegationId,
+          traceId: handle.delegationId,
+          senderId: "resident",
+          target: { actorId: address.actorId },
+          operation: "awaited",
+          body: renderInstruction(
+            admitted.request.payload.text,
+            admitted.request.acceptanceCriteria ?? [],
+          ),
+          at: ports.now(),
+          waitSpec: {
+            waitId,
+            ownerRef: { kind: "session", id: admitted.childOrigin.sessionId },
+            allowedActions: ["report_result"],
+            expectedResponders: [address.actorId],
+            resolutionPolicy: "first_reply",
+            expiresAt: admitted.request.deadline,
+            followUpWindow: 0,
+          },
+        });
+      } catch (error) {
+        // The delivery effect itself broke (no live connection, transport
+        // fault): the actor never held the request. The Wait the kernel may
+        // have opened expires on its own schedule — send.ts blesses exactly
+        // this ordering ("a delivery failure leaves an open Wait").
+        pending.delete(waitId);
+        signal.removeEventListener("abort", abort);
+        return {
+          status: "delivery_failed",
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
+
+      if (receipt.kind === "denied") {
+        pending.delete(waitId);
+        signal.removeEventListener("abort", abort);
+        return { status: "delivery_failed", reason: receipt.reason };
+      }
+
+      const text = await reply;
+      signal.removeEventListener("abort", abort);
+      // The kernel aborts on deadline and settles no_response itself; the
+      // driver only stops holding the pending entry.
+      if (text === undefined) return { status: "cancelled", reason: "deadline reached" };
+      return { status: "completed", output: text };
+    },
+  };
+}

--- a/apps/openomni/src/delegation/instruction.ts
+++ b/apps/openomni/src/delegation/instruction.ts
@@ -1,0 +1,17 @@
+/**
+ * How a delegated instruction reads when it reaches the worker — one renderer
+ * because the inline loop's opening message and the channel driver's outbound
+ * body are the SAME contract text: the instruction, then what makes it done.
+ */
+export function renderInstruction(
+  instruction: string,
+  acceptanceCriteria: readonly string[],
+): string {
+  if (acceptanceCriteria.length === 0) return instruction;
+  return [
+    instruction,
+    "",
+    "It is done when all of these hold:",
+    ...acceptanceCriteria.map((criterion) => `- ${criterion}`),
+  ].join("\n");
+}

--- a/apps/openomni/src/delegation/process-entry.ts
+++ b/apps/openomni/src/delegation/process-entry.ts
@@ -21,6 +21,7 @@ export const ProcessWorkerRequest = z
       .object({
         role: z.enum(["resident", "worker"]),
         depth: z.number().int().nonnegative(),
+        sessionId: z.string().min(1),
       })
       .strict(),
     model: Model.Ref,

--- a/apps/openomni/src/delegation/tool.ts
+++ b/apps/openomni/src/delegation/tool.ts
@@ -16,14 +16,29 @@ const Input = z
       .describe("ask = answer a question; assign = own a piece of work until its criteria are met."),
     scope: z
       .enum(["inline", "independent"])
+      .optional()
       .describe("inline = a child in this process sharing your domain; independent = its own worker."),
+    actorId: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("A registered external actor (a human or an outside agent) to hand the work to instead of an internal worker."),
     acceptanceCriteria: z
       .array(z.string().min(1))
       .optional()
       .describe("Required for assign, forbidden for ask: what makes the work done."),
     timeoutMs: z.number().int().positive().describe("How long to wait before giving up on an answer."),
   })
-  .strict();
+  .strict()
+  .superRefine((input, ctx) => {
+    if ((input.scope === undefined) === (input.actorId === undefined)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "exactly one of scope or actorId must be given",
+        path: ["scope"],
+      });
+    }
+  });
 
 export const DELEGATE_TOOL_NAME = "delegate";
 
@@ -35,7 +50,7 @@ export const DELEGATE_TOOL_NAME = "delegate";
 const INPUT_JSON_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
-  required: ["instruction", "mode", "scope", "timeoutMs"],
+  required: ["instruction", "mode", "timeoutMs"],
   properties: {
     instruction: {
       type: "string",
@@ -50,7 +65,14 @@ const INPUT_JSON_SCHEMA: Record<string, unknown> = {
     scope: {
       type: "string",
       enum: ["inline", "independent"],
-      description: "inline = a child in this process sharing your domain; independent = its own worker.",
+      description:
+        "inline = a child in this process sharing your domain; independent = its own worker. Exactly one of scope or actorId.",
+    },
+    actorId: {
+      type: "string",
+      minLength: 1,
+      description:
+        "A registered external actor (a human or an outside agent) to hand the work to instead of an internal worker. Exactly one of scope or actorId.",
     },
     acceptanceCriteria: {
       type: "array",
@@ -92,9 +114,11 @@ export function delegateToolExecutor(kernel: DelegationKernel, origin: Delegatio
     const result = await kernel.delegate(
       {
         address:
-          input.scope === "inline"
-            ? { kind: "core", scope: "inline" }
-            : { kind: "core", scope: "independent" },
+          input.actorId !== undefined
+            ? { kind: "actor", actorId: input.actorId }
+            : input.scope === "inline"
+              ? { kind: "core", scope: "inline" }
+              : { kind: "core", scope: "independent" },
         mode: input.mode,
         payload: { text: input.instruction },
         ...(input.acceptanceCriteria === undefined

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -3,6 +3,7 @@ import type { Model } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { catalogEntries } from "../tools/catalog";
 import { createDispatcher, HOST_TARGET } from "../tools/dispatch";
+import { renderInstruction } from "./instruction";
 import type { DelegationKernel } from "./kernel";
 import type { InlineWorkerRunner } from "./inline-driver";
 
@@ -15,16 +16,6 @@ export interface WorkerLoopOptions {
   readonly llm?: ChatAgentConfig["llm"];
   /** Resolved late: the kernel needs the runner this factory produces. */
   readonly kernel: () => DelegationKernel;
-}
-
-function instructionFor(input: Parameters<InlineWorkerRunner>[0]): string {
-  if (input.acceptanceCriteria.length === 0) return input.instruction;
-  return [
-    input.instruction,
-    "",
-    "It is done when all of these hold:",
-    ...input.acceptanceCriteria.map((criterion) => `- ${criterion}`),
-  ].join("\n");
 }
 
 /**
@@ -51,7 +42,13 @@ export function createInlineWorkerRunner(options: WorkerLoopOptions): InlineWork
     });
 
     const result = await agent.run({
-      messages: [{ role: "user", content: instructionFor(input), time: Date.now() }],
+      messages: [
+        {
+          role: "user",
+          content: renderInstruction(input.instruction, input.acceptanceCriteria),
+          time: Date.now(),
+        },
+      ],
       traceContext: {
         traceId: crypto.randomUUID(),
         sessionId: `delegation-${input.delegationId}`,

--- a/apps/openomni/src/gateway.ts
+++ b/apps/openomni/src/gateway.ts
@@ -1,12 +1,22 @@
-import { createGatewayRouter, type GatewayRouter } from "@openomni/channels";
+import {
+  type ChannelDeliveryRoute,
+  createGatewayRouter,
+  type GatewayRouter,
+} from "@openomni/channels";
 import { ChannelGrantStore } from "@openomni/ledger";
 import type { Gateway, Ingress } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 
 const WEBSOCKET_GRANT_ID = "openomni-resident-websocket";
 
+export interface OutboundMessaging {
+  readonly deliveryRoutes: ReadonlyMap<string, ChannelDeliveryRoute>;
+  readonly grants: () => readonly Gateway.SenderTargetGrant[];
+}
+
 export function createResidentGateway(
   deliver: (delivery: Gateway.Deliver) => Promise<Ingress.IngressResult>,
+  messaging?: OutboundMessaging,
 ): GatewayRouter {
   ChannelGrantStore.put({
     id: WEBSOCKET_GRANT_ID,
@@ -18,5 +28,6 @@ export function createResidentGateway(
   return createGatewayRouter({
     sink: Bus.publish,
     deliver,
+    ...(messaging === undefined ? {} : { messaging }),
   });
 }

--- a/apps/openomni/src/inbound.ts
+++ b/apps/openomni/src/inbound.ts
@@ -6,7 +6,11 @@ function correlation(
   threadId: string | undefined,
 ): Wait.Correlation {
   return {
-    endpointId: descriptor.namespace || descriptor.surface,
+    // The convention every registered ActorEndpoint id follows
+    // (`<channel>:<externalId>`), so a reply's claim can meet the Wait's
+    // recorded endpoint. NOT the per-connection channel id — a reconnect
+    // must still correlate.
+    endpointId: `${descriptor.surface}:${message.sender.id}`,
     channelId: descriptor.id ?? message.surfaceKey,
     ...(message.replyToId === undefined ? {} : { replyToMessageId: message.replyToId }),
     ...(threadId === undefined ? {} : { threadId }),

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -1,11 +1,12 @@
 import type { ChatAgentConfig } from "@openomni/agent";
-import { WebSocketHandler } from "@openomni/channels";
-import { initialize, Storage } from "@openomni/ledger";
+import { type GatewayRouter, WebSocketHandler } from "@openomni/channels";
+import { ActorRegistry, initialize, Storage } from "@openomni/ledger";
 import { createMachineHost, type MachineHost } from "@openomni/machines";
 import type { Placement } from "@openomni/placement";
-import type { Machine } from "@openomni/protocol";
+import type { Gateway, Ingress, Machine } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
-import { assertWsExposure, loadConfig, type OpenOmniConfig } from "./config";
+import { assertWsExposure, loadConfig, type OpenOmniConfig, type RegisteredActor } from "./config";
+import { createChannelDriver } from "./delegation/channel-driver";
 import { createInlineDriver } from "./delegation/inline-driver";
 import { createDelegationKernel, type DelegationKernel } from "./delegation/kernel";
 import { createProcessDriver } from "./delegation/process-driver";
@@ -43,10 +44,34 @@ function attachedTargets(
   return [HOST_TARGET, ...machines];
 }
 
+/** How a correlated reply's payload reads when handed back to the waiting delegation. */
+function replyText(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  return JSON.stringify(payload);
+}
+
 export async function startOpenOmni(options: StartOptions = {}) {
   const config = options.config ?? loadConfig();
   assertWsExposure(config);
   initialize({ dbPath: config.dbPath });
+
+  // Owner-admitted delegation targets. Registration is an upsert, so a
+  // restart re-asserting the same actors is a no-op.
+  const actors: readonly RegisteredActor[] = config.actors ?? [];
+  for (const actor of actors) {
+    ActorRegistry.registerIdentity({
+      id: actor.actorId,
+      kind: actor.kind,
+      trustTier: actor.trustTier,
+      ...(actor.displayName === undefined ? {} : { displayName: actor.displayName }),
+    });
+    ActorRegistry.registerEndpoint({
+      id: `ws:${actor.externalId}`,
+      actorId: actor.actorId,
+      channel: "ws",
+      externalId: actor.externalId,
+    });
+  }
 
   // A worker loop holds the same delegate tool the Resident does, so the
   // runner needs the kernel that the kernel needs the runner to build. The
@@ -61,9 +86,22 @@ export async function startOpenOmni(options: StartOptions = {}) {
     },
     ...(options.llm === undefined ? {} : { llm: options.llm }),
   });
+  // The gateway owns the send kernel the channel driver speaks through, and
+  // the gateway needs the deliver chain the kernel is part of — the same
+  // late-binding the runner/kernel pair uses.
+  let gateway: GatewayRouter | undefined;
+  const channelDriver = createChannelDriver({
+    send: (input) => {
+      if (gateway === undefined) throw new Error("messaging used before composition finished");
+      return gateway.messaging.send(input);
+    },
+    now: () => Date.now(),
+    newWaitId: () => crypto.randomUUID(),
+  });
   kernel = createDelegationKernel({
     drivers: {
       inline: createInlineDriver(runner),
+      channel: channelDriver,
       process: createProcessDriver({
         command: [
           process.execPath,
@@ -106,16 +144,56 @@ export async function startOpenOmni(options: StartOptions = {}) {
           newCellId: () => crypto.randomUUID(),
         };
 
-  const deliver = createResident({
+  const residentDeliver = createResident({
     model: config.model,
     apiKey: config.model.apiKey,
     tools: { delegation: kernel, ...(cells === undefined ? {} : { cells }) },
     targets: () => attachedTargets(host, machines?.enrolled ?? []),
     ...(options.llm === undefined ? {} : { llm: options.llm }),
   });
-  const gateway = createResidentGateway(deliver);
-  const wsHandler = new WebSocketHandler(async (message) => {
-    const result = await gateway.ingest(buildInboundEvent(message));
+
+  // A delivery the perimeter correlated to an open Wait is an actor's answer
+  // to a delegation, not a message for the Resident: it settles the waiting
+  // delegate call. A waitContext nothing is waiting on (a resume after this
+  // process restarted) falls through to the Resident as an ordinary message.
+  const deliver = async (delivery: Gateway.Deliver): Promise<Ingress.IngressResult> => {
+    const wait = delivery.waitContext;
+    if (wait !== undefined && channelDriver.resume(wait.waitId, replyText(delivery.event.payload))) {
+      return {
+        mode: "direct",
+        target: { kind: "resident" },
+        sessionId: delivery.sessionId ?? "",
+        result: { output: "Reply received — the delegation it answers is settling.", finishReason: "stop" },
+      };
+    }
+    return residentDeliver(delivery);
+  };
+
+  // Late-binds the handler the route delivers through: the gateway needs the
+  // route before the ws handler that needs the gateway exists.
+  let wsHandler: WebSocketHandler | undefined;
+  const wsRoute = async (externalId: string, body: string) => {
+    if (wsHandler === undefined) throw new Error("ws delivery used before composition finished");
+    return wsHandler.push(externalId, body);
+  };
+  gateway = createResidentGateway(
+    deliver,
+    actors.length === 0
+      ? undefined
+      : {
+          deliveryRoutes: new Map([["ws", wsRoute]]),
+          grants: () =>
+            actors.map((actor) => ({
+              id: `resident->${actor.actorId}`,
+              senderId: "resident",
+              targetActorId: actor.actorId,
+              operations: ["awaited" as const],
+            })),
+        },
+  );
+  const boundGateway = gateway;
+  wsHandler = new WebSocketHandler(async (message) => {
+    const result = await boundGateway.ingest(buildInboundEvent(message));
     return result.kind === "dropped" ? null : { text: result.result.output };
   }, Bus.publish, config.wsToken === undefined ? {} : { token: config.wsToken });
 

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -158,12 +158,23 @@ export async function startOpenOmni(options: StartOptions = {}) {
   // process restarted) falls through to the Resident as an ordinary message.
   const deliver = async (delivery: Gateway.Deliver): Promise<Ingress.IngressResult> => {
     const wait = delivery.waitContext;
-    if (wait !== undefined && channelDriver.resume(wait.waitId, replyText(delivery.event.payload))) {
+    // A wait-correlated route always carries the wait owner's session label
+    // (resolve-route pins `sessionId: state.wait.sessionId`), so no fallback:
+    // a labelless delivery is ordinary traffic for the Resident.
+    const sessionId = delivery.sessionId;
+    if (
+      wait !== undefined &&
+      sessionId !== undefined &&
+      channelDriver.resume(wait.waitId, replyText(delivery.event.payload))
+    ) {
       return {
         mode: "direct",
         target: { kind: "resident" },
-        sessionId: delivery.sessionId ?? "",
-        result: { output: "Reply received — the delegation it answers is settling.", finishReason: "stop" },
+        sessionId,
+        result: {
+          output: "Reply received — the delegation it answers is settling.",
+          finishReason: "stop",
+        },
       };
     }
     return residentDeliver(delivery);

--- a/apps/openomni/src/resident.ts
+++ b/apps/openomni/src/resident.ts
@@ -50,14 +50,21 @@ function history(sessionId: string): ChatAgentInput["messages"] {
   }));
 }
 
-const RESIDENT_ORIGIN: DelegationOrigin = { role: "resident", depth: 0 };
-
 export function createResident(options: ResidentOptions) {
-  const entries = catalogEntries(options.tools, RESIDENT_ORIGIN);
-
   return async function deliver(delivery: Gateway.Deliver): Promise<Ingress.IngressResult> {
+    const sessionId = delivery.sessionId;
+    if (sessionId === undefined) {
+      throw new Error("Resident delivery requires a routed sessionId");
+    }
+    if (typeof delivery.event.payload !== "string") {
+      throw new Error("Resident delivery payload must be text");
+    }
+
+    // Built per delivery because the origin carries THIS session: a Wait a
+    // delegation opens must be owned by the session that asked for the work.
+    const origin: DelegationOrigin = { role: "resident", depth: 0, sessionId };
     const targets = options.targets();
-    const catalog = createDispatcher(entries);
+    const catalog = createDispatcher(catalogEntries(options.tools, origin));
     const agent = ChatAgent.create({
       events: Bus,
       systemPrompt: RESIDENT_SYSTEM_PROMPT,
@@ -69,14 +76,6 @@ export function createResident(options: ResidentOptions) {
       auth: { type: "api", key: options.apiKey },
       ...(options.llm === undefined ? {} : { llm: options.llm }),
     });
-
-    const sessionId = delivery.sessionId;
-    if (sessionId === undefined) {
-      throw new Error("Resident delivery requires a routed sessionId");
-    }
-    if (typeof delivery.event.payload !== "string") {
-      throw new Error("Resident delivery payload must be text");
-    }
 
     Session.materialize({
       id: sessionId,

--- a/apps/openomni/test/channel-delegation-e2e.test.ts
+++ b/apps/openomni/test/channel-delegation-e2e.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunInput, Sink } from "@openomni/llm";
+import { Storage } from "@openomni/ledger";
+import type { Message } from "@openomni/protocol";
+import { startOpenOmni } from "../src/index";
+
+const WS_TOKEN = "channel-delegation-e2e-token";
+
+const directories: string[] = [];
+let stopApp: (() => void) | undefined;
+
+afterEach(() => {
+  stopApp?.();
+  stopApp = undefined;
+  Storage.reset();
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function message(input: RunInput, text: string): Message.WithParts {
+  const id = `fake-${input.trace.sessionId}-${input.messages.length}`;
+  const sessionID = input.trace.sessionId;
+  const part = { type: "text", text } as never;
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: input.model.id,
+      providerID: input.model.providerID,
+      agent: "resident",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: { input: 4, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      { ...(part as object), id: `${id}-text`, sessionID, messageID: id } as never,
+      {
+        id: `${id}-finish`,
+        sessionID,
+        messageID: id,
+        type: "step-finish",
+        reason: "stop",
+        cost: 0,
+        tokens: { input: 4, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+    ],
+  };
+}
+
+async function openSocket(url: string): Promise<WebSocket> {
+  const ws = new WebSocket(url);
+  await new Promise<void>((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", () => reject(new Error("socket failed to open")), { once: true });
+  });
+  return ws;
+}
+
+function nextFrame(
+  ws: WebSocket,
+  accept: (frame: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("no frame arrived")), 10_000);
+    const listener = (event: MessageEvent) => {
+      const frame = JSON.parse(String(event.data)) as Record<string, unknown>;
+      if (!accept(frame)) return;
+      clearTimeout(timer);
+      ws.removeEventListener("message", listener);
+      resolve(frame);
+    };
+    ws.addEventListener("message", listener);
+  });
+}
+
+test("the Resident delegates to an external actor over the channel and reports the reply", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "openomni-channel-delegation-"));
+  directories.push(directory);
+  const residentTexts: string[] = [];
+
+  const app = await startOpenOmni({
+    config: {
+      dbPath: join(directory, "chat.db"),
+      host: "127.0.0.1",
+      wsPort: 0,
+      wsToken: WS_TOKEN,
+      model: { provider: "fake", id: "channel-delegation-test", apiKey: "test-key" },
+      actors: [{ actorId: "alice", externalId: "alice", trustTier: "collaborator", kind: "human" }],
+    },
+    llm: {
+      resolveProviderModel: async (model) => ({
+        id: model.id,
+        name: model.id,
+        providerID: model.provider,
+      }),
+      run: async (input: RunInput, sink: Sink) => {
+        const lastUser = [...input.messages].reverse().find((entry) => entry.info.role === "user");
+        const asked = (lastUser?.parts ?? [])
+          .map((part) => ("text" in part && typeof part.text === "string" ? part.text : ""))
+          .join("");
+        residentTexts.push(asked);
+
+        if (asked.includes("please ask alice")) {
+          const executed = await input.toolExecutor?.({
+            id: "call-1",
+            tool: "delegate",
+            input: {
+              instruction: "review the quarterly report",
+              mode: "assign",
+              acceptanceCriteria: ["every section read"],
+              actorId: "alice",
+              timeoutMs: 10_000,
+            },
+          });
+          sink.onMessage(message(input, `alice reports: ${executed?.output ?? "nothing"}`));
+          return { type: "stop" };
+        }
+
+        sink.onMessage(message(input, "noted"));
+        return { type: "stop" };
+      },
+    },
+  });
+  stopApp = app.stop;
+
+  const base = `ws://127.0.0.1:${app.port}/ws?token=${WS_TOKEN}`;
+  const owner = await openSocket(base);
+  const alice = await openSocket(`${base}&actor=alice`);
+  const bob = await openSocket(`${base}&actor=bob`);
+
+  const instruction = nextFrame(alice, (frame) => frame.type === "message");
+  const ownerAnswer = nextFrame(owner, (frame) => frame.type === "response");
+  owner.send(JSON.stringify({ type: "message", text: "please ask alice to review the report" }));
+
+  const delivered = await instruction;
+  // The actor reads the same rendered contract text an inline worker reads.
+  expect(delivered.text).toBe(
+    "review the quarterly report\n\nIt is done when all of these hold:\n- every section read",
+  );
+  expect(typeof delivered.messageId).toBe("string");
+
+  // A responder the Wait does not expect cannot settle the delegation: bob's
+  // reply is delivered as an ordinary message and answered by the Resident.
+  const bobAnswer = nextFrame(bob, (frame) => frame.type === "response");
+  bob.send(
+    JSON.stringify({ type: "message", text: "bob butting in", replyToId: delivered.messageId }),
+  );
+  expect(((await bobAnswer) as { text: string }).text).toBe("noted");
+
+  const aliceAck = nextFrame(alice, (frame) => frame.type === "response");
+  alice.send(
+    JSON.stringify({
+      type: "message",
+      text: "every section read, numbers check out",
+      replyToId: delivered.messageId,
+    }),
+  );
+
+  // The actor's reply settles the waiting delegation instead of opening a turn.
+  expect(((await aliceAck) as { text: string }).text).toContain("Reply received");
+  expect(((await ownerAnswer) as { text: string }).text).toBe(
+    "alice reports: every section read, numbers check out",
+  );
+
+  // Exactly two Resident turns spoke: the owner's ask and bob's stray message.
+  // Alice's reply resumed the delegation without becoming a turn of its own.
+  expect(residentTexts.filter((text) => text.includes("please ask alice"))).toHaveLength(1);
+  expect(residentTexts.filter((text) => text.includes("bob butting in"))).toHaveLength(1);
+  expect(residentTexts.filter((text) => text.includes("numbers check out"))).toHaveLength(0);
+
+  owner.close();
+  alice.close();
+  bob.close();
+});

--- a/apps/openomni/test/channel-delegation.test.ts
+++ b/apps/openomni/test/channel-delegation.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import type { Gateway } from "@openomni/protocol";
+import { admit, type Admitted } from "../src/delegation/admission";
+import { createChannelDriver } from "../src/delegation/channel-driver";
+import { createDelegationKernel } from "../src/delegation/kernel";
+
+const NOW = 1_000_000;
+const DEADLINE = NOW + 5_000;
+
+function admitted(): Admitted {
+  const decision = admit(
+    {
+      address: { kind: "actor", actorId: "alice" },
+      mode: "assign",
+      payload: { text: "review the report" },
+      acceptanceCriteria: ["every section read"],
+      deadline: DEADLINE,
+    },
+    { role: "resident", depth: 0, sessionId: "session-origin" },
+    NOW,
+    { maxInlineDepth: 2 },
+  );
+  if (!decision.ok) throw new Error(decision.reason);
+  return decision;
+}
+
+const HANDLE = {
+  delegationId: "delegation-1",
+  address: { kind: "actor", actorId: "alice" },
+  transport: "channel",
+} as const;
+
+function sentReceipt(input: Gateway.SendInput): Gateway.SendReceipt {
+  const spec = input.waitSpec;
+  if (spec === undefined) throw new Error("channel driver must send awaited");
+  return {
+    kind: "sent",
+    operation: "awaited",
+    messageId: input.messageId,
+    senderId: input.senderId,
+    grantId: "grant-1",
+    target: { actorId: "alice", endpointId: "ws:alice", channel: "ws", externalId: "alice" },
+    wait: {
+      id: spec.waitId,
+      ownerRef: spec.ownerRef,
+      originMessageId: input.messageId,
+      correlation: { endpointId: "ws:alice", replyToMessageId: input.messageId },
+      allowedActions: spec.allowedActions,
+      expectedResponders: spec.expectedResponders,
+      resolutionPolicy: spec.resolutionPolicy,
+      status: "open",
+      partial: false,
+      replies: [],
+      revision: 0,
+      expiresAt: spec.expiresAt,
+      followUpWindow: spec.followUpWindow,
+      createdAt: input.at,
+      updatedAt: input.at,
+    },
+    at: input.at,
+  };
+}
+
+describe("channel delegation driver", () => {
+  test("sends the instruction as an awaited message whose Wait belongs to the originating session", async () => {
+    const sent: Gateway.SendInput[] = [];
+    const driver = createChannelDriver({
+      send: async (input) => {
+        sent.push(input);
+        return sentReceipt(input);
+      },
+      now: () => NOW,
+      newWaitId: () => "wait-1",
+    });
+
+    const outcome = driver.run(admitted(), HANDLE, new AbortController().signal);
+    // The send has been awaited by the time run is pending on the reply.
+    await Bun.sleep(0);
+    expect(driver.resume("wait-1", "all sections reviewed")).toBe(true);
+    expect(await outcome).toEqual({ status: "completed", output: "all sections reviewed" });
+
+    const input = sent[0];
+    if (input === undefined) throw new Error("nothing was sent");
+    expect(input.messageId).toBe("delegation-1");
+    expect(input.senderId).toBe("resident");
+    expect(input.operation).toBe("awaited");
+    expect(input.target).toEqual({ actorId: "alice" });
+    // The body is the same rendered contract text an inline worker reads.
+    expect(input.body).toBe(
+      "review the report\n\nIt is done when all of these hold:\n- every section read",
+    );
+    expect(input.waitSpec).toEqual({
+      waitId: "wait-1",
+      ownerRef: { kind: "session", id: "session-origin" },
+      allowedActions: ["report_result"],
+      expectedResponders: ["alice"],
+      resolutionPolicy: "first_reply",
+      expiresAt: DEADLINE,
+      followUpWindow: 0,
+    });
+  });
+
+  test("a settled wait resumes exactly once", async () => {
+    const driver = createChannelDriver({
+      send: async (input) => sentReceipt(input),
+      now: () => NOW,
+      newWaitId: () => "wait-1",
+    });
+    const outcome = driver.run(admitted(), HANDLE, new AbortController().signal);
+    await Bun.sleep(0);
+    expect(driver.resume("wait-1", "done")).toBe(true);
+    expect(driver.resume("wait-1", "done again")).toBe(false);
+    expect(await outcome).toEqual({ status: "completed", output: "done" });
+  });
+
+  test("resume with a waitId nothing is awaiting is refused", () => {
+    const driver = createChannelDriver({
+      send: async (input) => sentReceipt(input),
+      now: () => NOW,
+      newWaitId: () => "wait-1",
+    });
+    expect(driver.resume("wait-unknown", "hello")).toBe(false);
+  });
+
+  test("a denied send settles delivery_failed and stops awaiting the reply", async () => {
+    const driver = createChannelDriver({
+      send: async (input) => ({
+        kind: "denied",
+        code: "target_stale",
+        messageId: input.messageId,
+        senderId: input.senderId,
+        targetActorId: "alice",
+        reason: "actor alice has no allocated endpoint",
+        at: input.at,
+      }),
+      now: () => NOW,
+      newWaitId: () => "wait-1",
+    });
+    const outcome = await driver.run(admitted(), HANDLE, new AbortController().signal);
+    expect(outcome).toEqual({
+      status: "delivery_failed",
+      reason: "actor alice has no allocated endpoint",
+    });
+    expect(driver.resume("wait-1", "too late")).toBe(false);
+  });
+
+  test("a delivery effect that throws settles delivery_failed", async () => {
+    const driver = createChannelDriver({
+      send: async () => {
+        throw new Error("no live websocket connection for actor alice");
+      },
+      now: () => NOW,
+      newWaitId: () => "wait-1",
+    });
+    const outcome = await driver.run(admitted(), HANDLE, new AbortController().signal);
+    expect(outcome).toEqual({
+      status: "delivery_failed",
+      reason: "no live websocket connection for actor alice",
+    });
+    expect(driver.resume("wait-1", "too late")).toBe(false);
+  });
+
+  test("the kernel's deadline abort ends the pending reply, and silence settles no_response", async () => {
+    const driver = createChannelDriver({
+      send: async (input) => sentReceipt(input),
+      now: () => Date.now(),
+      newWaitId: () => "wait-1",
+    });
+    const kernel = createDelegationKernel({
+      drivers: { channel: driver },
+      now: () => Date.now(),
+      newDelegationId: () => "delegation-1",
+    });
+
+    const result = await kernel.delegate(
+      {
+        address: { kind: "actor", actorId: "alice" },
+        mode: "assign",
+        payload: { text: "review the report" },
+        acceptanceCriteria: ["every section read"],
+        deadline: Date.now() + 30,
+      },
+      { role: "resident", depth: 0, sessionId: "session-origin" },
+    );
+
+    if ("refused" in result) throw new Error(result.refused);
+    expect(result.settled.status).toBe("no_response");
+    // The abort cleaned the pending entry: a reply after the deadline finds
+    // nothing to settle and falls through to the Resident as a message.
+    expect(driver.resume("wait-1", "too late")).toBe(false);
+  });
+
+  test("only the Resident reaches the channel transport", async () => {
+    const decision = admit(
+      {
+        address: { kind: "actor", actorId: "alice" },
+        mode: "assign",
+        payload: { text: "review the report" },
+        acceptanceCriteria: ["every section read"],
+        deadline: DEADLINE,
+      },
+      { role: "worker", depth: 1, sessionId: "session-origin" },
+      NOW,
+      { maxInlineDepth: 2 },
+    );
+    expect(decision.ok).toBe(false);
+    if (decision.ok) throw new Error("a worker must not delegate to an actor");
+    expect(decision.reason).toContain("same-domain inline child");
+  });
+});

--- a/apps/openomni/test/channel-delegation.test.ts
+++ b/apps/openomni/test/channel-delegation.test.ts
@@ -74,8 +74,8 @@ describe("channel delegation driver", () => {
     });
 
     const outcome = driver.run(admitted(), HANDLE, new AbortController().signal);
-    // The send has been awaited by the time run is pending on the reply.
-    await Bun.sleep(0);
+    // The pending entry is registered synchronously BEFORE the send, so a
+    // reply may race the send's own return and still settle the delegation.
     expect(driver.resume("wait-1", "all sections reviewed")).toBe(true);
     expect(await outcome).toEqual({ status: "completed", output: "all sections reviewed" });
 
@@ -107,7 +107,6 @@ describe("channel delegation driver", () => {
       newWaitId: () => "wait-1",
     });
     const outcome = driver.run(admitted(), HANDLE, new AbortController().signal);
-    await Bun.sleep(0);
     expect(driver.resume("wait-1", "done")).toBe(true);
     expect(driver.resume("wait-1", "done again")).toBe(false);
     expect(await outcome).toEqual({ status: "completed", output: "done" });

--- a/apps/openomni/test/delegation.test.ts
+++ b/apps/openomni/test/delegation.test.ts
@@ -4,8 +4,8 @@ import { createInlineDriver } from "../src/delegation/inline-driver";
 import { createDelegationKernel, type DelegationDriver } from "../src/delegation/kernel";
 import { DELEGATE_TOOL_NAME, delegateToolExecutor, delegateToolSpec } from "../src/delegation/tool";
 
-const RESIDENT: DelegationOrigin = { role: "resident", depth: 0 };
-const WORKER: DelegationOrigin = { role: "worker", depth: 1 };
+const RESIDENT: DelegationOrigin = { role: "resident", depth: 0, sessionId: "session-origin" };
+const WORKER: DelegationOrigin = { role: "worker", depth: 1, sessionId: "session-origin" };
 const LIMITS = { maxInlineDepth: 2 };
 
 function ask(overrides: Record<string, unknown> = {}) {
@@ -46,7 +46,7 @@ describe("admission", () => {
   });
 
   test("inline chains stop at the configured depth instead of running away", () => {
-    const atCap = admit(ask(), { role: "worker", depth: 2 }, 1000, LIMITS);
+    const atCap = admit(ask(), { role: "worker", depth: 2, sessionId: "session-origin" }, 1000, LIMITS);
     expect(atCap).toMatchObject({ ok: false, reason: "inline delegation is capped at depth 2" });
   });
 
@@ -79,7 +79,7 @@ describe("admission", () => {
 
   test("a child presents as a worker one step deeper than its parent", () => {
     const decision = admit(ask(), RESIDENT, 1000, LIMITS);
-    expect(decision).toMatchObject({ ok: true, childOrigin: { role: "worker", depth: 1 } });
+    expect(decision).toMatchObject({ ok: true, childOrigin: { role: "worker", depth: 1, sessionId: "session-origin" } });
   });
 
   test("contract violations are reported, not thrown", () => {
@@ -183,7 +183,7 @@ describe("inline driver", () => {
       return "ok";
     });
     for (const parentDepth of [0, 1]) {
-      const decision = admit(ask(), { role: "worker", depth: parentDepth }, 1000, LIMITS);
+      const decision = admit(ask(), { role: "worker", depth: parentDepth, sessionId: "session-origin" }, 1000, LIMITS);
       if (!decision.ok) throw new Error(`expected admission at depth ${parentDepth}`);
       await driver.run(
         decision,
@@ -195,8 +195,8 @@ describe("inline driver", () => {
     // recursing, and the role so nothing downstream gets to declare a child a
     // worker on its own authority.
     expect(origins).toEqual([
-      { role: "worker", depth: 1 },
-      { role: "worker", depth: 2 },
+      { role: "worker", depth: 1, sessionId: "session-origin" },
+      { role: "worker", depth: 2, sessionId: "session-origin" },
     ]);
   });
 });
@@ -221,8 +221,10 @@ describe("delegate tool", () => {
     };
     const kernel = kernelWith({ run: async () => ({ status: "completed", output: "green" }) });
     const execute = delegateToolExecutor(kernel, RESIDENT);
-    expect(Object.keys(advertised.properties).sort()).toEqual(Object.keys(full).sort());
-    expect(advertised.required.sort()).toEqual(["instruction", "mode", "scope", "timeoutMs"]);
+    expect(Object.keys(advertised.properties).sort()).toEqual(
+      [...Object.keys(full), "actorId"].sort(),
+    );
+    expect(advertised.required.sort()).toEqual(["instruction", "mode", "timeoutMs"]);
     expect(advertised.properties.mode?.enum).toEqual(["ask", "assign"]);
     expect(advertised.properties.scope?.enum).toEqual(["inline", "independent"]);
     return expect(execute(full)).resolves.toBe("green");
@@ -259,7 +261,7 @@ describe("delegate tool", () => {
       scope: "independent",
       acceptanceCriteria: ["done"],
       timeoutMs: 5000,
-      origin: { role: "resident", depth: 0 },
+      origin: { role: "resident", depth: 0, sessionId: "session-origin" },
     });
     expect(answer).toBe("delegate refused: Unrecognized key(s) in object: 'origin'");
   });

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../src/delegation/process-entry";
 
 const WORKER = { model: { provider: "anthropic", id: "test-model" }, apiKey: "test-key" } as const;
-const RESIDENT = { role: "resident", depth: 0 } as const;
+const RESIDENT = { role: "resident", depth: 0, sessionId: "session-origin" } as const;
 
 /** A `core` worker asked for independent work: the address that resolves to `process`. */
 function independentAsk(text: string, deadline: number) {
@@ -52,7 +52,7 @@ test("the entry acks before it works, so delivery is observable separately from 
       delegationId: "d-1",
       instruction: "summarize",
       acceptanceCriteria: [],
-      origin: { role: "worker", depth: 1 },
+      origin: { role: "worker", depth: 1, sessionId: "session-origin" },
       model: WORKER.model,
       apiKey: WORKER.apiKey,
     }),
@@ -78,7 +78,7 @@ test("a worker that throws is a failed result, not a lost delivery", async () =>
       delegationId: "d-1",
       instruction: "summarize",
       acceptanceCriteria: [],
-      origin: { role: "worker", depth: 1 },
+      origin: { role: "worker", depth: 1, sessionId: "session-origin" },
       model: WORKER.model,
       apiKey: WORKER.apiKey,
     }),
@@ -288,6 +288,7 @@ test("the child receives the origin the parent admitted, so the depth cap crosse
   expect(JSON.parse((result.settled as { output: string }).output)).toEqual({
     role: "worker",
     depth: 1,
+    sessionId: "session-origin",
   });
 }, 30_000);
 
@@ -302,6 +303,7 @@ test("a worker may not open a process at all, so the driver is never reached", a
   const result = await kernel.delegate(independentAsk("audit", Date.now() + 20_000), {
     role: "worker",
     depth: 1,
+    sessionId: "session-origin",
   });
 
   if (!("refused" in result)) throw new Error("a worker opened a process");
@@ -403,6 +405,7 @@ test("admission refuses a worker who asks for independent work", async () => {
   const result = await kernel.delegate(independentAsk("fork", Date.now() + 5_000), {
     role: "worker",
     depth: 1,
+    sessionId: "session-origin",
   });
 
   if (!("refused" in result)) throw new Error("a worker reached the process transport");

--- a/apps/openomni/test/tools.test.ts
+++ b/apps/openomni/test/tools.test.ts
@@ -9,7 +9,7 @@ import { createCellRegistry } from "../src/tools/cell-registry";
 import type { CellPorts } from "../src/tools/run-code";
 import { cellDoor, RUN_CODE_TOOL_NAME, runCodeToolExecutor } from "../src/tools/run-code";
 
-const RESIDENT = { role: "resident", depth: 0 } as const;
+const RESIDENT = { role: "resident", depth: 0, sessionId: "session-origin" } as const;
 
 function machineTarget(capabilities: string[]): Placement.ToolTarget {
   return { kind: "machine", id: "alpha", capabilities };
@@ -169,7 +169,7 @@ describe("the cell door", () => {
   it("binds each cell to its own dispatcher, so one cell cannot borrow another's reach", async () => {
     const { kernel } = recordingDelegation();
     const registry = createCellRegistry();
-    const worker = { role: "worker", depth: 1 } as const;
+    const worker = { role: "worker", depth: 1, sessionId: "session-origin" } as const;
 
     // A worker with no delegation port holds an empty catalog.
     registry.bind("worker-cell", cellDoor(catalogEntries({}, worker)));

--- a/packages/channels/src/websocket.ts
+++ b/packages/channels/src/websocket.ts
@@ -117,7 +117,13 @@ export class WebSocketHandler {
     const hasConfiguredToken = this.config.token !== undefined && this.config.token.length > 0;
     const authenticated = hasConfiguredToken && auth.verdict.verdict === "allow";
 
-    const externalId = new URL(req.url).searchParams.get("actor")?.trim();
+    // An actor declaration binds this connection to a registered identity
+    // (delegated instructions are pushed to it, its replies settle Waits), so
+    // it requires the shared token — unlike plain owner chat, which loopback
+    // trust covers. On a tokenless bind the declaration is simply not taken.
+    const externalId = authenticated
+      ? new URL(req.url).searchParams.get("actor")?.trim()
+      : undefined;
     const ok = server.upgrade(req, {
       // `ws::dm:<uuid>` — empty namespace, so no workspace is derived and
       // actor endpoints registered as plain channel "ws" resolve.

--- a/packages/channels/src/websocket.ts
+++ b/packages/channels/src/websocket.ts
@@ -12,6 +12,13 @@ export interface WebSocketConfig {
 interface WsConnectionData {
   surfaceKey: string;
   authenticated: boolean;
+  /** Present when the connection declared who it is (`?actor=<externalId>`). */
+  externalId?: string;
+}
+
+interface WsConnection {
+  data: WsConnectionData;
+  send(msg: string): void;
 }
 
 interface WebSocketUpgradeOptions {
@@ -20,16 +27,39 @@ interface WebSocketUpgradeOptions {
 }
 
 export class WebSocketHandler {
+  /**
+   * Live connections by declared externalId, last-wins: a reconnect replaces
+   * the previous socket as the delivery target. Everyone on this socket is
+   * already behind the owner-tier upgrade gate, so the declaration is an
+   * address, not an authentication.
+   */
+  private readonly connections = new Map<string, WsConnection>();
+
   constructor(
     private readonly handler: Channel.MessageHandler,
     private readonly publish: PublishPort,
     private readonly config: WebSocketConfig = {},
   ) {}
 
+  /**
+   * Outbound delivery to a declared connection. Mints the platform message id
+   * the client must echo back as `replyToId` — returning it lets the send
+   * kernel re-key the Wait's correlation to it.
+   */
+  push(externalId: string, body: string): { externalMessageId: string } {
+    const connection = this.connections.get(externalId);
+    if (connection === undefined) {
+      throw new Error(`no live websocket connection for actor ${externalId}`);
+    }
+    const messageId = crypto.randomUUID();
+    connection.send(JSON.stringify({ type: "message", messageId, text: body }));
+    return { externalMessageId: messageId };
+  }
+
   get ws() {
     const self = this;
     return {
-      message(ws: { data: WsConnectionData; send(msg: string): void }, data: string | Buffer) {
+      message(ws: WsConnection, data: string | Buffer) {
         const raw = typeof data === "string" ? data : new TextDecoder().decode(data);
         // Origin: the first frame of an inbound websocket message — this ONE
         // mint is the message's trace, carried to the run (D11).
@@ -43,7 +73,10 @@ export class WebSocketHandler {
         });
         void self.handleMessage(ws, raw, traceId);
       },
-      open(ws: { data: WsConnectionData }) {
+      open(ws: WsConnection) {
+        if (ws.data.externalId !== undefined) {
+          self.connections.set(ws.data.externalId, ws);
+        }
         self.publish(Operational.Events.Info, {
           traceId: newTraceId(),
           time: Date.now(),
@@ -52,7 +85,11 @@ export class WebSocketHandler {
           context: { surfaceKey: ws.data.surfaceKey },
         });
       },
-      close(ws: { data: WsConnectionData }) {
+      close(ws: WsConnection) {
+        const externalId = ws.data.externalId;
+        if (externalId !== undefined && self.connections.get(externalId) === ws) {
+          self.connections.delete(externalId);
+        }
         self.publish(Operational.Events.Info, {
           traceId: newTraceId(),
           time: Date.now(),
@@ -80,21 +117,29 @@ export class WebSocketHandler {
     const hasConfiguredToken = this.config.token !== undefined && this.config.token.length > 0;
     const authenticated = hasConfiguredToken && auth.verdict.verdict === "allow";
 
+    const externalId = new URL(req.url).searchParams.get("actor")?.trim();
     const ok = server.upgrade(req, {
-      data: { surfaceKey: `ws:${crypto.randomUUID()}`, authenticated } satisfies WsConnectionData,
+      // `ws::dm:<uuid>` — empty namespace, so no workspace is derived and
+      // actor endpoints registered as plain channel "ws" resolve.
+      data: {
+        surfaceKey: `ws::dm:${crypto.randomUUID()}`,
+        authenticated,
+        ...(externalId ? { externalId } : {}),
+      } satisfies WsConnectionData,
       ...(auth.headers !== undefined ? { headers: auth.headers } : {}),
     });
     if (ok) return undefined;
     return new Response("WebSocket upgrade failed", { status: 400 });
   }
 
-  private async handleMessage(
-    ws: { data: WsConnectionData; send(msg: string): void },
-    raw: string,
-    traceId: string,
-  ): Promise<void> {
+  private async handleMessage(ws: WsConnection, raw: string, traceId: string): Promise<void> {
     try {
-      const parsed = JSON.parse(raw) as { type?: string; text?: string; surfaceKey?: string };
+      const parsed = JSON.parse(raw) as {
+        type?: string;
+        text?: string;
+        surfaceKey?: string;
+        replyToId?: string;
+      };
 
       if (!parsed.text) {
         ws.send(JSON.stringify({ type: "error", message: "text field required" }));
@@ -108,7 +153,10 @@ export class WebSocketHandler {
         traceId,
         surfaceKey,
         text: parsed.text,
-        sender: { id: "ws", name: "WebSocket" },
+        sender: { id: ws.data.externalId ?? "ws", name: ws.data.externalId ?? "WebSocket" },
+        ...(typeof parsed.replyToId === "string" && parsed.replyToId.length > 0
+          ? { replyToId: parsed.replyToId }
+          : {}),
         raw: { websocket: { authenticated: ws.data.authenticated } },
       });
 

--- a/packages/channels/test/websocket.test.ts
+++ b/packages/channels/test/websocket.test.ts
@@ -153,3 +153,101 @@ describe("WebSocketHandler authentication", () => {
     ]);
   });
 });
+
+describe("WebSocketHandler actor connections", () => {
+  function wsConnection(data: Record<string, unknown>) {
+    const sent: string[] = [];
+    return {
+      sent,
+      ws: { data: data as never, send: (msg: string) => sent.push(msg) },
+    };
+  }
+
+  it("binds ?actor= only on an authenticated upgrade", () => {
+    const handler = createHandler();
+    const upgrade = createUpgradeServer();
+    handler.handleUpgrade(
+      new Request("http://localhost/ws?actor=alice", {
+        headers: { "Sec-WebSocket-Protocol": "auth, secret-token" },
+      }),
+      upgrade.server,
+    );
+    const data = upgrade.options?.data as { externalId?: string; surfaceKey: string };
+    expect(data.externalId).toBe("alice");
+    // Empty namespace: no workspace is derived from the connection uuid.
+    expect(data.surfaceKey).toStartWith("ws::dm:");
+  });
+
+  it("ignores ?actor= on a tokenless upgrade — an actor declaration requires the shared token", () => {
+    const handler = new WebSocketHandler(async () => ({ text: "ok" }), noopPublish);
+    const upgrade = createUpgradeServer();
+    handler.handleUpgrade(new Request("http://localhost/ws?actor=alice"), upgrade.server);
+    const data = upgrade.options?.data as { externalId?: string; authenticated: boolean };
+    expect(data.authenticated).toBe(false);
+    expect(data.externalId).toBeUndefined();
+  });
+
+  it("push delivers to the declared connection and mints the platform message id", () => {
+    const handler = createHandler();
+    const { sent, ws } = wsConnection({
+      surfaceKey: "ws::dm:c1",
+      authenticated: true,
+      externalId: "alice",
+    });
+    handler.ws.open(ws);
+
+    const receipt = handler.push("alice", "review the report");
+    const frame = JSON.parse(sent[0] ?? "{}") as Record<string, unknown>;
+    expect(frame.type).toBe("message");
+    expect(frame.text).toBe("review the report");
+    expect(frame.messageId).toBe(receipt.externalMessageId);
+  });
+
+  it("push to an actor with no live connection fails loudly", () => {
+    const handler = createHandler();
+    expect(() => handler.push("alice", "hello")).toThrow(
+      "no live websocket connection for actor alice",
+    );
+  });
+
+  it("a reconnect replaces the delivery target and a stale close does not unregister it", () => {
+    const handler = createHandler();
+    const first = wsConnection({ surfaceKey: "ws::dm:c1", authenticated: true, externalId: "alice" });
+    const second = wsConnection({ surfaceKey: "ws::dm:c2", authenticated: true, externalId: "alice" });
+    handler.ws.open(first.ws);
+    handler.ws.open(second.ws);
+    // The stale socket closing after the reconnect must not orphan the actor.
+    handler.ws.close(first.ws);
+    handler.push("alice", "still here");
+    expect(second.sent).toHaveLength(1);
+    expect(first.sent).toHaveLength(0);
+
+    handler.ws.close(second.ws);
+    expect(() => handler.push("alice", "gone")).toThrow(
+      "no live websocket connection for actor alice",
+    );
+  });
+
+  it("carries replyToId and the declared sender identity into the inbound message", async () => {
+    let inbound: Channel.InboundMessage | undefined;
+    const handler = new WebSocketHandler(
+      async (message) => {
+        inbound = message;
+        return { text: "ok" };
+      },
+      noopPublish,
+      { token: "secret-token" },
+    );
+    const { ws } = wsConnection({
+      surfaceKey: "ws::dm:c1",
+      authenticated: true,
+      externalId: "alice",
+    });
+
+    handler.ws.message(ws, JSON.stringify({ text: "done", replyToId: "frame-7" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(inbound?.sender).toEqual({ id: "alice", name: "alice" });
+    expect(inbound?.replyToId).toBe("frame-7");
+  });
+});


### PR DESCRIPTION
Closes #787. Campaign PR-10 (after #769/#771/#773/#775/#777/#779/#781/#783/#785).

## What

The **channel transport** — the last of the four delegation wires (`inline`/`process`/`machine`/`channel`). The Resident can now `delegate({actorId})` to a registered external actor (a human or an outside agent) over the websocket channel; the actor's reply settles the waiting delegate call through the gateway's Wait machinery.

```
delegate({actorId: "alice"}) → DelegationKernel admission → channel driver
  → gateway #215 send kernel (grant → target resolution → durable Wait → ws push)
  → alice replies with replyToId → perimeter correlates → Deliver{waitContext}
  → resume bridge settles the pending delegation → Resident reports the outcome
```

## Design decisions

- **No new authority path.** Every judgment (sender grant, target endpoint resolution, budgets, Wait open/resolve, expected-responder gate) is the existing send kernel + perimeter router. The driver only maps receipts onto the delegation settlement vocabulary: denied receipt / delivery throw = `delivery_failed`, correlated reply = `completed`, kernel deadline = `no_response` (kernel-owned, driver just stops holding the pending entry).
- **`DelegationOrigin.sessionId`**: the Wait a channel delegation opens is owned (`ownerRef {kind:"session"}`) by the session that asked for the work. Inherited unchanged down the chain; threaded through the process-worker wire schema.
- **Actor addresses stay assign-only** (protocol refinement from #769) and **workers never reach the wire** (admission's same-domain-inline rule) — both pinned by tests.
- **ws surfaceKey fix**: `ws:<uuid>` parsed the connection uuid as a namespace → `workspace=<uuid>` → actor endpoint lookup could never match. Now `ws::dm:<uuid>` (empty namespace). Endpoint ids follow the repo convention `<channel>:<externalId>`; correlation endpointId derives from sender identity, not the per-connection channel id, so a reconnect still correlates.
- **Reply-race closed**: the driver registers its pending entry BEFORE the send, so a reply that races the send's return still settles the delegation instead of falling through as a Resident message.
- **Unmatched waitContext falls through** to the Resident as an ordinary message (e.g. a resume after restart) — never dropped.
- `?actor=<externalId>` on the ws upgrade is an **address, not an authentication**: everyone on the socket is already behind the owner-tier upgrade gate (`OPENOMNI_WS_TOKEN` / loopback-only).

## Verification

- `bun run build`, `turbo run check-types`, `check-deps`, `check-import-cycles`, `lint:tools`, `ultracite check .`, `check-dead-exports`: all green
- `bun test --timeout 15000`: 4009 pass / 0 fail (2 pre-existing skips)
- New: 7 driver unit tests (waitSpec ownership/responders/deadline, denied→delivery_failed, throw→delivery_failed, resume-once, abort cleanup + no_response, worker refusal) + full e2e (owner→Resident→delegate→actor ws frame→reply→settlement; wrong-responder reply cannot settle the Wait and is answered as an ordinary turn; the settling reply opens no Resident turn)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delegates work to registered external actors over WebSocket and settles via gateway-owned Waits. Tightens security: actor identity binding on `?actor=<externalId>` now requires an authenticated upgrade; previously a tokenless loopback could claim an actor.

- Channel driver sends awaited instructions via the gateway send kernel and maps outcomes: denied/throw → delivery_failed, correlated reply → completed, kernel deadline → no_response. Registers the pending wait before send to close reply races.
- Session ownership: `DelegationOrigin` now includes `sessionId`; Waits opened for channel delegations are owned by the originating session and inherited down the chain. Resume path requires a routed `sessionId`; no fallback.
- Delegate tool: exactly one of `scope` or `actorId` is required. Actor addresses remain assign-only; workers cannot reach the channel transport.
- WebSocket in `@openomni/channels`: `?actor=<externalId>` declares connection identity only on authenticated upgrades (`OPENOMNI_WS_TOKEN`); last connection wins. `push()` delivers outbound frames and returns the minted platform `messageId`; inbound frames may include `replyToId`. Fixes surfaceKey to `ws::dm:<uuid>` and correlates by `${surface}:${sender.id}` so reconnects still match.
- Resident gateway: adds outbound delivery routes/grants for actors; deliveries with `waitContext` resume the pending delegation; unmatched waits fall through to the Resident.
- Configuration/registry: `OPENOMNI_ACTORS` registers owner-admitted actors/endpoints (upserted via `@openomni/ledger`) and derives resident→actor awaited grants. Unifies instruction rendering for inline and channel workers.

**Rollout**
- Set `OPENOMNI_ACTORS` to a JSON array of { actorId, externalId, trustTier, kind?, displayName? }.
- Require a WebSocket token for actor delegation; clients must connect with `?actor=<externalId>` and echo `replyToId`. Tokenless owner chat still works; actor delegation does not without a token.
- Update delegate tool calls to provide exactly one of `scope` or `actorId`.

<sup>Written for commit e7c0165a8787a3e716cee5ed673ce8a5481d3384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering external actors with identities, trust levels, and display names.
  * Added awaited delegation to external actors over WebSocket, including correlated replies, timeouts, and delivery failure handling.
  * Added outbound actor-targeted messaging and reliable reconnection handling.
  * Delegation instructions now include acceptance criteria when provided.

* **Bug Fixes**
  * Improved reply correlation across reconnects.
  * Scoped delegation ownership to individual sessions for safer routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->