### PR TITLE
refactor(ipc): extract shared PendingCalls registry from client and server

### DIFF
--- a/packages/ipc/src/client.ts
+++ b/packages/ipc/src/client.ts
@@ -1,19 +1,14 @@
 import net from "node:net";
 import { Ipc } from "@openomni/protocol";
-import { LineDecoder, encode } from "./framing";
 import { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
+import { LineDecoder, encode } from "./framing";
+import { PendingCalls } from "./pending-calls";
 
 export interface IpcClient {
   call(method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown>;
   close(): void;
   readonly connected: boolean;
 }
-
-type PendingRequest = {
-  resolve: (value: unknown) => void;
-  reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-};
 
 export type ConnectIpcClientOptions = {
   connectTimeoutMs?: number;
@@ -38,7 +33,7 @@ export function connectIpcClient(
   return new Promise((resolve, reject) => {
     const socket = net.createConnection(socketPath);
     const decoder = new LineDecoder();
-    const pending = new Map<string, PendingRequest>();
+    const pending = new PendingCalls();
     let connected = false;
 
     const connectTimer = setTimeout(() => {
@@ -47,11 +42,7 @@ export function connectIpcClient(
     }, connectTimeoutMs);
 
     function failAllPending(err: Error): void {
-      for (const [, handler] of pending) {
-        clearTimeout(handler.timer);
-        handler.reject(err);
-      }
-      pending.clear();
+      pending.failAll(err);
     }
 
     socket.on("connect", () => {
@@ -76,15 +67,12 @@ export function connectIpcClient(
         const response = Ipc.Response.safeParse(raw);
         if (response.success) {
           const { id, result, error } = response.data;
-          const handler = pending.get(id);
-          if (!handler) continue;
-          clearTimeout(handler.timer);
-          pending.delete(id);
-          if (error) {
-            handler.reject(new IpcRemoteError(error.code, error.message));
-          } else {
-            handler.resolve(result);
-          }
+          pending.settle(
+            id,
+            error
+              ? { ok: false, error: new IpcRemoteError(error.code, error.message) }
+              : { ok: true, value: result },
+          );
           continue;
         }
 
@@ -207,15 +195,13 @@ export function connectIpcClient(
         if (!connected) {
           return Promise.reject(new IpcConnectionError("not connected"));
         }
-        return new Promise((res, rej) => {
-          const req = Ipc.createRequest(method, params);
-          const timer = setTimeout(() => {
-            pending.delete(req.id);
-            rej(new IpcTimeoutError(`request timeout: ${method}`));
-          }, timeoutMs);
-          pending.set(req.id, { resolve: res, reject: rej, timer });
-          socket.write(encode(req));
-        });
+        const req = Ipc.createRequest(method, params);
+        return pending.register(
+          req.id,
+          timeoutMs,
+          () => new IpcTimeoutError(`request timeout: ${method}`),
+          { send: () => socket.write(encode(req)) },
+        );
       },
       close() {
         connected = false;

--- a/packages/ipc/src/pending-calls.ts
+++ b/packages/ipc/src/pending-calls.ts
@@ -1,0 +1,98 @@
+/**
+ * Request-id correlation registry for in-flight IPC calls — the single
+ * owner of the pending-call Map that client.ts and server.ts used to
+ * hand-roll separately. One entry per outbound request: its promise
+ * controls, the per-request timeout timer, and optional caller metadata
+ * (the server stores the owning connectionId, so a dying connection fails
+ * only ITS calls and a response is honored only on the connection that
+ * asked for it).
+ *
+ * Timer hygiene is this module's job: every path that removes an entry —
+ * settle, timeout, failAll — clears that entry's timer first.
+ */
+
+type PendingEntry<TMeta> = {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+  meta: TMeta;
+};
+
+export class PendingCalls<TMeta = undefined> {
+  private readonly pending = new Map<string, PendingEntry<TMeta>>();
+
+  /** Number of in-flight calls (test/diagnostic surface). */
+  get size(): number {
+    return this.pending.size;
+  }
+
+  /**
+   * Registers one outbound call under `id` and arms its per-request
+   * timeout. The returned promise settles through settle()/failAll(), or
+   * rejects with `timeoutError()` when the timeout fires first — the
+   * entry is dropped either way, so a late response finds nothing.
+   *
+   * `options.send` dispatches the request frame AFTER the entry is
+   * stored, still inside the promise executor: a throwing send rejects
+   * the call instead of escaping synchronously, exactly like an inline
+   * executor would.
+   */
+  register(
+    id: string,
+    timeoutMs: number,
+    timeoutError: () => Error,
+    options?: {
+      /** Caller metadata stored on the entry and handed to `where` predicates. */
+      meta?: TMeta;
+      send?: () => void;
+    },
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(timeoutError());
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer, meta: options?.meta as TMeta });
+      options?.send?.();
+    });
+  }
+
+  /**
+   * Settles the call registered under `id`. Returns false — leaving the
+   * entry untouched — when the id is unknown or `where` rejects its
+   * metadata (e.g. a response arriving on a connection that never asked).
+   */
+  settle(
+    id: string,
+    outcome:
+      | { readonly ok: true; readonly value: unknown }
+      | { readonly ok: false; readonly error: Error },
+    where?: (meta: TMeta) => boolean,
+  ): boolean {
+    const entry = this.pending.get(id);
+    if (!entry) return false;
+    if (where && !where(entry.meta)) return false;
+    clearTimeout(entry.timer);
+    this.pending.delete(id);
+    if (outcome.ok) {
+      entry.resolve(outcome.value);
+    } else {
+      entry.reject(outcome.error);
+    }
+    return true;
+  }
+
+  /**
+   * Rejects in-flight calls with `err` and clears their timers — every
+   * call, or only those whose metadata matches `where` (the server's
+   * per-connection teardown).
+   */
+  failAll(err: Error, where?: (meta: TMeta) => boolean): void {
+    for (const [id, entry] of this.pending) {
+      if (where && !where(entry.meta)) continue;
+      clearTimeout(entry.timer);
+      this.pending.delete(id);
+      entry.reject(err);
+    }
+  }
+}

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -4,6 +4,7 @@ import { Ipc } from "@openomni/protocol";
 
 import { IpcConnectionError, IpcProtocolError, IpcRemoteError, IpcTimeoutError } from "./errors";
 import { LineDecoder, encode } from "./framing";
+import { PendingCalls } from "./pending-calls";
 
 function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
@@ -33,13 +34,6 @@ export interface IpcServer {
   useConnection(id: string): void;
   close(): void;
 }
-
-type PendingRequest = {
-  resolve: (value: unknown) => void;
-  reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-  connectionId: string;
-};
 
 // How long the pre-listen probe waits for the existing socket to answer
 // before concluding it is dead. No answer means "assume live": stealing a
@@ -121,7 +115,7 @@ export async function createIpcServer(
   };
 
   const connections = new Map<string, ConnectionState>();
-  const pending = new Map<string, PendingRequest>();
+  const pending = new PendingCalls<string>();
   let connCounter = 0;
   let activeConnectionId: string | undefined;
 
@@ -198,20 +192,11 @@ export async function createIpcServer(
   }
 
   function failPendingOf(connId: string, err: Error): void {
-    for (const [reqId, handler] of pending) {
-      if (handler.connectionId !== connId) continue;
-      clearTimeout(handler.timer);
-      pending.delete(reqId);
-      handler.reject(err);
-    }
+    pending.failAll(err, (connectionId) => connectionId === connId);
   }
 
   function failAllPending(err: Error): void {
-    for (const [, handler] of pending) {
-      clearTimeout(handler.timer);
-      handler.reject(err);
-    }
-    pending.clear();
+    pending.failAll(err);
   }
 
   const server = Bun.listen({
@@ -276,19 +261,16 @@ export async function createIpcServer(
           }
 
           if (parsed.type === "response") {
-            const handler = pending.get(parsed.id);
             // Response matching is scoped to the connection that owns the
             // request: another connection echoing (or guessing) the id must
             // not settle a pending it was never asked about.
-            if (handler && handler.connectionId === state.id) {
-              clearTimeout(handler.timer);
-              pending.delete(parsed.id);
-              if (parsed.error) {
-                handler.reject(new IpcRemoteError(parsed.error.code, parsed.error.message));
-              } else {
-                handler.resolve(parsed.result);
-              }
-            }
+            pending.settle(
+              parsed.id,
+              parsed.error
+                ? { ok: false, error: new IpcRemoteError(parsed.error.code, parsed.error.message) }
+                : { ok: true, value: parsed.result },
+              (connectionId) => connectionId === state.id,
+            );
           } else if (parsed.type === "request") {
             const respond = (result: unknown) => {
               sendFrame(state, Ipc.createResponse(parsed.id, result));
@@ -373,15 +355,13 @@ export async function createIpcServer(
       if (!conn) {
         return Promise.reject(new IpcConnectionError("no connected client"));
       }
-      return new Promise((res, rej) => {
-        const req = Ipc.createRequest(method, params);
-        const timer = setTimeout(() => {
-          pending.delete(req.id);
-          rej(new IpcTimeoutError(`request timeout: ${method}`));
-        }, timeoutMs);
-        pending.set(req.id, { resolve: res, reject: rej, timer, connectionId: conn.id });
-        sendFrame(conn, req);
-      });
+      const req = Ipc.createRequest(method, params);
+      return pending.register(
+        req.id,
+        timeoutMs,
+        () => new IpcTimeoutError(`request timeout: ${method}`),
+        { meta: conn.id, send: () => sendFrame(conn, req) },
+      );
     },
     notify(method, params) {
       const conn = getActiveConnection();

--- a/packages/ipc/test/pending-calls.test.ts
+++ b/packages/ipc/test/pending-calls.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { IpcConnectionError, IpcTimeoutError } from "../src/errors";
+import { PendingCalls } from "../src/pending-calls";
+
+describe("PendingCalls registry", () => {
+  test("register + settle resolves with the value and drops the entry", async () => {
+    const pending = new PendingCalls();
+    const call = pending.register("req-1", 1_000, () => new IpcTimeoutError("request timeout: m"));
+    expect(pending.size).toBe(1);
+    expect(pending.settle("req-1", { ok: true, value: { answer: 42 } })).toBe(true);
+    await expect(call).resolves.toEqual({ answer: 42 });
+    expect(pending.size).toBe(0);
+  });
+
+  test("settle returns false for an unknown id", () => {
+    const pending = new PendingCalls();
+    expect(pending.settle("nope", { ok: true, value: 1 })).toBe(false);
+  });
+
+  test("settle with an error outcome rejects with that exact error", async () => {
+    const pending = new PendingCalls();
+    const call = pending.register("req-1", 1_000, () => new IpcTimeoutError("x"));
+    const err = new IpcConnectionError("socket closed");
+    expect(pending.settle("req-1", { ok: false, error: err })).toBe(true);
+    const caught = await call.catch((e: unknown) => e);
+    expect(caught).toBe(err);
+  });
+
+  test("a where predicate that rejects the metadata leaves the entry pending", async () => {
+    const pending = new PendingCalls<string>();
+    const call = pending.register("req-1", 1_000, () => new IpcTimeoutError("x"), {
+      meta: "conn-1",
+    });
+    // Wrong connection: no settle, entry survives.
+    expect(pending.settle("req-1", { ok: true, value: 1 }, (conn) => conn === "conn-2")).toBe(
+      false,
+    );
+    expect(pending.size).toBe(1);
+    // Owning connection: settles.
+    expect(pending.settle("req-1", { ok: true, value: 2 }, (conn) => conn === "conn-1")).toBe(
+      true,
+    );
+    await expect(call).resolves.toBe(2);
+    expect(pending.size).toBe(0);
+  });
+
+  test("timeout rejects with the timeoutError() error and drops the entry", async () => {
+    const pending = new PendingCalls();
+    const call = pending.register("req-1", 10, () => new IpcTimeoutError("request timeout: slow"));
+    await expect(call).rejects.toBeInstanceOf(IpcTimeoutError);
+    await expect(call).rejects.toThrow("request timeout: slow");
+    expect(pending.size).toBe(0);
+    // A late response finds nothing to settle.
+    expect(pending.settle("req-1", { ok: true, value: 1 })).toBe(false);
+  });
+
+  test("send runs inside the executor: a throwing send rejects the call", async () => {
+    const pending = new PendingCalls();
+    const call = pending.register("req-1", 1_000, () => new IpcTimeoutError("x"), {
+      send: () => {
+        throw new IpcConnectionError("write failed");
+      },
+    });
+    await expect(call).rejects.toThrow("write failed");
+    pending.failAll(new IpcConnectionError("cleanup"));
+  });
+
+  test("failAll rejects every pending call with the given error and clears the registry", async () => {
+    const pending = new PendingCalls();
+    const first = pending.register("a", 1_000, () => new IpcTimeoutError("x"));
+    const second = pending.register("b", 1_000, () => new IpcTimeoutError("x"));
+    const err = new IpcConnectionError("client closed");
+    pending.failAll(err);
+    expect(await first.catch((e: unknown) => e)).toBe(err);
+    expect(await second.catch((e: unknown) => e)).toBe(err);
+    expect(pending.size).toBe(0);
+  });
+
+  test("failAll with a where predicate fails only matching entries", async () => {
+    const pending = new PendingCalls<string>();
+    const dying = pending.register("a", 1_000, () => new IpcTimeoutError("x"), { meta: "conn-1" });
+    const survivor = pending.register("b", 1_000, () => new IpcTimeoutError("x"), {
+      meta: "conn-2",
+    });
+    pending.failAll(new IpcConnectionError("socket closed"), (conn) => conn === "conn-1");
+    await expect(dying).rejects.toThrow("socket closed");
+    // The other connection's call is untouched and still settles normally.
+    expect(pending.size).toBe(1);
+    expect(pending.settle("b", { ok: true, value: "survived" })).toBe(true);
+    await expect(survivor).resolves.toBe("survived");
+    expect(pending.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## What / Why

Duplicate-logic audit finding **S1**: `packages/ipc/src/client.ts` and `packages/ipc/src/server.ts` each hand-rolled the same request-id correlation registry — a `Map<string, { resolve, reject, timer, ... }>` with per-request timeout timers and teardown-fails-all-pendings semantics.

Duplication fixed (pre-refactor line refs on `origin/main`):
- `packages/ipc/src/client.ts`: `PendingRequest` type (L13-17), `pending` Map (L41), `failAllPending` (L50-55), response settle (L79-92), timeout/register in `call()` (L213-222)
- `packages/ipc/src/server.ts`: `PendingRequest` type with `connectionId` (L37-42), `pending` Map (L124), `failPendingOf`/`failAllPending` (L201-217), connection-scoped response settle (L279-295), timeout/register in `call()` (L379-388)

## Change

- **New `packages/ipc/src/pending-calls.ts`**: single exported `PendingCalls<TMeta>` owner — `register` / `settle` / `failAll` with timer cleanup on every removal path (settle, timeout, failAll), plus optional per-entry metadata.
- **`client.ts` / `server.ts`** rewritten onto it. The server stores the owning `connectionId` as entry metadata: connection-scoped response matching and per-connection teardown (`failPendingOf`) become `settle`/`failAll` with a `where` predicate.
- **New `packages/ipc/test/pending-calls.test.ts`**: 8 focused unit tests (settle value/error identity, unknown-id no-op, `where`-predicate scoping, timeout rejection + late-response no-op, throwing-send containment, failAll global and metadata-scoped).

## Behavior preservation

Identical observable behavior, pinned by the existing suite:
- Same error classes/messages/codes (`IpcTimeoutError("request timeout: <method>")`, `IpcRemoteError(code, message)`, `IpcConnectionError` teardown reasons).
- Same timeout semantics (per-request timer, entry dropped on fire, late response finds nothing).
- Server `connectionId`-scoped failure and response matching preserved via metadata + `where` predicates.
- The request-frame write still runs **inside the promise executor** (`register`'s `send` hook), so a throwing `socket.write` rejects the call instead of escaping synchronously — as the inline executor did before.
- Wire method names untouched; no protocol change.

## Gate chain (all exit 0 in the worktree)

- `bunx turbo run build` ✅
- `bunx turbo run check-types` ✅
- `bun run script/check-deps.ts` ✅ (1 pre-existing stale-doc note for packages/telemetry/AGENTS.md, unrelated)
- `bun run script/check-import-cycles.ts` ✅ (346 modules, 0 cycles)
- `bun run lint:tools` ✅
- `bun run lint` ✅
- `bunx ultracite check --formatter-enabled=false .` ✅ exit 0 (1 pre-existing warning in `apps/openomni/test/work-item-wiring.test.ts`, present on `origin/main`, out of scope)
- `bun run script/check-dead-exports.ts` ✅ (0 known, none new)
- `bun test --timeout 15000` ✅ exit 0 — 2514 pass / 0 fail across 292 files (two consecutive full runs); `packages/ipc`: 62 pass / 0 fail across 9 files

## Verification notes

- Existing IPC tests are the behavior pin and stayed green throughout: `failure-classes`, `disconnect`, `backpressure`, `transport-resilience`, `ipc-bidirectional`, `server-edges`.
- Net LOC: +226 / −69 (of which +98 the new module, +93 its tests; client/server net −34).
- Judgment call: the shared module is deliberately **not** re-exported from the package barrel (`src/index.ts`) — the barrel is the published driver-band contract and the registry is an internal implementation detail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the duplicated in-flight request registry that `packages/ipc/src/client.ts` and `packages/ipc/src/server.ts` each hand-rolled into a single shared `PendingCalls` class. Behavior is unchanged: same error classes and messages, same per-request timeout semantics, and server response matching and teardown stay scoped to the owning connection via entry metadata.

**Refactors**
- `PendingCalls` owns `register` / `settle` / `failAll` and clears each entry's timer on every removal path.
- The server stores its `connectionId` as per-entry metadata and uses a `where` predicate for connection-scoped settlement and failure.
- The request frame still writes inside the promise executor, so a throwing `socket.write` rejects the call rather than escaping synchronously.
- Adds 8 unit tests covering settle identity, unknown-id no-ops, timeout rejection, predicate scoping, and `failAll`.

<sup>Written for commit c4ae4c6054df30bfd163b6b23c47843804f1ce6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

