### PR TITLE
refactor(channels): unify effective trust tier resolution

### DIFF
--- a/packages/channels/src/router/authority.ts
+++ b/packages/channels/src/router/authority.ts
@@ -10,6 +10,7 @@ import {
 import { decisionFromEvaluation, evaluatePermission } from "@openomni/policy";
 import type { ChannelGrantStore } from "@openomni/ledger";
 import { actorTrustTier, getActor, isAuthorizedTopLevelActor } from "./authority-actor";
+import { effectiveTrustTier } from "./effective-tier.js";
 
 interface PreRunContext {
   readonly event: unknown;
@@ -111,9 +112,11 @@ function applyChannelGrantTreatment(
   // channel adapter. Pinned by kernel-routing-access "materializes a
   // default-tier stranger". Tier-range validation at grant-write time is a
   // #498 Grant-convergence candidate, not a treatment-time concern.
+  const actorTier = actorTrustTier(actor);
+  const effectiveTier = effectiveTrustTier(actorTier, grant.defaultTier);
   const actorWithChannelDefault =
-    !actorTrustTier(actor) && grant.defaultTier
-      ? { ...(actor ?? { role: "user" }), trustTier: grant.defaultTier }
+    !actorTier && grant.defaultTier
+      ? { ...(actor ?? { role: "user" }), trustTier: effectiveTier }
       : actor;
 
   return {

--- a/packages/channels/src/router/effective-tier.ts
+++ b/packages/channels/src/router/effective-tier.ts
@@ -1,0 +1,9 @@
+import type { Actor } from "@openomni/protocol";
+
+/** Resolves the channel-grant tier used when the actor has no trust tier. */
+export function effectiveTrustTier(
+  actorTier: Actor.TrustTier | undefined,
+  defaultTier: Actor.TrustTier | undefined,
+): Actor.TrustTier | undefined {
+  return actorTier ?? defaultTier;
+}

--- a/packages/channels/src/router/resolve-route.ts
+++ b/packages/channels/src/router/resolve-route.ts
@@ -1,4 +1,5 @@
 import type { Actor, Ingress, Wait } from "@openomni/protocol";
+import { effectiveTrustTier } from "./effective-tier.js";
 
 /**
  * External routing arms of THE resolveRoute fold (#707 stage 2). The
@@ -286,7 +287,7 @@ export function resolveRoute(
     `channel.treatment:${state.channel.inboundTreatment}`,
   ];
   const actorId = state.actor?.id;
-  const trustTier = state.actor?.trustTier ?? state.channel.defaultTier;
+  const trustTier = effectiveTrustTier(state.actor?.trustTier, state.channel.defaultTier);
 
   if (trustTier === undefined) {
     return {

--- a/packages/channels/test/router/effective-tier.test.ts
+++ b/packages/channels/test/router/effective-tier.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { effectiveTrustTier } from "../../src/router/effective-tier.js";
+
+describe("effectiveTrustTier", () => {
+  test("keeps the actor trust tier over the channel default", () => {
+    expect(effectiveTrustTier("manager", "observer")).toBe("manager");
+  });
+
+  test("uses the channel default when the actor has no trust tier", () => {
+    expect(effectiveTrustTier(undefined, "observer")).toBe("observer");
+  });
+
+  test("refuses to resolve a tier when both are absent", () => {
+    expect(effectiveTrustTier(undefined, undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What / why

Centralizes actor trust-tier fallback to the channel-grant default in `effectiveTrustTier`, preserving route decision facts, missing-tier refusal, and authority principal materialization.

## Duplication evidence

- `packages/channels/src/router/resolve-route.ts:290` resolves the tier for route facts and the actor-identity refusal.
- `packages/channels/src/router/authority.ts:116` resolves the same actor-tier/channel-default fold before materializing the pre-run principal.

## Verification

All required gates passed:

- `bunx turbo run build && bunx turbo run check-types`
- `bun run script/check-deps.ts`
- `bun run script/check-import-cycles.ts`
- `bun run lint:tools`
- `bun run lint`
- `bunx ultracite check --formatter-enabled=false .`
- `bun run script/check-dead-exports.ts`
- `bun test --timeout 15000` (2509 pass, 0 fail)

Focused router tests also passed (25 pass, 0 fail).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies actor trust tier fallback into a single `effectiveTrustTier` helper, removing duplicated `actor tier ?? channel default` resolution in routing and authority materialization without changing behavior.

- Extracts the fallback logic shared by `resolve-route.ts` and `authority.ts`.
- Adds unit tests covering tier preference, channel-default fallback, and undefined resolution.

<sup>Written for commit 4ac60c9de0d2e87009e5f8d763bf7c1efe36c02f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

