### PR TITLE
fix(app,agent): delegation admission/boot durability + agent lifecycle closure (audit PR-5)

### DIFF
--- a/apps/openomni/src/delegation/admission.ts
+++ b/apps/openomni/src/delegation/admission.ts
@@ -27,6 +27,7 @@ const RefusalCode = z.enum([
   "deadline_passed",
   "parent_missing",
   "parent_lineage",
+  "parent_settled",
   "fanout_cap",
   "worker_transport",
   "inline_depth",
@@ -123,6 +124,12 @@ export function admit(
         trustedOrigin.rootDelegationId !== context.rootDelegationId))
   ) {
     return refusal("parent_lineage", "delegation lineage does not match the durable parent");
+  }
+  if (context?.parent?.status === "settled") {
+    return refusal(
+      "parent_settled",
+      `parent delegation ${context.parent.delegationId} is already settled`,
+    );
   }
 
   // The schema proves the requested deadline is a positive instant. Holding a

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -49,6 +49,10 @@ export interface DelegationDriver {
 
 interface DelegationStorePort {
   create(record: Delegation.Record): Delegation.Record;
+  claimOpenWithinRoot(
+    record: Delegation.Record,
+    maxFanout: number,
+  ): Delegation.Record | undefined;
   get(delegationId: string): Delegation.Record | undefined;
   /** Legacy test-port shape; production uses settleOnce for the CAS receipt. */
   settle?(delegationId: string, settlement: Delegation.Settled): Delegation.Settled | undefined;
@@ -118,7 +122,10 @@ const DelegationControlError = NamedError.create(
 
 // A module-level notification registry lets a fresh kernel in the same host
 // await a record settled by the previous kernel without polling or sleeps.
-type SettlementWaiter = (settlement: Delegation.Settled) => void;
+interface SettlementWaiter {
+  readonly settle: (settlement: Delegation.Settled) => void;
+  readonly stop: () => void;
+}
 const settlementWaiters = new Map<string, Set<SettlementWaiter>>();
 
 function settlementKey(settlement: Delegation.Settled): string {
@@ -226,6 +233,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
   const controllers = new Map<string, AbortController>();
   const delivered = new Set<string>();
   const emittedSettlements = new Set<string>();
+  const ownedWaiters = new Set<SettlementWaiter>();
   let recovered = false;
   let stopped = false;
 
@@ -257,7 +265,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     const waiters = settlementWaiters.get(settlement.delegationId);
     if (waiters === undefined) return;
     settlementWaiters.delete(settlement.delegationId);
-    for (const waiter of waiters) waiter(settlement);
+    for (const waiter of waiters) waiter.settle(settlement);
   }
 
   function clearTimer(delegationId: string): void {
@@ -571,7 +579,15 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       createdAt: now,
       ...(workItemId === undefined ? {} : { workItemId }),
     });
-    store.create(record);
+    const claimed = store.claimOpenWithinRoot(record, limits.maxFanout);
+    if (claimed === undefined) {
+      if (workItemId !== undefined) await options.workItems?.cancelAssign(workItemId);
+      const message = `delegation fanout is capped at ${limits.maxFanout} open records for root ${record.rootDelegationId}`;
+      return {
+        refused: message,
+        error: new AdmissionRefusal({ code: "fanout_cap", message }),
+      };
+    }
     publishAdmitted(record);
     arm(record);
 
@@ -625,26 +641,39 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       return Promise.resolve({ kind: "timeout", delegationId, deadline: record.deadline });
     }
 
-    return new Promise<DelegationAwaitResult>((resolve) => {
+    return new Promise<DelegationAwaitResult>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined;
       let waiters = settlementWaiters.get(delegationId);
       if (waiters === undefined) {
         waiters = new Set();
         settlementWaiters.set(delegationId, waiters);
       }
-      const onSettled: SettlementWaiter = (settlement) => {
-        if (timer !== undefined) clearTimeout(timer);
-        resolve({ kind: "settled", settlement });
+      const removeWaiter = (): void => {
+        waiters?.delete(waiter);
+        ownedWaiters.delete(waiter);
+        if (waiters?.size === 0) settlementWaiters.delete(delegationId);
       };
-      waiters.add(onSettled);
+      const waiter: SettlementWaiter = {
+        settle: (settlement) => {
+          if (timer !== undefined) clearTimeout(timer);
+          ownedWaiters.delete(waiter);
+          resolve({ kind: "settled", settlement });
+        },
+        stop: () => {
+          if (timer !== undefined) clearTimeout(timer);
+          removeWaiter();
+          reject(new Error("delegation kernel has been stopped"));
+        },
+      };
+      waiters.add(waiter);
+      ownedWaiters.add(waiter);
       // Close the check/register race without polling: settlement is a sync
       // fold, so a settled row here can only have won between the first read
       // and registration in another host/kernel.
       const latest = store.get(delegationId);
       if (latest?.status === "settled" && latest.settled !== undefined) {
-        waiters.delete(onSettled);
-        if (waiters.size === 0) settlementWaiters.delete(delegationId);
-        onSettled(latest.settled);
+        removeWaiter();
+        waiter.settle(latest.settled);
         return;
       }
       const deadlineBound = end === record.deadline;
@@ -655,8 +684,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
             scheduleAwaitTimeout();
             return;
           }
-          waiters?.delete(onSettled);
-          if (waiters?.size === 0) settlementWaiters.delete(delegationId);
+          removeWaiter();
           if (deadlineBound) {
             const settled = settle(delegationId, {
               status: "no_response",
@@ -716,6 +744,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     timers.clear();
     for (const controller of controllers.values()) controller.abort();
     controllers.clear();
+    for (const waiter of [...ownedWaiters]) waiter.stop();
   }
 
   const kernel: DelegationKernel = {

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -52,7 +52,10 @@ interface DelegationStorePort {
   claimOpenWithinRoot(
     record: Delegation.Record,
     maxFanout: number,
-  ): Delegation.Record | undefined;
+    constraints?: { readonly requireOpenParent?: string },
+  ):
+    | { readonly claimed: true; readonly record: Delegation.Record }
+    | { readonly claimed: false; readonly reason: "fanout_cap" | "parent_settled" };
   get(delegationId: string): Delegation.Record | undefined;
   /** Legacy test-port shape; production uses settleOnce for the CAS receipt. */
   settle?(delegationId: string, settlement: Delegation.Settled): Delegation.Settled | undefined;
@@ -194,6 +197,10 @@ function outcomeToSettlement(
     case "sent":
       return { status: "sent", delegationId, at };
   }
+}
+
+function stoppedKernelError(): Error {
+  return new Error("delegation kernel has been stopped");
 }
 
 function controlError(code: "not_found" | "not_open", delegationId: string): NamedError {
@@ -494,7 +501,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
 
   async function delegate(candidate: unknown, origin: DelegationOrigin): Promise<DelegationResult> {
     if (stopped) {
-      throw new Error("delegation kernel has been stopped");
+      throw stoppedKernelError();
     }
     const now = options.now();
     const delegationId = options.newDelegationId();
@@ -579,13 +586,38 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       createdAt: now,
       ...(workItemId === undefined ? {} : { workItemId }),
     });
-    const claimed = store.claimOpenWithinRoot(record, limits.maxFanout);
-    if (claimed === undefined) {
-      if (workItemId !== undefined) await options.workItems?.cancelAssign(workItemId);
-      const message = `delegation fanout is capped at ${limits.maxFanout} open records for root ${record.rootDelegationId}`;
+    const claim = store.claimOpenWithinRoot(record, limits.maxFanout, {
+      ...(record.parentDelegationId === undefined
+        ? {}
+        : { requireOpenParent: record.parentDelegationId }),
+    });
+    if (!claim.claimed) {
+      if (workItemId !== undefined) {
+        try {
+          await options.workItems?.cancelAssign(workItemId);
+        } catch (error) {
+          events.publish(Operational.Events.Error, {
+            traceId: record.delegationId,
+            sessionId: record.origin.sessionId,
+            time: options.now(),
+            component: "delegation",
+            msg: `WorkItem rollback failed for ${record.delegationId}`,
+            error: error instanceof Error ? error.message : String(error),
+            context: {
+              delegationId: record.delegationId,
+              workItemId,
+              refusal: claim.reason,
+            },
+          });
+        }
+      }
+      const message =
+        claim.reason === "parent_settled"
+          ? `parent delegation ${record.parentDelegationId ?? ""} is already settled`
+          : `delegation fanout is capped at ${limits.maxFanout} open records for root ${record.rootDelegationId}`;
       return {
         refused: message,
-        error: new AdmissionRefusal({ code: "fanout_cap", message }),
+        error: new AdmissionRefusal({ code: claim.reason, message }),
       };
     }
     publishAdmitted(record);
@@ -618,6 +650,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     delegationId: string,
     timeoutMs?: number,
   ): Promise<DelegationAwaitResult> {
+    if (stopped) return Promise.reject(stoppedKernelError());
     const record = store.get(delegationId);
     if (record === undefined) return Promise.reject(controlError("not_found", delegationId));
     if (record.status === "settled") {
@@ -662,7 +695,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
         stop: () => {
           if (timer !== undefined) clearTimeout(timer);
           removeWaiter();
-          reject(new Error("delegation kernel has been stopped"));
+          reject(stoppedKernelError());
         },
       };
       waiters.add(waiter);

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -10,6 +10,8 @@ import { Delegation, WorkItem, newTraceId } from "@openomni/protocol";
 export interface WorkItemLinkage {
   /** Commission the WorkItem and its attempt at admission. Returns the WorkItem id. */
   openAssign(input: OpenAssignInput): Promise<string>;
+  /** Roll back a commissioned assign whose final admission write was refused. */
+  cancelAssign(workItemId: string): Promise<void>;
   /** Close the attempt from the settlement fold. Unknown items are a no-op. */
   closeAttempt(input: CloseAttemptInput): Promise<void>;
   /**
@@ -71,10 +73,14 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
       await commission(item.workItemId, input, traceId);
     } catch (error) {
       // Never leave an orphan pending item behind a refused admission.
-      await WorkItemStore.cancel(item.workItemId, traceId);
+      await cancelAssign(item.workItemId, traceId);
       throw error;
     }
     return item.workItemId;
+  }
+
+  async function cancelAssign(workItemId: string, traceId = newTraceId()): Promise<void> {
+    await WorkItemStore.cancel(workItemId, traceId);
   }
 
   async function commission(
@@ -191,5 +197,5 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
     }
   }
 
-  return { openAssign, closeAttempt, recoverAttempts };
+  return { openAssign, cancelAssign, closeAttempt, recoverAttempts };
 }

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -389,8 +389,22 @@ export async function startOpenOmni(options: StartOptions = {}) {
     for (const surface of externalSurfaces) surface.stop(newTraceId());
     kernel?.stop();
     host?.close();
-    stopBusPersistence();
-    Storage.reset();
+    let flushError: unknown;
+    try {
+      await BusPersistence.flush();
+    } catch (caught) {
+      flushError = caught;
+    } finally {
+      stopBusPersistence();
+      Storage.reset();
+    }
+    if (flushError !== undefined) {
+      const rollbackFailure = new Error("OpenOmni boot failed and journal rollback flush failed") as Error & {
+        errors: readonly unknown[];
+      };
+      rollbackFailure.errors = [error, flushError];
+      throw rollbackFailure;
+    }
     throw error;
   }
 }

--- a/apps/openomni/test/boot-durability.test.ts
+++ b/apps/openomni/test/boot-durability.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import {
   BusPersistence,
   BusQuery,
@@ -233,6 +234,50 @@ describe("OpenOmni boot durability", () => {
         traceId: "trace-shutdown-flush",
       }),
     ]);
+  });
+
+  test("boot rollback flushes pending journal writes before storage resets", async () => {
+    const dbPath = newDatabasePath();
+    initialize({ dbPath });
+    WaitStore.create(
+      {
+        id: "wait-expired-during-failed-boot",
+        ownerRef: { kind: "workItem", id: "work-rollback" },
+        originMessageId: "message-rollback",
+        correlation: { endpointId: "ws:actor-1", replyToMessageId: "message-rollback" },
+        allowedActions: ["report_result"],
+        expectedResponders: ["actor-1"],
+        resolutionPolicy: "first_reply",
+        expiresAt: 1,
+        followUpWindow: 0,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      "trace-seed-rollback-wait",
+    );
+    Storage.reset();
+    const blocker = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response("occupied"),
+    });
+    const occupiedPort = blocker.port;
+    if (occupiedPort === undefined) throw new Error("blocker server did not bind a port");
+
+    await expect(
+      startOpenOmni({ config: { ...testConfig(dbPath), wsPort: occupiedPort } }),
+    ).rejects.toThrow();
+    blocker.stop();
+
+    const database = new Database(dbPath, { readonly: true });
+    try {
+      const row = database
+        .query("SELECT event_type FROM bus_event WHERE event_type = 'wait.expired'")
+        .get() as { event_type: string } | null;
+      expect(row?.event_type).toBe("wait.expired");
+    } finally {
+      database.close();
+    }
   });
 
   test("rolls back the bus journal and storage when boot fails after journaling started", async () => {

--- a/apps/openomni/test/delegation.test.ts
+++ b/apps/openomni/test/delegation.test.ts
@@ -178,6 +178,129 @@ describe("durable kernel", () => {
     ]);
   });
 
+  test("refuses an ask when its parent settles during transport preparation", async () => {
+    DelegationStore.create({
+      delegationId: "ask-parent",
+      operation: "ask",
+      address: { kind: "core", scope: "independent" },
+      transport: "process",
+      deadline: 10_000,
+      rootDelegationId: "ask-parent",
+      origin: RESIDENT,
+      instruction: "parent",
+      status: "open",
+      createdAt: 1,
+    });
+    let releasePreparation!: () => void;
+    let preparationEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      preparationEntered = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    const kernel = createDelegationKernel({
+      store: DelegationStore,
+      drivers: {
+        process: {
+          prepare: async () => {
+            preparationEntered();
+            await release;
+            return {};
+          },
+          run: () => new Promise(() => undefined),
+        },
+      },
+      now: () => 1_000,
+      newDelegationId: () => "ask-child",
+      wake: () => undefined,
+      bootSweep: false,
+      limits: LIMITS,
+    });
+    const delegated = kernel.delegate(
+      ask({ address: { kind: "core", scope: "independent" } }),
+      { ...RESIDENT, parentDelegationId: "ask-parent", rootDelegationId: "ask-parent" },
+    );
+
+    await entered;
+    await kernel.cancelDelegation("ask-parent");
+    releasePreparation();
+
+    await expect(delegated).resolves.toMatchObject({
+      error: { data: { code: "parent_settled" } },
+    });
+    expect(DelegationStore.get("ask-child")).toBeUndefined();
+    kernel.stop();
+  });
+
+  test("refuses and cancels an assign when its parent settles during transport preparation", async () => {
+    DelegationStore.create({
+      delegationId: "assign-parent",
+      operation: "ask",
+      address: { kind: "core", scope: "independent" },
+      transport: "process",
+      deadline: 10_000,
+      rootDelegationId: "assign-parent",
+      origin: RESIDENT,
+      instruction: "parent",
+      status: "open",
+      createdAt: 1,
+    });
+    let releasePreparation!: () => void;
+    let preparationEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      preparationEntered = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    const kernel = createDelegationKernel({
+      store: DelegationStore,
+      drivers: {
+        process: {
+          prepare: async () => {
+            preparationEntered();
+            await release;
+            return {};
+          },
+          run: () => new Promise(() => undefined),
+        },
+      },
+      workItems: createWorkItemLinkage({
+        model: { provider: "fake", id: "parent-settled-test" },
+        now: () => 1_000,
+      }),
+      now: () => 1_000,
+      newDelegationId: () => "assign-child",
+      wake: () => undefined,
+      bootSweep: false,
+      limits: LIMITS,
+    });
+    const delegated = kernel.delegate(
+      ask({
+        operation: "assign",
+        address: { kind: "core", scope: "independent" },
+        acceptanceCriteria: ["result is verified"],
+      }),
+      { ...RESIDENT, parentDelegationId: "assign-parent", rootDelegationId: "assign-parent" },
+    );
+
+    await entered;
+    await kernel.cancelDelegation("assign-parent");
+    releasePreparation();
+
+    await expect(delegated).resolves.toMatchObject({
+      error: { data: { code: "parent_settled" } },
+    });
+    expect(DelegationStore.get("assign-child")).toBeUndefined();
+    const commissioned = WorkItemStore.list().filter(
+      (item) => item.sourceChannel === "delegation" && item.sourceMessageId === "assign-child",
+    );
+    expect(commissioned).toHaveLength(1);
+    expect(commissioned[0]?.timestamps.cancelled).toEqual(expect.any(Number));
+    kernel.stop();
+  });
+
   test("atomically admits at most one concurrent child into the last fanout slot", async () => {
     DelegationStore.create({
       delegationId: "root",
@@ -335,6 +458,119 @@ describe("durable kernel", () => {
     kernel.stop();
   });
 
+  test("returns fanout refusal and reports an operational error when assign rollback fails", async () => {
+    DelegationStore.create({
+      delegationId: "rollback-root",
+      operation: "ask",
+      address: { kind: "core", scope: "independent" },
+      transport: "process",
+      deadline: 10_000,
+      rootDelegationId: "rollback-root",
+      origin: RESIDENT,
+      instruction: "root",
+      status: "open",
+      createdAt: 1,
+    });
+    for (let index = 1; index <= 6; index += 1) {
+      DelegationStore.create({
+        delegationId: `rollback-existing-${index}`,
+        operation: "ask",
+        address: { kind: "core", scope: "inline" },
+        transport: "inline",
+        deadline: 10_000,
+        parentDelegationId: "rollback-root",
+        rootDelegationId: "rollback-root",
+        origin: { ...WORKER, parentDelegationId: "rollback-root", rootDelegationId: "rollback-root" },
+        instruction: "existing child",
+        status: "open",
+        createdAt: index + 1,
+      });
+    }
+    let prepared = 0;
+    let releasePreparation!: () => void;
+    const bothPreparing = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    let nextId = 0;
+    let cancelledWorkItemId: string | undefined;
+    const commissioned = new Map<string, string>();
+    const events = eventCollector();
+    const kernel = createDelegationKernel({
+      store: DelegationStore,
+      drivers: {
+        process: {
+          prepare: async () => {
+            prepared += 1;
+            if (prepared === 2) releasePreparation();
+            await bothPreparing;
+            return {};
+          },
+          run: () => new Promise(() => undefined),
+        },
+      },
+      workItems: {
+        openAssign: (input) => {
+          const workItemId = `wi-${input.delegationId}`;
+          commissioned.set(workItemId, input.delegationId);
+          return Promise.resolve(workItemId);
+        },
+        cancelAssign: (workItemId) => {
+          cancelledWorkItemId = workItemId;
+          return Promise.reject(new Error("cancel failed"));
+        },
+        closeAttempt: () => Promise.resolve(),
+        recoverAttempts: () => Promise.resolve(),
+      },
+      now: () => 1_000,
+      newDelegationId: () => `rollback-candidate-${++nextId}`,
+      wake: () => undefined,
+      events,
+      bootSweep: false,
+      limits: LIMITS,
+    });
+    const request = ask({
+      operation: "assign",
+      address: { kind: "core", scope: "independent" },
+      acceptanceCriteria: ["result is verified"],
+    });
+    const origin = { ...RESIDENT, parentDelegationId: "rollback-root", rootDelegationId: "rollback-root" };
+
+    const results = await Promise.allSettled([
+      kernel.delegate(request, origin),
+      kernel.delegate(request, origin),
+    ]);
+
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(0);
+    const refusals = results.filter(
+      (result) => result.status === "fulfilled" && "refused" in result.value,
+    );
+    expect(refusals).toHaveLength(1);
+    expect(refusals[0]).toMatchObject({
+      value: { error: { data: { code: "fanout_cap" } } },
+    });
+    expect(cancelledWorkItemId).toBeDefined();
+    const delegationId = commissioned.get(cancelledWorkItemId ?? "");
+    expect(events.events.filter((event) => event.name === "operational.error")).toEqual([
+      {
+        name: "operational.error",
+        data: {
+          traceId: delegationId,
+          sessionId: "session-origin",
+          time: 1_000,
+          component: "delegation",
+          msg: `WorkItem rollback failed for ${delegationId}`,
+          error: "cancel failed",
+          context: {
+            delegationId,
+            workItemId: cancelledWorkItemId,
+            refusal: "fanout_cap",
+          },
+        },
+      },
+    ]);
+    kernel.stop();
+  });
+
   test("process/channel work returns the handle before its outcome and can be awaited again", async () => {
     const events = eventCollector();
     let finish!: (outcome: { status: "completed"; output: string }) => void;
@@ -437,6 +673,33 @@ describe("durable kernel", () => {
     kernel.stop();
 
     expect(await stopped).toEqual(new Error("delegation kernel has been stopped"));
+  });
+
+  test("awaiting an open delegation after stop rejects immediately with the stopped error", async () => {
+    const kernel = createDelegationKernel({
+      drivers: { process: { run: () => new Promise(() => undefined) } },
+      now: () => 1_000,
+      newDelegationId: () => "d-post-stop-waiter",
+      wake: () => undefined,
+      limits: LIMITS,
+    });
+    const started = await kernel.delegate(
+      {
+        address: { kind: "core", scope: "independent" },
+        operation: "ask",
+        payload: { text: "long-running" },
+        deadline: 10_000,
+      },
+      RESIDENT,
+    );
+    if ("refused" in started) throw new Error(started.refused);
+
+    kernel.stop();
+
+    await expect(kernel.awaitDelegation(started.handle.delegationId)).rejects.toMatchObject({
+      name: "Error",
+      message: "delegation kernel has been stopped",
+    });
   });
 
   test("an inline caller returns the deadline settlement even if its driver ignores abort", async () => {

--- a/apps/openomni/test/delegation.test.ts
+++ b/apps/openomni/test/delegation.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, test, vi } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DelegationStore, SqliteStorageAdapter, Storage } from "@openomni/ledger";
+import { DelegationStore, SqliteStorageAdapter, Storage, WorkItemStore } from "@openomni/ledger";
 import { admit, type AdmissionLimits } from "../src/delegation/admission";
 import { createChannelDriver } from "../src/delegation/channel-driver";
 import { createDelegationKernel } from "../src/delegation/kernel";
+import { createWorkItemLinkage } from "../src/delegation/work-item-linkage";
 import {
   AWAIT_DELEGATION_TOOL_NAME,
   CANCEL_DELEGATION_TOOL_NAME,
@@ -115,6 +116,31 @@ describe("admission fold", () => {
     });
     expect(result).toMatchObject({ ok: false, error: { data: { code: "fanout_cap" } } });
   });
+
+  test("a settled parent cannot commission another child", () => {
+    const result = admit(
+      ask(),
+      { ...WORKER, parentDelegationId: "parent", rootDelegationId: "root" },
+      1_000,
+      LIMITS,
+      {
+        delegationId: "child",
+        rootDelegationId: "root",
+        parent: {
+          delegationId: "parent",
+          rootDelegationId: "root",
+          deadline: 10_000,
+          status: "settled",
+        },
+        openFanout: 0,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { data: { code: "parent_settled" } },
+    });
+  });
 });
 
 describe("durable kernel", () => {
@@ -150,6 +176,163 @@ describe("durable kernel", () => {
       "delegation.delivered",
       "delegation.settled",
     ]);
+  });
+
+  test("atomically admits at most one concurrent child into the last fanout slot", async () => {
+    DelegationStore.create({
+      delegationId: "root",
+      operation: "ask",
+      address: { kind: "core", scope: "independent" },
+      transport: "process",
+      deadline: 10_000,
+      rootDelegationId: "root",
+      origin: RESIDENT,
+      instruction: "root",
+      status: "open",
+      createdAt: 1,
+    });
+    for (let index = 1; index <= 6; index += 1) {
+      DelegationStore.create({
+        delegationId: `existing-${index}`,
+        operation: "ask",
+        address: { kind: "core", scope: "inline" },
+        transport: "inline",
+        deadline: 10_000,
+        parentDelegationId: "root",
+        rootDelegationId: "root",
+        origin: {
+          ...WORKER,
+          parentDelegationId: "root",
+          rootDelegationId: "root",
+        },
+        instruction: "existing child",
+        status: "open",
+        createdAt: index + 1,
+      });
+    }
+
+    let prepared = 0;
+    let releasePreparation!: () => void;
+    const bothPreparing = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    let nextId = 0;
+    const kernel = createDelegationKernel({
+      store: DelegationStore,
+      drivers: {
+        inline: {
+          prepare: async () => {
+            prepared += 1;
+            if (prepared === 2) releasePreparation();
+            await bothPreparing;
+            return {};
+          },
+          run: async () => ({ status: "completed", output: "done" }),
+        },
+      },
+      now: () => 1_000,
+      newDelegationId: () => `candidate-${++nextId}`,
+      wake: () => undefined,
+      bootSweep: false,
+      limits: LIMITS,
+    });
+    const origin = {
+      ...WORKER,
+      parentDelegationId: "root",
+      rootDelegationId: "root",
+    };
+
+    const results = await Promise.all([kernel.delegate(ask(), origin), kernel.delegate(ask(), origin)]);
+
+    expect(results.filter((result) => "refused" in result)).toHaveLength(1);
+    kernel.stop();
+  });
+
+  test("cancels the commissioned WorkItem when a concurrent assign loses the final fanout claim", async () => {
+    DelegationStore.create({
+      delegationId: "assign-root",
+      operation: "ask",
+      address: { kind: "core", scope: "independent" },
+      transport: "process",
+      deadline: 10_000,
+      rootDelegationId: "assign-root",
+      origin: RESIDENT,
+      instruction: "root",
+      status: "open",
+      createdAt: 1,
+    });
+    for (let index = 1; index <= 6; index += 1) {
+      DelegationStore.create({
+        delegationId: `assign-existing-${index}`,
+        operation: "ask",
+        address: { kind: "core", scope: "inline" },
+        transport: "inline",
+        deadline: 10_000,
+        parentDelegationId: "assign-root",
+        rootDelegationId: "assign-root",
+        origin: {
+          ...WORKER,
+          parentDelegationId: "assign-root",
+          rootDelegationId: "assign-root",
+        },
+        instruction: "existing child",
+        status: "open",
+        createdAt: index + 1,
+      });
+    }
+
+    let prepared = 0;
+    let releasePreparation!: () => void;
+    const bothPreparing = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    let nextId = 0;
+    const kernel = createDelegationKernel({
+      store: DelegationStore,
+      drivers: {
+        process: {
+          prepare: async () => {
+            prepared += 1;
+            if (prepared === 2) releasePreparation();
+            await bothPreparing;
+            return {};
+          },
+          run: () => new Promise(() => undefined),
+        },
+      },
+      workItems: createWorkItemLinkage({
+        model: { provider: "fake", id: "fanout-test" },
+        now: () => 1_000,
+      }),
+      now: () => 1_000,
+      newDelegationId: () => `assign-candidate-${++nextId}`,
+      wake: () => undefined,
+      bootSweep: false,
+      limits: LIMITS,
+    });
+    const origin = {
+      ...RESIDENT,
+      parentDelegationId: "assign-root",
+      rootDelegationId: "assign-root",
+    };
+    const request = ask({
+      operation: "assign",
+      address: { kind: "core", scope: "independent" },
+      acceptanceCriteria: ["result is verified"],
+    });
+
+    const results = await Promise.all([
+      kernel.delegate(request, origin),
+      kernel.delegate(request, origin),
+    ]);
+
+    expect(results.filter((result) => "refused" in result)).toHaveLength(1);
+    const commissioned = WorkItemStore.list().filter(
+      (item) => item.sourceChannel === "delegation" && item.sourceMessageId.startsWith("assign-candidate-"),
+    );
+    expect(commissioned).toHaveLength(2);
+    expect(commissioned.filter((item) => item.timestamps.cancelled !== undefined)).toHaveLength(1);
+    kernel.stop();
   });
 
   test("process/channel work returns the handle before its outcome and can be awaited again", async () => {
@@ -226,6 +409,34 @@ describe("durable kernel", () => {
     await expect(kernel.cancelDelegation(started.handle.delegationId)).resolves.toMatchObject({ status: "cancelled" });
     expect(aborted).toBe(true);
     await expect(kernel.cancelDelegation(started.handle.delegationId)).resolves.toMatchObject({ status: "cancelled" });
+  });
+
+  test("stop rejects and removes a pending delegation awaiter", async () => {
+    const kernel = createDelegationKernel({
+      drivers: { process: { run: () => new Promise(() => undefined) } },
+      now: () => 1_000,
+      newDelegationId: () => "d-stop-waiter",
+      wake: () => undefined,
+      limits: LIMITS,
+    });
+    const started = await kernel.delegate(
+      {
+        address: { kind: "core", scope: "independent" },
+        operation: "ask",
+        payload: { text: "long-running" },
+        deadline: 10_000,
+      },
+      RESIDENT,
+    );
+    if ("refused" in started) throw new Error(started.refused);
+    const stopped = kernel.awaitDelegation(started.handle.delegationId).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    kernel.stop();
+
+    expect(await stopped).toEqual(new Error("delegation kernel has been stopped"));
   });
 
   test("an inline caller returns the deadline settlement even if its driver ignores abort", async () => {

--- a/apps/openomni/test/helpers/fake-work-items.ts
+++ b/apps/openomni/test/helpers/fake-work-items.ts
@@ -8,6 +8,7 @@ export function fakeWorkItemLinkage(): WorkItemLinkage {
       sequence += 1;
       return Promise.resolve(`wi-fake-${sequence}`);
     },
+    cancelAssign: () => Promise.resolve(),
     closeAttempt: () => Promise.resolve(),
     recoverAttempts: () => Promise.resolve(),
   };

--- a/packages/agent/src/compaction/compact.ts
+++ b/packages/agent/src/compaction/compact.ts
@@ -22,7 +22,11 @@ export interface CompactionOptions {
    * merges, it never regenerates. The mechanism owns the exclusions and the
    * threading; what the summarizer does with them is strategy.
    */
-  onSummarize?: (messages: Message.WithParts[], previousAnchor?: string) => Promise<string>;
+  onSummarize?: (
+    messages: Message.WithParts[],
+    previousAnchor?: string,
+    signal?: AbortSignal,
+  ) => Promise<string>;
   /**
    * Budget (chars) of most-recent user messages carried verbatim through a
    * cut. The newest user message is always preserved even when it alone

--- a/packages/agent/src/compaction/policy.ts
+++ b/packages/agent/src/compaction/policy.ts
@@ -16,7 +16,17 @@ type CompactionConfig = CompactionOptions & {
  * home for stateful policies (engines are built once per run and invoke
  * `create()` at registration).
  */
-export function createCompactionPolicy(config: CompactionConfig): PolicyRegistrationFactory {
+type CompactionPolicyRegistration = ReturnType<PolicyRegistrationFactory["create"]> & {
+  readonly onRunEnd?: () => void;
+  readonly speculationStarted?: () => Promise<void>;
+  readonly speculationSettled?: () => Promise<void>;
+};
+
+type CompactionPolicyFactory = PolicyRegistrationFactory & {
+  readonly create: () => CompactionPolicyRegistration;
+};
+
+export function createCompactionPolicy(config: CompactionConfig): CompactionPolicyFactory {
   return {
     kind: "factory",
     name: "builtin:compaction",
@@ -26,7 +36,7 @@ export function createCompactionPolicy(config: CompactionConfig): PolicyRegistra
 
 function buildRegistration(
   config: CompactionConfig,
-): ReturnType<PolicyRegistrationFactory["create"]> {
+): CompactionPolicyRegistration {
   const { events, priority, ...compaction } = config;
   const speculator: Speculator | undefined =
     compaction.onSummarize !== undefined && compaction.speculate !== false
@@ -50,6 +60,9 @@ function buildRegistration(
       ...(speculator === undefined ? {} : { "run.turn.post": [] }),
     },
     priority,
+    onRunEnd: () => speculator?.abort(),
+    speculationStarted: () => speculator?.started() ?? Promise.resolve(),
+    speculationSettled: () => speculator?.settled() ?? Promise.resolve(),
     fn: async (ctx) => {
       if (!ctx.messages || ctx.messages.length === 0) {
         return PolicyDecision.allow({ policyId: "builtin.compaction" });

--- a/packages/agent/src/compaction/speculate.ts
+++ b/packages/agent/src/compaction/speculate.ts
@@ -44,6 +44,12 @@ export interface Speculator {
   peek(): CompactionCandidate | undefined;
   /** The seam consumed (promoted or discarded) whatever was pending. */
   consume(): void;
+  /** Cancel and invalidate background work when the run reaches a terminal. */
+  abort(): void;
+  /** Resolves when the current background preparation starts. */
+  started(): Promise<void>;
+  /** Resolves when the current background preparation settles. */
+  settled(): Promise<void>;
 }
 
 export const DEFAULT_PREPARE_RATIO = 0.65;
@@ -60,11 +66,20 @@ function isIdPrefix(spanIds: readonly string[], messages: readonly Message.WithP
 export function createSpeculator(config: {
   readonly prepareRatio: number;
   readonly protectRecentMessages: number;
-  readonly onSummarize: (messages: Message.WithParts[], previousAnchor?: string) => Promise<string>;
+  readonly onSummarize: (
+    messages: Message.WithParts[],
+    previousAnchor?: string,
+    signal?: AbortSignal,
+  ) => Promise<string>;
 }): Speculator {
   let candidate: CompactionCandidate | undefined;
   let inFlight = false;
   let failStreak = 0;
+  let generation = 0;
+  let controller: AbortController | undefined;
+  let preparation = Promise.resolve();
+  let started = Promise.resolve();
+  let resolveStarted: (() => void) | undefined;
 
   return {
     maybePrepare(messages, contextTokens, contextWindowTokens, onFailure) {
@@ -81,14 +96,31 @@ export function createSpeculator(config: {
       if (plan === undefined || plan.summarizerInput.length === 0) return;
 
       inFlight = true;
-      void config
-        .onSummarize(plan.summarizerInput, plan.previousAnchor)
+      started = new Promise<void>((resolve) => {
+        resolveStarted = resolve;
+      });
+      const runGeneration = generation;
+      const preparationController = new AbortController();
+      controller = preparationController;
+      preparation = Promise.resolve()
+        .then(() => {
+          resolveStarted?.();
+          resolveStarted = undefined;
+          if (runGeneration !== generation || preparationController.signal.aborted) return undefined;
+          return config.onSummarize(
+            plan.summarizerInput,
+            plan.previousAnchor,
+            preparationController.signal,
+          );
+        })
         .then((merged) => {
+          if (runGeneration !== generation || merged === undefined) return;
           failStreak = 0;
           candidate =
             merged.trim().length > 0 ? { spanIds: plan.spanIds, anchorBody: merged } : undefined;
         })
         .catch((error: unknown) => {
+          if (runGeneration !== generation) return;
           // Absent candidate: the seam falls back to its synchronous merge,
           // which surfaces the same failure through the fail-closed bracket
           // if it repeats there. Nothing to rethrow into — this promise has
@@ -98,12 +130,24 @@ export function createSpeculator(config: {
           onFailure?.(error, failStreak);
         })
         .finally(() => {
-          inFlight = false;
+          if (runGeneration === generation) {
+            inFlight = false;
+            controller = undefined;
+          }
         });
     },
     peek: () => candidate,
     consume: () => {
       candidate = undefined;
     },
+    abort: () => {
+      generation += 1;
+      candidate = undefined;
+      controller?.abort();
+      controller = undefined;
+      inFlight = false;
+    },
+    started: () => started,
+    settled: () => preparation,
   };
 }

--- a/packages/agent/src/core/execution/run.ts
+++ b/packages/agent/src/core/execution/run.ts
@@ -100,6 +100,7 @@ export async function runAgent(
    * — escaped past its own record.
    */
   const finish = (result: AgentResult): AgentResult => {
+    engine.endRun();
     emitRunCompleted(config.events, state, agentBase, result.finishReason);
     return result;
   };
@@ -119,10 +120,10 @@ export async function runAgent(
     maxAttempts: retryPolicy.maxAttempts,
   });
 
-  const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
-  if (preRunResult) return finish(preRunResult);
-
   try {
+    const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
+    if (preRunResult) return finish(preRunResult);
+
     for (;;) {
       try {
         // Attempt identity for lifecycle policies (#694 observation material):
@@ -273,6 +274,7 @@ export async function runAgent(
       }
     }
   } catch (error) {
+    engine.endRun();
     emitRunFailed(
       config.events,
       agentBase,
@@ -327,10 +329,12 @@ async function resolveProviderModel(model: {
   throw new Error(`Model not found: ${model.id} for provider ${model.provider}`);
 }
 
+type RunPolicyEngine = PolicyEngineInstance & { readonly endRun: () => void };
+
 export function buildPolicyEngine(
   config: ChatAgentConfig,
   agentBase: AgentRunBase,
-): PolicyEngineInstance {
+): RunPolicyEngine {
   const engine = PolicyEngine.create({
     traceContext: {
       traceId: agentBase.traceId,
@@ -339,8 +343,23 @@ export function buildPolicyEngine(
     },
     auditEmit: (descriptor, data) => config.events.publish(descriptor, data),
   });
+  const onRunEnd: Array<() => void> = [];
   for (const reg of config.middleware ?? []) {
-    engine.register(reg);
+    if (reg.kind === "factory") {
+      const created = reg.create();
+      // Re-wrap the already-created registration so the generic engine keeps
+      // its async factory lane while this runner retains its run-end hook.
+      engine.register({ kind: "factory", name: reg.name, create: () => created });
+      const cleanup = (created as { readonly onRunEnd?: () => void }).onRunEnd;
+      if (cleanup !== undefined) onRunEnd.push(cleanup);
+    } else {
+      engine.register(reg);
+    }
   }
-  return engine;
+  return Object.assign(engine, {
+    endRun: () => {
+      for (const cleanup of onRunEnd) cleanup();
+      onRunEnd.length = 0;
+    },
+  });
 }

--- a/packages/agent/src/runtime/mcp/client.ts
+++ b/packages/agent/src/runtime/mcp/client.ts
@@ -158,15 +158,25 @@ export class McpClient {
         undefined,
         requestOptions(this.config, context),
       );
+      const result = convertMcpResult(
+        response as {
+          content: Array<{ type: string; text?: string }>;
+          isError?: boolean;
+        },
+        toolCallId,
+      );
+      this.events.publish(Mcp.Events.ToolCompleted, {
+        traceId,
+        serverName: this.config.name,
+        toolName: strippedName,
+        toolCallId,
+        durationMs: Date.now() - startTime,
+        resultSummary: result.output,
+        time: Date.now(),
+      });
 
       return {
-        ...convertMcpResult(
-          response as {
-            content: Array<{ type: string; text?: string }>;
-            isError?: boolean;
-          },
-          toolCallId,
-        ),
+        ...result,
         // #500 C4: the exposed (server-prefixed) name the caller invoked.
         toolName: name,
       };

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -380,6 +380,64 @@ it("handles toolExecutor errors by setting isError: true", async () => {
   expect(result.finishReason).toBe("stop");
 });
 
+it("records an unknown object outcome as a terminal failure", async () => {
+  mockRunFn = async () => ({}) as never;
+
+  await expect(
+    createAgent().run(runInput([{ role: "user", content: "unknown outcome" }])),
+  ).rejects.toThrow("Unknown outcome type: unknown");
+});
+
+it("records an unknown named outcome as a terminal failure", async () => {
+  mockRunFn = async () => ({ type: "unexpected" }) as never;
+
+  await expect(
+    createAgent().run(runInput([{ role: "user", content: "named outcome" }])),
+  ).rejects.toThrow("Unknown outcome type: unexpected");
+});
+
+it("fails with a terminal record when the default provider is missing", async () => {
+  process.env.OPENOMNI_DISABLE_MODELS_FETCH = "1";
+  try {
+    await expect(
+      ChatAgent.create({
+        events: Bus,
+        model: { provider: "missing-provider", id: "missing-model" },
+      }).run(runInput([{ role: "user", content: "lookup" }])),
+    ).rejects.toThrow("Provider not found: missing-provider");
+  } finally {
+    delete process.env.OPENOMNI_DISABLE_MODELS_FETCH;
+  }
+});
+
+it("fails with a terminal record when the default model is missing", async () => {
+  process.env.OPENOMNI_DISABLE_MODELS_FETCH = "1";
+  try {
+    await expect(
+      ChatAgent.create({
+        events: Bus,
+        model: { provider: "anthropic", id: "missing-model" },
+      }).run(runInput([{ role: "user", content: "lookup" }])),
+    ).rejects.toThrow("Model not found: missing-model for provider anthropic");
+  } finally {
+    delete process.env.OPENOMNI_DISABLE_MODELS_FETCH;
+  }
+});
+
+it("resolves a known model through the default provider path", async () => {
+  process.env.OPENOMNI_DISABLE_MODELS_FETCH = "1";
+  try {
+    const result = await ChatAgent.create({
+      events: Bus,
+      model: { provider: "anthropic", id: "claude-opus-4-5" },
+      llm: { run: async () => createStopOutcome() },
+    }).run(runInput([{ role: "user", content: "hello" }]));
+    expect(result.finishReason).toBe("stop");
+  } finally {
+    delete process.env.OPENOMNI_DISABLE_MODELS_FETCH;
+  }
+});
+
 it("throws when tools are configured without toolExecutor", async () => {
   const agent = ChatAgent.create({
     events: Bus,

--- a/packages/agent/test/compaction/speculate.test.ts
+++ b/packages/agent/test/compaction/speculate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Message } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { createCompactionPolicy } from "../../src/compaction/policy";
+import { createSpeculator } from "../../src/compaction/speculate";
 
 /**
  * L4 (#714): speculative prepare/promote. The expensive summarize runs in
@@ -100,7 +101,9 @@ function seamCtx(messages: Message.WithParts[], contextTokens: number) {
   } as never;
 }
 
-function build(summarize: (m: Message.WithParts[], p?: string) => Promise<string>) {
+function build(
+  summarize: (m: Message.WithParts[], p?: string, signal?: AbortSignal) => Promise<string>,
+) {
   return createCompactionPolicy({
     contextWindowTokens: 100,
     protectRecentMessages: 2,
@@ -108,6 +111,12 @@ function build(summarize: (m: Message.WithParts[], p?: string) => Promise<string
     events: Bus,
     priority: 900,
   }).create();
+}
+
+async function settle(registration: unknown): Promise<void> {
+  await (
+    registration as { readonly speculationSettled?: () => Promise<void> }
+  ).speculationSettled?.();
 }
 
 describe("speculative prepare/promote (L4)", () => {
@@ -140,11 +149,11 @@ describe("speculative prepare/promote (L4)", () => {
       return "candidate";
     });
     await registration.fn(turnPostCtx(history(), 60)); // below 0.65 × 100
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(0);
 
     await registration.fn(turnPostCtx(history(), 70)); // above
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
   });
 
@@ -162,9 +171,9 @@ describe("speculative prepare/promote (L4)", () => {
     await registration.fn(turnPostCtx(messages, 70));
     await registration.fn(turnPostCtx(messages, 75)); // while in flight
     release("candidate");
-    await Bun.sleep(0);
+    await settle(registration);
     await registration.fn(turnPostCtx(messages, 80)); // candidate already held
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
   });
 
@@ -176,7 +185,7 @@ describe("speculative prepare/promote (L4)", () => {
     });
     const messages = history();
     await registration.fn(turnPostCtx(messages, 70));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
 
     const decision = await registration.fn(seamCtx(messages, 85));
@@ -199,7 +208,7 @@ describe("speculative prepare/promote (L4)", () => {
     });
     const messages = history();
     await registration.fn(turnPostCtx(messages, 70));
-    await Bun.sleep(0);
+    await settle(registration);
 
     // Two more turns landed before the seam fired.
     const grown = [...messages, user("late-q"), assistant("late-a")];
@@ -226,7 +235,7 @@ describe("speculative prepare/promote (L4)", () => {
     });
     const messages = history();
     await registration.fn(turnPostCtx(messages, 70));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
 
     // History replaced (fresh ids): the candidate's span is no longer a prefix.
@@ -247,7 +256,7 @@ describe("speculative prepare/promote (L4)", () => {
     });
     const messages = history();
     await registration.fn(turnPostCtx(messages, 70));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
 
     // Seam falls back to the synchronous merge — the failure stayed out of
@@ -271,7 +280,7 @@ describe("speculative prepare/promote (L4)", () => {
     // render outweighs it.
     const tiny = [user("q"), assistant("a"), user("t1"), user("t2")];
     await registration.fn(turnPostCtx(tiny, 70));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
 
     // The history grew massively: the candidate's tiny-span promote cannot
@@ -303,7 +312,7 @@ describe("speculative prepare/promote (L4)", () => {
     });
     const messages = history();
     await registration.fn(turnPostCtx(messages, 70));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(1);
 
     // A seam that never reaches the candidate branch (history within the
@@ -321,6 +330,36 @@ describe("speculative prepare/promote (L4)", () => {
     );
   });
 
+  it("does not start preparation after an abort before its microtask", async () => {
+    let calls = 0;
+    const speculator = createSpeculator({
+      prepareRatio: 0.65,
+      protectRecentMessages: 2,
+      onSummarize: async () => {
+        calls += 1;
+        return "late";
+      },
+    });
+    speculator.maybePrepare(history(), 70, 100);
+    speculator.abort();
+    await speculator.settled();
+    expect(calls).toBe(0);
+  });
+
+  it("aborts an in-flight candidate when the run ends", async () => {
+    const registration = build(async () => "must-not-promote");
+    const messages = history();
+    await registration.fn(turnPostCtx(messages, 70));
+    (registration as { readonly onRunEnd?: () => void }).onRunEnd?.();
+    await settle(registration);
+
+    expect((registration as { readonly speculationSettled?: () => Promise<void> }).speculationSettled).toBeDefined();
+    const decision = await registration.fn(seamCtx(messages, 85));
+    expect((decision as { reasonCodes?: string[] }).reasonCodes).not.toContain(
+      "compaction_candidate_promoted",
+    );
+  });
+
   it("stops preparing after the failure streak cap, visibly", async () => {
     let calls = 0;
     const registration = build(async () => {
@@ -329,13 +368,13 @@ describe("speculative prepare/promote (L4)", () => {
     });
     const messages = history();
     await registration.fn(turnPostCtx(messages, 70));
-    await Bun.sleep(0);
+    await settle(registration);
     await registration.fn(turnPostCtx(messages, 72));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(2);
     // Streak cap reached: no more prepares this run.
     await registration.fn(turnPostCtx(messages, 74));
-    await Bun.sleep(0);
+    await settle(registration);
     expect(calls).toBe(2);
   });
 });

--- a/packages/agent/test/runtime/mcp/client-trace.test.ts
+++ b/packages/agent/test/runtime/mcp/client-trace.test.ts
@@ -40,6 +40,29 @@ describe("McpClient call audit trace", () => {
     Bus.reset();
   });
 
+  test("publishes the exact success payload for a completed tool call", async () => {
+    const client = createClient(async () => ({ content: [{ type: "text", text: "found it" }] }));
+    const completed = nextEvent(Mcp.Events.ToolCompleted);
+
+    const result = await client.callTool("search-server.search", {}, "call-complete", {
+      traceContext: {
+        traceId: "trace-mcp-complete",
+        sessionId: "session-mcp-complete",
+        runId: "run-mcp-complete",
+      },
+    });
+
+    expect(result.output).toBe("found it");
+    expect(await completed).toMatchObject({
+      traceId: "trace-mcp-complete",
+      serverName: "search-server",
+      toolName: "search",
+      toolCallId: "call-complete",
+      resultSummary: "found it",
+    });
+    expect((await completed).durationMs).toBeGreaterThanOrEqual(0);
+  });
+
   test("uses the execution trace for called and failed events", async () => {
     // Given
     Bus.reset();

--- a/packages/ledger/src/delegation/index.ts
+++ b/packages/ledger/src/delegation/index.ts
@@ -29,13 +29,19 @@ export namespace DelegationStore {
     return parsed;
   }
 
-  /** Atomically commits an open record only while its root has fanout capacity. */
+  export type OpenWithinRootClaim =
+    | { readonly claimed: true; readonly record: Delegation.Record }
+    | { readonly claimed: false; readonly reason: "fanout_cap" | "parent_settled" };
+
+  /** Atomically commits an open record only while all admission constraints hold. */
   export function claimOpenWithinRoot(
     record: Delegation.Record,
     maxFanout: number,
-  ): Delegation.Record | undefined {
+    constraints: { readonly requireOpenParent?: string } = {},
+  ): OpenWithinRootClaim {
     const parsed = Delegation.Record.parse(record);
     const adapter = requireAdapter();
+    let refusal: "fanout_cap" | "parent_settled" = "fanout_cap";
     const result = claimWithinCountedWindow({
       transaction: (operation) => Storage.get().transaction(operation),
       alreadyClaimed: () => {
@@ -46,15 +52,29 @@ export namespace DelegationStore {
         }
         return true;
       },
-      readWindowState: () => adapter.listOpenByRoot(parsed.rootDelegationId).length,
-      canClaim: (openFanout) => openFanout < maxFanout,
+      readWindowState: () => ({
+        openFanout: adapter.listOpenByRoot(parsed.rootDelegationId).length,
+        parent:
+          constraints.requireOpenParent === undefined
+            ? undefined
+            : adapter.get(constraints.requireOpenParent),
+      }),
+      canClaim: ({ openFanout, parent }) => {
+        if (constraints.requireOpenParent !== undefined && parent?.status !== "open") {
+          refusal = "parent_settled";
+          return false;
+        }
+        return openFanout < maxFanout;
+      },
       append: () => {
         if (!adapter.create(parsed)) {
           throw new Error(`Delegation already exists: ${parsed.delegationId}`);
         }
       },
     });
-    return result === "claimed" ? parsed : undefined;
+    return result === "claimed"
+      ? { claimed: true, record: parsed }
+      : { claimed: false, reason: refusal };
   }
 
   export function get(delegationId: string): Delegation.Record | undefined {

--- a/packages/ledger/src/delegation/index.ts
+++ b/packages/ledger/src/delegation/index.ts
@@ -1,4 +1,5 @@
 import { Delegation, type Storage as ProtocolStorage } from "@openomni/protocol";
+import { claimWithinCountedWindow } from "../storage/counted-window-claim.js";
 import { Storage } from "../storage/storage";
 
 function requireAdapter(): ProtocolStorage.DelegationSubAdapter {
@@ -26,6 +27,34 @@ export namespace DelegationStore {
       throw new Error(`Delegation already exists: ${parsed.delegationId}`);
     }
     return parsed;
+  }
+
+  /** Atomically commits an open record only while its root has fanout capacity. */
+  export function claimOpenWithinRoot(
+    record: Delegation.Record,
+    maxFanout: number,
+  ): Delegation.Record | undefined {
+    const parsed = Delegation.Record.parse(record);
+    const adapter = requireAdapter();
+    const result = claimWithinCountedWindow({
+      transaction: (operation) => Storage.get().transaction(operation),
+      alreadyClaimed: () => {
+        const existing = adapter.get(parsed.delegationId);
+        if (existing === undefined) return false;
+        if (JSON.stringify(existing) !== JSON.stringify(parsed)) {
+          throw new Error(`Delegation already exists: ${parsed.delegationId}`);
+        }
+        return true;
+      },
+      readWindowState: () => adapter.listOpenByRoot(parsed.rootDelegationId).length,
+      canClaim: (openFanout) => openFanout < maxFanout,
+      append: () => {
+        if (!adapter.create(parsed)) {
+          throw new Error(`Delegation already exists: ${parsed.delegationId}`);
+        }
+      },
+    });
+    return result === "claimed" ? parsed : undefined;
   }
 
   export function get(delegationId: string): Delegation.Record | undefined {

--- a/packages/ledger/test/delegation/store.test.ts
+++ b/packages/ledger/test/delegation/store.test.ts
@@ -147,6 +147,38 @@ for (const { name, create } of adapters) {
       expect(DelegationStore.countOpenByRoot("delegation-other")).toBe(1);
     });
 
+    test("atomically refuses a child claim when its required parent is settled", () => {
+      DelegationStore.create(buildDelegationRecord({
+        delegationId: "parent",
+        waitId: "wait-parent",
+        rootDelegationId: "parent",
+      }));
+      DelegationStore.settle("parent", {
+        status: "cancelled",
+        delegationId: "parent",
+        reason: "parent cancelled",
+        at: 200,
+      });
+      const child = buildDelegationRecord({
+        delegationId: "child",
+        waitId: "wait-child",
+        parentDelegationId: "parent",
+        rootDelegationId: "parent",
+        origin: {
+          role: "worker",
+          depth: 1,
+          sessionId: "session-1",
+          parentDelegationId: "parent",
+          rootDelegationId: "parent",
+        },
+      });
+
+      expect(
+        DelegationStore.claimOpenWithinRoot(child, 8, { requireOpenParent: "parent" }),
+      ).toEqual({ claimed: false, reason: "parent_settled" });
+      expect(DelegationStore.get("child")).toBeUndefined();
+    });
+
     test("lists all and only open delegations in admission order", () => {
       DelegationStore.create(buildDelegationRecord());
       DelegationStore.create(


### PR DESCRIPTION
## Scope (audit remediation PR-5: app delegation/boot + agent lifecycle)

Delegation kernel / boot (apps/openomni):
- **Settled-parent commission refusal**: admission fold now refuses a child whose durable parent delegation is already settled — typed refusal `parent_settled` (admission.ts). Previously `parent.status` was loaded but never checked.
- **Fanout cap atomic claim**: final admission write goes through `DelegationStore.claimOpenWithinRoot()`, which delegates to the #834 `claimWithinCountedWindow` primitive under `BEGIN IMMEDIATE` — two concurrent delegates can no longer both pass at cap-1. Losing assign claims roll back the already-commissioned WorkItem through the existing work-item-linkage cancellation path before returning `fanout_cap` (no orphaned WorkItems). Deterministic two-caller race test with an exact preparation barrier, no sleeps.
- **Boot rollback flush-before-reset**: producers stop, persistence flushes, then observer/storage reset (index.ts) — buffered journal writes can no longer be dropped by rollback. Scratch-revert loses `wait.expired`.
- **Stopped-kernel waiter cleanup**: `stop()` rejects exact pending `delegation_await` promises; settlement/timeout/stop all release ownership.
- **Wake receipt idempotency**: verified NOT a defect — `settleOnce` CAS makes duplicate wakes side-effect-free; call-path proof in the lane report (skip, no change).

Agent lifecycle (packages/agent):
- **MCP success event**: `Mcp.Events.ToolCompleted` (already defined in protocol) is now published on the success arm of `McpClient.callTool` with the exact schema payload; previously only ToolCalled/ToolFailed were emitted.
- **Pre-run throw terminal**: `dispatchPreRun` moved inside the terminal-owning `try` in execution/run.ts — no pre-loop throw can leave a run without a terminal outcome.
- **Speculative compaction abort linkage**: each preparation owns an AbortController + generation; run end aborts in-flight candidates and late resolutions cannot install a candidate. Controller/signal captured synchronously at scheduling time so an abort landing before the queued microtask skips the summarizer instead of invoking it with an undefined signal.
- **Timing tests -> exact signals**: speculation tests await the exact `speculationSettled` signal; remaining `Bun.sleep(0)` scheduler flushes are documented, no nonzero sleeps.

## Evidence
- Failing-first: every behavior change has verbatim RED output captured in the lane reports (worktree `.omo/pr5-app-delegation.md`, `.omo/pr5-agent-lifecycle.md`).
- Verifier: independent node scratch-reverted the 3 most critical hunks (fanout claim, boot flush, speculation linkage) and confirmed test discrimination; verdict + gate chain in `.omo/pr5-verify.md`, `.omo/gate-chain-pr5.log`.

## Coverage note (Owner visibility)
- `apps/openomni` has no entry in `script/conformance/coverage-baseline.json` and no CI coverage lane (ci.yml matrix covers 9 packages; app absent) — adding either is baseline GROWTH and needs Owner sign-off, so this PR does not touch the baseline. Local app coverage measured ~90.8%.
- `packages/agent` coverage restored to >= its 97.25% baseline with focused tests on pre-existing uncovered error branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delegation admission and boot rollback durability in `apps/openomni` and closes agent lifecycle gaps in `packages/agent`.

**Delegation & boot durability**
- `DelegationStore.claimOpenWithinRoot` atomically commits a child only while its parent is open and fanout allows, so settled-parent admission returns typed `parent_settled` and two concurrent delegates can no longer both pass at cap-1.
- Losing assign claims cancel their commissioned WorkItem; a failed cancel publishes an operational error without masking the refusal.
- Boot rollback flushes the bus journal before stopping persistence and resetting storage so buffered `wait.expired` writes survive; a flush failure carries both errors.
- `stop()` rejects pending `delegation_await` promises, and later calls reject immediately with the same error.

**Agent lifecycle**
- Successful MCP calls publish `Mcp.Events.ToolCompleted` with the schema payload; previously only ToolCalled/ToolFailed were emitted.
- Pre-run dispatch is inside the terminal-owning try so no pre-loop throw leaves a run without a terminal outcome.
- Speculative compaction aborts in-flight preparations on run end via per-preparation AbortController and generation, so an abort before its microtask skips the summarizer instead of invoking it with an undefined signal.
- Speculation tests await the exact `speculationSettled` signal instead of `Bun.sleep(0)`.
- `apps/openomni` has no CI coverage lane, so this PR doesn't change the coverage baseline; local app coverage measured ~90.8%.

<sup>Written for commit 92b7f94950e8aa9d9435d42722c3325d54c23368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards preventing delegations under settled parents or beyond fanout limits.
  - Added cancellation and rollback for assignments refused during delegation.
  - Added completion events for successful tool calls, including duration and result summaries.
  - Added cancellation support for in-progress response summarization.

- **Bug Fixes**
  - Improved cleanup when the application fails during startup.
  - Pending delegation waits now terminate cleanly when the kernel stops.
  - Unknown outcomes and missing providers or models now produce clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->