### PR TITLE
fix(channels): audit external surface claims

### DIFF
--- a/packages/channels/src/router/index.ts
+++ b/packages/channels/src/router/index.ts
@@ -101,11 +101,46 @@ export interface GatewayRouter {
  * the single arbiter; no session row is created or removed here (session
  * content is brain domain).
  */
-function claimResidentSurfaceSession(surfaceKey: string): string {
+function publishSurfaceStickinessClaim(
+  sink: GatewayRouterPorts["sink"],
+  surfaceKey: string,
+  requestedSessionId: string,
+  ownerSessionId: string,
+  mode: "external_resident_default" | "internal_claim_port",
+  expectedSessionId?: string,
+): void {
+  sink(Operational.Events.Info, {
+    traceId: newTraceId(),
+    time: Date.now(),
+    component: "gateway.router",
+    msg: "surface stickiness claim",
+    context: {
+      mode,
+      surfaceKey,
+      requestedSessionId,
+      ...(expectedSessionId === undefined ? {} : { expectedSessionId }),
+      ownerSessionId,
+      won: ownerSessionId === requestedSessionId,
+    },
+  });
+}
+
+function claimResidentSurfaceSession(
+  surfaceKey: string,
+  sink: GatewayRouterPorts["sink"],
+): string {
   const existing = SurfaceKey.lookup(surfaceKey);
   if (existing !== undefined) return existing;
-  const minted = crypto.randomUUID();
-  return SurfaceKey.claim(surfaceKey, minted);
+  const requestedSessionId = crypto.randomUUID();
+  const ownerSessionId = SurfaceKey.claim(surfaceKey, requestedSessionId);
+  publishSurfaceStickinessClaim(
+    sink,
+    surfaceKey,
+    requestedSessionId,
+    ownerSessionId,
+    "external_resident_default",
+  );
+  return ownerSessionId;
 }
 
 /**
@@ -380,7 +415,7 @@ export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
       // placement is brain judgment.
       let sessionId = pinned.activation?.durableSessionId;
       if (sessionId === undefined && route.selectedTarget.kind === "resident") {
-        sessionId = claimResidentSurfaceSession(extractSurfaceKey(pinned));
+        sessionId = claimResidentSurfaceSession(extractSurfaceKey(pinned), ports.sink);
       }
 
       return ports.deliver(buildDelivery(pinned, route.decision, waitContextOf(route), sessionId));
@@ -407,19 +442,14 @@ export function createGatewayRouter(ports: GatewayRouterPorts): GatewayRouter {
       // TODO(#708 residue): the internal surface-key namespace has no scoping
       // scheme yet — when one exists, this claim must be scoped to it and
       // cross-namespace claims rejected here.
-      ports.sink(Operational.Events.Info, {
-        traceId: newTraceId(),
-        time: Date.now(),
-        component: "gateway.router",
-        msg: "surface stickiness claim",
-        context: {
-          surfaceKey,
-          requestedSessionId: sessionId,
-          ...(expectedSessionId === undefined ? {} : { expectedSessionId }),
-          ownerSessionId,
-          won: ownerSessionId === sessionId,
-        },
-      });
+      publishSurfaceStickinessClaim(
+        ports.sink,
+        surfaceKey,
+        sessionId,
+        ownerSessionId,
+        "internal_claim_port",
+        expectedSessionId,
+      );
       return ownerSessionId;
     },
   };

--- a/packages/channels/test/router/ingest-sanitization.test.ts
+++ b/packages/channels/test/router/ingest-sanitization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Bus } from "@openomni/telemetry";
-import type { Gateway } from "@openomni/protocol";
+import type { Gateway, Ingress } from "@openomni/protocol";
+import { createGatewayRouter } from "../../src/router/index.js";
 import {
   deliveries,
   getRouter,
@@ -87,7 +88,36 @@ describe("ingest trust-boundary sanitization (audit A T2)", () => {
   });
 });
 
-describe("claimSurface observation (audit A T3)", () => {
+describe("surface stickiness claim observations (audit A T3)", () => {
+  it("publishes the CAS receipt through the injected sink for an external resident default", async () => {
+    const observed: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    const router = createGatewayRouter({
+      sink: (event, payload) =>
+        observed.push({ name: event.name, payload: payload as Record<string, unknown> }),
+      deliver: async (delivery): Promise<Ingress.IngressResult> => ({
+        mode: "direct",
+        target: delivery.event.target ?? { kind: "resident" },
+        sessionId: delivery.sessionId ?? "unrouted-session",
+        result: { output: "resident response", finishReason: "stop" },
+      }),
+    });
+
+    await router.ingest(makeEvent("user-1"));
+
+    const obs = observed.find(
+      (event) =>
+        event.name === "operational.info" &&
+        String(event.payload.msg) === "surface stickiness claim",
+    );
+    expect(obs?.payload.context).toMatchObject({
+      mode: "external_resident_default",
+      surfaceKey: "discord:guild:dev",
+      ownerSessionId: expect.any(String),
+      requestedSessionId: expect.any(String),
+      won: true,
+    });
+  });
+
   it("publishes a user-audit observation carrying the CAS receipt per claim", async () => {
     const router = getRouter();
     const observed: Array<{ name: string; payload: Record<string, unknown> }> = [];
@@ -105,6 +135,7 @@ describe("claimSurface observation (audit A T3)", () => {
     );
     expect(obs).toBeDefined();
     expect(obs?.payload.context).toMatchObject({
+      mode: "internal_claim_port",
       surfaceKey: "telegram:bot:chat:1",
       requestedSessionId: "sess-a",
       ownerSessionId: "sess-a",


### PR DESCRIPTION
## What and why
External resident surface-default claims now emit the same `operational.info` audit observation as the internal `claimSurface` port. Both paths use one receipt publisher and identify their source with `context.mode`.

## Duplication evidence
- `packages/channels/src/router/index.ts:104-157` owns the common CAS-receipt observation shape.
- `packages/channels/src/router/index.ts:418` invokes it after an external resident-default claim with `mode: external_resident_default`.
- `packages/channels/src/router/index.ts:443-450` invokes the same helper for the internal claim port with `mode: internal_claim_port`.

## Verification
- RED: `bun test --timeout 15000 packages/channels/test/router/ingest-sanitization.test.ts` failed because the injected sink had no external claim observation.
- GREEN: the same focused test passed (6 tests).
- Full gate chain passed: build, check-types, dependency and import-cycle checks, tool and repository lint, Ultracite, dead-export check, and `bun test --timeout 15000` (2507 passing).

## Notes
No protocol schema changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
External resident surface-default claims now emit the same `operational.info` audit observation as the internal `claimSurface` port, so both claim paths are auditable.

- Both paths publish through one shared receipt helper, distinguished by `context.mode` (`external_resident_default` vs `internal_claim_port`).
- No protocol schema changed.

<sup>Written for commit 5b394bc185d1f9e9570b9c6dd2c73b57b15da3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

