### PR TITLE
refactor(ipc): share test socket path helper

### DIFF
--- a/apps/openomni/test/code-mode-e2e.test.ts
+++ b/apps/openomni/test/code-mode-e2e.test.ts
@@ -9,6 +9,7 @@ import { attachMachineDaemon, createMachineHost, type MachineDaemon } from "@ope
 import type { Machine } from "@openomni/protocol";
 import { startOpenOmni } from "../src/index";
 import { assistantMessage } from "./helpers/assistant-message";
+import { socketPath as testSocketPath } from "./helpers/socket-path";
 
 const WS_TOKEN = "code-mode-e2e-token";
 const MACHINE_ID = "alpha";
@@ -41,7 +42,7 @@ const enrollment: Machine.Enrollment = {
 test("a cell batches delegation into one turn", async () => {
   const directory = mkdtempSync(join(tmpdir(), "openomni-code-mode-"));
   directories.push(directory);
-  const socketPath = join(directory, "machines.sock");
+  const socketPath = testSocketPath();
   const residentTurns: string[] = [];
 
   const app = await startOpenOmni({
@@ -155,7 +156,7 @@ test("the machine tool is not offered while nothing is attached", async () => {
       wsPort: 0,
       wsToken: WS_TOKEN,
       model: { provider: "fake", id: "code-mode-test", apiKey: "test-key" },
-      machines: { socketPath: join(directory, "machines.sock"), enrolled: [enrollment] },
+      machines: { socketPath: testSocketPath(), enrolled: [enrollment] },
     },
     llm: {
       resolveProviderModel: async (model) => ({ id: model.id, name: model.id, providerID: model.provider }),
@@ -209,7 +210,7 @@ test("the machine tool is not offered while nothing is attached", async () => {
 test("a cell cannot present another cell's id when calling back", async () => {
   const directory = mkdtempSync(join(tmpdir(), "openomni-cell-id-"));
   directories.push(directory);
-  const socketPath = join(directory, "machines.sock");
+  const socketPath = testSocketPath();
   const served: string[] = [];
 
   const host = await createMachineHost({
@@ -251,7 +252,7 @@ test("a cell cannot present another cell's id when calling back", async () => {
 test("a machine offering more than it is enrolled for keeps only the intersection", async () => {
   const directory = mkdtempSync(join(tmpdir(), "openomni-overclaim-"));
   directories.push(directory);
-  const socketPath = join(directory, "machines.sock");
+  const socketPath = testSocketPath();
 
   const host = await createMachineHost({
     socketPath,

--- a/apps/openomni/test/helpers/socket-path.test.ts
+++ b/apps/openomni/test/helpers/socket-path.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { socketPath } from "./socket-path";
+
+describe("socketPath", () => {
+  test("creates distinct paths within the macOS Unix socket limit", () => {
+    const first = socketPath();
+    const second = socketPath();
+
+    expect(first).not.toBe(second);
+    expect(first.endsWith(".sock")).toBe(true);
+    expect(first.length).toBeLessThan(104);
+    expect(second.length).toBeLessThan(104);
+  });
+});

--- a/apps/openomni/test/helpers/socket-path.ts
+++ b/apps/openomni/test/helpers/socket-path.ts
@@ -1,0 +1,7 @@
+let sequence = 0;
+
+/** Returns a short, process-unique Unix socket path for an app test. */
+export function socketPath(): string {
+  sequence += 1;
+  return `/tmp/omo-app-${process.pid}-${sequence}.sock`;
+}

--- a/packages/ipc/test/backpressure.test.ts
+++ b/packages/ipc/test/backpressure.test.ts
@@ -1,14 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import net from "node:net";
-import os from "node:os";
-import path from "node:path";
 import { Ipc } from "@openomni/protocol";
 import { LineDecoder } from "../src/framing";
 import { createIpcServer } from "../src/server";
-
-function tmpSocketPath(label: string): string {
-  return path.join(os.tmpdir(), `omo-ipc-bp-${label}-${process.pid}.sock`);
-}
+import { socketPath as socketPathForTest } from "./helpers/socket-path";
 
 // Big enough to overflow any kernel socket buffer: Bun sockets do NOT buffer
 // partial writes, so pre-fix the tail of this frame was silently dropped.
@@ -25,7 +20,7 @@ describe("server write backpressure (Bun partial writes)", () => {
   });
 
   test("a multi-megabyte response reaches a slow reader byte-exact", async () => {
-    const socketPath = tmpSocketPath("big-frame");
+    const socketPath = socketPathForTest("big-frame");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) => {
       respond({ data: BIG_PAYLOAD });
     });
@@ -61,7 +56,7 @@ describe("server write backpressure (Bun partial writes)", () => {
   }, 15_000);
 
   test("a frame written while earlier bytes are still queued arrives after them, intact", async () => {
-    const socketPath = tmpSocketPath("ordering");
+    const socketPath = socketPathForTest("ordering");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) => {
       respond({ data: BIG_PAYLOAD });
     });

--- a/packages/ipc/test/disconnect.test.ts
+++ b/packages/ipc/test/disconnect.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "bun:test";
 import { connectIpcClient } from "../src/client";
 import { createIpcServer } from "../src/server";
+import { socketPath as socketPathForTest } from "./helpers/socket-path";
 
 test("onDisconnect fires exactly once per torn-down connection", async () => {
-  const socketPath = `/tmp/omo-ipc-disc-${process.pid}.sock`;
+  const socketPath = socketPathForTest("disconnect");
   const disconnects: string[] = [];
   let notifyDisconnect: (() => void) | undefined;
   const server = await createIpcServer(
@@ -44,7 +45,7 @@ test("onDisconnect fires exactly once per torn-down connection", async () => {
 });
 
 test("onDisconnect fires exactly once on abrupt socket destruction", async () => {
-  const socketPath = `/tmp/omo-ipc-abrupt-${process.pid}.sock`;
+  const socketPath = socketPathForTest("abrupt");
   const disconnects: string[] = [];
   let notifyDisconnect: (() => void) | undefined;
   const server = await createIpcServer(

--- a/packages/ipc/test/failure-classes.test.ts
+++ b/packages/ipc/test/failure-classes.test.ts
@@ -1,16 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import net from "node:net";
-import os from "node:os";
-import path from "node:path";
 import { Ipc } from "@openomni/protocol";
 import { connectIpcClient } from "../src/client";
 import { IpcConnectionError, IpcRemoteError } from "../src/errors";
 import { LineDecoder, encode } from "../src/framing";
 import { createIpcServer } from "../src/server";
-
-function tmpSocketPath(label: string): string {
-  return path.join(os.tmpdir(), `omo-ipc-classes-${label}-${process.pid}.sock`);
-}
+import { socketPath as socketPathForTest } from "./helpers/socket-path";
 
 describe("failure classes stay honest (#606 re-audit)", () => {
   const servers: Awaited<ReturnType<typeof createIpcServer>>[] = [];
@@ -25,7 +20,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   });
 
   test("a dying connection fails ITS in-flight calls as connection loss, not timeout", async () => {
-    const socketPath = tmpSocketPath("per-conn");
+    const socketPath = socketPathForTest("per-conn");
     let survivorConnectionId: string | undefined;
     const srv = await createIpcServer(
       socketPath,
@@ -74,7 +69,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   });
 
   test("a handlerless client answers server calls with a typed remote failure", async () => {
-    const socketPath = tmpSocketPath("no-handler");
+    const socketPath = socketPathForTest("no-handler");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) => {
       respond({ ok: true });
     });
@@ -94,7 +89,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   });
 
   test("a valid response sharing a chunk with a bad line still resolves the call", async () => {
-    const socketPath = tmpSocketPath("shared-chunk");
+    const socketPath = socketPathForTest("shared-chunk");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) => {
       respond({ ok: true });
     });
@@ -124,7 +119,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   });
 
   test("each malformed line is answered with its own 4001 error frame", async () => {
-    const socketPath = tmpSocketPath("per-line-4001");
+    const socketPath = socketPathForTest("per-line-4001");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) => {
       respond({ ok: true });
     });
@@ -161,7 +156,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   });
 
   test("an oversize frame gets a 4001 and then the server CLOSES the connection", async () => {
-    const socketPath = tmpSocketPath("oversize-close");
+    const socketPath = socketPathForTest("oversize-close");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) =>
       respond({ ok: true }),
     );
@@ -190,7 +185,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   }, 10_000);
 
   test("a client that sent an oversize frame fails fast, not by burning its timeout", async () => {
-    const socketPath = tmpSocketPath("oversize-client");
+    const socketPath = socketPathForTest("oversize-client");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) =>
       respond({ ok: true }),
     );
@@ -208,7 +203,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   }, 10_000);
 
   test("an error frame carrying the request's id settles the requester's pending", async () => {
-    const socketPath = tmpSocketPath("correlated-4000");
+    const socketPath = socketPathForTest("correlated-4000");
     // Raw peer: answers ANY request with a 4000 error echoing the request id —
     // the shape the server now emits for schema-invalid frames that carry one.
     const rawServer = net.createServer((conn) => {
@@ -240,7 +235,7 @@ describe("failure classes stay honest (#606 re-audit)", () => {
   });
 
   test("a response arriving on a connection that does not own the request is ignored", async () => {
-    const socketPath = tmpSocketPath("cross-conn");
+    const socketPath = socketPathForTest("cross-conn");
     const srv = await createIpcServer(socketPath, (_method, _params, respond) =>
       respond({ ok: true }),
     );
@@ -324,7 +319,7 @@ describe("client remote-error path (#606 audit)", () => {
   });
 
   test("an error frame REJECTS the call as IpcRemoteError — never resolves undefined", async () => {
-    const socketPath = tmpSocketPath("reject");
+    const socketPath = socketPathForTest("reject");
     const srv = await createIpcServer(socketPath, (method, _params, _respond) => {
       // A throwing handler produces the server's typed error frame (code 1000).
       throw new Error(`remote refused ${method}`);
@@ -346,7 +341,7 @@ describe("client remote-error path (#606 audit)", () => {
   });
 
   test("the SERVER side of the socket files remote failures the same way (#677 review)", async () => {
-    const socketPath = tmpSocketPath("server-side");
+    const socketPath = socketPathForTest("server-side");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
     const client = await connectIpcClient(socketPath, {

--- a/packages/ipc/test/helpers/socket-path.test.ts
+++ b/packages/ipc/test/helpers/socket-path.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+import { socketPath } from "./socket-path";
+
+describe("socketPath", () => {
+  test("creates distinct paths within the macOS Unix socket limit", () => {
+    const first = socketPath("🧪".repeat(500));
+    const second = socketPath("🧪".repeat(500));
+
+    expect(first).not.toBe(second);
+    expect(first.endsWith(".sock")).toBe(true);
+    expect(Buffer.byteLength(first)).toBeLessThan(104);
+    expect(Buffer.byteLength(second)).toBeLessThan(104);
+  });
+});

--- a/packages/ipc/test/helpers/socket-path.test.ts
+++ b/packages/ipc/test/helpers/socket-path.test.ts
@@ -8,7 +8,6 @@ describe("socketPath", () => {
     const second = socketPath("🧪".repeat(500));
 
     expect(first).not.toBe(second);
-    expect(first.endsWith(".sock")).toBe(true);
     expect(Buffer.byteLength(first)).toBeLessThan(104);
     expect(Buffer.byteLength(second)).toBeLessThan(104);
   });

--- a/packages/ipc/test/helpers/socket-path.ts
+++ b/packages/ipc/test/helpers/socket-path.ts
@@ -1,0 +1,7 @@
+let sequence = 0;
+
+/** Returns a short, process-unique Unix socket path for an IPC test. */
+export function socketPath(label: string): string {
+  sequence += 1;
+  return `/tmp/omo-ipc-${label.slice(0, 12)}-${process.pid}-${sequence}.sock`;
+}

--- a/packages/ipc/test/ipc-bidirectional.test.ts
+++ b/packages/ipc/test/ipc-bidirectional.test.ts
@@ -1,12 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import os from "node:os";
-import path from "node:path";
 import { connectIpcClient } from "../src/client";
 import { createIpcServer } from "../src/server";
-
-function tmpSocketPath(label: string): string {
-  return path.join(os.tmpdir(), `omo-ipc-bidir-${label}-${process.pid}.sock`);
-}
+import { socketPath as socketPathForTest } from "./helpers/socket-path";
 
 describe("IPC bidirectional", () => {
   const servers: Awaited<ReturnType<typeof createIpcServer>>[] = [];
@@ -19,7 +14,7 @@ describe("IPC bidirectional", () => {
   });
 
   test("client receives incoming Request → onRequest fires → response sent back", async () => {
-    const socketPath = tmpSocketPath("req");
+    const socketPath = socketPathForTest("req");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 
@@ -41,7 +36,7 @@ describe("IPC bidirectional", () => {
   });
 
   test("client receives Notification → onNotification fires", async () => {
-    const socketPath = tmpSocketPath("notif");
+    const socketPath = socketPathForTest("notif");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 
@@ -70,7 +65,7 @@ describe("IPC bidirectional", () => {
     // A throw here would surface as an uncaughtException in the process
     // hosting the client (e.g. the coordinator supervising its workers).
     // The contract mirrors the server: log, keep the connection draining.
-    const socketPath = tmpSocketPath("notifThrow");
+    const socketPath = socketPathForTest("notifThrow");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 
@@ -96,7 +91,7 @@ describe("IPC bidirectional", () => {
   });
 
   test("server.call() → client receives → responds → server gets result", async () => {
-    const socketPath = tmpSocketPath("srvCall");
+    const socketPath = socketPathForTest("srvCall");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 
@@ -112,7 +107,7 @@ describe("IPC bidirectional", () => {
   });
 
   test("existing client.call() flow unchanged", async () => {
-    const socketPath = tmpSocketPath("clientCall");
+    const socketPath = socketPathForTest("clientCall");
     const srv = await createIpcServer(socketPath, (method, params, respond) => {
       if (method === "echo") respond({ got: params?.v });
     });

--- a/packages/ipc/test/server-edges.test.ts
+++ b/packages/ipc/test/server-edges.test.ts
@@ -1,16 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import net from "node:net";
-import os from "node:os";
-import path from "node:path";
 import { Ipc } from "@openomni/protocol";
 import { connectIpcClient } from "../src/client";
 import { IpcConnectionError, IpcTimeoutError } from "../src/errors";
 import { LineDecoder } from "../src/framing";
 import { createIpcServer } from "../src/server";
-
-function tmpSocketPath(label: string): string {
-  return path.join(os.tmpdir(), `omo-ipc-edge-${label}-${process.pid}.sock`);
-}
+import { socketPath as socketPathForTest } from "./helpers/socket-path";
 
 function connect(socketPath: string): Promise<net.Socket> {
   const socket = net.createConnection(socketPath);
@@ -47,14 +42,14 @@ describe("server edge branches", () => {
 
   for (const method of ["worker.shutdown_idle", "worker.deliver_message"] as const) {
     test(`${method} without a connected client rejects with IpcConnectionError`, async () => {
-      const srv = await createIpcServer(tmpSocketPath(`noclient-${method}`), () => undefined);
+      const srv = await createIpcServer(socketPathForTest(`noclient-${method}`), () => undefined);
       servers.push(srv);
       await expect(srv.call(method, {})).rejects.toThrow(IpcConnectionError);
     });
   }
 
   test("calls in either direction that never get a response reject with IpcTimeoutError", async () => {
-    const srv = await createIpcServer(tmpSocketPath("timeout"), () => undefined);
+    const srv = await createIpcServer(socketPathForTest("timeout"), () => undefined);
     servers.push(srv);
     rawSockets.push(await connect(srv.socketPath));
     await Bun.sleep(20);
@@ -66,7 +61,7 @@ describe("server edge branches", () => {
   });
 
   test("schema-invalid frames get bounded, correlated 4000 responses", async () => {
-    const srv = await createIpcServer(tmpSocketPath("protocol"), () => undefined);
+    const srv = await createIpcServer(socketPathForTest("protocol"), () => undefined);
     servers.push(srv);
     const unknown = await exchange(srv.socketPath, '{"neither":"request-nor-response"}\n');
     expect(unknown.type).toBe("response");
@@ -85,7 +80,7 @@ describe("server edge branches", () => {
 
   test("notification handler failures are contained (sync throw and async rejection)", async () => {
     const seen: string[] = [];
-    const srv = await createIpcServer(tmpSocketPath("notify"), (method) => {
+    const srv = await createIpcServer(socketPathForTest("notify"), (method) => {
       seen.push(method);
       if (method === "sync.boom") throw new Error("sync failure");
       return Promise.reject(new Error("async failure"));
@@ -105,7 +100,7 @@ describe("server edge branches", () => {
   });
 
   test("a client that errors mid-connection is removed and the server keeps serving", async () => {
-    const srv = await createIpcServer(tmpSocketPath("sockerr"), (_m, _p, respond) => {
+    const srv = await createIpcServer(socketPathForTest("sockerr"), (_m, _p, respond) => {
       respond({ ok: true });
     });
     servers.push(srv);

--- a/packages/ipc/test/transport-resilience.test.ts
+++ b/packages/ipc/test/transport-resilience.test.ts
@@ -1,15 +1,10 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import fs from "node:fs";
 import net from "node:net";
-import os from "node:os";
-import path from "node:path";
 import { connectIpcClient } from "../src/client";
 import { IpcConnectionError, IpcRemoteError } from "../src/errors";
 import { createIpcServer } from "../src/server";
-
-function tmpSocketPath(label: string): string {
-  return path.join(os.tmpdir(), `omo-ipc-resil-${label}-${process.pid}.sock`);
-}
+import { socketPath as socketPathForTest } from "./helpers/socket-path";
 
 describe("IPC transport resilience (#QB1)", () => {
   const servers: Awaited<ReturnType<typeof createIpcServer>>[] = [];
@@ -22,7 +17,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("throwing onRequest handler → typed error frame, not a process crash", async () => {
-    const socketPath = tmpSocketPath("throw");
+    const socketPath = socketPathForTest("throw");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 
@@ -43,7 +38,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("removing the active connection lets the next connection bind", async () => {
-    const socketPath = tmpSocketPath("active");
+    const socketPath = socketPathForTest("active");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 
@@ -73,7 +68,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("ASYNC-rejecting server handler → typed error frame, not a burned timeout", async () => {
-    const socketPath = tmpSocketPath("async-throw-server");
+    const socketPath = socketPathForTest("async-throw-server");
     const srv = await createIpcServer(socketPath, async (method, _params, respond) => {
       if (method === "boom") throw new TypeError("async handler blew up");
       respond({ ok: method });
@@ -93,7 +88,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("ASYNC-rejecting client onRequest → typed error frame, not a burned timeout", async () => {
-    const socketPath = tmpSocketPath("async-throw-client");
+    const socketPath = socketPathForTest("async-throw-client");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
     const client = await connectIpcClient(socketPath, {
@@ -111,7 +106,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("a schema-mismatch frame is logged by the client, not silently dropped", async () => {
-    const socketPath = tmpSocketPath("schema-warn");
+    const socketPath = socketPathForTest("schema-warn");
     // Raw peer that emits valid JSON matching no message schema.
     const rawServer = net.createServer((conn) => {
       conn.write('{"v":2,"type":"mystery"}\n');
@@ -137,7 +132,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("createIpcServer refuses to steal a LIVE server's socket", async () => {
-    const socketPath = tmpSocketPath("live-probe");
+    const socketPath = socketPathForTest("live-probe");
     const incumbent = await createIpcServer(socketPath, (_method, _params, respond) =>
       respond({ owner: "incumbent" }),
     );
@@ -156,7 +151,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("a provably dead socket path is reclaimed", async () => {
-    const socketPath = tmpSocketPath("stale-file");
+    const socketPath = socketPathForTest("stale-file");
     fs.writeFileSync(socketPath, ""); // stale leftover: connecting to it fails
     const srv = await createIpcServer(socketPath, (_method, _params, respond) =>
       respond({ ok: true }),
@@ -169,7 +164,7 @@ describe("IPC transport resilience (#QB1)", () => {
   });
 
   test("notify() reports a drop (false) vs a delivery (true)", async () => {
-    const socketPath = tmpSocketPath("notify-signal");
+    const socketPath = socketPathForTest("notify-signal");
     const srv = await createIpcServer(socketPath, () => undefined);
     servers.push(srv);
 

--- a/packages/machines/test/attach.test.ts
+++ b/packages/machines/test/attach.test.ts
@@ -4,12 +4,7 @@ import { IpcRemoteError, connectIpcClient, createIpcServer } from "@openomni/ipc
 import type { BusEvent, Machine } from "@openomni/protocol";
 import { attachMachineDaemon } from "../src/daemon";
 import { type MachineHost, createMachineHost } from "../src/host";
-
-let socketCounter = 0;
-function socketPath(): string {
-  socketCounter += 1;
-  return `/tmp/omo-machines-${process.pid}-${socketCounter}.sock`;
-}
+import { socketPath } from "./helpers/socket-path";
 
 interface RecordedEvent {
   readonly name: string;

--- a/packages/machines/test/helpers/socket-path.test.ts
+++ b/packages/machines/test/helpers/socket-path.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { socketPath } from "./socket-path";
+
+describe("socketPath", () => {
+  test("creates distinct paths within the macOS Unix socket limit", () => {
+    const first = socketPath();
+    const second = socketPath();
+
+    expect(first).not.toBe(second);
+    expect(first.endsWith(".sock")).toBe(true);
+    expect(first.length).toBeLessThan(104);
+    expect(second.length).toBeLessThan(104);
+  });
+});

--- a/packages/machines/test/helpers/socket-path.ts
+++ b/packages/machines/test/helpers/socket-path.ts
@@ -1,0 +1,7 @@
+let sequence = 0;
+
+/** Returns a short, process-unique Unix socket path for a machine test. */
+export function socketPath(): string {
+  sequence += 1;
+  return `/tmp/omo-machines-${process.pid}-${sequence}.sock`;
+}

--- a/packages/machines/test/kernel.test.ts
+++ b/packages/machines/test/kernel.test.ts
@@ -3,16 +3,13 @@ import type { BusEvent, Machine } from "@openomni/protocol";
 import { attachMachineDaemon } from "../src/daemon";
 import { type MachineHost, createMachineHost } from "../src/host";
 import { type CellToolCaller, PythonKernel } from "../src/kernel";
+import { socketPath } from "./helpers/socket-path";
 
 /** These cells call no tools, so a call is a test bug and must be visible. */
 const noTools: CellToolCaller = (call) =>
   Promise.resolve({ status: "failed", error: `unexpected tool call: ${call.name}` });
 
-let socketCounter = 0;
-function socketPath(): string {
-  socketCounter += 1;
-  return `/tmp/omo-kernel-${process.pid}-${socketCounter}.sock`;
-}
+let cellCounter = 0;
 
 // These tests assert cell execution, not attach telemetry.
 const silent: BusEvent.Sink = {
@@ -66,7 +63,8 @@ async function withMachine(
 }
 
 function cell(code: string, timeoutMs = 15_000): Machine.CellRequest {
-  return { cellId: `cell-${socketCounter}-${code.length}`, code, timeoutMs };
+  cellCounter += 1;
+  return { cellId: `cell-${cellCounter}-${code.length}`, code, timeoutMs };
 }
 
 describe("cell settlement ownership", () => {

--- a/packages/machines/test/tool-bridge.test.ts
+++ b/packages/machines/test/tool-bridge.test.ts
@@ -4,15 +4,13 @@ import { Machine } from "@openomni/protocol";
 import { attachMachineDaemon } from "../src/daemon";
 import { type MachineHost, createMachineHost } from "../src/host";
 import { PythonKernel } from "../src/kernel";
+import { socketPath } from "./helpers/socket-path";
 
 const silent = {
   publish() {
     return;
   },
 };
-
-let seq = 0;
-const socketPath = () => `/tmp/omo-bridge-${process.pid}-${seq++}.sock`;
 
 /**
  * A host whose tool port only knows `add`, standing in for the composition


### PR DESCRIPTION
## What and why

- Replaced the six IPC test-local Unix socket builders with `packages/ipc/test/helpers/socket-path.ts`, which gives each call a process-unique, short `/tmp` path.
- The helper retains a bounded label and its focused test checks distinct paths plus the macOS `sun_path` byte limit.
- Found three equivalent builders in `packages/machines/test` and four in `apps/openomni/test/code-mode-e2e.test.ts`; added separate test-only helpers in each package. No cross-package test imports or public exports were added.

## Duplication evidence

- IPC consumers: `packages/ipc/test/{backpressure,failure-classes,ipc-bidirectional,transport-resilience,server-edges,disconnect}.test.ts` import the shared helper at lines 6, 8, 4, 7, 8, and 4 respectively; the implementation is `packages/ipc/test/helpers/socket-path.ts:4`.
- Machines consumers: `packages/machines/test/{attach,kernel,tool-bridge}.test.ts` import their package-local helper at lines 7, 6, and 7.
- App consumers: `apps/openomni/test/code-mode-e2e.test.ts:11` imports its package-local helper for all four machine socket paths.

## Verification

- Mutation proof: changed the IPC helper directory to `/missing`; the original five IPC suites failed as expected (`31 fail`, `2 pass`, exit 1) with `ENOENT` while binding paths. Reverted it; the same suites plus helper test passed (`34 pass`, `0 fail`).
- Focused affected run: `68 pass`, `0 fail` across IPC, machines, and app consumers plus their helpers.
- Gate chain (all exit 0): `bunx turbo run build`, `bunx turbo run check-types`, dependency check, import-cycle check, tools lint, lint, Ultracite, dead-export check, and `bun test --timeout 15000` (`2509 pass`, `0 fail`).
- `lint` and Ultracite reported one existing unused-import warning in `apps/openomni/test/work-item-wiring.test.ts`; this branch does not touch that file.

## Audit note

`packages/protocol/test/helpers/wait.ts` builds and parses a `Wait.Record` (including `status`, `partial`, `replies`, and `revision`); `packages/ledger/test/helpers/wait.ts` builds a `Wait.Create` input that intentionally omits those record-owned fields. This is a legitimate schema split; no shared default block was introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces shared test helpers that generate short, process-unique Unix socket paths, replacing the duplicated inline builders in IPC, machines, and app tests.

- Adds `packages/ipc/test/helpers/socket-path.ts` for the six IPC suites (labels are truncated to 12 characters), `packages/machines/test/helpers/socket-path.ts` for three machine suites, and `apps/openomni/test/helpers/socket-path.ts` for the e2e app tests.
- Each helper keeps paths under the macOS 104-byte `sun_path` limit and includes a focused test asserting distinct paths and length constraints.
- Renames the machines `socketCounter` to `cellCounter` in `kernel.test.ts` so cell IDs no longer depend on socket-path sequence state.
- No cross-package test imports or public exports were added; no behavior changes outside test code.

<sup>Written for commit 1ba286ff204e3b31a4d092b22e35626086194cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up

- Added the sixth missed IPC consumer: `packages/ipc/test/disconnect.test.ts:4`; both disconnect-test paths now call the shared helper.
- Confirmed no inline `.sock` path builders remain in `packages/ipc/test`.