### PR TITLE
telemetry,ipc,policy: deslop — honest names, dedup unlink, doc fixes

### DIFF
--- a/packages/ipc/src/framing.ts
+++ b/packages/ipc/src/framing.ts
@@ -15,7 +15,7 @@ export function encode(msg: unknown): Uint8Array {
 export type DecodedChunk = {
   /** Every parseable frame in the chunk, delivered immediately, in wire order. */
   frames: unknown[];
-  /** Each non-JSON line, truncated to 64 chars for reporting — never re-queued. */
+  /** Each non-JSON line, truncated to MALFORMED_REPORT_CHARS for reporting — never re-queued. */
   malformed: string[];
 };
 

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -10,6 +10,17 @@ function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
+/** Remove the socket file, tolerating a concurrent removal (ENOENT). */
+function unlinkIfExists(socketPath: string): void {
+  try {
+    fs.unlinkSync(socketPath);
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+  }
+}
+
 export interface IpcServerOptions {
   /**
    * Fires once per connection after it is torn down (close or error). The
@@ -74,13 +85,7 @@ export async function createIpcServer(
     if (await probeSocketLive(socketPath)) {
       throw new IpcConnectionError(`socket ${socketPath} is in use by a live server`);
     }
-    try {
-      fs.unlinkSync(socketPath);
-    } catch (error) {
-      if (!isMissingFileError(error)) {
-        throw error;
-      }
-    }
+    unlinkIfExists(socketPath);
   }
 
   interface SocketData {
@@ -318,13 +323,7 @@ export async function createIpcServer(
     close() {
       peer.disconnectAll(new IpcConnectionError("server closed"));
       server.stop(true);
-      try {
-        fs.unlinkSync(socketPath);
-      } catch (error) {
-        if (!isMissingFileError(error)) {
-          throw error;
-        }
-      }
+      unlinkIfExists(socketPath);
     },
   };
 }

--- a/packages/policy/src/effects/conflicts.ts
+++ b/packages/policy/src/effects/conflicts.ts
@@ -1,6 +1,6 @@
 import type { Policy } from "@openomni/protocol";
 import { FAIL_CLOSED_CONFLICT, type Conflict, type EffectEntry, type FieldOwner } from "./types";
-import { flattenRecord, pathsOverlap, stableHash } from "./records";
+import { flattenRecord, pathsOverlap, stableKey } from "./records";
 
 export function collectPreConflicts(entries: EffectEntry[]): Conflict[] {
   return [
@@ -39,10 +39,10 @@ function collectRecordRewriteConflicts(
     if (!record) continue;
 
     for (const [path, value] of flattenRecord(record)) {
-      const valueHash = stableHash(value);
+      const valueKey = stableKey(value);
       const owner = highestPriorityOwner(owners, path, entry.policyId);
 
-      if (owner && owner.valueHash !== valueHash) {
+      if (owner && owner.valueKey !== valueKey) {
         if (owner.priority === entry.priority) {
           conflicts.push({
             message: `${effectType}.${path} rewritten by ${owner.policyId} and ${entry.policyId}`,
@@ -52,7 +52,7 @@ function collectRecordRewriteConflicts(
       }
 
       if (!owner || entry.priority >= owner.priority) {
-        owners.push({ path, policyId: entry.policyId, valueHash, priority: entry.priority });
+        owners.push({ path, policyId: entry.policyId, valueKey, priority: entry.priority });
       }
     }
   }
@@ -102,8 +102,8 @@ function collectSingleValueConflicts(
     const value = singleValueForEffect(entry.effect, effectType);
     if (value === undefined) continue;
 
-    const valueHash = stableHash(value);
-    if (owner && owner.policyId !== entry.policyId && owner.valueHash !== valueHash) {
+    const valueKey = stableKey(value);
+    if (owner && owner.policyId !== entry.policyId && owner.valueKey !== valueKey) {
       if (owner.priority === entry.priority) {
         conflicts.push({
           message: `${label}.${field} rewritten by ${owner.policyId} and ${entry.policyId}`,
@@ -113,7 +113,7 @@ function collectSingleValueConflicts(
     }
 
     if (!owner || entry.priority >= owner.priority) {
-      owner = { path: field, policyId: entry.policyId, valueHash, priority: entry.priority };
+      owner = { path: field, policyId: entry.policyId, valueKey, priority: entry.priority };
     }
   }
 

--- a/packages/policy/src/effects/ordering.ts
+++ b/packages/policy/src/effects/ordering.ts
@@ -1,6 +1,6 @@
 import type { Policy } from "@openomni/protocol";
 import type { EffectEntry, OrderedDecision } from "./types";
-import { stableHash } from "./records";
+import { stableKey } from "./records";
 
 export function orderDecisions(decisions: Policy.PolicyDecision[]): OrderedDecision[] {
   return decisions
@@ -36,10 +36,10 @@ export function collectEffectEntries(orderedDecisions: OrderedDecision[]): Effec
 
   for (const ordered of orderedDecisions) {
     ordered.decision.effects.forEach((effect, effectIndex) => {
-      const effectHash = stableHash(effect);
-      if (seenEffects.has(effectHash)) return;
+      const effectKey = stableKey(effect);
+      if (seenEffects.has(effectKey)) return;
 
-      seenEffects.add(effectHash);
+      seenEffects.add(effectKey);
       entries.push({
         effect,
         policyId: ordered.decision.policyId,

--- a/packages/policy/src/effects/records.ts
+++ b/packages/policy/src/effects/records.ts
@@ -34,7 +34,7 @@ export function deepMergeRecords(
   return result;
 }
 
-export function stableHash(value: unknown): string {
+export function stableKey(value: unknown): string {
   return stableStringify(value);
 }
 

--- a/packages/policy/src/effects/types.ts
+++ b/packages/policy/src/effects/types.ts
@@ -22,7 +22,7 @@ export interface Conflict {
 export interface FieldOwner {
   readonly path: string;
   readonly policyId: string;
-  readonly valueHash: string;
+  readonly valueKey: string;
   readonly priority: number;
 }
 

--- a/packages/telemetry/src/scope.ts
+++ b/packages/telemetry/src/scope.ts
@@ -63,9 +63,8 @@ export interface ScopeOptions {
  *
  * Validation happens at construction: a malformed scope is a wiring error the
  * process should not start with, while a throw from inside a run would be
- * telemetry cancelling observed work. {@link Emitter.child} and
- * {@link Emitter.child} derives its identity from an already-valid one, so it
- * cannot fail.
+ * telemetry cancelling observed work. {@link Emitter.child} derives its
+ * identity from an already-valid one, so it cannot fail.
  */
 export function scope(
   trace: Omit<TraceScope, "spanId"> & { readonly spanId?: SpanId },


### PR DESCRIPTION
- policy: rename stableHash -> stableKey (it is stable stringify, not a
  hash; the old name implied collision behavior it does not have)
- ipc: extract unlinkIfExists() shared by server create and close paths;
  fix framing doc magic number to reference the constant
- telemetry: drop duplicated {@link Emitter.child} sentence in scope docs

Part of the mass per-package deslop review; verified in isolation with full check-types, full bun test, and ultracite lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `stableHash` to `stableKey` in `policy` so the name no longer implies hash-collision behavior it doesn't have, extracts shared socket-file removal in the `ipc` server, and fixes two doc references. No behavior changes.

- The rename touches the function, call sites, and `FieldOwner.valueKey`.
- `ipc` now shares `unlinkIfExists()` between server create and close paths, replacing duplicated try/catch blocks.
- `framing.ts` references `MALFORMED_REPORT_CHARS` instead of a hard-coded 64.
- `scope.ts` drops the duplicated `{@link Emitter.child}` reference.

<sup>Written for commit 19b25cac81373d728300f2100a441b467cffa2b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when cleaning up IPC socket files, including safe handling of concurrent removal.
  * Improved consistency when identifying duplicate effects and detecting conflicting policy values.

* **Documentation**
  * Clarified malformed-data limits and telemetry scope behavior in developer-facing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->