### PR TITLE
refactor(ledger): extract shared frozen-store write-refusal helper

### DIFF
--- a/packages/ledger/src/pending-ask/index.ts
+++ b/packages/ledger/src/pending-ask/index.ts
@@ -1,4 +1,5 @@
 import { Communication } from "@openomni/protocol";
+import { frozenWriteRefusal } from "../storage/frozen";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter } from "../storage/timestamped-store";
 
@@ -25,13 +26,14 @@ function requireAdapter() {
 // (#498 C4 export diet) — derive it from there instead of a second export.
 type FrozenWriteMethod = Communication.PendingAsk.FrozenError["data"]["method"];
 
-function frozenWrite(method: FrozenWriteMethod): never {
-  throw new Communication.PendingAsk.FrozenError({
-    message: `PendingAskStore is frozen (#510 D2a): ${method} is retired — historical pending_ask rows are read-only archive`,
-    code: "pending_ask_frozen",
-    method,
-  });
-}
+// Explicit annotation required: TS only treats the call as never-returning
+// (TS2534) when the variable carries an explicit `=> never` type.
+const frozenWrite: (method: FrozenWriteMethod) => never = frozenWriteRefusal(
+  Communication.PendingAsk.FrozenError,
+  "pending_ask_frozen",
+  (method: FrozenWriteMethod) =>
+    `PendingAskStore is frozen (#510 D2a): ${method} is retired — historical pending_ask rows are read-only archive`,
+);
 
 export namespace PendingAskStore {
   // Frozen writer: the Create input vocabulary is retired with the write

--- a/packages/ledger/src/pending-interaction/index.ts
+++ b/packages/ledger/src/pending-interaction/index.ts
@@ -1,4 +1,5 @@
 import { Communication } from "@openomni/protocol";
+import { frozenWriteRefusal } from "../storage/frozen";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter } from "../storage/timestamped-store";
 
@@ -28,13 +29,14 @@ function requireAdapter() {
 // (#498 C4 export diet) — derive it from there instead of a second export.
 type FrozenWriteMethod = Communication.PendingInteraction.FrozenError["data"]["method"];
 
-function frozenWrite(method: FrozenWriteMethod): never {
-  throw new Communication.PendingInteraction.FrozenError({
-    message: `PendingInteractionStore is frozen (#548): ${method} is retired — historical pending_interaction rows are read-only archive`,
-    code: "pending_interaction_frozen",
-    method,
-  });
-}
+// Explicit annotation required: TS only treats the call as never-returning
+// (TS2534) when the variable carries an explicit `=> never` type.
+const frozenWrite: (method: FrozenWriteMethod) => never = frozenWriteRefusal(
+  Communication.PendingInteraction.FrozenError,
+  "pending_interaction_frozen",
+  (method: FrozenWriteMethod) =>
+    `PendingInteractionStore is frozen (#548): ${method} is retired — historical pending_interaction rows are read-only archive`,
+);
 
 function stillAcceptsFollowUp(
   record: Communication.PendingInteraction.Record,

--- a/packages/ledger/src/storage/frozen.ts
+++ b/packages/ledger/src/storage/frozen.ts
@@ -1,0 +1,24 @@
+import type { NamedError } from "@openomni/protocol";
+
+/**
+ * S2 duplicate-logic audit — shared frozen-store write refusal. The frozen
+ * ledger stores (#510 D2a PendingAsk, #548 PendingInteraction, #510 D2b
+ * WorkerRunState) each refuse every retired write method by throwing their
+ * own typed `NamedError` whose data carries the pinned `code`, the refused
+ * `method`, and a store-specific message. This helper builds that
+ * `frozenWrite(method): never` thrower once; each store supplies its error
+ * constructor, pinned code, and message template, so error-class ownership,
+ * data codes, and message text stay byte-for-byte identical to the
+ * hand-rolled originals. The refused-method vocabulary is inferred from the
+ * error constructor's `data.method`, keeping the FrozenError data the single
+ * owner of that vocabulary (#498 C4).
+ */
+export function frozenWriteRefusal<Method extends string, Code extends string>(
+  ErrorCtor: new (data: { message: string; code: Code; method: Method }) => NamedError,
+  code: Code,
+  message: (method: Method) => string,
+): (method: Method) => never {
+  return (method) => {
+    throw new ErrorCtor({ message: message(method), code, method });
+  };
+}

--- a/packages/ledger/src/worker-run/state-store.ts
+++ b/packages/ledger/src/worker-run/state-store.ts
@@ -1,5 +1,6 @@
 import { NamedError, type WorkItem } from "@openomni/protocol";
 import { z } from "zod";
+import { frozenWriteRefusal } from "../storage/frozen";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter } from "../storage/timestamped-store";
 
@@ -22,14 +23,6 @@ function requireAdapter(): WorkerRunStateStore.Adapter {
     Storage.get().workerRunState,
     "Storage adapter does not implement workerRunState",
   );
-}
-
-function frozenWrite(method: WorkerRunStateStore.WriteMethod): never {
-  throw new WorkerRunStateStore.FrozenError({
-    message: `WorkerRunStateStore is frozen (#510 D2b): ${method} is retired — historical worker_run_state rows are read-only archive`,
-    code: "worker_run_frozen",
-    method,
-  });
 }
 
 export namespace WorkerRunStateStore {
@@ -136,3 +129,15 @@ export namespace WorkerRunStateStore {
     return requireAdapter().get(sessionId, runId);
   }
 }
+
+// Declared after the namespace because the FrozenError class it closes over
+// is defined inside it; the namespace's write methods only call it at
+// invocation time, so module-evaluation order is safe. Explicit annotation
+// required: TS only treats the call as never-returning (TS2534) when the
+// variable carries an explicit `=> never` type.
+const frozenWrite: (method: WorkerRunStateStore.WriteMethod) => never = frozenWriteRefusal(
+  WorkerRunStateStore.FrozenError,
+  "worker_run_frozen",
+  (method: WorkerRunStateStore.WriteMethod) =>
+    `WorkerRunStateStore is frozen (#510 D2b): ${method} is retired — historical worker_run_state rows are read-only archive`,
+);

--- a/packages/ledger/test/storage/frozen.test.ts
+++ b/packages/ledger/test/storage/frozen.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { NamedError } from "@openomni/protocol";
+import { z } from "zod";
+import { frozenWriteRefusal } from "../../src/storage/frozen";
+
+/**
+ * S2 duplicate-logic audit — unit coverage for the shared frozen-store
+ * write-refusal helper consumed by PendingAskStore (#510 D2a),
+ * PendingInteractionStore (#548), and WorkerRunStateStore (#510 D2b). The
+ * per-store pins (typed class, data.code, data.method, message text) stay
+ * with the stores' own tests; this suite pins the helper's contract:
+ * constructor passthrough, code passthrough, and method interpolation.
+ */
+
+const TestFrozenError = NamedError.create(
+  "TestFrozenError",
+  z.object({
+    message: z.string(),
+    code: z.literal("test_frozen"),
+    method: z.enum(["create", "update"]),
+  }),
+);
+type TestFrozenError = InstanceType<typeof TestFrozenError>;
+
+const frozenWrite = frozenWriteRefusal(
+  TestFrozenError,
+  "test_frozen",
+  (method) => `TestStore is frozen: ${method} is retired`,
+);
+
+function catchThrown(fn: () => never): TestFrozenError {
+  try {
+    fn();
+  } catch (error) {
+    if (TestFrozenError.isInstance(error)) return error;
+    throw new Error(`expected the typed TestFrozenError, got: ${String(error)}`);
+  }
+  throw new Error("expected frozenWrite to throw");
+}
+
+describe("frozenWriteRefusal", () => {
+  test("throws the supplied error constructor with the pinned code and refused method", () => {
+    const thrown = catchThrown(() => frozenWrite("create"));
+    expect(thrown.name).toBe("TestFrozenError");
+    expect(thrown.data.code).toBe("test_frozen");
+    expect(thrown.data.method).toBe("create");
+  });
+
+  test("interpolates the refused method into the message template", () => {
+    const thrown = catchThrown(() => frozenWrite("update"));
+    expect(thrown.data.message).toBe("TestStore is frozen: update is retired");
+    expect(thrown.message).toBe("TestStore is frozen: update is retired");
+  });
+
+  test("each refusal builds a fresh error carrying that call's method", () => {
+    const first = catchThrown(() => frozenWrite("create"));
+    const second = catchThrown(() => frozenWrite("update"));
+    expect(first).not.toBe(second);
+    expect(first.data.method).toBe("create");
+    expect(second.data.method).toBe("update");
+  });
+});


### PR DESCRIPTION
## What / Why

Duplicate-logic audit, finding **S2**: three frozen ledger stores each hand-rolled an identical `frozenWrite(method): never` thrower that builds a typed `FrozenError` with a pinned `data.code`, the refused `method`, and a store-specific message:

- `packages/ledger/src/pending-ask/index.ts` (`frozenWrite`, #510 D2a — `Communication.PendingAsk.FrozenError`, code `pending_ask_frozen`)
- `packages/ledger/src/pending-interaction/index.ts` (`frozenWrite`, #548 — `Communication.PendingInteraction.FrozenError`, code `pending_interaction_frozen`)
- `packages/ledger/src/worker-run/state-store.ts` (`frozenWrite`, #510 D2b — ledger-internal `WorkerRunStateStore.FrozenError`, code `worker_run_frozen`)

This PR extracts the scaffolding into one shared helper, `frozenWriteRefusal(ErrorCtor, code, messageTemplate)` in `packages/ledger/src/storage/frozen.ts`, consumed by all three stores.

## Behavior preservation

- Error **class ownership is unchanged**: the two protocol-owned classes stay in `@openomni/protocol`; the worker-run class stays ledger-internal. Each store passes its own constructor to the helper.
- `data.code` values (`pending_ask_frozen`, `pending_interaction_frozen`, `worker_run_frozen`), `data.method` vocabularies, and **message strings are byte-for-byte identical** — each store supplies its own message template; only the throw plumbing is shared. Existing store tests (which pin class + code + method) stay green.
- The retired write-method vocabulary is still derived from the `FrozenError` data (#498 C4): the helper infers `Method` from the error constructor, and each store keeps its explicit `(method) => never` annotation (required — TS only treats the call as never-returning under TS2534 when the variable carries an explicit `=> never` type).

## Verification (gate chain, all in worktree)

- `bunx turbo run build` ✅ (5 → 14 tasks after change)
- `bunx turbo run check-types` ✅
- `bun run script/check-deps.ts` ✅ (1 pre-existing stale-doc note on `packages/telemetry/AGENTS.md`, unrelated)
- `bun run script/check-import-cycles.ts` ✅ 346 modules, 0 cycles
- `bun run lint:tools` ✅
- `bun run lint` ✅ (1 pre-existing warning in `apps/openomni/test/work-item-wiring.test.ts` unused import, untouched by this PR)
- `bunx ultracite check --formatter-enabled=false .` ✅ (same single pre-existing warning)
- `bun run script/check-dead-exports.ts` ✅ 0 known, none new
- `bun test --timeout 15000` ✅ **2509 pass / 0 fail** across 292 files
- Focused: new `packages/ledger/test/storage/frozen.test.ts` (3 tests pinning helper contract: constructor passthrough, code/method data, message interpolation, fresh error per call) + the three stores' existing pin suites → 14 pass / 0 fail

## Files changed

| File | Delta |
|---|---|
| `packages/ledger/src/storage/frozen.ts` | +24 (new shared helper) |
| `packages/ledger/src/pending-ask/index.ts` | hand-rolled thrower → helper |
| `packages/ledger/src/pending-interaction/index.ts` | hand-rolled thrower → helper |
| `packages/ledger/src/worker-run/state-store.ts` | hand-rolled thrower → helper (const placed after the namespace it closes over) |
| `packages/ledger/test/storage/frozen.test.ts` | +62 (new focused unit tests) |

Net: +117 / −22.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the identical frozen-write refusal logic from the three frozen ledger stores into a shared helper, removing duplication without changing any error behavior.

**Notes**
- Each store still owns its error class, pinned data code, and message template; the helper takes them as arguments.
- The refused-method type is inferred from the error constructor's `data.method`, keeping that vocabulary single-sourced.
- The helper returns a `(method) => never` function, and each store keeps an explicit `=> never` annotation for TypeScript's never-returning check.

<sup>Written for commit 479af345f6fc5bc0fb76392751bb18c9439df244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

