### PR TITLE
chore: deslop duplicated source shapes behind their single owners

### DIFF
--- a/packages/agent/src/core/execution/tools.ts
+++ b/packages/agent/src/core/execution/tools.ts
@@ -339,6 +339,24 @@ function sharedContext(context: ToolPolicyRunContext): Omit<
   };
 }
 
+/** The point-input fields every tool policy point shares, pre and post. */
+function toolPointInput(
+  context: ToolPolicyRunContext,
+  toolName: string,
+  call: Tool.Call,
+  labels: readonly string[] | undefined,
+  target: ReturnType<typeof policyTarget>,
+) {
+  return {
+    ...sharedContext(context),
+    toolId: toolName,
+    toolName,
+    toolCallId: call.id,
+    toolLabels: [...(labels ?? target.descriptor.labels)],
+    resourceDescriptor: target.descriptor,
+  };
+}
+
 async function dispatchToolPre(
   engine: PolicyEngineInstance,
   context: ToolPolicyRunContext,
@@ -349,13 +367,8 @@ async function dispatchToolPre(
 ): Promise<Policy.PolicyDecision> {
   const target = policyTarget(toolName, labels, descriptor);
   const input = {
-    ...sharedContext(context),
-    toolId: toolName,
-    toolName,
-    toolCallId: call.id,
-    toolLabels: [...(labels ?? target.descriptor.labels)],
+    ...toolPointInput(context, toolName, call, labels, target),
     toolInput: call.input,
-    resourceDescriptor: target.descriptor,
   };
   if (target.kind === "mcp") {
     const mcpInput = {
@@ -386,14 +399,9 @@ async function dispatchToolPost(
 ): Promise<Policy.PolicyDecision> {
   const target = policyTarget(toolName, labels, descriptor);
   const input = {
-    ...sharedContext(context),
-    toolId: toolName,
-    toolName,
-    toolCallId: call.id,
-    toolLabels: [...(labels ?? target.descriptor.labels)],
+    ...toolPointInput(context, toolName, call, labels, target),
     toolOutput: result.output,
     toolResult: result,
-    resourceDescriptor: target.descriptor,
   };
   if (target.kind === "mcp") {
     const mcpInput = {

--- a/packages/ledger/src/storage/sqlite-wait-adapter.ts
+++ b/packages/ledger/src/storage/sqlite-wait-adapter.ts
@@ -11,6 +11,26 @@ import {
  * (`Wait.Record.parse`); this adapter records receipts (`changes === 1`) and
  * re-validates only on read, across the persistence boundary.
  */
+/**
+ * The projection columns both writers stamp in the same order: the JSON
+ * snapshot, the CAS revision, status/partial, and the six correlation keys
+ * findByCorrelation matches on.
+ */
+function projectionBindings(record: Wait.Record) {
+  return [
+    JSON.stringify(record),
+    record.revision,
+    record.status,
+    record.partial ? 1 : 0,
+    record.correlation.endpointId ?? null,
+    record.correlation.channelId ?? null,
+    record.correlation.replyToMessageId ?? null,
+    record.correlation.threadId ?? null,
+    record.correlation.tokenHash ?? null,
+    record.correlation.externalConversationId ?? null,
+  ] as const;
+}
+
 export function createSqliteWaitAdapter(db: Database): ProtocolStorage.WaitSubAdapter {
   return {
     create(record) {
@@ -28,16 +48,7 @@ export function createSqliteWaitAdapter(db: Database): ProtocolStorage.WaitSubAd
           record.ownerRef.kind,
           record.ownerRef.id,
           record.originMessageId,
-          JSON.stringify(record),
-          record.revision,
-          record.status,
-          record.partial ? 1 : 0,
-          record.correlation.endpointId ?? null,
-          record.correlation.channelId ?? null,
-          record.correlation.replyToMessageId ?? null,
-          record.correlation.threadId ?? null,
-          record.correlation.tokenHash ?? null,
-          record.correlation.externalConversationId ?? null,
+          ...projectionBindings(record),
           record.expiresAt,
           followUpUntil(record),
           record.createdAt,
@@ -118,16 +129,7 @@ export function createSqliteWaitAdapter(db: Database): ProtocolStorage.WaitSubAd
            WHERE id = ? AND revision = ?`,
         )
         .run(
-          JSON.stringify(record),
-          record.revision,
-          record.status,
-          record.partial ? 1 : 0,
-          record.correlation.endpointId ?? null,
-          record.correlation.channelId ?? null,
-          record.correlation.replyToMessageId ?? null,
-          record.correlation.threadId ?? null,
-          record.correlation.tokenHash ?? null,
-          record.correlation.externalConversationId ?? null,
+          ...projectionBindings(record),
           followUpUntil(record),
           record.updatedAt,
           id,

--- a/packages/protocol/src/delegation/schema.ts
+++ b/packages/protocol/src/delegation/schema.ts
@@ -248,29 +248,17 @@ export type SettledStatus = z.infer<typeof SettledStatus>;
  * open->settled compare-and-swap. Protocol owns the serializable shape; the
  * store implementation lives in the ledger.
  */
-const RecordBase = z
-  .object({
-    delegationId: z.string().min(1),
-    operation: Operation,
-    address: WorkerAddress,
-    transport: Transport,
-    /** Effective deadline (epoch ms) — the same instant the Handle carries. */
-    deadline: EpochMs.int().positive(),
-    waitId: z.string().min(1).optional(),
-    workItemId: z.string().min(1).optional(),
-    parentDelegationId: z.string().min(1).optional(),
-    rootDelegationId: z.string().min(1),
-    origin: Origin,
-    /** Summary of the request payload text (truncation is the writer's choice). */
-    instruction: z.string().min(1),
-    status: z.enum(["open", "settled"]),
-    settled: Settled.optional(),
-    createdAt: EpochMs,
-    settledAt: EpochMs.optional(),
-    /** Receipt written only after the owner-session settlement wake succeeds. */
-    wokenAt: EpochMs.optional(),
-  })
-  .strict();
+const RecordBase = Handle.extend({
+  origin: Origin,
+  /** Summary of the request payload text (truncation is the writer's choice). */
+  instruction: z.string().min(1),
+  status: z.enum(["open", "settled"]),
+  settled: Settled.optional(),
+  createdAt: EpochMs,
+  settledAt: EpochMs.optional(),
+  /** Receipt written only after the owner-session settlement wake succeeds. */
+  wokenAt: EpochMs.optional(),
+}).strict();
 
 export const Record = RecordBase.superRefine((record, ctx) => {
   if (record.status === "settled" && (record.settled === undefined || record.settledAt === undefined)) {

--- a/packages/protocol/src/wait/schema.ts
+++ b/packages/protocol/src/wait/schema.ts
@@ -164,15 +164,9 @@ export const Create = RecordBase.omit({
 });
 export type Create = z.infer<typeof Create>;
 
-export const CorrelationQuery = z
-  .object({
-    endpointId: z.string().min(1).optional(),
-    channelId: z.string().min(1).optional(),
-    replyToMessageId: z.string().min(1).optional(),
-    threadId: z.string().min(1).optional(),
-    tokenHash: z.string().min(1).optional(),
-    externalConversationId: z.string().min(1).optional(),
-  })
+// Derived from the single owner of the correlation fields; omitting
+// engagementId is the load-bearing part (it must never become a matching key).
+export const CorrelationQuery = Correlation.omit({ engagementId: true })
   .strict()
   .refine((query) => Object.values(query).some((value) => value !== undefined), {
     message: "At least one correlation field is required",


### PR DESCRIPTION
## What

Repo-wide slop sweep, closing the review series. The survey first, then the smallest true fixes.

### Survey results (what was checked, what was found)
- **knip**: clean — no unused files, exports, or dependencies (only config hints).
- **dead-export ratchet**: 0 known issues, baseline already `{}` — nothing to shrink.
- **TODO/FIXME/HACK** in src: none.
- **Bare `catch {}` blocks** (10): every one is a documented boundary guard (URL parse, hostile Error getters, malformed gateway frames, observer isolation, CAS-conflict expiry). Kept.
- **`legacy`/`deprecated` mentions**: all are live migration-compat paths (frozen `worker_run_state` upcasts, actor-resolver legacy shapes, ledger hash-chain compat) — product behavior, not slop. Kept per reconcile-before-deletion.
- **Silent-default `??` fallbacks** in src: all are Zod-boundary refusal messages or optional-field defaults at real system boundaries. Kept.
- **jscpd (`--min-tokens 70`) over all src**: 6 clones — 4 real, 2 documented-deliberate.

### The 4 real duplications, now derived from their single owners
- `packages/agent/src/core/execution/tools.ts` — `toolPointInput()` shares the pre/post tool policy point input base; the mcp narrowing branches keep their distinct fail-closed (pre) vs fail-open (post) rationales.
- `packages/ledger/src/storage/sqlite-wait-adapter.ts` — `projectionBindings()` is the one spelling of the projection columns both writers stamp (INSERT and the CAS UPDATE), so the correlation columns can no longer drift between them.
- `packages/protocol/src/delegation/schema.ts` — `RecordBase` now extends `Handle` instead of restating its nine fields.
- `packages/protocol/src/wait/schema.ts` — `CorrelationQuery` derives from `Correlation` via `omit({ engagementId })`; the omission is the load-bearing invariant (engagementId must never become a matching key, gateway-design §5).

### Deliberately kept
- `policy-point.ts` inline structural validators (documented declaration-emission reason for the duplication with `Tool.Spec`/`Tool.Result`).
- Test-side `as never` casts: they fabricate deliberately-invalid shapes for adversarial tests.

No shipped behavior changes, so `docs/implementation-status.md` needs no update.

## Verification
- Schema-snapshot conformance lint green — the derived schemas produce identical shapes.
- `check-types`, `lint`, `lint:tools`, topology/deps/import-cycles/dead-exports/tsconfig/ledger gates: all green.
- Full repo suite after rebase onto latest main: **2575 pass / 0 fail** (306 files).
- jscpd over src after: 2 clones remaining, both the documented-deliberate pair.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the four real source duplications found in the repo-wide slop sweep, deriving each from its single owner instead of restating it. No behavior changes — schema-snapshot lint confirms identical shapes and the full suite passes (2575 pass, 0 fail).

**Refactors**
- `toolPointInput()` in `packages/agent/src/core/execution/tools.ts` shares the pre/post tool policy input base; the MCP narrowing branches keep their distinct fail-open vs fail-closed rationales.
- `projectionBindings()` in `packages/ledger/src/storage/sqlite-wait-adapter.ts` is the single spelling of the projection columns both the INSERT and CAS UPDATE writers stamp.
- `RecordBase` in `packages/protocol/src/delegation/schema.ts` extends `Handle` instead of restating its nine fields.
- `CorrelationQuery` in `packages/protocol/src/wait/schema.ts` derives from `Correlation` via `omit({ engagementId })` — the omission is load-bearing so `engagementId` can never become a matching key.

**Kept deliberately**
- `policy-point.ts` inline structural validators stay duplicated for documented declaration-emission reasons.
- Test-side `as never` casts fabricate invalid shapes for adversarial tests; all bare `catch {}` blocks are documented boundary guards.
- The rest of the survey came back clean: knip, dead exports, and TODO/FIXME are all zero.

<sup>Written for commit 7dbfa1e866c3066d348c5ac758c580acd4f79b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal consistency when processing tool actions and storing wait records.
  - Streamlined protocol validation by deriving related schemas from shared definitions.
  - Preserved existing validation rules and database behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->