### PR TITLE
feat(app): delegation driver registry with generation pinning and draining

### DIFF
--- a/apps/openomni/src/composition/driver-registry.ts
+++ b/apps/openomni/src/composition/driver-registry.ts
@@ -1,0 +1,132 @@
+/**
+ * Delegation driver registry — generation pinning and draining.
+ *
+ * The kernel resolves `drivers[transport]` at dispatch time, which makes the
+ * driver table the composition seam: this registry presents a live view whose
+ * property reads always answer with the *current* registration, so a driver
+ * can be replaced while the kernel keeps running.
+ *
+ * The generation rules are the point:
+ *
+ * - A dispatch that already resolved a registration completes under it. A
+ *   swap never migrates, aborts, or re-routes work the old generation holds.
+ * - New dispatches only ever see the newest registration. There is no window
+ *   in which a disposed or replaced driver accepts new work.
+ * - `drain()` resolves exactly when the last run dispatched through that
+ *   registration returns — an awaitable fact, not a timing guess.
+ *
+ * Unregistering is registration-scoped: disposing a replaced registration
+ * never evicts its successor. An empty slot is not defaulted — the kernel
+ * owns the refusal (`delivery_failed: no driver for <transport> transport`),
+ * which keeps exactly one judgment seat for undeliverable work.
+ */
+
+import { Delegation } from "@openomni/protocol";
+import type { DelegationDriver } from "../delegation/kernel";
+
+interface DriverRegistration {
+  readonly transport: Delegation.Transport;
+  /** Monotone per transport; the newest registration is the one dispatching. */
+  readonly generation: number;
+  /** Runs dispatched through this registration that have not yet returned. */
+  inFlight(): number;
+  /** Resolves when every run dispatched through this registration has returned. */
+  drain(): Promise<void>;
+  /**
+   * Removes this registration from the live view if it is still the current
+   * one. Work already dispatched through it keeps running to completion —
+   * disposing revokes admission, never history.
+   */
+  dispose(): void;
+}
+
+interface DriverRegistry {
+  /** Registers a driver, replacing (not disturbing) the previous generation. */
+  register(transport: Delegation.Transport, driver: DelegationDriver): DriverRegistration;
+  /** Live table for the kernel: each read resolves the current generation. */
+  readonly drivers: Partial<Record<Delegation.Transport, DelegationDriver>>;
+}
+
+interface Entry {
+  readonly generation: number;
+  readonly wrapped: DelegationDriver;
+  inFlight: number;
+  drainWaiters: (() => void)[];
+}
+
+function settleDrain(entry: Entry): void {
+  if (entry.inFlight === 0) {
+    for (const wake of entry.drainWaiters.splice(0)) {
+      wake();
+    }
+  }
+}
+
+/** Counts a run against its registration; the count is exact, not sampled. */
+function wrap(driver: DelegationDriver, entry: () => Entry): DelegationDriver {
+  const wrapped: DelegationDriver = {
+    async run(admitted, handle, signal, report) {
+      const owner = entry();
+      owner.inFlight += 1;
+      try {
+        return await driver.run(admitted, handle, signal, report);
+      } finally {
+        owner.inFlight -= 1;
+        settleDrain(owner);
+      }
+    },
+  };
+  // The kernel treats `prepare !== undefined` as a capability signal; the
+  // wrapper must mirror the underlying driver's shape exactly.
+  const prepare = driver.prepare?.bind(driver);
+  if (prepare !== undefined) {
+    return { ...wrapped, prepare };
+  }
+  return wrapped;
+}
+
+export function createDriverRegistry(): DriverRegistry {
+  const table = new Map<Delegation.Transport, Entry>();
+  const generations = new Map<Delegation.Transport, number>();
+
+  const drivers: Partial<Record<Delegation.Transport, DelegationDriver>> = {};
+  // Derived from the protocol schema so a new transport can never be
+  // silently absent from the live view.
+  for (const transport of Delegation.Transport.options) {
+    Object.defineProperty(drivers, transport, {
+      enumerable: true,
+      get: () => table.get(transport)?.wrapped,
+    });
+  }
+
+  return {
+    drivers,
+    register(transport, driver) {
+      const generation = (generations.get(transport) ?? 0) + 1;
+      generations.set(transport, generation);
+      const entry: Entry = {
+        generation,
+        wrapped: wrap(driver, () => entry),
+        inFlight: 0,
+        drainWaiters: [],
+      };
+      table.set(transport, entry);
+      return {
+        transport,
+        generation,
+        inFlight: () => entry.inFlight,
+        drain() {
+          if (entry.inFlight === 0) {
+            return Promise.resolve();
+          }
+          return new Promise((resolve) => entry.drainWaiters.push(resolve));
+        },
+        dispose() {
+          if (table.get(transport) === entry) {
+            table.delete(transport);
+          }
+        },
+      };
+    },
+  };
+}

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -41,6 +41,7 @@ import { createProcessDriver } from "./delegation/process-driver";
 import { createInlineWorkerRunner } from "./delegation/worker-loop";
 import { createResidentGateway } from "./gateway";
 import { createComposer } from "./composition/composer";
+import { createDriverRegistry } from "./composition/driver-registry";
 import { openCuratedMemory } from "./memory/store";
 import { buildInboundEvent } from "./inbound";
 import { createResident } from "./resident";
@@ -256,6 +257,32 @@ export async function startOpenOmni(options: StartOptions = {}) {
       now: () => Date.now(),
       newWaitId: () => crypto.randomUUID(),
     });
+    // The kernel reads this table at dispatch time, so registrations made
+    // (or replaced) after boot are visible to the very next dispatch. Each
+    // boot registration is a composer-owned effect: disposing revokes the
+    // driver's admission to new work while in-flight runs complete under the
+    // generation that dispatched them.
+    const driverRegistry = createDriverRegistry();
+    await composer.mount("delegation.drivers", (ctx) => {
+      const registrations = [
+        driverRegistry.register("inline", createInlineDriver(runner)),
+        driverRegistry.register("channel", channelDriver),
+        driverRegistry.register(
+          "process",
+          createProcessDriver({
+            command: [process.execPath, processEntryPath(import.meta.url)],
+            worker: {
+              model: { provider: config.model.provider, id: config.model.id },
+              apiKey: config.model.apiKey,
+            },
+            dbPath: config.dbPath,
+          }),
+        ),
+      ];
+      for (const registration of registrations) {
+        ctx.effect(() => registration.dispose());
+      }
+    });
     kernel = createDelegationKernel({
       events: Bus,
       workItems: createWorkItemLinkage({
@@ -264,18 +291,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
       }),
       wake: (wake) => wakeDelivery.deliver(wake),
       bootSweep: false,
-      drivers: {
-        inline: createInlineDriver(runner),
-        channel: channelDriver,
-        process: createProcessDriver({
-          command: [process.execPath, processEntryPath(import.meta.url)],
-          worker: {
-            model: { provider: config.model.provider, id: config.model.id },
-            apiKey: config.model.apiKey,
-          },
-          dbPath: config.dbPath,
-        }),
-      },
+      drivers: driverRegistry.drivers,
       now: () => Date.now(),
       newDelegationId: () => crypto.randomUUID(),
     });

--- a/apps/openomni/test/driver-registry.test.ts
+++ b/apps/openomni/test/driver-registry.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import type { Delegation } from "@openomni/protocol";
+import { createDriverRegistry } from "../src/composition/driver-registry";
+import type { Admitted } from "../src/delegation/admission";
+import type { DelegationDriver, DriverOutcome } from "../src/delegation/kernel";
+
+// The wrapper forwards these opaquely; the registry never inspects them.
+const admitted = {} as Admitted;
+const handle = {} as Delegation.Handle;
+const signal = new AbortController().signal;
+
+function completed(output: string): DriverOutcome {
+  return { status: "completed", output };
+}
+
+/** A driver whose run resolves only when the test says so. */
+function deferredDriver(output: string): {
+  driver: DelegationDriver;
+  finish: () => void;
+} {
+  let release: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    driver: {
+      async run() {
+        await gate;
+        return completed(output);
+      },
+    },
+    finish: () => release?.(),
+  };
+}
+
+describe("delegation driver registry", () => {
+  test("a run resolved before a swap completes under its own generation", async () => {
+    const registry = createDriverRegistry();
+    const old = deferredDriver("old-generation");
+    registry.register("inline", old.driver);
+
+    const resolved = registry.drivers.inline;
+    expect(resolved).toBeDefined();
+    const inFlight = resolved?.run(admitted, handle, signal);
+
+    // Swap while the old generation still holds work.
+    registry.register("inline", { run: async () => completed("new-generation") });
+
+    // New dispatches see only the new generation.
+    const next = await registry.drivers.inline?.run(admitted, handle, signal);
+    expect(next).toEqual(completed("new-generation"));
+
+    // The pinned run still answers from the driver that accepted it.
+    old.finish();
+    expect(await inFlight).toEqual(completed("old-generation"));
+  });
+
+  test("drain resolves exactly when the last in-flight run returns", async () => {
+    const registry = createDriverRegistry();
+    const slow = deferredDriver("done");
+    const registration = registry.register("inline", slow.driver);
+
+    const run = registry.drivers.inline?.run(admitted, handle, signal);
+    expect(registration.inFlight()).toBe(1);
+    const drained = registration.drain().then(() => "drained" as const);
+
+    // While the run is held open, the drain promise cannot have settled:
+    // an already-resolved sentinel wins the race deterministically.
+    expect(await Promise.race([drained, Promise.resolve("pending" as const)])).toBe("pending");
+
+    slow.finish();
+    await run;
+    expect(await drained).toBe("drained");
+    expect(registration.inFlight()).toBe(0);
+  });
+
+  test("drain on an idle registration resolves immediately", async () => {
+    const registry = createDriverRegistry();
+    const registration = registry.register("process", {
+      run: async () => completed("unused"),
+    });
+    await registration.drain();
+    expect(registration.inFlight()).toBe(0);
+  });
+
+  test("a rejecting run is still counted out of its generation", async () => {
+    const registry = createDriverRegistry();
+    const registration = registry.register("inline", {
+      run: () => Promise.reject(new Error("driver exploded")),
+    });
+    await expect(registry.drivers.inline?.run(admitted, handle, signal)).rejects.toThrow(
+      "driver exploded",
+    );
+    await registration.drain();
+    expect(registration.inFlight()).toBe(0);
+  });
+
+  test("disposing a replaced registration never evicts its successor", () => {
+    const registry = createDriverRegistry();
+    const first = registry.register("inline", { run: async () => completed("first") });
+    const second = registry.register("inline", { run: async () => completed("second") });
+    expect(second.generation).toBeGreaterThan(first.generation);
+
+    first.dispose();
+    expect(registry.drivers.inline).toBeDefined();
+
+    second.dispose();
+    expect(registry.drivers.inline).toBeUndefined();
+  });
+
+  test("generations are monotone per transport, independent across transports", () => {
+    const registry = createDriverRegistry();
+    const inline1 = registry.register("inline", { run: async () => completed("a") });
+    const inline2 = registry.register("inline", { run: async () => completed("b") });
+    const channel1 = registry.register("channel", { run: async () => completed("c") });
+    expect(inline1.generation).toBe(1);
+    expect(inline2.generation).toBe(2);
+    expect(channel1.generation).toBe(1);
+  });
+
+  test("the wrapper mirrors prepare exactly: present when present, absent when absent", async () => {
+    const registry = createDriverRegistry();
+    registry.register("channel", {
+      prepare: () => ({ waitId: "wait-42" }),
+      run: async () => completed("with-prepare"),
+    });
+    registry.register("inline", { run: async () => completed("without-prepare") });
+
+    expect(registry.drivers.channel?.prepare).toBeDefined();
+    expect(await registry.drivers.channel?.prepare?.(admitted, handle)).toEqual({
+      waitId: "wait-42",
+    });
+    expect(registry.drivers.inline?.prepare).toBeUndefined();
+  });
+
+  test("an unregistered transport reads as undefined, never a default", () => {
+    const registry = createDriverRegistry();
+    expect(registry.drivers.process).toBeUndefined();
+    expect(registry.drivers.channel).toBeUndefined();
+  });
+});

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -59,7 +59,7 @@ The legacy product kernel, local-process coordinator, and old server host were d
 ## Planned, not implemented
 
 - Transactional outbox projection from authoritative message/state writes to Bus observation; current session-message events are emitted after the durable transaction and therefore do not close the post-commit crash window.
-- Dynamic component/plugin composition with reactive dependencies and generation draining; reversible registration ownership ships as the app's composition substrate (`apps/openomni/src/composition/composer.ts`), which owns boot rollback and shutdown as one reverse-order release. The shipped component events currently observe Resident/Worker invocation generations only.
+- Dynamic component/plugin composition with reactive dependencies; reversible registration ownership ships as the app's composition substrate (`apps/openomni/src/composition/composer.ts`), which owns boot rollback and shutdown as one reverse-order release, and generation draining ships for delegation drivers (`apps/openomni/src/composition/driver-registry.ts`): the kernel resolves drivers per dispatch from the live registry, a swap pins in-flight work to the generation that accepted it, and `drain()` resolves exactly when that generation's last run returns. The shipped component events currently observe Resident/Worker invocation generations only.
 - Connector installation/execution beyond retained protocol and storage primitives (#216 class).
 - Memory.Engine / FTS5 session search (#220).
 - P4 role surfaces (Governor, Jester, Voice).


### PR DESCRIPTION
## What

Second PR of the dynamic-composition series: **generation pinning and draining** for delegation drivers.

- `apps/openomni/src/composition/driver-registry.ts` — a registry occupying the seam the kernel already has: `drivers[transport]` is resolved per dispatch, so the registry's live view (property getters answering with the current registration's wrapped driver) makes drivers swappable at runtime with **zero kernel changes**.
- Boot registers `inline`/`channel`/`process` through the registry inside a composer-mounted `delegation.drivers` stage; each registration's dispose is a composer-owned effect — the registry is the substrate's second consumer, per the "substrate grows when a second consumer exists" rule from PR #858.

## Generation semantics

- A run resolved before a swap **completes under the generation that accepted it** — a swap never migrates, aborts, or re-routes held work.
- New dispatches only ever see the newest registration; there is no window where a replaced driver accepts new work.
- `drain()` resolves exactly when that generation's last run returns — an awaitable fact (in-flight counting inside the wrapper's `finally`), not a timing guess.
- Disposing a replaced registration never evicts its successor; generations are monotone per transport.
- An empty slot reads `undefined` — the kernel keeps its owned `delivery_failed: no driver for <transport> transport` refusal. No silent default.

## Deliberate boundaries

- The wrapper mirrors `prepare` exactly (present iff the underlying driver has it) — the kernel treats `prepare !== undefined` as a capability signal.
- The transport list in the live view is derived from `Delegation.Transport.options`, so a new protocol transport can never be silently absent.
- Teardown order (LIFO): `kernel.stop()` runs before driver registrations dispose — the kernel stops dispatching before admission is revoked.
- Shutdown disposes registrations without awaiting drain: the kernel's abort-based stop remains the shutdown semantic; drain is for swaps.

## Verification

- `bun test --timeout 15000`: 2554 pass / 0 fail (full suite, single run).
- `check-types`, `lint`, `lint:tools`, `ultracite check`, and all `script/` gates green.
- New `apps/openomni/test/driver-registry.test.ts` pins: pinning across a mid-flight swap, drain-cannot-resolve-while-in-flight (deterministic promise race, no sleeps), immediate drain on idle, rejecting runs counted out, dispose-of-replaced-registration safety, per-transport generation monotonicity, `prepare` mirroring, and undefined-not-defaulted empty slots.
- `docs/implementation-status.md` updated in the same PR (doc-state sync law).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a delegation driver registry so `inline`, `channel`, and `process` drivers can be swapped at runtime without kernel changes. Runs already in flight are pinned to the generation that accepted them; new dispatches only see the newest registration.

**New Features**
- The kernel resolves `drivers[transport]` per dispatch, so the registry's live view is the only seam needed for runtime swaps.
- `drain()` resolves exactly when the generation's last run returns; disposing a replaced registration never evicts its successor.
- Empty slots stay `undefined` so the kernel keeps its `delivery_failed` refusal; the wrapper mirrors `prepare` exactly.
- Boot registers drivers through the registry inside a composer-mounted `delegation.drivers` stage; each registration's dispose is a composer-owned effect.
- Shutdown disposes registrations without awaiting drain; `kernel.stop()` runs before registrations dispose.
- New tests cover pinning, drain, dispose safety, generation monotonicity, `prepare` mirroring, and empty slots; `docs/implementation-status.md` is updated.

<sup>Written for commit f800ae9759988cbb88a3888dfda90eea63669d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

