### PR TITLE
app: deslop — kernel closure capture, memory guard, honest tool schema

### DIFF
--- a/apps/openomni/src/cli/daemon.ts
+++ b/apps/openomni/src/cli/daemon.ts
@@ -132,6 +132,12 @@ function launchdDomainTarget(target: DaemonTarget): string {
   return `gui/${target.uid}/${LAUNCHD_LABEL}`;
 }
 
+/** (Re)loads the launchd job: a previous generation may be loaded, so bootout is allowed to fail. */
+function launchdReload(target: DaemonTarget, io: DaemonIo): void {
+  io.exec(["launchctl", "bootout", launchdDomainTarget(target)]);
+  run(io, ["launchctl", "bootstrap", `gui/${target.uid}`, unitPath(target)]);
+}
+
 /** (Re)loads the service: idempotent, safe to run over an existing install. */
 export function daemonInstall(target: DaemonTarget, io: DaemonIo): string {
   const path = unitPath(target);
@@ -139,9 +145,7 @@ export function daemonInstall(target: DaemonTarget, io: DaemonIo): string {
     // launchd opens the configured log paths itself; missing parents kill the job at load.
     io.makeDir(dirname(logPath(target)));
     io.writeFile(path, renderLaunchdPlist(target));
-    // A previous generation may be loaded; bootout is allowed to fail.
-    io.exec(["launchctl", "bootout", launchdDomainTarget(target)]);
-    run(io, ["launchctl", "bootstrap", `gui/${target.uid}`, path]);
+    launchdReload(target, io);
     return `installed and started (launchd: ${path})`;
   }
   io.writeFile(path, renderSystemdUnit(target));
@@ -208,8 +212,7 @@ export function daemonStart(target: DaemonTarget, io: DaemonIo): string {
     throw new Error("not installed — run `openomni daemon install` first");
   }
   if (target.platform === "darwin") {
-    io.exec(["launchctl", "bootout", launchdDomainTarget(target)]);
-    run(io, ["launchctl", "bootstrap", `gui/${target.uid}`, path]);
+    launchdReload(target, io);
     return "started";
   }
   run(io, ["systemctl", "--user", "start", SYSTEMD_UNIT]);

--- a/apps/openomni/src/cli/doctor.ts
+++ b/apps/openomni/src/cli/doctor.ts
@@ -63,7 +63,7 @@ export async function runDoctor(ports: DoctorPorts): Promise<DoctorReport> {
       checks.push({
         name: "linger",
         status: "warn",
-        detail: "disabled or unverifiable — daemon dies at logout; run `loginctl enable-linger`",
+        detail: "disabled — daemon dies at logout; run `loginctl enable-linger`",
       });
     }
   } else {
@@ -76,7 +76,9 @@ export async function runDoctor(ports: DoctorPorts): Promise<DoctorReport> {
 
   const rawPort = ports.effectiveEnv.get("OPENOMNI_WS_PORT");
   const port =
-    rawPort !== undefined && /^\d+$/.test(rawPort) && Number(rawPort) >= 1 ? Number(rawPort) : 3000;
+    rawPort !== undefined && /^\d+$/.test(rawPort) && Number(rawPort) >= 1 && Number(rawPort) <= 65_535
+      ? Number(rawPort)
+      : 3000;
   const healthy = await ports.probeHealth(port);
   if (healthy) {
     checks.push({ name: "health", status: "pass", detail: `http://127.0.0.1:${port}/health ok` });

--- a/apps/openomni/src/cli/env-file.ts
+++ b/apps/openomni/src/cli/env-file.ts
@@ -38,12 +38,16 @@ export function parseEnvFile(text: string): ReadonlyMap<string, string> {
   return entries;
 }
 
-function unquote(value: string): string {
-  const quoted =
+function isQuoted(value: string): boolean {
+  return (
     value.length >= 2 &&
     ((value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'")));
-  return quoted ? value.slice(1, -1) : value;
+      (value.startsWith("'") && value.endsWith("'")))
+  );
+}
+
+function unquote(value: string): string {
+  return isQuoted(value) ? value.slice(1, -1) : value;
 }
 
 export function renderEnvFile(entries: readonly EnvEntry[]): string {
@@ -56,11 +60,9 @@ export function renderEnvFile(entries: readonly EnvEntry[]): string {
     }
     // Round-trip: a value the parser would unquote gets one protective
     // quote layer, so `"secret"` reads back as `"secret"`, not `secret`.
-    const wouldUnquote =
-      entry.value.length >= 2 &&
-      ((entry.value.startsWith('"') && entry.value.endsWith('"')) ||
-        (entry.value.startsWith("'") && entry.value.endsWith("'")));
-    const value = wouldUnquote ? `"${entry.value}"` : entry.value;
+    // Edge whitespace gets the same layer — the parser trims bare values.
+    const value =
+      isQuoted(entry.value) || /^\s|\s$/.test(entry.value) ? `"${entry.value}"` : entry.value;
     return `${entry.key}=${value}`;
   });
   return `${lines.join("\n")}\n`;

--- a/apps/openomni/src/cli/onboard.ts
+++ b/apps/openomni/src/cli/onboard.ts
@@ -34,6 +34,9 @@ export async function gatherOnboarding(ask: Ask): Promise<readonly EnvEntry[]> {
   const provider = await askRequired(ask, "Model provider (anthropic | openai)", {
     fallback: "anthropic",
   });
+  if (provider !== "anthropic" && provider !== "openai") {
+    throw new Error(`Model provider must be "anthropic" or "openai", got "${provider}"`);
+  }
   const modelId = await askRequired(ask, "Model id");
   const apiKey = await askRequired(ask, "Model API key", { secret: true });
   const port = await askRequired(ask, "WebSocket port", { fallback: "3000" });

--- a/apps/openomni/src/config.ts
+++ b/apps/openomni/src/config.ts
@@ -104,18 +104,32 @@ const Actors = z
   )
   .min(1);
 
+/** Reads an env var holding JSON, naming the variable on both parse and schema failure. */
+function parseEnvJson<T>(
+  name: string,
+  schema: { safeParse: (value: unknown) => { success: true; data: T } | { success: false; error: z.ZodError } },
+): T | undefined {
+  const raw = process.env[name]?.trim();
+  if (raw === undefined || raw.length === 0) return undefined;
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${name} is invalid JSON: ${String(error)}`);
+  }
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error(`${name} is invalid: ${parsed.error.issues[0]?.message}`);
+  }
+  return parsed.data;
+}
+
 /**
  * Like enrollment, actor admission is the Owner's decision read from config:
  * who may be delegated to is never inferred from whoever connects.
  */
 function actorsFromEnv(): OpenOmniConfig["actors"] {
-  const raw = process.env.OPENOMNI_ACTORS?.trim();
-  if (raw === undefined || raw.length === 0) return undefined;
-  const parsed = Actors.safeParse(JSON.parse(raw));
-  if (!parsed.success) {
-    throw new Error(`OPENOMNI_ACTORS is invalid: ${parsed.error.issues[0]?.message}`);
-  }
-  return parsed.data;
+  return parseEnvJson("OPENOMNI_ACTORS", Actors);
 }
 
 function channelsFromEnv(): OpenOmniConfig["channels"] {
@@ -141,13 +155,7 @@ function channelsFromEnv(): OpenOmniConfig["channels"] {
 }
 
 function socialBudgetsFromEnv(): OpenOmniConfig["socialBudgets"] {
-  const raw = process.env.OPENOMNI_SOCIAL_BUDGETS?.trim();
-  if (raw === undefined || raw.length === 0) return undefined;
-  const parsed = SocialBudgets.safeParse(JSON.parse(raw));
-  if (!parsed.success) {
-    throw new Error(`OPENOMNI_SOCIAL_BUDGETS is invalid: ${parsed.error.issues[0]?.message}`);
-  }
-  return parsed.data;
+  return parseEnvJson("OPENOMNI_SOCIAL_BUDGETS", SocialBudgets);
 }
 
 /**
@@ -156,17 +164,12 @@ function socialBudgetsFromEnv(): OpenOmniConfig["socialBudgets"] {
  * later slice; the shape the host consumes is already the protocol's.
  */
 function machinesFromEnv(): OpenOmniConfig["machines"] {
-  const raw = process.env.OPENOMNI_MACHINES_ENROLLED?.trim();
-  if (raw === undefined || raw.length === 0) return undefined;
-
-  const parsed = Enrollments.safeParse(JSON.parse(raw));
-  if (!parsed.success) {
-    throw new Error(`OPENOMNI_MACHINES_ENROLLED is invalid: ${parsed.error.issues[0]?.message}`);
-  }
+  const enrolled = parseEnvJson("OPENOMNI_MACHINES_ENROLLED", Enrollments);
+  if (enrolled === undefined) return undefined;
   return {
     socketPath:
       process.env.OPENOMNI_MACHINES_SOCKET?.trim() || join(homedir(), ".openomni", "machines.sock"),
-    enrolled: parsed.data,
+    enrolled,
   };
 }
 

--- a/apps/openomni/src/delegation/admission.ts
+++ b/apps/openomni/src/delegation/admission.ts
@@ -110,10 +110,12 @@ export function admit(
   const trustedOrigin = parsedOrigin.data;
   const request = parsed.data;
 
-  if (context?.parentMissing === true) {
-    return refusal("parent_missing", `parent delegation ${trustedOrigin.parentDelegationId} does not exist`);
-  }
-  if (context !== undefined && trustedOrigin.parentDelegationId !== undefined && context.parent === undefined) {
+  if (
+    context?.parentMissing === true ||
+    (context !== undefined &&
+      trustedOrigin.parentDelegationId !== undefined &&
+      context.parent === undefined)
+  ) {
     return refusal("parent_missing", `parent delegation ${trustedOrigin.parentDelegationId} does not exist`);
   }
   if (

--- a/apps/openomni/src/delegation/process-driver.ts
+++ b/apps/openomni/src/delegation/process-driver.ts
@@ -90,7 +90,18 @@ export function createProcessDriver(options: ProcessDriverOptions): DelegationDr
         if (resultLine.done) {
           return { status: "failed", error: "worker process exited without a result" };
         }
-        const parsed = ProcessWorkerResult.safeParse(JSON.parse(resultLine.value));
+        let resultJson: unknown;
+        try {
+          resultJson = JSON.parse(resultLine.value);
+        } catch {
+          // Without this guard a non-JSON line would surface as a generic
+          // failure from the outer catch instead of naming the bad output.
+          return {
+            status: "failed",
+            error: `worker process wrote a malformed result: ${resultLine.value}`,
+          };
+        }
+        const parsed = ProcessWorkerResult.safeParse(resultJson);
         if (!parsed.success) {
           return {
             status: "failed",

--- a/apps/openomni/src/delegation/process-entry.ts
+++ b/apps/openomni/src/delegation/process-entry.ts
@@ -96,6 +96,8 @@ function processWorkerRun(
     instruction: request.instruction,
     acceptanceCriteria: request.acceptanceCriteria,
     origin: request.origin,
+    // Never fires by design: process-level cancellation is the driver
+    // killing this worker process, not an in-band abort.
     signal: new AbortController().signal,
   });
 }

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -134,10 +134,10 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
 
   async function closeAttempt(input: CloseAttemptInput): Promise<void> {
     const { record, settlement } = input;
+    if (record.workItemId === undefined || settlement.status === "sent") return;
     // Spend rides the durable settlement itself, so a restart-sweep re-close
     // recovers the same tokens the live fold would have recorded.
     const tokens = settlement.status === "completed" ? settlement.usage?.tokens : undefined;
-    if (record.workItemId === undefined || settlement.status === "sent") return;
     const item = await WorkItemStore.get(record.workItemId);
     // Unknown item: a legacy record upcast points at nothing durable — no-op.
     if (item === undefined || item.attemptTerminal !== undefined) return;

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -329,7 +329,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
             toolsFor: (origin) =>
               catalogEntries(
                 {
-                  delegation: kernel,
+                  delegation: delegationKernel,
                   cells,
                   ...(machinesPort === undefined ? {} : { machines: machinesPort }),
                   memory,
@@ -346,7 +346,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
       model: config.model,
       apiKey: config.model.apiKey,
       tools: {
-        delegation: kernel,
+        delegation: delegationKernel,
         ...(cells === undefined ? {} : { cells }),
         ...(machinesPort === undefined ? {} : { machines: machinesPort }),
         memory,

--- a/apps/openomni/src/memory/store.ts
+++ b/apps/openomni/src/memory/store.ts
@@ -120,6 +120,14 @@ export function openCuratedMemory(path: string): CuratedMemory {
     return { index, content: entry.content };
   }
 
+  // Fail here, not on the next load: a persisted empty entry would make
+  // every later FileShape.parse throw and brick the whole store.
+  function assertContent(content: string): void {
+    if (content.length === 0) {
+      throw new MemoryRefusal("entry content must be non-empty");
+    }
+  }
+
   function mintId(file: MemoryFile): string {
     let id = crypto.randomUUID().slice(0, 8);
     while (MEMORY_STORES.some((store) => file[store].some((entry) => entry.id === id))) {
@@ -130,6 +138,7 @@ export function openCuratedMemory(path: string): CuratedMemory {
 
   return {
     add(store, content) {
+      assertContent(content);
       const file = loadFile(path);
       assertBudget(store, usedChars(file[store]) + content.length);
       const id = mintId(file);
@@ -138,6 +147,7 @@ export function openCuratedMemory(path: string): CuratedMemory {
       return id;
     },
     replace(store, id, content) {
+      assertContent(content);
       const file = loadFile(path);
       const existing = entryAt(file, store, id);
       assertBudget(store, usedChars(file[store]) - existing.content.length + content.length);

--- a/apps/openomni/src/tools/run-code.ts
+++ b/apps/openomni/src/tools/run-code.ts
@@ -19,13 +19,9 @@ export interface CellPorts {
     | { readonly status: "refused"; readonly reason: "machine_not_attached" | "kernel_not_available" }
   >;
   /**
-   * The whole catalog `origin` holds — machine-placed tools included — which
-   * is then folded against the brain alone. Handing over everything and
-   * letting placement subtract is what keeps machine tools out of a cell
-   * structurally: a cell already runs on a machine, so reaching back to the
-   * brain to reach another machine is the round trip code mode exists to
-   * remove. A machine tool added later is excluded by the same fold, with
-   * nobody having to remember this rule.
+   * The whole catalog `origin` holds — machine-placed tools included. The
+   * brain-only fold that subtracts machine tools lives at the enforcement
+   * point: see {@link cellDoor}.
    */
   toolsFor(origin: DelegationOrigin): readonly CatalogEntry[];
   newCellId(): string;

--- a/apps/openomni/src/tools/work-items.ts
+++ b/apps/openomni/src/tools/work-items.ts
@@ -60,25 +60,40 @@ const COMPLETE_JSON_SCHEMA: Record<string, unknown> = {
       type: "array",
       minItems: 1,
       description: "One judgment per criterion. Only verified admits.",
+      // Mirrors the Judgment discriminated union: an asserted judgment
+      // carries no check fields; verified/refuted require both.
       items: {
-        type: "object",
-        additionalProperties: false,
-        required: ["criterionId", "value"],
-        properties: {
-          criterionId: { type: "string", minLength: 1 },
-          value: { type: "string", enum: ["verified", "refuted", "asserted"] },
-          checkedPredicate: {
-            type: "string",
-            minLength: 1,
-            description: "What you actually checked (verified and refuted only).",
+        oneOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["criterionId", "value"],
+            properties: {
+              criterionId: { type: "string", minLength: 1 },
+              value: { type: "string", const: "asserted" },
+            },
           },
-          evidenceIds: {
-            type: "array",
-            minItems: 1,
-            items: { type: "string", minLength: 1 },
-            description: "Evidence ids the check consumed (verified and refuted only).",
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["criterionId", "value", "checkedPredicate", "evidenceIds"],
+            properties: {
+              criterionId: { type: "string", minLength: 1 },
+              value: { type: "string", enum: ["verified", "refuted"] },
+              checkedPredicate: {
+                type: "string",
+                minLength: 1,
+                description: "What you actually checked.",
+              },
+              evidenceIds: {
+                type: "array",
+                minItems: 1,
+                items: { type: "string", minLength: 1 },
+                description: "Evidence ids the check consumed.",
+              },
+            },
           },
-        },
+        ],
       },
     },
   },


### PR DESCRIPTION
- index: closures capture the const delegationKernel instead of the mutable
  boot-rollback let, so rollback cannot hand them a dead reference
- memory store: validate non-empty content on add/replace (a persisted empty
  entry would fail every later file parse and brick the store)
- work_items tool: advertised JSON schema mirrors the Zod discriminated
  union (asserted carries no check fields; verified/refuted require them)
- delegation: name malformed worker result lines instead of a generic
  failure; merge duplicate parent_missing refusal; move linkage token
  computation below its guard; document the never-fired worker abort signal
- cli: launchdReload() helper dedups darwin install/start; doctor port upper
  bound; env-file quotes edge-whitespace values; onboard validates provider
- config: parseEnvJson() names the env var in JSON/schema errors

Part of the mass per-package deslop review; verified in isolation with full check-types, full bun test, and ultracite lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens `openomni` across a cleanup pass: closes a rollback closure bug, prevents the memory store from persisting entries that brick it, and makes several CLI and tool validations match reality.

**Bug Fixes**
- Closures now capture the const `delegationKernel`, so boot-rollback cannot hand them a dead reference.
- Memory `add`/`replace` reject empty content before persisting.
- `work_items` schema mirrors the Zod union: `asserted` carries no check fields; `verified`/`refuted` require both.
- Malformed worker result lines are named as such instead of surfacing as a generic failure.
- `doctor` rejects ports above 65,535; `onboard` rejects providers other than `anthropic` or `openai`.
- `env-file` quoting now also protects values with leading/trailing whitespace.

**Refactors**
- `launchdReload()` dedups darwin install/start paths.
- `parseEnvJson()` names the env var in JSON and schema errors.
- Merged duplicate `parent_missing` refusals and moved linkage token computation below its guard.

<sup>Written for commit 4777979c18c519461a8fb93a04039161e96256ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

