### PR TITLE
protocol: deslop — derive SettledStatus, drop dead thread kind, dedup folds

### DIFF
--- a/packages/protocol/src/channel/index.ts
+++ b/packages/protocol/src/channel/index.ts
@@ -100,7 +100,9 @@ export namespace Channel {
    *   - Chat:    telegram:botId:chat:chatId
    */
   export namespace SurfaceKey {
-    export type ChannelKind = "dm" | "group" | "channel" | "thread" | "chat";
+    // "thread" is NOT a kind: threads are sub-keys under a channel (the
+    // `:thread:<id>` marker pair) — see the encoding examples above.
+    export type ChannelKind = "dm" | "group" | "channel" | "chat";
 
     export interface ParsedKey {
       readonly surface: string;
@@ -149,13 +151,7 @@ export namespace Channel {
       return assertWellFormed(parts.join(":"));
     }
 
-    const KNOWN_KINDS: ReadonlySet<string> = new Set<ChannelKind>([
-      "dm",
-      "group",
-      "channel",
-      "thread",
-      "chat",
-    ]);
+    const KNOWN_KINDS: ReadonlySet<string> = new Set<ChannelKind>(["dm", "group", "channel", "chat"]);
 
     export function fromChannel(descriptor: ChannelDescriptor): string {
       const parts = [descriptor.surface, descriptor.namespace, descriptor.kind, descriptor.id];
@@ -179,15 +175,13 @@ export namespace Channel {
         if (seg == null) {
           continue;
         }
-        if (KNOWN_KINDS.has(seg)) {
-          if (seg === "thread") {
-            threadId = segments[i + 1];
-            i++;
-          } else {
-            kind = seg as ChannelKind;
-            id = segments[i + 1];
-            i++;
-          }
+        if (seg === "thread") {
+          threadId = segments[i + 1];
+          i++;
+        } else if (KNOWN_KINDS.has(seg)) {
+          kind = seg as ChannelKind;
+          id = segments[i + 1];
+          i++;
         }
       }
 

--- a/packages/protocol/src/delegation/schema.ts
+++ b/packages/protocol/src/delegation/schema.ts
@@ -39,7 +39,7 @@ export const Operation = z.enum(["notify", "ask", "assign"]);
 export type Operation = z.infer<typeof Operation>;
 
 /**
- * The four delegation transports a kernel driver can resolve an address
+ * The three delegation transports a kernel driver can resolve an address
  * onto. Distinct from the core-model "Lane" noun (Built-in/Action/Worker/
  * Subagent execution lanes) — this is the wire, not the role.
  */
@@ -231,15 +231,14 @@ export const Settled = SettledUnion.superRefine((settled, ctx) => {
 });
 export type Settled = z.infer<typeof Settled>;
 
-export const SettledStatus = z.enum([
-  "completed",
-  "failed",
-  "cancelled",
-  "delivery_failed",
-  "no_response",
-  "interrupted",
-  "sent",
-]);
+// Derived from the union discriminants so the status vocabulary cannot
+// drift from the settled shapes.
+export const SettledStatus = z.enum(
+  SettledUnion.options.map((option) => option.shape.status.value) as [
+    Settled["status"],
+    ...Settled["status"][],
+  ],
+);
 export type SettledStatus = z.infer<typeof SettledStatus>;
 
 /**

--- a/packages/protocol/src/engagement/fold.ts
+++ b/packages/protocol/src/engagement/fold.ts
@@ -115,7 +115,11 @@ function edgeAllowed(from: Schema.State, to: Schema.State): boolean {
   return (EDGES[from] ?? []).includes(to);
 }
 
-function apply(record: Schema.Record, input: TransitionInput, to: Schema.State): Schema.Record {
+function apply(
+  record: Schema.Record,
+  input: Readonly<{ at: number; waitIds?: string[] }>,
+  to: Schema.State,
+): Schema.Record {
   const openWaitIds = TERMINAL.has(to) ? [] : (input.waitIds ?? record.openWaitIds);
   return {
     ...record,
@@ -183,13 +187,7 @@ export function expire(record: Schema.Record, input: { at: number }): Outcome {
   }
   return {
     kind: "expired",
-    record: {
-      ...record,
-      state: "expired",
-      openWaitIds: [],
-      revision: record.revision + 1,
-      updatedAt: input.at,
-    },
+    record: apply(record, input, "expired"),
     from: record.state,
   };
 }

--- a/packages/protocol/src/event/operational.ts
+++ b/packages/protocol/src/event/operational.ts
@@ -25,7 +25,7 @@ export namespace Operational {
     readonly error?: string;
   }
 
-  /** Builds a `LogBase` operational envelope with the producer's timestamp. */
+  /** Attaches the producer's timestamp to log fields (no validation here — the bus event schema validates on publish). */
   export function envelope<Fields extends LogFields>(
     fields: Fields,
     time: number,
@@ -58,12 +58,9 @@ export namespace Operational {
      */
     export const GovernorIncident = BusEvent.define(
       "operational.governor.incident",
-      Base.extend({
-        component: z.string(),
+      LogBase.omit({ sessionId: true }).extend({
         /** Incident class, e.g. "chain_break". */
         incident: z.string(),
-        msg: z.string(),
-        context: z.record(z.string(), z.unknown()).optional(),
       }),
       { visibility: "internal" },
     );

--- a/packages/protocol/src/ingress/index.ts
+++ b/packages/protocol/src/ingress/index.ts
@@ -305,9 +305,11 @@ export function targetKey(target: Ingress.Target): string {
  * same event shape, so the persisted surface↔session rows can never fork by
  * copy drift.
  *
- * Format: "surface:workspace:channel" for legacy events. Explicit ADR-008
- * targets append `target:<target-key>` so resident and worker sessions do
- * not collide.
+ * Format: "surface:workspace:channel" for legacy events. Explicit
+ * NON-resident ADR-008 targets append `target:<target-key>` so worker
+ * sessions do not collide; resident targets keep the bare key (the resident
+ * is the default target, so appending would fork existing resident
+ * surface↔session rows).
  */
 export function extractSurfaceKey(event: {
   surface: string;
@@ -343,5 +345,10 @@ export function extractText(payload: unknown): string {
     return (payload as { text: string }).text;
   }
   if (payload === null || payload === undefined) return "";
-  return JSON.stringify(payload) ?? "";
+  try {
+    return JSON.stringify(payload) ?? "";
+  } catch {
+    // Circular structures / BigInt throw from JSON.stringify — fail safe.
+    return "";
+  }
 }

--- a/packages/protocol/src/ingress/route-record.ts
+++ b/packages/protocol/src/ingress/route-record.ts
@@ -33,9 +33,13 @@ export const ROUTE_DECIDED_FACT_TYPE = "route.decided";
 // safety): the protocol schemas allow plain strings, so a ":" inside a
 // channel or id could otherwise forge a foreign scope's key (e.g.
 // channel "C1" + id "x:5" colliding with channel "C1:x" + id "5").
-export function routeStreamId(scope: RouteStreamScope): string {
+function scopedStreamId(prefix: string, scope: RouteStreamScope): string {
   const component = (value: string | undefined) => encodeURIComponent(value ?? "");
-  return `route:${component(scope.surface)}:${component(scope.workspace)}:${component(scope.channel)}:${component(scope.id)}`;
+  return `${prefix}:${component(scope.surface)}:${component(scope.workspace)}:${component(scope.channel)}:${component(scope.id)}`;
+}
+
+export function routeStreamId(scope: RouteStreamScope): string {
+  return scopedStreamId("route", scope);
 }
 
 /** The ledger append input for a `route.decided` fact (the fact-payload builder). */
@@ -50,8 +54,7 @@ export const ROUTE_NOT_DELIVERED_FACT_TYPE = "route.not_delivered";
 // inbound id as the route decision it corrects, on a distinct class prefix so
 // the route stream's single-fact route.decided replay gate is untouched.
 export function routeCorrectionStreamId(scope: RouteStreamScope): string {
-  const component = (value: string | undefined) => encodeURIComponent(value ?? "");
-  return `route_correction:${component(scope.surface)}:${component(scope.workspace)}:${component(scope.channel)}:${component(scope.id)}`;
+  return scopedStreamId("route_correction", scope);
 }
 
 /** The ledger append input for a `route.not_delivered` correction fact. */

--- a/packages/protocol/src/policy/policy-point.ts
+++ b/packages/protocol/src/policy/policy-point.ts
@@ -36,8 +36,8 @@ const policyPointIds = [
 ] as const;
 
 // Adding a registered policy point intentionally touches this ID list, the
-// registry entry, and the migration mapping so schema, contract, and legacy
-// timing compatibility remain reviewable in one protocol-layer change.
+// registry entry, and the input validator below so schema and contract
+// remain reviewable in one protocol-layer change.
 const policyPoint = z.object({
   point: TimingValue,
   allowedEffects: z.array(PolicyEffectType),

--- a/packages/protocol/src/trace/index.ts
+++ b/packages/protocol/src/trace/index.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 
 /** 32 lowercase hex characters (W3C trace id). */
 type TraceId = string;
@@ -22,12 +21,14 @@ export function newTraceId(): TraceId {
  * package); the two must stay field-compatible on the traceparent pair.
  */
 export namespace TraceContext {
-  const Schema = z.object({
-    traceId: z.string(),
-    sessionId: z.string().optional(),
-    runId: z.string().optional(),
-    agentName: z.string().optional(),
-    parentSpanId: z.string().optional(),
-  });
-  export type Type = z.infer<typeof Schema>;
+  // A plain type, not a Zod schema: every consumer propagates this
+  // structurally (no runtime validation seam exists), so a schema here
+  // would be dead runtime weight.
+  export type Type = {
+    traceId: string;
+    sessionId?: string | undefined;
+    runId?: string | undefined;
+    agentName?: string | undefined;
+    parentSpanId?: string | undefined;
+  };
 }

--- a/packages/protocol/src/work-item/attempt.ts
+++ b/packages/protocol/src/work-item/attempt.ts
@@ -232,15 +232,6 @@ export type Attempt = z.infer<typeof Attempt>;
 export const AttemptOutcome = z.enum(["succeeded", "failed", "cancelled", "interrupted"]);
 export type AttemptOutcome = z.infer<typeof AttemptOutcome>;
 
-/**
- * #510 D2b — projection of the `work_item.attempt_finished` decision-class
- * fact: the current attempt's terminal record. `endedAt`/`error` moved here
- * from the worker-run store (whose in-memory extras map lost them on
- * restart) — attempt lifecycle data with no other home in the WorkItem
- * vocabulary. Cleared by the next `work_item.attempt_allocated` fact (a new
- * execution instance). The legacy `lastMessageId` extra was NOT carried
- * over: it never had a production writer, so it earns no vocabulary here.
- */
 /** Transport-reported spend. Visibility only — never an admission input. */
 export const AttemptUsage = z
   .object({
@@ -250,6 +241,15 @@ export const AttemptUsage = z
   .strict();
 export type AttemptUsage = z.infer<typeof AttemptUsage>;
 
+/**
+ * #510 D2b — projection of the `work_item.attempt_finished` decision-class
+ * fact: the current attempt's terminal record. `endedAt`/`error` moved here
+ * from the worker-run store (whose in-memory extras map lost them on
+ * restart) — attempt lifecycle data with no other home in the WorkItem
+ * vocabulary. Cleared by the next `work_item.attempt_allocated` fact (a new
+ * execution instance). The legacy `lastMessageId` extra was NOT carried
+ * over: it never had a production writer, so it earns no vocabulary here.
+ */
 export const AttemptTerminal = z
   .object({
     attemptId: AttemptId,

--- a/packages/protocol/src/work-item/completion-admission.ts
+++ b/packages/protocol/src/work-item/completion-admission.ts
@@ -283,6 +283,26 @@ export const CompletionContract = z
   .strict();
 export type CompletionContract = z.infer<typeof CompletionContract>;
 
+/** Fact ids must be unique ACROSS collections, not merely within each one. */
+function requireUniqueFactIds(
+  ctx: z.RefinementCtx,
+  collections: ReadonlyArray<readonly [string, ReadonlyArray<Readonly<{ id: string }>>]>,
+): void {
+  const seen = new Set<string>();
+  for (const [collection, entries] of collections) {
+    for (const [index, entry] of entries.entries()) {
+      if (seen.has(entry.id)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `duplicate completion fact id: ${entry.id}`,
+          path: [collection, index, "id"],
+        });
+      }
+      seen.add(entry.id);
+    }
+  }
+}
+
 const CompletionRequestShape = z
   .object({
     version: CurrentVersion,
@@ -303,27 +323,14 @@ const CompletionRequestShape = z
   })
   .strict()
   .superRefine((request, ctx) => {
-    const factGroups = [
+    requireUniqueFactIds(ctx, [
       ["claims", request.claims],
       ["observations", request.observations],
       ["results", request.results],
       ["invalidations", request.invalidations],
       ["verificationErrors", request.verificationErrors],
       ["effects", request.effects],
-    ] as const;
-    const factIds = new Set<string>();
-    for (const [group, facts] of factGroups) {
-      for (const [index, fact] of facts.entries()) {
-        if (factIds.has(fact.id)) {
-          ctx.addIssue({
-            code: "custom",
-            message: `duplicate completion fact id: ${fact.id}`,
-            path: [group, index, "id"],
-          });
-        }
-        factIds.add(fact.id);
-      }
-    }
+    ]);
     validateSourceIdentityOrigin(request.origin, request.sourceIdentity, ctx);
   });
 
@@ -498,8 +505,7 @@ const CompletionFactsShape = z
   })
   .strict()
   .superRefine((facts, ctx) => {
-    const seen = new Set<string>();
-    const collections: ReadonlyArray<readonly [string, ReadonlyArray<Readonly<{ id: string }>>]> = [
+    requireUniqueFactIds(ctx, [
       ["criteria", facts.criteria],
       ["claims", facts.claims],
       ["observations", facts.observations],
@@ -509,19 +515,7 @@ const CompletionFactsShape = z
       ["effects", facts.effects],
       ["requestReservations", facts.requestReservations],
       ["admissions", facts.admissions],
-    ];
-    for (const [collection, entries] of collections) {
-      for (const [index, entry] of entries.entries()) {
-        if (seen.has(entry.id)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `duplicate completion fact id: ${entry.id}`,
-            path: [collection, index, "id"],
-          });
-        }
-        seen.add(entry.id);
-      }
-    }
+    ]);
   });
 
 export const CompletionFacts = CompletionFactsShape;

--- a/packages/protocol/src/work-item/hash.ts
+++ b/packages/protocol/src/work-item/hash.ts
@@ -15,8 +15,9 @@ export function generateHash(): string {
   crypto.getRandomValues(bytes);
   let n = 0n;
   for (const b of bytes) n = (n << 8n) | BigInt(b);
-  // constrain to exactly 36^12 range to guarantee 12-char base36 output
-  const BASE12 = 4738381338321616896n;
-  n = n % BASE12;
+  // Cap at 36^12 so toString(36) yields at most 12 chars; padStart below
+  // pads shorter values, so the output is always exactly 12 chars.
+  const BASE36_POW_12 = 36n ** 12n;
+  n = n % BASE36_POW_12;
   return `wi_${n.toString(36).padStart(12, "0")}`;
 }


### PR DESCRIPTION
- SurfaceKey.ChannelKind: remove dead "thread" kind (threads are sub-keys
  under a channel, never a kind); simplify the parser branch accordingly
- delegation SettledStatus: derive the enum from SettledUnion discriminants
  so the status vocabulary cannot drift from the settled shapes
- engagement fold: route expire() through the shared apply() helper instead
  of a hand-cloned record
- Operational.GovernorIncident: build on LogBase.omit/extend instead of
  restating its fields
- comment/doc drift fixes in trace, ingress, work-item, policy-point

Part of the mass per-package deslop review; verified in isolation with full check-types, full bun test, and ultracite lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the `protocol` package: removes a dead thread kind, derives `SettledStatus` from shapes, deduplicates folds, and fixes stale comments.

**Key changes**
- `SurfaceKey` drops the unused `thread` kind; threads remain sub-key markers in the parser.
- `SettledStatus` is now derived from `SettledUnion` discriminants, so the status vocabulary can’t drift from the settled shapes.
- `expire()` in the engagement fold reuses the shared `apply()` helper.
- `GovernorIncident` inherits from `LogBase` (excluding `sessionId`) instead of restating its fields.
- Extracted a shared `requireUniqueFactIds` helper for both completion-admission validators.
- `TraceContext` becomes a plain type without a runtime Zod schema.
- `extractText` now safely returns `""` when `JSON.stringify` throws (circular structures, BigInt).
- Fixed comment drift in `ingress`, `policy-point`, `work-item`, and `trace`.

<sup>Written for commit 1caed97780820161f2dd8d9d4d26ead5dddfde53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved channel key parsing so thread identifiers are handled correctly.
  - Prevented text extraction failures for circular data and unsupported numeric values.
  - Preserved correct routing for resident and non-resident targets.
  - Ensured scoped stream identifiers remain reliable when values contain special characters.
  - Improved consistency of delegation status definitions and duplicate fact validation.

- **Documentation**
  - Clarified transport, timestamp, routing, policy, and work-item documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->