### PR TITLE
refactor(ledger): unify storage unavailable error

### DIFF
--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -1,6 +1,7 @@
 export { BusPersistence } from "./bus-persistence/index.js";
 export { BusQuery } from "./bus-persistence/query";
 export { Storage, SqliteStorageAdapter, initialize } from "./storage";
+export { StorageUnavailableError } from "./storage/sqlite-busy.js";
 export { LedgerAppend } from "./storage/append-port";
 export { Session } from "./session";
 export { TranscriptStore } from "./session/transcript";

--- a/packages/ledger/src/storage/sqlite-busy.ts
+++ b/packages/ledger/src/storage/sqlite-busy.ts
@@ -19,3 +19,21 @@ export function isSqliteBusyError(error: unknown): boolean {
   const code = (error as { code?: unknown }).code;
   return typeof code === "string" && code.startsWith("SQLITE_BUSY");
 }
+
+/** A retriable store transaction failure caused by SQLite write contention. */
+export class StorageUnavailableError extends Error {
+  readonly name = "StorageUnavailableError";
+  readonly code = "unavailable";
+
+  constructor(
+    readonly store: string,
+    readonly resourceId: string,
+    cause: unknown,
+  ) {
+    super(
+      `${store} storage busy: ${resourceId} — ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+}

--- a/packages/ledger/src/work-item/attempt-run.ts
+++ b/packages/ledger/src/work-item/attempt-run.ts
@@ -171,7 +171,7 @@ async function mutateRun(
     // Contention (a concurrent transition won the head) and losing the
     // acquire race both mean "not acquired/finished" — the caller retries
     // from a fresh read or reports the run as no longer active. A BUSY
-    // storage layer is NEITHER: swallowing WorkItemUnavailableError here
+    // storage layer is NEITHER: swallowing StorageUnavailableError here
     // silently lost terminal attempt facts (runs stuck "running" forever),
     // so it rethrows to the caller like every other storage failure.
     if (error instanceof AttemptRunNotActiveError || error instanceof WorkItemRevisionError) {

--- a/packages/ledger/src/work-item/facts.ts
+++ b/packages/ledger/src/work-item/facts.ts
@@ -1,5 +1,5 @@
 import { Ledger, type Storage as ProtocolStorage, type WorkItem } from "@openomni/protocol";
-import { isSqliteBusyError } from "../storage/sqlite-busy.js";
+import { isSqliteBusyError, StorageUnavailableError } from "../storage/sqlite-busy.js";
 
 /**
  * #510 C1 — every WorkItem lifecycle write is a decision-class fact on the
@@ -41,20 +41,6 @@ export class WorkItemDuplicateError extends Error {
   }
 }
 
-export class WorkItemUnavailableError extends Error {
-  readonly name = "WorkItemUnavailableError";
-  readonly code = "unavailable";
-
-  constructor(
-    readonly hash: string,
-    cause: unknown,
-  ) {
-    super(
-      `WorkItem storage busy: ${hash} — ${cause instanceof Error ? cause.message : String(cause)}`,
-    );
-  }
-}
-
 /**
  * Store transaction entry (#510 review fix minor): a SQLITE_BUSY at the
  * write unit (see storage/sqlite-busy.ts for how bun:sqlite surfaces it)
@@ -70,7 +56,9 @@ export function runWorkItemTransaction<T>(
   try {
     return storage.transaction(write);
   } catch (error) {
-    if (isSqliteBusyError(error)) throw new WorkItemUnavailableError(hash, error);
+    if (isSqliteBusyError(error)) {
+      throw new StorageUnavailableError("work-item", hash, error);
+    }
     throw error;
   }
 }

--- a/packages/ledger/test/storage/sqlite-busy.test.ts
+++ b/packages/ledger/test/storage/sqlite-busy.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { isSqliteBusyError } from "../../src/storage/sqlite-busy";
-import { runWorkItemTransaction, WorkItemUnavailableError } from "../../src/work-item/facts";
+import { isSqliteBusyError, StorageUnavailableError } from "../../src/storage/sqlite-busy";
+import { runWorkItemTransaction } from "../../src/work-item/facts";
 
 describe("isSqliteBusyError", () => {
   test("matches a real bun:sqlite SQLITE_BUSY (pins how the driver surfaces it)", () => {
@@ -61,7 +61,7 @@ describe("isSqliteBusyError", () => {
 });
 
 describe("runWorkItemTransaction", () => {
-  test("maps SQLITE_BUSY to the typed WorkItemUnavailableError; other errors pass through", () => {
+  test("maps SQLITE_BUSY to the shared typed storage error; other errors pass through", () => {
     const busyStorage = {
       transaction<T>(_operation: () => T): T {
         throw Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY", errno: 5 });
@@ -74,9 +74,10 @@ describe("runWorkItemTransaction", () => {
     } catch (error) {
       thrown = error;
     }
-    expect(thrown).toBeInstanceOf(WorkItemUnavailableError);
-    expect((thrown as WorkItemUnavailableError).code).toBe("unavailable");
-    expect((thrown as WorkItemUnavailableError).hash).toBe("wi-busy");
+    expect(thrown).toBeInstanceOf(StorageUnavailableError);
+    expect((thrown as StorageUnavailableError).code).toBe("unavailable");
+    expect((thrown as StorageUnavailableError).store).toBe("work-item");
+    expect((thrown as StorageUnavailableError).resourceId).toBe("wi-busy");
 
     const failingStorage = {
       transaction<T>(_operation: () => T): T {

--- a/packages/ledger/test/work-item/attempt-run.test.ts
+++ b/packages/ledger/test/work-item/attempt-run.test.ts
@@ -117,7 +117,7 @@ describe("WorkItemAttemptRun", () => {
     if (!workItem) throw new Error("workItem adapter missing");
     const original = workItem.compareAndSet.bind(workItem);
     // SQLITE_BUSY shape as pinned by sqlite-busy.test.ts; facts.ts maps it to
-    // WorkItemUnavailableError. The old catch swallowed it into `false`, which
+    // StorageUnavailableError. The old catch swallowed it into `false`, which
     // callers discard — a busy DB silently lost the terminal attempt fact.
     Object.defineProperty(workItem, "compareAndSet", {
       configurable: true,


### PR DESCRIPTION
## What and why
- Adds `StorageUnavailableError` as the single exported ledger owner for retriable SQLite contention failures.
- `runWorkItemTransaction` now throws the shared error with `store: "work-item"` and the affected `resourceId`; the pinned test migrated from `WorkItemUnavailableError`.
- Evidence: `packages/ledger/src/work-item/facts.ts:59` previously constructed the work-item-specific error; its replacement is owned at `packages/ledger/src/storage/sqlite-busy.ts:24` and exported from `packages/ledger/src/index.ts:4`.
- The requested `EffectStoreError` call site was already removed by baseline commit `da2b167a` (the effect ledger was pruned); repository search found no production consumer discriminating either old class, so there is no legitimate split blocker.

## Verification
- `bunx turbo run build`
- `bunx turbo run check-types`
- `bun run script/check-deps.ts`
- `bun run script/check-import-cycles.ts`
- `bun run lint:tools`
- `bun run lint`
- `bunx ultracite check --formatter-enabled=false .`
- `bun run script/check-dead-exports.ts`
- `bun test --timeout 15000` (2506 passed)

No protocol schema changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies SQLite busy error handling by replacing the work-item-specific `WorkItemUnavailableError` with a shared `StorageUnavailableError` that carries `store` and `resourceId` fields.

- Moved the error class into `sqlite-busy.ts` and exported it from the package index.
- `runWorkItemTransaction` now throws `StorageUnavailableError` with `store: "work-item"` and the affected resource ID.
- Removes `WorkItemUnavailableError`; no production consumers exist.
- Tests updated to assert the new error shape.

<sup>Written for commit 5b7c86be9dd33bc9646b5ace5c80139e14cbfb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

