### PR TITLE
agent: deslop — dedup injected-message construction, comment accuracy

### DIFF
--- a/packages/agent/src/core/budget.ts
+++ b/packages/agent/src/core/budget.ts
@@ -68,8 +68,9 @@ export function effectiveMaxToolCalls(budget?: AgentBudget): number {
 }
 
 /**
- * Pure evaluator: the sole source of the 4-state budget verdict and the facts
- * telemetry needs. No Bus emit, no mutation — see {@link checkBudget} (query)
+ * Sole evaluator of the 4-state budget verdict and the facts telemetry
+ * needs (reads the clock, mutates nothing, emits nothing) — see
+ * {@link checkBudget} (query)
  * and {@link publishBudgetTelemetry} (command) for the split callers.
  */
 function evaluateBudget(state: BudgetState, budget?: AgentBudget): BudgetEvaluation {
@@ -111,7 +112,7 @@ function evaluateBudget(state: BudgetState, budget?: AgentBudget): BudgetEvaluat
 }
 
 /**
- * Query (pure): the budget status. Emits nothing — callers that want the
+ * Query: the budget status. Emits nothing — callers that want the
  * observability telemetry call {@link publishBudgetTelemetry}. This split
  * lets the run.turn.pre budget builtins read the status as a predicate
  * without each re-emitting the per-turn telemetry event (double-effect).

--- a/packages/agent/src/core/execution/effects.ts
+++ b/packages/agent/src/core/execution/effects.ts
@@ -29,6 +29,17 @@ export function matchesToolPattern(toolName: string, pattern: string): boolean {
 }
 
 export namespace PolicyEffectApplier {
+  /** Builds one prompt.inject_message message, honoring the effect's role. */
+  function injectedMessage(
+    effect: Extract<Policy.PolicyDecision["effects"][number], { type: "prompt.inject_message" }>,
+    parentID: string,
+    sessionId: string,
+  ): Message.WithParts {
+    return effect.role === "assistant"
+      ? createAssistantMessage(effect.message, parentID, sessionId)
+      : createUserMessage(effect.message, sessionId, { policyInjected: true });
+  }
+
   export function continuationMessages(
     decision: Policy.PolicyDecision,
     sessionId: string,
@@ -38,10 +49,7 @@ export namespace PolicyEffectApplier {
     let assistantParentID = parentID;
     for (const effect of decision.effects) {
       if (effect.type === "prompt.inject_message") {
-        const message =
-          effect.role === "assistant"
-            ? createAssistantMessage(effect.message, assistantParentID, sessionId)
-            : createUserMessage(effect.message, sessionId, { policyInjected: true });
+        const message = injectedMessage(effect, assistantParentID, sessionId);
         messages.push(message);
         assistantParentID = message.info.id;
       } else if (effect.type === "run.continue_with_prompt") {
@@ -72,10 +80,7 @@ export namespace PolicyEffectApplier {
     let parentID = state.messages.at(-1)?.info.id ?? "";
     for (const effect of decision.effects) {
       if (effect.type === "prompt.inject_message") {
-        const message =
-          effect.role === "assistant"
-            ? createAssistantMessage(effect.message, parentID, state.sessionId)
-            : createUserMessage(effect.message, state.sessionId, { policyInjected: true });
+        const message = injectedMessage(effect, parentID, state.sessionId);
         messages.push(message);
         parentID = message.info.id;
       } else if (effect.type === "prompt.append_context") {

--- a/packages/agent/src/core/execution/run-events.ts
+++ b/packages/agent/src/core/execution/run-events.ts
@@ -25,13 +25,10 @@ export function emitTurnStart(
   state: RunState,
   agentBase: AgentRunBase,
 ): void {
-  const turnIndex = state.turnIndex;
-  const sessionId = agentBase.sessionId;
   events.publish(RunEvents.TurnStart, {
     ...agentBase,
-    sessionId,
     time: Date.now(),
-    turnIndex,
+    turnIndex: state.turnIndex,
   });
 }
 
@@ -41,10 +38,8 @@ export function emitTurnComplete(
   agentBase: AgentRunBase,
   turnUsage: TokenUsage,
 ): void {
-  const sessionId = agentBase.sessionId;
   events.publish(RunEvents.TurnComplete, {
     ...agentBase,
-    sessionId,
     time: Date.now(),
     turnIndex: state.turnIndex,
     usage: {

--- a/packages/agent/src/core/execution/tools.ts
+++ b/packages/agent/src/core/execution/tools.ts
@@ -237,6 +237,10 @@ export function createToolExecutor(
     );
 
     recordDecision(activeTraceContext, "invoke.result", postDecision);
+    // Post is a post-hoc point: the tool already ran, so a blocking verdict
+    // alone cannot un-run it. Only the explicit run.abort effect withholds the
+    // result; a bare blocking post-verdict is recorded (recordDecision above)
+    // and the result flows on — the authorization gate was the pre point.
     const postAbort = effectOf(postDecision, "run.abort");
     if (PolicyDecision.isBlocking(postDecision) && postAbort) {
       const reason = postAbort.reason ?? PolicyDecision.reason(postDecision, "middleware");

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,5 @@
-// Agent package public API — ChatAgent only
+// Agent package public API: the ChatAgent loop plus the policy-engine and
+// budget surfaces a product composes it with.
 export { ChatAgent } from "./core/chat-agent";
 export type { ChatAgentInstance } from "./core/chat-agent";
 export type { ChatAgentConfig, ChatAgentInput, AgentResult } from "./core/types";


### PR DESCRIPTION
- effects: extract injectedMessage() shared by continuation and prompt
  message effects (was copy-pasted)
- run-events: drop redundant sessionId locals
- budget/tools/index: comment accuracy fixes (including the index header
  that claimed ChatAgent-only exports)

Part of the mass per-package deslop review; verified in isolation with full check-types, full bun test, and ultracite lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes small correctness and readability issues in the agent package: dedups injected-message construction, removes redundant locals, and corrects misleading comments.

- Extracts `injectedMessage()` shared by continuation and prompt-message effects, replacing the copy-pasted construction.
- Drops redundant `sessionId` locals in turn-start/complete event emission.
- Corrects comments in `budget.ts`, `tools.ts`, and the `index.ts` header that claimed ChatAgent-only exports.

<sup>Written for commit 596f9f507600bf3ea9b3abd016e536c4aec0122f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

