### PR TITLE
delegation: deterministic W3C trace ids for every delegation emitter

### DIFF
--- a/apps/openomni/src/delegation/channel-driver.ts
+++ b/apps/openomni/src/delegation/channel-driver.ts
@@ -2,6 +2,7 @@ import type { ExistingAgentMessaging } from "@openomni/channels";
 import type { Delegation, Gateway } from "@openomni/protocol";
 import type { Admitted } from "./admission";
 import { renderInstruction } from "./instruction";
+import { delegationTraceId } from "./trace";
 import type {
   DelegationDriver,
   DriverOutcome,
@@ -60,7 +61,7 @@ export function createChannelDriver(ports: ChannelDriverPorts): ChannelDelegatio
 
       const common = {
         messageId: handle.delegationId,
-        traceId: handle.delegationId,
+        traceId: delegationTraceId(handle.delegationId),
         senderId: "resident",
         target: { actorId: address.actorId },
         body: renderInstruction(

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -1,6 +1,7 @@
 import { Deadline, Delegation, NamedError, newTraceId, Operational, type BusEvent } from "@openomni/protocol";
 import { DelegationStore } from "@openomni/ledger";
 import type { WorkItemLinkage } from "./work-item-linkage";
+import { delegationTraceId } from "./trace";
 import { z } from "zod";
 import {
   admit,
@@ -247,7 +248,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
   function publishAdmitted(record: Delegation.Record): void {
     events.publish(Delegation.Events.Admitted, {
       delegationId: record.delegationId,
-      traceId: record.delegationId,
+      traceId: delegationTraceId(record.delegationId),
       time: record.createdAt,
       operation: record.operation,
       addressKind: record.address.kind,
@@ -262,7 +263,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     delivered.add(handle.delegationId);
     events.publish(Delegation.Events.Delivered, {
       delegationId: handle.delegationId,
-      traceId: handle.delegationId,
+      traceId: delegationTraceId(handle.delegationId),
       time: options.now(),
       transport: handle.transport,
     });
@@ -316,7 +317,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     clearTimer(delegationId);
     events.publish(Delegation.Events.Settled, {
       delegationId,
-      traceId: delegationId,
+      traceId: delegationTraceId(delegationId),
       time: persisted.settledAt ?? winner.at,
       status: winner.status,
     });
@@ -340,7 +341,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
         )
         .catch((error: unknown) => {
           events.publish(Operational.Events.Error, {
-            traceId: delegationId,
+            traceId: delegationTraceId(delegationId),
             sessionId: persisted.origin.sessionId,
             time: options.now(),
             component: "delegation",
@@ -360,7 +361,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     const reportFailure = (error: unknown): void => {
       const detail = error instanceof Error ? error.message : String(error);
       events.publish(Operational.Events.Error, {
-        traceId: record.delegationId,
+        traceId: delegationTraceId(record.delegationId),
         sessionId: record.origin.sessionId,
         time: options.now(),
         component: "delegation",
@@ -597,7 +598,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
           await options.workItems?.cancelAssign(workItemId);
         } catch (error) {
           events.publish(Operational.Events.Error, {
-            traceId: record.delegationId,
+            traceId: delegationTraceId(record.delegationId),
             sessionId: record.origin.sessionId,
             time: options.now(),
             component: "delegation",

--- a/apps/openomni/src/delegation/trace.ts
+++ b/apps/openomni/src/delegation/trace.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+const HEX_32 = /^[0-9a-f]{32}$/;
+const NIL = "0".repeat(32);
+
+/**
+ * Deterministic W3C trace id for one delegation.
+ *
+ * Production delegation ids are UUIDs, whose hex digits are exactly a
+ * 32-char lowercase trace id once the hyphens go — so the trace id stays
+ * greppable 1:1 against the delegation id. Any other id (test doubles) and
+ * the nil UUID — the all-zero trace id is invalid per W3C — derive
+ * deterministically from a digest instead, so every consumer of the same
+ * delegation still lands on the same trace.
+ */
+export function delegationTraceId(delegationId: string): string {
+  const canonical = delegationId.split("-").join("").toLowerCase();
+  if (HEX_32.test(canonical) && canonical !== NIL) return canonical;
+  return createHash("sha256").update(delegationId).digest("hex").slice(0, 32);
+}

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -33,6 +33,7 @@ import {
   type DelegationKernel,
   type DelegationWake,
 } from "./delegation/kernel";
+import { delegationTraceId } from "./delegation/trace";
 import { createWakeDeliveryQueue } from "./delegation/wake-delivery";
 import { createWorkItemLinkage } from "./delegation/work-item-linkage";
 import { createCompletionPort } from "./work-item/completion";
@@ -121,7 +122,7 @@ function createLlmToolPort(model: OpenOmniConfig["model"]): LlmPort {
         model: resolveLlmToolModel(await ModelsDev.get(), { provider: model.provider, id: model.id }),
         auth: { type: "api", key: model.apiKey },
         trace: {
-          traceId: `llm-tool:${crypto.randomUUID()}`,
+          traceId: newTraceId(),
           sessionId,
           runId: crypto.randomUUID(),
         },
@@ -150,15 +151,7 @@ function replyText(payload: unknown): string {
 
 /** Builds the internal, persisted Resident turn used for one settlement wake. */
 function delegationWakeDelivery(wake: DelegationWake): Gateway.Deliver {
-  // Deterministic W3C trace id: production delegation ids are UUIDs, whose
-  // hex digits are exactly a 32-char lowercase trace id once the hyphens go.
-  // A non-UUID id (test doubles) falls back to a fresh trace id, and so does
-  // the nil UUID — the all-zero trace id is invalid per W3C.
-  const canonical = wake.record.delegationId.split("-").join("").toLowerCase();
-  const traceId =
-    /^[0-9a-f]{32}$/.test(canonical) && canonical !== "00000000000000000000000000000000"
-      ? canonical
-      : newTraceId();
+  const traceId = delegationTraceId(wake.record.delegationId);
   return Gateway.Deliver.parse({
     sessionId: wake.record.origin.sessionId,
     event: {

--- a/apps/openomni/test/delegation-trace.test.ts
+++ b/apps/openomni/test/delegation-trace.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { delegationTraceId } from "../src/delegation/trace";
+
+const W3C_TRACE = /^[0-9a-f]{32}$/;
+
+describe("delegationTraceId", () => {
+  test("a UUID delegation id maps 1:1 onto its hyphen-stripped hex digits", () => {
+    const delegationId = "c4a4e104-355e-47a8-9781-be3b6d604fa2";
+    expect(delegationTraceId(delegationId)).toBe("c4a4e104355e47a89781be3b6d604fa2");
+  });
+
+  test("the nil UUID never becomes the invalid all-zero trace id", () => {
+    const traceId = delegationTraceId("00000000-0000-0000-0000-000000000000");
+    expect(traceId).toMatch(W3C_TRACE);
+    expect(traceId).not.toBe("0".repeat(32));
+  });
+
+  test("non-UUID ids derive deterministic, distinct, valid trace ids", () => {
+    const first = delegationTraceId("d-wake-failure");
+    expect(first).toMatch(W3C_TRACE);
+    expect(delegationTraceId("d-wake-failure")).toBe(first);
+    expect(delegationTraceId("d-other")).not.toBe(first);
+  });
+});

--- a/apps/openomni/test/delegation.test.ts
+++ b/apps/openomni/test/delegation.test.ts
@@ -6,6 +6,7 @@ import { DelegationStore, SqliteStorageAdapter, Storage, WorkItemStore } from "@
 import { admit, type AdmissionLimits } from "../src/delegation/admission";
 import { createChannelDriver } from "../src/delegation/channel-driver";
 import { createDelegationKernel } from "../src/delegation/kernel";
+import { delegationTraceId } from "../src/delegation/trace";
 import { createWorkItemLinkage } from "../src/delegation/work-item-linkage";
 import {
   AWAIT_DELEGATION_TOOL_NAME,
@@ -554,7 +555,7 @@ describe("durable kernel", () => {
       {
         name: "operational.error",
         data: {
-          traceId: delegationId,
+          traceId: delegationTraceId(delegationId ?? ""),
           sessionId: "session-origin",
           time: 1_000,
           component: "delegation",
@@ -1021,7 +1022,7 @@ describe("delegation controls and tool surface", () => {
     );
 
     await expect(failed).resolves.toMatchObject({
-      traceId: "d-wake-failure",
+      traceId: delegationTraceId("d-wake-failure"),
       component: "delegation",
       msg: "delegation wake failed for d-wake-failure",
       error: "resident unavailable",


### PR DESCRIPTION
## What

Follow-up to #846. That PR made the Resident/Worker observation path reject non-W3C trace ids; this one removes the remaining producers of them.

- New `delegation/trace.ts` owns one deterministic derivation: UUID delegation ids map 1:1 onto their hyphen-stripped hex digits (trace stays greppable against the delegation id); non-UUID ids and the nil UUID derive from a sha256 digest — deterministic, so every consumer of the same delegation lands on the same trace and tests pin exact values instead of matching a random fallback.
- Kernel event sites (Admitted/Delivered/Settled + three operational errors), the channel-driver send, and the settlement wake (previously an inline copy of this logic in `index.ts`) all use the helper.
- The in-cell `llm` bridge drops its `llm-tool:${uuid}` pseudo-trace for `newTraceId()`. App source now has zero non-W3C trace producers.

## What deliberately stays

Channel adapters, the gateway router sink, and WaitService keep direct `Bus.publish`: they are the perimeter, minting a fresh trace root per inbound event — there is no invocation identity to stamp, and a long-lived scope would fabricate wrong correlation. The kernel keeps its injected sink for the same reason: its events are domain facts carrying explicit delegation identity.

## Adversarial checks done

- No consumer compares `traceId` to `delegationId`; correlation is keyed on `waitId`/`messageId`, both still the raw delegation id.
- No parser of the `llm-tool:` prefix exists.
- Downstream readers (ledger persistence, resident, policy audit) treat trace ids as opaque strings.

## Verification

- Full suite: 2536 pass / 0 fail (302 files, 3 new tests)
- check-types 15/15, build 5/5, deps/import-cycles/dead-exports clean
- Changed-file lint and `git diff --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes every delegation emitter produce a valid W3C trace id, replacing raw delegation IDs and the `llm-tool` pseudo-trace that violated the W3C observation contract.

**Deterministic derivation**
- UUID delegation ids map 1:1 onto their hyphen-stripped hex digits, keeping traces greppable against the delegation id.
- Non-UUID ids and the nil UUID derive from a sha256 digest, so every consumer of the same delegation lands on the same trace.
- The kernel's six event sites, the channel-driver send, and the settlement wake now use the new helper.
- Perimeter producers (channel adapters, gateway router sink, WaitService) keep minting a fresh trace root per inbound event, since there is no invocation identity to stamp.
- Correlation is unchanged: `waitId`/`messageId` stay the raw delegation id, and downstream readers treat trace ids as opaque strings.

<sup>Written for commit b98ee91d02a459b2d9bbd659ce54993b45add386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

