### PR TITLE
feat(protocol): settlementToAttemptOutcome — settlement→attempt terminal mapping owner

### DIFF
--- a/packages/protocol/src/delegation/attempt-linkage.test.ts
+++ b/packages/protocol/src/delegation/attempt-linkage.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { Delegation } from "./index.js";
+
+describe("Delegation.settlementToAttemptOutcome", () => {
+  test.each([
+    ["completed", "succeeded"],
+    ["failed", "failed"],
+    ["cancelled", "cancelled"],
+    ["delivery_failed", "interrupted"],
+    ["no_response", "interrupted"],
+    ["interrupted", "interrupted"],
+  ] as const)("%s settles the attempt as %s", (settled, outcome) => {
+    expect(Delegation.settlementToAttemptOutcome(settled)).toBe(outcome);
+  });
+
+  test("refuses sent — a notify settlement carries no attempt", () => {
+    expect(() =>
+      Delegation.settlementToAttemptOutcome("sent" as never),
+    ).toThrow("notify settlement (sent) carries no attempt to close");
+  });
+});

--- a/packages/protocol/src/delegation/attempt-linkage.ts
+++ b/packages/protocol/src/delegation/attempt-linkage.ts
@@ -1,0 +1,34 @@
+import type { WorkItem } from "../work-item/index.js";
+import type { SettledStatus } from "./schema.js";
+
+/**
+ * The single owner of "how a delegation settlement closes a WorkItem
+ * attempt" (docs/machines-and-delegation.md): completed is the driver's
+ * success, failed its definite failure, cancelled the owner's withdrawal,
+ * and every non-answer (delivery_failed, no_response, kernel interruption)
+ * is `interrupted` — the attempt ended without the executor's verdict.
+ *
+ * `sent` is excluded from the domain: only notify settles as sent, and a
+ * notify carries no WorkItem attempt to close (assign is the only
+ * WorkItem-bearing operation).
+ */
+export function settlementToAttemptOutcome(
+  status: Exclude<SettledStatus, "sent">,
+): WorkItem.AttemptOutcome {
+  switch (status) {
+    case "completed":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    case "delivery_failed":
+    case "no_response":
+    case "interrupted":
+      return "interrupted";
+    default: {
+      const unreachable: never = status;
+      throw new Error(`notify settlement (${String(unreachable)}) carries no attempt to close`);
+    }
+  }
+}

--- a/packages/protocol/src/delegation/index.ts
+++ b/packages/protocol/src/delegation/index.ts
@@ -1,3 +1,4 @@
+import { settlementToAttemptOutcome as settlementToAttemptOutcomeFold } from "./attempt-linkage.js";
 import { Events as EventDescriptors } from "./events.js";
 import * as Schema from "./schema.js";
 
@@ -36,4 +37,6 @@ export namespace Delegation {
   export type Record = Schema.Record;
 
   export const Events = EventDescriptors;
+
+  export const settlementToAttemptOutcome = settlementToAttemptOutcomeFold;
 }


### PR DESCRIPTION
## What

One new pure fold in `packages/protocol/src/delegation/attempt-linkage.ts`, exported as `Delegation.settlementToAttemptOutcome` — the single owner of how a delegation settlement closes a WorkItem attempt (WorkItem wiring campaign, protocol slice).

| Settled status | Attempt outcome |
|---|---|
| completed | succeeded |
| failed | failed |
| cancelled | cancelled |
| delivery_failed / no_response / interrupted | interrupted |
| sent | **excluded from domain** (notify carries no attempt; forced call throws pinned refusal) |

## Deliberately deferred

`assign⇒workItemId` superRefine on `Delegation.Record` moves to the app-wiring PR: the kernel does not stamp `workItemId` yet, so landing the refinement here would break every existing assign path — the invariant ships in the same PR as its writer (one enforcement layer, born with the write).

## Verification

- RED→GREEN: `attempt-linkage.test.ts` 7 fail before implementation → 7 pass after (exhaustive per-status table + sent refusal).
- Full local gate chain green: build, turbo check-types, check-deps, check-import-cycles, lint:tools, ultracite check ., check-dead-exports, `bun test --timeout 15000` → 2474 pass / 0 fail.
- Pure fold only: type-only import of WorkItem vocabulary, no I/O, no new Tier-2 noun (member on existing `Delegation` namespace).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Delegation.settlementToAttemptOutcome` in `packages/protocol`, a pure function that maps a delegation settlement to the WorkItem attempt outcome it closes. This makes the protocol the single owner of that mapping.

- Maps `completed`→`succeeded`, `failed`→`failed`, `cancelled`→`cancelled`, and `delivery_failed`/`no_response`/`interrupted`→`interrupted`.
- Excludes `sent` from the domain: a notify settlement carries no attempt, so a forced call throws a pinned refusal.
- Defers the `assign⇒workItemId` invariant to the app-wiring PR — the kernel doesn't stamp `workItemId` yet, so landing it now would break every existing assign path.
- Tests cover all settled statuses plus the `sent` refusal.

<sup>Written for commit 7004987930222d9b9f1824d5d8d281eb4039a3f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

