### PR TITLE
test(app): kill three mutation survivors in composition series

### DIFF
--- a/apps/openomni/test/driver-registry.test.ts
+++ b/apps/openomni/test/driver-registry.test.ts
@@ -74,6 +74,32 @@ describe("delegation driver registry", () => {
     expect(registration.inFlight()).toBe(0);
   });
 
+  test("drain outlives the first return while a second run is still in flight", async () => {
+    const registry = createDriverRegistry();
+    const releases: (() => void)[] = [];
+    const registration = registry.register("inline", {
+      run: () =>
+        new Promise<DriverOutcome>((resolve) => {
+          releases.push(() => resolve(completed("ok")));
+        }),
+    });
+
+    const first = registry.drivers.inline?.run(admitted, handle, signal);
+    const second = registry.drivers.inline?.run(admitted, handle, signal);
+    expect(registration.inFlight()).toBe(2);
+    const drained = registration.drain().then(() => "drained" as const);
+
+    // The first return must not settle the drain: one run still holds work.
+    releases[0]?.();
+    await first;
+    expect(await Promise.race([drained, Promise.resolve("pending" as const)])).toBe("pending");
+
+    releases[1]?.();
+    await second;
+    expect(await drained).toBe("drained");
+    expect(registration.inFlight()).toBe(0);
+  });
+
   test("drain on an idle registration resolves immediately", async () => {
     const registry = createDriverRegistry();
     const registration = registry.register("process", {

--- a/apps/openomni/test/gateway-contracts.test.ts
+++ b/apps/openomni/test/gateway-contracts.test.ts
@@ -3,9 +3,9 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RunInput, Sink } from "@openomni/llm";
-import { ActorRegistry, Session, Storage } from "@openomni/ledger";
+import { ActorRegistry, ChannelGrantStore, Session, Storage } from "@openomni/ledger";
 import { Gateway, type Message, newTraceId } from "@openomni/protocol";
-import { createResidentGateway } from "../src/gateway";
+import { createResidentGateway, registerTrustedChannelGrant } from "../src/gateway";
 import { openCuratedMemory } from "../src/memory/store";
 import { createPolicyRegistry } from "../src/composition/policy-registry";
 import { createResident } from "../src/resident";
@@ -67,6 +67,51 @@ beforeEach(() => {
 afterEach(() => {
   Storage.reset();
   rmSync(directory, { recursive: true, force: true });
+});
+
+describe("channel grant registration", () => {
+  test("the revoker removes exactly the grant it registered", () => {
+    const revokeTelegram = registerTrustedChannelGrant("telegram");
+    const revokeDiscord = registerTrustedChannelGrant("discord");
+    expect(ChannelGrantStore.resolve({ surface: "telegram" })?.grant.kind).toBe(
+      "trusted_channel",
+    );
+
+    revokeTelegram();
+
+    // Only the telegram grant is gone; the sibling surface keeps its authority.
+    expect(ChannelGrantStore.resolve({ surface: "telegram" })).toBeUndefined();
+    expect(ChannelGrantStore.resolve({ surface: "discord" })?.grant.kind).toBe(
+      "trusted_channel",
+    );
+    revokeDiscord();
+    expect(ChannelGrantStore.resolve({ surface: "discord" })).toBeUndefined();
+  });
+});
+
+describe("Resident delivery contract", () => {
+  test("refuses a delivery without a routed sessionId before touching any state", async () => {
+    const resident = createResident({
+      model: MODEL,
+      apiKey: "test-key",
+      policies: createPolicyRegistry({ mandatory: [] }),
+      tools: { memory: openCuratedMemory(join(directory, "memory.json")) },
+      targets: () => [{ kind: "host", id: "brain", capabilities: [] }],
+      llm: {
+        resolveProviderModel: async (model) => ({
+          id: model.id,
+          name: model.id,
+          providerID: model.provider,
+        }),
+        run: async () => {
+          throw new Error("the model must never run for an unrouted delivery");
+        },
+      },
+    });
+
+    const unrouted = Gateway.Deliver.parse({ ...evidenceDelivery("hi"), sessionId: undefined });
+    await expect(resident(unrouted)).rejects.toThrow("Resident delivery requires a routed sessionId");
+  });
 });
 
 describe("Resident inbound treatment", () => {


### PR DESCRIPTION
## What

Mutation-testing audit of the dynamic-composition series found three surviving mutants — three real test gaps. This PR adds exactly the three tests that kill them. Tests only; no source changes.

## The survivors and their killers

1. **Grant revocation was never asserted** (`gateway.ts` — `ChannelGrantStore.remove` could be deleted and every test still passed). New test registers grants for two surfaces, revokes one, and asserts the revoked surface loses its `trusted_channel` grant while the sibling keeps its authority — the semantic core of the channel-componentization PR, now pinned.
2. **`drain()` early-settle was invisible** (`driver-registry.ts` — the `inFlight === 0` settle condition could be replaced with `true` and tests passed, because the only drain scenario held a single run: first return = last return). New test holds **two** in-flight runs, releases them one at a time, and asserts drain is still pending after the first return and resolves exactly after the second — deterministic promise race, no sleeps.
3. **The unrouted-delivery guard was uncovered** (`resident.ts:117` — the `sessionId === undefined` throw could be removed silently). New test delivers without a routed sessionId and asserts the typed refusal, with an LLM port that throws if the model is ever reached — proving the run is refused before any state is touched.

## Verification

- Empirical mutation recheck: all three mutants re-injected against this branch — **all KILLED** (were SURVIVED on main).
- Full suite: 2563 pass / 0 fail, single run. `check-types` 0 errors, ultracite clean on touched files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three tests that close real gaps found in a mutation-testing audit of the dynamic-composition series. Tests only; no source changes.

- Pins grant revocation: revoking one surface's `trusted_channel` grant leaves the sibling surface's authority intact.
- Pins `drain()` early-settle: with two in-flight runs, drain stays pending until the last run resolves.
- Pins the unrouted-delivery guard: a delivery without a routed `sessionId` is refused before the model is reached.

<sup>Written for commit a65dd7674c660654c004c71ff16fa925e495f456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent operations so completion tracking waits until all active runs finish.
  * Ensured channel grant revocation removes only the grant associated with that channel.
  * Rejected deliveries missing a routed session identifier before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->