### PR TITLE
refactor(app): decompose boot and resident turn stages, close coverage gaps

### DIFF
--- a/apps/openomni/src/channels.ts
+++ b/apps/openomni/src/channels.ts
@@ -55,7 +55,7 @@ const defaultFactories: ChannelFactories = {
     new GitHubAdapter(secret, config, Bus.publish, token, botUsername),
 };
 
-interface BuiltChannel {
+export interface BuiltChannel {
   readonly surface: Channel.Surface;
   /** Outbound seam, keyed by `surface.id`: present only for channels the Resident can message into. */
   readonly deliveryRoute?: ChannelDeliveryRoute;

--- a/apps/openomni/src/composition/composer.ts
+++ b/apps/openomni/src/composition/composer.ts
@@ -49,7 +49,7 @@ interface EffectContext {
   effect(disposer: Disposer): void;
 }
 
-interface Composer {
+export interface Composer {
   /**
    * Runs one stage. If `apply` throws, the disposers it already registered
    * run in reverse before the error propagates — a failed stage leaves
@@ -87,6 +87,21 @@ async function release(fiber: Fiber): Promise<readonly Error[]> {
   }
   fiber.disposers.length = 0;
   return failures;
+}
+
+/**
+ * Fail-closed unwinding for a failed composition run: release everything the
+ * composer holds, then rethrow the original cause. When the release itself
+ * also fails, both faults surface together — the rollback failure must never
+ * shadow what actually broke the run.
+ */
+export async function rollbackToCause(composer: Composer, cause: Error): Promise<never> {
+  try {
+    await composer.dispose();
+  } catch (rollbackError) {
+    throw new AggregateError([cause, rollbackError], "composition failed and its rollback failed");
+  }
+  throw cause;
 }
 
 export function createComposer(): Composer {

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -14,7 +14,7 @@ import {
   Session,
   Storage,
 } from "@openomni/ledger";
-import { ModelsDev, run as llmRun, type Sink } from "@openomni/llm";
+
 import { createMachineHost, type MachineHost } from "@openomni/machines";
 import type { Placement } from "@openomni/placement";
 import {
@@ -22,14 +22,13 @@ import {
   Gateway,
   type Ingress,
   type Machine,
-  type Message,
   newTraceId,
 } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
-import { channelProfile } from "./channels";
+import { type BuiltChannel, channelProfile } from "./channels";
 import { assertWsExposure, loadConfig, type OpenOmniConfig, type RegisteredActor } from "./config";
 import type { ArtifactsPort } from "./tools/artifacts";
-import { type LlmPort, resolveLlmToolModel } from "./tools/llm";
+import { createLlmToolPort } from "./tools/llm";
 import type { MachinesPort } from "./tools/machines";
 import { createChannelDriver } from "./delegation/channel-driver";
 import { createInlineDriver } from "./delegation/inline-driver";
@@ -45,7 +44,7 @@ import { createCompletionPort } from "./work-item/completion";
 import { createProcessDriver } from "./delegation/process-driver";
 import { createInlineWorkerRunner } from "./delegation/worker-loop";
 import { createResidentGateway, registerTrustedChannelGrant } from "./gateway";
-import { createComposer } from "./composition/composer";
+import { type Composer, createComposer, rollbackToCause } from "./composition/composer";
 import { createPolicyRegistry } from "./composition/policy-registry";
 import { createDriverRegistry } from "./composition/driver-registry";
 import { openCuratedMemory } from "./memory/store";
@@ -82,77 +81,116 @@ function attachedTargets(
 }
 
 /**
- * The llm tool's one-shot sub-model call: a single user message, no tools,
- * one step, its own synthesized trace — a nested run must never borrow the
- * turn's run identity. Auth is the configured key, exactly as the Resident
- * and the worker loop authenticate.
+ * Owner-admitted delegation targets, recorded as durable identity facts.
+ * Registration is an upsert, so a restart re-asserting the same actors is a
+ * no-op — which is also why this is not a composer effect: durable facts are
+ * history, not runtime handles.
  */
-function createLlmToolPort(model: OpenOmniConfig["model"]): LlmPort {
-  return async (prompt) => {
-    const sessionId = "llm-tool";
-    const messageId = crypto.randomUUID();
-    const request: Message.WithParts = {
-      info: {
-        id: messageId,
-        sessionID: sessionId,
-        role: "user",
-        time: { created: Date.now() },
-        agent: "llm-tool",
-        model: { providerID: model.provider, modelID: model.id },
-      },
-      parts: [
-        {
-          id: crypto.randomUUID(),
-          sessionID: sessionId,
-          messageID: messageId,
-          type: "text",
-          text: prompt,
-        },
-      ],
-    };
-    let answer = "";
-    const sink: Sink = {
-      onMessage: (message) => {
-        if (message.info.role !== "assistant") return;
-        answer = message.parts
-          .filter((part): part is Message.TextPart => part.type === "text")
-          .map((part) => part.text)
-          .join("");
-      },
-      onToolCall: () => undefined,
-      onToolResult: () => undefined,
-    };
-    const outcome = await llmRun(
-      {
-        messages: [request],
-        tools: [],
-        maxSteps: 1,
-        model: resolveLlmToolModel(await ModelsDev.get(), { provider: model.provider, id: model.id }),
-        auth: { type: "api", key: model.apiKey },
-        trace: {
-          traceId: newTraceId(),
-          sessionId,
-          runId: crypto.randomUUID(),
-        },
-        events: Bus,
-      },
-      sink,
-    );
-    if (outcome.type !== "stop") {
-      const reason =
-        "error" in outcome && outcome.error !== undefined
-          ? outcome.error.message
-          : `the sub-model run ended as ${outcome.type}`;
-      // Thrown, not returned: the consumer is cell code, and a failure string
-      // returned as data would be stored as if it were model output.
-      throw new Error(`llm failed: ${reason}`);
+function registerActors(actors: readonly RegisteredActor[]): void {
+  for (const actor of actors) {
+    ActorRegistry.registerIdentity({
+      id: actor.actorId,
+      kind: actor.kind,
+      trustTier: actor.trustTier,
+      ...(actor.displayName === undefined ? {} : { displayName: actor.displayName }),
+    });
+    const channel = actor.channel ?? "ws";
+    ActorRegistry.registerEndpoint({
+      id: `${channel}:${actor.externalId}`,
+      actorId: actor.actorId,
+      channel,
+      externalId: actor.externalId,
+    });
+  }
+}
+
+/**
+ * The Resident's view of its body: every enrolled machine, attached or not,
+ * reduced to the effective (enrollment∩offer) capability fold the host
+ * attachment table holds.
+ */
+export function createMachinesPort(
+  host: Pick<MachineHost, "attached"> | undefined,
+  machines: OpenOmniConfig["machines"],
+): MachinesPort | undefined {
+  if (host === undefined || machines === undefined) return undefined;
+  return () =>
+    machines.enrolled.map((enrollment) => {
+      const capabilities = host.attached(enrollment.machineId);
+      return capabilities === undefined
+        ? { machineId: enrollment.machineId, attached: false, capabilities: [] }
+        : {
+            machineId: enrollment.machineId,
+            attached: true,
+            capabilities: [...capabilities],
+          };
+    });
+}
+
+/**
+ * The app's HTTP surface: the ws upgrade seam, unauthenticated liveness (no
+ * clock, no version, no state), and — only when a GitHub channel is composed —
+ * its webhook ingress. Everything else is 404.
+ */
+function createHttpRoutes(
+  wsHandler: WebSocketHandler,
+  githubWebhookHandler: ((request: Request) => Promise<Response>) | undefined,
+) {
+  return (
+    request: Request,
+    bunServer: Parameters<WebSocketHandler["handleUpgrade"]>[1],
+  ): Response | Promise<Response> | undefined => {
+    const url = new URL(request.url);
+    if (request.headers.get("upgrade") === "websocket" && url.pathname === "/ws") {
+      // undefined = the upgrade succeeded; a Response = the upgrade was denied.
+      return wsHandler.handleUpgrade(request, bunServer);
     }
-    return answer;
+    if (request.method === "GET" && url.pathname === "/health") {
+      return Response.json({ ok: true });
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/github/webhook" &&
+      githubWebhookHandler !== undefined
+    ) {
+      return githubWebhookHandler(request);
+    }
+    return new Response("Not found", { status: 404 });
   };
 }
 
+/**
+ * Each channel component is its own stage, mounted before the ws server so
+ * its authority and outbound route exist before any ingress is reachable.
+ * Disposal revokes exactly what the component registered: the listener, the
+ * delivery route, and the trusted-channel grant — fail-closed for any
+ * traffic that arrives afterwards.
+ */
+export async function mountChannelStages(
+  composer: Composer,
+  builtChannels: readonly BuiltChannel[],
+  deliveryRoutes: Map<string, ChannelDeliveryRoute>,
+  recoveryTraceId: string,
+): Promise<void> {
+  for (const built of builtChannels) {
+    const surfaceId = built.surface.id;
+    await composer.mount(`channel.${surfaceId}`, async (ctx) => {
+      ctx.effect(registerTrustedChannelGrant(surfaceId));
+      const route = built.deliveryRoute;
+      if (route !== undefined) {
+        deliveryRoutes.set(surfaceId, route);
+        ctx.effect(() => {
+          deliveryRoutes.delete(surfaceId);
+        });
+      }
+      await built.surface.start(recoveryTraceId);
+      ctx.effect(() => built.surface.stop(newTraceId()));
+    });
+  }
+}
+
 /** How a correlated reply's payload reads when handed back to the waiting delegation. */
-function replyText(payload: unknown): string {
+export function replyText(payload: unknown): string {
   if (typeof payload === "string") return payload;
   return JSON.stringify(payload);
 }
@@ -213,24 +251,8 @@ export async function startOpenOmni(options: StartOptions = {}) {
         Storage.reset();
       });
     });
-    // Owner-admitted delegation targets. Registration is an upsert, so a
-    // restart re-asserting the same actors is a no-op.
     const actors: readonly RegisteredActor[] = config.actors ?? [];
-    for (const actor of actors) {
-      ActorRegistry.registerIdentity({
-        id: actor.actorId,
-        kind: actor.kind,
-        trustTier: actor.trustTier,
-        ...(actor.displayName === undefined ? {} : { displayName: actor.displayName }),
-      });
-      const channel = actor.channel ?? "ws";
-      ActorRegistry.registerEndpoint({
-        id: `${channel}:${actor.externalId}`,
-        actorId: actor.actorId,
-        channel,
-        externalId: actor.externalId,
-      });
-    }
+    registerActors(actors);
 
     // A worker loop holds the same delegate tool the Resident does, so the
     // runner needs the kernel that the kernel needs the runner to build. The
@@ -333,30 +355,14 @@ export async function startOpenOmni(options: StartOptions = {}) {
     // the memory tool, frozen into the system prompt per session.
     const memory = openCuratedMemory(config.memoryPath);
 
-    // The Resident's view of its body: every enrolled machine, attached or
-    // not, reduced to the effective (enrollment∩offer) capability fold the
-    // host attachment table holds.
     const machineHost = host;
-    const machinesPort: MachinesPort | undefined =
-      machineHost === undefined || machines === undefined
-        ? undefined
-        : () =>
-            machines.enrolled.map((enrollment) => {
-              const capabilities = machineHost.attached(enrollment.machineId);
-              return capabilities === undefined
-                ? { machineId: enrollment.machineId, attached: false, capabilities: [] }
-                : {
-                    machineId: enrollment.machineId,
-                    attached: true,
-                    capabilities: [...capabilities],
-                  };
-            });
+    const machinesPort = createMachinesPort(machineHost, machines);
 
     const completionPort = createCompletionPort({
       writer: completionWriter,
       now: () => Date.now(),
     });
-    const llmPort = createLlmToolPort(config.model);
+    const llmPort = createLlmToolPort(config.model, options.llm ?? {});
     const artifactsPort: ArtifactsPort = { store: Artifact.store, get: Artifact.get };
     const cells: CellPorts | undefined =
       machineHost === undefined
@@ -493,26 +499,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
     // kernel's deliverWake is the single owner of wake-failure reporting.
     wakeDelivery.arm((wake) => residentDeliver(delegationWakeDelivery(wake)).then(() => undefined));
 
-    // Each channel component is its own stage, mounted before the ws server so
-    // its authority and outbound route exist before any ingress is reachable.
-    // Disposal revokes exactly what the component registered: the listener,
-    // the delivery route, and the trusted-channel grant — fail-closed for any
-    // traffic that arrives afterwards.
-    for (const built of builtChannels) {
-      const surfaceId = built.surface.id;
-      await composer.mount(`channel.${surfaceId}`, async (ctx) => {
-        ctx.effect(registerTrustedChannelGrant(surfaceId));
-        const route = built.deliveryRoute;
-        if (route !== undefined) {
-          deliveryRoutes.set(surfaceId, route);
-          ctx.effect(() => {
-            deliveryRoutes.delete(surfaceId);
-          });
-        }
-        await built.surface.start(recoveryTraceId);
-        ctx.effect(() => built.surface.stop(newTraceId()));
-      });
-    }
+    await mountChannelStages(composer, builtChannels, deliveryRoutes, recoveryTraceId);
 
     wsHandler = new WebSocketHandler(
       routingHandler,
@@ -524,25 +511,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
       hostname: config.host,
       port: config.wsPort,
       websocket: wsHandler.ws,
-      fetch(request, bunServer) {
-        const url = new URL(request.url);
-        if (request.headers.get("upgrade") === "websocket" && url.pathname === "/ws") {
-          // undefined = the upgrade succeeded; a Response = the upgrade was denied.
-          return wsHandler.handleUpgrade(request, bunServer);
-        }
-        if (request.method === "GET" && url.pathname === "/health") {
-          // Unauthenticated liveness only: no clock, no version, no state.
-          return Response.json({ ok: true });
-        }
-        if (
-          request.method === "POST" &&
-          url.pathname === "/github/webhook" &&
-          githubWebhookHandler !== undefined
-        ) {
-          return githubWebhookHandler(request);
-        }
-        return new Response("Not found", { status: 404 });
-      },
+      fetch: createHttpRoutes(wsHandler, githubWebhookHandler),
     });
 
     if (server.port === undefined) throw new Error("OpenOmni ws server did not bind a TCP port");
@@ -567,15 +536,7 @@ export async function startOpenOmni(options: StartOptions = {}) {
     // Fail-closed boot rollback: a failure after the journal started leaves
     // no leaked Bus observer, no armed kernel timer, and no configured
     // storage behind — a later boot starts clean.
-    try {
-      await composer.dispose();
-    } catch (rollbackError) {
-      throw new AggregateError(
-        [error, rollbackError],
-        "OpenOmni boot failed and its rollback failed",
-      );
-    }
-    throw error;
+    return rollbackToCause(composer, error instanceof Error ? error : new Error(String(error)));
   }
 }
 

--- a/apps/openomni/src/resident.ts
+++ b/apps/openomni/src/resident.ts
@@ -61,6 +61,52 @@ interface ResidentOptions {
   readonly policies: PolicyRegistry;
 }
 
+interface DeliveryClassification {
+  readonly sessionId: string;
+  readonly payload: string;
+  readonly evidenceOnly: boolean;
+  readonly systemKind: "delegation.settled" | "evidence_only" | undefined;
+}
+
+/**
+ * The delivery's authority reading, settled once per turn. The authoritative
+ * perimeter verdict is actorContext.inboundTreatment (§2a projection); event
+ * meta and the recorded decision carry copies the schema does not require to
+ * agree. Fail closed on disagreement: ANY evidence_only stamp downgrades the
+ * turn, and only a delivery with no evidence_only anywhere runs at full
+ * authority. A mismatch can therefore only reduce authority, never elevate it.
+ */
+function classifyDelivery(delivery: Gateway.Deliver): DeliveryClassification {
+  const sessionId = delivery.sessionId;
+  if (sessionId === undefined) {
+    throw new Error("Resident delivery requires a routed sessionId");
+  }
+  const payload = delivery.event.payload;
+  if (typeof payload !== "string") {
+    throw new Error("Resident delivery payload must be text");
+  }
+  const evidenceOnly =
+    delivery.actorContext?.inboundTreatment === "evidence_only" ||
+    delivery.decision.inboundTreatment === "evidence_only" ||
+    delivery.event.meta?.inboundTreatment === "evidence_only";
+  const systemKind =
+    delivery.event.meta?.kind === "delegation.settled"
+      ? "delegation.settled"
+      : evidenceOnly
+        ? "evidence_only"
+        : undefined;
+  return { sessionId, payload, evidenceOnly, systemKind };
+}
+
+/** Who an evidence-only observation is attributed to in its framing. */
+function evidenceOrigin(delivery: Gateway.Deliver): string {
+  return (
+    delivery.actorContext?.actorId ??
+    delivery.actorContext?.origin.externalId ??
+    delivery.event.surface
+  );
+}
+
 function addTextPart(sessionId: string, messageId: string, text: string): void {
   Session.addPart(messageId, {
     id: crypto.randomUUID(),
@@ -111,34 +157,65 @@ export function createResident(options: ResidentOptions) {
     return buildAgentPrompt(RESIDENT_PRESET, { memorySnapshot: snapshot });
   }
 
+  function recordUserTurn(delivery: Gateway.Deliver, turn: DeliveryClassification): string {
+    const userId = crypto.randomUUID();
+    Session.addMessage(turn.sessionId, {
+      id: userId,
+      sessionID: turn.sessionId,
+      role: "user",
+      time: { created: Date.now() },
+      agent: turn.systemKind === undefined ? "resident" : "system",
+      model: { providerID: options.model.provider, modelID: options.model.id },
+      ...(turn.systemKind === undefined ? {} : { system: turn.systemKind }),
+    });
+    addTextPart(
+      turn.sessionId,
+      userId,
+      turn.evidenceOnly
+        ? frameEvidenceOnlyText(turn.payload, evidenceOrigin(delivery))
+        : turn.payload,
+    );
+    return userId;
+  }
+
+  function recordAssistantTurn(
+    sessionId: string,
+    userId: string,
+    result: Awaited<ReturnType<ReturnType<typeof ChatAgent.create>["run"]>>,
+  ): void {
+    const assistantId = crypto.randomUUID();
+    Session.addMessage(sessionId, {
+      id: assistantId,
+      sessionID: sessionId,
+      role: "assistant",
+      time: { created: Date.now(), completed: Date.now() },
+      parentID: userId,
+      modelID: options.model.id,
+      providerID: options.model.provider,
+      agent: "resident",
+      path: { cwd: process.cwd(), root: process.cwd() },
+      cost: 0,
+      tokens: {
+        input: result.usage.inputTokens,
+        output: result.usage.outputTokens,
+        reasoning: result.usage.reasoningTokens ?? 0,
+        cache: {
+          read: result.usage.cacheReadTokens ?? 0,
+          write: result.usage.cacheWriteTokens ?? 0,
+        },
+      },
+      finish: result.finishReason,
+    });
+    addTextPart(sessionId, assistantId, result.text);
+  }
+
   return async function deliver(delivery: Gateway.Deliver): Promise<Ingress.IngressResult> {
-    const sessionId = delivery.sessionId;
-    if (sessionId === undefined) {
-      throw new Error("Resident delivery requires a routed sessionId");
-    }
-    if (typeof delivery.event.payload !== "string") {
-      throw new Error("Resident delivery payload must be text");
-    }
+    const turn = classifyDelivery(delivery);
+    const { sessionId, evidenceOnly } = turn;
 
     // Built per delivery because the origin carries THIS session: a Wait a
     // delegation opens must be owned by the session that asked for the work.
     const origin: DelegationOrigin = { role: "resident", depth: 0, sessionId };
-    // The authoritative perimeter verdict is actorContext.inboundTreatment
-    // (§2a projection); event meta and the recorded decision carry copies the
-    // schema does not require to agree. Fail closed on disagreement: ANY
-    // evidence_only stamp downgrades the turn, and only a delivery with no
-    // evidence_only anywhere runs at full authority. A mismatch can therefore
-    // only reduce authority, never elevate it.
-    const evidenceOnly =
-      delivery.actorContext?.inboundTreatment === "evidence_only" ||
-      delivery.decision.inboundTreatment === "evidence_only" ||
-      delivery.event.meta?.inboundTreatment === "evidence_only";
-    const systemKind =
-      delivery.event.meta?.kind === "delegation.settled"
-        ? "delegation.settled"
-        : evidenceOnly
-          ? "evidence_only"
-          : undefined;
     const targets = options.targets();
     const catalog = createDispatcher(catalogEntries(options.tools, origin));
     // An evidence-only turn gets no execution surface: the model is offered
@@ -175,28 +252,7 @@ export function createResident(options: ResidentOptions) {
       model: { providerID: options.model.provider, modelID: options.model.id },
     });
 
-    const userId = crypto.randomUUID();
-    Session.addMessage(sessionId, {
-      id: userId,
-      sessionID: sessionId,
-      role: "user",
-      time: { created: Date.now() },
-      agent: systemKind === undefined ? "resident" : "system",
-      model: { providerID: options.model.provider, modelID: options.model.id },
-      ...(systemKind === undefined ? {} : { system: systemKind }),
-    });
-    addTextPart(
-      sessionId,
-      userId,
-      evidenceOnly
-        ? frameEvidenceOnlyText(
-            delivery.event.payload,
-            delivery.actorContext?.actorId ??
-              delivery.actorContext?.origin.externalId ??
-              delivery.event.surface,
-          )
-        : delivery.event.payload,
-    );
+    const userId = recordUserTurn(delivery, turn);
 
     const result = await observation.run(() =>
       agent.run({
@@ -210,30 +266,7 @@ export function createResident(options: ResidentOptions) {
       }),
     );
 
-    const assistantId = crypto.randomUUID();
-    Session.addMessage(sessionId, {
-      id: assistantId,
-      sessionID: sessionId,
-      role: "assistant",
-      time: { created: Date.now(), completed: Date.now() },
-      parentID: userId,
-      modelID: options.model.id,
-      providerID: options.model.provider,
-      agent: "resident",
-      path: { cwd: process.cwd(), root: process.cwd() },
-      cost: 0,
-      tokens: {
-        input: result.usage.inputTokens,
-        output: result.usage.outputTokens,
-        reasoning: result.usage.reasoningTokens ?? 0,
-        cache: {
-          read: result.usage.cacheReadTokens ?? 0,
-          write: result.usage.cacheWriteTokens ?? 0,
-        },
-      },
-      finish: result.finishReason,
-    });
-    addTextPart(sessionId, assistantId, result.text);
+    recordAssistantTurn(sessionId, userId, result);
 
     return {
       mode: "direct",

--- a/apps/openomni/src/tools/llm.ts
+++ b/apps/openomni/src/tools/llm.ts
@@ -1,5 +1,6 @@
-import { type ModelsDev, Provider } from "@openomni/llm";
-import type { Tool } from "@openomni/protocol";
+import { ModelsDev, Provider, run as llmRun, type Sink } from "@openomni/llm";
+import { type Message, type Model, newTraceId, type Tool } from "@openomni/protocol";
+import { Bus } from "@openomni/telemetry";
 import { z } from "zod";
 
 /**
@@ -78,6 +79,95 @@ export function llmToolExecutor(llm: LlmPort) {
  * configured credential to the wrong provider. The agent loop's own resolver
  * refuses unlisted models for the same reason.
  */
+/**
+ * The same substitution seam ChatAgentConfig["llm"] gives the Resident and
+ * the worker loop: absent fields use the real provider I/O. Boot passes its
+ * `options.llm` through, so a composition booted on a fake model never lets
+ * this one port slip out to the network.
+ */
+export interface LlmIo {
+  readonly run?: typeof llmRun;
+  readonly resolveProviderModel?: (model: Model.Ref) => Promise<Provider.Model>;
+}
+
+/**
+ * The llm tool's one-shot sub-model call: a single user message, no tools,
+ * one step, its own synthesized trace — a nested run must never borrow the
+ * turn's run identity. Auth is the configured key, exactly as the Resident
+ * and the worker loop authenticate.
+ */
+export function createLlmToolPort(
+  model: { readonly provider: string; readonly id: string; readonly apiKey: string },
+  io: LlmIo = {},
+): LlmPort {
+  return async (prompt) => {
+    const sessionId = "llm-tool";
+    const messageId = crypto.randomUUID();
+    const request: Message.WithParts = {
+      info: {
+        id: messageId,
+        sessionID: sessionId,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "llm-tool",
+        model: { providerID: model.provider, modelID: model.id },
+      },
+      parts: [
+        {
+          id: crypto.randomUUID(),
+          sessionID: sessionId,
+          messageID: messageId,
+          type: "text",
+          text: prompt,
+        },
+      ],
+    };
+    let answer = "";
+    const sink: Sink = {
+      onMessage: (message) => {
+        if (message.info.role !== "assistant") return;
+        answer = message.parts
+          .filter((part): part is Message.TextPart => part.type === "text")
+          .map((part) => part.text)
+          .join("");
+      },
+      onToolCall: () => undefined,
+      onToolResult: () => undefined,
+    };
+    const ref: Model.Ref = { provider: model.provider, id: model.id };
+    const resolved =
+      io.resolveProviderModel === undefined
+        ? resolveLlmToolModel(await ModelsDev.get(), ref)
+        : await io.resolveProviderModel(ref);
+    const outcome = await (io.run ?? llmRun)(
+      {
+        messages: [request],
+        tools: [],
+        maxSteps: 1,
+        model: resolved,
+        auth: { type: "api", key: model.apiKey },
+        trace: {
+          traceId: newTraceId(),
+          sessionId,
+          runId: crypto.randomUUID(),
+        },
+        events: Bus,
+      },
+      sink,
+    );
+    if (outcome.type !== "stop") {
+      const reason =
+        "error" in outcome && outcome.error !== undefined
+          ? outcome.error.message
+          : `the sub-model run ended as ${outcome.type}`;
+      // Thrown, not returned: the consumer is cell code, and a failure string
+      // returned as data would be stored as if it were model output.
+      throw new Error(`llm failed: ${reason}`);
+    }
+    return answer;
+  };
+}
+
 export function resolveLlmToolModel(
   data: Record<string, ModelsDev.Provider>,
   model: { readonly provider: string; readonly id: string },

--- a/apps/openomni/test/boot-wiring.test.ts
+++ b/apps/openomni/test/boot-wiring.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ChannelDeliveryRoute } from "@openomni/channels";
+import { ChannelGrantStore, Storage } from "@openomni/ledger";
+import type { Channel } from "@openomni/protocol";
+import type { BuiltChannel } from "../src/channels";
+import { createComposer } from "../src/composition/composer";
+import { createMachinesPort, mountChannelStages, replyText } from "../src/index";
+
+describe("replyText", () => {
+  test("hands a string payload back verbatim and serializes anything else", () => {
+    expect(replyText("done")).toBe("done");
+    expect(replyText({ status: "done", count: 2 })).toBe('{"status":"done","count":2}');
+  });
+});
+
+describe("createMachinesPort", () => {
+  const enrolled = [
+    { name: "a", machineId: "machine:a", allowedCapabilities: ["shell"], enrolledAt: 1 },
+    { name: "b", machineId: "machine:b", allowedCapabilities: ["shell"], enrolledAt: 1 },
+  ];
+  const machines = { socketPath: "/tmp/unused.sock", enrolled };
+
+  test("is absent without a host or enrollment", () => {
+    expect(createMachinesPort(undefined, machines)).toBeUndefined();
+    expect(createMachinesPort({ attached: () => undefined }, undefined)).toBeUndefined();
+  });
+
+  test("folds enrollment against live attachment per read", () => {
+    const port = createMachinesPort(
+      { attached: (machineId) => (machineId === "machine:a" ? ["shell"] : undefined) },
+      machines,
+    );
+    if (port === undefined) throw new Error("expected a machines port");
+
+    expect(port()).toEqual([
+      { machineId: "machine:a", attached: true, capabilities: ["shell"] },
+      { machineId: "machine:b", attached: false, capabilities: [] },
+    ]);
+  });
+});
+
+describe("mountChannelStages", () => {
+  beforeEach(() => {
+    Storage.initialize({ dbPath: ":memory:" });
+  });
+
+  afterEach(() => {
+    Storage.reset();
+  });
+
+  function fakeChannel(id: string, deliveryRoute?: ChannelDeliveryRoute) {
+    const calls: string[] = [];
+    const surface: Channel.Surface = {
+      id,
+      config: { triggers: [] },
+      async start() {
+        calls.push("start");
+      },
+      async stop() {
+        calls.push("stop");
+      },
+      onMessage() {
+        // The handler was bound at build time; the stage never rebinds it.
+      },
+    };
+    const built: BuiltChannel = {
+      surface,
+      ...(deliveryRoute === undefined ? {} : { deliveryRoute }),
+    };
+    return { built, calls };
+  }
+
+  test("a stage owns its grant, route, and surface; dispose revokes all three", async () => {
+    const composer = createComposer();
+    const deliveryRoutes = new Map<string, ChannelDeliveryRoute>();
+    const route: ChannelDeliveryRoute = async () => ({});
+    const routed = fakeChannel("telegram", route);
+    const ingressOnly = fakeChannel("github");
+
+    await mountChannelStages(
+      composer,
+      [routed.built, ingressOnly.built],
+      deliveryRoutes,
+      "00-11111111111111111111111111111111-2222222222222222-01",
+    );
+
+    expect(routed.calls).toEqual(["start"]);
+    expect(deliveryRoutes.get("telegram")).toBe(route);
+    // Ingress-only channels register no outbound route.
+    expect(deliveryRoutes.has("github")).toBe(false);
+    expect(ChannelGrantStore.resolve({ surface: "telegram" })?.grant.kind).toBe(
+      "trusted_channel",
+    );
+    expect(ChannelGrantStore.resolve({ surface: "github" })?.grant.kind).toBe("trusted_channel");
+
+    await composer.dispose();
+
+    expect(routed.calls).toEqual(["start", "stop"]);
+    expect(ingressOnly.calls).toEqual(["start", "stop"]);
+    expect(deliveryRoutes.has("telegram")).toBe(false);
+    expect(ChannelGrantStore.resolve({ surface: "telegram" })).toBeUndefined();
+    expect(ChannelGrantStore.resolve({ surface: "github" })).toBeUndefined();
+  });
+});

--- a/apps/openomni/test/channel-composition.test.ts
+++ b/apps/openomni/test/channel-composition.test.ts
@@ -149,4 +149,26 @@ describe("OpenOmni channel composition", () => {
       status: 202,
     });
   });
+
+  it("builds the real channel adapters when no factories are injected", () => {
+    const handler: Channel.MessageHandler = async () => ({ text: "resident reply" });
+    const config: OpenOmniConfig = {
+      ...baseConfig(),
+      channels: {
+        discord: { token: "discord-token" },
+        telegram: { token: "telegram-token" },
+        github: { secret: "github-secret" },
+      },
+    };
+
+    // Construction only — adapters connect in start(), which is never called.
+    const built = channelProfile(config).map((row) => row.build(handler));
+
+    expect(built.map((channel) => channel.surface.id)).toEqual(["telegram", "github", "discord"]);
+    const [telegram, github, discord] = built;
+    expect(telegram?.deliveryRoute).toBeDefined();
+    expect(discord?.deliveryRoute).toBeDefined();
+    expect(github?.deliveryRoute).toBeUndefined();
+    expect(github?.webhookHandler).toBeDefined();
+  });
 });

--- a/apps/openomni/test/composition.test.ts
+++ b/apps/openomni/test/composition.test.ts
@@ -1,7 +1,49 @@
 import { describe, expect, test } from "bun:test";
-import { createComposer } from "../src/composition/composer";
+import { createComposer, rollbackToCause } from "../src/composition/composer";
 
 const noop = () => undefined;
+
+describe("rollback to cause", () => {
+  test("releases the composer and rethrows the original cause by identity", async () => {
+    const composer = createComposer();
+    let released = false;
+    await composer.mount("stage", (ctx) => {
+      ctx.effect(() => {
+        released = true;
+      });
+    });
+    const cause = new Error("the run broke");
+
+    const thrown = await rollbackToCause(composer, cause).then(
+      () => null,
+      (error: Error) => error,
+    );
+
+    expect(thrown).toBe(cause);
+    expect(released).toBe(true);
+  });
+
+  test("surfaces both faults when the rollback itself fails", async () => {
+    const composer = createComposer();
+    const disposeError = new Error("disposer broke");
+    await composer.mount("stage", (ctx) => {
+      ctx.effect(() => {
+        throw disposeError;
+      });
+    });
+    const cause = new Error("the run broke");
+
+    const thrown = await rollbackToCause(composer, cause).then(
+      () => null,
+      (error: AggregateError) => error,
+    );
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect(thrown?.message).toBe("composition failed and its rollback failed");
+    expect(thrown?.errors[0]).toBe(cause);
+    expect(thrown?.errors[1]).toBeInstanceOf(AggregateError);
+  });
+});
 
 describe("composition substrate", () => {
   test("mounted stages report active with their owned effect counts", async () => {

--- a/apps/openomni/test/e2e.test.ts
+++ b/apps/openomni/test/e2e.test.ts
@@ -252,4 +252,36 @@ describe("OpenOmni Resident WebSocket", () => {
     await expect(opened(ws)).rejects.toThrow("WebSocket failed before opening");
     expect(Session.list()).toHaveLength(0);
   });
+
+  it("rolls a failed boot back and leaves the next boot clean", async () => {
+    // Occupy the port so Bun.serve fails AFTER the journal and kernel stages
+    // mounted — the composer must unwind them and rethrow the original cause.
+    const occupant = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response("occupied"),
+    });
+    const directory = mkdtempSync(join(tmpdir(), "openomni-resident-"));
+    directories.push(directory);
+    const config: OpenOmniConfig = {
+      dbPath: join(directory, "chat.db"),
+      memoryPath: join(directory, "memory.json"),
+      host: "127.0.0.1",
+      wsPort: occupant.port ?? 0,
+      wsToken: WS_TOKEN,
+      model: { provider: "fake", id: "resident-test", apiKey: "test-key" },
+    };
+    try {
+      await expect(bootWithConfig(config)).rejects.toThrow(/in use|EADDRINUSE|Failed to (listen|start server)/i);
+
+      // The rollback released storage: the same config boots cleanly once the
+      // port frees up.
+      await occupant.stop(true);
+      const app = await bootWithConfig(config);
+      const health = await fetch(`http://127.0.0.1:${app.port}/health`);
+      expect(await health.json()).toEqual({ ok: true });
+    } finally {
+      await occupant.stop(true);
+    }
+  });
 });

--- a/apps/openomni/test/gateway-contracts.test.ts
+++ b/apps/openomni/test/gateway-contracts.test.ts
@@ -111,6 +111,15 @@ describe("Resident delivery contract", () => {
 
     const unrouted = Gateway.Deliver.parse({ ...evidenceDelivery("hi"), sessionId: undefined });
     await expect(resident(unrouted)).rejects.toThrow("Resident delivery requires a routed sessionId");
+
+    // The same fail-closed classification refuses a non-text payload: the
+    // Resident's turn contract is text in, text out.
+    const base = evidenceDelivery("hi");
+    const structured = Gateway.Deliver.parse({
+      ...base,
+      event: { ...base.event, payload: { not: "text" } },
+    });
+    await expect(resident(structured)).rejects.toThrow("Resident delivery payload must be text");
   });
 });
 

--- a/apps/openomni/test/rlm-tools.test.ts
+++ b/apps/openomni/test/rlm-tools.test.ts
@@ -12,11 +12,14 @@ import {
 import { catalogEntries, collectToolSpecs } from "../src/tools/catalog";
 import { createDispatcher, HOST_TARGET } from "../src/tools/dispatch";
 import {
+  createLlmToolPort,
   LLM_TOOL_NAME,
   llmToolExecutor,
   MAX_LLM_CALLS,
   resolveLlmToolModel,
 } from "../src/tools/llm";
+import type { RunInput } from "@openomni/llm";
+import { assistantMessage } from "./helpers/assistant-message";
 
 const RESIDENT = { role: "resident", depth: 0, sessionId: "session-origin" } as const;
 
@@ -132,6 +135,72 @@ describe("the llm tool", () => {
 
     expect(result.isError).toBeUndefined();
     expect(result.output).toBe("ok");
+  });
+});
+
+describe("the llm tool port", () => {
+  const MODEL = { provider: "fake", id: "port-test", apiKey: "port-key" } as const;
+  const resolveProviderModel = async (model: { provider: string; id: string }) => ({
+    id: model.id,
+    name: model.id,
+    providerID: model.provider,
+  });
+
+  it("runs one toolless step under its own trace and returns the assistant text", async () => {
+    let seen: RunInput | undefined;
+    const port = createLlmToolPort(MODEL, {
+      resolveProviderModel,
+      run: async (input, sink) => {
+        seen = input;
+        sink.onMessage(assistantMessage(input, { id: "sub-reply", text: "the answer" }));
+        return { type: "stop" };
+      },
+    });
+
+    expect(await port("summarize")).toBe("the answer");
+    expect(seen?.tools).toEqual([]);
+    expect(seen?.maxSteps).toBe(1);
+    expect(seen?.auth).toEqual({ type: "api", key: "port-key" });
+    expect(seen?.model).toMatchObject({ id: "port-test", providerID: "fake" });
+    // A nested run must never borrow the turn's identity: the trace is its own.
+    expect(seen?.trace.sessionId).toBe("llm-tool");
+    const parts = seen?.messages[0]?.parts ?? [];
+    expect(parts[0]).toMatchObject({ type: "text", text: "summarize" });
+  });
+
+  it("ignores non-assistant messages when reading the answer", async () => {
+    const port = createLlmToolPort(MODEL, {
+      resolveProviderModel,
+      run: async (input, sink) => {
+        const echo = input.messages[0];
+        if (echo !== undefined) sink.onMessage(echo);
+        // The port discards tool activity too: a one-step toolless run has no
+        // executor, so these projections must be inert.
+        sink.onToolCall({ id: "call-1", tool: "noop", input: {} });
+        sink.onToolResult({ id: "result-1", toolCallId: "call-1", output: "ignored" });
+        return { type: "stop" };
+      },
+    });
+
+    expect(await port("anything")).toBe("");
+  });
+
+  it("throws the provider's failure instead of returning it as data", async () => {
+    const port = createLlmToolPort(MODEL, {
+      resolveProviderModel,
+      run: async () => ({ type: "error", error: new Error("provider on fire") }),
+    });
+
+    await expect(port("q")).rejects.toThrow("llm failed: provider on fire");
+  });
+
+  it("names the outcome when a non-stop run carries no error", async () => {
+    const port = createLlmToolPort(MODEL, {
+      resolveProviderModel,
+      run: async () => ({ type: "aborted" }),
+    });
+
+    await expect(port("q")).rejects.toThrow("llm failed: the sub-model run ended as aborted");
   });
 });
 


### PR DESCRIPTION
## What

Decomposes the two remaining over-budget functions from the composition series and closes the coverage gaps the audit found. No behavior changes except one deliberate fix (below).

### Boot (`index.ts`)
`startOpenOmni` (was CC 23 / cognitive 28) is now a linear script over named module-level stages:
- `registerActors` — the durable actor upsert loop.
- `createMachinesPort` — the enrollment∩attachment fold; its `host` param narrows to `Pick<MachineHost, "attached">`, the only thing it reads.
- `createHttpRoutes` — the ws-upgrade / health / webhook / 404 dispatch.
- `mountChannelStages` — the per-channel composer stage (grant, route, surface lifecycle), now unit-tested directly against a real composer + real `ChannelGrantStore`.
- The boot catch delegates to a new `rollbackToCause(composer, cause)` in `composer.ts` — dispose, aggregate on double fault, rethrow by identity — unit-tested for both faces, which the in-boot AggregateError never was.

### Resident (`resident.ts`)
`deliver` (was CC 26) now reads as classify → record user turn → run → record assistant turn: `classifyDelivery` owns the fail-closed sessionId/text/evidence-only reading (doc comment moved with it), `recordUserTurn`/`recordAssistantTurn` own the ledger writes.

### LLM tool port (`tools/llm.ts`)
`createLlmToolPort` moved out of `index.ts` next to `resolveLlmToolModel`, and now accepts the same `{ run?, resolveProviderModel? }` seam `ChatAgentConfig["llm"]` already defines. **Deliberate behavior fix:** boot passes `options.llm` through, so a composition booted on a fake model no longer lets this one port slip out to the real network. Production (no `options.llm`) is byte-identical.

## Tests added
- `boot-wiring.test.ts`: replyText, machines-port fold (attached/absent), channel-stage mount/dispose revocation of grant+route+surface.
- `rlm-tools.test.ts`: llm port — trace isolation, toolless one-step input, non-assistant/tool-activity discard, thrown provider failure, non-stop-without-error naming.
- `composition.test.ts`: `rollbackToCause` rethrow-by-identity and double-fault AggregateError.
- `e2e.test.ts`: real failed boot (occupied port) rolls back and the same config boots cleanly afterwards.
- `gateway-contracts.test.ts`: non-text payload refusal.
- `channel-composition.test.ts`: default (real-adapter) factory construction, no `start()`.

## Metrics (measured, not estimated)
- Cyclomatic max 18 (`startOpenOmni`, was 23; resident deliver was 26), cognitive max 13 (was 28) — eslint `complexity` + sonarjs on transpiled output.
- Coverage: `resident.ts`, `channels.ts`, `tools/llm.ts`, `composer.ts` 100% funcs/lines; `index.ts` 99.74% lines / 98.44% funcs — the sole uncovered "line" is the `});` closer of the machines-port map arrow whose both branches are asserted (Bun lcov artifact). CRAP max ≈ 18.
- Full suite 2575 pass / 0 fail single run; check-types, lint, ultracite, and all `script/` gates green.

## Not covered, on purpose
The `io.resolveProviderModel === undefined` branch of the llm port reaches `ModelsDev.get()`, which fetches the live model catalog on cache miss — a network boundary a unit test must not cross.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposes the two remaining over-budget functions from the composition series and closes the coverage gaps the audit found. One deliberate behavior fix: boot now passes `options.llm` into the llm tool port, so a composition booted on a fake model no longer lets that port reach the real network — production (no `options.llm`) is unchanged.

**Refactors**
- `startOpenOmni` becomes a linear script of module-level stages: actor registration, machines port, HTTP routes, and per-channel mounts.
- Boot rollback moves to `rollbackToCause` in `composer.ts`, which disposes, rethrows the original cause by identity, and surfaces both faults if rollback fails.
- Resident `deliver` splits into classify → record user turn → run → record assistant turn via `classifyDelivery`, `recordUserTurn`, and `recordAssistantTurn`.
- `createLlmToolPort` moves next to `resolveLlmToolModel` and accepts the same `{ run?, resolveProviderModel? }` seam `ChatAgentConfig["llm"]` already defines.
- New tests cover boot wiring, llm port substitution, rollback double-fault, failed-boot e2e rollback, non-text payload refusal, and real-adapter factory construction.

<sup>Written for commit ed0b6a52fb08899e17e539e9db6f1894ea723424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

