### PR TITLE
feat: drive-loop policy for assigned native workers + attempt usage

### DIFF
--- a/apps/openomni/src/delegation/drive-loop.ts
+++ b/apps/openomni/src/delegation/drive-loop.ts
@@ -1,0 +1,70 @@
+/**
+ * Goal-style drive policy for native worker runs (inline/process transports
+ * only — a channel counterpart merely delivers and waits, it is never driven).
+ * Pure: the transport driver feeds one observation per completed agent run
+ * and acts on the decision. The policy lives here, never in the WorkItem
+ * schema — the contract stays executor-agnostic.
+ */
+
+export const DRIVE_CONTINUATION_CAP = 8;
+export const DRIVE_REPETITION_STREAK = 3;
+export const DRIVE_TOOLLESS_STALL_STREAK = 3;
+export const DRIVE_BLOCKED_RECURRENCE = 3;
+
+export interface DriveObservation {
+  /** Final text of the completed worker run. */
+  readonly text: string;
+  /** The agent loop's own ending for that run. */
+  readonly finishReason: "stop" | "stalled" | "max-steps";
+}
+
+export interface DriveState {
+  readonly runs: number;
+  readonly lastText: string | undefined;
+  readonly repetitionStreak: number;
+  readonly stallStreak: number;
+  readonly blockedStreak: number;
+}
+
+type DriveStopReason = "continuation_cap" | "repetition" | "toolless_stall" | "blocked";
+
+export type DriveDecision =
+  | { readonly action: "done" }
+  | { readonly action: "continue"; readonly prompt: string; readonly state: DriveState }
+  | { readonly action: "stop"; readonly reason: DriveStopReason };
+
+export function initialDriveState(): DriveState {
+  return { runs: 0, lastText: undefined, repetitionStreak: 0, stallStreak: 0, blockedStreak: 0 };
+}
+
+const BLOCKED_CLAIM = /^\s*BLOCKED\b/i;
+
+const CONTINUE_PROMPT =
+  "The assignment is not finished. Continue working toward the acceptance criteria with your tools, produce evidence, then give your final answer.";
+
+const BLOCKED_PROMPT =
+  "You reported BLOCKED. Re-verify the blocker with your tools; if it is not absolute, continue the assignment. Repeat the BLOCKED report only if the same blocker truly recurs.";
+
+export function decideDrive(state: DriveState, observation: DriveObservation): DriveDecision {
+  const runs = state.runs + 1;
+  const blocked = BLOCKED_CLAIM.test(observation.text);
+  const repetitionStreak = state.lastText === observation.text ? state.repetitionStreak + 1 : 1;
+  const blockedStreak = blocked ? state.blockedStreak + 1 : 0;
+  // A recurring blocker is the truthful stop reason even when its wording
+  // repeats verbatim, so the blocked gate outranks the repetition gate.
+  if (blockedStreak >= DRIVE_BLOCKED_RECURRENCE) return { action: "stop", reason: "blocked" };
+  if (repetitionStreak >= DRIVE_REPETITION_STREAK) return { action: "stop", reason: "repetition" };
+  if (observation.finishReason === "stop" && !blocked) return { action: "done" };
+
+  // "max-steps" is live work: the step budget ended mid-flight, which is
+  // progress — it resets the stall and blocked streaks.
+  const stallStreak = observation.finishReason === "stalled" ? state.stallStreak + 1 : 0;
+  if (stallStreak >= DRIVE_TOOLLESS_STALL_STREAK) return { action: "stop", reason: "toolless_stall" };
+  if (runs >= DRIVE_CONTINUATION_CAP) return { action: "stop", reason: "continuation_cap" };
+
+  return {
+    action: "continue",
+    prompt: blocked ? BLOCKED_PROMPT : CONTINUE_PROMPT,
+    state: { runs, lastText: observation.text, repetitionStreak, stallStreak, blockedStreak },
+  };
+}

--- a/apps/openomni/src/delegation/drive-loop.ts
+++ b/apps/openomni/src/delegation/drive-loop.ts
@@ -6,6 +6,8 @@
  * schema — the contract stays executor-agnostic.
  */
 
+import { RunReasonCode } from "@openomni/agent";
+
 export const DRIVE_CONTINUATION_CAP = 8;
 export const DRIVE_REPETITION_STREAK = 3;
 export const DRIVE_TOOLLESS_STALL_STREAK = 3;
@@ -60,7 +62,7 @@ export function decideDrive(state: DriveState, observation: DriveObservation): D
   if (repetitionStreak >= DRIVE_REPETITION_STREAK) return { action: "stop", reason: "repetition" };
   if (observation.finishReason === "stop" && !blocked) return { action: "done" };
 
-  const stallStreak = observation.finishReason === "stalled" ? state.stallStreak + 1 : 0;
+  const stallStreak = observation.finishReason === RunReasonCode.Stalled ? state.stallStreak + 1 : 0;
   if (stallStreak >= DRIVE_TOOLLESS_STALL_STREAK) return { action: "stop", reason: "toolless_stall" };
   if (runs >= DRIVE_CONTINUATION_CAP) return { action: "stop", reason: "continuation_cap" };
 

--- a/apps/openomni/src/delegation/drive-loop.ts
+++ b/apps/openomni/src/delegation/drive-loop.ts
@@ -47,7 +47,11 @@ const BLOCKED_PROMPT =
 
 export function decideDrive(state: DriveState, observation: DriveObservation): DriveDecision {
   const runs = state.runs + 1;
-  const blocked = BLOCKED_CLAIM.test(observation.text);
+  // "max-steps" is live work: the step budget ended mid-flight, which is
+  // progress — it resets the stall and blocked streaks even when the
+  // truncated text happens to open with a BLOCKED claim.
+  const liveWork = observation.finishReason === "max-steps";
+  const blocked = !liveWork && BLOCKED_CLAIM.test(observation.text);
   const repetitionStreak = state.lastText === observation.text ? state.repetitionStreak + 1 : 1;
   const blockedStreak = blocked ? state.blockedStreak + 1 : 0;
   // A recurring blocker is the truthful stop reason even when its wording
@@ -56,8 +60,6 @@ export function decideDrive(state: DriveState, observation: DriveObservation): D
   if (repetitionStreak >= DRIVE_REPETITION_STREAK) return { action: "stop", reason: "repetition" };
   if (observation.finishReason === "stop" && !blocked) return { action: "done" };
 
-  // "max-steps" is live work: the step budget ended mid-flight, which is
-  // progress — it resets the stall and blocked streaks.
   const stallStreak = observation.finishReason === "stalled" ? state.stallStreak + 1 : 0;
   if (stallStreak >= DRIVE_TOOLLESS_STALL_STREAK) return { action: "stop", reason: "toolless_stall" };
   if (runs >= DRIVE_CONTINUATION_CAP) return { action: "stop", reason: "continuation_cap" };

--- a/apps/openomni/src/delegation/inline-driver.ts
+++ b/apps/openomni/src/delegation/inline-driver.ts
@@ -6,13 +6,14 @@ import type { DelegationDriver, DriverOutcome, DriverReport } from "./kernel";
 export type InlineWorkerRunner = (
   input: {
     readonly delegationId: string;
+    readonly operation: Delegation.Operation;
     readonly instruction: string;
     readonly acceptanceCriteria: readonly string[];
     /** Admission-stamped worker identity and delegation lineage. */
     readonly origin: DelegationOrigin;
     readonly signal: AbortSignal;
   },
-) => Promise<string>;
+) => Promise<{ readonly text: string; readonly tokens: number }>;
 
 /**
  * The volatile inline transport. The kernel still records it before this runs,
@@ -30,6 +31,7 @@ export function createInlineDriver(run: InlineWorkerRunner): DelegationDriver {
       report?.delivered();
       const output = await run({
         delegationId: handle.delegationId,
+        operation: admitted.request.operation,
         instruction: admitted.request.payload.text,
         acceptanceCriteria: admitted.request.acceptanceCriteria ?? [],
         origin: admitted.childOrigin,
@@ -40,7 +42,7 @@ export function createInlineDriver(run: InlineWorkerRunner): DelegationDriver {
       // kernel's terminal CAS. Reporting cancelled also avoids presenting it
       // as usable output to a caller whose inline turn is still unwinding.
       if (signal.aborted) return { status: "cancelled", reason: "delegation stopped" };
-      return { status: "completed", output };
+      return { status: "completed", output: output.text, usage: { tokens: output.tokens } };
     },
   };
 }

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -171,7 +171,13 @@ function outcomeToSettlement(
 ): Delegation.Settled {
   switch (outcome.status) {
     case "completed":
-      return { status: "completed", delegationId, output: outcome.output, at };
+      return {
+        status: "completed",
+        delegationId,
+        output: outcome.output,
+        at,
+        ...(outcome.usage === undefined ? {} : { usage: outcome.usage }),
+      };
     case "failed":
       return { status: "failed", delegationId, error: outcome.error, at };
     case "cancelled":
@@ -266,11 +272,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
    * waiter notification, timer cleanup, and wake delivery happen only after
    * that CAS has recorded the settlement.
    */
-  function settle(
-    delegationId: string,
-    candidate: Delegation.Settled,
-    usage?: { readonly tokens: number },
-  ): Delegation.Settled | undefined {
+  function settle(delegationId: string, candidate: Delegation.Settled): Delegation.Settled | undefined {
     const current = store.get(delegationId);
     if (current === undefined) return undefined;
     if (current.status === "settled") return current.settled;
@@ -319,11 +321,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     if (persisted.operation === "assign" && persisted.workItemId !== undefined && workItems !== undefined) {
       void Promise.resolve()
         .then(() =>
-          workItems.closeAttempt({
-            record: persisted,
-            settlement: winner,
-            ...(usage === undefined ? {} : { usage }),
-          }),
+          workItems.closeAttempt({ record: persisted, settlement: winner }),
         )
         .catch((error: unknown) => {
           events.publish(Operational.Events.Error, {
@@ -472,11 +470,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
         const outcome = await driver.run(admitted, handle, controller.signal, report);
         if (stopped) return undefined;
         const settlement = outcomeToSettlement(handle.delegationId, outcome, options.now());
-        return settle(
-          handle.delegationId,
-          settlement,
-          outcome.status === "completed" ? outcome.usage : undefined,
-        );
+        return settle(handle.delegationId, settlement);
       } catch (error) {
         if (stopped) return undefined;
         return settle(handle.delegationId, {

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -12,7 +12,12 @@ import {
 
 /** What a transport reports after it has been dispatched. */
 export type DriverOutcome =
-  | { readonly status: "completed"; readonly output: string }
+  | {
+      readonly status: "completed";
+      readonly output: string;
+      /** Transport-reported spend; visibility only, never an admission input. */
+      readonly usage?: { readonly tokens: number };
+    }
   | { readonly status: "failed"; readonly error: string }
   | { readonly status: "cancelled"; readonly reason: string }
   | { readonly status: "delivery_failed"; readonly reason: string }
@@ -264,6 +269,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
   function settle(
     delegationId: string,
     candidate: Delegation.Settled,
+    usage?: { readonly tokens: number },
   ): Delegation.Settled | undefined {
     const current = store.get(delegationId);
     if (current === undefined) return undefined;
@@ -312,7 +318,13 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     const workItems = options.workItems;
     if (persisted.operation === "assign" && persisted.workItemId !== undefined && workItems !== undefined) {
       void Promise.resolve()
-        .then(() => workItems.closeAttempt({ record: persisted, settlement: winner }))
+        .then(() =>
+          workItems.closeAttempt({
+            record: persisted,
+            settlement: winner,
+            ...(usage === undefined ? {} : { usage }),
+          }),
+        )
         .catch((error: unknown) => {
           events.publish(Operational.Events.Error, {
             traceId: delegationId,
@@ -460,7 +472,11 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
         const outcome = await driver.run(admitted, handle, controller.signal, report);
         if (stopped) return undefined;
         const settlement = outcomeToSettlement(handle.delegationId, outcome, options.now());
-        return settle(handle.delegationId, settlement);
+        return settle(
+          handle.delegationId,
+          settlement,
+          outcome.status === "completed" ? outcome.usage : undefined,
+        );
       } catch (error) {
         if (stopped) return undefined;
         return settle(handle.delegationId, {

--- a/apps/openomni/src/delegation/process-driver.ts
+++ b/apps/openomni/src/delegation/process-driver.ts
@@ -64,6 +64,7 @@ export function createProcessDriver(options: ProcessDriverOptions): DelegationDr
       try {
         const request: ProcessWorkerRequest = {
           delegationId: handle.delegationId,
+          operation: admitted.request.operation,
           instruction: admitted.request.payload.text,
           acceptanceCriteria: admitted.request.acceptanceCriteria ?? [],
           origin: admitted.childOrigin,

--- a/apps/openomni/src/delegation/process-entry.ts
+++ b/apps/openomni/src/delegation/process-entry.ts
@@ -9,6 +9,7 @@ import { createInlineWorkerRunner } from "./worker-loop";
 export const ProcessWorkerRequest = z
   .object({
     delegationId: z.string().min(1),
+    operation: Delegation.Operation,
     instruction: z.string().min(1),
     acceptanceCriteria: z.array(z.string()),
     origin: Delegation.Origin,
@@ -23,12 +24,20 @@ export type ProcessWorkerRequest = z.infer<typeof ProcessWorkerRequest>;
 export const PROCESS_WORKER_ACK = JSON.stringify({ delivered: true });
 
 export const ProcessWorkerResult = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("completed"), output: z.string() }).strict(),
+  z
+    .object({
+      status: z.literal("completed"),
+      output: z.string(),
+      usage: z.object({ tokens: z.number().int().nonnegative() }).strict().optional(),
+    })
+    .strict(),
   z.object({ status: z.literal("failed"), error: z.string() }).strict(),
 ]);
 export type ProcessWorkerResult = z.infer<typeof ProcessWorkerResult>;
 
-export type ProcessWorkerRun = (request: ProcessWorkerRequest) => Promise<string>;
+export type ProcessWorkerRun = (
+  request: ProcessWorkerRequest,
+) => Promise<{ readonly text: string; readonly tokens: number }>;
 
 /** Child processes may only open inline children; independent work is refused. */
 export function createChildKernel(runner: InlineWorkerRunner): DelegationKernel {
@@ -56,7 +65,8 @@ export async function serveProcessWorker(
   writeLine(PROCESS_WORKER_ACK);
   let result: ProcessWorkerResult;
   try {
-    result = { status: "completed", output: await run(request) };
+    const output = await run(request);
+    result = { status: "completed", output: output.text, usage: { tokens: output.tokens } };
   } catch (error) {
     result = {
       status: "failed",
@@ -67,7 +77,9 @@ export async function serveProcessWorker(
 }
 
 /** Runs the same Worker loop in the child process. */
-function processWorkerRun(request: ProcessWorkerRequest): Promise<string> {
+function processWorkerRun(
+  request: ProcessWorkerRequest,
+): Promise<{ readonly text: string; readonly tokens: number }> {
   if (request.dbPath !== undefined && Storage.getInitializedDbPath() === null) {
     initialize({ dbPath: request.dbPath });
   }
@@ -80,6 +92,7 @@ function processWorkerRun(request: ProcessWorkerRequest): Promise<string> {
   kernel = createChildKernel(runner);
   return runner({
     delegationId: request.delegationId,
+    operation: request.operation,
     instruction: request.instruction,
     acceptanceCriteria: request.acceptanceCriteria,
     origin: request.origin,

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -30,6 +30,8 @@ interface OpenAssignInput {
 interface CloseAttemptInput {
   readonly record: Delegation.Record;
   readonly settlement: Delegation.Settled;
+  /** Transport-reported spend; visibility only, never an admission input. */
+  readonly usage?: { readonly tokens: number };
 }
 
 export interface WorkItemLinkageOptions {
@@ -127,7 +129,7 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
   }
 
   async function closeAttempt(input: CloseAttemptInput): Promise<void> {
-    const { record, settlement } = input;
+    const { record, settlement, usage } = input;
     if (record.workItemId === undefined || settlement.status === "sent") return;
     const item = await WorkItemStore.get(record.workItemId);
     // Unknown item: a legacy record upcast points at nothing durable — no-op.
@@ -160,7 +162,13 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
       record.delegationId,
       Delegation.settlementToAttemptOutcome(settlement.status),
       traceId,
-      { endedAt: options.now() },
+      {
+        endedAt: options.now(),
+        usage: WorkItem.AttemptUsage.parse({
+          seconds: Math.max(0, (settlement.at - record.createdAt) / 1000),
+          ...(usage === undefined ? {} : { tokens: usage.tokens }),
+        }),
+      },
     );
   }
 

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -30,8 +30,6 @@ interface OpenAssignInput {
 interface CloseAttemptInput {
   readonly record: Delegation.Record;
   readonly settlement: Delegation.Settled;
-  /** Transport-reported spend; visibility only, never an admission input. */
-  readonly usage?: { readonly tokens: number };
 }
 
 export interface WorkItemLinkageOptions {
@@ -129,7 +127,10 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
   }
 
   async function closeAttempt(input: CloseAttemptInput): Promise<void> {
-    const { record, settlement, usage } = input;
+    const { record, settlement } = input;
+    // Spend rides the durable settlement itself, so a restart-sweep re-close
+    // recovers the same tokens the live fold would have recorded.
+    const tokens = settlement.status === "completed" ? settlement.usage?.tokens : undefined;
     if (record.workItemId === undefined || settlement.status === "sent") return;
     const item = await WorkItemStore.get(record.workItemId);
     // Unknown item: a legacy record upcast points at nothing durable — no-op.
@@ -166,7 +167,7 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
         endedAt: options.now(),
         usage: WorkItem.AttemptUsage.parse({
           seconds: Math.max(0, (settlement.at - record.createdAt) / 1000),
-          ...(usage === undefined ? {} : { tokens: usage.tokens }),
+          ...(tokens === undefined ? {} : { tokens }),
         }),
       },
     );

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -5,6 +5,7 @@ import { buildAgentPrompt } from "../prompt/build";
 import { WORKER_PRESET } from "../prompt/roles";
 import { catalogEntries } from "../tools/catalog";
 import { createDispatcher, HOST_TARGET } from "../tools/dispatch";
+import { decideDrive, initialDriveState, type DriveState } from "./drive-loop";
 import { renderInstruction } from "./instruction";
 import type { DelegationKernel } from "./kernel";
 import type { InlineWorkerRunner } from "./inline-driver";
@@ -40,22 +41,41 @@ export function createInlineWorkerRunner(options: WorkerLoopOptions): InlineWork
       ...(options.llm === undefined ? {} : { llm: options.llm }),
     });
 
-    const result = await agent.run({
-      messages: [
-        {
-          role: "user",
-          content: renderInstruction(input.instruction, input.acceptanceCriteria),
-          time: Date.now(),
-        },
-      ],
-      traceContext: {
-        traceId: crypto.randomUUID(),
-        sessionId: `delegation-${input.delegationId}`,
-        runId: crypto.randomUUID(),
-        agentName: "worker",
+    const messages: Array<{ role: "user" | "assistant"; content: string; time: number }> = [
+      {
+        role: "user",
+        content: renderInstruction(input.instruction, input.acceptanceCriteria),
+        time: Date.now(),
       },
-    });
+    ];
+    const traceContext = {
+      traceId: crypto.randomUUID(),
+      sessionId: `delegation-${input.delegationId}`,
+      runId: crypto.randomUUID(),
+      agentName: "worker",
+    };
 
-    return result.text;
+    // Assigned work is driven goal-style (drive-loop.ts); ask/notify runs
+    // once — a question is answered, never nannied.
+    let tokens = 0;
+    let state: DriveState = initialDriveState();
+    for (;;) {
+      const result = await agent.run({ messages, traceContext });
+      tokens += result.usage.totalTokens;
+      if (input.operation !== "assign") return { text: result.text, tokens };
+      const decision = decideDrive(state, {
+        text: result.text,
+        finishReason: result.finishReason,
+      });
+      if (decision.action === "done") return { text: result.text, tokens };
+      if (decision.action === "stop") {
+        return { text: `[drive stopped: ${decision.reason}]\n${result.text}`, tokens };
+      }
+      state = decision.state;
+      messages.push(
+        { role: "assistant", content: result.text, time: Date.now() },
+        { role: "user", content: decision.prompt, time: Date.now() },
+      );
+    }
   };
 }

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -48,19 +48,20 @@ export function createInlineWorkerRunner(options: WorkerLoopOptions): InlineWork
         time: Date.now(),
       },
     ];
-    const traceContext = {
-      traceId: crypto.randomUUID(),
-      sessionId: `delegation-${input.delegationId}`,
-      runId: crypto.randomUUID(),
-      agentName: "worker",
-    };
+    const traceId = crypto.randomUUID();
+    const sessionId = `delegation-${input.delegationId}`;
 
     // Assigned work is driven goal-style (drive-loop.ts); ask/notify runs
     // once — a question is answered, never nannied.
     let tokens = 0;
     let state: DriveState = initialDriveState();
     for (;;) {
-      const result = await agent.run({ messages, traceContext });
+      // Each driven run is its own run identity so telemetry never conflates
+      // two agent runs under one runId.
+      const result = await agent.run({
+        messages,
+        traceContext: { traceId, sessionId, runId: crypto.randomUUID(), agentName: "worker" },
+      });
       tokens += result.usage.totalTokens;
       if (input.operation !== "assign") return { text: result.text, tokens };
       const decision = decideDrive(state, {

--- a/apps/openomni/test/drive-loop.test.ts
+++ b/apps/openomni/test/drive-loop.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import {
+  DRIVE_BLOCKED_RECURRENCE,
+  DRIVE_CONTINUATION_CAP,
+  DRIVE_REPETITION_STREAK,
+  DRIVE_TOOLLESS_STALL_STREAK,
+  decideDrive,
+  initialDriveState,
+} from "../src/delegation/drive-loop";
+import type { DriveDecision, DriveObservation, DriveState } from "../src/delegation/drive-loop";
+
+function drive(observations: readonly DriveObservation[]): DriveDecision {
+  let state: DriveState = initialDriveState();
+  let decision: DriveDecision = { action: "done" };
+  for (const observation of observations) {
+    decision = decideDrive(state, observation);
+    if (decision.action !== "continue") return decision;
+    state = decision.state;
+  }
+  return decision;
+}
+
+const working: DriveObservation = { text: "still working through the checks", finishReason: "max-steps" };
+const stalled = (text: string): DriveObservation => ({ text, finishReason: "stalled" });
+const blocked = (text: string): DriveObservation => ({ text, finishReason: "stop" });
+
+test("a natural stop is done — the drive loop never nannies a finished run", () => {
+  expect(drive([{ text: "all criteria hold; evidence attached", finishReason: "stop" }])).toEqual({
+    action: "done",
+  });
+});
+
+test("an exhausted step budget is live work: the loop continues with streaks reset", () => {
+  const first = decideDrive(initialDriveState(), stalled("hm"));
+  expect(first.action).toBe("continue");
+  const second = decideDrive(first.action === "continue" ? first.state : initialDriveState(), working);
+  expect(second.action).toBe("continue");
+  if (second.action === "continue") {
+    expect(second.state.stallStreak).toBe(0);
+    expect(second.state.blockedStreak).toBe(0);
+  }
+});
+
+test("three consecutive stalls stop the loop as a toolless stall", () => {
+  const observations = Array.from({ length: DRIVE_TOOLLESS_STALL_STREAK }, (_, i) => stalled(`stall ${i}`));
+  expect(drive(observations)).toEqual({ action: "stop", reason: "toolless_stall" });
+  expect(drive(observations.slice(0, DRIVE_TOOLLESS_STALL_STREAK - 1)).action).toBe("continue");
+});
+
+test("identical continued output three times running stops the loop as repetition", () => {
+  const observations = Array.from({ length: DRIVE_REPETITION_STREAK }, () => working);
+  expect(drive(observations)).toEqual({ action: "stop", reason: "repetition" });
+});
+
+test("a blocked claim needs three recurrences before the loop believes it", () => {
+  const claims = Array.from({ length: DRIVE_BLOCKED_RECURRENCE }, (_, i) => blocked(`BLOCKED: gate ${i} is closed`));
+  expect(drive(claims)).toEqual({ action: "stop", reason: "blocked" });
+  const early = drive(claims.slice(0, DRIVE_BLOCKED_RECURRENCE - 1));
+  expect(early.action).toBe("continue");
+  if (early.action === "continue") expect(early.prompt).toContain("BLOCKED");
+});
+
+test("real progress resets a blocked streak", () => {
+  const outcome = drive([blocked("BLOCKED: a"), working, blocked("BLOCKED: b"), working, blocked("BLOCKED: c")]);
+  expect(outcome.action).toBe("continue");
+});
+
+test("the continuation cap bounds the loop at eight runs total", () => {
+  const observations = Array.from({ length: DRIVE_CONTINUATION_CAP }, (_, i) =>
+    i % 2 === 0 ? working : stalled(`s${i}`),
+  );
+  expect(drive(observations)).toEqual({ action: "stop", reason: "continuation_cap" });
+});

--- a/apps/openomni/test/drive-loop.test.ts
+++ b/apps/openomni/test/drive-loop.test.ts
@@ -60,6 +60,17 @@ test("a blocked claim needs three recurrences before the loop believes it", () =
   if (early.action === "continue") expect(early.prompt).toContain("BLOCKED");
 });
 
+test("a truncated run opening with BLOCKED is still live work: the blocked streak resets", () => {
+  const truncated: DriveObservation = { text: "BLOCKED: retrying the registry", finishReason: "max-steps" };
+  // The mid-flight run resets the streak, so a third stop-claim continues...
+  expect(drive([blocked("BLOCKED: a"), truncated, blocked("BLOCKED: b")]).action).toBe("continue");
+  // ...and only three consecutive settled claims after the reset stop the loop.
+  expect(drive([blocked("BLOCKED: a"), truncated, blocked("BLOCKED: b"), blocked("BLOCKED: c"), blocked("BLOCKED: d")])).toEqual({
+    action: "stop",
+    reason: "blocked",
+  });
+});
+
 test("real progress resets a blocked streak", () => {
   const outcome = drive([blocked("BLOCKED: a"), working, blocked("BLOCKED: b"), working, blocked("BLOCKED: c")]);
   expect(outcome.action).toBe("continue");

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -2,9 +2,12 @@ import { expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DelegationStore } from "@openomni/ledger";
+import { DelegationStore, WorkItemStore } from "@openomni/ledger";
+import { WorkItem } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
 import { createDelegationKernel } from "../src/delegation/kernel";
 import { createProcessDriver } from "../src/delegation/process-driver";
+import { createWorkItemLinkage } from "../src/delegation/work-item-linkage";
 import {
   createChildKernel,
   PROCESS_WORKER_ACK,
@@ -302,3 +305,101 @@ test("concurrent process delegations have independent durable ids and answers", 
   );
   expect(new Set(settled).size).toBe(4);
 });
+
+
+const CHILD_DRIVE_ENTRY = `
+import { createChildKernel, serveProcessWorker } from "/Users/ino/Develop/openomni-wt-prc/apps/openomni/src/delegation/process-entry";
+import { createInlineWorkerRunner } from "/Users/ino/Develop/openomni-wt-prc/apps/openomni/src/delegation/worker-loop";
+
+const tokens = { input: 4, output: 5, reasoning: 0, cache: { read: 0, write: 0 } };
+const llm = {
+  resolveProviderModel: async (model) => ({ id: model.id, name: model.id, providerID: model.provider }),
+  run: async (input, sink) => {
+    const id = "fake-" + input.messages.length;
+    const sessionID = input.trace.sessionId;
+    sink.onMessage({
+      info: {
+        id, sessionID, role: "assistant", time: { created: Date.now() }, parentID: "",
+        modelID: input.model.id, providerID: input.model.providerID, agent: "worker",
+        path: { cwd: "", root: "" }, cost: 0, tokens,
+      },
+      parts: [
+        { id: id + "-text", sessionID, messageID: id, type: "text", text: "BLOCKED: the registry is unreachable" },
+        { id: id + "-finish", sessionID, messageID: id, type: "step-finish", reason: "stop", cost: 0, tokens },
+      ],
+    });
+    return { type: "stop" };
+  },
+};
+
+const line = await new Response(Bun.stdin.stream()).text();
+let kernel;
+const runner = createInlineWorkerRunner({
+  model: { provider: "fake", id: "drive-test" },
+  apiKey: "test-key",
+  llm,
+  kernel: () => kernel,
+});
+kernel = createChildKernel(runner);
+await serveProcessWorker(line, (out) => console.log(out), (request) =>
+  runner({
+    delegationId: request.delegationId,
+    operation: request.operation,
+    instruction: request.instruction,
+    acceptanceCriteria: request.acceptanceCriteria,
+    origin: request.origin,
+    signal: new AbortController().signal,
+  }),
+);
+process.exit(0);
+`;
+
+test("an assign rides the real wire: parent driver, spawned child, drive loop, usage, settlement", async () => {
+  // The child OS process runs the REAL serveProcessWorker and the REAL worker
+  // drive loop; only the provider call is stubbed, exactly where
+  // processWorkerRun would talk to a model.
+  const entry = fakeEntry(CHILD_DRIVE_ENTRY);
+  const kernel = createDelegationKernel({
+    drivers: {
+      process: createProcessDriver({ command: [process.execPath, entry], worker: WORKER }),
+    },
+    now: () => Date.now(),
+    newDelegationId: () => "d-wire-drive",
+    wake: () => undefined,
+    workItems: createWorkItemLinkage({ model: WORKER.model, now: () => Date.now() }),
+  });
+  const result = await kernel.delegate(
+    {
+      operation: "assign",
+      address: { kind: "core", scope: "independent" },
+      payload: { text: "publish the package" },
+      acceptanceCriteria: ["the package is live"],
+      deadline: Date.now() + 20_000,
+    },
+    RESIDENT,
+  );
+  if ("refused" in result) throw new Error(result.refused);
+  // Subscribe after admission: attempt ALLOCATION also publishes an Updated
+  // event whose fields clear `attemptTerminal` — only the post-settlement
+  // closure event is the one this test waits for.
+  const closed = new Promise<string>((resolve) => {
+    const unsubscribe = Bus.subscribe(WorkItem.Events.Updated, (event) => {
+      if (event.payload.fields.includes("attemptTerminal")) {
+        unsubscribe();
+        resolve(event.payload.workItemId);
+      }
+    });
+  });
+  const settled = await kernel.awaitDelegation(result.handle.delegationId, 20_000);
+  if (settled.kind !== "settled" || settled.settlement.status !== "completed") {
+    throw new Error(`process did not settle completed: ${JSON.stringify(settled)}`);
+  }
+  // Drive loop ran in the child: three driven runs, blocked stop, summed spend.
+  expect(settled.settlement.output).toBe("[drive stopped: blocked]\nBLOCKED: the registry is unreachable");
+  expect(settled.settlement.usage).toEqual({ tokens: 27 });
+  const workItemId = await closed;
+  expect(workItemId).toBe(DelegationStore.get("d-wire-drive")?.workItemId ?? "");
+  const item = await WorkItemStore.get(workItemId);
+  expect(item?.attemptTerminal).toMatchObject({ usage: { tokens: 27 } });
+  kernel.stop();
+}, 20_000);

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -53,6 +53,7 @@ test("the entry acks before it works, so delivery is observable separately from 
   await serveProcessWorker(
     JSON.stringify({
       delegationId: "d-1",
+      operation: "ask",
       instruction: "summarize",
       acceptanceCriteria: [],
       origin: { role: "worker", depth: 1, sessionId: "session-origin" },
@@ -65,12 +66,12 @@ test("the entry acks before it works, so delivery is observable separately from 
     },
     async () => {
       order.push("run");
-      return "done";
+      return { text: "done", tokens: 7 };
     },
   );
   expect(written[0]).toBe(PROCESS_WORKER_ACK);
   expect(order).toEqual(["write", "run", "write"]);
-  expect(JSON.parse(written[1] ?? "")).toEqual({ status: "completed", output: "done" });
+  expect(JSON.parse(written[1] ?? "")).toEqual({ status: "completed", output: "done", usage: { tokens: 7 } });
 });
 
 test("a worker that throws is a failed result, not a lost delivery", async () => {
@@ -78,6 +79,7 @@ test("a worker that throws is a failed result, not a lost delivery", async () =>
   await serveProcessWorker(
     JSON.stringify({
       delegationId: "d-1",
+      operation: "ask",
       instruction: "summarize",
       acceptanceCriteria: [],
       origin: { role: "worker", depth: 1, sessionId: "session-origin" },
@@ -96,7 +98,7 @@ test("a worker that throws is a failed result, not a lost delivery", async () =>
 test("a request that does not parse never acks", async () => {
   const written: string[] = [];
   await expect(
-    serveProcessWorker('{"instruction":"no origin"}', (line) => written.push(line), async () => "x"),
+    serveProcessWorker('{"instruction":"no origin"}', (line) => written.push(line), async () => ({ text: "x", tokens: 0 })),
   ).rejects.toThrow("Required");
   expect(written).toEqual([]);
 });
@@ -105,6 +107,7 @@ test("the request schema carries lineage and refuses a malformed origin", () => 
   expect(
     ProcessWorkerRequest.safeParse({
       delegationId: "d-1",
+      operation: "ask",
       instruction: "x",
       acceptanceCriteria: [],
       origin: { role: "worker" },
@@ -115,6 +118,7 @@ test("the request schema carries lineage and refuses a malformed origin", () => 
   expect(
     ProcessWorkerRequest.parse({
       delegationId: "d-1",
+      operation: "ask",
       instruction: "x",
       acceptanceCriteria: [],
       origin: {
@@ -260,13 +264,13 @@ test("a child kernel does not sweep the host's open process row", () => {
     status: "open",
     createdAt: 1_000,
   });
-  const kernel = createChildKernel(async () => "inner");
+  const kernel = createChildKernel(async () => ({ text: "inner", tokens: 0 }));
   expect(DelegationStore.get("d-parent-open")?.status).toBe("open");
   kernel.stop();
 });
 
 test("the child kernel has no process driver", async () => {
-  const kernel = createChildKernel(async () => "inner");
+  const kernel = createChildKernel(async () => ({ text: "inner", tokens: 0 }));
   const result = await kernel.delegate(independentAsk("fork", Date.now() + 5_000), RESIDENT);
   if ("refused" in result) throw new Error(result.refused);
   const settled = await kernel.awaitDelegation(result.handle.delegationId);

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -307,9 +307,10 @@ test("concurrent process delegations have independent durable ids and answers", 
 });
 
 
+const DELEGATION_SRC = new URL("../src/delegation", import.meta.url).pathname;
 const CHILD_DRIVE_ENTRY = `
-import { createChildKernel, serveProcessWorker } from "/Users/ino/Develop/openomni-wt-prc/apps/openomni/src/delegation/process-entry";
-import { createInlineWorkerRunner } from "/Users/ino/Develop/openomni-wt-prc/apps/openomni/src/delegation/worker-loop";
+import { createChildKernel, serveProcessWorker } from "${DELEGATION_SRC}/process-entry";
+import { createInlineWorkerRunner } from "${DELEGATION_SRC}/worker-loop";
 
 const tokens = { input: 4, output: 5, reasoning: 0, cache: { read: 0, write: 0 } };
 const llm = {
@@ -379,14 +380,19 @@ test("an assign rides the real wire: parent driver, spawned child, drive loop, u
     RESIDENT,
   );
   if ("refused" in result) throw new Error(result.refused);
-  // Subscribe after admission: attempt ALLOCATION also publishes an Updated
-  // event whose fields clear `attemptTerminal` — only the post-settlement
-  // closure event is the one this test waits for.
-  const closed = new Promise<string>((resolve) => {
+  const workItemId = DelegationStore.get("d-wire-drive")?.workItemId ?? "";
+  expect(workItemId).not.toBe("");
+  // Subscribe after admission, correlated to THIS work item: attempt
+  // ALLOCATION also publishes an Updated event whose fields clear
+  // `attemptTerminal` — only the post-settlement closure event counts.
+  const closed = new Promise<void>((resolve) => {
     const unsubscribe = Bus.subscribe(WorkItem.Events.Updated, (event) => {
-      if (event.payload.fields.includes("attemptTerminal")) {
+      if (
+        event.payload.workItemId === workItemId &&
+        event.payload.fields.includes("attemptTerminal")
+      ) {
         unsubscribe();
-        resolve(event.payload.workItemId);
+        resolve();
       }
     });
   });
@@ -397,8 +403,7 @@ test("an assign rides the real wire: parent driver, spawned child, drive loop, u
   // Drive loop ran in the child: three driven runs, blocked stop, summed spend.
   expect(settled.settlement.output).toBe("[drive stopped: blocked]\nBLOCKED: the registry is unreachable");
   expect(settled.settlement.usage).toEqual({ tokens: 27 });
-  const workItemId = await closed;
-  expect(workItemId).toBe(DelegationStore.get("d-wire-drive")?.workItemId ?? "");
+  await closed;
   const item = await WorkItemStore.get(workItemId);
   expect(item?.attemptTerminal).toMatchObject({ usage: { tokens: 27 } });
   kernel.stop();

--- a/apps/openomni/test/work-item-wiring.test.ts
+++ b/apps/openomni/test/work-item-wiring.test.ts
@@ -250,7 +250,7 @@ test("a restart sweep re-closes an attempt whose settlement write was lost", asy
   await delegateAssign(kernel);
   const workItemId = DelegationStore.get("dg-wiring-1")?.workItemId ?? "";
   const closed = attemptClosed(workItemId);
-  settle({ status: "completed", output: "done" });
+  settle({ status: "completed", output: "done", usage: { tokens: 555 } });
   await kernel.awaitDelegation("dg-wiring-1", 5_000);
   await closed;
   kernel.stop();
@@ -270,6 +270,9 @@ test("a restart sweep re-closes an attempt whose settlement write was lost", asy
   // evidence or reopen the attempt.
   const record = DelegationStore.get("dg-wiring-1");
   if (record === undefined || record.settled === undefined) throw new Error("record not settled");
+  // Tokens ride the durable settlement, so a crash between settlement and
+  // attempt closure loses nothing: the sweep re-closes from this record alone.
+  expect(record.settled).toMatchObject({ status: "completed", usage: { tokens: 555 } });
   await linkage.closeAttempt({ record, settlement: record.settled });
   await linkage.recoverAttempts((id) => DelegationStore.get(id));
   const after = await WorkItemStore.get(workItemId);
@@ -284,7 +287,7 @@ test("completion re-runs the whole admission recipe when the receipt loses a hea
   await delegateAssign(kernel);
   const workItemId = DelegationStore.get("dg-wiring-1")?.workItemId ?? "";
   const closed = attemptClosed(workItemId);
-  settle({ status: "completed", output: "done" });
+  settle({ status: "completed", output: "done", usage: { tokens: 555 } });
   await kernel.awaitDelegation("dg-wiring-1", 5_000);
   await closed;
   kernel.stop();

--- a/apps/openomni/test/work-item-wiring.test.ts
+++ b/apps/openomni/test/work-item-wiring.test.ts
@@ -243,6 +243,35 @@ test("work_items and complete_work are a Resident-only catalog surface", () => {
   expect(workerNames).not.toContain("complete_work");
 });
 
+test("a crash between settlement and closure loses nothing: the sweep rebuilds the terminal with its tokens", async () => {
+  bootLedger();
+  const { driver } = deferredDriver();
+  const kernel = bootKernel(driver);
+  await delegateAssign(kernel);
+  const workItemId = DelegationStore.get("dg-wiring-1")?.workItemId ?? "";
+  // The settlement CAS commits directly against the store — the kernel's
+  // closeAttempt hook never fires, exactly the crash window recovery covers.
+  DelegationStore.settleOnce("dg-wiring-1", {
+    status: "completed",
+    delegationId: "dg-wiring-1",
+    output: "done before the crash",
+    at: Date.now(),
+    usage: { tokens: 777 },
+  });
+  kernel.stop();
+  expect((await WorkItemStore.get(workItemId))?.attemptTerminal).toBeUndefined();
+
+  const linkage = createWorkItemLinkage({
+    model: { provider: "fake", id: "fake-model" },
+    now: () => Date.now(),
+  });
+  await linkage.recoverAttempts((id) => DelegationStore.get(id));
+  const after = await WorkItemStore.get(workItemId);
+  expect(after?.attemptTerminal).toMatchObject({ usage: { tokens: 777 } });
+  expect(after?.evidence).toHaveLength(1);
+  expect(after?.evidence[0]?.passed).toBe(false);
+});
+
 test("a restart sweep re-closes an attempt whose settlement write was lost", async () => {
   bootLedger();
   const { driver, settle } = deferredDriver();

--- a/apps/openomni/test/work-item-wiring.test.ts
+++ b/apps/openomni/test/work-item-wiring.test.ts
@@ -103,7 +103,11 @@ test("settlement demotes worker output to Evidence and closes the attempt withou
   const workItemId = DelegationStore.get("dg-wiring-1")?.workItemId ?? "";
   const closed = attemptClosed(workItemId);
 
-  settle({ status: "completed", output: "widget assembled; report at /tmp/report.md" });
+  settle({
+    status: "completed",
+    output: "widget assembled; report at /tmp/report.md",
+    usage: { tokens: 4321 },
+  });
   const settlement = await kernel.awaitDelegation("dg-wiring-1", 5_000);
   expect(settlement.kind).toBe("settled");
   await closed;
@@ -119,6 +123,10 @@ test("settlement demotes worker output to Evidence and closes the attempt withou
   // The kernel never auto-completes: completion is admission-only.
   expect(WorkItem.deriveStatus(item as WorkItem.Info)).not.toBe("completed");
   expect(item?.completionTerminalReceipt).toBeUndefined();
+  // Usage is visibility only: recorded on the attempt terminal, never an
+  // admission input.
+  expect(item?.attemptTerminal?.usage?.tokens).toBe(4321);
+  expect(item?.attemptTerminal?.usage?.seconds).toBeGreaterThanOrEqual(0);
 });
 
 test("a failed settlement fails the WorkItem with failing evidence", async () => {

--- a/apps/openomni/test/worker-drive.test.ts
+++ b/apps/openomni/test/worker-drive.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import type { RunInput, Sink } from "@openomni/llm";
 import type { Message } from "@openomni/protocol";
 import type { DelegationKernel } from "../src/delegation/kernel";
-import { createChildKernel } from "../src/delegation/process-entry";
+import { createChildKernel, PROCESS_WORKER_ACK, serveProcessWorker } from "../src/delegation/process-entry";
 import { createInlineWorkerRunner } from "../src/delegation/worker-loop";
 
 const ORIGIN = { role: "worker", depth: 1, sessionId: "session-drive" } as const;
@@ -109,4 +109,42 @@ test("an assigned worker that finishes naturally is not nannied", async () => {
   stop();
   expect(runs).toBe(1);
   expect(output.text).toBe("done; the package is live");
+});
+
+test("the process wire drives an assign end to end: request line in, driven usage out", async () => {
+  const { runner, stop } = bootRunner(async (input, sink) => {
+    sink.onMessage(reply(input, "BLOCKED: the registry is unreachable"));
+    return { type: "stop" };
+  });
+  const written: string[] = [];
+  // The run callback mirrors processWorkerRun: the parsed wire request feeds
+  // the same runner the child process builds, operation included.
+  await serveProcessWorker(
+    JSON.stringify({
+      delegationId: "d-wire-assign",
+      operation: "assign",
+      instruction: "publish the package",
+      acceptanceCriteria: ["the package is live"],
+      origin: ORIGIN,
+      model: { provider: "fake", id: "drive-test" },
+      apiKey: "test-key",
+    }),
+    (line) => written.push(line),
+    (request) =>
+      runner({
+        delegationId: request.delegationId,
+        operation: request.operation,
+        instruction: request.instruction,
+        acceptanceCriteria: request.acceptanceCriteria,
+        origin: request.origin,
+        signal: new AbortController().signal,
+      }),
+  );
+  stop();
+  expect(written[0]).toBe(PROCESS_WORKER_ACK);
+  expect(JSON.parse(written[1] ?? "")).toEqual({
+    status: "completed",
+    output: "[drive stopped: blocked]\nBLOCKED: the registry is unreachable",
+    usage: { tokens: 27 },
+  });
 });

--- a/apps/openomni/test/worker-drive.test.ts
+++ b/apps/openomni/test/worker-drive.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import type { RunInput, Sink } from "@openomni/llm";
 import type { Message } from "@openomni/protocol";
 import type { DelegationKernel } from "../src/delegation/kernel";
-import { createChildKernel, PROCESS_WORKER_ACK, serveProcessWorker } from "../src/delegation/process-entry";
+import { createChildKernel } from "../src/delegation/process-entry";
 import { createInlineWorkerRunner } from "../src/delegation/worker-loop";
 
 const ORIGIN = { role: "worker", depth: 1, sessionId: "session-drive" } as const;
@@ -111,40 +111,3 @@ test("an assigned worker that finishes naturally is not nannied", async () => {
   expect(output.text).toBe("done; the package is live");
 });
 
-test("the process wire drives an assign end to end: request line in, driven usage out", async () => {
-  const { runner, stop } = bootRunner(async (input, sink) => {
-    sink.onMessage(reply(input, "BLOCKED: the registry is unreachable"));
-    return { type: "stop" };
-  });
-  const written: string[] = [];
-  // The run callback mirrors processWorkerRun: the parsed wire request feeds
-  // the same runner the child process builds, operation included.
-  await serveProcessWorker(
-    JSON.stringify({
-      delegationId: "d-wire-assign",
-      operation: "assign",
-      instruction: "publish the package",
-      acceptanceCriteria: ["the package is live"],
-      origin: ORIGIN,
-      model: { provider: "fake", id: "drive-test" },
-      apiKey: "test-key",
-    }),
-    (line) => written.push(line),
-    (request) =>
-      runner({
-        delegationId: request.delegationId,
-        operation: request.operation,
-        instruction: request.instruction,
-        acceptanceCriteria: request.acceptanceCriteria,
-        origin: request.origin,
-        signal: new AbortController().signal,
-      }),
-  );
-  stop();
-  expect(written[0]).toBe(PROCESS_WORKER_ACK);
-  expect(JSON.parse(written[1] ?? "")).toEqual({
-    status: "completed",
-    output: "[drive stopped: blocked]\nBLOCKED: the registry is unreachable",
-    usage: { tokens: 27 },
-  });
-});

--- a/apps/openomni/test/worker-drive.test.ts
+++ b/apps/openomni/test/worker-drive.test.ts
@@ -110,4 +110,3 @@ test("an assigned worker that finishes naturally is not nannied", async () => {
   expect(runs).toBe(1);
   expect(output.text).toBe("done; the package is live");
 });
-

--- a/apps/openomni/test/worker-drive.test.ts
+++ b/apps/openomni/test/worker-drive.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test";
+import type { RunInput, Sink } from "@openomni/llm";
+import type { Message } from "@openomni/protocol";
+import type { DelegationKernel } from "../src/delegation/kernel";
+import { createChildKernel } from "../src/delegation/process-entry";
+import { createInlineWorkerRunner } from "../src/delegation/worker-loop";
+
+const ORIGIN = { role: "worker", depth: 1, sessionId: "session-drive" } as const;
+
+function reply(input: RunInput, text: string): Message.WithParts {
+  const id = `fake-${input.messages.length}`;
+  const sessionID = input.trace.sessionId;
+  const tokens = { input: 4, output: 5, reasoning: 0, cache: { read: 0, write: 0 } };
+  return {
+    info: {
+      id,
+      sessionID,
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: "",
+      modelID: input.model.id,
+      providerID: input.model.providerID,
+      agent: "worker",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens,
+    },
+    parts: [
+      { id: `${id}-text`, sessionID, messageID: id, type: "text", text } as never,
+      { id: `${id}-finish`, sessionID, messageID: id, type: "step-finish", reason: "stop", cost: 0, tokens },
+    ],
+  };
+}
+
+function bootRunner(run: (input: RunInput, sink: Sink) => Promise<{ type: "stop" }>) {
+  let kernel: DelegationKernel;
+  const runner = createInlineWorkerRunner({
+    model: { provider: "fake", id: "drive-test" },
+    apiKey: "test-key",
+    llm: {
+      resolveProviderModel: async (model) => ({ id: model.id, name: model.id, providerID: model.provider }),
+      run,
+    },
+    kernel: () => kernel,
+  });
+  kernel = createChildKernel(runner);
+  return { runner, stop: () => kernel.stop() };
+}
+
+test("an assigned worker claiming BLOCKED is re-driven and believed only on the third recurrence", async () => {
+  const prompts: string[][] = [];
+  const { runner, stop } = bootRunner(async (input, sink) => {
+    prompts.push(input.messages.map((m) => JSON.stringify(m)));
+    sink.onMessage(reply(input, "BLOCKED: the registry is unreachable"));
+    return { type: "stop" };
+  });
+  const output = await runner({
+    delegationId: "d-drive-1",
+    operation: "assign",
+    instruction: "publish the package",
+    acceptanceCriteria: ["the package is live"],
+    origin: ORIGIN,
+    signal: new AbortController().signal,
+  });
+  stop();
+  expect(prompts.length).toBe(3);
+  expect(prompts[1]?.some((m) => m.includes("Re-verify the blocker"))).toBe(true);
+  expect(output.text).toBe("[drive stopped: blocked]\nBLOCKED: the registry is unreachable");
+  // Spend accumulates across driven runs: 9 tokens per stubbed run.
+  expect(output.tokens).toBe(27);
+});
+
+test("an ask run is answered once, never driven — even when the answer says BLOCKED", async () => {
+  let runs = 0;
+  const { runner, stop } = bootRunner(async (input, sink) => {
+    runs += 1;
+    sink.onMessage(reply(input, "BLOCKED: cannot answer"));
+    return { type: "stop" };
+  });
+  const output = await runner({
+    delegationId: "d-drive-2",
+    operation: "ask",
+    instruction: "is the registry up?",
+    acceptanceCriteria: [],
+    origin: ORIGIN,
+    signal: new AbortController().signal,
+  });
+  stop();
+  expect(runs).toBe(1);
+  expect(output.text).toBe("BLOCKED: cannot answer");
+  expect(output.tokens).toBe(9);
+});
+
+test("an assigned worker that finishes naturally is not nannied", async () => {
+  let runs = 0;
+  const { runner, stop } = bootRunner(async (input, sink) => {
+    runs += 1;
+    sink.onMessage(reply(input, "done; the package is live"));
+    return { type: "stop" };
+  });
+  const output = await runner({
+    delegationId: "d-drive-3",
+    operation: "assign",
+    instruction: "publish the package",
+    acceptanceCriteria: ["the package is live"],
+    origin: ORIGIN,
+    signal: new AbortController().signal,
+  });
+  stop();
+  expect(runs).toBe(1);
+  expect(output.text).toBe("done; the package is live");
+});

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -20,6 +20,7 @@ Single source of truth for current wiring between accepted design and running co
 | Curated memory | implemented and wired | `apps/openomni/src/memory/`, `apps/openomni/src/tools/memory.ts` | Bounded system/Owner stores, atomic writes, Resident-only add/replace/remove, snapshot frozen on first session delivery. |
 | Agent loop | implemented and wired | `packages/agent/src/core/` | Stateless loop, policy interception, placement gate, retry, budgets, parallel tools, and compaction. Product lifecycle remains outside the package. |
 | Policy engine | implemented and wired where consumed | `packages/policy/`, `packages/agent/src/core/policy/` | Generic evaluation and agent-loop points survive. Removed product-specific registration sites are not counted as wired. |
+| Drive-loop worker policy | implemented and wired | `apps/openomni/src/delegation/drive-loop.ts`, `apps/openomni/src/delegation/worker-loop.ts` | Assigned native worker runs (inline/process transports) are driven goal-style: continuation cap 8, repetition streak 3, toolless-stall streak 3, live work counts as progress, and a blocked claim is believed only on its third recurrence. Ask/notify runs once; the channel driver is never driven. Attempt terminals record transport-reported usage (tokens, seconds) as visibility only. |
 | IPC transport | implemented and wired | `packages/ipc/`, `packages/machines/`, `apps/openomni/src/delegation/process-driver.ts` | Thin bidirectional transport used by machines and process delegation. |
 
 ## Durable contracts retained in core packages
@@ -57,5 +58,4 @@ The legacy product kernel, local-process coordinator, and old server host were d
 - Connector installation/execution beyond retained protocol and storage primitives (#216 class).
 - Memory.Engine / FTS5 session search (#220).
 - P4 role surfaces (Governor, Jester, Voice).
-- Drive-loop continuation policy on inline/process delegation drivers and Attempt usage accounting (next WorkItem slice).
 - Stakes and effective-authority consumers; any such work must inherit their contracts rather than recreating legacy code.

--- a/packages/ledger/src/work-item/attempt-run.ts
+++ b/packages/ledger/src/work-item/attempt-run.ts
@@ -51,6 +51,7 @@ interface AttemptRunView {
 type AttemptRunTerminalExtra = Readonly<{
   endedAt?: number;
   error?: string;
+  usage?: WorkItem.AttemptUsage;
 }>;
 
 /** Acquire/finish contention resolves as "not acquired", never as a crash. */
@@ -309,6 +310,7 @@ export namespace WorkItemAttemptRun {
         outcome,
         endedAt: extra.endedAt ?? now,
         ...(extra.error === undefined ? {} : { error: extra.error }),
+        ...(extra.usage === undefined ? {} : { usage: extra.usage }),
       });
       const failed = outcome === "failed" || outcome === "interrupted";
       const cancelled = outcome === "cancelled";

--- a/packages/protocol/src/delegation/schema.ts
+++ b/packages/protocol/src/delegation/schema.ts
@@ -166,6 +166,8 @@ const SettledUnion = z.discriminatedUnion("status", [
       delegationId: z.string().min(1),
       output: z.string(),
       at: z.number(),
+      /** Transport-reported spend; visibility only, never an admission input. */
+      usage: z.object({ tokens: z.number().int().nonnegative() }).strict().optional(),
     })
     .strict(),
   z

--- a/packages/protocol/src/work-item/attempt.ts
+++ b/packages/protocol/src/work-item/attempt.ts
@@ -303,12 +303,22 @@ export type AttemptOutcome = z.infer<typeof AttemptOutcome>;
  * execution instance). The legacy `lastMessageId` extra was NOT carried
  * over: it never had a production writer, so it earns no vocabulary here.
  */
+/** Transport-reported spend. Visibility only — never an admission input. */
+export const AttemptUsage = z
+  .object({
+    tokens: z.number().int().nonnegative().optional(),
+    seconds: z.number().nonnegative(),
+  })
+  .strict();
+export type AttemptUsage = z.infer<typeof AttemptUsage>;
+
 export const AttemptTerminal = z
   .object({
     attemptId: AttemptId,
     outcome: AttemptOutcome,
     endedAt: z.number(),
     error: z.string().optional(),
+    usage: AttemptUsage.optional(),
   })
   .strict();
 export type AttemptTerminal = z.infer<typeof AttemptTerminal>;

--- a/packages/protocol/src/work-item/index.ts
+++ b/packages/protocol/src/work-item/index.ts
@@ -118,6 +118,8 @@ export namespace WorkItem {
 
   export const AttemptTerminal = AttemptContract.AttemptTerminal;
   export type AttemptTerminal = AttemptContract.AttemptTerminal;
+  export const AttemptUsage = AttemptContract.AttemptUsage;
+  export type AttemptUsage = AttemptContract.AttemptUsage;
 
   export const ContentFingerprintInputs = AttemptContract.ContentFingerprintInputs;
   export type ContentFingerprintInputs = AttemptContract.ContentFingerprintInputs;


### PR DESCRIPTION
## What

PR-C of the WorkItem wiring campaign (follows #812, #813, #815).

1. **Drive-loop policy** (`apps/openomni/src/delegation/drive-loop.ts`, pure): assigned native worker runs are driven goal-style — continuation cap **8**, repetition-hash streak **3**, toolless-stall streak **3**, live work (`max-steps`) counts as progress and resets streaks, and a `BLOCKED` claim is believed only on its **third consecutive recurrence** (with a re-verify prompt in between). A recurring blocker outranks the repetition gate so the stop reason stays truthful.
2. **Attach points are the transports, never the schema**: the policy engages in `worker-loop.ts` only for `operation === "assign"` (ask/notify answer once), reached through the inline and process drivers. The channel driver has zero drive-loop involvement — `grep -rn drive-loop apps/openomni/src packages | grep -v test` matches `worker-loop.ts` only. `WorkItem` schemas carry no policy fields.
3. **Attempt usage (visibility only)**: `WorkItem.AttemptUsage {tokens?, seconds}` on the attempt terminal. Inline/process transports report summed `usage.totalTokens` across driven runs; the settle fold threads it into `closeAttempt`, which records `seconds = (settlement.at - record.createdAt)/1000`. Never an admission input — completion admission is untouched.

## Evidence

- RED→GREEN: `drive-loop.test.ts` failed on the absent module ("Export named 'DRIVE_BLOCKED_RECURRENCE' not found"), and the wiring assertion `attemptTerminal.usage.tokens === 4321` failed type-check before the schema/threading landed; both green now.
- New tests: 7 pure policy tests (cap/repetition/stall/blocked-recurrence/progress-reset/natural-stop), 3 worker-loop wiring tests through a real child kernel + llm stub (assign BLOCKED×3 stops with re-verify prompt and 27 summed tokens; ask never driven; natural finish not nannied), work-item wiring asserts `usage {tokens: 4321, seconds >= 0}` on the closed attempt.
- Full local gate chain green: build, turbo check-types, check-deps, check-import-cycles, lint:tools, ultracite `.`, check-dead-exports, `bun test --timeout 15000` (2496 pass / 0 fail).
- `docs/implementation-status.md` moved in this PR (backlog line → wired row).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drives assigned native worker runs goal-style so incomplete work gets re-prompted instead of settling after one attempt, and records transport-reported usage on closed attempt terminals.

- Runs are re-driven up to 8 times, stopping only on a natural stop, 3 identical texts, 3 toolless stalls, or a third consecutive BLOCKED claim (with a re-verify prompt in between); `max-steps` counts as live progress and resets streaks, and each driven run keeps its own run identity.
- The drive policy engages only for `operation === "assign"` through the inline and process drivers; ask/notify runs once, and the channel driver is never driven.
- Closed attempts now record `usage {seconds, tokens?}` as visibility only — it never affects admission; tokens ride the durable settlement so a crashed close recovers the same spend.

<sup>Written for commit 65e8e8143032b8afd2e8ce816f650fc3555afb28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

