### PR TITLE
fix: real delegation-to-run correlation and saga integrity (slop PR10)

### DIFF
--- a/apps/openomni/src/delegation/admission.ts
+++ b/apps/openomni/src/delegation/admission.ts
@@ -12,6 +12,8 @@ export type DelegationOrigin = Delegation.Origin;
 export interface Admitted {
   readonly ok: true;
   readonly delegationId: string;
+  /** Correlation allocated by the kernel before an assigned worker is commissioned. */
+  readonly workerRunId?: string;
   readonly request: Delegation.Request;
   readonly transport: Delegation.Transport;
   readonly effectiveDeadline: number;
@@ -78,6 +80,7 @@ export interface AdmissionLimits {
 export interface AdmissionContext {
   readonly delegationId: string;
   readonly rootDelegationId: string;
+  readonly workerRunId?: string;
   readonly parent?: Pick<Delegation.Record, "delegationId" | "rootDelegationId" | "deadline" | "status">;
   readonly parentMissing?: boolean;
   readonly openFanout: number;
@@ -224,6 +227,7 @@ export function admit(
   return {
     ok: true,
     delegationId,
+    ...(context?.workerRunId === undefined ? {} : { workerRunId: context.workerRunId }),
     request,
     transport,
     effectiveDeadline,

--- a/apps/openomni/src/delegation/inline-driver.ts
+++ b/apps/openomni/src/delegation/inline-driver.ts
@@ -6,6 +6,8 @@ import type { DelegationDriver, DriverOutcome, DriverReport } from "./kernel";
 export type InlineWorkerRunner = (
   input: {
     readonly delegationId: string;
+    /** Run identity allocated before commissioning, when this is an assigned worker. */
+    readonly workerRunId?: string;
     readonly operation: Delegation.Operation;
     readonly instruction: string;
     readonly acceptanceCriteria: readonly string[];
@@ -31,6 +33,7 @@ export function createInlineDriver(run: InlineWorkerRunner): DelegationDriver {
       report?.delivered();
       const output = await run({
         delegationId: handle.delegationId,
+        ...(admitted.workerRunId === undefined ? {} : { workerRunId: admitted.workerRunId }),
         operation: admitted.request.operation,
         instruction: admitted.request.payload.text,
         acceptanceCriteria: admitted.request.acceptanceCriteria ?? [],

--- a/apps/openomni/src/delegation/inline-driver.ts
+++ b/apps/openomni/src/delegation/inline-driver.ts
@@ -1,6 +1,7 @@
 import type { Delegation } from "@openomni/protocol";
 import type { Admitted, DelegationOrigin } from "./admission";
 import type { DelegationDriver, DriverOutcome, DriverReport } from "./kernel";
+import { WorkerRunError } from "./worker-loop";
 
 /** Runs one isolated in-process worker turn. */
 export type InlineWorkerRunner = (
@@ -31,7 +32,9 @@ export function createInlineDriver(run: InlineWorkerRunner): DelegationDriver {
     ): Promise<DriverOutcome> {
       if (signal.aborted) return { status: "cancelled", reason: "delegation stopped" };
       report?.delivered();
-      const output = await run({
+      let output: Awaited<ReturnType<InlineWorkerRunner>>;
+      try {
+        output = await run({
         delegationId: handle.delegationId,
         ...(admitted.workerRunId === undefined ? {} : { workerRunId: admitted.workerRunId }),
         operation: admitted.request.operation,
@@ -39,7 +42,11 @@ export function createInlineDriver(run: InlineWorkerRunner): DelegationDriver {
         acceptanceCriteria: admitted.request.acceptanceCriteria ?? [],
         origin: admitted.childOrigin,
         signal,
-      });
+        });
+      } catch (error) {
+        if (error instanceof WorkerRunError) return { status: "failed", error: error.message, workerRunId: error.runId };
+        throw error;
+      }
 
       // A completion racing after cancellation/deadline cannot replace the
       // kernel's terminal CAS. Reporting cancelled also avoids presenting it

--- a/apps/openomni/src/delegation/inline-driver.ts
+++ b/apps/openomni/src/delegation/inline-driver.ts
@@ -15,7 +15,7 @@ export type InlineWorkerRunner = (
     readonly origin: DelegationOrigin;
     readonly signal: AbortSignal;
   },
-) => Promise<{ readonly text: string; readonly tokens: number }>;
+) => Promise<{ readonly text: string; readonly tokens: number; readonly runId?: string }>;
 
 /**
  * The volatile inline transport. The kernel still records it before this runs,
@@ -45,7 +45,12 @@ export function createInlineDriver(run: InlineWorkerRunner): DelegationDriver {
       // kernel's terminal CAS. Reporting cancelled also avoids presenting it
       // as usable output to a caller whose inline turn is still unwinding.
       if (signal.aborted) return { status: "cancelled", reason: "delegation stopped" };
-      return { status: "completed", output: output.text, usage: { tokens: output.tokens } };
+      return {
+        status: "completed",
+        output: output.text,
+        ...(output.runId === undefined ? {} : { workerRunId: output.runId }),
+        usage: { tokens: output.tokens },
+      };
     },
   };
 }

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -538,6 +538,10 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     }
     const now = options.now();
     const delegationId = options.newDelegationId();
+    // Process workers need a real run identity before their WorkItem attempt
+    // is commissioned; the worker loop consumes this as its first run ID.
+    const workerRunId =
+      candidate !== undefined && origin.role === "resident" ? crypto.randomUUID() : undefined;
     const parentDelegationId = origin.parentDelegationId;
     const parent = parentDelegationId === undefined ? undefined : store.get(parentDelegationId);
     const rootDelegationId = parent?.rootDelegationId ?? delegationId;
@@ -550,6 +554,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     const decision = admit(candidate, origin, now, limits, {
       delegationId,
       rootDelegationId,
+      ...(workerRunId === undefined ? {} : { workerRunId }),
       ...(parent === undefined ? {} : { parent }),
       ...(parentDelegationId !== undefined && parent === undefined ? { parentMissing: true } : {}),
       openFanout: store.countOpenByRoot(rootDelegationId),
@@ -596,6 +601,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       try {
         workItemId = await options.workItems.openAssign({
           delegationId,
+          ...(decision.workerRunId === undefined ? {} : { workerRunId: decision.workerRunId }),
           transport: decision.transport,
           instruction: decision.request.payload.text,
           acceptanceCriteria: decision.request.acceptanceCriteria ?? [],

--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -18,12 +18,14 @@ export type DriverOutcome =
   | {
       readonly status: "completed";
       readonly output: string;
+      /** The worker run that produced this outcome, when the transport reports one. */
+      readonly workerRunId?: string;
       /** Transport-reported spend; visibility only, never an admission input. */
       readonly usage?: { readonly tokens: number };
     }
-  | { readonly status: "failed"; readonly error: string }
-  | { readonly status: "cancelled"; readonly reason: string }
-  | { readonly status: "delivery_failed"; readonly reason: string }
+  | { readonly status: "failed"; readonly error: string; readonly workerRunId?: string }
+  | { readonly status: "cancelled"; readonly reason: string; readonly workerRunId?: string }
+  | { readonly status: "delivery_failed"; readonly reason: string; readonly workerRunId?: string }
   | { readonly status: "sent" };
 
 /** Transport identifiers allocated before the durable record is written. */
@@ -211,14 +213,33 @@ function outcomeToSettlement(
         delegationId,
         output: outcome.output,
         at,
+        ...(outcome.workerRunId === undefined ? {} : { workerRunId: outcome.workerRunId }),
         ...(outcome.usage === undefined ? {} : { usage: outcome.usage }),
       };
     case "failed":
-      return { status: "failed", delegationId, error: outcome.error, at };
+      return {
+        status: "failed",
+        delegationId,
+        error: outcome.error,
+        at,
+        ...(outcome.workerRunId === undefined ? {} : { workerRunId: outcome.workerRunId }),
+      };
     case "cancelled":
-      return { status: "cancelled", delegationId, reason: outcome.reason, at };
+      return {
+        status: "cancelled",
+        delegationId,
+        reason: outcome.reason,
+        at,
+        ...(outcome.workerRunId === undefined ? {} : { workerRunId: outcome.workerRunId }),
+      };
     case "delivery_failed":
-      return { status: "delivery_failed", delegationId, reason: outcome.reason, at };
+      return {
+        status: "delivery_failed",
+        delegationId,
+        reason: outcome.reason,
+        at,
+        ...(outcome.workerRunId === undefined ? {} : { workerRunId: outcome.workerRunId }),
+      };
     case "sent":
       return { status: "sent", delegationId, at };
   }
@@ -538,10 +559,6 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     }
     const now = options.now();
     const delegationId = options.newDelegationId();
-    // Process workers need a real run identity before their WorkItem attempt
-    // is commissioned; the worker loop consumes this as its first run ID.
-    const workerRunId =
-      candidate !== undefined && origin.role === "resident" ? crypto.randomUUID() : undefined;
     const parentDelegationId = origin.parentDelegationId;
     const parent = parentDelegationId === undefined ? undefined : store.get(parentDelegationId);
     const rootDelegationId = parent?.rootDelegationId ?? delegationId;
@@ -551,16 +568,22 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       origin.role === "worker" && parentDelegationId !== undefined
         ? options.leases?.listLiveByHolder(parentDelegationId, now)
         : undefined;
-    const decision = admit(candidate, origin, now, limits, {
+    const admitted = admit(candidate, origin, now, limits, {
       delegationId,
       rootDelegationId,
-      ...(workerRunId === undefined ? {} : { workerRunId }),
       ...(parent === undefined ? {} : { parent }),
       ...(parentDelegationId !== undefined && parent === undefined ? { parentMissing: true } : {}),
       openFanout: store.countOpenByRoot(rootDelegationId),
       ...(liveLeases === undefined ? {} : { leases: liveLeases }),
     });
-    if (!decision.ok) return { refused: decision.reason, error: decision.error };
+    if (!admitted.ok) return { refused: admitted.reason, error: admitted.error };
+    // Only an internal process worker has a worker loop that can consume this
+    // identity. Channel assignments must never persist a fabricated UUID.
+    const workerRunId = admitted.transport === "process" ? crypto.randomUUID() : undefined;
+    const decision: Admitted = {
+      ...admitted,
+      ...(workerRunId === undefined ? {} : { workerRunId }),
+    };
 
     const baseHandle: Delegation.Handle = {
       delegationId,
@@ -601,11 +624,14 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       try {
         workItemId = await options.workItems.openAssign({
           delegationId,
-          ...(decision.workerRunId === undefined ? {} : { workerRunId: decision.workerRunId }),
+          ...(decision.workerRunId === undefined && handle.waitId === undefined
+            ? {}
+            : { workerRunId: decision.workerRunId ?? handle.waitId }),
           transport: decision.transport,
           instruction: decision.request.payload.text,
           acceptanceCriteria: decision.request.acceptanceCriteria ?? [],
-          sessionId: origin.sessionId,
+          sessionId:
+            decision.transport === "process" ? `delegation-${delegationId}` : origin.sessionId,
         });
       } catch (error) {
         const message = `WorkItem commissioning failed: ${error instanceof Error ? error.message : String(error)}`;

--- a/apps/openomni/src/delegation/process-driver.ts
+++ b/apps/openomni/src/delegation/process-driver.ts
@@ -48,6 +48,9 @@ export function createProcessDriver(options: ProcessDriverOptions): DelegationDr
       report?: DriverReport,
     ): Promise<DriverOutcome> {
       if (signal.aborted) return { status: "cancelled", reason: "delegation stopped" };
+      if (admitted.workerRunId === undefined) {
+        return { status: "delivery_failed", reason: "process worker run identity was not admitted" };
+      }
       let child: Bun.Subprocess<"pipe", "pipe", "pipe">;
       try {
         child = Bun.spawn({
@@ -68,7 +71,7 @@ export function createProcessDriver(options: ProcessDriverOptions): DelegationDr
       try {
         const request: ProcessWorkerRequest = {
           delegationId: handle.delegationId,
-          ...(admitted.workerRunId === undefined ? {} : { workerRunId: admitted.workerRunId }),
+          workerRunId: admitted.workerRunId,
           operation: admitted.request.operation,
           instruction: admitted.request.payload.text,
           acceptanceCriteria: admitted.request.acceptanceCriteria ?? [],

--- a/apps/openomni/src/delegation/process-driver.ts
+++ b/apps/openomni/src/delegation/process-driver.ts
@@ -68,6 +68,7 @@ export function createProcessDriver(options: ProcessDriverOptions): DelegationDr
       try {
         const request: ProcessWorkerRequest = {
           delegationId: handle.delegationId,
+          ...(admitted.workerRunId === undefined ? {} : { workerRunId: admitted.workerRunId }),
           operation: admitted.request.operation,
           instruction: admitted.request.payload.text,
           acceptanceCriteria: admitted.request.acceptanceCriteria ?? [],

--- a/apps/openomni/src/delegation/process-entry.ts
+++ b/apps/openomni/src/delegation/process-entry.ts
@@ -9,7 +9,8 @@ import { createInlineWorkerRunner } from "./worker-loop";
 export const ProcessWorkerRequest = z
   .object({
     delegationId: z.string().min(1),
-    workerRunId: z.string().min(1).optional(),
+    /** Wire v2: every process request carries the run identity it must consume. */
+    workerRunId: z.string().min(1),
     operation: Delegation.Operation,
     instruction: z.string().min(1),
     acceptanceCriteria: z.array(z.string()),
@@ -41,16 +42,17 @@ export const ProcessWorkerResult = z.discriminatedUnion("status", [
     .object({
       status: z.literal("completed"),
       output: z.string(),
+      workerRunId: z.string().min(1),
       usage: z.object({ tokens: z.number().int().nonnegative() }).strict().optional(),
     })
     .strict(),
-  z.object({ status: z.literal("failed"), error: z.string() }).strict(),
+  z.object({ status: z.literal("failed"), error: z.string(), workerRunId: z.string().min(1) }).strict(),
 ]);
 export type ProcessWorkerResult = z.infer<typeof ProcessWorkerResult>;
 
 export type ProcessWorkerRun = (
   request: ProcessWorkerRequest,
-) => Promise<{ readonly text: string; readonly tokens: number }>;
+) => Promise<{ readonly text: string; readonly tokens: number; readonly runId?: string }>;
 
 /** Child processes may only open inline children; independent work is refused. */
 export function createChildKernel(runner: InlineWorkerRunner): DelegationKernel {
@@ -79,11 +81,17 @@ export async function serveProcessWorker(
   let result: ProcessWorkerResult;
   try {
     const output = await run(request);
-    result = { status: "completed", output: output.text, usage: { tokens: output.tokens } };
+    result = {
+      status: "completed",
+      output: output.text,
+      workerRunId: output.runId ?? request.workerRunId,
+      usage: { tokens: output.tokens },
+    };
   } catch (error) {
     result = {
       status: "failed",
       error: error instanceof Error ? error.message : String(error),
+      workerRunId: request.workerRunId,
     };
   }
   writeLine(JSON.stringify(result));
@@ -92,7 +100,7 @@ export async function serveProcessWorker(
 /** Runs the same Worker loop in the child process. */
 function processWorkerRun(
   request: ProcessWorkerRequest,
-): Promise<{ readonly text: string; readonly tokens: number }> {
+): Promise<{ readonly text: string; readonly tokens: number; readonly runId?: string }> {
   if (request.dbPath !== undefined && Storage.getInitializedDbPath() === null) {
     initialize({ dbPath: request.dbPath });
   }

--- a/apps/openomni/src/delegation/process-entry.ts
+++ b/apps/openomni/src/delegation/process-entry.ts
@@ -3,7 +3,7 @@ import { Delegation, Model } from "@openomni/protocol";
 import { z } from "zod";
 import { createDelegationKernel, type DelegationKernel } from "./kernel";
 import { createInlineDriver, type InlineWorkerRunner } from "./inline-driver";
-import { createInlineWorkerRunner } from "./worker-loop";
+import { createInlineWorkerRunner, WorkerRunError } from "./worker-loop";
 
 /** Child-process wire: parse, acknowledge delivery, then report one outcome. */
 export const ProcessWorkerRequest = z
@@ -91,7 +91,7 @@ export async function serveProcessWorker(
     result = {
       status: "failed",
       error: error instanceof Error ? error.message : String(error),
-      workerRunId: request.workerRunId,
+      workerRunId: error instanceof WorkerRunError ? error.runId : request.workerRunId,
     };
   }
   writeLine(JSON.stringify(result));

--- a/apps/openomni/src/delegation/process-entry.ts
+++ b/apps/openomni/src/delegation/process-entry.ts
@@ -9,6 +9,7 @@ import { createInlineWorkerRunner } from "./worker-loop";
 export const ProcessWorkerRequest = z
   .object({
     delegationId: z.string().min(1),
+    workerRunId: z.string().min(1).optional(),
     operation: Delegation.Operation,
     instruction: z.string().min(1),
     acceptanceCriteria: z.array(z.string()),
@@ -105,6 +106,7 @@ function processWorkerRun(
   kernel = createChildKernel(runner);
   return runner({
     delegationId: request.delegationId,
+    ...(request.workerRunId === undefined ? {} : { workerRunId: request.workerRunId }),
     operation: request.operation,
     instruction: request.instruction,
     acceptanceCriteria: request.acceptanceCriteria,

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -24,6 +24,8 @@ export interface WorkItemLinkage {
 
 interface OpenAssignInput {
   readonly delegationId: string;
+  /** The worker run identity allocated before the WorkItem assignment. */
+  readonly workerRunId?: string;
   readonly transport: Delegation.Transport;
   readonly instruction: string;
   readonly acceptanceCriteria: readonly string[];
@@ -93,7 +95,7 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
       workItemId,
       {
         executorKind: executorKindOf(input.transport),
-        workerRunId: input.delegationId,
+        workerRunId: input.workerRunId ?? input.delegationId,
         workSessionId: input.sessionId,
       },
       traceId,
@@ -165,9 +167,13 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
       },
       traceId,
     );
+    // The assignment is the source of truth for the run correlation. Older
+    // records fall back to delegationId for compatibility with pre-correlation
+    // rows; new process assignments carry the actual worker-loop run UUID.
+    const workerRunId = item.workerRunId ?? record.delegationId;
     await WorkItemAttemptRun.finish(
       record.origin.sessionId,
-      record.delegationId,
+      workerRunId,
       Delegation.settlementToAttemptOutcome(settlement.status),
       traceId,
       {

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -167,17 +167,18 @@ export function createWorkItemLinkage(options: WorkItemLinkageOptions): WorkItem
       },
       traceId,
     );
-    // The assignment is the source of truth for the run correlation. Older
-    // records fall back to delegationId for compatibility with pre-correlation
-    // rows; new process assignments carry the actual worker-loop run UUID.
-    const workerRunId = item.workerRunId ?? record.delegationId;
+    // Locate the attempt using its commissioned pair. The settlement carries
+    // the final driven run ID and stores it on the terminal attempt fact.
+    const assignedRunId = item.workerRunId ?? record.delegationId;
+    const workSessionId = item.workSessionId ?? record.origin.sessionId;
     await WorkItemAttemptRun.finish(
-      record.origin.sessionId,
-      workerRunId,
+      workSessionId,
+      assignedRunId,
       Delegation.settlementToAttemptOutcome(settlement.status),
       traceId,
       {
         endedAt: options.now(),
+        ...(settlement.workerRunId === undefined ? {} : { workerRunId: settlement.workerRunId }),
         usage: WorkItem.AttemptUsage.parse({
           seconds: Math.max(0, (settlement.at - record.createdAt) / 1000),
           ...(tokens === undefined ? {} : { tokens }),

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -46,10 +46,13 @@ export function createInlineWorkerRunner(options: WorkerLoopOptions): InlineWork
     // once — a question is answered, never nannied.
     let tokens = 0;
     let state: DriveState = initialDriveState();
+    let firstRun = true;
     for (;;) {
-      // Each driven run is its own run identity so telemetry never conflates
-      // two agent runs under one runId.
-      const runId = crypto.randomUUID();
+      // The initial run identity is allocated during admission and recorded
+      // on the commissioned WorkItem. Driven follow-ups remain distinct runs
+      // for telemetry, while the attempt remains correlated to its first run.
+      const runId = firstRun && input.workerRunId !== undefined ? input.workerRunId : crypto.randomUUID();
+      firstRun = false;
       const observation = observeComponent({
         traceId,
         sessionId,

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -82,14 +82,14 @@ export function createInlineWorkerRunner(options: WorkerLoopOptions): InlineWork
         }),
       );
       tokens += result.usage.totalTokens;
-      if (input.operation !== "assign") return { text: result.text, tokens };
+      if (input.operation !== "assign") return { text: result.text, tokens, runId };
       const decision = decideDrive(state, {
         text: result.text,
         finishReason: result.finishReason,
       });
-      if (decision.action === "done") return { text: result.text, tokens };
+      if (decision.action === "done") return { text: result.text, tokens, runId };
       if (decision.action === "stop") {
-        return { text: `[drive stopped: ${decision.reason}]\n${result.text}`, tokens };
+        return { text: `[drive stopped: ${decision.reason}]\n${result.text}`, tokens, runId };
       }
       state = decision.state;
       messages.push(

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -11,6 +11,16 @@ import { renderInstruction } from "./instruction";
 import type { DelegationKernel } from "./kernel";
 import type { InlineWorkerRunner } from "./inline-driver";
 
+export class WorkerRunError extends Error {
+  constructor(
+    message: string,
+    readonly runId: string,
+  ) {
+    super(message);
+    this.name = "WorkerRunError";
+  }
+}
+
 export interface WorkerLoopOptions {
   readonly model: Model.Ref;
   readonly apiKey: string;
@@ -75,12 +85,17 @@ export function createInlineWorkerRunner(options: WorkerLoopOptions): InlineWork
         signal: input.signal,
         ...(options.llm === undefined ? {} : { llm: options.llm }),
       });
-      const result = await observation.run(() =>
-        agent.run({
-          messages,
-          traceContext: { traceId, sessionId, runId, agentName: "worker" },
-        }),
-      );
+      let result: Awaited<ReturnType<typeof agent.run>>;
+      try {
+        result = await observation.run(() =>
+          agent.run({
+            messages,
+            traceContext: { traceId, sessionId, runId, agentName: "worker" },
+          }),
+        );
+      } catch (error) {
+        throw new WorkerRunError(error instanceof Error ? error.message : String(error), runId);
+      }
       tokens += result.usage.totalTokens;
       if (input.operation !== "assign") return { text: result.text, tokens, runId };
       const decision = decideDrive(state, {

--- a/apps/openomni/test/channel-delegation.test.ts
+++ b/apps/openomni/test/channel-delegation.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { Gateway } from "@openomni/protocol";
-import { DelegationStore } from "@openomni/ledger";
+import { DelegationStore, WorkItemStore } from "@openomni/ledger";
 import { admit, type Admitted } from "../src/delegation/admission";
 import { createChannelDriver } from "../src/delegation/channel-driver";
 import { createDelegationKernel } from "../src/delegation/kernel";
 import { eventCollector, awaitedReceipt, RESIDENT, useDelegationStore } from "./helpers/delegation";
 import { fakeWorkItemLinkage } from "./helpers/fake-work-items";
+import { createWorkItemLinkage } from "../src/delegation/work-item-linkage";
 
 useDelegationStore();
 
@@ -140,6 +141,32 @@ describe("channel delegation driver", () => {
       status: "delivery_failed",
       reason: "socket closed",
     });
+  });
+
+  test("durable channel assignment correlates its attempt to the prepared wait id", async () => {
+    const driver = createChannelDriver({
+      send: async (input) => awaitedReceipt(input),
+      now: () => NOW,
+      newWaitId: () => "wait-durable",
+      conversations: { open: () => { throw new Error("not reached"); }, get: () => undefined },
+    });
+    const kernel = createDelegationKernel({
+      drivers: { channel: driver },
+      now: () => NOW,
+      newDelegationId: () => "delegation-durable",
+      wake: () => undefined,
+      workItems: createWorkItemLinkage({ model: { provider: "test", id: "model" }, now: () => NOW }),
+    });
+    const started = await kernel.delegate({
+      address: { kind: "actor", actorId: "alice" }, operation: "assign",
+      payload: { text: "review" }, acceptanceCriteria: ["read"], deadline: DEADLINE,
+    }, RESIDENT);
+    if ("refused" in started) throw new Error(started.refused);
+    const workItemId = DelegationStore.get("delegation-durable")?.workItemId;
+    const item = await WorkItemStore.get(workItemId ?? "");
+    expect(item?.workerRunId).toBe("wait-durable");
+    expect(item?.workerRunId).not.toMatch(/^[0-9a-f-]{36}$/);
+    kernel.stop();
   });
 
   test("the kernel resolves a correlated reply from the durable record", async () => {

--- a/apps/openomni/test/model-transport.test.ts
+++ b/apps/openomni/test/model-transport.test.ts
@@ -184,6 +184,7 @@ describe("operator transport reaches every model caller", () => {
   it("the process worker wire carries it across the process boundary", () => {
     const request = ProcessWorkerRequest.parse({
       delegationId: "d-1",
+      workerRunId: "run-transport",
       operation: "ask",
       instruction: "answer",
       acceptanceCriteria: [],
@@ -199,6 +200,7 @@ describe("operator transport reaches every model caller", () => {
   it("the process worker wire rejects an unknown transport field", () => {
     const parsed = ProcessWorkerRequest.safeParse({
       delegationId: "d-1",
+      workerRunId: "run-transport",
       operation: "ask",
       instruction: "answer",
       acceptanceCriteria: [],

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -56,6 +56,7 @@ test("the entry acks before it works, so delivery is observable separately from 
   await serveProcessWorker(
     JSON.stringify({
       delegationId: "d-1",
+      workerRunId: "run-1",
       operation: "ask",
       instruction: "summarize",
       acceptanceCriteria: [],
@@ -74,7 +75,7 @@ test("the entry acks before it works, so delivery is observable separately from 
   );
   expect(written[0]).toBe(PROCESS_WORKER_ACK);
   expect(order).toEqual(["write", "run", "write"]);
-  expect(JSON.parse(written[1] ?? "")).toEqual({ status: "completed", output: "done", usage: { tokens: 7 } });
+  expect(JSON.parse(written[1] ?? "")).toEqual({ status: "completed", output: "done", workerRunId: "run-1", usage: { tokens: 7 } });
 });
 
 test("a worker that throws is a failed result, not a lost delivery", async () => {
@@ -82,6 +83,7 @@ test("a worker that throws is a failed result, not a lost delivery", async () =>
   await serveProcessWorker(
     JSON.stringify({
       delegationId: "d-1",
+      workerRunId: "run-1",
       operation: "ask",
       instruction: "summarize",
       acceptanceCriteria: [],
@@ -95,7 +97,7 @@ test("a worker that throws is a failed result, not a lost delivery", async () =>
     },
   );
   expect(written[0]).toBe(PROCESS_WORKER_ACK);
-  expect(JSON.parse(written[1] ?? "")).toEqual({ status: "failed", error: "model refused" });
+  expect(JSON.parse(written[1] ?? "")).toEqual({ status: "failed", error: "model refused", workerRunId: "run-1" });
 });
 
 test("a request that does not parse never acks", async () => {
@@ -121,6 +123,7 @@ test("the request schema carries lineage and refuses a malformed origin", () => 
   expect(
     ProcessWorkerRequest.parse({
       delegationId: "d-1",
+      workerRunId: "run-1",
       operation: "ask",
       instruction: "x",
       acceptanceCriteria: [],
@@ -144,7 +147,7 @@ test("an independent delegation returns its handle before a real process result,
     const line = await new Response(Bun.stdin.stream()).text();
     const request = JSON.parse(line);
     console.log(JSON.stringify({ delivered: true }));
-    console.log(JSON.stringify({ status: "completed", output: "handled: " + request.instruction + " pid:" + process.pid }));
+    console.log(JSON.stringify({ status: "completed", output: "handled: " + request.instruction + " pid:" + process.pid, workerRunId: request.workerRunId }));
   `);
   const kernel = kernelWith(entry);
   const result = await kernel.delegate(independentAsk("audit the ledger", Date.now() + 20_000), RESIDENT);
@@ -233,7 +236,7 @@ test("the child receives the admission-stamped worker lineage", async () => {
   const entry = fakeEntry(`
     const request = JSON.parse(await new Response(Bun.stdin.stream()).text());
     console.log(JSON.stringify({ delivered: true }));
-    console.log(JSON.stringify({ status: "completed", output: JSON.stringify(request.origin) }));
+    console.log(JSON.stringify({ status: "completed", output: JSON.stringify(request.origin), workerRunId: request.workerRunId }));
   `);
   const kernel = kernelWith(entry);
   const result = await kernel.delegate(independentAsk("audit", Date.now() + 20_000), RESIDENT);
@@ -287,7 +290,7 @@ test("concurrent process delegations have independent durable ids and answers", 
   const entry = fakeEntry(`
     const request = JSON.parse(await new Response(Bun.stdin.stream()).text());
     console.log(JSON.stringify({ delivered: true }));
-    console.log(JSON.stringify({ status: "completed", output: request.instruction }));
+    console.log(JSON.stringify({ status: "completed", output: request.instruction, workerRunId: request.workerRunId }));
   `);
   const kernel = kernelWith(entry);
   const results = await Promise.all(
@@ -325,7 +328,7 @@ const llm = {
         path: { cwd: "", root: "" }, cost: 0, tokens,
       },
       parts: [
-        { id: id + "-text", sessionID, messageID: id, type: "text", text: "BLOCKED: the registry is unreachable" },
+        { id: id + "-text", sessionID, messageID: id, type: "text", text: input.messages.length === 1 && JSON.stringify(input.messages).includes("single") ? "done" : "BLOCKED: the registry is unreachable" },
         { id: id + "-finish", sessionID, messageID: id, type: "step-finish", reason: "stop", cost: 0, tokens },
       ],
     });
@@ -410,5 +413,34 @@ test("an assign rides the real wire: parent driver, spawned child, drive loop, u
   await closed;
   const item = await WorkItemStore.get(workItemId);
   expect(item?.attemptTerminal).toMatchObject({ usage: { tokens: 27 } });
+  expect(item?.attemptTerminal?.workerRunId).toBe(settled.settlement.workerRunId);
+  expect(settled.settlement.workerRunId).toBeDefined();
+  expect(settled.settlement.workerRunId).not.toBe(commissioned?.workerRunId);
+  expect(item?.workSessionId).toBe(`delegation-d-wire-drive`);
+  kernel.stop();
+}, 20_000);
+
+test("a single process run consumes the commissioned run identity", async () => {
+  const entry = fakeEntry(CHILD_DRIVE_ENTRY);
+  const kernel = createDelegationKernel({
+    drivers: { process: createProcessDriver({ command: [process.execPath, entry], worker: WORKER }) },
+    now: () => Date.now(),
+    newDelegationId: () => "d-wire-single",
+    wake: () => undefined,
+    workItems: createWorkItemLinkage({ model: WORKER.model, now: () => Date.now() }),
+  });
+  const result = await kernel.delegate({
+    operation: "assign",
+    address: { kind: "core", scope: "independent" },
+    payload: { text: "single run" },
+    acceptanceCriteria: ["done"],
+    deadline: Date.now() + 20_000,
+  }, RESIDENT);
+  if ("refused" in result) throw new Error(result.refused);
+  const record = DelegationStore.get("d-wire-single");
+  const item = await WorkItemStore.get(record?.workItemId ?? "");
+  const settled = await kernel.awaitDelegation("d-wire-single", 20_000);
+  if (settled.kind !== "settled" || settled.settlement.status !== "completed") throw new Error("not settled");
+  expect(settled.settlement.workerRunId).toBe(item?.workerRunId);
   kernel.stop();
 }, 20_000);

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -319,6 +319,9 @@ const tokens = { input: 4, output: 5, reasoning: 0, cache: { read: 0, write: 0 }
 const llm = {
   resolveProviderModel: async (model) => ({ id: model.id, name: model.id, providerID: model.provider }),
   run: async (input, sink) => {
+    if (input.messages.length > 1 && JSON.stringify(input.messages).includes("throw-second")) {
+      throw new Error("second run failed");
+    }
     const id = "fake-" + input.messages.length;
     const sessionID = input.trace.sessionId;
     sink.onMessage({
@@ -417,6 +420,32 @@ test("an assign rides the real wire: parent driver, spawned child, drive loop, u
   expect(settled.settlement.workerRunId).toBeDefined();
   expect(settled.settlement.workerRunId).not.toBe(commissioned?.workerRunId);
   expect(item?.workSessionId).toBe(`delegation-d-wire-drive`);
+  kernel.stop();
+}, 20_000);
+
+test("a second-run exception settles with the second worker run identity", async () => {
+  const entry = fakeEntry(CHILD_DRIVE_ENTRY);
+  const kernel = createDelegationKernel({
+    drivers: { process: createProcessDriver({ command: [process.execPath, entry], worker: WORKER }) },
+    now: () => Date.now(),
+    newDelegationId: () => "d-wire-throw-second",
+    wake: () => undefined,
+    workItems: createWorkItemLinkage({ model: WORKER.model, now: () => Date.now() }),
+  });
+  const result = await kernel.delegate({
+    operation: "assign",
+    address: { kind: "core", scope: "independent" },
+    payload: { text: "throw-second" },
+    acceptanceCriteria: ["done"],
+    deadline: Date.now() + 20_000,
+  }, RESIDENT);
+  if ("refused" in result) throw new Error(result.refused);
+  const record = DelegationStore.get("d-wire-throw-second");
+  const commissioned = await WorkItemStore.get(record?.workItemId ?? "");
+  const settled = await kernel.awaitDelegation("d-wire-throw-second", 20_000);
+  if (settled.kind !== "settled" || settled.settlement.status !== "failed") throw new Error("not failed");
+  expect(settled.settlement.workerRunId).toBeDefined();
+  expect(settled.settlement.workerRunId).not.toBe(commissioned?.workerRunId);
   kernel.stop();
 }, 20_000);
 

--- a/apps/openomni/test/process-transport.test.ts
+++ b/apps/openomni/test/process-transport.test.ts
@@ -345,6 +345,7 @@ kernel = createChildKernel(runner);
 await serveProcessWorker(line, (out) => console.log(out), (request) =>
   runner({
     delegationId: request.delegationId,
+    workerRunId: request.workerRunId,
     operation: request.operation,
     instruction: request.instruction,
     acceptanceCriteria: request.acceptanceCriteria,
@@ -382,6 +383,9 @@ test("an assign rides the real wire: parent driver, spawned child, drive loop, u
   if ("refused" in result) throw new Error(result.refused);
   const workItemId = DelegationStore.get("d-wire-drive")?.workItemId ?? "";
   expect(workItemId).not.toBe("");
+  const commissioned = await WorkItemStore.get(workItemId);
+  expect(commissioned?.workerRunId).toBeDefined();
+  expect(commissioned?.workerRunId).not.toBe("d-wire-drive");
   // Subscribe after admission, correlated to THIS work item: attempt
   // ALLOCATION also publishes an Updated event whose fields clear
   // `attemptTerminal` — only the post-settlement closure event counts.

--- a/apps/openomni/test/worker-drive.test.ts
+++ b/apps/openomni/test/worker-drive.test.ts
@@ -3,7 +3,7 @@ import type { RunInput, Sink } from "@openomni/llm";
 import type { Message } from "@openomni/protocol";
 import type { DelegationKernel } from "../src/delegation/kernel";
 import { createChildKernel } from "../src/delegation/process-entry";
-import { createInlineWorkerRunner } from "../src/delegation/worker-loop";
+import { createInlineWorkerRunner, WorkerRunError } from "../src/delegation/worker-loop";
 
 const ORIGIN = { role: "worker", depth: 1, sessionId: "session-drive" } as const;
 
@@ -89,6 +89,28 @@ test("an ask run is answered once, never driven — even when the answer says BL
   expect(runs).toBe(1);
   expect(output.text).toBe("BLOCKED: cannot answer");
   expect(output.tokens).toBe(9);
+});
+
+test("a later worker-run failure carries the active run id", async () => {
+  const runIds: string[] = [];
+  const { runner, stop } = bootRunner(async (input, sink) => {
+    runIds.push(input.trace.runId);
+    if (runIds.length === 2) throw new WorkerRunError("second run failed", input.trace.runId);
+    sink.onMessage(reply(input, "BLOCKED: retry me"));
+    return { type: "stop" };
+  });
+  const output = await runner({
+    delegationId: "d-drive-failure",
+    operation: "assign",
+    instruction: "retry the task",
+    acceptanceCriteria: ["task complete"],
+    origin: ORIGIN,
+    signal: new AbortController().signal,
+  });
+  stop();
+  expect(runIds.length).toBeGreaterThan(1);
+  expect(output.runId).toBe(runIds.at(-1));
+  expect(output.runId).not.toBe(runIds[0]);
 });
 
 test("an assigned worker that finishes naturally is not nannied", async () => {

--- a/packages/ledger/src/work-item/attempt-run.ts
+++ b/packages/ledger/src/work-item/attempt-run.ts
@@ -52,6 +52,7 @@ type AttemptRunTerminalExtra = Readonly<{
   endedAt?: number;
   error?: string;
   usage?: WorkItem.AttemptUsage;
+  workerRunId?: string;
 }>;
 
 /** Acquire/finish contention resolves as "not acquired", never as a crash. */
@@ -307,6 +308,7 @@ export namespace WorkItemAttemptRun {
       }
       const terminal = WorkItem.AttemptTerminal.parse({
         attemptId: existing.currentAttemptId,
+        ...(extra.workerRunId === undefined ? {} : { workerRunId: extra.workerRunId }),
         outcome,
         endedAt: extra.endedAt ?? now,
         ...(extra.error === undefined ? {} : { error: extra.error }),

--- a/packages/protocol/src/delegation/schema.ts
+++ b/packages/protocol/src/delegation/schema.ts
@@ -165,6 +165,7 @@ const SettledUnion = z.discriminatedUnion("status", [
     .object({
       status: z.literal("completed"),
       delegationId: z.string().min(1),
+      workerRunId: z.string().min(1).optional(),
       output: z.string(),
       at: EpochMs,
       /** Transport-reported spend; visibility only, never an admission input. */
@@ -175,6 +176,7 @@ const SettledUnion = z.discriminatedUnion("status", [
     .object({
       status: z.literal("failed"),
       delegationId: z.string().min(1),
+      workerRunId: z.string().min(1).optional(),
       error: z.string().min(1),
       at: EpochMs,
     })
@@ -183,6 +185,7 @@ const SettledUnion = z.discriminatedUnion("status", [
     .object({
       status: z.literal("cancelled"),
       delegationId: z.string().min(1),
+      workerRunId: z.string().min(1).optional(),
       reason: z.string().min(1),
       at: EpochMs,
     })
@@ -191,6 +194,7 @@ const SettledUnion = z.discriminatedUnion("status", [
     .object({
       status: z.literal("delivery_failed"),
       delegationId: z.string().min(1),
+      workerRunId: z.string().min(1).optional(),
       reason: z.string().min(1),
       at: EpochMs,
     })
@@ -199,6 +203,7 @@ const SettledUnion = z.discriminatedUnion("status", [
     .object({
       status: z.literal("no_response"),
       delegationId: z.string().min(1),
+      workerRunId: z.string().min(1).optional(),
       /** The deadline (epoch ms) whose expiry produced this terminal. */
       deadline: EpochMs.int().positive(),
       at: EpochMs,
@@ -208,6 +213,7 @@ const SettledUnion = z.discriminatedUnion("status", [
     .object({
       status: z.literal("interrupted"),
       delegationId: z.string().min(1),
+      workerRunId: z.string().min(1).optional(),
       at: EpochMs,
     })
     .strict(),

--- a/packages/protocol/src/work-item/attempt.ts
+++ b/packages/protocol/src/work-item/attempt.ts
@@ -240,6 +240,8 @@ export type AttemptUsage = z.infer<typeof AttemptUsage>;
 export const AttemptTerminal = z
   .object({
     attemptId: AttemptId,
+    /** Worker run that produced the terminal outcome, distinct across driven reruns. */
+    workerRunId: z.string().min(1).optional(),
     outcome: AttemptOutcome,
     endedAt: EpochMs,
     error: z.string().optional(),


### PR DESCRIPTION
## Summary

- Allocate the real worker run UUID before assign WorkItem commissioning.
- Thread it through admission, process IPC, and the worker loop's first run.
- Close attempts using the WorkItem's durable worker-run assignment, with a legacy delegation-id fallback.
- Preserve the existing delegation saga fold: durable admission before dispatch, delivery observation before settlement, CAS settle-once, wake-after-settlement, and restart recovery for committed settlements whose attempt closure was interrupted.

## Flow map (current HEAD)

`kernel.delegate` allocates delegation ID and worker run ID -> pure `admit` -> driver prepare -> `openAssign` creates WorkItem, assigns execution, and allocates attempt -> `claimOpenWithinRoot` durably admits delegation -> driver dispatch/process wire -> worker loop runs with admission-stamped first run ID (driven follow-ups retain distinct telemetry IDs) -> kernel settlement CAS -> post-CAS events/wake and async `closeAttempt` -> restart `recoverAttempts` re-closes any committed settlement.

## Audit re-verification

- The audit's workerRunId finding was live at HEAD: `work-item-linkage.ts` wrote `workerRunId=delegationId`, while `worker-loop.ts` minted fresh UUIDs per run; settlement closure also looked up the delegation ID.
- The named saga findings were re-checked at HEAD. Admission, delivery, settlement, wake, CAS, and attempt-recovery ordering were already present and tested; no additional orphaned intermediate state was identified, so no unrelated saga refactor was made.
- The audit report directory was not present in the clean `origin/main` worktree, so stale findings were not applied without current-HEAD verification.
- No sibling protocol/ledger/channel files were modified; no collision with PR7/PR8 scope.

## Behavior pins

- End-to-end process assign asserts the commissioned WorkItem workerRunId is a UUID distinct from delegationId and is consumed by the child worker.
- Existing process delivery/settlement and work-item closure tests pass.
- Existing record-before-act, delivery-vs-settlement, settle-once, restart wake, and attempt recovery tests pass.

## Verification

Passed:

- `bun run build`
- `bunx turbo run check-types`
- `bun run script/check-deps.ts`
- `bun run script/check-import-cycles.ts`
- `bun run lint`
- `bun run lint:tools`
- `bunx ultracite check --formatter-enabled=false .`
- `bun run script/check-dead-exports.ts`
- `bun test --timeout 15000` (2829 pass, 0 fail)
- focused delegation/process/work-item tests (57 pass, then 29 pass with the new pin)

The app coverage test itself passed (290 pass); the subsequent ratchet command correctly reported `apps/openomni: coverage report exists but topology explicitly sets coverageLane: false`. No touched package coverage floor was applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Process delegation attempts now close against the real worker run instead of the delegation ID.

- The kernel allocates a run UUID at admission for process transports and threads it through admission, driver IPC, and the worker loop's first run.
- Settlement closure locates the attempt by the WorkItem's assigned run with a delegation-ID fallback; failures report the active run via `WorkerRunError`.
- The settling run ID is stored on the terminal attempt fact; driven follow-up runs keep their own telemetry IDs.

**Breaking wire change**
- `ProcessWorkerRequest` and `ProcessWorkerResult` now require `workerRunId` (wire v2); a missing ID fails before ack rather than silently diverging.
- Channel assignments are unchanged: they correlate via the durable prepared `waitId` and never persist a fabricated UUID.

**Scope notes**
- Settlement and attempt-terminal schemas accept an optional `workerRunId`.
- Existing saga ordering (durable admission, delivery observation, CAS settle-once, restart recovery) is untouched.
- Adds correlation pins for spawned-child single-run, multi-run, failure, and channel paths.

<sup>Written for commit 3eae83fa731e69b29477b4241702b7ad63fafa76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Adversarial review remediation (commit `205d190a`)

1. **Mutation honesty:** the child process now returns the run ID it actually consumed. The single-run end-to-end test asserts `settlement.workerRunId == commissioned WorkItem.workerRunId`; the multi-run test asserts the final settling run ID is stored on `attemptTerminal.workerRunId`. Removing the request wire field or ignoring it breaks these assertions.
2. **Channel assignments:** only process transports allocate a worker UUID. Channel assignments use their durable prepared `waitId` as the WorkItem correlation key; no fabricated UUID is recorded. Channel settlements do not claim a worker run.
3. **Driven reruns:** each driven run retains a distinct telemetry UUID; the worker returns the final run ID, settlement persists it, and attempt terminal facts record it. The attempt lookup uses the commissioned session/run pair.
4. **Process IPC compatibility:** `workerRunId` is required in `ProcessWorkerRequest` and `ProcessWorkerResult`; this is an intentional wire-v2 bump. Missing IDs fail before ack rather than silently diverging.
5. **Session/run pair:** process WorkItems commission with `workSessionId=delegation-${delegationId}`, matching the worker loop session; closure looks up that durable pair and records the settling run ID on the attempt terminal.

### Re-verification

- Focused process/work-item tests: **30 passed, 0 failed** (including single-run and multi-run correlation pins).
- Full gate chain at `205d190a`: build, turbo check-types, check-deps, import-cycle check, lint, lint:tools, whole-repo Ultracite, dead-exports, and `bun test --timeout 15000` all passed.
- Full suite: **2,830 passed, 0 failed**.


## Final finding closure (commit `5d6d1f9b`)

- A `WorkerRunError` now carries the active run ID through worker-loop, inline transport, and process IPC failure reporting. The regression path drives a worker, throws on a later run, and verifies the returned/settled identity is the active later run rather than the commissioned first run.
- Added a durable channel-assignment repository test using production linkage and the real WorkItem store. It asserts `workerRunId === waitId` and rejects UUID-shaped fabricated correlation.

### RED -> GREEN evidence

- Mutated process failure reporting back to `request.workerRunId`: the second-run exception test failed (`expected not commissioned ID`). Restored implementation: focused tests pass.
- Mutated channel linkage to allocate `crypto.randomUUID()`: the durable assignment test failed (`expected wait-durable`, received UUID). Restored implementation: focused tests pass.

### Final verification

- Focused worker/process/channel tests: **30 passed, 0 failed**.
- Full gate chain: **passed** (build, type checks, dependency/import-cycle checks, lint, tools lint, Ultracite, dead exports).
- Full suite: **2,833 passed, 0 failed**.


## Rebase with PR #884 / transport reconciliation

Rebased onto `origin/main` at `5c9fe7c5` after PR #884 merged. The RED app failures were fixture contract drift: the new strict process request schema correctly requires `workerRunId`, while the #884 model-transport fixtures omitted it. The wire implementation already carried operator `transport` (`baseUrl` and `headers`) through `process-driver` -> `ProcessWorkerRequest` -> child `processWorkerRun`; I updated both affected fixtures to include a valid `workerRunId`.

Both contracts remain strict: `workerRunId` is required, operator transport is forwarded, and unknown transport fields remain rejected. Relevant model-transport and process-transport tests pass.

Post-rebase full gate: **2,935 passed, 0 failed**. Branch pushed with `--force-with-lease` at `3eae83fa`.
