### PR TITLE
refactor(llm): centralize abortable sleep

### DIFF
--- a/packages/agent/src/core/execution/run.ts
+++ b/packages/agent/src/core/execution/run.ts
@@ -6,7 +6,7 @@ import {
   handleError,
   handleStop,
 } from "./turn";
-import { ModelsDev, Provider, run as llmRun } from "@openomni/llm";
+import { ModelsDev, Provider, Retry as LlmRetry, run as llmRun } from "@openomni/llm";
 import type { Sink } from "@openomni/llm";
 import { Placement } from "@openomni/placement";
 import { DEFAULT_THRESHOLD_RATIO } from "../../compaction/compact";
@@ -262,7 +262,7 @@ export async function runAgent(
           // terminal record contradict this run's own retry record.
           failureReasons.push(decision.failure.reason);
           thrownFailure = decision.failure;
-          await Retry.sleep(decision.backoffMs, config.signal);
+          await LlmRetry.sleep(decision.backoffMs, config.signal);
           thrownFailure = undefined;
           attempt += 1;
           continue;

--- a/packages/agent/src/core/retry.ts
+++ b/packages/agent/src/core/retry.ts
@@ -131,27 +131,3 @@ export function shouldRetry(policy: RetryPolicy, reason: RetryReason, attempt: n
   if (policy.retryOn === undefined || policy.retryOn.length === 0) return true;
   return policy.retryOn.includes(reason);
 }
-
-export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  if (signal?.aborted) {
-    return Promise.reject(abortError());
-  }
-
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(
-      () => {
-        signal?.removeEventListener("abort", onAbort);
-        resolve();
-      },
-      Math.max(0, Math.floor(ms)),
-    );
-
-    function onAbort(): void {
-      clearTimeout(timeout);
-      signal?.removeEventListener("abort", onAbort);
-      reject(abortError());
-    }
-
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
-}

--- a/packages/agent/test/core/retry.test.ts
+++ b/packages/agent/test/core/retry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Retry } from "@openomni/llm";
 
 import {
   abortError,
@@ -7,7 +8,6 @@ import {
   isAbort,
   type RetryPolicy,
   shouldRetry,
-  sleep,
 } from "../../src/core/retry";
 
 describe("Retry.sleep", () => {
@@ -17,7 +17,7 @@ describe("Retry.sleep", () => {
 
     const started = Date.now();
 
-    await expect(sleep(5_000, controller.signal)).rejects.toThrow("aborted");
+    await expect(Retry.sleep(5_000, controller.signal)).rejects.toThrow(/aborted/i);
     expect(Date.now() - started).toBeLessThan(100);
   });
 
@@ -27,7 +27,7 @@ describe("Retry.sleep", () => {
     setTimeout(() => controller.abort(), 5);
     const started = Date.now();
 
-    await expect(sleep(5_000, controller.signal)).rejects.toThrow("aborted");
+    await expect(Retry.sleep(5_000, controller.signal)).rejects.toThrow(/aborted/i);
     expect(Date.now() - started).toBeLessThan(500);
   });
 
@@ -48,7 +48,7 @@ describe("Retry.sleep", () => {
       return originalRemoveEventListener(...args);
     }) as AbortSignal["removeEventListener"];
 
-    await sleep(1, signal);
+    await Retry.sleep(1, signal);
 
     expect(added).toBe(1);
     expect(removed).toBe(1);

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,4 +1,5 @@
 export { Auth } from "./auth";
 export { Provider, ModelsDev } from "./provider";
+export { Retry } from "./retry";
 export { run, Run, type RunInput } from "./run";
 export type { Sink } from "./sink";

--- a/packages/llm/src/retry/index.ts
+++ b/packages/llm/src/retry/index.ts
@@ -6,8 +6,8 @@ export namespace Retry {
   export const RETRY_MAX_DELAY_NO_HEADERS = 30_000;
   export const RETRY_MAX_DELAY = 2_147_483_647;
 
-  export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
-    if (signal.aborted) {
+  export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
       throw new DOMException("Aborted", "AbortError");
     }
 
@@ -18,12 +18,12 @@ export namespace Retry {
       };
       const timeout = setTimeout(
         () => {
-          signal.removeEventListener("abort", abortHandler);
+          signal?.removeEventListener("abort", abortHandler);
           resolve();
         },
         Math.min(ms, RETRY_MAX_DELAY),
       );
-      signal.addEventListener("abort", abortHandler, { once: true });
+      signal?.addEventListener("abort", abortHandler, { once: true });
     });
   }
 

--- a/packages/llm/test/public-surface.test.ts
+++ b/packages/llm/test/public-surface.test.ts
@@ -10,7 +10,7 @@ describe("@openomni/llm root public surface", () => {
 
     // Then: only package-level namespaces and entry points are exposed.
     // #500 C1: `Run` (Outcome vocabulary) moved here from protocol; `Sink` is type-only.
-    expect(publicKeys).toEqual(["Auth", "ModelsDev", "Provider", "Run", "run"]);
+    expect(publicKeys).toEqual(["Auth", "ModelsDev", "Provider", "Retry", "Run", "run"]);
   });
 
   test("does not expose lower-level implementation helpers", async () => {
@@ -23,7 +23,6 @@ describe("@openomni/llm root public surface", () => {
       "fetchProxyModels",
       "enrichWithCatalog",
       "Message",
-      "Retry",
       "Processor",
       "Tool",
       "toModelMessages",

--- a/packages/llm/test/retry/retry.test.ts
+++ b/packages/llm/test/retry/retry.test.ts
@@ -41,6 +41,10 @@ describe("Retry", () => {
   });
 
   describe("sleep(ms, abortSignal)", () => {
+    test("resolves without an abort signal", async () => {
+      await Retry.sleep(0);
+    });
+
     test("resolves after specified milliseconds", async () => {
       const start = Date.now();
       await Retry.sleep(100, new AbortController().signal);


### PR DESCRIPTION
## What and why
- Make `@openomni/llm` the sole exported owner of the abortable retry sleep helper.
- Export `Retry` from the LLM root barrel and accept an optional `AbortSignal`, so agent retry waits use the same implementation without changing LLM abort behavior.
- Delete the duplicate agent helper and route the production wait through `LlmRetry.sleep`.

## Duplication evidence
- Former duplicate: `packages/agent/src/core/retry.ts:135-157` (deleted).
- Owner: `packages/llm/src/retry/index.ts:9`; root export: `packages/llm/src/index.ts:3`.
- Agent consumer: `packages/agent/src/core/execution/run.ts:265`.

## Verification
- RED: `bun test --timeout 15000 packages/llm/test/retry/retry.test.ts` failed before the optional-signal implementation with `TypeError: undefined is not an object (evaluating signal.aborted)`.
- GREEN: focused LLM/agent retry and LLM public-surface tests pass (66 tests).
- Full gate chain passed: build, check-types, check-deps, import-cycle check, lint:tools, lint, Ultracite, dead-export check, and `bun test --timeout 15000` (2507 pass, 0 fail).
- `lint`/Ultracite retain the pre-existing unused-import warning in `apps/openomni/test/work-item-wiring.test.ts`; both commands exit 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the abortable retry sleep helper so `@openomni/llm` is the sole owner and agent retry waits use the same implementation.

- `Retry.sleep` now accepts an optional `AbortSignal` and is exported from the LLM root barrel.
- Deletes the duplicate agent helper and routes agent retry waits through `LlmRetry.sleep`.
- Abort behavior is unchanged; passing no signal lets the sleep resolve normally.

<sup>Written for commit 5660ea2ceab8b89859c6c09f36df01b4497904ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

