### PR TITLE
llm: deslop — auth tmp-file leak, empty-cache fallback, decouple usage type

### DIFF
--- a/packages/llm/src/auth/storage.ts
+++ b/packages/llm/src/auth/storage.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { join, dirname, resolve } from "node:path";
-import { mkdirSync, existsSync, writeFileSync, renameSync } from "node:fs";
+import { mkdirSync, existsSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { NamedError } from "../error";
 
@@ -45,7 +45,17 @@ const ensureAuthDir = (filepath: string) => {
 const writeAuthFile = (filepath: string, contents: string): void => {
   const tmpPath = `${filepath}.${crypto.randomUUID()}.tmp`;
   writeFileSync(tmpPath, contents, { mode: 0o600 });
-  renameSync(tmpPath, filepath);
+  try {
+    renameSync(tmpPath, filepath);
+  } catch (error) {
+    // Never leave a plaintext-credential temp file behind on a failed swap.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* already gone */
+    }
+    throw error;
+  }
 };
 
 async function enqueueWrite<T>(filepath: string, write: () => Promise<T>): Promise<T> {

--- a/packages/llm/src/model/index.ts
+++ b/packages/llm/src/model/index.ts
@@ -33,13 +33,16 @@ export namespace ModelsDev {
     return process.env.OPENOMNI_MODELS_URL || "https://models.dev";
   }
 
+  function cachePath(): string {
+    return process.env.OPENOMNI_MODELS_PATH ?? DEFAULT_CACHE_PATH;
+  }
+
   async function writeCache(data: Record<string, Provider>): Promise<void> {
     try {
       const { mkdirSync } = await import("node:fs");
-      const cachePath = process.env.OPENOMNI_MODELS_PATH ?? DEFAULT_CACHE_PATH;
-      const cacheDir = cachePath.substring(0, cachePath.lastIndexOf("/"));
-      mkdirSync(cacheDir, { recursive: true });
-      await Bun.write(cachePath, JSON.stringify(data));
+      const { dirname } = await import("node:path");
+      mkdirSync(dirname(cachePath()), { recursive: true });
+      await Bun.write(cachePath(), JSON.stringify(data));
     } catch {
       /* non-fatal */
     }
@@ -92,10 +95,14 @@ export namespace ModelsDev {
   }
 
   export const Data = lazy(async (): Promise<Record<string, Provider>> => {
-    const cachePath = process.env.OPENOMNI_MODELS_PATH ?? DEFAULT_CACHE_PATH;
-    const file = Bun.file(cachePath);
+    const file = Bun.file(cachePath());
     const cached = await file.json().catch(() => undefined);
-    if (cached) return sanitizeRemoteCatalog(cached);
+    if (cached) {
+      const sanitized = sanitizeRemoteCatalog(cached);
+      // A cache that sanitizes to nothing (e.g. the trusted-package set
+      // changed since it was written) must not shadow the fetch/snapshot.
+      if (Object.keys(sanitized).length > 0) return sanitized;
+    }
 
     if (!process.env.OPENOMNI_DISABLE_MODELS_FETCH) {
       try {

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -363,7 +363,6 @@ export namespace Processor {
     message: string,
     data?: Record<string, unknown>,
   ): void {
-    if (!sessionID) return;
     events.publish(Operational.Events.Info, {
       traceId,
       time: Date.now(),

--- a/packages/llm/src/run.ts
+++ b/packages/llm/src/run.ts
@@ -65,6 +65,11 @@ export interface RunInput {
   events: BusEvent.Sink;
 }
 
+export interface RunDependencies {
+  /** Overrides provider stream creation for an isolated caller or test harness. */
+  createStream?: Processor.ProcessorOptions["createStream"];
+}
+
 /**
  * #500 C1: the loop-run result vocabulary, moved here from protocol — this
  * package's `run()` is the sole producer and the consumers (agent core) all
@@ -72,11 +77,6 @@ export interface RunInput {
  * namespace, so there is no collision (`run` the function and `Run` the
  * namespace are distinct identifiers).
  */
-export interface RunDependencies {
-  /** Overrides provider stream creation for an isolated caller or test harness. */
-  createStream?: Processor.ProcessorOptions["createStream"];
-}
-
 export namespace Run {
   const FailureUsage = z.object({
     inputTokens: z.number(),

--- a/packages/llm/src/token/index.ts
+++ b/packages/llm/src/token/index.ts
@@ -1,12 +1,9 @@
 import type { Token } from "@openomni/protocol";
-import type { LanguageModelUsage } from "ai";
 import { InvalidUsageError } from "../error";
-
-type UsageInput = Partial<LanguageModelUsage>;
 
 export namespace TokenTracker {
   export function extractUsage(response: {
-    readonly usage?: UsageInput | unknown;
+    readonly usage?: unknown;
     readonly providerMetadata?: unknown;
   }): Token.ProviderUsage {
     // Absent/non-record usage still validates providerMetadata-sourced positions:

--- a/packages/llm/test/model/catalog-loading.test.ts
+++ b/packages/llm/test/model/catalog-loading.test.ts
@@ -203,7 +203,7 @@ describe("ModelsDev catalog loading", () => {
       }
     });
 
-    it("should ignore malformed cache data instead of throwing", async () => {
+    it("should fall back to the bundled snapshot when the cache sanitizes to nothing", async () => {
       await writeCacheCatalog({
         openai: null,
         anthropic: {
@@ -215,7 +215,8 @@ describe("ModelsDev catalog loading", () => {
         },
       });
 
-      await expect(ModelsDev.get()).resolves.toEqual({});
+      const snapshot = (await import("../../src/model/models-snapshot.json")).default;
+      await expect(ModelsDev.get()).resolves.toEqual(snapshot);
     });
 
     it("should drop malformed model records from trusted providers", async () => {


### PR DESCRIPTION
- writeAuthFile: unlink the tmp file when rename fails instead of leaking it
- model catalog: an empty sanitized cache now falls through to fetch/bundled
  snapshot instead of serving an empty catalog
- token accounting: accept unknown usage input instead of coupling to the
  ai package type
- remove dead sessionID guard in processor; move run.ts docblock

Part of the mass per-package deslop review; verified in isolation with full check-types, full bun test, and ultracite lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several `llm` package issues found in the deslop review: auth temp files no longer leak on failed renames, an empty sanitized model catalog falls back to fetch or the bundled snapshot, and token usage extraction no longer depends on the `ai` type.

- Removes the temp auth file when the rename fails.
- Uses the bundled snapshot when the cache sanitizes to an empty catalog.
- Accepts arbitrary usage objects in `TokenTracker.extractUsage`.
- Drops a dead `sessionID` guard and moves the `RunDependencies` docblock.

<sup>Written for commit 69a11ff373c4375f7782bddab9663e1df88c9d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

