### PR TITLE
test: replace timing-based waits with deterministic completion signals

### DIFF
--- a/packages/agent/test/core/retry.test.ts
+++ b/packages/agent/test/core/retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { Retry } from "@openomni/llm";
 
 import {
@@ -14,21 +14,31 @@ describe("Retry.sleep", () => {
   it("rejects immediately when the signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort();
+    // "Immediately" means no timer was ever scheduled. That is the exact
+    // observable; the old `elapsed < 100` bound was a proxy a loaded machine
+    // could fail while a real 50ms regression still passed it.
+    const timeout = spyOn(globalThis, "setTimeout");
 
-    const started = Date.now();
-
-    await expect(Retry.sleep(5_000, controller.signal)).rejects.toThrow(/aborted/i);
-    expect(Date.now() - started).toBeLessThan(100);
+    try {
+      await expect(Retry.sleep(5_000, controller.signal)).rejects.toThrow(/aborted/i);
+      expect(timeout).not.toHaveBeenCalled();
+    } finally {
+      timeout.mockRestore();
+    }
   });
 
   it("rejects when the signal aborts during sleep", async () => {
     const controller = new AbortController();
+    const sleeping = Retry.sleep(5_000, controller.signal);
 
-    setTimeout(() => controller.abort(), 5);
-    const started = Date.now();
+    // The sleep registered its timer and abort listener synchronously, so the
+    // abort races nothing: no 5ms timer and no wall-clock bound needed. The
+    // rejection identity IS the proof that the abort cut the pending sleep
+    // short - a 5s sleep that ran to completion resolves, it does not reject.
+    await Promise.resolve();
+    controller.abort();
 
-    await expect(Retry.sleep(5_000, controller.signal)).rejects.toThrow(/aborted/i);
-    expect(Date.now() - started).toBeLessThan(500);
+    await expect(sleeping).rejects.toThrow(/aborted/i);
   });
 
   it("removes the abort listener after normal completion", async () => {
@@ -48,10 +58,24 @@ describe("Retry.sleep", () => {
       return originalRemoveEventListener(...args);
     }) as AbortSignal["removeEventListener"];
 
-    await Retry.sleep(1, signal);
+    let fireTimer: (() => void) | undefined;
+    const timeout = spyOn(globalThis, "setTimeout").mockImplementation(
+      ((callback: Parameters<typeof setTimeout>[0]) => {
+        if (typeof callback === "function") fireTimer = callback;
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+    );
 
-    expect(added).toBe(1);
-    expect(removed).toBe(1);
+    try {
+      const sleeping = Retry.sleep(1, signal);
+      expect(added).toBe(1);
+      if (fireTimer === undefined) expect.unreachable("Expected sleep to schedule a timer");
+      fireTimer();
+      await sleeping;
+      expect(removed).toBe(1);
+    } finally {
+      timeout.mockRestore();
+    }
   });
 });
 

--- a/packages/channels/test/websocket.test.ts
+++ b/packages/channels/test/websocket.test.ts
@@ -114,14 +114,24 @@ describe("WebSocketHandler authentication", () => {
       message = inbound;
       return { text: "ok" };
     }, noopPublish);
+    // `handler.ws.message` fires `void handleMessage(...)`
+    // (src/websocket.ts:72) and returns nothing to await. The reply frame is
+    // the LAST step of that path (src/websocket.ts:171), so resolving from
+    // inside `send` is the exact completion signal for the whole path -
+    // strictly stronger than a macrotask guess, which cannot distinguish
+    // "finished" from "not started yet".
+    const replied = Promise.withResolvers<void>();
     const sent: string[] = [];
     const ws = {
       data: { surfaceKey: "ws:test", authenticated: true },
-      send: (msg: string) => sent.push(msg),
+      send: (msg: string) => {
+        sent.push(msg);
+        replied.resolve();
+      },
     };
 
     handler.ws.message(ws, JSON.stringify({ text: "show open tasks" }));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await replied.promise;
 
     expect(message?.raw).toEqual({ websocket: { authenticated: true } });
     expect(sent).toEqual([JSON.stringify({ type: "response", text: "ok" })]);
@@ -157,9 +167,21 @@ describe("WebSocketHandler authentication", () => {
 describe("WebSocketHandler actor connections", () => {
   function wsConnection(data: Record<string, unknown>) {
     const sent: string[] = [];
+    // Resolves on the first frame the handler writes back. `ws.send` is the
+    // final step of the inbound path (src/websocket.ts:171), so awaiting it is
+    // the exact completion signal for a `handler.ws.message` call, which is
+    // fire-and-forget (src/websocket.ts:72).
+    const framed = Promise.withResolvers<void>();
     return {
       sent,
-      ws: { data: data as never, send: (msg: string) => sent.push(msg) },
+      framed: framed.promise,
+      ws: {
+        data: data as never,
+        send: (msg: string) => {
+          sent.push(msg);
+          framed.resolve();
+        },
+      },
     };
   }
 
@@ -238,16 +260,19 @@ describe("WebSocketHandler actor connections", () => {
       noopPublish,
       { token: "secret-token" },
     );
-    const { ws } = wsConnection({
+    const { ws, framed, sent } = wsConnection({
       surfaceKey: "ws::dm:c1",
       authenticated: true,
       externalId: "alice",
     });
 
     handler.ws.message(ws, JSON.stringify({ text: "done", replyToId: "frame-7" }));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await framed;
 
     expect(inbound?.sender).toEqual({ id: "alice", name: "alice" });
     expect(inbound?.replyToId).toBe("frame-7");
+    // The frame the wait resolved on is the handler's reply, not an error
+    // frame from the catch arm (src/websocket.ts:173-180).
+    expect(sent).toEqual([JSON.stringify({ type: "response", text: "ok" })]);
   });
 });

--- a/packages/ledger/test/bus-persistence/bus-persistence.test.ts
+++ b/packages/ledger/test/bus-persistence/bus-persistence.test.ts
@@ -34,19 +34,23 @@ function rows(): BusEventRow[] {
   return db().query("SELECT * FROM bus_event ORDER BY id ASC").all() as BusEventRow[];
 }
 
-async function flushPersistence(): Promise<void> {
-  await new Promise((resolve) => queueMicrotask(resolve));
-  await new Promise((resolve) => queueMicrotask(resolve));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-async function waitForRows(expectedCount: number): Promise<BusEventRow[]> {
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    const current = rows();
-    if (current.length >= expectedCount) return current;
-    await flushPersistence();
+/**
+ * `BusPersistence.flush()` is the exact quiescence barrier: it returns only on
+ * a turn that commits nothing with no writes in flight
+ * (`src/bus-persistence/runtime-state.ts:128-143`), which
+ * `flush-barrier.test.ts:50-57` pins. A shortfall after it is a real
+ * persistence defect, so this throws with the observed count instead of
+ * handing back a short array for a downstream assertion to misreport.
+ */
+async function persistedRows(expectedCount: number): Promise<BusEventRow[]> {
+  await BusPersistence.flush();
+  const current = rows();
+  if (current.length < expectedCount) {
+    throw new Error(
+      `persistence barrier resolved with ${current.length} rows, expected at least ${expectedCount}`,
+    );
   }
-  return rows();
+  return current;
 }
 
 function createSession(): ReturnType<typeof Session.create> {
@@ -95,7 +99,7 @@ describe("BusPersistence", () => {
       label: "ok",
     });
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     expect(persisted).toHaveLength(1);
     expect(persisted[0]).toMatchObject({
       session_id: session.id,
@@ -134,7 +138,7 @@ describe("BusPersistence", () => {
     Bus.publish(untraceable, { sessionId: session.id, time: Date.now() });
     Bus.publish(traced, { sessionId: session.id, traceId: "trace-verbatim", time: Date.now() });
 
-    const persisted = await waitForRows(2);
+    const persisted = await persistedRows(2);
     expect(persisted).toHaveLength(2);
     // Queryable absence: the sentinel is greppable in the ledger, and no
     // random mint launders the untraceable event into a plausible trace.
@@ -164,7 +168,7 @@ describe("BusPersistence", () => {
     BusPersistence.start();
     Bus.publish(event, {});
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     expect(persisted[0]).toMatchObject({
       session_id: session.id,
       trace_id: "trace-from-schema",
@@ -203,7 +207,7 @@ describe("BusPersistence", () => {
     BusPersistence.start();
     Bus.publish(event, rawPayload);
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     const firstRaw = persisted[0];
     if (firstRaw === undefined) throw new Error("shape");
     expect(firstRaw).toMatchObject({
@@ -235,7 +239,7 @@ describe("BusPersistence", () => {
     BusPersistence.start();
     Bus.publish(event, rawPayload);
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     const firstRaw = persisted[0];
     if (firstRaw === undefined) throw new Error("shape");
     expect(firstRaw).toMatchObject({
@@ -256,7 +260,7 @@ describe("BusPersistence", () => {
 
     BusPersistence.start();
     Bus.publish(event, { sessionId: session.id, traceId: "trace-ephemeral", time: Date.now() });
-    await flushPersistence();
+    await BusPersistence.flush();
 
     expect(rows()).toEqual([]);
   });
@@ -278,7 +282,7 @@ describe("BusPersistence", () => {
       });
     }
 
-    const persisted = await waitForRows(5);
+    const persisted = await persistedRows(5);
     expect(persisted).toHaveLength(5);
     expect(persisted.map((row) => JSON.parse(row.data).index)).toEqual([0, 1, 2, 3, 4]);
     expect(persisted.map((row) => row.id)).toEqual([1, 2, 3, 4, 5]);
@@ -354,7 +358,7 @@ describe("BusPersistence", () => {
       time: Number.POSITIVE_INFINITY,
     });
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     expect(persisted[0]).toMatchObject({
       session_id: session.id,
       trace_id: "trace-non-finite",
@@ -372,7 +376,7 @@ describe("BusPersistence", () => {
 
     BusPersistence.start();
     Bus.publish(event, { sessionID: session.id, marker: "m1" });
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
 
     expect(persisted.map((row) => row.event_type)).toEqual(["legacy.session_id.recorded"]);
     for (const row of persisted) {
@@ -427,7 +431,7 @@ describe("BusPersistence", () => {
       time: 2,
     });
 
-    const persisted = await waitForRows(2);
+    const persisted = await persistedRows(2);
     expect(persisted.map((row) => row.session_id)).toEqual([session.id, session.id]);
     expect(persisted.map((row) => row.event_type)).toEqual([
       "legacy_probe.opened",
@@ -476,7 +480,7 @@ describe("BusPersistence", () => {
       time: 3,
     });
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     const runRow = persisted.find((row) => row.event_type === "worker_run.evaluated");
     expect(runRow?.session_id).toBe(workSession.id);
   });
@@ -499,7 +503,7 @@ describe("BusPersistence", () => {
       time: Date.UTC(2026, 4, 10, 1, 2, 9),
     });
 
-    const persisted = await waitForRows(1);
+    const persisted = await persistedRows(1);
     expect(persisted[0]).toMatchObject({
       session_id: null,
       trace_id: "trace-worker-lookup-error",
@@ -526,7 +530,7 @@ describe("BusPersistence", () => {
           time: Date.now(),
         });
       }).not.toThrow();
-      await flushPersistence();
+      await BusPersistence.flush();
 
       expect(rows()).toEqual([]);
       expect(warning).toBeDefined();
@@ -544,11 +548,11 @@ describe("BusPersistence", () => {
 
     BusPersistence.start();
     Bus.publish(event, { sessionId: session.id, traceId: "trace-before", time: Date.now() });
-    expect(await waitForRows(1)).toHaveLength(1);
+    expect(await persistedRows(1)).toHaveLength(1);
 
     BusPersistence.stop();
     Bus.publish(event, { sessionId: session.id, traceId: "trace-after", time: Date.now() });
-    await flushPersistence();
+    await BusPersistence.flush();
 
     expect(rows()).toHaveLength(1);
   });
@@ -583,9 +587,7 @@ describe("BusPersistence", () => {
         generatedAt: new Date("2026-05-16T00:00:00.000Z"),
       },
     });
-    await BusPersistence.flush();
-
-    const redactRows = await waitForRows(1);
+    const redactRows = await persistedRows(1);
     const redactRow = redactRows[0];
     if (redactRow === undefined) throw new Error("shape");
     const data = JSON.parse(redactRow.data) as {
@@ -637,7 +639,7 @@ describe("BusPersistence", () => {
       context,
     });
 
-    const cycleRows = await waitForRows(1);
+    const cycleRows = await persistedRows(1);
     const cycleRow = cycleRows[0];
     if (cycleRow === undefined) throw new Error("shape");
     const data = JSON.parse(cycleRow.data) as {
@@ -684,7 +686,7 @@ describe("BusPersistence", () => {
       writeSpy.mockRestore();
     }
 
-    const msgRows = await waitForRows(1);
+    const msgRows = await persistedRows(1);
     const msgRow = msgRows[0];
     if (msgRow === undefined) throw new Error("shape");
     const data = JSON.parse(msgRow.data) as {

--- a/packages/ledger/test/bus-persistence/hash-chain.test.ts
+++ b/packages/ledger/test/bus-persistence/hash-chain.test.ts
@@ -52,19 +52,24 @@ function chainRows(sessionId?: string): EventChainRow[] {
   return db().query("SELECT * FROM event_chain ORDER BY seq ASC").all() as EventChainRow[];
 }
 
-async function flushPersistence(): Promise<void> {
-  await new Promise((resolve) => queueMicrotask(resolve));
-  await new Promise((resolve) => queueMicrotask(resolve));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-async function waitForRows(expectedCount: number): Promise<BusEventRow[]> {
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    const current = busRows();
-    if (current.length >= expectedCount) return current;
-    await flushPersistence();
+/**
+ * `BusPersistence.flush()` is the exact quiescence barrier: it returns only on
+ * a turn that commits nothing with no writes in flight
+ * (`src/bus-persistence/runtime-state.ts:128-143`), which
+ * `flush-barrier.test.ts:50-57` pins. A shortfall after it is a real
+ * persistence defect, so this throws with the observed count instead of
+ * handing back a short array — several call sites discard the return value and
+ * would otherwise assert against a chain the writer never finished.
+ */
+async function persistedRows(expectedCount: number): Promise<BusEventRow[]> {
+  await BusPersistence.flush();
+  const current = busRows();
+  if (current.length < expectedCount) {
+    throw new Error(
+      `persistence barrier resolved with ${current.length} rows, expected at least ${expectedCount}`,
+    );
   }
-  return busRows();
+  return current;
 }
 
 function createSession(): ReturnType<typeof Session.create> {
@@ -109,7 +114,7 @@ describe("Hash Chain", () => {
       index: 0,
     });
 
-    const rows = await waitForRows(1);
+    const rows = await persistedRows(1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.prev_hash).toBe(GENESIS_SEED);
     expect(rows[0]?.event_hash).toBeString();
@@ -129,7 +134,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    const rows = await waitForRows(3);
+    const rows = await persistedRows(3);
     expect(rows).toHaveLength(3);
 
     const [row0, row1, row2] = rows;
@@ -152,7 +157,7 @@ describe("Hash Chain", () => {
       index: 0,
     });
 
-    await waitForRows(1);
+    await persistedRows(1);
     const chain = chainRows(session.id);
     const events = busRows(session.id);
 
@@ -182,7 +187,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(5);
+    await persistedRows(5);
     const result = await BusQuery.verifyChainIntegrity(session.id);
 
     expect(result.valid).toBe(true);
@@ -203,7 +208,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(3);
+    await persistedRows(3);
     const rows = busRows(session.id);
     BusPersistence.stop();
     const firstRow = rows[0];
@@ -251,7 +256,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(2);
+    await persistedRows(2);
     BusPersistence.stop();
     // session_id is not part of the hash input, so detaching the rows from
     // the session moves them onto the sessionless chain without breaking it.
@@ -276,7 +281,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(3);
+    await persistedRows(3);
     const rows = busRows(session.id);
     const tamperedRow = rows[1];
     if (tamperedRow === undefined) throw new Error("shape");
@@ -302,7 +307,7 @@ describe("Hash Chain", () => {
       index: 0,
     });
 
-    await waitForRows(1);
+    await persistedRows(1);
     const rows = busRows(session.id);
     const tamperedRow = rows[0];
     if (tamperedRow === undefined) throw new Error("shape");
@@ -330,7 +335,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(3);
+    await persistedRows(3);
     const rows = busRows(session.id);
     const tamperedRow = rows[2];
     if (tamperedRow === undefined) throw new Error("shape");
@@ -363,7 +368,7 @@ describe("Hash Chain", () => {
       index: 0,
     });
 
-    await waitForRows(2);
+    await persistedRows(2);
     const rowsA = busRows(sessionA.id);
     const rowsB = busRows(sessionB.id);
 
@@ -390,7 +395,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(3);
+    await persistedRows(3);
     const chainBefore = chainRows(session.id);
     expect(chainBefore).toHaveLength(3);
 
@@ -416,7 +421,7 @@ describe("Hash Chain", () => {
       });
     }
 
-    await waitForRows(3);
+    await persistedRows(3);
     const audit = chainRows(session.id);
 
     expect(audit).toHaveLength(3);

--- a/packages/ledger/test/bus-persistence/persistence-attribution.test.ts
+++ b/packages/ledger/test/bus-persistence/persistence-attribution.test.ts
@@ -27,12 +27,6 @@ function rows(eventType: string): BusEventRow[] {
     .all(eventType) as BusEventRow[];
 }
 
-async function flushPersistence(): Promise<void> {
-  await new Promise((resolve) => queueMicrotask(resolve));
-  await new Promise((resolve) => queueMicrotask(resolve));
-  await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 describe("persistence attribution refuses to launder foreign ids", () => {
   beforeEach(() => {
     Bus.reset();
@@ -52,7 +46,7 @@ describe("persistence attribution refuses to launder foreign ids", () => {
     // FK-failed against the session table and silently DROPPED every wait.*
     // row. Wait events carry no session; they belong to the sessionless chain.
     WaitStore.create(buildWaitCreate(), "trace-wait-persist");
-    await flushPersistence();
+    await BusPersistence.flush();
 
     expect(rows("wait.opened")).toEqual([
       { session_id: null, event_type: "wait.opened", trace_id: "trace-wait-persist" },
@@ -68,14 +62,14 @@ describe("persistence attribution refuses to launder foreign ids", () => {
       title: "Doomed",
       model: { providerID: "test", modelID: "test-model" },
     });
-    await flushPersistence();
+    await BusPersistence.flush();
     // While the session lives, its created row is session-attributed.
     expect(rows("session.created")).toEqual([
       { session_id: session.id, event_type: "session.created", trace_id: "trace-delete-persist" },
     ]);
 
     Session.remove(session.id, "trace-delete-persist");
-    await flushPersistence();
+    await BusPersistence.flush();
 
     expect(rows("session.deleted")).toEqual([
       { session_id: null, event_type: "session.deleted", trace_id: "trace-delete-persist" },
@@ -125,8 +119,7 @@ describe("persistence failure is loud and contained", () => {
       model: { providerID: "test", modelID: "test-model" },
     });
     WaitStore.create(buildWaitCreate({ id: "wait-poison" }), "trace-poison");
-    await flushPersistence();
-    await flushPersistence();
+    await BusPersistence.flush();
 
     // The poison row (session.created → bogus FK) is gone; its batch-mate
     // survived the per-row retry.
@@ -165,8 +158,7 @@ describe("persistence failure is loud and contained", () => {
       component: "test-producer",
       msg: "poison warn",
     });
-    await flushPersistence();
-    await flushPersistence();
+    await BusPersistence.flush();
 
     // Exactly ONE logical drop: the poison warn. The self-warn persisted, so
     // it must not have re-entered the drop path (no double count).

--- a/packages/ledger/test/session/events.test.ts
+++ b/packages/ledger/test/session/events.test.ts
@@ -6,9 +6,15 @@ import { Session } from "../../src/session";
 import { Storage } from "../../src/storage/storage";
 import "../../src/storage/initialize";
 
-/** Bus delivery is microtask-queued; flush before asserting on received events. */
+/**
+ * `Bus.publish` dispatches every subscriber in exactly one `queueMicrotask`
+ * (`packages/telemetry/src/bus.ts:55-64`) with a synchronous handler body, and
+ * the microtask queue drains completely before an awaiting continuation
+ * resumes. One hop is therefore the exact completion signal for the publishes
+ * already made, not a guess at scheduling latency.
+ */
 function flushBus(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
+  return new Promise((resolve) => queueMicrotask(resolve));
 }
 
 describe("Session events carry the caller's trace (D11)", () => {

--- a/packages/ledger/test/ttl.test.ts
+++ b/packages/ledger/test/ttl.test.ts
@@ -7,9 +7,17 @@ import { Bus } from "@openomni/telemetry";
 import { Storage } from "../src/storage/storage";
 import "../src/storage/initialize";
 
-/** Bus delivery is microtask-queued; flush before asserting on received events. */
+/**
+ * `Bus.publish` queues every subscriber in exactly one `queueMicrotask`
+ * (`packages/telemetry/src/bus.ts:55-64`), and the queue drains completely
+ * before an awaiting continuation resumes. Every call under test here returns
+ * synchronously, so anything it published is already queued when this runs:
+ * one hop is the exact signal in both directions - it proves a delivery
+ * arrived, and for the negative cases it proves the queue was drained past the
+ * point where an unwanted delivery would have landed.
+ */
 function flushBus(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
+  return new Promise((resolve) => queueMicrotask(resolve));
 }
 
 describe("Session TTL", () => {

--- a/packages/ledger/test/worker-run/frozen.test.ts
+++ b/packages/ledger/test/worker-run/frozen.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { Storage } from "../../src/storage/storage";
 import "../../src/storage/initialize";
@@ -43,8 +44,26 @@ function seedFrozenRun(
   });
 }
 
-async function flushBus(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
+const OBSERVER_DRAINED = "observer-drained";
+
+/**
+ * Positive control for a negative assertion. `Bus.publish` dispatches every
+ * observer in exactly one `queueMicrotask` (`packages/telemetry/src/bus.ts:38-49`)
+ * and the queue drains completely before an awaiting continuation resumes, so
+ * publishing a sentinel AFTER the frozen writes and awaiting its arrival in the
+ * same observer proves two things a timer cannot: the observer is live, and the
+ * queue drained past the point where any publish from those writes would have
+ * been delivered. A bare timer proves only that some duration elapsed, so a
+ * slow-but-real publish would still pass the `toEqual([])` below.
+ */
+async function observerDrained(): Promise<void> {
+  Bus.publish(Operational.Events.Warn, {
+    traceId: "trace-frozen-drain",
+    time: Date.now(),
+    component: OBSERVER_DRAINED,
+    msg: "drain sentinel",
+  });
+  await new Promise((resolve) => queueMicrotask(resolve));
 }
 
 beforeEach(() => {
@@ -113,8 +132,10 @@ describe("WorkerRun freeze (#510 D2b)", () => {
     }
     expectFrozen(thrownIfCurrent, "updateStatusIfCurrent");
 
-    await flushBus();
-    expect(events).toEqual([]);
+    await observerDrained();
+    // Only the drain sentinel arrived: the frozen writes published nothing,
+    // and the observer is proven live rather than merely idle for a duration.
+    expect(events).toEqual([Operational.Events.Warn.name]);
     expect(WorkerRunStateStore.get("sess-frozen", "run-legacy-store")?.status).toBe("starting");
   });
 

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -203,10 +203,9 @@ describe("Processor instant transport-failure streak", () => {
       // attempts, and the two waits between them are probe delays, not the
       // 2s/4s exponential ladder.
       expect(attemptCount).toBe(3);
-      expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([
-        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
-        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
-      ]);
+      // 250ms is the externally required short-probe contract. Keep the
+      // expectation independent of the production constant so drift is loud.
+      expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([250, 250]);
 
       // Each decided delay is also published as `backoffMs` on RetryDecided
       // (src/processor/index.ts:308-317), pinning the externally visible
@@ -214,10 +213,7 @@ describe("Processor instant transport-failure streak", () => {
       const decided = events
         .named(LlmCall.Events.RetryDecided.name)
         .map((event) => (event as { backoffMs?: number }).backoffMs);
-      expect(decided).toEqual([
-        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
-        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
-      ]);
+      expect(decided).toEqual([250, 250]);
 
       // A retryable error declined for a non-"non_retryable" reason must say
       // why, through the port.

--- a/packages/llm/test/processor/retry-cap.test.ts
+++ b/packages/llm/test/processor/retry-cap.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
   anthropicModel as model,
   assistantMessage as buildAssistantMessage,
@@ -170,6 +170,10 @@ describe("Processor instant transport-failure streak", () => {
 
   test("three instant connection failures end the run instead of burning the backoff budget", async () => {
     let attemptCount = 0;
+    // Delay selection is observable through both the retry event and this
+    // scheduler boundary. Resolve it synchronously so the test pins the exact
+    // probe ladder without spending 500ms on real timers.
+    const sleep = spyOn(Retry, "sleep").mockResolvedValue(undefined);
     const processor = Processor.create({
       assistantMessage: buildAssistantMessage(
         "msg-instant-streak",
@@ -192,24 +196,40 @@ describe("Processor instant transport-failure streak", () => {
       }),
     });
 
-    const startedAt = Date.now();
-    await expect(processor.process({ system: "" })).rejects.toBeDefined();
-    const elapsed = Date.now() - startedAt;
+    try {
+      await expect(processor.process({ system: "" })).rejects.toBeDefined();
 
-    // The streak declines on the third instant failure: exactly three
-    // attempts, and the two waits between them are probe delays, not the
-    // 2s/4s exponential ladder (which alone would exceed 6s here).
-    expect(attemptCount).toBe(3);
-    expect(elapsed).toBeLessThan(2000);
+      // The streak declines on the third instant failure: exactly three
+      // attempts, and the two waits between them are probe delays, not the
+      // 2s/4s exponential ladder.
+      expect(attemptCount).toBe(3);
+      expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([
+        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
+        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
+      ]);
 
-    // A retryable error declined for a non-"non_retryable" reason must say
-    // why, through the port.
-    const declined = events
-      .named(Operational.Events.Error.name)
-      .map((event) => event as { component?: string; msg?: string; error?: string });
-    const fromRetry = declined.filter((event) => event.component === "llm.retry");
-    expect(fromRetry).toHaveLength(1);
-    expect(fromRetry[0]?.msg).toBe("retry declined");
-    expect(String(fromRetry[0]?.error)).toContain("transport");
+      // Each decided delay is also published as `backoffMs` on RetryDecided
+      // (src/processor/index.ts:308-317), pinning the externally visible
+      // decision rather than inferring it from an elapsed-time upper bound.
+      const decided = events
+        .named(LlmCall.Events.RetryDecided.name)
+        .map((event) => (event as { backoffMs?: number }).backoffMs);
+      expect(decided).toEqual([
+        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
+        Retry.INSTANT_FAILURE_PROBE_DELAY_MS,
+      ]);
+
+      // A retryable error declined for a non-"non_retryable" reason must say
+      // why, through the port.
+      const declined = events
+        .named(Operational.Events.Error.name)
+        .map((event) => event as { component?: string; msg?: string; error?: string });
+      const fromRetry = declined.filter((event) => event.component === "llm.retry");
+      expect(fromRetry).toHaveLength(1);
+      expect(fromRetry[0]?.msg).toBe("retry declined");
+      expect(String(fromRetry[0]?.error)).toContain("transport");
+    } finally {
+      sleep.mockRestore();
+    }
   });
 });

--- a/packages/llm/test/retry/retry.test.ts
+++ b/packages/llm/test/retry/retry.test.ts
@@ -42,19 +42,48 @@ describe("Retry", () => {
 
   describe("sleep(ms, abortSignal)", () => {
     test("resolves without an abort signal", async () => {
-      await Retry.sleep(0);
+      let fireTimer: (() => void) | undefined;
+      const timeout = vi.spyOn(globalThis, "setTimeout").mockImplementation(
+        ((callback: Parameters<typeof setTimeout>[0]) => {
+          if (typeof callback === "function") fireTimer = callback;
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        }) as typeof setTimeout,
+      );
+      try {
+        const sleeping = Retry.sleep(0);
+        if (fireTimer === undefined) expect.unreachable("Expected sleep to schedule a timer");
+        fireTimer();
+        await sleeping;
+      } finally {
+        timeout.mockRestore();
+      }
     });
 
-    test("resolves after specified milliseconds", async () => {
-      const start = Date.now();
-      await Retry.sleep(100, new AbortController().signal);
-      expect(Date.now() - start).toBeGreaterThanOrEqual(90);
+    test("schedules exactly the requested delay", async () => {
+      // The contract is which delay reaches the timer, not how long the test
+      // process actually slept: an elapsed-time assertion pins the platform
+      // scheduler instead of `sleep` and costs the full delay every run.
+      const timeout = vi.spyOn(globalThis, "setTimeout");
+      const controller = new AbortController();
+      try {
+        const sleeping = Retry.sleep(100, controller.signal);
+
+        expect(timeout).toHaveBeenCalledWith(expect.any(Function), 100);
+        controller.abort();
+        await expect(sleeping).rejects.toHaveProperty("name", "AbortError");
+      } finally {
+        timeout.mockRestore();
+      }
     });
 
     test("respects AbortSignal and throws AbortError", async () => {
       const controller = new AbortController();
       const promise = Retry.sleep(1000, controller.signal);
-      setTimeout(() => controller.abort(), 50);
+      // Aborting on the next microtask, not after a 50ms timer: the sleep is
+      // already pending (its `setTimeout` was registered synchronously by
+      // src/retry/index.ts:19-26), so the abort races nothing.
+      await Promise.resolve();
+      controller.abort();
       try {
         await promise;
         expect.unreachable("Should have thrown AbortError");
@@ -79,15 +108,20 @@ describe("Retry", () => {
     test("rejects immediately when signal is already aborted", async () => {
       const controller = new AbortController();
       controller.abort();
-      const start = Date.now();
+      // "Immediately" means no timer was ever scheduled (src/retry/index.ts:10-12
+      // throws before the Promise body runs). Pinning that is exact; the old
+      // `elapsed < 100` bound was a proxy that a loaded machine could fail and
+      // that a 50ms regression would still pass.
+      const timeout = vi.spyOn(globalThis, "setTimeout");
       try {
-        await Retry.sleep(5000, controller.signal);
-        expect.unreachable("Should have thrown AbortError");
-      } catch (error) {
-        expect(error).toBeInstanceOf(DOMException);
-        expect((error as DOMException).name).toBe("AbortError");
+        await expect(Retry.sleep(5000, controller.signal)).rejects.toHaveProperty(
+          "name",
+          "AbortError",
+        );
+        expect(timeout).not.toHaveBeenCalled();
+      } finally {
+        timeout.mockRestore();
       }
-      expect(Date.now() - start).toBeLessThan(100);
     });
 
     test("caps delay at RETRY_MAX_DELAY", async () => {


### PR DESCRIPTION
## Summary

Replace scheduler guesses in ledger, channels, LLM, and agent tests with exact completion signals. This branch is rebased onto `origin/main` at `62328a60` (including the ledger commit-coordinator refactor in #869).

No production code changed. No shared fixtures were extracted. Assertions were preserved or strengthened.

## Deterministic conversions

### Ledger persistence barrier

- `packages/ledger/test/bus-persistence/bus-persistence.test.ts:38-689`: replaced two microtask hops plus `setTimeout(0)` and retry-until-shortfall polling with `BusPersistence.flush()`, the persistence quiescence barrier. `persistedRows()` now throws with the observed shortfall instead of returning an incomplete array.
- `packages/ledger/test/bus-persistence/hash-chain.test.ts:56-424`: same barrier conversion for hash-chain writes; call sites that previously discarded a polling result now cannot proceed before persistence is quiescent.
- `packages/ledger/test/bus-persistence/persistence-attribution.test.ts:49-161`: replaced all hand-rolled flush turns, including redundant double flushes, with one exact persistence barrier.

Mutation proof: forced a lossy writer (`if (queue.length > 0) { resolve(); return; }` in `persistence-writer.ts`). **RED:** 14/49 failed, including the new explicit shortfall (`resolved with 1 rows, expected at least 5`). Reverted. **GREEN:** 49/49.

### Ledger bus delivery

- `packages/ledger/test/session/events.test.ts:10-49`: replaced `setTimeout(0)` with the single `queueMicrotask` hop used by `Bus.publish`.
- `packages/ledger/test/ttl.test.ts:11-296`: replaced timer flushes with exact bus microtask completion for positive and negative assertions.
- `packages/ledger/test/worker-run/frozen.test.ts:47-137`: replaced a timer followed by `events === []` with a live sentinel publish and FIFO drain; the assertion now proves the observer was active and no frozen write published ahead of the sentinel.

Mutation proofs:
- `get()` deletes/publishes on expiry: **RED** TTL expired-without-delete (1/11).
- `list()` publishes while filtering: **RED** TTL exclude-without-delete (1/11).
- `remove()` drops Deleted: **RED** TTL sweep plus session trace tests (2/13).
- frozen `updateStatusIfCurrent` publishes before refusal: **RED** frozen suite (1/2).
- observer dispatch disabled: **RED** new sentinel assertion; the old timer plus empty-array assertion stayed green, proving the false-green hole.

All reverted. **GREEN:** 15/15.

### WebSocket reply frames

- `packages/channels/test/websocket.test.ts:114-136`: subscribes to the reply frame through the `ws.send` stub before calling fire-and-forget `handler.ws.message`, then awaits that exact final-path signal.
- `packages/channels/test/websocket.test.ts:167-183`: `wsConnection` exposes a deferred resolved by the first outbound frame.
- `packages/channels/test/websocket.test.ts:260-275`: awaits the frame for sender/reply correlation and additionally pins the response bytes, excluding catch-arm error frames.

Mutation proofs:
- authenticated metadata hardcoded false: **RED** auth metadata test.
- sender fixed to fallback identity: **RED** actor message test.
- `replyToId` dropped: **RED** actor message test.
- reply `ws.send` suppressed: **RED** both converted tests on bounded Bun timeout; the former timer-only actor test did not assert the frame.

All reverted. **GREEN:** 12/12.

### Retry scheduling and aborts

- `packages/llm/test/retry/retry.test.ts:44-124`: captured and directly fired timer callbacks for normal completion; replaced elapsed-time assertions with exact scheduled-delay and no-timer observations; aborts now happen after synchronous listener registration without a 50ms timer.
- `packages/agent/test/core/retry.test.ts:14-77`: replaced elapsed upper bounds with no-timer and direct abort observations; normal completion directly fires the captured timer and pins listener cleanup without a real sleep.
- `packages/llm/test/processor/retry-cap.test.ts:171-230`: resolves only the `Retry.sleep` scheduler boundary synchronously, then pins both exact scheduler delays and emitted `RetryDecided.backoffMs` values instead of inferring behavior from `elapsed < 2000`.

Mutation proofs:
- requested timer delay changed to zero: **RED** expected 100, received 0.
- already-aborted path schedules work: **RED** both no-timer tests, expected 0 calls, received 1.
- abort listener dropped: **RED** both in-flight abort tests.
- timer callback drops `resolve()`: **RED** no-signal completion on bounded timeout.
- normal callback drops listener cleanup: **RED** expected one removal, received zero.
- instant transport failures use full backoff: **RED** expected `[250, 250]`, received `[2000, 4000]`.

All reverted. **GREEN:** 67/67 focused tests in 87ms.

## Verification

Full required chain, in order:

```text
build                         Tasks: 5 successful, 5 total
check-types                   Tasks: 15 successful, 15 total
check-deps                    OK (2 stale docs reported, no violations)
check-import-cycles           OK: 346 modules, 0 value-import cycles
lint                          OK: guard lint scanned 690 TypeScript files
lint:tools                    OK: side-effect lint scanned 2 hot files
ultracite                     Checked 780 files; no fixes applied
check-dead-exports            OK: 11 workspaces, 0 known issues, none new
bun test --timeout 15000      2723 pass, 0 fail, 8463 assertions (321 files, 33.14s)
```

Coverage runs:

```text
agent       403 pass, 0 fail   | 98.2%
channels    300 pass, 0 fail   | 96.14%
ledger      454 pass, 0 fail   | 97.55%
llm         284 pass, 0 fail   | 97.04%
protocol    677 pass, 0 fail   | 97.61%
telemetry    45 pass, 0 fail   | 98.99%
ipc          64 pass, 0 fail   | 95.42%
policy      159 pass, 0 fail   | 96.77%
placement    16 pass, 0 fail   | 100%
coverage ratchet: OK (0.5pp tolerance)
```

No coverage floor or baseline changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces scheduler-guessing waits in ledger, channels, LLM, and agent tests with exact completion signals, closing false-green holes where timer-based assertions verified nothing. No production code changed; assertions were preserved or strengthened.

**Refactors**
- Ledger persistence tests await `BusPersistence.flush()`; `persistedRows()` now throws with the observed shortfall instead of returning a short array.
- Bus-delivery waits use the single `queueMicrotask` hop `Bus.publish` actually uses; the frozen-worker test proves the observer is live with a sentinel publish.
- WebSocket tests await a deferred resolved by the `ws.send` stub and pin the reply-frame bytes, so a suppressed reply can no longer pass.
- Retry and processor tests fire captured timers, assert no timer is scheduled for aborted sleeps, and pin backoff delays as literals — including the 250ms instant-failure probe — instead of elapsed-time bounds.

Mutation proofs showed each converted assertion goes red when the targeted regression is forced in, including a disabled observer the old timer-based test stayed green on. Full suite: 2723 pass.

<sup>Written for commit 524fe4845b0c4ab3e970a9f631424aa7b562e113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Adversarial review follow-up

- `packages/llm/test/processor/retry-cap.test.ts:206-216`: replaced both production-derived `Retry.INSTANT_FAILURE_PROBE_DELAY_MS` expectations with the externally required literal `[250, 250]`, covering both the scheduler boundary and emitted `RetryDecided.backoffMs` values. Audited the other newly converted assertions; none derive their expected contract value from a production constant.
- Mutation proof: changed `INSTANT_FAILURE_PROBE_DELAY_MS` from `250` to `251`. **RED:** scheduler assertion received `[251, 251]`, expected `[250, 250]`. Reverted. **GREEN:** LLM package 284/284; full `bun test --timeout 15000` 2723/2723 (8463 assertions).
