### PR TITLE
test(channels): migrate router suites onto shared router/store fixtures

### DIFF
--- a/packages/channels/test/router/_router-fixture.ts
+++ b/packages/channels/test/router/_router-fixture.ts
@@ -53,10 +53,19 @@ const sinkEvents: Array<{ readonly name: string; readonly data: unknown }> = [];
 
 let router: GatewayRouter | undefined;
 
-export function resetRouterState(): void {
+/**
+ * The store half of the fixture, without the router: fresh in-memory Storage
+ * and Bus. Router-less kernel suites (messaging send kernel, WaitService)
+ * duplicated this trio inline; this is the one home.
+ */
+export function resetStores(): void {
   Storage.reset();
   Bus.reset();
   Storage.initialize({ dbPath: ":memory:" });
+}
+
+export function resetRouterState(): void {
+  resetStores();
   deliveries.length = 0;
   sinkEvents.length = 0;
   router = makeRouter();

--- a/packages/channels/test/router/authority-validation.test.ts
+++ b/packages/channels/test/router/authority-validation.test.ts
@@ -1,13 +1,17 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { Gateway, Policy } from "@openomni/protocol";
-import { ChannelGrantStore, Storage } from "@openomni/ledger";
-import { Bus } from "@openomni/telemetry";
-import { createGatewayRouter } from "../../src/router/index.js";
+import { ChannelGrantStore } from "@openomni/ledger";
 import {
   applyChannelGrantTreatment,
   IngressAuthorityMiddleware,
 } from "../../src/router/authority.js";
-import { makeInboundEvent } from "./_router-fixture.js";
+import {
+  deliveries,
+  kernelRouter,
+  makeInboundEvent,
+  resetRouterState,
+  routingDecisions,
+} from "./_router-fixture.js";
 
 // Moved from openomni test/policy/ingress-authority-validation.test.ts at the
 // #707 seam flip: runRoutedPreRun now parses Gateway.DeliveredEvent (no
@@ -174,19 +178,7 @@ describe("IngressAuthorityMiddleware trust and validation", () => {
 });
 
 describe("GatewayRouter channel default tier composite (e2e)", () => {
-  const deliveries: Gateway.Deliver[] = [];
-
-  beforeEach(() => {
-    Storage.reset();
-    Bus.reset();
-    Storage.initialize({ dbPath: ":memory:" });
-    deliveries.length = 0;
-  });
-
-  afterEach(() => {
-    Storage.reset();
-    Bus.reset();
-  });
+  beforeEach(resetRouterState);
 
   test("trusted_channel defaultTier observer admits an unregistered actor at the channel ceiling, then the authority check denies", async () => {
     ChannelGrantStore.put({
@@ -197,22 +189,7 @@ describe("GatewayRouter channel default tier composite (e2e)", () => {
       defaultTier: "observer",
       createdBy: "act_owner",
     });
-    const decisions: unknown[] = [];
-    const router = createGatewayRouter({
-      sink: (event, data) => {
-        if (event.name === "ingress.routing.decision") decisions.push(data);
-        Bus.publish(event, data);
-      },
-      deliver: async (delivery) => {
-        deliveries.push(delivery);
-        return {
-          mode: "direct",
-          target: { kind: "resident" },
-          sessionId: delivery.sessionId ?? "unrouted-session",
-          result: { output: "resident response", finishReason: "stop" },
-        };
-      },
-    });
+    const router = kernelRouter();
     const event = {
       id: "evt-observer-default",
       traceId: "trace-test",
@@ -231,6 +208,7 @@ describe("GatewayRouter channel default tier composite (e2e)", () => {
       "actor is not authorized to create top-level inbound work",
     );
 
+    const decisions = routingDecisions();
     expect(decisions).toHaveLength(1);
     expect(decisions[0]).toMatchObject({
       stage: "surface_default",

--- a/packages/channels/test/router/conformance/no-bypass.test.ts
+++ b/packages/channels/test/router/conformance/no-bypass.test.ts
@@ -1,8 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import type { Gateway } from "@openomni/protocol";
-import { ChannelGrantStore, Storage } from "@openomni/ledger";
-import { Bus } from "@openomni/telemetry";
-import { createGatewayRouter } from "../../../src/router/index.js";
+import { ChannelGrantStore } from "@openomni/ledger";
+import { deliveries, kernelRouter, resetRouterState } from "../_router-fixture";
 
 // The no-bypass property at the flipped seam (#707): an unauthorized inbound
 // principal is blocked by the gateway router BEFORE the brain's Deliver port
@@ -38,9 +37,7 @@ async function catchError(promise: Promise<unknown>): Promise<unknown> {
 }
 
 beforeEach(() => {
-  Bus.reset();
-  Storage.reset();
-  Storage.initialize({ dbPath: ":memory:" });
+  resetRouterState();
   ChannelGrantStore.put({
     id: "grant-internal",
     surface: "internal",
@@ -49,30 +46,9 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
-  Bus.reset();
-  Storage.reset();
-});
-
 describe("policy no-bypass conformance — gateway governed paths", () => {
   it("blocks unauthorized ingress before delivering to the brain", async () => {
-    const deliveries: Gateway.Deliver[] = [];
-    const router = createGatewayRouter({
-      sink: (event, data) => {
-        Bus.publish(event, data);
-      },
-      deliver: async (delivery) => {
-        deliveries.push(delivery);
-        return {
-          mode: "direct",
-          target: { kind: "resident" },
-          sessionId: delivery.sessionId ?? "unrouted-session",
-          result: { output: "should not deliver", finishReason: "stop" },
-        };
-      },
-    });
-
-    const error = await catchError(router.ingest(unauthorizedInboundEvent()));
+    const error = await catchError(kernelRouter().ingest(unauthorizedInboundEvent()));
 
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain(

--- a/packages/channels/test/router/integration.test.ts
+++ b/packages/channels/test/router/integration.test.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { ChannelGrantStore, Storage } from "@openomni/ledger";
-import { Bus } from "@openomni/telemetry";
-import { createGatewayRouter, type GatewayRouter } from "../../src/router/index.js";
+import { ChannelGrantStore } from "@openomni/ledger";
+import type { GatewayRouter } from "../../src/router/index.js";
+import { kernelRouter, resetRouterState } from "./_router-fixture";
 
 let router: GatewayRouter;
 
 beforeEach(() => {
-  Storage.reset();
-  Bus.reset();
-  Storage.initialize({ dbPath: ":memory:" });
+  resetRouterState();
   for (const surface of ["slack", "tui"]) {
     ChannelGrantStore.put({
       id: `grant-${surface}`,
@@ -18,17 +16,7 @@ beforeEach(() => {
       createdBy: "act_owner",
     });
   }
-  router = createGatewayRouter({
-    sink: (event, data) => {
-      Bus.publish(event, data);
-    },
-    deliver: async (delivery) => ({
-      mode: "direct",
-      target: delivery.event.target ?? { kind: "resident" },
-      sessionId: delivery.sessionId ?? crypto.randomUUID(),
-      result: { output: "resident response", finishReason: "stop" },
-    }),
-  });
+  router = kernelRouter();
 });
 
 describe("GatewayRouter integration pipeline", () => {

--- a/packages/channels/test/router/messaging/composition.test.ts
+++ b/packages/channels/test/router/messaging/composition.test.ts
@@ -1,12 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { extractSurfaceKey, type Gateway, type Ingress } from "@openomni/protocol";
-import { ActorRegistry, ChannelGrantStore, Storage } from "@openomni/ledger";
-import { Bus } from "@openomni/telemetry";
-import {
-  type ChannelDeliveryRoute,
-  createGatewayRouter,
-  type GatewayRouter,
-} from "../../../src/router/index.js";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { extractSurfaceKey, type Gateway } from "@openomni/protocol";
+import { ActorRegistry, ChannelGrantStore } from "@openomni/ledger";
+import type { ChannelDeliveryRoute, GatewayRouter } from "../../../src/router/index.js";
+import { makeRouter as makeFixtureRouter, resetRouterState } from "../_router-fixture";
 
 /**
  * Covers the messaging-composed router path (#708): the router built WITH
@@ -44,14 +40,7 @@ const strangerEvent = {
 } satisfies Gateway.DeliveredEvent;
 
 function makeRouter(routes: ReadonlyMap<string, ChannelDeliveryRoute> = deliveryRoutes()): GatewayRouter {
-  return createGatewayRouter({
-    sink: (event, data) => Bus.publish(event, data),
-    deliver: async (delivery: Gateway.Deliver): Promise<Ingress.IngressResult> => ({
-      mode: "direct",
-      target: delivery.event.target ?? { kind: "resident" },
-      sessionId: delivery.sessionId ?? "s-stub",
-      result: { output: "ok", finishReason: "stop" },
-    }),
+  return makeFixtureRouter({
     messaging: {
       deliveryRoutes: routes,
       grants: () => [],
@@ -73,9 +62,7 @@ function makeRouter(routes: ReadonlyMap<string, ChannelDeliveryRoute> = delivery
 }
 
 beforeEach(() => {
-  Storage.reset();
-  Bus.reset();
-  Storage.initialize({ dbPath: ":memory:" });
+  resetRouterState();
   delivered.length = 0;
   // A broadcast channel admits a first-contact stranger as evidence_only with
   // a resolved identity — the materialization precondition (routed + endpoint).
@@ -99,11 +86,6 @@ beforeEach(() => {
     externalId: "buyer-external",
     workspace: "shop-ws",
   });
-});
-
-afterEach(() => {
-  Storage.reset();
-  Bus.reset();
 });
 
 describe("messaging-composed gateway router (#708)", () => {

--- a/packages/channels/test/router/messaging/scoped-grant.test.ts
+++ b/packages/channels/test/router/messaging/scoped-grant.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { Gateway } from "@openomni/protocol";
-import { ActorRegistry, Storage } from "@openomni/ledger";
+import { ActorRegistry } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
 import {
   deliverySurfaceKey,
@@ -9,6 +9,7 @@ import {
 } from "../../../src/router/messaging/grant.js";
 import { createExistingAgentMessaging } from "../../../src/router/messaging/send.js";
 import { buildSendInput, messagingNow, registerAgentFixture } from "../../helpers/messaging.js";
+import { resetStores } from "../_router-fixture";
 
 /**
  * #708 scope-aware grant arm: a rule-materialized (reply-scoped) instance is
@@ -104,19 +105,12 @@ describe("send kernel over reply-scoped instances", () => {
   }
 
   beforeEach(() => {
-    Bus.reset();
-    Storage.reset();
-    Storage.initialize({ dbPath: ":memory:" });
+    resetStores();
     delivered = [];
     grants = [scopedInstance()];
     registerAgentFixture("actor:sender");
     // channel "qa", externalId "target-1" → surface key "qa:target-1".
     registerAgentFixture("actor:target", [{ id: "endpoint:target", externalId: "target-1" }]);
-  });
-
-  afterEach(() => {
-    Storage.reset();
-    Bus.reset();
   });
 
   test("a send into the initiating container is granted by the scoped instance", async () => {

--- a/packages/channels/test/router/messaging/send.test.ts
+++ b/packages/channels/test/router/messaging/send.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { Gateway } from "@openomni/protocol";
 import { ActorRegistry, EgressBudgetStore, Storage, WaitStore } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
@@ -14,6 +14,7 @@ import {
   messagingNow,
   registerAgentFixture,
 } from "../../helpers/messaging.js";
+import { resetStores } from "../_router-fixture";
 
 const SendInput = Gateway.SendInput;
 type SenderTargetGrant = Gateway.SenderTargetGrant;
@@ -34,18 +35,11 @@ function messaging() {
 }
 
 beforeEach(() => {
-  Bus.reset();
-  Storage.reset();
-  Storage.initialize({ dbPath: ":memory:" });
+  resetStores();
   deliveries = [];
   grants = [buildGrant("grant:sender->target")];
   registerAgentFixture("actor:sender");
   registerAgentFixture("actor:target", [{ id: "endpoint:target", externalId: "target-1" }]);
-});
-
-afterEach(() => {
-  Storage.reset();
-  Bus.reset();
 });
 
 describe("sender-target grant (policy plane)", () => {
@@ -487,13 +481,10 @@ async function probe(point: FaultPoint): Promise<Probe> {
 }
 
 beforeEach(() => {
-  Storage.reset();
-  Storage.initialize({ dbPath: ":memory:" });
+  resetStores();
   registerAgentFixture("actor:sender");
   registerAgentFixture("actor:target", [{ id: "endpoint:target", externalId: "target-1" }]);
 });
-
-afterEach(() => Storage.reset());
 
 describe("gateway send crash reconciliation transition table", () => {
   test.each([

--- a/packages/channels/test/router/messaging/social-budget.test.ts
+++ b/packages/channels/test/router/messaging/social-budget.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { Gateway } from "@openomni/protocol";
-import { EgressBudgetStore, Storage } from "@openomni/ledger";
+import { EgressBudgetStore } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
 import { createExistingAgentMessaging } from "../../../src/router/messaging/send.js";
 import { evaluateSocialBudget } from "../../../src/router/messaging/social-budget.js";
@@ -10,6 +10,7 @@ import {
   messagingNow,
   registerAgentFixture,
 } from "../../helpers/messaging.js";
+import { resetStores } from "../_router-fixture";
 
 const ZERO_STATE: Gateway.EgressDebitState = {
   countInWindow: 0,
@@ -159,19 +160,12 @@ describe("send kernel active-egress gate (#219 seam)", () => {
   }
 
   beforeEach(() => {
-    Bus.reset();
-    Storage.reset();
-    Storage.initialize({ dbPath: ":memory:" });
+    resetStores();
     deliveries = [];
     grants = [buildGrant("grant:sender->target")];
     budgets = [];
     registerAgentFixture("actor:sender");
     registerAgentFixture("actor:target", [{ id: "endpoint:target", externalId: "target-1" }]);
-  });
-
-  afterEach(() => {
-    Storage.reset();
-    Bus.reset();
   });
 
   test("backward-compat: with NO budget source injected, a cold proactive send is unaffected", async () => {

--- a/packages/channels/test/router/wait/lifecycle.test.ts
+++ b/packages/channels/test/router/wait/lifecycle.test.ts
@@ -1,22 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { Wait } from "@openomni/protocol";
 import { Storage, WaitStore } from "@openomni/ledger";
 import { Bus } from "@openomni/telemetry";
 import { WaitService } from "../../../src/router/wait/index";
 import { buildWaitCreate } from "../../helpers/wait";
+import { resetStores } from "../_router-fixture";
 
 const flushBus = () => new Promise<void>((resolve) => queueMicrotask(() => resolve()));
 
-beforeEach(() => {
-  Bus.reset();
-  Storage.reset();
-  Storage.initialize({ dbPath: ":memory:" });
-});
-
-afterEach(() => {
-  Storage.reset();
-  Bus.reset();
-});
+beforeEach(resetStores);
 
 describe("WaitService", () => {
   test("open records exactly one durable Wait for an awaited delivery", () => {


### PR DESCRIPTION
## What / Why

Duplicate-logic audit finding **T2**: eight router test suites rebuilt the shared `_router-fixture` store/router assembly inline. This migrates them onto the shared fixtures, extending the fixture surface with one new export (`resetStores()` — the store half of `resetRouterState()`, without the router) for router-less kernel suites.

## Duplication fixed (file:line evidence, pre-change)

- `integration.test.ts:8-32` — inline `Storage.reset/Bus.reset/Storage.initialize` + `createGatewayRouter` with recording deliver stub → `resetRouterState` + `kernelRouter` (`_router-fixture.ts:67-73,88-101`)
- `authority-validation.test.ts:163-206` — e2e arm's inline reset trio + router with decision-filtering sink (exactly `routingDecisions()`, `_router-fixture.ts:134-137`) and delivery-recording stub → fixture `kernelRouter`/`deliveries`/`routingDecisions`
- `conformance/no-bypass.test.ts:35-72` — inline reset trio + router whose deliver stub only counted deliveries → fixture `deliveries` + `kernelRouter`
- `messaging/composition.test.ts:46-72,75-103` — inline reset trio + `createGatewayRouter`; only the `messaging` port was bespoke → `makeRouter({ messaging })` override (fixture already supports `Partial<GatewayRouterPorts>`, `_router-fixture.ts:88`)
- `messaging/send.test.ts:36-49,490-496`, `messaging/social-budget.test.ts:161-175`, `messaging/scoped-grant.test.ts:106-120`, `wait/lifecycle.test.ts:10-19` — the bare `Storage.reset/Bus.reset/Storage.initialize(:memory:)` trio → new `resetStores()` export (`_router-fixture.ts:60-66`)

## Left as-is (judgment calls)

- `kernel-routing-persistence.test.ts` — needs a **file-backed** db (reads `bus_event` rows over an independent connection) and **real Session rows** (FK target); the fixture hardcodes `:memory:` and fabricated-UUID surface claims.
- `wait/matcher.test.ts` — per-test `Storage.initialize` placement is the assertion surface (one test deliberately runs with storage uninitialized).
- `routing-pipeline`/`routing-precedence`/`wait/correlation`/`messaging/reply-grant`/`reply-scope-guard`/`existing-agent-message-driver` — pure-function or mock-only suites; no store/router assembly to migrate.

## Verification

- Behavior-preserving: channels suite **254 pass / 0 fail, 901 expect() calls** — identical before and after; no assertion touched.
- Mutation proof: dropped the fixture's sink recording (`sinkEvents.push`, consumed by the migrated authority-validation e2e arm via `routingDecisions()`) → `(fail) ... expected 1, got 0` at `authority-validation.test.ts:212`; reverted → 254 pass.
- Net LOC: **+54 / −150** in `packages/channels/test/router/` (9 files).

## Gate chain (all exit 0)

- `bunx turbo run build` ✓ / `check-types` ✓
- `check-deps.ts` ✓ (1 pre-existing stale-doc notice), `check-import-cycles.ts` ✓, `lint:tools` ✓
- `lint` ✓ and `ultracite check` ✓ (1 pre-existing warning in `apps/openomni/test/work-item-wiring.test.ts`, untouched here)
- `check-dead-exports.ts` ✓
- `bun test --timeout 15000` ✓ — 2506 pass / 0 fail across 291 files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates eight router test suites in `packages/channels/test/router/` from duplicated inline store/router setup onto the shared `_router-fixture` fixtures. Behavior is unchanged — all 254 tests and 901 `expect()` calls pass identically before and after — and the fixture gains one new export, `resetStores()`, for router-less kernel suites.

**Refactors**
- Adds `resetStores()` to `_router-fixture` as the store-only half of `resetRouterState()`.
- `integration`, `authority-validation` (e2e arm), and `conformance/no-bypass` now use `resetRouterState()` + `kernelRouter()`, including the fixture's `deliveries` and `routingDecisions` exports.
- `messaging/composition` now uses the fixture's `makeRouter()` with messaging port overrides.
- `messaging/send`, `messaging/social-budget`, `messaging/scoped-grant`, and `wait/lifecycle` now call `resetStores()` instead of the inline reset trio.
- `kernel-routing-persistence` and `wait/matcher` stay inline: the former needs a file-backed DB and real Session rows, the latter relies on per-test storage initialization placement.

<sup>Written for commit e3af45006c8061abac975d805f2c3c8ca8b1dd7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

