### PR TITLE
fix(ledger): atomic egress claims, deterministic grant resolution, honest chain accounting

### DIFF
--- a/packages/channels/src/router/messaging/send.ts
+++ b/packages/channels/src/router/messaging/send.ts
@@ -253,26 +253,14 @@ function recordAdmission(
   return raced;
 }
 
-function recordDebitOnce(input: SendInput, sendClass: MessageClass): void {
-  try {
-    EgressBudgetStore.record({
-      id: `gateway-send:${input.messageId}`,
-      senderId: input.senderId,
-      targetActorId: input.target.actorId,
-      class: sendClass,
-      at: input.at,
-    });
-  } catch (error) {
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "code" in error &&
-      error.code === "SQLITE_CONSTRAINT_PRIMARYKEY"
-    ) {
-      return;
-    }
-    throw error;
-  }
+function debitRow(input: SendInput, sendClass: MessageClass): Gateway.EgressDebitRow {
+  return {
+    id: `gateway-send:${input.messageId}`,
+    senderId: input.senderId,
+    targetActorId: input.target.actorId,
+    class: sendClass,
+    at: input.at,
+  };
 }
 
 export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAgentMessaging {
@@ -359,30 +347,26 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
         const budget = ports
           .budgets?.()
           .find((candidate) => candidate.targetActorId === input.target.actorId);
-        const state =
-          budget === undefined
-            ? { countInWindow: 0, notifyInWindow: 0, converseInWindow: 0 }
-            : EgressBudgetStore.readState(
-                input.senderId,
-                input.target.actorId,
-                input.at - budget.windowMs,
-              );
-        const verdict = evaluateSocialBudget(budget, state, { class: sendClass, at: input.at });
-        if (verdict !== "allow") {
+        const claim = EgressBudgetStore.claim(
+          debitRow(input, sendClass),
+          input.at - (budget?.windowMs ?? 0),
+          (state) => evaluateSocialBudget(budget, state, { class: sendClass, at: input.at }),
+        );
+        if (claim.kind === "refused") {
           return deny(
             input,
-            verdict.suppress,
-            `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${verdict.suppress})`,
+            claim.reason.suppress,
+            `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${claim.reason.suppress})`,
           );
         }
       }
       admission = recordAdmission(input, resolution.target, budgeted, sendClass);
     }
     if (admission.budgeted) {
-      // Deterministic identity closes both sides of the admission/debit crash
-      // window: missing debit is appended; an already-recorded debit is a
-      // proven resume and changes no budget count.
-      recordDebitOnce(input, admission.sendClass);
+      // Repair admissions written by an older process (or a crash between its
+      // admission and debit). Deterministic claim identity makes this a no-op
+      // for the normal claim-before-admission path.
+      EgressBudgetStore.claim(debitRow(input, admission.sendClass), input.at, () => "allow");
     }
     // #219 escalation seam (DEFERRED, out of this PR): the autonomous
     // timer-fired 봉수 rung-advance would attach its counting coordinate HERE —

--- a/packages/channels/test/router/messaging/send.test.ts
+++ b/packages/channels/test/router/messaging/send.test.ts
@@ -24,6 +24,26 @@ const flushBus = () => new Promise<void>((resolve) => queueMicrotask(() => resol
 let deliveries: OutboundMessage[];
 let grants: SenderTargetGrant[];
 
+function inspectDebitCount(): number {
+  let count: number | undefined;
+  EgressBudgetStore.claim(
+    {
+      id: "test:inspection-never-recorded",
+      senderId: "actor:sender",
+      targetActorId: "actor:target",
+      class: "notify",
+      at: messagingNow,
+    },
+    0,
+    (state) => {
+      count = state.countInWindow;
+      return "inspect" as const;
+    },
+  );
+  if (count === undefined) throw new Error("egress claim evaluator was not called");
+  return count;
+}
+
 function messaging() {
   return createExistingAgentMessaging({
     deliver: (message) => {
@@ -475,7 +495,7 @@ async function probe(point: FaultPoint): Promise<Probe> {
     receipts: [resumed],
     effects: external.size,
     attempts,
-    debits: EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow,
+    debits: inspectDebitCount(),
     wait: input.waitSpec === undefined ? undefined : WaitStore.get(input.waitSpec.waitId),
   };
 }

--- a/packages/channels/test/router/messaging/social-budget.test.ts
+++ b/packages/channels/test/router/messaging/social-budget.test.ts
@@ -18,6 +18,26 @@ const ZERO_STATE: Gateway.EgressDebitState = {
   converseInWindow: 0,
 };
 
+function inspectDebitState(senderId: string, targetActorId: string): Gateway.EgressDebitState {
+  let observed: Gateway.EgressDebitState | undefined;
+  EgressBudgetStore.claim(
+    {
+      id: "test:inspection-never-recorded",
+      senderId,
+      targetActorId,
+      class: "notify",
+      at: messagingNow,
+    },
+    0,
+    (state) => {
+      observed = state;
+      return "inspect" as const;
+    },
+  );
+  if (observed === undefined) throw new Error("egress claim evaluator was not called");
+  return observed;
+}
+
 const budget = (overrides: Partial<Gateway.SocialBudget> = {}): Gateway.SocialBudget => ({
   id: "budget:target",
   targetActorId: "actor:target",
@@ -173,7 +193,7 @@ describe("send kernel active-egress gate (#219 seam)", () => {
     expect(receipt.kind).toBe("sent");
     expect(deliveries).toEqual(["message:test"]);
     // The gate never touched the debit ledger.
-    expect(EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow).toBe(0);
+    expect(inspectDebitState("actor:sender", "actor:target").countInWindow).toBe(0);
   });
 
   test("fail-safe default: gate wired but no budget entry → cold proactive denied budget_exhausted", async () => {
@@ -182,7 +202,7 @@ describe("send kernel active-egress gate (#219 seam)", () => {
     if (receipt.kind !== "denied") throw new Error("expected denial");
     expect(receipt.code).toBe("budget_exhausted");
     expect(deliveries).toHaveLength(0);
-    expect(EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow).toBe(0);
+    expect(inspectDebitState("actor:sender", "actor:target").countInWindow).toBe(0);
   });
 
   test("an admitted send records a debit (record-before-act)", async () => {
@@ -190,7 +210,7 @@ describe("send kernel active-egress gate (#219 seam)", () => {
     const receipt = await messaging().send(buildSendInput());
     expect(receipt.kind).toBe("sent");
     expect(deliveries).toEqual(["message:test"]);
-    const state = EgressBudgetStore.readState("actor:sender", "actor:target", 0);
+    const state = inspectDebitState("actor:sender", "actor:target");
     expect(state.countInWindow).toBe(1);
     expect(state.notifyInWindow).toBe(1);
     expect(state.lastSendAt).toBe(messagingNow);
@@ -255,6 +275,6 @@ describe("send kernel active-egress gate (#219 seam)", () => {
     const receipt = await messaging().send(buildSendInput());
     expect(receipt.kind).toBe("sent");
     expect(deliveries).toEqual(["message:test"]);
-    expect(EgressBudgetStore.readState("actor:sender", "actor:target", 0).countInWindow).toBe(0);
+    expect(inspectDebitState("actor:sender", "actor:target").countInWindow).toBe(0);
   });
 });

--- a/packages/ledger/src/bus-persistence/chain-query.ts
+++ b/packages/ledger/src/bus-persistence/chain-query.ts
@@ -27,6 +27,7 @@ function walkChain(rows: HashChainRow[]): ChainIntegrityResult {
   if (rows.length === 0) return { valid: true, totalVerified: 0 };
 
   let expectedPrev = GENESIS_SEED;
+  let totalVerified = 0;
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i] as HashChainRow | undefined;
     if (!row) continue;
@@ -40,7 +41,7 @@ function walkChain(rows: HashChainRow[]): ChainIntegrityResult {
     if (row.prev_hash !== expectedPrev) {
       return {
         valid: false,
-        totalVerified: i,
+        totalVerified,
         brokenAtId: row.id,
         brokenAtEventType: row.event_type,
       };
@@ -57,14 +58,15 @@ function walkChain(rows: HashChainRow[]): ChainIntegrityResult {
     if (recomputed !== row.event_hash) {
       return {
         valid: false,
-        totalVerified: i,
+        totalVerified,
         brokenAtId: row.id,
         brokenAtEventType: row.event_type,
       };
     }
 
     expectedPrev = row.event_hash;
+    totalVerified += 1;
   }
 
-  return { valid: true, totalVerified: rows.length };
+  return { valid: true, totalVerified };
 }

--- a/packages/ledger/src/channel-grant/index.ts
+++ b/packages/ledger/src/channel-grant/index.ts
@@ -37,6 +37,66 @@ function specificity(grant: Actor.ChannelGrant): number {
   return (grant.workspace === undefined ? 0 : 1) + (grant.channel === undefined ? 0 : 1);
 }
 
+const treatmentRestriction: Record<Actor.InboundTreatment, number> = {
+  drop: 0,
+  evidence_only: 1,
+  full_access: 2,
+};
+
+const defaultTierRestriction: Record<Actor.TrustTier, number> = {
+  assigned_worker: 1,
+  observer: 2,
+  collaborator: 3,
+  manager: 4,
+  co_owner: 5,
+  owner: 6,
+};
+
+const kindRestriction: Record<Actor.ChannelGrantKind, number> = {
+  blocked_channel: 0,
+  broadcast_channel: 1,
+  trusted_channel: 2,
+};
+
+function effectiveTreatment(grant: Actor.ChannelGrant): Actor.InboundTreatment {
+  const treatment = grant.inboundTreatment ?? defaultTreatment(grant.kind);
+  if (grant.kind === "blocked_channel" || treatment === "drop") return "drop";
+  if (grant.kind === "broadcast_channel") return "evidence_only";
+  return treatment;
+}
+
+function compareStableText(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * Resolution keeps the existing specificity lattice, then orders equal-score
+ * grants fail-closed: effective treatment (drop → evidence → full), absent or
+ * lower-authority default tier, intrinsically restrictive kind, then grant ID
+ * by code-unit order. IDs are unique stable identities, so the final key makes
+ * this a backend- and insertion-independent total order.
+ */
+function compareResolutionOrder(a: Actor.ChannelGrant, b: Actor.ChannelGrant): number {
+  const specificityOrder = specificity(b) - specificity(a);
+  if (specificityOrder !== 0) return specificityOrder;
+
+  const treatmentOrder =
+    treatmentRestriction[effectiveTreatment(a)] - treatmentRestriction[effectiveTreatment(b)];
+  if (treatmentOrder !== 0) return treatmentOrder;
+
+  const defaultTierOrder =
+    (a.defaultTier === undefined ? 0 : defaultTierRestriction[a.defaultTier]) -
+    (b.defaultTier === undefined ? 0 : defaultTierRestriction[b.defaultTier]);
+  if (defaultTierOrder !== 0) return defaultTierOrder;
+
+  const kindOrder = kindRestriction[a.kind] - kindRestriction[b.kind];
+  if (kindOrder !== 0) return kindOrder;
+
+  return compareStableText(a.id, b.id);
+}
+
 export namespace ChannelGrantStore {
   export type Grant = Actor.ChannelGrant;
 
@@ -57,7 +117,7 @@ export namespace ChannelGrantStore {
     const grants = requireAdapter()
       .list()
       .filter((grant) => matches(grant, input))
-      .sort((a, b) => specificity(b) - specificity(a));
+      .sort(compareResolutionOrder);
     const grant = grants[0];
     if (!grant) return undefined;
     return {

--- a/packages/ledger/src/egress/index.ts
+++ b/packages/ledger/src/egress/index.ts
@@ -1,23 +1,20 @@
 /**
- * EgressBudgetStore: the active-egress debit ledger (#219, perimeter domain —
- * gateway-design §4). Records ADMITTED proactive sends and folds the window
- * projection the pure budget evaluator consumes.
+ * EgressBudgetStore: atomic active-egress counted-window claims (#219,
+ * perimeter domain — gateway-design §4).
  *
- * Perimeter isolation (S8): consumed ONLY by the channels gateway router (the
- * send kernel), exactly like the wait store — the brain never reaches it. A
- * missing sub-adapter fails closed: the egress gate must never fabricate an
- * "admitted" answer.
- *
- * Record-before-act: the debit is written when a send is ADMITTED (not
- * suppressed), so split outreach across separate calls cannot evade the cap and
- * the cooldown clock survives a restart.
+ * Perimeter isolation (S8): consumed ONLY by the channels gateway router. A
+ * missing sub-adapter fails closed; storage errors propagate before any send.
  */
 
 import type { Gateway } from "@openomni/protocol";
-import { requireSubAdapter } from "../storage/timestamped-store";
 import { Storage } from "../storage/storage";
+import { requireSubAdapter } from "../storage/timestamped-store";
 
 export namespace EgressBudgetStore {
+  export type ClaimResult<Refusal> =
+    | Readonly<{ kind: "claimed" }>
+    | Readonly<{ kind: "refused"; reason: Refusal }>;
+
   function subAdapter(): NonNullable<Storage.Adapter["egressBudget"]> {
     return requireSubAdapter(
       Storage.get().egressBudget,
@@ -25,21 +22,25 @@ export namespace EgressBudgetStore {
     );
   }
 
-  /** Append one admitted-send debit row (record-before-act). */
-  export function record(row: Gateway.EgressDebitRow): void {
-    subAdapter().record(row);
-  }
-
   /**
-   * Fold the window projection for one (sender, target) pair. `windowStartAt`
-   * is the caller's `at - budget.windowMs`; `lastSendAt` is window-independent
-   * (the cooldown clock runs off the most recent admitted send).
+   * Atomically evaluate and append one counted-window claim. `windowStartAt`
+   * is the caller's inclusive lower bound. The evaluator stays at the policy
+   * boundary; the adapter only serializes projection-read + append.
    */
-  export function readState(
-    senderId: string,
-    targetActorId: string,
+  export function claim<Refusal>(
+    row: Gateway.EgressDebitRow,
     windowStartAt: number,
-  ): Gateway.EgressDebitState {
-    return subAdapter().readState(senderId, targetActorId, windowStartAt);
+    evaluate: (state: Gateway.EgressDebitState) => "allow" | Refusal,
+  ): ClaimResult<Refusal> {
+    const refusals: Refusal[] = [];
+    const result = subAdapter().claim(row, windowStartAt, (state) => {
+      const verdict = evaluate(state);
+      if (verdict === "allow") return true;
+      refusals.push(verdict);
+      return false;
+    });
+    return result === "claimed"
+      ? { kind: "claimed" }
+      : { kind: "refused", reason: refusals[0] as Refusal };
   }
 }

--- a/packages/ledger/src/storage/counted-window-claim.ts
+++ b/packages/ledger/src/storage/counted-window-claim.ts
@@ -1,0 +1,24 @@
+export type CountedWindowClaimResult = "claimed" | "refused";
+
+/**
+ * Atomically claims one item against a counted window.
+ *
+ * The caller owns the persisted row and window projection; this primitive owns
+ * the indivisible read/decision/append sequence. `alreadyClaimed` makes retrying
+ * a deterministic claim idempotent without charging the window twice.
+ */
+export function claimWithinCountedWindow<State>(operations: {
+  transaction<T>(operation: () => T): T;
+  alreadyClaimed(): boolean;
+  readWindowState(): State;
+  canClaim(state: State): boolean;
+  append(): void;
+}): CountedWindowClaimResult {
+  return operations.transaction(() => {
+    if (operations.alreadyClaimed()) return "claimed";
+    const state = operations.readWindowState();
+    if (!operations.canClaim(state)) return "refused";
+    operations.append();
+    return "claimed";
+  });
+}

--- a/packages/ledger/src/storage/sqlite-egress-budget-adapter.ts
+++ b/packages/ledger/src/storage/sqlite-egress-budget-adapter.ts
@@ -1,47 +1,89 @@
 import { Gateway, type Storage as ProtocolStorage } from "@openomni/protocol";
 import type { Database } from "bun:sqlite";
+import { claimWithinCountedWindow } from "./counted-window-claim.js";
 
 /**
- * Durable active-egress debit rows (#219, perimeter domain — gateway-design
- * §4). Append-only: one row per ADMITTED proactive send. `readState` folds the
- * window projection the pure budget evaluator consumes in a single query so the
- * gate reads counts + the cooldown clock without materializing rows. The write
- * shape is owned by the EgressBudgetStore; this adapter re-validates on read
- * across the persistence boundary.
+ * Durable active-egress counted-window claims (#219, perimeter domain —
+ * gateway-design §4). The projection read and admitted-row append run under
+ * one BEGIN IMMEDIATE so two connections cannot both consume the same
+ * remaining slot. Append-only: one row per ADMITTED proactive send.
  */
 export function createSqliteEgressBudgetAdapter(
   db: Database,
 ): ProtocolStorage.EgressBudgetSubAdapter {
   return {
-    record(row) {
+    claim(row, windowStartAt, canClaim) {
       const parsed = Gateway.EgressDebitRow.parse(row);
-      db.query(
-        `INSERT INTO egress_debit (id, sender_id, target_actor_id, class, at, time_created)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-      ).run(parsed.id, parsed.senderId, parsed.targetActorId, parsed.class, parsed.at, Date.now());
-    },
-    readState(senderId, targetActorId, windowStartAt) {
-      const row = db
-        .query(
-          `SELECT
-             COUNT(*) FILTER (WHERE at >= ?) AS count_in_window,
-             COUNT(*) FILTER (WHERE at >= ? AND class = 'notify') AS notify_in_window,
-             COUNT(*) FILTER (WHERE at >= ? AND class = 'converse') AS converse_in_window,
-             MAX(at) AS last_send_at
-           FROM egress_debit
-           WHERE sender_id = ? AND target_actor_id = ?`,
-        )
-        .get(windowStartAt, windowStartAt, windowStartAt, senderId, targetActorId) as {
-        count_in_window: number;
-        notify_in_window: number;
-        converse_in_window: number;
-        last_send_at: number | null;
-      } | null;
-      return Gateway.EgressDebitState.parse({
-        countInWindow: row?.count_in_window ?? 0,
-        notifyInWindow: row?.notify_in_window ?? 0,
-        converseInWindow: row?.converse_in_window ?? 0,
-        ...(row?.last_send_at == null ? {} : { lastSendAt: row.last_send_at }),
+      return claimWithinCountedWindow({
+        transaction: (operation) => db.transaction(operation).immediate(),
+        alreadyClaimed: () => {
+          const existing = db
+            .query(
+              `SELECT sender_id, target_actor_id, class, at
+               FROM egress_debit
+               WHERE id = ?`,
+            )
+            .get(parsed.id) as {
+            sender_id: string;
+            target_actor_id: string;
+            class: string;
+            at: number;
+          } | null;
+          if (existing === null) return false;
+          if (
+            existing.sender_id !== parsed.senderId ||
+            existing.target_actor_id !== parsed.targetActorId ||
+            existing.class !== parsed.class ||
+            existing.at !== parsed.at
+          ) {
+            throw new Error(`egress debit id ${parsed.id} already identifies a different claim`);
+          }
+          return true;
+        },
+        readWindowState: () => {
+          const state = db
+            .query(
+              `SELECT
+                 COUNT(*) FILTER (WHERE at >= ?) AS count_in_window,
+                 COUNT(*) FILTER (WHERE at >= ? AND class = 'notify') AS notify_in_window,
+                 COUNT(*) FILTER (WHERE at >= ? AND class = 'converse') AS converse_in_window,
+                 MAX(at) AS last_send_at
+               FROM egress_debit
+               WHERE sender_id = ? AND target_actor_id = ?`,
+            )
+            .get(
+              windowStartAt,
+              windowStartAt,
+              windowStartAt,
+              parsed.senderId,
+              parsed.targetActorId,
+            ) as {
+            count_in_window: number;
+            notify_in_window: number;
+            converse_in_window: number;
+            last_send_at: number | null;
+          } | null;
+          return Gateway.EgressDebitState.parse({
+            countInWindow: state?.count_in_window ?? 0,
+            notifyInWindow: state?.notify_in_window ?? 0,
+            converseInWindow: state?.converse_in_window ?? 0,
+            ...(state?.last_send_at == null ? {} : { lastSendAt: state.last_send_at }),
+          });
+        },
+        canClaim,
+        append: () => {
+          db.query(
+            `INSERT INTO egress_debit (id, sender_id, target_actor_id, class, at, time_created)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          ).run(
+            parsed.id,
+            parsed.senderId,
+            parsed.targetActorId,
+            parsed.class,
+            parsed.at,
+            Date.now(),
+          );
+        },
       });
     },
   };

--- a/packages/ledger/test/bus-persistence/hash-chain.test.ts
+++ b/packages/ledger/test/bus-persistence/hash-chain.test.ts
@@ -238,6 +238,31 @@ describe("Hash Chain", () => {
     expect(result.totalVerified).toBe(2);
   });
 
+  test("verifyChainIntegrity walks the sessionless chain when no session is given", async () => {
+    const session = createSession();
+    BusPersistence.start();
+
+    for (let i = 0; i < 2; i++) {
+      Bus.publish(testEvent, {
+        sessionId: session.id,
+        traceId: `trace-sessionless-${i}`,
+        time: 3700 + i,
+        index: i,
+      });
+    }
+
+    await waitForRows(2);
+    BusPersistence.stop();
+    // session_id is not part of the hash input, so detaching the rows from
+    // the session moves them onto the sessionless chain without breaking it.
+    db().query("UPDATE bus_event SET session_id = NULL").run();
+
+    const result = await BusQuery.verifyChainIntegrity();
+
+    expect(result.valid).toBe(true);
+    expect(result.totalVerified).toBe(2);
+  });
+
   test("verifyChainIntegrity detects tampered event_hash", async () => {
     const session = createSession();
     BusPersistence.start();

--- a/packages/ledger/test/bus-persistence/hash-chain.test.ts
+++ b/packages/ledger/test/bus-persistence/hash-chain.test.ts
@@ -190,6 +190,54 @@ describe("Hash Chain", () => {
     expect(result.brokenAtId).toBeUndefined();
   });
 
+  test("verifyChainIntegrity does not count rows without hashes as verified", async () => {
+    const session = createSession();
+    BusPersistence.start();
+
+    for (let i = 0; i < 3; i++) {
+      Bus.publish(testEvent, {
+        sessionId: session.id,
+        traceId: `trace-unhashed-${i}`,
+        time: 3500 + i,
+        index: i,
+      });
+    }
+
+    await waitForRows(3);
+    const rows = busRows(session.id);
+    BusPersistence.stop();
+    const firstRow = rows[0];
+    const historicalRow = rows[1];
+    const followingRow = rows[2];
+    if (
+      firstRow === undefined ||
+      historicalRow === undefined ||
+      followingRow === undefined ||
+      firstRow.event_hash === null
+    ) {
+      throw new Error("shape");
+    }
+
+    db()
+      .query("UPDATE bus_event SET prev_hash = NULL, event_hash = NULL WHERE id = ?")
+      .run(historicalRow.id);
+    const followingHash = computeEventHash({
+      prevHash: firstRow.event_hash,
+      eventType: followingRow.event_type,
+      data: followingRow.data,
+      traceId: followingRow.trace_id,
+      timeCreated: followingRow.time_created,
+    });
+    db()
+      .query("UPDATE bus_event SET prev_hash = ?, event_hash = ? WHERE id = ?")
+      .run(firstRow.event_hash, followingHash, followingRow.id);
+
+    const result = await BusQuery.verifyChainIntegrity(session.id);
+
+    expect(result.valid).toBe(true);
+    expect(result.totalVerified).toBe(2);
+  });
+
   test("verifyChainIntegrity detects tampered event_hash", async () => {
     const session = createSession();
     BusPersistence.start();

--- a/packages/ledger/test/channel-grant/persistence.test.ts
+++ b/packages/ledger/test/channel-grant/persistence.test.ts
@@ -128,6 +128,64 @@ describe("ChannelGrantStore SQLite persistence", () => {
     ]);
   });
 
+  test("equal-treatment conflicts fall through tier, kind, then id tie-breaks", () => {
+    const surfaceInput = { surface: "discord" } as const;
+    const resolveBothOrders = (
+      first: ChannelGrantStore.Grant,
+      second: ChannelGrantStore.Grant,
+    ): (string | undefined)[] =>
+      [
+        [first, second],
+        [second, first],
+      ].map((grants) => {
+        configureChannelGrantAdapter(createInsertionOrderedChannelGrantAdapter());
+        for (const grant of grants) ChannelGrantStore.put(grant);
+        return ChannelGrantStore.resolve(surfaceInput)?.grant.id;
+      });
+
+    // Same effective treatment (full_access): the lower default tier wins,
+    // even though its id sorts later.
+    const observerTier = {
+      id: "b-observer",
+      surface: "discord",
+      kind: "trusted_channel",
+      defaultTier: "observer",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    const ownerTier = { ...observerTier, id: "a-owner", defaultTier: "owner" } as const;
+    expect(resolveBothOrders(observerTier, ownerTier)).toEqual(["b-observer", "b-observer"]);
+
+    // Same treatment and no tiers: the intrinsically more restrictive kind
+    // wins, again against id order.
+    const broadcastKind = {
+      id: "b-broadcast",
+      surface: "discord",
+      kind: "broadcast_channel",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    const trustedEvidence = {
+      id: "a-trusted",
+      surface: "discord",
+      kind: "trusted_channel",
+      inboundTreatment: "evidence_only",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    expect(resolveBothOrders(broadcastKind, trustedEvidence)).toEqual([
+      "b-broadcast",
+      "b-broadcast",
+    ]);
+
+    // Fully tied grants resolve by grant id code-unit order as the stable key.
+    const firstId = {
+      id: "a-first",
+      surface: "discord",
+      kind: "trusted_channel",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    const secondId = { ...firstId, id: "b-second" } as const;
+    expect(resolveBothOrders(firstId, secondId)).toEqual(["a-first", "a-first"]);
+  });
+
   test("explicit inbound treatment overrides kind default", () => {
     ChannelGrantStore.put({
       id: "grant-override",

--- a/packages/ledger/test/channel-grant/persistence.test.ts
+++ b/packages/ledger/test/channel-grant/persistence.test.ts
@@ -4,6 +4,55 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ChannelGrantStore, SqliteStorageAdapter, Storage } from "../../src/index.js";
 
+function createInsertionOrderedChannelGrantAdapter(): NonNullable<Storage.Adapter["channelGrant"]> {
+  const grants = new Map<string, ChannelGrantStore.Grant>();
+  return {
+    get: (id) => grants.get(id),
+    set: (grant) => grants.set(grant.id, grant),
+    list: () => [...grants.values()],
+    remove: (id) => grants.delete(id),
+  };
+}
+
+function configureChannelGrantAdapter(
+  channelGrant: NonNullable<Storage.Adapter["channelGrant"]>,
+): void {
+  const base = Storage.get();
+  Storage.configure({
+    transaction: base.transaction.bind(base),
+    close: base.close?.bind(base),
+    session: base.session,
+    message: base.message,
+    part: base.part,
+    channelGrant,
+  });
+}
+
+const restrictiveGrant = {
+  id: "z-restrictive",
+  surface: "discord",
+  workspace: "guild",
+  kind: "blocked_channel",
+  createdBy: "act_owner",
+  createdAt: 200,
+} as const satisfies ChannelGrantStore.Grant;
+
+const permissiveGrant = {
+  id: "a-permissive",
+  surface: "discord",
+  channel: "design",
+  kind: "trusted_channel",
+  defaultTier: "owner",
+  createdBy: "act_owner",
+  createdAt: 100,
+} as const satisfies ChannelGrantStore.Grant;
+
+const equalSpecificityInput = {
+  surface: "discord",
+  workspace: "guild",
+  channel: "design",
+} as const;
+
 describe("ChannelGrantStore SQLite persistence", () => {
   let tmpDir: string;
   let dbPath: string;
@@ -46,6 +95,37 @@ describe("ChannelGrantStore SQLite persistence", () => {
     });
     expect(resolved?.grant.id).toBe("grant-channel");
     expect(resolved?.inboundTreatment).toBe("evidence_only");
+  });
+
+  test("equal-specificity conflicts choose the restrictive grant regardless of insertion order", () => {
+    const winners = [
+      [permissiveGrant, restrictiveGrant],
+      [restrictiveGrant, permissiveGrant],
+    ].map((grants) => {
+      configureChannelGrantAdapter(createInsertionOrderedChannelGrantAdapter());
+      for (const grant of grants) ChannelGrantStore.put(grant);
+      return ChannelGrantStore.resolve(equalSpecificityInput)?.grant.id;
+    });
+
+    expect(winners).toEqual([restrictiveGrant.id, restrictiveGrant.id]);
+  });
+
+  test("insertion-ordered and SQLite backends agree on equal-specificity conflicts", () => {
+    configureChannelGrantAdapter(createInsertionOrderedChannelGrantAdapter());
+    ChannelGrantStore.put(restrictiveGrant);
+    ChannelGrantStore.put(permissiveGrant);
+    const insertionOrderedWinner = ChannelGrantStore.resolve(equalSpecificityInput)?.grant.id;
+
+    Storage.reset();
+    Storage.configure(new SqliteStorageAdapter(dbPath));
+    ChannelGrantStore.put(restrictiveGrant);
+    ChannelGrantStore.put(permissiveGrant);
+    const sqliteWinner = ChannelGrantStore.resolve(equalSpecificityInput)?.grant.id;
+
+    expect([insertionOrderedWinner, sqliteWinner]).toEqual([
+      restrictiveGrant.id,
+      restrictiveGrant.id,
+    ]);
   });
 
   test("explicit inbound treatment overrides kind default", () => {

--- a/packages/ledger/test/egress/egress-budget-store.test.ts
+++ b/packages/ledger/test/egress/egress-budget-store.test.ts
@@ -100,6 +100,17 @@ describe("EgressBudgetStore", () => {
     expect(adapter.claim(first, NOW - WINDOW, () => false)).toBe("claimed");
   });
 
+  test("retrying an id with different fields is refused as a conflicting claim", () => {
+    const adapter = Storage.get().egressBudget;
+    if (adapter === undefined) throw new Error("egress budget adapter missing");
+
+    expect(adapter.claim(row("conflict-a"), NOW - WINDOW, () => true)).toBe("claimed");
+    const conflicting = { ...row("conflict-a"), targetActorId: "act_someone_else" };
+    expect(() => adapter.claim(conflicting, NOW - WINDOW, () => true)).toThrow(
+      "already identifies a different claim",
+    );
+  });
+
   test("the claim holds one write transaction across read and append", () => {
     // Discriminating atomicity proof: canClaim runs between the projection
     // read and the append. While it runs, a second connection with zero busy

--- a/packages/ledger/test/egress/egress-budget-store.test.ts
+++ b/packages/ledger/test/egress/egress-budget-store.test.ts
@@ -1,15 +1,26 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { EgressBudgetStore, Storage } from "../../src/index";
 
-/**
- * #219 active-egress debit ledger: append-only record of admitted proactive
- * sends, folded into the window/cooldown projection the pure budget evaluator
- * consumes. Perimeter-domain surface (S8) — written only by the channels send
- * kernel. A missing sub-adapter fails closed.
- */
+/** #219 active-egress debit ledger: atomic, idempotent counted-window claims. */
 describe("EgressBudgetStore", () => {
   const NOW = 5_000_000_000_000;
   const WINDOW = 60_000;
+
+  const row = (
+    id: string,
+    overrides: Partial<Parameters<typeof EgressBudgetStore.claim>[0]> = {},
+  ) => ({
+    id,
+    senderId: "s",
+    targetActorId: "t",
+    class: "notify" as const,
+    at: NOW,
+    ...overrides,
+  });
 
   beforeEach(() => {
     Storage.reset();
@@ -20,61 +31,113 @@ describe("EgressBudgetStore", () => {
     Storage.reset();
   });
 
-  test("an empty ledger reads a zero state", () => {
-    const state = EgressBudgetStore.readState("s", "t", NOW - WINDOW);
-    expect(state).toEqual({ countInWindow: 0, notifyInWindow: 0, converseInWindow: 0 });
+  test("an empty ledger presents a zero state to the first claim", () => {
+    let observed: unknown;
+    const result = EgressBudgetStore.claim(row("first"), NOW - WINDOW, (state) => {
+      observed = state;
+      return "allow";
+    });
+    expect(result).toEqual({ kind: "claimed" });
+    expect(observed).toEqual({ countInWindow: 0, notifyInWindow: 0, converseInWindow: 0 });
   });
 
-  test("records fold into per-class window counts and a window-independent lastSendAt", () => {
-    EgressBudgetStore.record({
-      id: "d1",
-      senderId: "s",
-      targetActorId: "t",
-      class: "notify",
-      at: NOW - 90_000,
-    });
-    EgressBudgetStore.record({
-      id: "d2",
-      senderId: "s",
-      targetActorId: "t",
-      class: "notify",
-      at: NOW - 10_000,
-    });
-    EgressBudgetStore.record({
-      id: "d3",
-      senderId: "s",
-      targetActorId: "t",
-      class: "converse",
-      at: NOW - 5_000,
-    });
+  test("claims fold per-class window counts and a window-independent lastSendAt", () => {
+    EgressBudgetStore.claim(row("d1", { at: NOW - 90_000 }), NOW - WINDOW, () => "allow");
+    EgressBudgetStore.claim(row("d2", { at: NOW - 10_000 }), NOW - WINDOW, () => "allow");
+    EgressBudgetStore.claim(
+      row("d3", { class: "converse", at: NOW - 5_000 }),
+      NOW - WINDOW,
+      () => "allow",
+    );
 
-    const state = EgressBudgetStore.readState("s", "t", NOW - WINDOW);
-    // d1 is outside the 60s window; d2 + d3 are inside.
-    expect(state.countInWindow).toBe(2);
-    expect(state.notifyInWindow).toBe(1);
-    expect(state.converseInWindow).toBe(1);
-    // lastSendAt ignores the window — it is the cooldown clock.
-    expect(state.lastSendAt).toBe(NOW - 5_000);
+    let observed: unknown;
+    const probe = EgressBudgetStore.claim(row("probe"), NOW - WINDOW, (state) => {
+      observed = state;
+      return "inspect" as const;
+    });
+    expect(probe).toEqual({ kind: "refused", reason: "inspect" });
+    expect(observed).toEqual({
+      countInWindow: 2,
+      notifyInWindow: 1,
+      converseInWindow: 1,
+      lastSendAt: NOW - 5_000,
+    });
   });
 
-  test("debits are isolated per (sender, target) pair", () => {
-    EgressBudgetStore.record({
-      id: "a",
-      senderId: "s",
-      targetActorId: "t1",
-      class: "notify",
-      at: NOW,
+  test("claims are isolated per (sender, target) pair", () => {
+    EgressBudgetStore.claim(row("a", { targetActorId: "t1" }), NOW - WINDOW, () => "allow");
+    EgressBudgetStore.claim(row("b", { targetActorId: "t2" }), NOW - WINDOW, () => "allow");
+
+    let observed: unknown;
+    EgressBudgetStore.claim(row("probe", { targetActorId: "other" }), NOW - WINDOW, (state) => {
+      observed = state;
+      return "inspect" as const;
     });
-    EgressBudgetStore.record({
-      id: "b",
-      senderId: "s",
-      targetActorId: "t2",
-      class: "notify",
-      at: NOW,
-    });
-    expect(EgressBudgetStore.readState("s", "t1", NOW - WINDOW).countInWindow).toBe(1);
-    expect(EgressBudgetStore.readState("s", "t2", NOW - WINDOW).countInWindow).toBe(1);
-    expect(EgressBudgetStore.readState("s", "other", NOW - WINDOW).countInWindow).toBe(0);
+    expect(observed).toEqual({ countInWindow: 0, notifyInWindow: 0, converseInWindow: 0 });
+  });
+
+  test("two contenders for the last SQLite window slot produce exactly one claim", () => {
+    const adapter = Storage.get().egressBudget;
+    if (adapter === undefined) throw new Error("egress budget adapter missing");
+
+    const results = [row("race-a"), row("race-b")].map((candidate) =>
+      adapter.claim(candidate, NOW - WINDOW, (state) => state.countInWindow < 1),
+    );
+
+    expect(results).toEqual(["claimed", "refused"]);
+  });
+
+  test("retrying a recorded claim is idempotent and never charges the window twice", () => {
+    const adapter = Storage.get().egressBudget;
+    if (adapter === undefined) throw new Error("egress budget adapter missing");
+
+    const first = row("retry-a");
+    expect(adapter.claim(first, NOW - WINDOW, (state) => state.countInWindow < 1)).toBe("claimed");
+    expect(adapter.claim(row("retry-b"), NOW - WINDOW, (state) => state.countInWindow < 1)).toBe(
+      "refused",
+    );
+    // The retry short-circuits on the recorded id even under a now-full window.
+    expect(adapter.claim(first, NOW - WINDOW, () => false)).toBe("claimed");
+  });
+
+  test("the claim holds one write transaction across read and append", () => {
+    // Discriminating atomicity proof: canClaim runs between the projection
+    // read and the append. While it runs, a second connection with zero busy
+    // timeout must be unable to write — that is only true when the claim
+    // opened BEGIN IMMEDIATE before reading. A no-op transaction wrapper
+    // would leave the probe insert free to succeed and fail this test.
+    const dir = mkdtempSync(join(tmpdir(), "egress-claim-"));
+    const dbPath = join(dir, "claim.sqlite");
+    Storage.reset();
+    Storage.initialize({ dbPath });
+    try {
+      const adapter = Storage.get().egressBudget;
+      if (adapter === undefined) throw new Error("egress budget adapter missing");
+      const probe = new Database(dbPath);
+      probe.exec("PRAGMA busy_timeout = 0");
+      const insertProbeRow = () => {
+        probe.exec(
+          `INSERT INTO egress_debit (id, sender_id, target_actor_id, class, at, time_created)
+           VALUES ('probe', 's', 't', 'notify', ${NOW}, ${NOW})`,
+        );
+      };
+
+      let probedInsideClaim = false;
+      const result = adapter.claim(row("lock-holder"), NOW - WINDOW, () => {
+        probedInsideClaim = true;
+        expect(insertProbeRow).toThrow(/SQLITE_BUSY|database is locked/);
+        return true;
+      });
+
+      expect(probedInsideClaim).toBe(true);
+      expect(result).toBe("claimed");
+      // Once the claim committed, the same probe write is free to proceed.
+      insertProbeRow();
+      probe.close();
+    } finally {
+      Storage.reset();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("fails closed when the sub-adapter is absent", () => {
@@ -84,7 +147,7 @@ describe("EgressBudgetStore", () => {
       message: {} as never,
       part: {} as never,
     } as never);
-    expect(() => EgressBudgetStore.readState("s", "t", 0)).toThrow(
+    expect(() => EgressBudgetStore.claim(row("missing"), 0, () => "allow")).toThrow(
       "does not implement egressBudget",
     );
   });

--- a/packages/protocol/src/storage/perimeter.ts
+++ b/packages/protocol/src/storage/perimeter.ts
@@ -48,17 +48,16 @@ declare module "./namespace.js" {
      * Active-egress debit ledger (#219, perimeter domain): a per-(senderId,
      * targetActorId) append-only log of ADMITTED proactive sends. The gateway
      * router is the sole writer (same isolation as the wait store — the brain
-     * never reaches it). `record` appends one admitted send;
-     * `readState` folds the window projection the pure budget evaluator consumes
-     * (`windowStartAt` is the caller's `at - budget.windowMs`).
+     * never reaches it). `claim` atomically folds the projection, asks the
+     * perimeter evaluator whether the row fits, and appends only when admitted.
+     * Retrying the same row id is idempotently `claimed`.
      */
     export interface EgressBudgetSubAdapter {
-      record(row: Gateway.EgressDebitRow): void;
-      readState(
-        senderId: string,
-        targetActorId: string,
+      claim(
+        row: Gateway.EgressDebitRow,
         windowStartAt: number,
-      ): Gateway.EgressDebitState;
+        canClaim: (state: Gateway.EgressDebitState) => boolean,
+      ): "claimed" | "refused";
     }
   }
 }


### PR DESCRIPTION
Audit-remediation PR-4 (ledger domain). Three defects, each RED->GREEN.

## 1. Egress budget TOCTOU -> atomic counted-window claim
`EgressBudgetStore` exposed check (`readState`) and record as two separate public steps; two concurrent sends could both pass the check for the last window slot and overshoot the budget. New `claimWithinCountedWindow` primitive owns the indivisible read/decision/append sequence; the SQLite adapter runs it under `BEGIN IMMEDIATE`. The old split surface is **deleted** (not kept alongside) and all callers (channels send kernel, tests) migrated to the claim shape. Retrying a recorded id is idempotent (`alreadyClaimed` short-circuit, identity-checked). RED captured both contenders claiming the last slot (`Expected 1, Received 2`).

Atomicity is pinned by a discriminating test: a second connection with `busy_timeout=0` attempts a write **inside** the claim's `canClaim` callback and must hit `SQLITE_BUSY`; a no-op transaction wrapper makes the probe succeed and the test fail (mutation-verified locally).

The primitive is shaped for the delegation fanout-cap claim (next PR) - counted-claim-within-window, no speculative parameters.

## 2. Channel-grant equal-specificity nondeterminism -> most-restrictive-wins
Equal-specificity grant conflicts fell to backend iteration order (insertion-ordered test adapter vs SQLite `time_created, id`), so authorization ceilings could flip across backends/restarts. Resolution now applies one documented total order after listing: specificity, then more-restrictive effective inbound treatment (`drop` > `evidence_only` > `full_access`), then more-restrictive anonymous default tier, then intrinsically more restrictive kind, then grant id (code-unit order) as the final stable key. Fail-closed justification: these grants gate ingress access, evidence-vs-command treatment, and anonymous tier materialization - an ambiguous conflict must not select the more permissive ceiling by storage accident. RED proved the winner flipped with insertion order and that backends disagreed.

## 3. chain-query totalVerified honesty
`verifyChainIntegrity` counted null-hash (pre-migration) rows into `totalVerified` (`rows.length` on success, raw row index on failure), claiming integrity proof for rows never hash-checked. `walkChain` now increments the counter only after a row passes link + recomputed-hash verification. RED captured the dishonest count (3 reported, 2 verified). Skipping historical null-hash rows is retained; they just no longer count as verified.

## Verification
- Full local gate chain green (`.omo/gate-chain-pr4.log`): build, turbo check-types, check-deps, check-import-cycles, lint:tools, lint, ultracite (whole repo), check-dead-exports, `bun test --timeout 15000` -> 2544 pass / 0 fail.
- Orchestrator spot-checks beyond the lane reports: BEGIN IMMEDIATE wrapping verified by reading the adapter; no-op-wrapper mutation run personally (test fails as designed); production-dead in-memory egress adapter caught by the verify lane and deleted; dead barrel exports removed.
- Concurrency tests use deterministic interleaving through the public API (in-transaction probe callback), no sleeps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three ledger audit findings: an egress budget check-then-record race that could overshoot the window, equal-specificity grant conflicts that resolved by backend storage order, and chain-integrity counts that credited rows never hash-checked.

**Bug Fixes**
- `EgressBudgetStore` claims atomically — window read, decision, and append run under one `BEGIN IMMEDIATE` — so concurrent sends cannot overshoot; the split `record`/`readState` surface is removed and retrying a recorded id is idempotent.
- Equal-specificity grant conflicts resolve by a documented most-restrictive-wins order (effective treatment, anonymous tier, kind, grant id), so backends and restarts agree.
- `verifyChainIntegrity` counts only rows that pass link and hash verification; historical null-hash rows no longer inflate `totalVerified`.

<sup>Written for commit 3063a22ebfe6b24b88959bed0f8e92d23b5e4cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved egress budget enforcement to prevent duplicate charges and handle concurrent requests safely.
  - Budget limits now consistently apply across retries and messaging destinations.
  - Channel-grant conflicts now resolve deterministically, favoring more restrictive outcomes.
  - Corrected hash-chain verification counts when records lack hash data.

- **Reliability**
  - Improved consistency across storage backends and insertion orders.
  - Strengthened validation of message admission and budget tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->