### PR TITLE
protocol: semantic unification — JSON owner, frozen digest, deadline & EpochMs

### DIFF
--- a/packages/ledger/src/engagement/index.ts
+++ b/packages/ledger/src/engagement/index.ts
@@ -1,4 +1,4 @@
-import { Engagement, type Storage as ProtocolStorage } from "@openomni/protocol";
+import { Deadline, Engagement, type Storage as ProtocolStorage } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { isSqliteBusyError } from "../storage/sqlite-busy";
 import { Storage } from "../storage/storage";
@@ -257,7 +257,9 @@ export namespace EngagementStore {
     const active = requireAdapter().list({ ownerSessionId, states: [...ACTIVE_STATES] });
     const alive: Engagement.Record[] = [];
     for (const record of active) {
-      if (record.expiresAt !== undefined && now > record.expiresAt) {
+      // Canonical deadline boundary (Deadline.isExpired): the exact instant
+      // is expired — must agree with the Engagement fold's deadline gates.
+      if (record.expiresAt !== undefined && Deadline.isExpired(now, record.expiresAt)) {
         try {
           expire(record.id, traceId, now);
         } catch (error) {

--- a/packages/ledger/test/engagement/store.test.ts
+++ b/packages/ledger/test/engagement/store.test.ts
@@ -190,6 +190,13 @@ describe("EngagementStore expiry", () => {
     expect(again.map((record) => record.id)).toEqual(["eng-2"]);
   });
 
+  test("listActive expires a record at the exact deadline instant (Deadline.isExpired boundary)", () => {
+    EngagementStore.open(buildCreate({ terms: { deadline: T0 + 500 } }), "trace-open", T0);
+    const atDeadline = EngagementStore.listActive("ses-owner", "trace-boundary", T0 + 500);
+    expect(atDeadline).toEqual([]);
+    expect(EngagementStore.get("eng-1")?.state).toBe("expired");
+  });
+
   test("listActive scopes to the owner session", () => {
     EngagementStore.open(buildCreate(), "trace-open", T0);
     EngagementStore.open(

--- a/packages/protocol/src/actor/index.ts
+++ b/packages/protocol/src/actor/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Model } from "../model/index.js";
 import { Tool } from "../tool/index.js";
+import { EpochMs } from "../time.js";
 
 export namespace Actor {
   /**
@@ -44,8 +45,8 @@ export namespace Actor {
     trustTier: TrustTier,
     displayName: z.string().min(1).optional(),
     metadata: Metadata.optional(),
-    createdAt: z.number().optional(),
-    updatedAt: z.number().optional(),
+    createdAt: EpochMs.optional(),
+    updatedAt: EpochMs.optional(),
   });
   export type Identity = z.infer<typeof Identity>;
 
@@ -57,9 +58,9 @@ export namespace Actor {
     workspace: z.string().min(1).optional(),
     displayName: z.string().min(1).optional(),
     metadata: Metadata.optional(),
-    verifiedAt: z.number().optional(),
-    createdAt: z.number().optional(),
-    updatedAt: z.number().optional(),
+    verifiedAt: EpochMs.optional(),
+    createdAt: EpochMs.optional(),
+    updatedAt: EpochMs.optional(),
   });
   export type Endpoint = z.infer<typeof Endpoint>;
 
@@ -77,10 +78,10 @@ export namespace Actor {
     kind: BlacklistKind,
     value: z.string().min(1),
     reason: z.string().min(1).optional(),
-    expiresAt: z.number().optional(),
+    expiresAt: EpochMs.optional(),
     createdBy: z.string().min(1),
-    createdAt: z.number().optional(),
-    updatedAt: z.number().optional(),
+    createdAt: EpochMs.optional(),
+    updatedAt: EpochMs.optional(),
   });
   export type BlacklistEntry = z.infer<typeof BlacklistEntry>;
 
@@ -103,8 +104,8 @@ export namespace Actor {
     defaultTier: TrustTier.optional(),
     inboundTreatment: InboundTreatment.optional(),
     createdBy: z.string().min(1),
-    createdAt: z.number().optional(),
-    updatedAt: z.number().optional(),
+    createdAt: EpochMs.optional(),
+    updatedAt: EpochMs.optional(),
   });
   export type ChannelGrant = z.infer<typeof ChannelGrant>;
 

--- a/packages/protocol/src/cron/index.ts
+++ b/packages/protocol/src/cron/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EpochMs } from "../time.js";
 
 export namespace CronJob {
   export const Target = z.object({
@@ -13,8 +14,8 @@ export namespace CronJob {
     payload: z.string(),
     schedule: z.string(),
     target: Target,
-    createdAt: z.number(),
-    nextFireAt: z.number().optional(),
+    createdAt: EpochMs,
+    nextFireAt: EpochMs.optional(),
   });
   export type Info = z.infer<typeof Info>;
 }

--- a/packages/protocol/src/delegation/events.ts
+++ b/packages/protocol/src/delegation/events.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
 import { Operation, SettledStatus, Transport } from "./schema.js";
+import { EpochMs } from "../time.js";
 
 const EventBase = z.object({
   delegationId: z.string().min(1),
   traceId: z.string().min(1),
-  time: z.number(),
+  time: EpochMs,
 });
 
 export const Events = {
@@ -22,7 +23,7 @@ export const Events = {
       addressKind: z.enum(["core", "actor"]),
       transport: Transport,
       /** Effective deadline (epoch ms) the record was committed under. */
-      deadline: z.number().int().positive(),
+      deadline: EpochMs.int().positive(),
       rootDelegationId: z.string().min(1),
     }),
     { visibility: "llm_reason" },

--- a/packages/protocol/src/delegation/schema.ts
+++ b/packages/protocol/src/delegation/schema.ts
@@ -269,7 +269,7 @@ const RecordBase = z
     createdAt: EpochMs,
     settledAt: EpochMs.optional(),
     /** Receipt written only after the owner-session settlement wake succeeds. */
-    wokenAt: z.number().optional(),
+    wokenAt: EpochMs.optional(),
   })
   .strict();
 

--- a/packages/protocol/src/delegation/schema.ts
+++ b/packages/protocol/src/delegation/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EpochMs } from "../time.js";
 
 /**
  * Where delegated work goes (docs/machines-and-delegation.md §3).
@@ -52,7 +53,7 @@ export const Request = z
     payload: z.object({ text: z.string().min(1) }).strict(),
     acceptanceCriteria: z.array(z.string().min(1)).optional(),
     /** Epoch ms. Required: no unbounded delegation exists (kernel-contract Wait law). */
-    deadline: z.number().int().positive(),
+    deadline: EpochMs.int().positive(),
   })
   .strict()
   .superRefine((request, ctx) => {
@@ -132,7 +133,7 @@ export const Handle = z
     address: WorkerAddress,
     transport: Transport,
     /** Effective deadline (epoch ms): min(requested, parentDeadline) computed at admission. */
-    deadline: z.number().int().positive(),
+    deadline: EpochMs.int().positive(),
     waitId: z.string().min(1).optional(),
     workItemId: z.string().min(1).optional(),
     parentDelegationId: z.string().min(1).optional(),
@@ -165,7 +166,7 @@ const SettledUnion = z.discriminatedUnion("status", [
       status: z.literal("completed"),
       delegationId: z.string().min(1),
       output: z.string(),
-      at: z.number(),
+      at: EpochMs,
       /** Transport-reported spend; visibility only, never an admission input. */
       usage: z.object({ tokens: z.number().int().nonnegative() }).strict().optional(),
     })
@@ -175,7 +176,7 @@ const SettledUnion = z.discriminatedUnion("status", [
       status: z.literal("failed"),
       delegationId: z.string().min(1),
       error: z.string().min(1),
-      at: z.number(),
+      at: EpochMs,
     })
     .strict(),
   z
@@ -183,7 +184,7 @@ const SettledUnion = z.discriminatedUnion("status", [
       status: z.literal("cancelled"),
       delegationId: z.string().min(1),
       reason: z.string().min(1),
-      at: z.number(),
+      at: EpochMs,
     })
     .strict(),
   z
@@ -191,7 +192,7 @@ const SettledUnion = z.discriminatedUnion("status", [
       status: z.literal("delivery_failed"),
       delegationId: z.string().min(1),
       reason: z.string().min(1),
-      at: z.number(),
+      at: EpochMs,
     })
     .strict(),
   z
@@ -199,22 +200,22 @@ const SettledUnion = z.discriminatedUnion("status", [
       status: z.literal("no_response"),
       delegationId: z.string().min(1),
       /** The deadline (epoch ms) whose expiry produced this terminal. */
-      deadline: z.number().int().positive(),
-      at: z.number(),
+      deadline: EpochMs.int().positive(),
+      at: EpochMs,
     })
     .strict(),
   z
     .object({
       status: z.literal("interrupted"),
       delegationId: z.string().min(1),
-      at: z.number(),
+      at: EpochMs,
     })
     .strict(),
   z
     .object({
       status: z.literal("sent"),
       delegationId: z.string().min(1),
-      at: z.number(),
+      at: EpochMs,
     })
     .strict(),
 ]);
@@ -255,7 +256,7 @@ const RecordBase = z
     address: WorkerAddress,
     transport: Transport,
     /** Effective deadline (epoch ms) — the same instant the Handle carries. */
-    deadline: z.number().int().positive(),
+    deadline: EpochMs.int().positive(),
     waitId: z.string().min(1).optional(),
     workItemId: z.string().min(1).optional(),
     parentDelegationId: z.string().min(1).optional(),
@@ -265,8 +266,8 @@ const RecordBase = z
     instruction: z.string().min(1),
     status: z.enum(["open", "settled"]),
     settled: Settled.optional(),
-    createdAt: z.number(),
-    settledAt: z.number().optional(),
+    createdAt: EpochMs,
+    settledAt: EpochMs.optional(),
     /** Receipt written only after the owner-session settlement wake succeeds. */
     wokenAt: z.number().optional(),
   })

--- a/packages/protocol/src/engagement/events.ts
+++ b/packages/protocol/src/engagement/events.ts
@@ -2,12 +2,13 @@ import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
 import { RejectionCode } from "./fold.js";
 import { State } from "./schema.js";
+import { EpochMs } from "../time.js";
 
 const EventBase = z.object({
   id: z.string().min(1),
   traceId: z.string().min(1),
   ownerSessionId: z.string().min(1),
-  time: z.number(),
+  time: EpochMs,
 });
 
 /**

--- a/packages/protocol/src/engagement/fold.ts
+++ b/packages/protocol/src/engagement/fold.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
+import { Deadline } from "../deadline/index.js";
 import * as Schema from "./schema.js";
+import { EpochMs } from "../time.js";
 
 /**
  * Pure deterministic engagement state machine (gateway-design §5, #709).
@@ -33,7 +35,7 @@ const TransitionInputBase = z
   .object({
     /** Requested target state. `expired` is never requestable; `planning` is entry-only. */
     to: Schema.State,
-    at: z.number(),
+    at: EpochMs,
     /** The declared move, recorded verbatim on the transition event. */
     reason: z.string().min(1),
     /**
@@ -128,7 +130,11 @@ export function transition(record: Schema.Record, input: TransitionInput): Outco
   if (TERMINAL.has(record.state)) {
     return { kind: "rejected", code: "engagement_terminal", record, at: input.at };
   }
-  if (record.expiresAt !== undefined && input.at > record.expiresAt && input.to !== "aborted") {
+  if (
+    record.expiresAt !== undefined &&
+    Deadline.isExpired(input.at, record.expiresAt) &&
+    input.to !== "aborted"
+  ) {
     return { kind: "rejected", code: "deadline_passed", record, at: input.at };
   }
   if (input.termCrossed === true && input.to !== "aborted") {
@@ -172,7 +178,7 @@ export function expire(record: Schema.Record, input: { at: number }): Outcome {
   if (TERMINAL.has(record.state)) {
     return { kind: "rejected", code: "engagement_terminal", record, at: input.at };
   }
-  if (record.expiresAt === undefined || input.at <= record.expiresAt) {
+  if (record.expiresAt === undefined || !Deadline.isExpired(input.at, record.expiresAt)) {
     return { kind: "rejected", code: "not_expired", record, at: input.at };
   }
   return {

--- a/packages/protocol/src/engagement/schema.ts
+++ b/packages/protocol/src/engagement/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { NamedError } from "../error/index.js";
+import { EpochMs } from "../time.js";
 
 /**
  * Engagement — the durable delegation object (gateway-design §5, #709).
@@ -35,7 +36,7 @@ const Terms = z
   .object({
     spendCeiling: z.number().positive().optional(),
     autoApprove: z.string().min(1).optional(),
-    deadline: z.number().optional(),
+    deadline: EpochMs.optional(),
     speakTriggers: z.array(z.string().min(1)).optional(),
   })
   .strict();
@@ -52,9 +53,9 @@ export const Record = z
     /** Waits that may resume this engagement in its current state. */
     openWaitIds: z.array(z.string().min(1)),
     /** Machine-enforced expiry instant, seeded from terms.deadline at open. */
-    expiresAt: z.number().optional(),
-    createdAt: z.number(),
-    updatedAt: z.number(),
+    expiresAt: EpochMs.optional(),
+    createdAt: EpochMs,
+    updatedAt: EpochMs,
     revision: z.number().int().nonnegative(),
   })
   .strict();
@@ -73,7 +74,7 @@ export const Create = Record.omit({
   createdAt: true,
   updatedAt: true,
 }).extend({
-  createdAt: z.number().optional(),
+  createdAt: EpochMs.optional(),
 });
 export type Create = z.infer<typeof Create>;
 

--- a/packages/protocol/src/event/ingress.ts
+++ b/packages/protocol/src/event/ingress.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { Actor } from "../actor/index.js";
 import { BusEvent } from "../bus/index.js";
+import { EpochMs } from "../time.js";
 
 const Base = z.object({
   traceId: z.string(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 const RoutingDecisionBase = Base.extend({

--- a/packages/protocol/src/event/llm.ts
+++ b/packages/protocol/src/event/llm.ts
@@ -1,12 +1,13 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
 import { Token } from "../token/index.js";
+import { EpochMs } from "../time.js";
 
 const Base = z.object({
   traceId: z.string(),
   sessionId: z.string(),
   runId: z.string().optional(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 export namespace LlmCall {

--- a/packages/protocol/src/event/mcp.ts
+++ b/packages/protocol/src/event/mcp.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
+import { EpochMs } from "../time.js";
 
 const Base = z.object({
   traceId: z.string(),
   serverName: z.string(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 export namespace Mcp {

--- a/packages/protocol/src/event/operational.ts
+++ b/packages/protocol/src/event/operational.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
+import { EpochMs } from "../time.js";
 
 const Base = z.object({
   traceId: z.string(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 const LogBase = Base.extend({

--- a/packages/protocol/src/event/policy.ts
+++ b/packages/protocol/src/event/policy.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
+import { EpochMs } from "../time.js";
 // Deep imports (not ../policy/index.js): the Policy namespace re-exports these
 // descriptors as `Policy.Events`, so importing the barrel here would be a cycle.
 import { PolicyEffects } from "../policy/effects.js";
@@ -9,7 +10,7 @@ const PolicyBase = z.object({
   traceId: z.string(),
   sessionId: z.string(),
   runId: z.string().optional(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 // Audit events retain upcast-on-read compatibility with historical obligations

--- a/packages/protocol/src/event/tool.ts
+++ b/packages/protocol/src/event/tool.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
+import { EpochMs } from "../time.js";
 
 const Base = z.object({
   traceId: z.string(),
@@ -8,7 +9,7 @@ const Base = z.object({
   actor: z.record(z.string(), z.unknown()).optional(),
   toolCallId: z.string(),
   toolName: z.string(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 export const Events = {

--- a/packages/protocol/src/gateway/events.ts
+++ b/packages/protocol/src/gateway/events.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
 import { Gateway } from "./schema.js";
+import { EpochMs } from "../time.js";
 
 const EventBase = z.object({
   messageId: z.string().min(1),
   traceId: z.string().min(1),
   senderId: z.string().min(1),
   targetActorId: z.string().min(1),
-  time: z.number(),
+  time: EpochMs,
 });
 
 /**

--- a/packages/protocol/src/gateway/schema.ts
+++ b/packages/protocol/src/gateway/schema.ts
@@ -3,6 +3,7 @@ import { Actor } from "../actor/index.js";
 import { Events as IngressEvents } from "../event/ingress.js";
 import { Ingress } from "../ingress/index.js";
 import { Wait } from "../wait/index.js";
+import { EpochMs } from "../time.js";
 
 /**
  * Gateway contracts (docs/gateway-design.md §2, stage 0 — #706).
@@ -137,7 +138,7 @@ const SenderTargetGrantSchema = z
     senderId: z.string().min(1),
     targetActorId: z.string().min(1),
     operations: z.array(MessageOperationSchema).min(1),
-    expiresAt: z.number().optional(),
+    expiresAt: EpochMs.optional(),
     /** Present iff this grant was materialized from a ReplyGrantRule — the provenance link that makes `maxLiveInstances` countable. */
     ruleId: z.string().min(1).optional(),
     /** Perimeter-fact scope of a materialized instance: replies stay inside the initiating container. */
@@ -192,8 +193,8 @@ const ReplyGrantRuleSchema = z
     instanceTtlMs: z.number().int().positive(),
     maxLiveInstances: z.number().int().positive(),
     createdBy: z.string().min(1),
-    createdAt: z.number().optional(),
-    updatedAt: z.number().optional(),
+    createdAt: EpochMs.optional(),
+    updatedAt: EpochMs.optional(),
   })
   .strict();
 
@@ -251,7 +252,7 @@ const SocialBudgetSchema = z
       .strict()
       .optional(),
     doNotContact: z.boolean().optional(),
-    expiresAt: z.number().optional(),
+    expiresAt: EpochMs.optional(),
   })
   .strict();
 
@@ -267,7 +268,7 @@ const EgressDebitRowSchema = z
     senderId: z.string().min(1),
     targetActorId: z.string().min(1),
     class: MessageClassSchema,
-    at: z.number(),
+    at: EpochMs,
   })
   .strict();
 
@@ -282,7 +283,7 @@ const EgressDebitStateSchema = z
     countInWindow: z.number().int().nonnegative(),
     notifyInWindow: z.number().int().nonnegative(),
     converseInWindow: z.number().int().nonnegative(),
-    lastSendAt: z.number().optional(),
+    lastSendAt: EpochMs.optional(),
   })
   .strict();
 
@@ -299,7 +300,7 @@ const AwaitSpecSchema = z
     expectedResponders: z.array(z.string().min(1)).min(1),
     resolutionPolicy: Wait.ResolutionPolicy,
     quorum: Wait.Quorum.optional(),
-    expiresAt: z.number(),
+    expiresAt: EpochMs,
     followUpWindow: z.number().int().nonnegative(),
     /** Extra correlation fields (threadId, channelId, …); endpointId and replyToMessageId are derived from the delivery itself. */
     correlation: Wait.Correlation.optional(),
@@ -317,7 +318,7 @@ const SendInputBase = z
     operation: MessageOperationSchema,
     body: z.string().min(1),
     /** Injected timestamp — messaging never reads the wall clock. */
-    at: z.number(),
+    at: EpochMs,
     waitSpec: AwaitSpecSchema.optional(),
     /**
      * #219 policy-intent axis, additive-optional for backward compat. Absent →

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -11,6 +11,7 @@ import { Policy } from "../policy/index.js";
 import { Tool } from "../tool/index.js";
 import { Wait } from "../wait/index.js";
 import * as RouteRecord from "./route-record.js";
+import { EpochMs } from "../time.js";
 
 /**
  * #500 A6: every production-written actor key is declared (`runId` and
@@ -92,8 +93,8 @@ const ActivationMetadataSchemaImpl = z
       .object({
         kind: z.enum(["cron", "webhook", "manual", "internal"]),
         id: z.string().optional(),
-        scheduledAt: z.number().optional(),
-        firedAt: z.number().optional(),
+        scheduledAt: EpochMs.optional(),
+        firedAt: EpochMs.optional(),
         attempt: z.number().optional(),
       })
       .catchall(z.unknown())

--- a/packages/protocol/src/json.ts
+++ b/packages/protocol/src/json.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * Internal single owner for plain-JSON validation and canonical JSON
+ * serialization. Not exported from the package barrel: protocol modules
+ * import it relatively; external packages consume the domains built on it
+ * (policy effects, work-item attempt identity).
+ */
+
+export type PlainValue =
+  | null
+  | boolean
+  | number
+  | string
+  | PlainValue[]
+  | { readonly [key: string]: PlainValue };
+
+// Validation at this boundary must never execute caller-supplied code:
+// property values are read through data-property descriptors (an accessor
+// property is refused without invoking its getter), symbol-keyed own
+// properties are refused (JSON serialization would silently drop them),
+// and any throw from an exotic object (hostile Proxy trap) is contained by
+// the guard and reported as an ordinary parse failure. A fully transparent
+// Proxy over plain data is indistinguishable by design — the contract here
+// is structural.
+function isPlainValueUnsafe(value: unknown): value is PlainValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return true;
+  if (typeof value === "number") return Number.isFinite(value) && !Object.is(value, -0);
+  if (Array.isArray(value)) {
+    if (Object.getOwnPropertySymbols(value).length > 0) return false;
+    // Named own properties make key count exceed length; holes surface as
+    // absent index descriptors below — together this refuses sparse arrays,
+    // extra properties, and the one-hole + one-named-property cancellation.
+    if (Object.keys(value).length !== value.length) return false;
+    for (let index = 0; index < value.length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, index);
+      if (descriptor === undefined || !("value" in descriptor)) return false;
+      if (!isPlainValueUnsafe(descriptor.value)) return false;
+    }
+    return true;
+  }
+  if (typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return false;
+  if (Object.getOwnPropertySymbols(value).length > 0) return false;
+  for (const key of Object.keys(value)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") return false;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !("value" in descriptor)) return false;
+    if (!isPlainValueUnsafe(descriptor.value)) return false;
+  }
+  return true;
+}
+
+export function isPlainValue(value: unknown): value is PlainValue {
+  try {
+    return isPlainValueUnsafe(value);
+  } catch {
+    return false;
+  }
+}
+
+export const PlainValueSchema: z.ZodType<PlainValue> = z.custom<PlainValue>(
+  (value) => isPlainValue(value),
+  { message: "Expected a plain JSON value" },
+);
+
+function renderCanonical(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("canonical JSON accepts finite numbers only");
+    return Object.is(value, -0) ? "0" : String(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => renderCanonical(entry)).join(",")}]`;
+  if (typeof value === "object") {
+    const prototype: unknown = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("canonical JSON accepts plain objects only");
+    }
+    const fields: string[] = [];
+    for (const key of Object.keys(value).sort()) {
+      const nested = (value as Record<string, unknown>)[key];
+      if (nested === undefined) throw new Error(`canonical JSON cannot express undefined at ${key}`);
+      fields.push(`${JSON.stringify(key)}:${renderCanonical(nested)}`);
+    }
+    return `{${fields.join(",")}}`;
+  }
+  throw new Error(`canonical JSON cannot express a ${typeof value}`);
+}
+
+/**
+ * ONE digest owner for canonical JSON identity: sorted object keys, no
+ * whitespace, finite numbers, plain data only — undefined and non-JSON
+ * values fail loudly — hashed with sha256 under the `sha256:` prefix.
+ */
+export function canonicalDigest(value: unknown): string {
+  return `sha256:${createHash("sha256").update(renderCanonical(value)).digest("hex")}`;
+}

--- a/packages/protocol/src/json.ts
+++ b/packages/protocol/src/json.ts
@@ -24,7 +24,7 @@ export type PlainValue =
 // the guard and reported as an ordinary parse failure. A fully transparent
 // Proxy over plain data is indistinguishable by design — the contract here
 // is structural.
-function isPlainValueUnsafe(value: unknown): value is PlainValue {
+function isPlainValueUnsafe(value: unknown, allowLegacyKeys: boolean): value is PlainValue {
   if (value === null || typeof value === "boolean" || typeof value === "string") return true;
   if (typeof value === "number") return Number.isFinite(value) && !Object.is(value, -0);
   if (Array.isArray(value)) {
@@ -36,31 +36,57 @@ function isPlainValueUnsafe(value: unknown): value is PlainValue {
     for (let index = 0; index < value.length; index += 1) {
       const descriptor = Object.getOwnPropertyDescriptor(value, index);
       if (descriptor === undefined || !("value" in descriptor)) return false;
-      if (!isPlainValueUnsafe(descriptor.value)) return false;
+      if (!isPlainValueUnsafe(descriptor.value, allowLegacyKeys)) return false;
     }
     return true;
   }
   if (typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return false;
   if (Object.getOwnPropertySymbols(value).length > 0) return false;
   for (const key of Object.keys(value)) {
-    if (key === "__proto__" || key === "constructor" || key === "prototype") return false;
+    if (!allowLegacyKeys && (key === "__proto__" || key === "constructor" || key === "prototype"))
+      return false;
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (descriptor === undefined || !("value" in descriptor)) return false;
-    if (!isPlainValueUnsafe(descriptor.value)) return false;
+    if (!isPlainValueUnsafe(descriptor.value, allowLegacyKeys)) return false;
   }
   return true;
 }
 
+/**
+ * Strict live-boundary profile (policy effects): own keys named __proto__,
+ * constructor, or prototype are refused outright — hostile input never gets
+ * to look like plain data.
+ */
 export function isPlainValue(value: unknown): value is PlainValue {
   try {
-    return isPlainValueUnsafe(value);
+    return isPlainValueUnsafe(value, false);
   } catch {
     return false;
   }
 }
 
+/**
+ * Persisted-fact profile (work-item attempt identity): identical structural
+ * guard, but own keys named __proto__/constructor/prototype are ACCEPTED.
+ * Pre-hardening schemas admitted such keys into immutable persisted facts
+ * (e.g. attempt fingerprint parameters inside work_item.attempt_allocated),
+ * so a read schema that refused them would invalidate historical bytes (era
+ * law). Values are only ever READ through data-property descriptors and
+ * canonically rendered — never assigned onto another object — so accepting
+ * these key names creates no prototype-pollution path here. The remaining
+ * strictness deltas vs the old schema (-0, accessor properties, symbol keys,
+ * sparse arrays) are unreachable in persisted bytes: rows are written with
+ * JSON.stringify (never emits -0) and read with JSON.parse (only dense
+ * arrays and plain data properties), so no historical row is invalidated.
+ */
 export const PlainValueSchema: z.ZodType<PlainValue> = z.custom<PlainValue>(
-  (value) => isPlainValue(value),
+  (value) => {
+    try {
+      return isPlainValueUnsafe(value, true);
+    } catch {
+      return false;
+    }
+  },
   { message: "Expected a plain JSON value" },
 );
 

--- a/packages/protocol/src/ledger/schema.ts
+++ b/packages/protocol/src/ledger/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { NamedError } from "../error/index.js";
+import { EpochMs } from "../time.js";
 
 /**
  * Durability class of a ledger write connection (#510). Decision-class
@@ -22,7 +23,7 @@ export const Input = z
     type: z.string().min(1),
     data: z.record(z.string(), z.unknown()),
     /** Milliseconds since epoch; the append core defaults it to now. */
-    timeCreated: z.number().int().nonnegative().optional(),
+    timeCreated: EpochMs.int().nonnegative().optional(),
   })
   .strict();
 export type Input = z.infer<typeof Input>;
@@ -92,7 +93,7 @@ export const RecordedFact = z
     seq: z.number().int().positive(),
     type: z.string().min(1),
     data: z.record(z.string(), z.unknown()),
-    timeCreated: z.number().int().nonnegative(),
+    timeCreated: EpochMs.int().nonnegative(),
   })
   .strict();
 export type RecordedFact = z.infer<typeof RecordedFact>;
@@ -120,7 +121,7 @@ export const ChainBreak = z
     code: ChainBreakCode,
     expected: z.string(),
     actual: z.string(),
-    detectedAt: z.number(),
+    detectedAt: EpochMs,
   })
   .strict();
 export type ChainBreak = z.infer<typeof ChainBreak>;

--- a/packages/protocol/src/machine/events.ts
+++ b/packages/protocol/src/machine/events.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
 import { CapabilityId, MachineId, uniqueCapabilities } from "./schema.js";
+import { EpochMs } from "../time.js";
 
 const EventBase = z.object({
   machineId: MachineId,
-  time: z.number(),
+  time: EpochMs,
 });
 
 export const Events = {

--- a/packages/protocol/src/machine/schema.ts
+++ b/packages/protocol/src/machine/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EpochMs } from "../time.js";
 
 /**
  * Capability id grammar: two-plus dot-separated lowercase segments —
@@ -48,7 +49,7 @@ export const Enrollment = z
     machineId: MachineId,
     name: z.string().min(1),
     allowedCapabilities: z.array(CapabilityId).min(1).superRefine(uniqueCapabilities),
-    enrolledAt: z.number(),
+    enrolledAt: EpochMs,
   })
   .strict();
 export type Enrollment = z.infer<typeof Enrollment>;
@@ -65,7 +66,7 @@ export const Offer = z
     daemonVersion: z.string().min(1),
     /** e.g. "darwin-arm64" — display/diagnostic fact, never a matching key. */
     platform: z.string().min(1),
-    offeredAt: z.number(),
+    offeredAt: EpochMs,
   })
   .strict();
 export type Offer = z.infer<typeof Offer>;

--- a/packages/protocol/src/message/index.ts
+++ b/packages/protocol/src/message/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Token } from "../token/index.js";
 import { Tool } from "../tool/index.js";
+import { EpochMs } from "../time.js";
 
 export namespace Message {
   const PartBase = z.object({
@@ -14,8 +15,8 @@ export namespace Message {
     text: z.string(),
     time: z
       .object({
-        start: z.number(),
-        end: z.number().optional(),
+        start: EpochMs,
+        end: EpochMs.optional(),
       })
       .optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
@@ -28,8 +29,8 @@ export namespace Message {
     /** Provider reasoning signature; resent only under a same-model check (#545 T2). */
     signature: z.string().optional(),
     time: z.object({
-      start: z.number(),
-      end: z.number().optional(),
+      start: EpochMs,
+      end: EpochMs.optional(),
     }),
     metadata: z.record(z.string(), z.unknown()).optional(),
   });
@@ -86,7 +87,7 @@ export namespace Message {
   export const UserMessage = MessageBase.extend({
     role: z.literal("user"),
     time: z.object({
-      created: z.number(),
+      created: EpochMs,
     }),
     agent: z.string(),
     model: z.object({
@@ -102,8 +103,8 @@ export namespace Message {
   export const AssistantMessage = MessageBase.extend({
     role: z.literal("assistant"),
     time: z.object({
-      created: z.number(),
-      completed: z.number().optional(),
+      created: EpochMs,
+      completed: EpochMs.optional(),
     }),
     parentID: z.string(),
     modelID: z.string(),

--- a/packages/protocol/src/policy/effects.ts
+++ b/packages/protocol/src/policy/effects.ts
@@ -1,68 +1,14 @@
 import { z } from "zod";
+import { isPlainValue } from "../json.js";
 
 export namespace PolicyEffects {
-  type JsonPlainValue =
-    | null
-    | boolean
-    | number
-    | string
-    | JsonPlainValue[]
-    | { readonly [key: string]: JsonPlainValue };
-
-  // Validation at this boundary must never execute caller-supplied code:
-  // property values are read through data-property descriptors (an accessor
-  // property is refused without invoking its getter), symbol-keyed own
-  // properties are refused (JSON serialization would silently drop them),
-  // and any throw from an exotic object (hostile Proxy trap) is contained by
-  // the guard and reported as an ordinary parse failure. A fully transparent
-  // Proxy over plain data is indistinguishable by design — the contract here
-  // is structural.
-  function isJsonPlainValue(value: unknown): value is JsonPlainValue {
-    if (value === null || typeof value === "boolean" || typeof value === "string") return true;
-    if (typeof value === "number") return Number.isFinite(value) && !Object.is(value, -0);
-    if (Array.isArray(value)) {
-      if (Object.getOwnPropertySymbols(value).length > 0) return false;
-      // Named own properties make key count exceed length; holes surface as
-      // absent index descriptors below — together this refuses sparse arrays,
-      // extra properties, and the one-hole + one-named-property cancellation.
-      if (Object.keys(value).length !== value.length) return false;
-      for (let index = 0; index < value.length; index += 1) {
-        const descriptor = Object.getOwnPropertyDescriptor(value, index);
-        if (descriptor === undefined || !("value" in descriptor)) return false;
-        if (!isJsonPlainValue(descriptor.value)) return false;
-      }
-      return true;
-    }
-    if (typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype)
-      return false;
-    if (Object.getOwnPropertySymbols(value).length > 0) return false;
-    for (const key of Object.keys(value)) {
-      if (key === "__proto__" || key === "constructor" || key === "prototype") return false;
-      const descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if (descriptor === undefined || !("value" in descriptor)) return false;
-      if (!isJsonPlainValue(descriptor.value)) return false;
-    }
-    return true;
-  }
-
-  function isJsonPlainValueSafe(value: unknown): boolean {
-    try {
-      return isJsonPlainValue(value);
-    } catch {
-      return false;
-    }
-  }
-
   const JsonPlainObject = z.custom<Record<string, unknown>>(
     (value): value is Record<string, unknown> =>
-      typeof value === "object" &&
-      value !== null &&
-      !Array.isArray(value) &&
-      isJsonPlainValueSafe(value),
+      typeof value === "object" && value !== null && !Array.isArray(value) && isPlainValue(value),
     { message: "Expected a JSON-plain object" },
   );
   const JsonPlainArray = z.custom<unknown[]>(
-    (value): value is unknown[] => Array.isArray(value) && isJsonPlainValueSafe(value),
+    (value): value is unknown[] => Array.isArray(value) && isPlainValue(value),
     { message: "Expected a JSON-plain array" },
   );
 

--- a/packages/protocol/src/time.ts
+++ b/packages/protocol/src/time.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+/**
+ * Internal single owner for timestamp vocabulary. Not exported from the
+ * package barrel: protocol schemas import it relatively so every wall-clock
+ * field shares one contract instead of re-declaring bare `z.number()`.
+ *
+ * Epoch instants are finite and non-negative. No integer constraint: a
+ * fractional millisecond is a valid instant, and persisted rows must keep
+ * parsing across eras.
+ */
+export const EpochMs = z.number().finite().nonnegative();
+export type EpochMs = z.infer<typeof EpochMs>;

--- a/packages/protocol/src/tool/index.ts
+++ b/packages/protocol/src/tool/index.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { Events as EventDescriptors } from "../event/tool.js";
 import { CapabilityId } from "../machine/schema.js";
 import type { TraceContext } from "../trace/index.js";
+import { EpochMs } from "../time.js";
 
 export namespace Tool {
   /**
@@ -77,7 +78,7 @@ export namespace Tool {
     status: z.literal("running"),
     input: z.record(z.string(), z.unknown()),
     time: z.object({
-      start: z.number(),
+      start: EpochMs,
     }),
   });
 
@@ -88,8 +89,8 @@ export namespace Tool {
     title: z.string(),
     metadata: z.record(z.string(), z.unknown()),
     time: z.object({
-      start: z.number(),
-      end: z.number(),
+      start: EpochMs,
+      end: EpochMs,
     }),
   });
 
@@ -98,8 +99,8 @@ export namespace Tool {
     input: z.record(z.string(), z.unknown()),
     error: z.string(),
     time: z.object({
-      start: z.number(),
-      end: z.number(),
+      start: EpochMs,
+      end: EpochMs,
     }),
   });
 

--- a/packages/protocol/src/transcript/schema.ts
+++ b/packages/protocol/src/transcript/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Message } from "../message/index.js";
+import { EpochMs } from "../time.js";
 
 /**
  * Transcript fact vocabulary (#545 T1): conversation history as an
@@ -37,14 +38,14 @@ export type Usage = z.infer<typeof Usage>;
 const TransitionRunning = z
   .object({
     to: z.literal("running"),
-    at: z.number(),
+    at: EpochMs,
   })
   .strict();
 
 const TransitionCompleted = z
   .object({
     to: z.literal("completed"),
-    at: z.number(),
+    at: EpochMs,
     output: z.string(),
     title: z.string().optional(),
     /**
@@ -59,7 +60,7 @@ const TransitionCompleted = z
 const TransitionError = z
   .object({
     to: z.literal("error"),
-    at: z.number(),
+    at: EpochMs,
     error: z.string(),
   })
   .strict();
@@ -67,7 +68,7 @@ const TransitionError = z
 const TransitionInterrupted = z
   .object({
     to: z.literal("interrupted"),
-    at: z.number(),
+    at: EpochMs,
     partialOutput: z.string().optional(),
   })
   .strict();
@@ -121,7 +122,7 @@ const MessageFinishedFact = z
     type: z.literal("message.finished"),
     attemptId: Id,
     messageId: Id,
-    at: z.number(),
+    at: EpochMs,
     finish: FinishReason,
     usage: Usage,
   })

--- a/packages/protocol/src/wait/events.ts
+++ b/packages/protocol/src/wait/events.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
 import { RejectionCode } from "./fold.js";
 import { OwnerKind, Status } from "./schema.js";
+import { EpochMs } from "../time.js";
 
 const EventBase = z.object({
   id: z.string().min(1),
@@ -9,7 +10,7 @@ const EventBase = z.object({
   ownerKind: OwnerKind,
   ownerId: z.string().min(1),
   status: Status,
-  time: z.number(),
+  time: EpochMs,
 });
 
 export const Events = {
@@ -25,13 +26,13 @@ export const Events = {
     }),
     { visibility: "llm_reason" },
   ),
-  Resolved: BusEvent.define("wait.resolved", EventBase.extend({ resolvedAt: z.number() }), {
+  Resolved: BusEvent.define("wait.resolved", EventBase.extend({ resolvedAt: EpochMs }), {
     visibility: "llm_reason",
   }),
   Expired: BusEvent.define("wait.expired", EventBase.extend({ partial: z.boolean() }), {
     visibility: "llm_reason",
   }),
-  Cancelled: BusEvent.define("wait.cancelled", EventBase.extend({ cancelledAt: z.number() }), {
+  Cancelled: BusEvent.define("wait.cancelled", EventBase.extend({ cancelledAt: EpochMs }), {
     visibility: "llm_reason",
   }),
   ReplyRejected: BusEvent.define(
@@ -54,7 +55,7 @@ export const Events = {
       traceId: z.string().min(1),
       sessionId: z.string().min(1),
       phase: z.enum(["opened", "answered", "failed"]),
-      time: z.number(),
+      time: EpochMs,
     }),
     { visibility: "internal" },
   ),

--- a/packages/protocol/src/wait/fold.ts
+++ b/packages/protocol/src/wait/fold.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Deadline } from "../deadline/index.js";
 import type * as Schema from "./schema.js";
+import { EpochMs } from "../time.js";
 
 /**
  * Pure deterministic Wait state machine (#215). Time (`at`) and reply
@@ -31,7 +32,7 @@ export const ReplyInput = z
      */
     responderCandidates: z.array(z.string().min(1)),
     messageId: z.string().min(1).optional(),
-    at: z.number(),
+    at: EpochMs,
   })
   .strict();
 export type ReplyInput = z.infer<typeof ReplyInput>;
@@ -56,7 +57,7 @@ export type RejectionCode = z.infer<typeof RejectionCode>;
 export const DeliveryReceiptInput = z
   .object({
     externalMessageId: z.string().min(1),
-    at: z.number(),
+    at: EpochMs,
   })
   .strict();
 export type DeliveryReceiptInput = z.infer<typeof DeliveryReceiptInput>;

--- a/packages/protocol/src/wait/schema.ts
+++ b/packages/protocol/src/wait/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { NamedError } from "../error/index.js";
+import { EpochMs } from "../time.js";
 
 export const OwnerKind = z.enum(["workItem", "session"]);
 export type OwnerKind = z.infer<typeof OwnerKind>;
@@ -64,7 +65,7 @@ export const Reply = z
     replyKey: z.string().min(1),
     responderId: z.string().min(1),
     messageId: z.string().min(1).optional(),
-    receivedAt: z.number(),
+    receivedAt: EpochMs,
   })
   .strict();
 export type Reply = z.infer<typeof Reply>;
@@ -89,12 +90,12 @@ const RecordBase = z
     partial: z.boolean(),
     replies: z.array(Reply),
     revision: z.number().int().nonnegative(),
-    expiresAt: z.number(),
+    expiresAt: EpochMs,
     followUpWindow: z.number().int().nonnegative(),
-    createdAt: z.number(),
-    updatedAt: z.number(),
-    resolvedAt: z.number().optional(),
-    cancelledAt: z.number().optional(),
+    createdAt: EpochMs,
+    updatedAt: EpochMs,
+    resolvedAt: EpochMs.optional(),
+    cancelledAt: EpochMs.optional(),
   })
   .strict();
 
@@ -158,8 +159,8 @@ export const Create = RecordBase.omit({
   resolvedAt: true,
   cancelledAt: true,
 }).extend({
-  createdAt: z.number().optional(),
-  updatedAt: z.number().optional(),
+  createdAt: EpochMs.optional(),
+  updatedAt: EpochMs.optional(),
 });
 export type Create = z.infer<typeof Create>;
 

--- a/packages/protocol/src/work-item/attempt.ts
+++ b/packages/protocol/src/work-item/attempt.ts
@@ -1,5 +1,6 @@
-import { createHash } from "node:crypto";
 import { z } from "zod";
+import { canonicalDigest, PlainValueSchema } from "../json.js";
+import { EpochMs } from "../time.js";
 
 /**
  * #510 C2 — Attempt identity vocabulary.
@@ -21,52 +22,9 @@ import { z } from "zod";
  *     attempt and points at the attempt whose result it reuses.
  */
 
-// ---------------------------------------------------------------------------
-// canonicalization + digest owner
-// ---------------------------------------------------------------------------
-
-/**
- * ONE exported digest owner for attempt identity: canonical JSON (sorted
- * object keys, no whitespace, finite numbers, plain data only — undefined
- * and non-JSON values fail loudly) hashed with sha256.
- *
- * TODO(#510 phase D / convention unification): the evidence conformance
- * canonical product verifier module (verifier-conformance-
- * canonical.ts `hashCanonicalJson`) owns an equivalent digest that protocol
- * cannot import (openomni depends on protocol, not the reverse). The
- * restructure audit's digest-owner finding (bare-hex vs `sha256:`-prefixed
- * conventions) already demands convergence — when the canonical module
- * moves below protocol, unify on a single owner.
- */
-export function canonicalDigest(value: unknown): string {
-  return `sha256:${createHash("sha256").update(renderCanonical(value)).digest("hex")}`;
-}
-
-function renderCanonical(value: unknown): string {
-  if (value === null) return "null";
-  if (typeof value === "boolean") return value ? "true" : "false";
-  if (typeof value === "number") {
-    if (!Number.isFinite(value)) throw new Error("canonical JSON accepts finite numbers only");
-    return Object.is(value, -0) ? "0" : String(value);
-  }
-  if (typeof value === "string") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map((entry) => renderCanonical(entry)).join(",")}]`;
-  if (typeof value === "object") {
-    const prototype: unknown = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) {
-      throw new Error("canonical JSON accepts plain objects only");
-    }
-    const fields: string[] = [];
-    for (const key of Object.keys(value).sort()) {
-      const nested = (value as Record<string, unknown>)[key];
-      if (nested === undefined)
-        throw new Error(`canonical JSON cannot express undefined at ${key}`);
-      fields.push(`${JSON.stringify(key)}:${renderCanonical(nested)}`);
-    }
-    return `{${fields.join(",")}}`;
-  }
-  throw new Error(`canonical JSON cannot express a ${typeof value}`);
-}
+// Attempt identity digests come from the internal canonical-JSON owner
+// (../json). Re-exported so WorkItem.canonicalDigest keeps its public seat.
+export { canonicalDigest };
 
 // ---------------------------------------------------------------------------
 // building blocks
@@ -96,17 +54,11 @@ const ReferenceId = z
   .max(512)
   .regex(/^(?:sha256:[a-f0-9]{64}|(?:ref|version):[A-Za-z0-9._+/@:-]+)$/);
 
-type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
-const JsonValue: z.ZodType<JsonValue> = z.lazy(() =>
-  z.union([
-    z.null(),
-    z.boolean(),
-    z.number().finite(),
-    z.string(),
-    z.array(JsonValue),
-    z.record(z.string(), JsonValue),
-  ]),
-);
+// Plain-JSON values share the hardened internal owner (../json): accessor
+// properties, symbol keys, prototype-key smuggling, sparse arrays, and -0
+// are refused — everything a JSON round-trip produces still passes, so
+// persisted fingerprints keep parsing across eras.
+const JsonValue = PlainValueSchema;
 
 /**
  * A declared-but-unavailable fingerprint input. Coverage fields are always
@@ -302,7 +254,7 @@ export const AttemptTerminal = z
   .object({
     attemptId: AttemptId,
     outcome: AttemptOutcome,
-    endedAt: z.number(),
+    endedAt: EpochMs,
     error: z.string().optional(),
     usage: AttemptUsage.optional(),
   })

--- a/packages/protocol/src/work-item/completion-admission.ts
+++ b/packages/protocol/src/work-item/completion-admission.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import { sha256JsonRef } from "./hash.js";
+import { createHash } from "node:crypto";
+import { EpochMs } from "../time.js";
 
 const Reference = z.string().min(1);
-const Timestamp = z.number().finite();
+const Timestamp = EpochMs;
 const CurrentVersion = z.literal(1);
 
 export const CompletionReport = z.object({
@@ -567,6 +568,15 @@ export function canonicalCompletionReport(input: CompletionReport): CompletionRe
   });
 }
 
+/**
+ * FROZEN BYTES — do not change this serialization. `completionReportRef`
+ * equality is re-verified inside `CompletionAdmission`'s superRefine on
+ * every parse of a persisted admission row, so any algorithm change breaks
+ * historical rows. Determinism holds without key sorting because the input
+ * is `CompletionReport.parse` output: a closed zod object whose key order
+ * is fixed by the schema shape.
+ */
 export function completionReportReference(input: CompletionReport): string {
-  return sha256JsonRef(canonicalCompletionReport(input));
+  const bytes = JSON.stringify(canonicalCompletionReport(input));
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 }

--- a/packages/protocol/src/work-item/events.ts
+++ b/packages/protocol/src/work-item/events.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { BusEvent } from "../bus/index.js";
+import { EpochMs } from "../time.js";
 import {
   CompletionDecision,
   CompletionRequest,
@@ -12,7 +13,7 @@ const BaseEvent = z.object({
   runId: z.string().optional(),
   taskId: z.string().optional(),
   sessionId: z.string().optional(),
-  time: z.number(),
+  time: EpochMs,
 });
 
 const Created = BusEvent.define(

--- a/packages/protocol/src/work-item/hash.ts
+++ b/packages/protocol/src/work-item/hash.ts
@@ -1,11 +1,5 @@
-import { createHash } from "node:crypto";
-
 export function criterionId(workItemId: string, index: number, statement: string): string {
   return `criterion:${workItemId}:${index}:${stableToken(statement)}`;
-}
-
-export function sha256JsonRef(value: unknown): string {
-  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
 }
 
 function stableToken(input: string): string {

--- a/packages/protocol/src/work-item/index.ts
+++ b/packages/protocol/src/work-item/index.ts
@@ -1,10 +1,6 @@
 import * as AttemptContract from "./attempt.js";
 import { Events as EventDescriptors } from "./events.js";
-import {
-  criterionId as createCriterionId,
-  generateHash as createHash,
-  sha256JsonRef as createSha256JsonRef,
-} from "./hash.js";
+import { criterionId as createCriterionId, generateHash as createHash } from "./hash.js";
 import * as Schema from "./schemas.js";
 import { deriveStatus as resolveStatus } from "./status.js";
 import * as Completion from "./completion-admission.js";
@@ -141,6 +137,5 @@ export namespace WorkItem {
   export const deriveStatus = resolveStatus;
   export const criterionId = createCriterionId;
   export const generateHash = createHash;
-  export const sha256JsonRef = createSha256JsonRef;
   export const Events = EventDescriptors;
 }

--- a/packages/protocol/src/work-item/schemas.ts
+++ b/packages/protocol/src/work-item/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { AttemptTerminal } from "./attempt.js";
+import { EpochMs } from "../time.js";
 import {
   CompletionContract,
   CompletionFacts,
@@ -18,15 +19,15 @@ export const Blocker = z.object({
   id: z.string(),
   description: z.string(),
   kind: z.enum(["dependency", "error", "waiting_input", "external", "unknown"]),
-  createdAt: z.number(),
-  resolvedAt: z.number().optional(),
+  createdAt: EpochMs,
+  resolvedAt: EpochMs.optional(),
 });
 export type Blocker = z.infer<typeof Blocker>;
 
 const ReadBackBase = z.object({
   target: z.string().min(1),
   passed: z.boolean(),
-  observedAt: z.number(),
+  observedAt: EpochMs,
   statusCode: z.number().int().min(100).max(599).optional(),
   matchedText: z.string().min(1).optional(),
 });
@@ -120,7 +121,7 @@ export const Evidence = z
     attempt: z.number().int().positive().optional(),
     basisRef: z.string().min(1).optional(),
     criterionId: z.string().min(1).optional(),
-    createdAt: z.number(),
+    createdAt: EpochMs,
   })
   .superRefine((evidence, ctx) => {
     if (evidence.readBack && evidence.passed !== evidence.readBack.passed) {
@@ -180,13 +181,13 @@ const InfoShape = z.object({
    */
   attemptTerminal: AttemptTerminal.optional(),
   timestamps: z.object({
-    created: z.number(),
-    updated: z.number(),
-    started: z.number().optional(),
-    completed: z.number().optional(),
-    failed: z.number().optional(),
-    cancelled: z.number().optional(),
-    deadline: z.number().optional(),
+    created: EpochMs,
+    updated: EpochMs,
+    started: EpochMs.optional(),
+    completed: EpochMs.optional(),
+    failed: EpochMs.optional(),
+    cancelled: EpochMs.optional(),
+    deadline: EpochMs.optional(),
   }),
   relations: z.object({
     parentId: z.string().optional(),

--- a/packages/protocol/test/delegation/delegation.test.ts
+++ b/packages/protocol/test/delegation/delegation.test.ts
@@ -320,6 +320,27 @@ describe("Delegation.Record durable shape", () => {
     );
   });
 
+  test("wokenAt is a wall-clock instant — negatives refused", () => {
+    expect(
+      Delegation.Record.safeParse({
+        ...OPEN_RECORD,
+        status: "settled",
+        settled: { status: "completed", delegationId: "d-1", output: "done", at: 5 },
+        settledAt: 5,
+        wokenAt: -1,
+      }).success,
+    ).toBe(false);
+    expect(
+      Delegation.Record.safeParse({
+        ...OPEN_RECORD,
+        status: "settled",
+        settled: { status: "completed", delegationId: "d-1", output: "done", at: 5 },
+        settledAt: 5,
+        wokenAt: 6,
+      }).success,
+    ).toBe(true);
+  });
+
   test("sent is terminal for notify only — pinned where operation meets settlement", () => {
     const sentRecord = {
       ...OPEN_RECORD,

--- a/packages/protocol/test/engagement/fold.test.ts
+++ b/packages/protocol/test/engagement/fold.test.ts
@@ -203,6 +203,23 @@ describe("Engagement deadline expiry", () => {
     expect(again.code).toBe("engagement_terminal");
   });
 
+  test("the exact deadline instant is expired — canonical inclusive semantics", () => {
+    // Deadline.isExpired: now >= deadline. Work arriving AT the deadline is
+    // late, and expire() fires AT the deadline — both folds share one owner,
+    // so no ordering of the two at the same instant can produce two outcomes.
+    const record = opened({ deadline: T0 + 500 });
+    const atInstant = Engagement.transition(record, {
+      at: T0 + 500,
+      to: "deliberating",
+      reason: "boundary",
+    });
+    expect(atInstant.kind).toBe("rejected");
+    if (atInstant.kind !== "rejected") throw new Error("unreachable");
+    expect(atInstant.code).toBe("deadline_passed");
+    const expired = Engagement.expire(record, { at: T0 + 500 });
+    expect(expired.kind).toBe("expired");
+  });
+
   test("expire before the deadline (or without one) is not_expired", () => {
     const withDeadline = opened({ deadline: T0 + 500 });
     const early = Engagement.expire(withDeadline, { at: T0 + 100 });

--- a/packages/protocol/test/tool.test.ts
+++ b/packages/protocol/test/tool.test.ts
@@ -63,16 +63,22 @@ describe("Tool.StatePending", () => {
 });
 
 describe("Tool.StateRunning", () => {
-  test("parses valid running state with negative start time", () => {
-    const state = Tool.State.parse({
+  test("refuses a negative start time — timestamps share the EpochMs contract", () => {
+    const negative = Tool.State.safeParse({
       status: "running",
       input: { task: "demo" },
       time: { start: -5 },
     });
+    expect(negative.success).toBe(false);
 
+    const state = Tool.State.parse({
+      status: "running",
+      input: { task: "demo" },
+      time: { start: 1_700_000_000_000 },
+    });
     expect(state.status).toBe("running");
     if (state.status !== "running") throw new Error("shape");
-    expect(state.time.start).toBe(-5);
+    expect(state.time.start).toBe(1_700_000_000_000);
   });
 
   test("rejects missing time", () => {

--- a/packages/protocol/test/work-item-fingerprint-era.test.ts
+++ b/packages/protocol/test/work-item-fingerprint-era.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { WorkItem } from "../src/index.js";
+
+/**
+ * Era pin: pre-hardening fingerprint schemas admitted own keys named
+ * __proto__/constructor/prototype into immutable persisted facts (e.g.
+ * work_item.attempt_allocated). The persisted-fact JSON profile must keep
+ * accepting those bytes forever; only the live policy boundary refuses them
+ * (pinned in test/policy/effect-json-plain.test.ts).
+ */
+describe("work-item fingerprint era compatibility", () => {
+  const legacyInputs = () =>
+    JSON.parse(
+      `{"workInput":"do it","handlerKind":"agent","handlerCodeRef":"ref:abc","model":{"provider":"openai","id":"gpt","parameters":{"nested":{"__proto__":{"enabled":true}},"constructor":"c","prototype":1}},"upstreamFingerprints":{"absent":true,"reason":"none consumed"},"dependencyLock":{"absent":true,"reason":"unlocked"}}`,
+    ) as unknown;
+
+  test("accepts persisted fingerprints carrying __proto__/constructor/prototype own keys", () => {
+    const inputs = legacyInputs();
+    const digest = WorkItem.canonicalDigest(inputs);
+    const parsed = WorkItem.ContentFingerprint.parse({ inputs, digest });
+    const parameters = parsed.inputs.model.parameters as Record<string, unknown>;
+    expect(Object.keys(parameters)).toEqual(["nested", "constructor", "prototype"]);
+    // Nested legacy keys survive as own data properties (no rebuild, no
+    // prototype mutation), so the digest re-render stays byte-stable.
+    expect(Object.keys(parameters.nested as object)).toEqual(["__proto__"]);
+    expect(Object.getPrototypeOf(parameters.nested)).toBe(Object.prototype);
+    expect(WorkItem.canonicalDigest(parsed.inputs)).toBe(digest);
+  });
+
+  test("still refuses non-JSON structure the old schema also could not persist", () => {
+    const inputs = legacyInputs() as { model: { parameters: Record<string, unknown> } };
+    const accessor: Record<string, unknown> = {};
+    Object.defineProperty(accessor, "sneaky", {
+      enumerable: true,
+      get: () => "boo",
+    });
+    inputs.model.parameters = accessor;
+    const digest = `sha256:${"0".repeat(64)}`;
+    expect(WorkItem.ContentFingerprint.safeParse({ inputs, digest }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Third PR of the protocol deslop campaign (after #841, #843): semantic unification of duplicated primitives.

## Changes

### 1. One plain-JSON owner (`src/json.ts`, internal)
Two validators existed: the hostile-input-hardened guard in `policy/effects.ts` and a loose `z.lazy` union in `work-item/attempt.ts`. The hardened guard is now the single owner; both domains consume it. Work-item acceptance tightens (accessors, symbol keys, proto-key smuggling, sparse arrays, -0 refused) — era-safe because every JSON round-trip value passes.

### 2. One canonical digest owner + frozen legacy bytes
`canonicalDigest` (sorted-key canonical render) moved to `src/json.ts`; `WorkItem.canonicalDigest` keeps its seat. `sha256JsonRef` (JSON.stringify digest with an unsorted-keys hole as a *generic* export) is deleted; its bytes are inlined privately into the sole consumer `completionReportReference` with a FROZEN BYTES contract: ref equality is re-verified inside `CompletionAdmission` superRefine on **every parse of persisted rows**, so the algorithm cannot change; determinism holds because input is closed-schema zod-parse output (schema-ordered keys, no records/passthrough). `WorkItem.sha256JsonRef` removed (zero external consumers). Stale `TODO(#510 phase D)` resolved (referenced verifier module no longer exists).

### 3. Deadline semantics unified
`engagement/fold.ts` was the only fold diverging from canonical `Deadline.isExpired` (`now >= deadline`): it used strict `>`. Both gates (transition `deadline_passed`, `expire`) now share the owner — **behavior change at the exact instant**: work arriving AT the deadline is late, expire fires AT the deadline. Pinned with an exact-instant boundary test; no prior test pinned the old exclusive boundary.

### 4. EpochMs timestamp vocabulary (`src/time.ts`, internal)
101 bare `z.number()` wall-clock fields (plus completion-admission's local `Timestamp = z.number().finite()`) now share `EpochMs = z.number().finite().nonnegative()`. No integer constraint (fractional ms is a valid instant; era safety). One test pinning negative tool start-time acceptance flipped to refusal.

### Adjudicated as deliberate (no change)
- **Per-file event `Base` envelopes**: AGENTS.md documents "no exported universal BaseEvent contract" as a design decision; the five file-local Bases are convention, not drift. Their `time` fields did adopt EpochMs.
- **Id convention (~295 bare `z.string()` id sites)**: branded/pattern ids would be a large era-sensitive churn with no current defect behind it — deferred, documented here.
- **`work-item/index.ts` hash import aliasing**: exists to dodge namespace-member name collision; not ceremony.

Internal modules are flat files (`src/json.ts`, `src/time.ts`), not barrel-exported and not domain dirs — the #467 vocab ratchet governs public domain namespaces, which these are not; no baseline growth.

## Gates
build, turbo check-types (15/15), topology, deps, import-cycles, lint(+guards), lint:tools, whole-repo ultracite, dead-exports, tsconfig-inheritance, ledger-rename, ledger-schema-drift, `git diff --check`, full `bun test` 2526 pass / 0 fail, coverage ratchet OK (agent +0.95pp, ipc +2.31pp improved).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates duplicated plain-JSON validation, canonical digest, deadline, and timestamp primitives into single shared owners in `packages/protocol`, removing divergent copies that had drifted.

**Behavior changes**
- Work-item `JsonValue` uses the hardened plain-JSON guard: accessor properties, symbol keys, sparse arrays, and `-0` are refused; the persisted-fact profile still accepts `__proto__`/`constructor`/`prototype` keys in immutable facts, so legacy fingerprints parse, while the live policy boundary refuses them.
- Engagement deadlines are now inclusive: work arriving exactly at the deadline is rejected (`deadline_passed`), `expire` fires at the deadline instant, and the ledger's lazy-expiry hydration guard uses the same canonical boundary.
- `EpochMs` (finite, nonnegative) replaces bare `z.number()` at 101 wall-clock sites; negative timestamps are now refused.

**Refactors**
- New internal `src/json.ts` owns both the hardened plain-JSON guard (moved from `policy/effects.ts`) and the canonical sorted-key digest (moved from `work-item/attempt.ts`).
- `sha256JsonRef` and `WorkItem.sha256JsonRef` are deleted; the bytes are frozen into `completionReportReference` and re-verified on every parse, so the algorithm cannot change.
- New internal `src/time.ts` exports `EpochMs`, adopted across all event, record, and facade schemas.

<sup>Written for commit 368a6494b436eb86490e0ebe6bba8983b2536e2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent validation for epoch-millisecond timestamps across protocol records and events.
  * Added canonical JSON validation and stable SHA-256 digest generation for persisted data.
* **Bug Fixes**
  * Records now expire exactly at their deadline, ensuring consistent boundary behavior.
  * Negative timestamps are rejected where wall-clock times are required.
* **Compatibility**
  * Legacy work-item fingerprint data with reserved keys remains readable while retaining stable digests.
* **Tests**
  * Added coverage for deadline boundaries, timestamp validation, and fingerprint compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->