### PR TITLE
docs: drop stale coordinator vocabulary from source comments

### DIFF
--- a/packages/channels/src/router/authority.ts
+++ b/packages/channels/src/router/authority.ts
@@ -140,10 +140,10 @@ export namespace IngressAuthorityMiddleware {
    * mode). Only the authority check is real authorization: an unconditional
    * direct `Policy.evaluate` whose decision is fanned to the observer.
    * Schema and mode dispatch are pipeline mechanics — they throw directly
-   * and are not observed as policy decisions. The coordinator-presence check
-   * that historically ran here is brain machinery (worker-target deliveries
-   * need a coordinator) and lives in the brain's Deliver consumer since the
-   * #707 seam flip — same behavior, new home.
+   * and are not observed as policy decisions. The executor-presence check
+   * that historically ran here (worker-target deliveries need a live
+   * executor) moved to the app's Deliver consumer in the #707 seam flip —
+   * same behavior, new home.
    */
   export async function runRoutedPreRun(ctx: PreRunContext): Promise<PreRunResult> {
     // schema (fail-closed): the original ZodError is the abort surface.

--- a/packages/channels/src/types.ts
+++ b/packages/channels/src/types.ts
@@ -2,9 +2,8 @@ import type { Channel, BusEvent } from "@openomni/protocol";
 
 /**
  * Observation port: channel code reports Operational telemetry through this
- * injected function instead of importing the session Bus directly (precedent:
- * the execution coordinator's `events.publish` injection). The composition
- * root (bootstrap/channels.ts) binds it to Bus.publish; tests bind a
+ * injected function instead of importing the session Bus directly. The
+ * composition root (bootstrap/channels.ts) binds it to Bus.publish; tests bind a
  * collector or noop. #499 promotes this to the Channel protocol contract.
  */
 export type PublishPort = BusEvent.Sink["publish"];

--- a/packages/llm/src/processor/index.ts
+++ b/packages/llm/src/processor/index.ts
@@ -271,9 +271,8 @@ export namespace Processor {
                   });
                 }
                 // Abort classification reads the signal, not the error shape:
-                // production callers abort with a custom reason
-                // (controller.abort(new Error("cancelled by coordinator"))),
-                // so throwIfAborted() throws a plain Error that the
+                // a caller may abort with a custom reason (a plain Error), so
+                // throwIfAborted() throws a plain Error that the
                 // DOMException check alone misclassifies as "error" — hiding
                 // the turn from replay and marking in-flight tools as failed
                 // instead of interrupted.

--- a/packages/protocol/src/bus/index.ts
+++ b/packages/protocol/src/bus/index.ts
@@ -25,7 +25,7 @@ export namespace BusEvent {
   }
 
   /**
-   * Event-publishing port for ring-2 drivers (coordinator, llm). Drivers
+   * Event-publishing port for driver-band packages (agent, llm). Drivers
    * receive a Sink instead of importing the ledger's Bus directly; the
    * composition root binds it to Bus.publish, tests bind a collector.
    * This is the one binding P2 swaps when Ledger.append (fail-closed)


### PR DESCRIPTION
The coordinator component left the tree with the sole-app switchover;
four comments still described it as live machinery:

- llm processor: abort-classification comment cited a coordinator abort
  call as the production example; reworded to the general custom-reason
  case (no such caller exists anymore)
- channels types: PublishPort precedent parenthetical pointed at the
  coordinator's events.publish injection
- channels router authority: the historical presence-check note now says
  executor/app instead of coordinator/brain, same #707 pointer
- protocol bus: Sink port consumers are the driver-band packages
  (agent, llm), not (coordinator, llm)

Comment-only change; no behavior. The policy Resource.Source
'coordinator' union member is deliberately untouched — it is a
fixture-versioned wire contract (protocol policy conformance harness)
and its removal needs a fixture migration, not a comment sweep.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates stale source comments across four files to remove references to the retired coordinator component.

- Rewords the llm processor abort-classification comment to the general custom-reason case, since no coordinator abort caller exists.
- Removes the coordinator `events.publish` precedent from the channels `PublishPort` doc.
- Updates the channels router authority comment to say executor/app instead of coordinator/brain.
- Fixes the protocol bus doc to name agent and llm as the Sink port consumers.

Comment-only change; no behavior. The `'coordinator'` union member in the policy `Resource.Source` contract is intentionally left alone—removing it requires a fixture migration, not a comment sweep.

<sup>Written for commit e5b54bbbbc747818bfac48be2b1b422ee2374e8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified delivery-processing responsibilities for worker-target messages.
  * Updated telemetry and event-publishing documentation to reflect current terminology.
  * Improved comments describing stream-abort handling.
* **Behavior**
  * No runtime behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->