### PR TITLE
fix(machines): queue-inclusive cell deadline

### DIFF
--- a/packages/machines/src/kernel.ts
+++ b/packages/machines/src/kernel.ts
@@ -124,8 +124,31 @@ export class PythonKernel {
   private tail: Promise<void> = Promise.resolve();
 
   run(request: Machine.CellRequest, callTool: CellToolCaller): Promise<Machine.CellResult> {
-    const result = this.tail.then(() => this.execute(request, callTool));
-    this.tail = result.then(
+    const deadline = Date.now() + request.timeoutMs;
+    let queueExpired = false;
+    let resolveResult!: (result: Machine.CellResult) => void;
+    let rejectResult!: (error: Error) => void;
+    const result = new Promise<Machine.CellResult>((resolve, reject) => {
+      resolveResult = resolve;
+      rejectResult = reject;
+    });
+    const queueTimer = setTimeout(() => {
+      queueExpired = true;
+      resolveResult({ status: "timed_out", cellId: request.cellId });
+    }, request.timeoutMs);
+
+    const operation = this.tail.then(() => {
+      clearTimeout(queueTimer);
+      if (queueExpired) return;
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        queueExpired = true;
+        resolveResult({ status: "timed_out", cellId: request.cellId });
+        return;
+      }
+      return this.execute(request, callTool, remainingMs).then(resolveResult, rejectResult);
+    });
+    this.tail = operation.then(
       () => undefined,
       () => undefined,
     );
@@ -143,6 +166,7 @@ export class PythonKernel {
   private execute(
     request: Machine.CellRequest,
     callTool: CellToolCaller,
+    timeoutMs: number,
   ): Promise<Machine.CellResult> {
     const process = this.process ?? this.start();
     return new Promise((resolve, reject) => {
@@ -153,7 +177,7 @@ export class PythonKernel {
         // but the next queued cell is guaranteed a fresh, unwedgeable process.
         this.discard(process);
         resolve({ status: "timed_out", cellId: request.cellId });
-      }, request.timeoutMs);
+      }, timeoutMs);
       this.pending = { resolve, reject, timer, process, cellId: request.cellId, callTool };
       process.stdin.write(`${JSON.stringify(request)}\n`);
     });

--- a/packages/machines/test/kernel.test.ts
+++ b/packages/machines/test/kernel.test.ts
@@ -70,6 +70,37 @@ function cell(code: string, timeoutMs = 15_000): Machine.CellRequest {
 }
 
 describe("cell settlement ownership", () => {
+  test("a queued cell times out from its enqueue deadline without replacing the interpreter", async () => {
+    const kernel = new PythonKernel();
+    try {
+      const first = kernel.run(
+        {
+          cellId: "blocking",
+          code: "value = 42\nimport time\ntime.sleep(0.08)",
+          timeoutMs: 1_000,
+        },
+        noTools,
+      );
+      const queued = kernel.run(
+        { cellId: "queued", code: "value = 99", timeoutMs: 5 },
+        noTools,
+      );
+
+      expect(await first).toMatchObject({ status: "completed", cellId: "blocking" });
+      expect(await queued).toMatchObject({ status: "timed_out", cellId: "queued" });
+      // The queued timeout never ran, so it must not discard the persistent interpreter.
+      await expect(
+        kernel.run({ cellId: "after-queue", code: "value", timeoutMs: 1_000 }, noTools),
+      ).resolves.toMatchObject({
+        status: "completed",
+        cellId: "after-queue",
+        value: "42",
+      });
+    } finally {
+      kernel.close();
+    }
+  });
+
   test("a replaced interpreter's exit never settles its successor's cell", async () => {
     // Queued in the same microtask as the timing-out cell, so the successor is
     // already pending when the killed interpreter's exit event lands. That is


### PR DESCRIPTION
## Problem
`PythonKernel.run()` queued cells behind a long-running cell, but `execute()` started each cell's `timeoutMs` timer only after queue wait. A queued cell could therefore run beyond its own deadline.

## Fix
Measure the deadline at `run()` enqueue time. Queued cells settle as `timed_out` when that deadline elapses and are skipped without replacing the interpreter. Cells that start execution receive only their remaining budget; execution-time timeouts retain the existing interpreter replacement/state-loss behavior.

## RED evidence (before fix)
Captured by running the committed regression test against the parent kernel:

```
error: expect(received).toMatchObject(expected)
  {
    "cellId": "queued",
-   "status": "timed_out",
+   "output": {
+     "stderr": "",
+     "stdout": "",
+   },
+   "status": "completed",
  }
(fail) cell settlement ownership > a queued cell times out from its enqueue deadline without replacing the interpreter [108.98ms]
0 pass
8 filtered out
1 fail
Ran 1 test across 1 file. [209.00ms]
```

## Gate-chain results
All green from the worktree root:

- `bun run build`
  ```
  Tasks: 5 successful, 5 total
  Cached: 4 cached, 5 total
  Time: 6.231s
  ```
- `bunx turbo run check-types`
  ```
  Tasks: 15 successful, 15 total
  Cached: 13 cached, 15 total
  Time: 9.043s
  ```
- `bun run script/check-deps.ts`
  ```
  OK: dependency direction, import boundaries, golden principles, and doc freshness are valid
  ```
- `bun run script/check-import-cycles.ts`
  ```
  OK: import-cycle check - 334 modules, 0 value-import cycles
  ```
- `bun run lint:tools`
  ```
  OK: conformance lint - vocab ratchet, tool lint, naming, earned, schema snapshot
  ```
- `bunx ultracite check --formatter-enabled=false .`
  ```
  Checked 726 files in 369ms. No fixes applied.
  ```
- `bun run script/check-dead-exports.ts`
  ```
  OK: dead-export ratchet - 0 known issues, none new
  ```
- `bun test --timeout 15000`
  ```
  2492 pass
  0 fail
  7851 expect() calls
  Ran 2492 tests across 287 files. [54.31s]
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cell execution timeouts now apply consistently while waiting in the queue and during execution.
  * Queued cells that exceed their timeout no longer start running, preserving the active interpreter and subsequent execution state.

* **Tests**
  * Added coverage for queued-cell timeout behavior and state retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->