### PR TITLE
feat(app): composition substrate owning boot rollback and shutdown

### DIFF
--- a/apps/openomni/src/composition/composer.ts
+++ b/apps/openomni/src/composition/composer.ts
@@ -1,0 +1,168 @@
+/**
+ * Composition substrate — reversible effect ownership for the sole app's
+ * boot and shutdown.
+ *
+ * The gap this closes (implementation-status: dynamic composition) has three
+ * clauses; this module owns the first — *reversible registration ownership*.
+ * Everything boot builds that must later be torn down (the bus journal, the
+ * delegation kernel's timers, the machine host, the ws server, channel
+ * surfaces) is acquired inside a fiber and released by that fiber, in exact
+ * reverse order. Before this, both the boot-rollback path and the stop path
+ * restated the teardown sequence by hand, so a new stage could leak by
+ * forgetting one line in two places.
+ *
+ * Two boundaries are deliberate and load-bearing:
+ *
+ * - Durable facts are not effects. Actor registration, ledger writes, and
+ *   journal rows are history; disposing a fiber releases runtime handles
+ *   (listeners, timers, sockets, observers) and never reaches back to erase
+ *   what was recorded.
+ * - There is no silent default. A fiber either mounted and owns its effects,
+ *   or it failed and its effects already ran. Nothing here fabricates a
+ *   half-present stage.
+ *
+ * Reactive dependency activation and generation draining land with their
+ * first consumers (channel surfaces, delegation drivers) — this module grows
+ * when a second consumer exists, not before.
+ */
+
+/** Where a fiber is in its life. `pending` arrives with reactive injection. */
+type FiberState = "mounting" | "active" | "failed" | "disposed";
+
+interface FiberSnapshot {
+  readonly id: string;
+  readonly state: FiberState;
+  /** How many disposers this fiber owns right now. */
+  readonly effects: number;
+}
+
+/** Teardown for one acquired thing. Runs at most once, in reverse order. */
+type Disposer = () => void | Promise<void>;
+
+interface EffectContext {
+  /**
+   * Claims ownership of one acquired thing: the disposer runs when this
+   * fiber is disposed — on shutdown, on boot rollback, or when a later stage
+   * of a failed mount unwinds this one. Registering after `apply` has
+   * returned throws: an effect nobody owns is a leak by definition.
+   */
+  effect(disposer: Disposer): void;
+}
+
+interface Composer {
+  /**
+   * Runs one stage. If `apply` throws, the disposers it already registered
+   * run in reverse before the error propagates — a failed stage leaves
+   * nothing half-acquired behind.
+   */
+  mount(id: string, apply: (ctx: EffectContext) => void | Promise<void>): Promise<void>;
+  /**
+   * Tears every fiber down in reverse mount order. Every disposer runs even
+   * when an earlier one throws; the failures are reported together after the
+   * last one, never by abandoning the rest. Concurrent and repeated calls
+   * share the one release pass — a disposer can never run twice.
+   */
+  dispose(): Promise<void>;
+  /** What is mounted, in mount order — the inspection seam for tests and diagnostics. */
+  snapshot(): readonly FiberSnapshot[];
+}
+
+interface Fiber {
+  readonly id: string;
+  state: FiberState;
+  readonly disposers: Disposer[];
+}
+
+/** Runs one fiber's disposers newest-first; returns the failures, never throws. */
+async function release(fiber: Fiber): Promise<readonly unknown[]> {
+  const failures: unknown[] = [];
+  for (const disposer of [...fiber.disposers].reverse()) {
+    try {
+      await disposer();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  fiber.disposers.length = 0;
+  return failures;
+}
+
+function withErrors(message: string, errors: readonly unknown[]): Error {
+  const failure = new Error(message) as Error & { errors: readonly unknown[] };
+  failure.errors = errors;
+  return failure;
+}
+
+export function createComposer(): Composer {
+  const fibers: Fiber[] = [];
+  let disposed = false;
+  let disposal: Promise<void> | undefined;
+
+  return {
+    async mount(id, apply) {
+      if (disposed) {
+        throw new Error(`composition is disposed; cannot mount ${id}`);
+      }
+      const fiber: Fiber = { id, state: "mounting", disposers: [] };
+      fibers.push(fiber);
+      let accepting = true;
+      const ctx: EffectContext = {
+        effect(disposer) {
+          if (!accepting) {
+            throw new Error(
+              `effect registered after ${id} finished mounting — it would be owned by nobody`,
+            );
+          }
+          fiber.disposers.push(disposer);
+        },
+      };
+      try {
+        await apply(ctx);
+        accepting = false;
+        fiber.state = "active";
+      } catch (error) {
+        accepting = false;
+        fiber.state = "failed";
+        const rollbackFailures = await release(fiber);
+        if (rollbackFailures.length > 0) {
+          throw withErrors(`composition stage ${id} failed and its rollback failed`, [
+            error,
+            ...rollbackFailures,
+          ]);
+        }
+        throw error;
+      }
+    },
+
+    dispose() {
+      // One release pass, shared by every caller: a second stop (shutdown
+      // handler racing an explicit stop) must observe the same teardown, not
+      // run the disposers again.
+      disposal ??= (async () => {
+        disposed = true;
+        const failures: unknown[] = [];
+        for (const fiber of [...fibers].reverse()) {
+          // A failed fiber already ran its rollback; its effects are gone.
+          if (fiber.state !== "active") {
+            fiber.state = "disposed";
+            continue;
+          }
+          failures.push(...(await release(fiber)));
+          fiber.state = "disposed";
+        }
+        if (failures.length > 0) {
+          throw withErrors("composition dispose failed", failures);
+        }
+      })();
+      return disposal;
+    },
+
+    snapshot() {
+      return fibers.map((fiber) => ({
+        id: fiber.id,
+        state: fiber.state,
+        effects: fiber.disposers.length,
+      }));
+    },
+  };
+}

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -484,7 +484,12 @@ export async function startOpenOmni(options: StartOptions = {}) {
     const boundServer = server;
     const boundPort: number = server.port;
     await composer.mount("ws.server", (ctx) => {
-      ctx.effect(() => boundServer.stop());
+      // Initiate the graceful stop without awaiting it: Bun resolves this
+      // promise only after every open client connection closes, and shutdown
+      // must not wait on clients (the pre-composer stop never did).
+      ctx.effect(() => {
+        void boundServer.stop();
+      });
     });
     // Each surface is its own stage: the one that fails to start owns nothing,
     // and the ones already listening unwind in reverse on the rollback path.

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -40,6 +40,7 @@ import { createCompletionPort } from "./work-item/completion";
 import { createProcessDriver } from "./delegation/process-driver";
 import { createInlineWorkerRunner } from "./delegation/worker-loop";
 import { createResidentGateway } from "./gateway";
+import { createComposer } from "./composition/composer";
 import { openCuratedMemory } from "./memory/store";
 import { buildInboundEvent } from "./inbound";
 import { createResident } from "./resident";
@@ -187,14 +188,24 @@ function delegationWakeDelivery(wake: DelegationWake): Gateway.Deliver {
 export async function startOpenOmni(options: StartOptions = {}) {
   const config = options.config ?? loadConfig();
   assertWsExposure(config);
-  const completionWriter = initialize({ dbPath: config.dbPath });
-  const stopBusPersistence = BusPersistence.start();
-  // Boot owns the kernel and host handles from this scope so the rollback
-  // path below can tear down whatever a failed boot already built.
+  // Every stage whose teardown matters is mounted on the composer: boot
+  // rollback and shutdown are the same reverse-order release, owned by the
+  // stage that acquired the thing rather than restated by hand in two places.
+  const composer = createComposer();
   let kernel: DelegationKernel | undefined;
-  let host: MachineHost | undefined;
-  let externalSurfaces: Channel.Surface[] = [];
   try {
+    let completionWriter!: Storage.WorkItemCompletionWriter;
+    await composer.mount("journal", (ctx) => {
+      completionWriter = initialize({ dbPath: config.dbPath });
+      const stopBusPersistence = BusPersistence.start();
+      // Journal shutdown contract: every accepted event row is committed
+      // before the observer detaches and storage closes.
+      ctx.effect(async () => {
+        await BusPersistence.flush();
+        stopBusPersistence();
+        Storage.reset();
+      });
+    });
     // Owner-admitted delegation targets. Registration is an upsert, so a
     // restart re-asserting the same actors is a no-op.
     const actors: readonly RegisteredActor[] = config.actors ?? [];
@@ -269,14 +280,17 @@ export async function startOpenOmni(options: StartOptions = {}) {
       newDelegationId: () => crypto.randomUUID(),
     });
     // Const capture for the closures below (the outer `let kernel` exists so
-    // boot rollback can stop a partially built kernel).
+    // the runner's late-binding getter can reach it).
     const delegationKernel = kernel;
+    await composer.mount("delegation.kernel", (ctx) => {
+      ctx.effect(() => delegationKernel.stop());
+    });
 
     // The cell door is bound per cell rather than globally, so a cell serves
     // exactly the tools its own dispatcher holds.
     const registry = createCellRegistry();
     const machines = config.machines;
-    host =
+    const host: MachineHost | undefined =
       machines === undefined
         ? undefined
         : await createMachineHost({
@@ -286,6 +300,10 @@ export async function startOpenOmni(options: StartOptions = {}) {
             now: () => Date.now(),
             callTool: registry.callTool,
           });
+    if (host !== undefined) {
+      const attachedHost = host;
+      await composer.mount("machines", (ctx) => ctx.effect(() => attachedHost.close()));
+    }
 
     // Self-referential: a cell's catalog is the same one that dispatches cells,
     // and placement subtracts what a cell cannot reach.
@@ -296,8 +314,6 @@ export async function startOpenOmni(options: StartOptions = {}) {
     // The Resident's view of its body: every enrolled machine, attached or
     // not, reduced to the effective (enrollment∩offer) capability fold the
     // host attachment table holds.
-    // A const capture keeps the narrowing the closures below rely on (the
-    // outer `let host` exists only so boot rollback can reach the handle).
     const machineHost = host;
     const machinesPort: MachinesPort | undefined =
       machineHost === undefined || machines === undefined
@@ -396,7 +412,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
       return result.kind === "dropped" ? null : { text: result.result.output };
     };
     const channelSetup = createChannelDrivers(config, routingHandler);
-    externalSurfaces = channelSetup.surfaces;
+    const externalSurfaces = channelSetup.surfaces;
 
     let wsHandler: WebSocketHandler | undefined;
     const wsRoute = async (externalId: string, body: string) => {
@@ -465,49 +481,39 @@ export async function startOpenOmni(options: StartOptions = {}) {
     });
 
     if (server.port === undefined) throw new Error("OpenOmni ws server did not bind a TCP port");
-    try {
-      await Promise.all(externalSurfaces.map((surface) => surface.start(recoveryTraceId)));
-    } catch (error) {
-      server.stop();
-      throw error;
+    const boundServer = server;
+    const boundPort: number = server.port;
+    await composer.mount("ws.server", (ctx) => {
+      ctx.effect(() => boundServer.stop());
+    });
+    // Each surface is its own stage: the one that fails to start owns nothing,
+    // and the ones already listening unwind in reverse on the rollback path.
+    for (const surface of externalSurfaces) {
+      await composer.mount(`channel.${surface.id}`, async (ctx) => {
+        await surface.start(recoveryTraceId);
+        ctx.effect(() => surface.stop(newTraceId()));
+      });
     }
     return {
-      port: server.port,
-      async stop(): Promise<void> {
-        server.stop();
-        for (const surface of externalSurfaces) surface.stop(newTraceId());
-        kernel?.stop();
-        host?.close();
-        // Journal shutdown contract: every accepted event row is committed
-        // before the observer detaches and storage closes.
-        await BusPersistence.flush();
-        stopBusPersistence();
-        Storage.reset();
-      },
+      port: boundPort,
+      // Shutdown is the same reverse-order release boot rollback uses: the
+      // composer owns the sequence, so a new stage cannot leak by forgetting
+      // a line here.
+      stop: () => composer.dispose(),
     };
   } catch (error) {
     // Fail-closed boot rollback: a failure after the journal started leaves
     // no leaked Bus observer, no armed kernel timer, and no configured
     // storage behind — a later boot starts clean.
-    for (const surface of externalSurfaces) surface.stop(newTraceId());
-    kernel?.stop();
-    host?.close();
-    let flushError: unknown;
     try {
-      await BusPersistence.flush();
-    } catch (caught) {
-      flushError = caught;
-    } finally {
-      stopBusPersistence();
-      Storage.reset();
-    }
-    if (flushError !== undefined) {
+      await composer.dispose();
+    } catch (rollbackError) {
       const rollbackFailure = new Error(
-        "OpenOmni boot failed and journal rollback flush failed",
+        "OpenOmni boot failed and its rollback failed",
       ) as Error & {
         errors: readonly unknown[];
       };
-      rollbackFailure.errors = [error, flushError];
+      rollbackFailure.errors = [error, rollbackError];
       throw rollbackFailure;
     }
     throw error;

--- a/apps/openomni/test/channel-delegation-e2e.test.ts
+++ b/apps/openomni/test/channel-delegation-e2e.test.ts
@@ -10,10 +10,10 @@ import { assistantMessage } from "./helpers/assistant-message";
 const WS_TOKEN = "channel-delegation-e2e-token";
 
 const directories: string[] = [];
-let stopApp: (() => void) | undefined;
+let stopApp: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  stopApp?.();
+afterEach(async () => {
+  await stopApp?.();
   stopApp = undefined;
   Storage.reset();
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });

--- a/apps/openomni/test/code-mode-e2e.test.ts
+++ b/apps/openomni/test/code-mode-e2e.test.ts
@@ -23,13 +23,13 @@ const WS_TOKEN = "code-mode-e2e-token";
 const MACHINE_ID = "alpha";
 
 const directories: string[] = [];
-let stopApp: (() => void) | undefined;
+let stopApp: (() => Promise<void>) | undefined;
 let daemon: MachineDaemon | undefined;
 
-afterEach(() => {
+afterEach(async () => {
   daemon?.close();
   daemon = undefined;
-  stopApp?.();
+  await stopApp?.();
   stopApp = undefined;
   Storage.reset();
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });

--- a/apps/openomni/test/composition.test.ts
+++ b/apps/openomni/test/composition.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { createComposer } from "../src/composition/composer";
+
+const noop = () => undefined;
+
+describe("composition substrate", () => {
+  test("mounted stages report active with their owned effect counts", async () => {
+    const composer = createComposer();
+    await composer.mount("a", (ctx) => {
+      ctx.effect(noop);
+      ctx.effect(noop);
+    });
+    await composer.mount("b", noop);
+    expect(composer.snapshot()).toEqual([
+      { id: "a", state: "active", effects: 2 },
+      { id: "b", state: "active", effects: 0 },
+    ]);
+  });
+
+  test("dispose releases effects newest-first across and within fibers", async () => {
+    const composer = createComposer();
+    const order: string[] = [];
+    await composer.mount("first", (ctx) => {
+      ctx.effect(() => {
+        order.push("first.1");
+      });
+      ctx.effect(() => {
+        order.push("first.2");
+      });
+    });
+    await composer.mount("second", (ctx) => {
+      ctx.effect(() => {
+        order.push("second.1");
+      });
+    });
+    await composer.dispose();
+    expect(order).toEqual(["second.1", "first.2", "first.1"]);
+    expect(composer.snapshot().map((fiber) => fiber.state)).toEqual(["disposed", "disposed"]);
+  });
+
+  test("a failed mount releases its own effects and rethrows the cause", async () => {
+    const composer = createComposer();
+    const order: string[] = [];
+    await composer.mount("ok", (ctx) => {
+      ctx.effect(() => {
+        order.push("ok.release");
+      });
+    });
+    const boom = new Error("stage exploded");
+    await expect(
+      composer.mount("bad", (ctx) => {
+        ctx.effect(() => {
+        order.push("bad.release");
+      });
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+    // Only the failed fiber unwound; the earlier fiber still owns its effect.
+    expect(order).toEqual(["bad.release"]);
+    expect(composer.snapshot()).toEqual([
+      { id: "ok", state: "active", effects: 1 },
+      { id: "bad", state: "failed", effects: 0 },
+    ]);
+  });
+
+  test("a failed mount whose rollback also fails reports both causes", async () => {
+    const composer = createComposer();
+    const mountFailure = new Error("mount failed");
+    const releaseFailure = new Error("release failed");
+    const rejection = composer.mount("bad", (ctx) => {
+      ctx.effect(() => {
+        throw releaseFailure;
+      });
+      throw mountFailure;
+    });
+    await expect(rejection).rejects.toThrow(
+      "composition stage bad failed and its rollback failed",
+    );
+    const caught = (await rejection.catch((error: unknown) => error)) as Error & {
+      errors: readonly unknown[];
+    };
+    expect(caught.errors).toEqual([mountFailure, releaseFailure]);
+  });
+
+  test("dispose runs every disposer even when one throws, then reports the failures", async () => {
+    const composer = createComposer();
+    const order: string[] = [];
+    const failure = new Error("release failed");
+    await composer.mount("a", (ctx) => {
+      ctx.effect(() => {
+        order.push("a.release");
+      });
+    });
+    await composer.mount("b", (ctx) => {
+      ctx.effect(() => {
+        throw failure;
+      });
+    });
+    const rejection = composer.dispose();
+    await expect(rejection).rejects.toThrow("composition dispose failed");
+    const caught = (await rejection.catch((error: unknown) => error)) as Error & {
+      errors: readonly unknown[];
+    };
+    expect(caught.errors).toEqual([failure]);
+    // The failing disposer did not abandon the rest.
+    expect(order).toEqual(["a.release"]);
+  });
+
+  test("a failed fiber's effects do not run again on dispose", async () => {
+    const composer = createComposer();
+    let releases = 0;
+    await expect(
+      composer.mount("bad", (ctx) => {
+        ctx.effect(() => {
+          releases += 1;
+        });
+        throw new Error("mount failed");
+      }),
+    ).rejects.toThrow("mount failed");
+    await composer.dispose();
+    expect(releases).toBe(1);
+  });
+
+  test("dispose is idempotent and mounting afterwards throws", async () => {
+    const composer = createComposer();
+    let releases = 0;
+    await composer.mount("a", (ctx) => {
+      ctx.effect(() => {
+        releases += 1;
+      });
+    });
+    await composer.dispose();
+    await composer.dispose();
+    expect(releases).toBe(1);
+    await expect(composer.mount("late", noop)).rejects.toThrow(
+      "composition is disposed; cannot mount late",
+    );
+  });
+
+  test("concurrent dispose calls share one release pass", async () => {
+    const composer = createComposer();
+    let releases = 0;
+    await composer.mount("a", (ctx) => {
+      ctx.effect(async () => {
+        await Promise.resolve();
+        releases += 1;
+      });
+    });
+    // A shutdown handler racing an explicit stop must not run disposers twice.
+    await Promise.all([composer.dispose(), composer.dispose()]);
+    expect(releases).toBe(1);
+  });
+
+  test("registering an effect after apply returns is an ownership leak and throws", async () => {
+    const composer = createComposer();
+    let escaped: ((disposer: () => void) => void) | undefined;
+    await composer.mount("a", (ctx) => {
+      escaped = (disposer) => ctx.effect(disposer);
+    });
+    expect(escaped).toBeDefined();
+    expect(() => escaped?.(noop)).toThrow(
+      "effect registered after a finished mounting — it would be owned by nobody",
+    );
+  });
+
+  test("async disposers are awaited in order", async () => {
+    const composer = createComposer();
+    const order: string[] = [];
+    await composer.mount("a", (ctx) => {
+      ctx.effect(async () => {
+        await Promise.resolve();
+        order.push("a.release");
+      });
+    });
+    await composer.mount("b", (ctx) => {
+      ctx.effect(() => {
+        order.push("b.release");
+      });
+    });
+    await composer.dispose();
+    expect(order).toEqual(["b.release", "a.release"]);
+  });
+});

--- a/apps/openomni/test/delegation-e2e.test.ts
+++ b/apps/openomni/test/delegation-e2e.test.ts
@@ -11,10 +11,10 @@ const WS_TOKEN = "delegation-e2e-token";
 const WORKER_ANSWER = "the build is green";
 
 const directories: string[] = [];
-let stopApp: (() => void) | undefined;
+let stopApp: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  stopApp?.();
+afterEach(async () => {
+  await stopApp?.();
   stopApp = undefined;
   Storage.reset();
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });

--- a/apps/openomni/test/e2e.test.ts
+++ b/apps/openomni/test/e2e.test.ts
@@ -11,7 +11,7 @@ import { assistantMessage } from "./helpers/assistant-message";
 
 const REPLY = "A deterministic Resident reply.";
 const directories: string[] = [];
-let stopApp: (() => void) | undefined;
+let stopApp: (() => Promise<void>) | undefined;
 
 function nextMessage(ws: WebSocket): Promise<MessageEvent> {
   return new Promise((resolve, reject) => {
@@ -55,8 +55,8 @@ function opened(ws: WebSocket): Promise<void> {
   });
 }
 
-afterEach(() => {
-  stopApp?.();
+afterEach(async () => {
+  await stopApp?.();
   stopApp = undefined;
   Storage.reset();
   for (const directory of directories.splice(0))

--- a/apps/openomni/test/memory-e2e.test.ts
+++ b/apps/openomni/test/memory-e2e.test.ts
@@ -7,11 +7,11 @@ import { Storage } from "@openomni/ledger";
 import { startOpenOmni } from "../src/index";
 import { assistantMessage } from "./helpers/assistant-message";
 
-let stopApp: (() => void) | undefined;
+let stopApp: (() => Promise<void>) | undefined;
 const directories: string[] = [];
 
-afterEach(() => {
-  stopApp?.();
+afterEach(async () => {
+  await stopApp?.();
   stopApp = undefined;
   Storage.reset();
   for (const directory of directories.splice(0))

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -59,7 +59,7 @@ The legacy product kernel, local-process coordinator, and old server host were d
 ## Planned, not implemented
 
 - Transactional outbox projection from authoritative message/state writes to Bus observation; current session-message events are emitted after the durable transaction and therefore do not close the post-commit crash window.
-- Dynamic component/plugin composition with reactive dependencies, generation draining, and reversible registration ownership; the shipped component events currently observe Resident/Worker invocation generations only.
+- Dynamic component/plugin composition with reactive dependencies and generation draining; reversible registration ownership ships as the app's composition substrate (`apps/openomni/src/composition/composer.ts`), which owns boot rollback and shutdown as one reverse-order release. The shipped component events currently observe Resident/Worker invocation generations only.
 - Connector installation/execution beyond retained protocol and storage primitives (#216 class).
 - Memory.Engine / FTS5 session search (#220).
 - P4 role surfaces (Governor, Jester, Voice).


### PR DESCRIPTION
## What

First of the dynamic-composition series (implementation-status: "Dynamic component/plugin composition" gap). This PR ships **reversible registration ownership**:

- `apps/openomni/src/composition/composer.ts` — a minimal composition substrate: stages mount as fibers, acquire teardown via `ctx.effect(...)`, and release LIFO in reverse mount order. Fiber states (`mounting/active/failed/disposed`) are inspectable via `snapshot()`.
- `startOpenOmni` now mounts its effect-owning stages (`journal`, `delegation.kernel`, `machines`, `ws.server`, `channel.<id>`) on the composer. The hand-written rollback `catch` and the `stop()` body are both replaced by `composer.dispose()` — boot rollback and shutdown are the same reverse-order release.

## Contracts preserved (pinned by existing tests)

- Journal flush precedes `Storage.reset()` on both the stop and rollback paths.
- A failed boot leaves no leaked Bus observer, no armed kernel timer, no configured storage.
- Rollback flush failure reports both the boot error and the flush error together.
- Shutdown handlers still exit only after the full async stop.

## New guarantees

- A stage that fails to mount unwinds only its own already-acquired effects; earlier stages unwind via the shared dispose pass.
- Concurrent/repeated `dispose()` shares one release pass — a disposer can never run twice (shutdown handler racing an explicit stop).
- Registering an effect after its stage finished mounting throws: an effect nobody owns is a leak by definition.
- Every disposer runs even when an earlier one throws; failures are aggregated, never abandoned.

## Deliberate boundaries

- Durable facts (actor registration, ledger writes) are not effects — disposing releases runtime handles, never history.
- No service table, no reactive activation, no generations yet: those land with their first real consumers (delegation driver registry, channel components) in the follow-up PRs. Substrate grows when a second consumer exists, not before.

## Behavior changes worth noting

- Channel surfaces start sequentially as individual stages (was `Promise.all`); a failed surface start unwinds exactly the surfaces already listening.
- `stop()` now resets storage even if the journal flush throws (failures aggregated) — previously a stop-path flush failure skipped the reset.
- e2e `afterEach` hooks called `stop()` fire-and-forget and passed by microtask timing luck; they now await it, per the repo's exact-completion test law.

## Verification

- `bun test --timeout 15000`: 2545 pass / 0 fail (full suite, single run).
- `check-types`, `lint`, `lint:tools`, `ultracite check`, and all `script/` gates (topology, deps, import-cycles, dead-exports, tsconfig, ledger rename/drift) green.
- New `apps/openomni/test/composition.test.ts` covers LIFO order, partial-mount rollback, rollback-failure aggregation, dispose aggregation, double-release prevention, idempotent/concurrent dispose, post-mount effect rejection, async disposer ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a composition substrate (`apps/openomni/src/composition/composer.ts`) where boot stages mount as fibers, own their teardown as effects, and release in reverse mount order — making boot rollback and `stop()` the same `dispose()` pass in `startOpenOmni`, so a new stage can't leak by forgetting a teardown line in two places.

- A failed stage unwinds only its own effects; earlier stages unwind via the shared dispose pass.
- Concurrent or repeated `dispose()` shares one release pass; every disposer runs even when an earlier one throws, with failures aggregated.
- Registering an effect after a stage finished mounting throws — an unowned effect is a leak.
- Durable facts (actor registration, ledger writes) are deliberately not effects: dispose releases runtime handles, never history.
- Full suite (2545 tests), types, lint, and script gates are green.

**Behavior changes**
- Channel surfaces start sequentially as individual stages (was `Promise.all`); a failed start unwinds exactly the surfaces already listening.
- `stop()` now resets storage even when the journal flush throws; previously a flush failure skipped the reset.
- The ws server stage starts its graceful stop without awaiting it — `server.stop()` resolves only after clients disconnect, so awaiting would deadlock shutdown; the pre-composer stop also didn't wait on clients.
- e2e `afterEach` hooks now await `stop()` instead of fire-and-forget.

<sup>Written for commit e2aaaba7b3fae336ce10593fd105dabd235cecfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable lifecycle management for application startup and shutdown.
  * Resources are released in reverse creation order, including during failed startup.
  * Shutdown now safely handles repeated or simultaneous requests and reports multiple cleanup errors together.

* **Bug Fixes**
  * Improved cleanup reliability when startup or resource disposal encounters errors.

* **Documentation**
  * Updated implementation status to reflect the shipped composition and rollback capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->