### PR TITLE
refactor(app): standard AggregateError and zero any/unknown in composition series

### DIFF
--- a/apps/openomni/src/composition/composer.ts
+++ b/apps/openomni/src/composition/composer.ts
@@ -74,23 +74,19 @@ interface Fiber {
 }
 
 /** Runs one fiber's disposers newest-first; returns the failures, never throws. */
-async function release(fiber: Fiber): Promise<readonly unknown[]> {
-  const failures: unknown[] = [];
+async function release(fiber: Fiber): Promise<readonly Error[]> {
+  const failures: Error[] = [];
   for (const disposer of [...fiber.disposers].reverse()) {
     try {
       await disposer();
     } catch (error) {
-      failures.push(error);
+      // Disposers throw Errors; anything else is normalized at this boundary
+      // so the aggregate stays a plain Error list.
+      failures.push(error instanceof Error ? error : new Error(String(error)));
     }
   }
   fiber.disposers.length = 0;
   return failures;
-}
-
-function withErrors(message: string, errors: readonly unknown[]): Error {
-  const failure = new Error(message) as Error & { errors: readonly unknown[] };
-  failure.errors = errors;
-  return failure;
 }
 
 export function createComposer(): Composer {
@@ -125,10 +121,10 @@ export function createComposer(): Composer {
         fiber.state = "failed";
         const rollbackFailures = await release(fiber);
         if (rollbackFailures.length > 0) {
-          throw withErrors(`composition stage ${id} failed and its rollback failed`, [
-            error,
-            ...rollbackFailures,
-          ]);
+          throw new AggregateError(
+            [error, ...rollbackFailures],
+            `composition stage ${id} failed and its rollback failed`,
+          );
         }
         throw error;
       }
@@ -140,7 +136,7 @@ export function createComposer(): Composer {
       // run the disposers again.
       disposal ??= (async () => {
         disposed = true;
-        const failures: unknown[] = [];
+        const failures: Error[] = [];
         for (const fiber of [...fibers].reverse()) {
           // A failed fiber already ran its rollback; its effects are gone.
           if (fiber.state !== "active") {
@@ -151,7 +147,7 @@ export function createComposer(): Composer {
           fiber.state = "disposed";
         }
         if (failures.length > 0) {
-          throw withErrors("composition dispose failed", failures);
+          throw new AggregateError(failures, "composition dispose failed");
         }
       })();
       return disposal;

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -570,13 +570,10 @@ export async function startOpenOmni(options: StartOptions = {}) {
     try {
       await composer.dispose();
     } catch (rollbackError) {
-      const rollbackFailure = new Error(
+      throw new AggregateError(
+        [error, rollbackError],
         "OpenOmni boot failed and its rollback failed",
-      ) as Error & {
-        errors: readonly unknown[];
-      };
-      rollbackFailure.errors = [error, rollbackError];
-      throw rollbackFailure;
+      );
     }
     throw error;
   }

--- a/apps/openomni/test/composition.test.ts
+++ b/apps/openomni/test/composition.test.ts
@@ -76,10 +76,12 @@ describe("composition substrate", () => {
     await expect(rejection).rejects.toThrow(
       "composition stage bad failed and its rollback failed",
     );
-    const caught = (await rejection.catch((error: unknown) => error)) as Error & {
-      errors: readonly unknown[];
-    };
-    expect(caught.errors).toEqual([mountFailure, releaseFailure]);
+    const caught = await rejection.then(
+      () => null,
+      (error: AggregateError) => error,
+    );
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect(caught?.errors).toEqual([mountFailure, releaseFailure]);
   });
 
   test("dispose runs every disposer even when one throws, then reports the failures", async () => {
@@ -98,10 +100,12 @@ describe("composition substrate", () => {
     });
     const rejection = composer.dispose();
     await expect(rejection).rejects.toThrow("composition dispose failed");
-    const caught = (await rejection.catch((error: unknown) => error)) as Error & {
-      errors: readonly unknown[];
-    };
-    expect(caught.errors).toEqual([failure]);
+    const caught = await rejection.then(
+      () => null,
+      (error: AggregateError) => error,
+    );
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect(caught?.errors).toEqual([failure]);
     // The failing disposer did not abandon the rest.
     expect(order).toEqual(["a.release"]);
   });

--- a/apps/openomni/test/policy-registry.test.ts
+++ b/apps/openomni/test/policy-registry.test.ts
@@ -1,13 +1,26 @@
 import { describe, expect, it } from "bun:test";
 import type { ChatAgentConfig } from "@openomni/agent";
+import { PolicyDecision } from "@openomni/protocol";
 import { createPolicyRegistry, MissingMandatoryPolicyError } from "../src/composition/policy-registry";
 
 type Middleware = NonNullable<ChatAgentConfig["middleware"]>[number];
+type RunContext = { events: ChatAgentConfig["events"] };
 
-const runContext = { events: undefined as unknown as ChatAgentConfig["events"] };
+const runContext: RunContext = {
+  events: {
+    publish: () => undefined,
+  },
+};
 
 function middleware(name: string): Middleware {
-  return { kind: "factory", name, create: () => ({}) } as unknown as Middleware;
+  return {
+    kind: "point",
+    name,
+    pointIds: [],
+    effectCapabilities: {},
+    priority: 0,
+    fn: () => PolicyDecision.allow({ policyId: name }),
+  };
 }
 
 describe("policy registry", () => {
@@ -16,13 +29,13 @@ describe("policy registry", () => {
     registry.register("first", () => middleware("first"));
     registry.register("second", () => middleware("second"));
 
-    const built = registry.middlewareFor(runContext) as ReadonlyArray<{ name: string }>;
+    const built = registry.middlewareFor(runContext);
     expect(built.map((entry) => entry.name)).toEqual(["first", "second"]);
   });
 
   it("passes the run context to each factory per build", () => {
     const registry = createPolicyRegistry({ mandatory: [] });
-    const seen: unknown[] = [];
+    const seen: RunContext[] = [];
     registry.register("observer", (run) => {
       seen.push(run);
       return middleware("observer");
@@ -35,14 +48,14 @@ describe("policy registry", () => {
 
   it("suspends a run fail-closed when a declared-mandatory policy is missing", () => {
     const registry = createPolicyRegistry({ mandatory: ["compaction"] });
-    let caught: unknown;
+    let caught: MissingMandatoryPolicyError | null = null;
     try {
       registry.middlewareFor(runContext);
     } catch (error) {
-      caught = error;
+      expect(error).toBeInstanceOf(MissingMandatoryPolicyError);
+      caught = error as MissingMandatoryPolicyError;
     }
-    expect(caught).toBeInstanceOf(MissingMandatoryPolicyError);
-    expect((caught as MissingMandatoryPolicyError).missing).toEqual(["compaction"]);
+    expect(caught?.missing).toEqual(["compaction"]);
   });
 
   it("suspends again when a mandatory registration is disposed without replacement", () => {
@@ -63,8 +76,7 @@ describe("policy registry", () => {
     expect(registry.middlewareFor(runContext)).toHaveLength(2);
 
     optional.dispose();
-    const built = registry.middlewareFor(runContext) as ReadonlyArray<{ name: string }>;
-    expect(built.map((entry) => entry.name)).toEqual(["compaction"]);
+    expect(registry.middlewareFor(runContext).map((entry) => entry.name)).toEqual(["compaction"]);
   });
 
   it("never lets a replaced registration's dispose evict its successor", () => {
@@ -73,7 +85,8 @@ describe("policy registry", () => {
     registry.register("compaction", () => middleware("replacement"));
 
     original.dispose();
-    const built = registry.middlewareFor(runContext) as ReadonlyArray<{ name: string }>;
-    expect(built.map((entry) => entry.name)).toEqual(["replacement"]);
+    expect(registry.middlewareFor(runContext).map((entry) => entry.name)).toEqual([
+      "replacement",
+    ]);
   });
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2020"],
+    "lib": ["ES2021"],
     "moduleResolution": "bundler",
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## What

Removes every hand-rolled failure aggregate and type-dodging cast the composition series introduced, replacing them with the standard `AggregateError`. Series files now contain **zero `any`/`unknown` type tokens**.

- `composer.ts`: `release()` returns `readonly Error[]` (non-`Error` throwables are normalized at the catch boundary — disposers throw `Error`s in practice, so this is a no-op in real flows); mount-rollback double faults and dispose failures now throw `AggregateError` instead of a hand-built `Error & { errors: readonly unknown[] }` cast.
- `index.ts`: the boot double-fault does the same.
- `tsconfig.base.json`: `lib` ES2020 → ES2021, the release that ships `AggregateError`. **`target` stays ES2020**, so emit (including the protocol package build) is unchanged — this is a type-surface-only bump. Bun executes it natively either way.
- `composition.test.ts`: rejection assertions now check `instanceof AggregateError` and read the typed `.errors` list via a typed rejection handler — no casts.
- `policy-registry.test.ts`: the `as unknown as Middleware` stand-ins are gone; tests now build a real canonical point registration (`PolicyDecision.allow`) and a real event sink, so they exercise the actual middleware contract instead of a shape lie.

## Deliberately kept

`replyText(payload: unknown)` in `index.ts` keeps its `unknown`: the payload arrives from the wire as `Ingress.payload: z.unknown()` — a genuine system boundary where `unknown` is the honest type. Narrowing it would falsify the contract, not clean it.

## Verification

- Full suite: 2560 pass / 0 fail single run; `check-types` 0 errors; lint, ultracite, and all `script/` gates green (including `verify-tsconfig-inheritance` for the lib bump).
- `grep -cE "\bunknown\b|\bany\b"` over all six series source/test files: 0 type tokens (two remaining hits are English prose in doc comments).
- Error identity is preserved: aggregates carry the original thrown `Error` instances, asserted by `toEqual` on `.errors`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the composition series on `AggregateError` and removes every `any`/`unknown` cast, so the error path is typed and honest without changing behavior.

**Refactors**
- `composer.ts` and `index.ts` now throw `AggregateError` for rollback and dispose failures instead of hand-built `Error` objects with a non-standard `errors` property.
- `release()` normalizes non-`Error` throws to `Error` at the boundary, keeping the aggregate typed as `Error[]`.
- `tsconfig.base.json` bumps `lib` to ES2021 for `AggregateError` types; `target` stays ES2020 so emit is unchanged.
- Tests now assert on `AggregateError.errors` and build real `PolicyDecision` registrations instead of casting stand-ins.
- `replyText` keeps its `unknown` parameter because it sits at a genuine wire boundary; narrowing it would falsify the contract.

<sup>Written for commit 4d519aa77f9d561f1fd2123aafbf78ce8094766d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

