### PR TITLE
protocol: completeness re-audit — delete orphaned operational events + surplus export

### DIFF
--- a/packages/protocol/src/event/operational.ts
+++ b/packages/protocol/src/event/operational.ts
@@ -47,23 +47,6 @@ export namespace Operational {
       { visibility: "llm_reason" },
     );
 
-    export const BootstrapCompleted = BusEvent.define(
-      "operational.bootstrap.completed",
-      Base.extend({
-        mode: z.enum(["local", "coordinator"]),
-        channelCount: z.number(),
-      }),
-      { visibility: "internal" },
-    );
-
-    export const ShutdownInitiated = BusEvent.define(
-      "operational.shutdown.initiated",
-      Base.extend({
-        reason: z.string(),
-      }),
-      { visibility: "internal" },
-    );
-
     /**
      * #510 — a structural incident addressed to the Governor role (the
      * post-hoc fix actor; see docs/core-model.md). Persisted as
@@ -85,17 +68,5 @@ export namespace Operational {
       { visibility: "internal" },
     );
 
-    export const RecoveryStarted = BusEvent.define("operational.recovery.started", Base, {
-      visibility: "ephemeral",
-    });
-
-    export const RecoveryCompleted = BusEvent.define(
-      "operational.recovery.completed",
-      Base.extend({
-        sessionsRecovered: z.number(),
-        durationMs: z.number(),
-      }),
-      { visibility: "internal" },
-    );
   }
 }

--- a/packages/protocol/src/policy/index.ts
+++ b/packages/protocol/src/policy/index.ts
@@ -7,7 +7,6 @@ import { PolicyPointModule } from "./policy-point.js";
 import { PolicyResource } from "./resource.js";
 
 export { PolicyPermission } from "./permission.js";
-export { policyKernelVersion } from "./definition.js";
 
 export namespace Policy {
   export const LabelEntry = PolicyPermission.LabelEntry;

--- a/packages/protocol/test/policy/conformance/versioning.test.ts
+++ b/packages/protocol/test/policy/conformance/versioning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { Policy, policyKernelVersion } from "../../../src/policy/index.js";
+import { policyKernelVersion } from "../../../src/policy/definition.js";
+import { Policy } from "../../../src/policy/index.js";
 
 type PolicyPointContract =
   (typeof Policy.PolicyPoint.Registry)[keyof typeof Policy.PolicyPoint.Registry];

--- a/packages/protocol/test/policy/module-surface.test.ts
+++ b/packages/protocol/test/policy/module-surface.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
-import { Policy, PolicyDecision, PolicyPermission, policyKernelVersion } from "../../src/index.js";
+import { Policy, PolicyDecision, PolicyPermission } from "../../src/index.js";
 import {
   Policy as PolicyIndex,
   PolicyDecision as PolicyDecisionIndex,
   PolicyPermission as PolicyPermissionIndex,
-  policyKernelVersion as policyKernelVersionIndex,
 } from "../../src/policy/index.js";
 
 // #498 receipts: `evaluate` moved to @openomni/policy (evaluatePermission),
@@ -71,7 +70,6 @@ describe("policy module public surface", () => {
     expect(PolicyDecision.allow).toBe(PolicyDecisionIndex.allow);
     expect(Policy.Resource.Descriptor).toBe(PolicyIndex.Resource.Descriptor);
     expect(PolicyPermission.isSafeInputPattern).toBe(PolicyPermissionIndex.isSafeInputPattern);
-    expect(policyKernelVersion).toBe(policyKernelVersionIndex);
   });
 
   test("locks the public policy namespace keys", () => {

--- a/script/conformance/coverage-baseline.json
+++ b/script/conformance/coverage-baseline.json
@@ -1,12 +1,12 @@
 {
   "packages/agent": {
-    "linesFound": 2726,
-    "linesHit": 2651,
-    "pct": 97.25
+    "linesFound": 2883,
+    "linesHit": 2831,
+    "pct": 98.2
   },
   "packages/channels": {
-    "linesFound": 3261,
-    "linesHit": 3123,
+    "linesFound": 3266,
+    "linesHit": 3128,
     "pct": 95.77
   },
   "packages/ipc": {
@@ -15,18 +15,18 @@
     "pct": 92.5
   },
   "packages/ledger": {
-    "linesFound": 4850,
-    "linesHit": 4669,
-    "pct": 96.27
+    "linesFound": 4860,
+    "linesHit": 4679,
+    "pct": 96.28
   },
   "packages/llm": {
-    "linesFound": 1971,
-    "linesHit": 1914,
-    "pct": 97.11
+    "linesFound": 2022,
+    "linesHit": 1966,
+    "pct": 97.23
   },
   "packages/placement": {
-    "linesFound": 22,
-    "linesHit": 22,
+    "linesFound": 44,
+    "linesHit": 44,
     "pct": 100
   },
   "packages/policy": {

--- a/script/conformance/protocol-event-pairing.test.ts
+++ b/script/conformance/protocol-event-pairing.test.ts
@@ -6,7 +6,6 @@ const terminalSuffixes = ["completed", "failed", "cancelled", "settled"] as cons
 
 const expectedPairs: Readonly<Record<string, readonly string[]>> = {
   "llm.call.started": ["llm.call.completed", "llm.call.failed"],
-  "operational.recovery.started": ["operational.recovery.completed"],
   "tool.execution.started": ["tool.execution.completed"],
 };
 
@@ -50,9 +49,7 @@ describe("protocol start/terminal event vocabulary", () => {
     expect(pairingProblems(names)).toEqual([]);
 
     const missingTerminal = new Set(names);
-    missingTerminal.delete("operational.recovery.completed");
-    expect(pairingProblems(missingTerminal)).toContain(
-      "operational.recovery.started terminals: none",
-    );
+    missingTerminal.delete("tool.execution.completed");
+    expect(pairingProblems(missingTerminal)).toContain("tool.execution.started terminals: none");
   });
 });


### PR DESCRIPTION
Follow-up to the protocol deslop campaign (#841, #843, #844): the post-campaign completeness re-audit found residual dead public surface.

## Deleted
- `Operational.Events.BootstrapCompleted` / `ShutdownInitiated` / `RecoveryStarted` / `RecoveryCompleted`: zero publishers, zero subscribers (src+test, all packages/apps/scripts), zero docs references. `BootstrapCompleted` still carried `mode: local|coordinator` — vocabulary of the coordinator deleted in #797. Orphaned legacy.
- `policyKernelVersion` public barrel re-export: the const stays (it is the registration handshake version used by `PolicyPointModule`), but no consumer outside protocol reads it — surplus public seat removed. Conformance version pin now imports the definition module directly.

## Kept (adjudicated)
- `Operational.Events.GovernorIncident`: also zero consumers today, but it is documented target contract — the event contract names its first producer (boot tail verification, one incident per detected chain-break) and `packages/ledger/src/ledger-core/chain.ts` defers to exactly that producer. Deleting it would erase the designed contract for the open boot-verification work.
- `ledger/blacklist` `expiresAt > now`: checked for deadline-boundary drift — it already agrees with the inclusive `Deadline.isExpired` boundary (entry inactive AT the instant). No change needed.

## Also
- Event-pairing conformance: recovery started/completed pair removed; the pairing self-check rewired to the `tool.execution` pair.
- Coverage baselines shrunk (autonomous direction): agent 97.25→98.2, ledger 96.27→96.28, llm 97.11→97.23 (floor raises only; ipc kept at main 92.5 — CI runner measures 94.16% vs local 94.81%, a raise would sit inside env variance — policy/protocol floors kept at main values: lowering a floor is Owner-gated, and the campaign LOC deletion shifted denominators within tolerance).

## Gates
build, turbo check-types 15/15, topology, deps, import-cycles, lint(+guards), lint:tools, whole-repo ultracite, dead-exports, tsconfig-inheritance, ledger-rename, ledger-schema-drift, full `bun test` 2530 pass / 0 fail, coverage ratchet OK, `git diff --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes dead protocol surface found in the post-campaign completeness re-audit: four orphaned `Operational.Events` lifecycle events and the `policyKernelVersion` public barrel re-export.

- `GovernorIncident` stays — it is a documented target contract with a named producer.
- Event-pairing conformance now checks the `tool.execution` pair instead of the removed recovery pair.
- `policyKernelVersion` remains internally for the registration handshake; the conformance test imports the definition module directly.
- Coverage baselines updated (agent 97.25→98.2, ledger 96.27→96.28, llm 97.11→97.23) — floor raises only, with policy/protocol floors kept at main values because lowering a floor is Owner-gated and the campaign LOC deletion shifted denominators within tolerance.

<sup>Written for commit 3180d6ba608392682b39902991574341fd0e7a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

