### PR TITLE
channels: deslop — timing-safe authn, gateway parse guard, mention fixes

### DIFF
--- a/packages/channels/src/authn/github.ts
+++ b/packages/channels/src/authn/github.ts
@@ -10,43 +10,32 @@ interface GitHubAuthState {
   response?: Response;
 }
 
+function hmacVerdict(allowed: boolean, denyReason: string): Policy.PolicyDecision {
+  return evaluateChannelPermission({
+    action: "channel.authn.github-hmac",
+    resource: "github.webhook",
+    field: "authenticated",
+    allowed,
+    allowReason: "github signature verified",
+    denyReason,
+  });
+}
+
 async function evaluateGitHubHmac(state: GitHubAuthState): Promise<Policy.PolicyDecision> {
-  const policyId = "channel.authn.github-hmac";
   const signature = state.request.headers.get("x-hub-signature-256");
   if (!signature) {
     state.response = new Response("Missing signature", { status: 401 });
-    return evaluateChannelPermission({
-      action: policyId,
-      resource: "github.webhook",
-      field: "authenticated",
-      allowed: false,
-      allowReason: "github signature verified",
-      denyReason: "github signature missing",
-    });
+    return hmacVerdict(false, "github signature missing");
   }
 
   const body = await state.request.text();
   state.body = body;
   if (!(await verifyGitHubSignature(body, signature, state.secret))) {
     state.response = new Response("Invalid signature", { status: 401 });
-    return evaluateChannelPermission({
-      action: policyId,
-      resource: "github.webhook",
-      field: "authenticated",
-      allowed: false,
-      allowReason: "github signature verified",
-      denyReason: "github signature invalid",
-    });
+    return hmacVerdict(false, "github signature invalid");
   }
 
-  return evaluateChannelPermission({
-    action: policyId,
-    resource: "github.webhook",
-    field: "authenticated",
-    allowed: true,
-    allowReason: "github signature verified",
-    denyReason: "github signature invalid",
-  });
+  return hmacVerdict(true, "github signature invalid");
 }
 
 export async function authenticateGitHubWebhook(input: {

--- a/packages/channels/src/authn/websocket.ts
+++ b/packages/channels/src/authn/websocket.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { Operational } from "@openomni/protocol";
 import type { Policy } from "@openomni/protocol";
 import { newTraceId } from "@openomni/protocol";
@@ -30,6 +31,14 @@ function readSubprotocolAuth(
   return token ? { token, selected: "auth" } : undefined;
 }
 
+/** Constant-time token check — hash both sides so length differences leak nothing. */
+function tokensEqual(provided: string, expected: string): boolean {
+  return timingSafeEqual(
+    createHash("sha256").update(provided).digest(),
+    createHash("sha256").update(expected).digest(),
+  );
+}
+
 function evaluateWebSocketToken(state: WebSocketAuthState): Policy.PolicyDecision {
   const policyId = "channel.authn.websocket-token";
   if (!state.token) {
@@ -46,7 +55,7 @@ function evaluateWebSocketToken(state: WebSocketAuthState): Policy.PolicyDecisio
   const url = new URL(state.request.url);
   const subprotocolAuth = readSubprotocolAuth(state.request);
   const provided = subprotocolAuth?.token ?? url.searchParams.get("token");
-  if (provided !== state.token) {
+  if (provided === null || !tokensEqual(provided, state.token)) {
     state.publish(Operational.Events.Warn, {
       traceId: state.traceId,
       time: Date.now(),

--- a/packages/channels/src/discord/client.ts
+++ b/packages/channels/src/discord/client.ts
@@ -42,7 +42,12 @@ export class DiscordClient implements ChannelClient {
       "/users/@me/channels",
       { recipient_id: recipientId },
       traceId,
-    )) as { id: string };
+    )) as { id?: unknown };
+    if (typeof channel.id !== "string") {
+      throw new DiscordApiError({
+        message: "Discord DM channel response carried no string id",
+      });
+    }
     return channel.id;
   }
 

--- a/packages/channels/src/discord/gateway.ts
+++ b/packages/channels/src/discord/gateway.ts
@@ -91,7 +91,20 @@ export class DiscordGateway {
       let resolved = false;
 
       ws.addEventListener("message", (event) => {
-        const payload = JSON.parse(String(event.data)) as GatewayPayload;
+        let payload: GatewayPayload;
+        try {
+          payload = JSON.parse(String(event.data)) as GatewayPayload;
+        } catch {
+          // One malformed frame must not become an uncaught listener throw;
+          // drop it — the gateway's own heartbeat/close handling recovers.
+          this.publish(Operational.Events.Warn, {
+            traceId: newTraceId(),
+            time: Date.now(),
+            component: "server",
+            msg: "discord gateway frame was not valid JSON; dropped",
+          });
+          return;
+        }
         const ready = this.handlePayload(payload);
         if (ready && !resolved) {
           resolved = true;

--- a/packages/channels/src/discord/gateway.ts
+++ b/packages/channels/src/discord/gateway.ts
@@ -11,6 +11,28 @@ export interface GatewayCallbacks {
 }
 
 /**
+ * Accept a READY resume URL only when it points at a Discord gateway origin
+ * (`wss://*.discord.gg`) or the same origin the trusted gateway-URL fetch
+ * connected to; anything else returns null, which falls back to a freshly
+ * fetched gateway URL on the next reconnect.
+ */
+function validResumeUrl(raw: string, trustedOrigin: string | null): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname;
+  const discordGateway =
+    parsed.protocol === "wss:" && (host === "discord.gg" || host.endsWith(".discord.gg"));
+  if (!(discordGateway || parsed.origin === trustedOrigin)) {
+    return null;
+  }
+  return `${raw}?v=10&encoding=json`;
+}
+
+/**
  * Discord gateway connection state machine. Heartbeat and payload routing
  * live INSIDE this class (#520): the former heartbeat.ts/dispatch-router.ts
  * satellite split severed the two data paths the protocol depends on — no
@@ -27,6 +49,8 @@ export class DiscordGateway {
   private sequence: number | null = null;
   private sessionId: string | null = null;
   private resumeUrl: string | null = null;
+  /** Origin of the last trusted (fetched, not payload-provided) gateway URL. */
+  private gatewayOrigin: string | null = null;
   private reconnectAttempt = 0;
 
   constructor(
@@ -39,7 +63,18 @@ export class DiscordGateway {
 
   async start(): Promise<void> {
     this.running = true;
-    await this.openSocket(await this.fetchGatewayUrl());
+    await this.openSocket(await this.fetchTrustedGatewayUrl());
+  }
+
+  /** Fetch a gateway URL and remember its origin as the trusted resume anchor. */
+  private async fetchTrustedGatewayUrl(): Promise<string> {
+    const url = await this.fetchGatewayUrl();
+    try {
+      this.gatewayOrigin = new URL(url).origin;
+    } catch {
+      this.gatewayOrigin = null;
+    }
+    return url;
   }
 
   stop(): void {
@@ -63,7 +98,7 @@ export class DiscordGateway {
     let url = this.resumeUrl && this.sessionId ? this.resumeUrl : undefined;
     while (url === undefined && this.running) {
       try {
-        url = await this.fetchGatewayUrl();
+        url = await this.fetchTrustedGatewayUrl();
       } catch (err) {
         this.reconnectAttempt++;
         const backoffMs = calculateBackoff(this.reconnectAttempt);
@@ -247,7 +282,10 @@ export class DiscordGateway {
     if (event === "READY") {
       const d = data as { session_id: string; resume_gateway_url: string; user: DiscordUser };
       this.sessionId = d.session_id;
-      this.resumeUrl = `${d.resume_gateway_url}?v=10&encoding=json`;
+      // The resume URL arrives in a server payload; pin it to Discord's
+      // gateway origin before it can ever become a socket target, so a
+      // spoofed READY cannot redirect the resume connection elsewhere.
+      this.resumeUrl = validResumeUrl(d.resume_gateway_url, this.gatewayOrigin);
       this.reconnectAttempt = 0;
       this.callbacks.onReady({ botId: d.user.id, botUsername: d.user.username });
       return true;

--- a/packages/channels/src/discord/normalizer.ts
+++ b/packages/channels/src/discord/normalizer.ts
@@ -20,7 +20,7 @@ export class DiscordNormalizer implements InboundNormalizer<DiscordMessage> {
 
     let content = message.content;
     if (mentioned && !isDM) {
-      content = content.replace(new RegExp(`<@!?${this.ctx.botId}>\\s*`), "").trim();
+      content = content.replace(new RegExp(`<@!?${this.ctx.botId}>\\s*`, "g"), "").trim();
     }
     content = normalizeContent(content, this.ctx.triggers);
     if (!content) return null;

--- a/packages/channels/src/discord/surface.ts
+++ b/packages/channels/src/discord/surface.ts
@@ -116,7 +116,6 @@ export class DiscordAdapter implements Channel.Surface {
     const acquisition = this.dedupe.acquire(message.id);
     if (acquisition.duplicate) return;
     const dedupeToken = acquisition.token;
-    if (dedupeToken === undefined) return;
     if (message.author.bot) return;
     if (!message.content) return;
 

--- a/packages/channels/src/github/normalizer.ts
+++ b/packages/channels/src/github/normalizer.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Channel } from "@openomni/protocol";
 import { normalizeContent } from "../support/trigger";
 import type { GitHubEventContent } from "./types";
@@ -5,6 +6,10 @@ import type { GitHubEventContent } from "./types";
 export interface GitHubNormalizerContext {
   botUsername?: string;
   triggers: Channel.Config["triggers"];
+}
+
+function textDigest(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 12);
 }
 
 export class GitHubNormalizer {
@@ -30,8 +35,9 @@ export class GitHubNormalizer {
     if (normalizedText.trim().length === 0) return null;
 
     return {
-      id:
-        deliveryId ?? `${eventKey}-${content.issueNumber}-${content.sender}-${content.text.length}`,
+      // Fallback id (no x-github-delivery): hash the text — a length suffix
+      // would collide for equal-length comments and silently drop the second.
+      id: deliveryId ?? `${eventKey}-${content.issueNumber}-${content.sender}-${textDigest(content.text)}`,
       traceId,
       surfaceKey,
       text: normalizedText,

--- a/packages/channels/src/github/types.ts
+++ b/packages/channels/src/github/types.ts
@@ -13,16 +13,18 @@ interface GitHubRepository {
   name: string;
 }
 
+interface GitHubIssue {
+  number: number;
+  title: string;
+  body?: string;
+  pull_request?: unknown;
+  labels?: GitHubLabel[];
+  user: GitHubUser;
+}
+
 export interface GitHubIssueCommentPayload {
   action: string;
-  issue: {
-    number: number;
-    title: string;
-    body?: string;
-    pull_request?: unknown;
-    labels?: GitHubLabel[];
-    user: GitHubUser;
-  };
+  issue: GitHubIssue;
   comment: {
     id: number;
     body: string;
@@ -33,14 +35,7 @@ export interface GitHubIssueCommentPayload {
 
 export interface GitHubIssuesPayload {
   action: string;
-  issue: {
-    number: number;
-    title: string;
-    body?: string;
-    pull_request?: unknown;
-    labels?: GitHubLabel[];
-    user: GitHubUser;
-  };
+  issue: GitHubIssue;
   repository: GitHubRepository;
 }
 

--- a/packages/channels/src/router/authority.ts
+++ b/packages/channels/src/router/authority.ts
@@ -91,7 +91,7 @@ function evaluateIngressAuthority(event: Gateway.DeliveredEvent): Policy.PolicyD
   return { ...decision, factsUsed: resourceLabels };
 }
 
-export /**
+/**
  * Stamps the treatment onto meta VERBATIM — no runtime validation against
  * Actor.InboundTreatment. Today every producer is schema-derived (grants are
  * Zod-parsed at write and read, and routing-resolution passes the parsed
@@ -99,7 +99,7 @@ export /**
  * unchecked — a test carried an out-of-enum value through here for a year
  * (#652 review). Convergence of this seam belongs to #498.
  */
-function applyChannelGrantTreatment(
+export function applyChannelGrantTreatment(
   event: Gateway.DeliveredEvent,
   grant: ChannelGrantStore.Grant,
   inboundTreatment: Actor.InboundTreatment,

--- a/packages/channels/src/router/messaging/send.ts
+++ b/packages/channels/src/router/messaging/send.ts
@@ -64,12 +64,10 @@ export type MessagingPorts = Readonly<{
   /**
    * Concrete delivery owner (server channel / API / connector). Required at
    * construction — there is no ownerless send path, so "no owner" cannot be
-   * silently skipped (fail-closed, rule 7).
-   */
-  /**
-   * At-least-once delivery: retries carry the same `message.idempotencyKey` so
-   * a concrete owner can provide bounded dedupe or platform read-back. The
-   * guarantee remains at-least-once when composition does not forward the key.
+   * silently skipped (fail-closed, rule 7). At-least-once delivery: retries
+   * carry the same `message.idempotencyKey` so a concrete owner can provide
+   * bounded dedupe or platform read-back; the guarantee remains at-least-once
+   * when composition does not forward the key.
    */
   deliver: (
     message: OutboundMessage,
@@ -347,16 +345,16 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
         const budget = ports
           .budgets?.()
           .find((candidate) => candidate.targetActorId === input.target.actorId);
-        const claim = EgressBudgetStore.claim(
+        const budgetClaim = EgressBudgetStore.claim(
           debitRow(input, sendClass),
           input.at - (budget?.windowMs ?? 0),
           (state) => evaluateSocialBudget(budget, state, { class: sendClass, at: input.at }),
         );
-        if (claim.kind === "refused") {
+        if (budgetClaim.kind === "refused") {
           return deny(
             input,
-            claim.reason.suppress,
-            `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${claim.reason.suppress})`,
+            budgetClaim.reason.suppress,
+            `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${budgetClaim.reason.suppress})`,
           );
         }
       }

--- a/packages/channels/src/support/chunk-text.ts
+++ b/packages/channels/src/support/chunk-text.ts
@@ -11,13 +11,16 @@ export function splitText(text: string, maxLength: number): string[] {
       break;
     }
 
-    let splitAt = remaining.lastIndexOf("\n", maxLength);
-    if (splitAt < maxLength / 2) {
-      splitAt = maxLength;
+    const newlineAt = remaining.lastIndexOf("\n", maxLength);
+    if (newlineAt >= maxLength / 2) {
+      // Split on the newline and drop it — it separated the chunks; keeping
+      // it would prepend every subsequent chunk with a blank first line.
+      chunks.push(remaining.slice(0, newlineAt));
+      remaining = remaining.slice(newlineAt + 1);
+    } else {
+      chunks.push(remaining.slice(0, maxLength));
+      remaining = remaining.slice(maxLength);
     }
-
-    chunks.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt);
   }
 
   return chunks;

--- a/packages/channels/src/support/dedupe.ts
+++ b/packages/channels/src/support/dedupe.ts
@@ -55,7 +55,9 @@ export class Dedupe {
     if (this.seen.get(id)?.token === token) this.seen.delete(id);
   }
 
-  acquire(id: string): { readonly duplicate: boolean; readonly token?: DedupeToken } {
+  acquire(
+    id: string,
+  ): { readonly duplicate: true } | { readonly duplicate: false; readonly token: DedupeToken } {
     // prune every 100 operations to amortize cost
     if (++this.ops >= 100) {
       this.ops = 0;

--- a/packages/channels/src/support/trigger.ts
+++ b/packages/channels/src/support/trigger.ts
@@ -20,9 +20,11 @@ function evaluateRule(rule: Channel.TriggerRule, ctx: Channel.TriggerContext): b
     case "prefix":
       return ctx.text.startsWith(rule.value);
 
-    case "label":
-      if (!ctx.labels || ctx.labels.length === 0) return false;
-      return rule.values.some((v) => ctx.labels?.includes(v) ?? false);
+    case "label": {
+      const labels = ctx.labels;
+      if (!labels || labels.length === 0) return false;
+      return rule.values.some((v) => labels.includes(v));
+    }
 
     case "channel":
       if (!ctx.channelId) return ctx.isDM === true;
@@ -41,7 +43,9 @@ function stripTriggerPrefix(text: string, rules: Channel.TriggerRule[]): string 
   const prefix = rules.find(
     (r): r is Extract<Channel.TriggerRule, { type: "prefix" }> => r.type === "prefix",
   );
-  if (prefix) {
+  // Only strip when the text actually starts with the prefix — a message
+  // admitted by another trigger (mention, label) must not lose its head.
+  if (prefix && text.startsWith(prefix.value)) {
     return text.slice(prefix.value.length).trim();
   }
   return text;

--- a/packages/channels/src/telegram/normalizer.ts
+++ b/packages/channels/src/telegram/normalizer.ts
@@ -37,7 +37,7 @@ export class TelegramNormalizer implements InboundNormalizer<TelegramMessage> {
       text: content,
       sender: {
         id: String(userId),
-        name: message.from?.username ?? message.from?.first_name,
+        name: message.from.username ?? message.from.first_name,
       },
       ...(message.reply_to_message
         ? { replyToId: String(message.reply_to_message.message_id) }

--- a/packages/channels/src/telegram/surface.ts
+++ b/packages/channels/src/telegram/surface.ts
@@ -73,7 +73,6 @@ export class TelegramAdapter implements Channel.Surface {
           const acquisition = this.dedupe.acquire(dedupeKey);
           if (acquisition.duplicate) return;
           const dedupeToken = acquisition.token;
-          if (dedupeToken === undefined) return;
           // Origin: the first frame of an inbound telegram message — this ONE
           // mint is the message's trace, carried to the run (D11).
           const messageTraceId = newTraceId();
@@ -141,7 +140,10 @@ export class TelegramAdapter implements Channel.Surface {
       triggers: this.config.triggers,
       ctx: {
         event: "message",
-        mentioned: this.botUsername !== "" && text.includes(`@${this.botUsername}`),
+        // Word-boundary match: `@foo` must not count a mention of `@foobar`.
+        mentioned:
+          this.botUsername !== "" &&
+          new RegExp(`@${this.botUsername}(?![A-Za-z0-9_])`).test(text),
         channelId: chatId,
         senderId: String(message.from.id),
         isDM: message.chat.type === "private",

--- a/packages/channels/src/websocket.ts
+++ b/packages/channels/src/websocket.ts
@@ -146,7 +146,6 @@ export class WebSocketHandler {
       const parsed = JSON.parse(raw) as {
         type?: string;
         text?: string;
-        surfaceKey?: string;
         replyToId?: string;
       };
 

--- a/packages/channels/test/telegram-dedupe.test.ts
+++ b/packages/channels/test/telegram-dedupe.test.ts
@@ -205,9 +205,8 @@ describe("outbound adapter delivery dedupe capability", () => {
       now += 6;
       const second = dedupe.acquire("same-id");
 
-      expect(first.duplicate).toBe(false);
       expect(second.duplicate).toBe(false);
-      if (first.token === undefined) throw new Error("first acquisition was not accepted");
+      if (first.duplicate) throw new Error("first acquisition was not accepted");
       dedupe.forget("same-id", first.token);
       expect(dedupe.isDuplicate("same-id")).toBe(true);
     } finally {
@@ -222,9 +221,8 @@ describe("outbound adapter delivery dedupe capability", () => {
     dedupe.acquire("eviction-trigger");
     const second = dedupe.acquire("same-id");
 
-    expect(first.duplicate).toBe(false);
     expect(second.duplicate).toBe(false);
-    if (first.token === undefined) throw new Error("first acquisition was not accepted");
+    if (first.duplicate) throw new Error("first acquisition was not accepted");
     dedupe.forget("same-id", first.token);
     expect(dedupe.isDuplicate("same-id")).toBe(true);
   });


### PR DESCRIPTION
- websocket authn: constant-time token comparison (sha256 + timingSafeEqual)
  instead of ===
- discord gateway: guard JSON.parse on inbound frames (warn + drop) so one
  malformed frame cannot throw
- discord client: validate createDmChannel response id
- discord normalizer: mention regex gets the missing g flag
- telegram: word-boundary mention matching (@name no longer matches @namex);
  narrow message.from access
- github: fallback message id uses a sha256 digest instead of text.length;
  shared GitHubIssue type; hmacVerdict() helper
- dedupe.acquire(): discriminated union result; chunk-text drops the split
  newline; remove dead token guards and dead surfaceKey field

Part of the mass per-package deslop review; verified in isolation with full check-types, full bun test, and ultracite lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `channels` package: WebSocket auth compares tokens in constant time, the Discord gateway survives malformed and spoofed frames, and several message-processing bugs are fixed.

**Behavior changes**
- WebSocket tokens compare via sha256 + `timingSafeEqual` instead of `===`.
- The Discord gateway warns and drops malformed inbound frames instead of throwing; DM creation validates the returned `id`.
- READY resume URLs are pinned to a trusted gateway origin, so a spoofed payload can't redirect the resume socket (request-forgery).
- Discord bot-ping stripping gets the missing `g` flag, so repeated pings are removed.
- Telegram mentions require a word boundary — `@name` no longer matches `@namex`.
- GitHub fallback message ids hash the text (sha256) instead of using `text.length`, which collided for equal-length comments.
- `splitText` drops the newline it splits on, so later chunks no longer start with a blank line.
- Prefix stripping only applies when the text actually starts with the prefix.
- `dedupe.acquire()` returns a discriminated union; the dead `token === undefined` guards and unused `surfaceKey` field are removed.

<sup>Written for commit 7ec9f880761ab2eae58e7ae00ce619bc0ee25787. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

