### PR TITLE
chore(app-test): drop unused Delegation import (audit follow-up)

### DIFF
--- a/apps/openomni/test/work-item-wiring.test.ts
+++ b/apps/openomni/test/work-item-wiring.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DelegationStore, Storage, WorkItemStore, initialize } from "@openomni/ledger";
-import { Delegation, WorkItem } from "@openomni/protocol";
+import { WorkItem } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import type { DelegationOrigin } from "../src/delegation/admission";
 import { createDelegationKernel, type DriverOutcome } from "../src/delegation/kernel";


### PR DESCRIPTION
One-line hygiene follow-up to the audit-remediation campaign (#831-#839): `apps/openomni/test/work-item-wiring.test.ts` imported `Delegation` without using it — the sole remaining `ultracite check .` diagnostic on main. No behavior change; suite 2580-test chain otherwise green on be8dfb6c.

Verify: `bun test apps/openomni/test/work-item-wiring.test.ts` green; `bunx ultracite check --formatter-enabled=false apps/openomni/test/work-item-wiring.test.ts` zero diagnostics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `Delegation` import from `apps/openomni/test/work-item-wiring.test.ts` to clear the last `ultracite` lint diagnostic on main. No behavior change; the test only uses `WorkItem` from that module.

<sup>Written for commit 2b3d7579659efe1680d2c77e88a6f9327bdf8af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal type reference from the work-item wiring tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->