### PR TITLE
refactor(protocol): centralize Python kernel capability

### DIFF
--- a/apps/openomni/src/tools/run-code.ts
+++ b/apps/openomni/src/tools/run-code.ts
@@ -1,7 +1,7 @@
 import type { ChatAgentConfig } from "@openomni/agent";
 import { placementGatedExecutor } from "@openomni/agent";
 import { Placement } from "@openomni/placement";
-import type { Machine, Tool } from "@openomni/protocol";
+import { Machine, type Tool } from "@openomni/protocol";
 import { z } from "zod";
 import type { DelegationOrigin } from "../delegation/admission";
 import type { CatalogEntry } from "./dispatch";
@@ -101,7 +101,7 @@ export function runCodeToolSpec(): Tool.Spec {
     inputSchema: INPUT_JSON_SCHEMA,
     safe: false,
     placement: "machine",
-    requires: ["kernel.py"],
+    requires: [Machine.WellKnownCapability.pythonKernel],
   };
 }
 

--- a/packages/machines/src/daemon.ts
+++ b/packages/machines/src/daemon.ts
@@ -17,11 +17,11 @@ export interface MachineDaemon {
 /**
  * Machine-side daemon for the localhost slice: connect to the host socket,
  * offer the capability set, and hold the connection open — the live
- * connection IS the attachment. A daemon that offers `kernel.py` serves cells
+ * connection IS the attachment. A daemon that offers the Python-kernel capability serves cells
  * over the reverse request channel using one attachment-scoped interpreter.
  */
 export async function attachMachineDaemon(options: MachineDaemonOptions): Promise<MachineDaemon> {
-  const kernel = options.offer.offeredCapabilities.includes("kernel.py")
+  const kernel = options.offer.offeredCapabilities.includes(Machine.WellKnownCapability.pythonKernel)
     ? new PythonKernel()
     : undefined;
   // Assigned before any request can arrive: the host can only send RunCell
@@ -32,10 +32,10 @@ export async function attachMachineDaemon(options: MachineDaemonOptions): Promis
       if (method !== Machine.WireMethod.RunCell) {
         throw new Error(`unknown method: ${method}`);
       }
-      // The host gate owns this refusal; a daemon that never offered kernel.py
+      // The host gate owns this refusal; a daemon that never offered the Python-kernel capability
       // still re-checks because the host is across a trust boundary.
       if (kernel === undefined) {
-        throw new Error("kernel.py was not offered by this machine");
+        throw new Error(`${Machine.WellKnownCapability.pythonKernel} was not offered by this machine`);
       }
       const request = Machine.CellRequest.parse(params);
       respond(

--- a/packages/machines/src/host.ts
+++ b/packages/machines/src/host.ts
@@ -160,7 +160,7 @@ export async function createMachineHost(options: MachineHostOptions): Promise<Ma
         return { status: "refused", reason: "machine_not_attached" };
       }
       const attachment = attachments.get(connectionId);
-      if (!attachment?.capabilities.includes("kernel.py")) {
+      if (!attachment?.capabilities.includes(Machine.WellKnownCapability.pythonKernel)) {
         return { status: "refused", reason: "kernel_not_available" };
       }
       server.useConnection(connectionId);

--- a/packages/protocol/src/machine/index.ts
+++ b/packages/protocol/src/machine/index.ts
@@ -10,6 +10,7 @@ import { Events as MachineEvents } from "./events.js";
 export namespace Machine {
   export const CapabilityId = Schema.CapabilityId;
   export type CapabilityId = Schema.CapabilityId;
+  export const WellKnownCapability = Schema.WellKnownCapability;
   export const MachineId = Schema.MachineId;
   export type MachineId = Schema.MachineId;
   export const WireMethod = Schema.WireMethod;

--- a/packages/protocol/src/machine/schema.ts
+++ b/packages/protocol/src/machine/schema.ts
@@ -15,6 +15,11 @@ export const CapabilityId = z
   });
 export type CapabilityId = z.infer<typeof CapabilityId>;
 
+/** Capability ids whose behavior is defined by the machine protocol. */
+export const WellKnownCapability = {
+  pythonKernel: "kernel.py",
+} as const satisfies Record<string, CapabilityId>;
+
 export const MachineId = z.string().min(1);
 export type MachineId = z.infer<typeof MachineId>;
 

--- a/packages/protocol/test/machine/machine.test.ts
+++ b/packages/protocol/test/machine/machine.test.ts
@@ -16,6 +16,12 @@ const offer = {
   offeredAt: 2,
 } satisfies Machine.Offer;
 
+describe("Machine.WellKnownCapability", () => {
+  test("exports the Python kernel capability", () => {
+    expect(Machine.WellKnownCapability.pythonKernel).toBe("kernel.py");
+  });
+});
+
 describe("Machine.CapabilityId grammar", () => {
   test("accepts dot-namespaced lowercase ids", () => {
     for (const id of ["fs.read", "kernel.py", "screen.read", "input.write", "a.b_c.d0", "a.b"]) {


### PR DESCRIPTION
## What and why

Promotes the protocol-defined Python kernel capability from repeated literals to `Machine.WellKnownCapability.pythonKernel`, preventing enrollment, daemon, host, and tool-catalog drift.

## Duplication evidence

- `packages/protocol/src/machine/schema.ts:18-21` owns the typed constant; `packages/protocol/src/machine/index.ts:13` re-exports it through `Machine`.
- Replaced production consumers at `packages/machines/src/daemon.ts:24`, `packages/machines/src/host.ts:163`, and `apps/openomni/src/tools/run-code.ts:104`.
- `rg kernel\.py` now finds source occurrences only in the owning schema (plus documentation and tests).

## Verification

- Rebuilt protocol dist with `rm -rf packages/protocol/dist && bunx turbo run build` before testing.
- Full required gate chain passed: build, check-types, dependency check, import-cycle check, tools lint, lint, Ultracite, dead-export check, and `bun test --timeout 15000` (2507 pass, 0 fail).
- Focused tests passed: protocol machine, machines kernel, and openomni tools (50 pass, 0 fail).

## Notes

- Added an export-contract test for the well-known capability; behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the protocol-defined Python kernel capability so enrollment, daemon, host, and tool-catalog code no longer hardcode `"kernel.py"`; behavior is unchanged.

- Adds `Machine.WellKnownCapability.pythonKernel` as the single source of truth in `packages/protocol` and re-exports it through `Machine`.
- Replaces every repeated `"kernel.py"` literal in daemon, host, and tool-catalog consumers with the constant.
- Adds an export-contract test that pins the well-known capability value.

<sup>Written for commit 926d7bb7ced849af67aca31e9bbc73151004d0b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

