### PR TITLE
refactor(ipc): centralize process line framing

### DIFF
--- a/apps/openomni/package.json
+++ b/apps/openomni/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@openomni/agent": "workspace:*",
     "@openomni/channels": "workspace:*",
+    "@openomni/ipc": "workspace:*",
     "@openomni/ledger": "workspace:*",
     "@openomni/llm": "workspace:*",
     "@openomni/protocol": "workspace:*",

--- a/apps/openomni/src/delegation/process-driver.ts
+++ b/apps/openomni/src/delegation/process-driver.ts
@@ -1,7 +1,12 @@
+import { LineSplitter } from "@openomni/ipc";
 import type { Delegation, Model } from "@openomni/protocol";
 import type { Admitted } from "./admission";
 import type { DelegationDriver, DriverOutcome, DriverReport } from "./kernel";
-import { PROCESS_WORKER_ACK, ProcessWorkerResult, type ProcessWorkerRequest } from "./process-entry";
+import {
+  PROCESS_WORKER_ACK,
+  ProcessWorkerResult,
+  type ProcessWorkerRequest,
+} from "./process-entry";
 
 /** One delegation per child OS process; ack and result remain distinct facts. */
 export interface ProcessDriverOptions {
@@ -12,18 +17,12 @@ export interface ProcessDriverOptions {
 }
 
 async function* lines(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
-  const decoder = new TextDecoder();
-  let buffer = "";
+  const splitter = new LineSplitter();
   for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    let end = buffer.indexOf("\n");
-    while (end >= 0) {
-      yield buffer.slice(0, end);
-      buffer = buffer.slice(end + 1);
-      end = buffer.indexOf("\n");
-    }
+    yield* splitter.push(chunk);
   }
-  if (buffer.length > 0) yield buffer;
+  const trailing = splitter.finish();
+  if (trailing !== undefined) yield trailing;
 }
 
 function errorText(error: unknown): string {

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
       "dependencies": {
         "@openomni/agent": "workspace:*",
         "@openomni/channels": "workspace:*",
+        "@openomni/ipc": "workspace:*",
         "@openomni/ledger": "workspace:*",
         "@openomni/llm": "workspace:*",
         "@openomni/machines": "workspace:*",

--- a/packages/ipc/src/framing.ts
+++ b/packages/ipc/src/framing.ts
@@ -19,18 +19,16 @@ export type DecodedChunk = {
   malformed: string[];
 };
 
-export class LineDecoder {
+/** Stream-agnostic newline framing with streaming UTF-8 decoding. */
+export class LineSplitter {
   private buffer = "";
   private decoder = new TextDecoder();
 
-  /**
-   * Decode a chunk into complete frames. A malformed line costs only itself:
-   * every parseable sibling in the chunk still delivers, in order, and the bad
-   * line lands in `malformed` for the caller to report. Oversize lines and
-   * oversize buffers stay reset+throw — that path is a DoS guard, not a
-   * per-frame failure, and it deliberately drops the whole decode buffer.
-   */
-  push(chunk: string | Uint8Array): DecodedChunk {
+  get buffered(): string {
+    return this.buffer;
+  }
+
+  push(chunk: string | Uint8Array): string[] {
     if (typeof chunk === "string") {
       // String chunks cannot complete a pending byte sequence; discard stale decoder state.
       this.decoder = new TextDecoder();
@@ -41,8 +39,36 @@ export class LineDecoder {
 
     const lines = this.buffer.split("\n");
     this.buffer = lines.pop() ?? "";
+    return lines;
+  }
 
-    if (Buffer.byteLength(this.buffer, "utf-8") > MAX_FRAME_BYTES) {
+  /** Return trailing non-newline-terminated data without flushing partial UTF-8 bytes. */
+  finish(): string | undefined {
+    const trailing = this.buffer || undefined;
+    this.reset();
+    return trailing;
+  }
+
+  reset(): void {
+    this.buffer = "";
+    this.decoder = new TextDecoder();
+  }
+}
+
+export class LineDecoder {
+  private splitter = new LineSplitter();
+
+  /**
+   * Decode a chunk into complete frames. A malformed line costs only itself:
+   * every parseable sibling in the chunk still delivers, in order, and the bad
+   * line lands in `malformed` for the caller to report. Oversize lines and
+   * oversize buffers stay reset+throw — that path is a DoS guard, not a
+   * per-frame failure, and it deliberately drops the whole decode buffer.
+   */
+  push(chunk: string | Uint8Array): DecodedChunk {
+    const lines = this.splitter.push(chunk);
+
+    if (Buffer.byteLength(this.splitter.buffered, "utf-8") > MAX_FRAME_BYTES) {
       this.reset();
       throw new IpcProtocolError(`IPC frame exceeds maximum size of ${MAX_FRAME_BYTES} bytes`);
     }
@@ -65,7 +91,6 @@ export class LineDecoder {
   }
 
   reset(): void {
-    this.buffer = "";
-    this.decoder = new TextDecoder();
+    this.splitter.reset();
   }
 }

--- a/packages/ipc/src/index.ts
+++ b/packages/ipc/src/index.ts
@@ -4,6 +4,6 @@
 // barrel as a published contract; it never grows a kernel/ledger/policy import.
 export { connectIpcClient, type IpcClient } from "./client";
 export { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
-export { encode } from "./framing";
+export { encode, LineSplitter } from "./framing";
 export { createIpcServer, type IpcServer } from "./server";
 export { typedCall } from "./typed-call";

--- a/packages/ipc/test/framing.test.ts
+++ b/packages/ipc/test/framing.test.ts
@@ -1,8 +1,19 @@
 import { describe, test, expect } from "bun:test";
-import { LineDecoder } from "../src/framing";
+import { LineDecoder, LineSplitter } from "../src/framing";
 import { IpcProtocolError } from "../src/errors";
 
 const FRAME_LIMIT_BYTES = 16 * 1024 * 1024;
+
+describe("LineSplitter", () => {
+  test("buffers partial lines, emits complete siblings, and returns trailing data", () => {
+    const splitter = new LineSplitter();
+    const encoder = new TextEncoder();
+
+    expect(splitter.push(encoder.encode("first\nsecond\npart"))).toEqual(["first", "second"]);
+    expect(splitter.push(encoder.encode("ial"))).toEqual([]);
+    expect(splitter.finish()).toBe("partial");
+  });
+});
 
 describe("LineDecoder", () => {
   test("decodes complete lines", () => {

--- a/script/check-deps.ts
+++ b/script/check-deps.ts
@@ -160,6 +160,7 @@ const RULES: Record<PackageKey, PackageRule> = {
     allowedDeps: new Set([
       "@openomni/protocol",
       "@openomni/channels",
+      "@openomni/ipc",
       "@openomni/agent",
       "@openomni/llm",
       "@openomni/ledger",


### PR DESCRIPTION
## What / why
- Replaces the duplicate stdout newline framing at `apps/openomni/src/delegation/process-driver.ts:19-25` with the IPC-owned `LineSplitter`.
- Adds the stream-agnostic splitter at `packages/ipc/src/framing.ts:23-57`; `LineDecoder` now consumes that same owner, preserving the established UTF-8 streaming, partial-line, multi-line, and trailing-data behavior.
- Owner-directed dedupe: adds `@openomni/ipc` to the app manifest and its explicit allowlist at `script/check-deps.ts:163`. Growing that allowlist is the dependency-owner sign-off surface.

## Verification
- Focused: `bun test packages/ipc/test/framing.test.ts`, `bun test apps/openomni/test/process-transport.test.ts`, and `bun test apps/openomni/test/delegation-e2e.test.ts`.
- Gate chain passed: `bunx turbo run build && bunx turbo run check-types`; `bun run script/check-deps.ts`; `bun run script/check-import-cycles.ts`; `bun run lint:tools`; `bun run lint`; `bunx ultracite check --formatter-enabled=false .`; `bun run script/check-dead-exports.ts`; `bun test --timeout 15000` (2507 passing).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes stdout line framing in `@openomni/ipc` so the delegation driver and `LineDecoder` share one stream-agnostic splitter, with no behavior change for UTF-8 streaming, partial lines, or trailing data.

- Replaces the duplicate newline framing in `apps/openomni/src/delegation/process-driver.ts` with the IPC-owned `LineSplitter`.
- Exports `LineSplitter` from `@openomni/ipc`; `LineDecoder` now delegates to it while keeping the frame-size DoS guard intact.
- Adds `@openomni/ipc` to the app's dependencies and to the allowlist in `script/check-deps.ts`.

<sup>Written for commit 05b47ebc43a03a2a0c34494159817a33c8bf3ae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

