### PR TITLE
refactor: consolidate wait admission and grant normalization in channels (slop PR8)

### DIFF
--- a/apps/openomni/test/boot-wiring.test.ts
+++ b/apps/openomni/test/boot-wiring.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { ChannelDeliveryRoute } from "@openomni/channels";
-import { ChannelGrantStore, Storage } from "@openomni/ledger";
+import { resolveChannelGrant, type ChannelDeliveryRoute } from "@openomni/channels";
+import { Storage } from "@openomni/ledger";
 import type { Channel } from "@openomni/protocol";
 import type { BuiltChannel } from "../src/channels";
 import { createComposer } from "../src/composition/composer";
@@ -88,17 +88,15 @@ describe("mountChannelStages", () => {
     expect(deliveryRoutes.get("telegram")).toBe(route);
     // Ingress-only channels register no outbound route.
     expect(deliveryRoutes.has("github")).toBe(false);
-    expect(ChannelGrantStore.resolve({ surface: "telegram" })?.grant.kind).toBe(
-      "trusted_channel",
-    );
-    expect(ChannelGrantStore.resolve({ surface: "github" })?.grant.kind).toBe("trusted_channel");
+    expect(resolveChannelGrant({ surface: "telegram" })?.grant.kind).toBe("trusted_channel");
+    expect(resolveChannelGrant({ surface: "github" })?.grant.kind).toBe("trusted_channel");
 
     await composer.dispose();
 
     expect(routed.calls).toEqual(["start", "stop"]);
     expect(ingressOnly.calls).toEqual(["start", "stop"]);
     expect(deliveryRoutes.has("telegram")).toBe(false);
-    expect(ChannelGrantStore.resolve({ surface: "telegram" })).toBeUndefined();
-    expect(ChannelGrantStore.resolve({ surface: "github" })).toBeUndefined();
+    expect(resolveChannelGrant({ surface: "telegram" })).toBeUndefined();
+    expect(resolveChannelGrant({ surface: "github" })).toBeUndefined();
   });
 });

--- a/apps/openomni/test/gateway-contracts.test.ts
+++ b/apps/openomni/test/gateway-contracts.test.ts
@@ -3,8 +3,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolveChannelGrant } from "@openomni/channels";
 import type { RunInput } from "@openomni/llm";
-import { ActorRegistry, ChannelGrantStore, Session, Storage } from "@openomni/ledger";
+import { ActorRegistry, Session, Storage } from "@openomni/ledger";
 import { Gateway, type Message } from "@openomni/protocol";
 import { createResidentGateway, registerTrustedChannelGrant } from "../src/gateway";
 import { openCuratedMemory } from "../src/memory/store";
@@ -114,19 +115,15 @@ describe("channel grant registration", () => {
   test("the revoker removes exactly the grant it registered", () => {
     const revokeTelegram = registerTrustedChannelGrant("telegram");
     const revokeDiscord = registerTrustedChannelGrant("discord");
-    expect(ChannelGrantStore.resolve({ surface: "telegram" })?.grant.kind).toBe(
-      "trusted_channel",
-    );
+    expect(resolveChannelGrant({ surface: "telegram" })?.grant.kind).toBe("trusted_channel");
 
     revokeTelegram();
 
     // Only the telegram grant is gone; the sibling surface keeps its authority.
-    expect(ChannelGrantStore.resolve({ surface: "telegram" })).toBeUndefined();
-    expect(ChannelGrantStore.resolve({ surface: "discord" })?.grant.kind).toBe(
-      "trusted_channel",
-    );
+    expect(resolveChannelGrant({ surface: "telegram" })).toBeUndefined();
+    expect(resolveChannelGrant({ surface: "discord" })?.grant.kind).toBe("trusted_channel");
     revokeDiscord();
-    expect(ChannelGrantStore.resolve({ surface: "discord" })).toBeUndefined();
+    expect(resolveChannelGrant({ surface: "discord" })).toBeUndefined();
   });
 });
 

--- a/packages/channels/AGENTS.md
+++ b/packages/channels/AGENTS.md
@@ -13,8 +13,10 @@ src/
 ├── authn/            # Perimeter judgment: policy-engine decisions, trigger/webhook/upgrade authn
 ├── router/           # Gateway router (#707): createGatewayRouter, resolve-route (external arms),
 │   │                 #   routing-resolution (route.decided record + replay gate), routing-execution
-│   │                 #   (wait resumption arms), authority (routed pre-run), actor-resolver
-│   ├── wait/         # findWaitCandidates, matcher wrapper, WaitService (sole wait-store writer)
+│   │                 #   (wait resumption arms), authority (routed pre-run), actor-resolver,
+│   │                 #   raw-fact blacklist matching and channel-grant ranking/default treatment
+│   ├── wait/         # sole Wait admission/control owner: raw-row visibility, candidate precedence,
+│   │                 # matcher composition, fold invocation, and WaitService (sole wait-store writer)
 │   └── messaging/    # #215 send kernel: createExistingAgentMessaging, grant evaluation (scope-less + scope-aware
 │                     #   arms), #708 reply-grant instance materialization (in-memory by ruling; durable store = #709),
 │                     #   #219 social-budget egress gate (pure fold + EgressBudgetStore debits), audit events

--- a/packages/channels/src/index.ts
+++ b/packages/channels/src/index.ts
@@ -4,6 +4,7 @@ export { TelegramAdapter } from "./telegram/surface.js";
 export { GitHubAdapter } from "./github/surface.js";
 export { WebSocketHandler } from "./websocket.js";
 export { createGatewayRouter } from "./router/index.js";
+export { resolveChannelGrant } from "./router/channel-grant.js";
 export { WaitService } from "./router/wait/index.js";
 export type { ChannelDeliveryRoute, GatewayRouter } from "./router/index.js";
 export type { ExistingAgentMessaging } from "./router/messaging/send.js";

--- a/packages/channels/src/router/actor-resolver.ts
+++ b/packages/channels/src/router/actor-resolver.ts
@@ -1,5 +1,7 @@
 import type { Actor, Gateway, Ingress } from "@openomni/protocol";
-import { ActorRegistry, BlacklistStore, ChannelGrantStore } from "@openomni/ledger";
+import { ActorRegistry } from "@openomni/ledger";
+import { matchBlacklist } from "./blacklist.js";
+import { resolveChannelGrant } from "./channel-grant.js";
 
 function legacyActorFields(actor: Ingress.Actor | undefined): Ingress.Actor | undefined {
   if (!actor) return undefined;
@@ -35,7 +37,7 @@ function mintProvisionalContact(
   externalId: string,
   now: number,
 ): Actor.ResolvedEndpoint | undefined {
-  const resolution = ChannelGrantStore.resolve({
+  const resolution = resolveChannelGrant({
     surface: event.surface,
     workspace: event.workspace,
     channel: event.channel,
@@ -44,7 +46,7 @@ function mintProvisionalContact(
   const policy = resolution.grant.provisionalMint;
   const tier = resolution.grant.defaultTier;
   if (policy === undefined || tier === undefined) return undefined;
-  const blacklisted = BlacklistStore.match({
+  const blacklisted = matchBlacklist({
     channel: event.surface,
     candidates: [
       event.surface,

--- a/packages/channels/src/router/blacklist.ts
+++ b/packages/channels/src/router/blacklist.ts
@@ -1,0 +1,49 @@
+import type { Actor } from "@openomni/protocol";
+import { BlacklistStore } from "@openomni/ledger";
+
+export interface BlacklistMatchInput {
+  readonly actorId?: string;
+  readonly endpointId?: string;
+  readonly channel?: string;
+  readonly candidates?: readonly string[];
+}
+
+function isActive(entry: Actor.BlacklistEntry, now: number): boolean {
+  return entry.expiresAt === undefined || entry.expiresAt > now;
+}
+
+function wildcardMatches(pattern: string, candidate: string): boolean {
+  if (pattern === "*") return true;
+  const parts = pattern.split("*");
+  if (parts.length === 1) return pattern === candidate;
+
+  let offset = 0;
+  for (const [index, part] of parts.entries()) {
+    if (part === "") continue;
+    const found = candidate.indexOf(part, offset);
+    if (found === -1) return false;
+    if (index === 0 && found !== 0) return false;
+    offset = found + part.length;
+  }
+
+  const last = parts[parts.length - 1];
+  return last === "" || candidate.endsWith(last ?? "");
+}
+
+function entryMatches(entry: Actor.BlacklistEntry, input: BlacklistMatchInput): boolean {
+  const candidates = input.candidates ?? [];
+  if (entry.kind === "actor") return entry.value === input.actorId;
+  if (entry.kind === "endpoint") return entry.value === input.endpointId;
+  if (entry.kind === "channel") {
+    return entry.value === input.channel || candidates.includes(entry.value);
+  }
+  return candidates.some((candidate) => wildcardMatches(entry.value, candidate));
+}
+
+/** Matches raw blacklist facts at the perimeter, where deny authority lives. */
+export function matchBlacklist(
+  input: BlacklistMatchInput,
+  now = Date.now(),
+): Actor.BlacklistEntry | undefined {
+  return BlacklistStore.list().find((entry) => isActive(entry, now) && entryMatches(entry, input));
+}

--- a/packages/channels/src/router/channel-grant.ts
+++ b/packages/channels/src/router/channel-grant.ts
@@ -1,0 +1,100 @@
+import type { Actor } from "@openomni/protocol";
+import { ChannelGrantStore } from "@openomni/ledger";
+
+export interface ChannelGrantMatchInput {
+  readonly surface: string;
+  readonly workspace?: string;
+  readonly channel?: string;
+}
+
+export interface ChannelGrantResolution {
+  readonly grant: Actor.ChannelGrant;
+  readonly inboundTreatment: Actor.InboundTreatment;
+}
+
+function defaultTreatment(kind: Actor.ChannelGrantKind): Actor.InboundTreatment {
+  if (kind === "trusted_channel") return "full_access";
+  if (kind === "broadcast_channel") return "evidence_only";
+  return "drop";
+}
+
+function matches(grant: Actor.ChannelGrant, input: ChannelGrantMatchInput): boolean {
+  if (grant.surface !== input.surface) return false;
+  if (grant.workspace !== undefined && grant.workspace !== input.workspace) return false;
+  if (grant.channel !== undefined && grant.channel !== input.channel) return false;
+  return true;
+}
+
+function specificity(grant: Actor.ChannelGrant): number {
+  return (grant.workspace === undefined ? 0 : 1) + (grant.channel === undefined ? 0 : 1);
+}
+
+const treatmentRestriction: Record<Actor.InboundTreatment, number> = {
+  drop: 0,
+  evidence_only: 1,
+  full_access: 2,
+};
+
+const defaultTierRestriction: Record<Actor.TrustTier, number> = {
+  assigned_worker: 1,
+  observer: 2,
+  collaborator: 3,
+  manager: 4,
+  co_owner: 5,
+  owner: 6,
+};
+
+const kindRestriction: Record<Actor.ChannelGrantKind, number> = {
+  blocked_channel: 0,
+  broadcast_channel: 1,
+  trusted_channel: 2,
+};
+
+function effectiveTreatment(grant: Actor.ChannelGrant): Actor.InboundTreatment {
+  const treatment = grant.inboundTreatment ?? defaultTreatment(grant.kind);
+  if (grant.kind === "blocked_channel" || treatment === "drop") return "drop";
+  if (grant.kind === "broadcast_channel") return "evidence_only";
+  return treatment;
+}
+
+function compareStableText(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * Chooses the perimeter's effective channel grant. Specificity wins first;
+ * equal-score grants use a fail-closed, backend-independent total order.
+ */
+function compareResolutionOrder(a: Actor.ChannelGrant, b: Actor.ChannelGrant): number {
+  const specificityOrder = specificity(b) - specificity(a);
+  if (specificityOrder !== 0) return specificityOrder;
+
+  const treatmentOrder =
+    treatmentRestriction[effectiveTreatment(a)] - treatmentRestriction[effectiveTreatment(b)];
+  if (treatmentOrder !== 0) return treatmentOrder;
+
+  const defaultTierOrder =
+    (a.defaultTier === undefined ? 0 : defaultTierRestriction[a.defaultTier]) -
+    (b.defaultTier === undefined ? 0 : defaultTierRestriction[b.defaultTier]);
+  if (defaultTierOrder !== 0) return defaultTierOrder;
+
+  const kindOrder = kindRestriction[a.kind] - kindRestriction[b.kind];
+  if (kindOrder !== 0) return kindOrder;
+
+  return compareStableText(a.id, b.id);
+}
+
+export function resolveChannelGrant(
+  input: ChannelGrantMatchInput,
+): ChannelGrantResolution | undefined {
+  const grants = ChannelGrantStore.list().filter((grant) => matches(grant, input));
+  grants.sort(compareResolutionOrder);
+  const grant = grants[0];
+  if (grant === undefined) return undefined;
+  return {
+    grant,
+    inboundTreatment: effectiveTreatment(grant),
+  };
+}

--- a/packages/channels/src/router/messaging/send.ts
+++ b/packages/channels/src/router/messaging/send.ts
@@ -10,7 +10,6 @@ import {
 } from "@openomni/protocol";
 import {
   ActorRegistry,
-  BlacklistStore,
   ConversationStore,
   EgressBudgetStore,
   LedgerAppend,
@@ -18,6 +17,7 @@ import {
   WaitStore,
 } from "@openomni/ledger";
 import { WaitService } from "../wait/index.js";
+import { matchBlacklist } from "../blacklist.js";
 import {
   deliverySurfaceKey,
   hasScopedSenderTargetCandidate,
@@ -139,7 +139,7 @@ function conversationGate(
   if (conversation.contactId !== target.actorId || conversation.endpointId !== target.endpointId) {
     return `conversation ${conversationId} is not pinned to ${target.actorId} at ${target.endpointId}`;
   }
-  const dnc = BlacklistStore.match({
+  const dnc = matchBlacklist({
     actorId: target.actorId,
     endpointId: target.endpointId,
     channel: target.channel,

--- a/packages/channels/src/router/routing-resolution.ts
+++ b/packages/channels/src/router/routing-resolution.ts
@@ -9,13 +9,13 @@ import {
   type BusEvent,
 } from "@openomni/protocol";
 import {
-  BlacklistStore,
-  ChannelGrantStore,
   ConversationStore,
   LedgerAppend,
   SurfaceKey,
 } from "@openomni/ledger";
 import { applyChannelGrantTreatment } from "./authority.js";
+import { matchBlacklist } from "./blacklist.js";
+import { resolveChannelGrant, type ChannelGrantResolution } from "./channel-grant.js";
 import { replyGrantEndpointFacts, replyGrantEndpointFromFacts } from "./messaging/reply-grant.js";
 import { resolveRoute, type RouteState } from "./resolve-route.js";
 import { findWaitCandidates, type WaitResolution } from "./wait/index.js";
@@ -189,7 +189,7 @@ function selectedRouteTarget(
   throw new TypeError("wait-correlation route has no executable wait target");
 }
 
-type ChannelResolution = ReturnType<typeof ChannelGrantStore.resolve>;
+type ChannelResolution = ChannelGrantResolution | undefined;
 
 function channelState(
   resolution: ChannelResolution,
@@ -260,7 +260,7 @@ function blacklistState(
   correlation: ScopedCorrelation | undefined,
 ): RouteState["blacklist"] {
   const actor = event.meta?.actor;
-  const entry = BlacklistStore.match({
+  const entry = matchBlacklist({
     actorId: typeof actor?.actorId === "string" ? actor.actorId : undefined,
     endpointId:
       (typeof actor?.endpointId === "string" ? actor.endpointId : undefined) ??
@@ -314,7 +314,7 @@ function resolveKernelRoute<Event extends Gateway.DeliveredEvent>(
     event.activation?.durableSessionId ?? SurfaceKey.lookup(extractSurfaceKey(event));
   const blacklist = blacklistState(event, correlation);
   const conversation = conversationState(event, correlation);
-  const channelResolution = ChannelGrantStore.resolve({
+  const channelResolution = resolveChannelGrant({
     surface: event.surface,
     workspace: event.workspace,
     channel: event.channel,

--- a/packages/channels/src/router/wait/correlation.ts
+++ b/packages/channels/src/router/wait/correlation.ts
@@ -19,6 +19,17 @@ export type WaitResolution =
   | Readonly<{ kind: "match"; candidate: WaitCandidate }>
   | Readonly<{ kind: "ambiguous"; candidates: readonly WaitCandidate[] }>;
 
+function stillCorrelatable(record: Wait.Record, now: number): boolean {
+  // Open rows remain visible past the deadline so admission can return the
+  // typed deadline_passed rejection instead of leaking into surface routing.
+  if (record.status === "open") return true;
+  return (
+    record.status === "resolved" &&
+    record.resolvedAt !== undefined &&
+    now <= record.resolvedAt + record.followUpWindow
+  );
+}
+
 function resolveLevel(rawCandidates: readonly WaitCandidate[]): WaitResolution | undefined {
   const candidates = [
     ...new Map(rawCandidates.map((candidate) => [candidate.key, candidate])).values(),
@@ -29,11 +40,15 @@ function resolveLevel(rawCandidates: readonly WaitCandidate[]): WaitResolution |
   return { kind: "ambiguous", candidates };
 }
 
-export function findWaitCandidates(correlation: Wait.Correlation | undefined): WaitResolution {
+export function findWaitCandidates(
+  correlation: Wait.Correlation | undefined,
+  now = Date.now(),
+): WaitResolution {
   if (correlation === undefined) return { kind: "none" };
   for (const query of Wait.waitTierLevels(correlation)) {
     const resolution = resolveLevel(
       WaitStore.findByCorrelation(query)
+        .filter((record) => stillCorrelatable(record, now))
         .filter((record) => Wait.waitPinsAllowClaim(record, correlation))
         .map((record) => ({ key: `wait:${record.id}`, wait: record }) as const),
     );

--- a/packages/channels/src/router/wait/lifecycle.ts
+++ b/packages/channels/src/router/wait/lifecycle.ts
@@ -1,4 +1,4 @@
-import { Deadline, Operational, type Wait, type BusEvent } from "@openomni/protocol";
+import { Deadline, Operational, Wait, type BusEvent } from "@openomni/protocol";
 import { WaitStore } from "@openomni/ledger";
 
 /**
@@ -11,6 +11,12 @@ import { WaitStore } from "@openomni/ledger";
  * and never write (the sync-ask audit itself is brain machinery and stayed
  * brain-side at the seam flip).
  */
+function requireWait(id: string): Wait.Record {
+  const record = WaitStore.get(id);
+  if (record !== undefined) return record;
+  throw new Wait.StoreError({ message: `Wait not found: ${id}`, code: "not_found", waitId: id });
+}
+
 export namespace WaitService {
   /** Opens the one durable Wait for an awaited delivery. Fails closed on a missing adapter or duplicate origin message. */
   export function open(input: Wait.Create, traceId: string): Wait.Record {
@@ -23,7 +29,9 @@ export namespace WaitService {
    * outcome under a revision compare-and-set.
    */
   export function attachReply(id: string, input: Wait.ReplyInput, traceId: string): Wait.Outcome {
-    return WaitStore.attachReply(id, input, traceId);
+    const parsed = Wait.ReplyInput.parse(input);
+    const outcome = Wait.attachReply(requireWait(id), parsed);
+    return WaitStore.commit(outcome, traceId, parsed.replyKey);
   }
 
   /**
@@ -37,7 +45,8 @@ export namespace WaitService {
     input: Wait.DeliveryReceiptInput,
     traceId: string,
   ): Wait.Outcome {
-    return WaitStore.recordDeliveryReceipt(id, input, traceId);
+    const parsed = Wait.DeliveryReceiptInput.parse(input);
+    return WaitStore.commit(Wait.recordDeliveryReceipt(requireWait(id), parsed), traceId);
   }
 
   /**
@@ -46,7 +55,7 @@ export namespace WaitService {
    * attached) before returning the typed rejection.
    */
   export function expire(id: string, traceId: string, at = Date.now()): Wait.Outcome {
-    return WaitStore.expire(id, traceId, at);
+    return WaitStore.commit(Wait.expire(requireWait(id), { at }), traceId);
   }
 
   /**
@@ -62,6 +71,10 @@ export namespace WaitService {
    * the sweep is mid-flow, not a trace origin — ONE id covers the whole
    * sweep, including every per-corrupt-wait error it records.
    */
+  export function cancel(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+    return WaitStore.commit(Wait.cancel(requireWait(id), { at }), traceId);
+  }
+
   export function sweepExpired(
     traceId: string,
     publish: BusEvent.Sink["publish"],

--- a/packages/channels/test/router/blacklist-matching.test.ts
+++ b/packages/channels/test/router/blacklist-matching.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { BlacklistStore, Storage } from "@openomni/ledger";
+import { matchBlacklist } from "../../src/router/blacklist";
+
+beforeEach(() => {
+  Storage.reset();
+  Storage.initialize({ dbPath: ":memory:" });
+});
+
+describe("blacklist perimeter matching", () => {
+  test("matches active actor and endpoint facts", () => {
+    BlacklistStore.put({
+      id: "bl-actor",
+      kind: "actor",
+      value: "act_bad",
+      createdBy: "act_owner",
+    });
+    BlacklistStore.put({
+      id: "bl-endpoint",
+      kind: "endpoint",
+      value: "ep_old",
+      expiresAt: 2,
+      createdBy: "act_owner",
+    });
+
+    expect(matchBlacklist({ actorId: "act_bad" })?.id).toBe("bl-actor");
+    expect(matchBlacklist({ endpointId: "ep_old" }, 1)?.id).toBe("bl-endpoint");
+    expect(matchBlacklist({ endpointId: "ep_old" }, 2)).toBeUndefined();
+  });
+
+  test("matches wildcard pattern facts without crossing unmatched segments", () => {
+    BlacklistStore.put({
+      id: "bl-pattern",
+      kind: "pattern",
+      value: "discord:*:dev",
+      createdBy: "act_owner",
+    });
+
+    expect(matchBlacklist({ candidates: ["discord:guild:dev"] })?.id).toBe("bl-pattern");
+    expect(matchBlacklist({ candidates: ["discord:other:prod"] })).toBeUndefined();
+  });
+
+  test("matches channel facts against the canonical channel and candidates", () => {
+    BlacklistStore.put({
+      id: "bl-channel",
+      kind: "channel",
+      value: "dev",
+      createdBy: "act_owner",
+    });
+
+    expect(matchBlacklist({ channel: "dev" })?.id).toBe("bl-channel");
+    expect(matchBlacklist({ candidates: ["dev"] })?.id).toBe("bl-channel");
+  });
+});

--- a/packages/channels/test/router/channel-grant-resolution.test.ts
+++ b/packages/channels/test/router/channel-grant-resolution.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ChannelGrantStore, Storage } from "@openomni/ledger";
+import { resolveChannelGrant } from "../../src/router/channel-grant";
+
+beforeEach(() => {
+  Storage.reset();
+  Storage.initialize({ dbPath: ":memory:" });
+});
+
+const restrictiveGrant = {
+  id: "z-restrictive",
+  surface: "discord",
+  workspace: "guild",
+  kind: "blocked_channel",
+  createdBy: "act_owner",
+  createdAt: 200,
+} as const satisfies ChannelGrantStore.Grant;
+
+const permissiveGrant = {
+  id: "a-permissive",
+  surface: "discord",
+  channel: "design",
+  kind: "trusted_channel",
+  defaultTier: "owner",
+  createdBy: "act_owner",
+  createdAt: 100,
+} as const satisfies ChannelGrantStore.Grant;
+
+const equalSpecificityInput = {
+  surface: "discord",
+  workspace: "guild",
+  channel: "design",
+} as const;
+
+function resolveBothOrders(
+  first: ChannelGrantStore.Grant,
+  second: ChannelGrantStore.Grant,
+): (string | undefined)[] {
+  return [
+    [first, second],
+    [second, first],
+  ].map((grants) => {
+    Storage.reset();
+    Storage.initialize({ dbPath: ":memory:" });
+    for (const grant of grants) ChannelGrantStore.put(grant);
+    return resolveChannelGrant({ surface: "discord" })?.grant.id;
+  });
+}
+
+describe("channel grant authority", () => {
+  test("chooses the most specific matching grant", () => {
+    ChannelGrantStore.put({
+      id: "grant-surface",
+      surface: "discord",
+      kind: "trusted_channel",
+      createdBy: "act_owner",
+    });
+    ChannelGrantStore.put({
+      id: "grant-channel",
+      surface: "discord",
+      workspace: "guild",
+      channel: "design",
+      kind: "broadcast_channel",
+      defaultTier: "observer",
+      createdBy: "act_owner",
+    });
+
+    expect(resolveChannelGrant(equalSpecificityInput)).toMatchObject({
+      grant: { id: "grant-channel" },
+      inboundTreatment: "evidence_only",
+    });
+  });
+
+  test("equal-specificity conflicts choose the restrictive grant regardless of insertion order", () => {
+    const winners = [
+      [permissiveGrant, restrictiveGrant],
+      [restrictiveGrant, permissiveGrant],
+    ].map((grants) => {
+      Storage.reset();
+      Storage.initialize({ dbPath: ":memory:" });
+      for (const grant of grants) ChannelGrantStore.put(grant);
+      return resolveChannelGrant(equalSpecificityInput)?.grant.id;
+    });
+
+    expect(winners).toEqual([restrictiveGrant.id, restrictiveGrant.id]);
+  });
+
+  test("equal-treatment conflicts fall through tier, kind, then id tie-breaks", () => {
+    const observerTier = {
+      id: "b-observer",
+      surface: "discord",
+      kind: "trusted_channel",
+      defaultTier: "observer",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    const ownerTier = { ...observerTier, id: "a-owner", defaultTier: "owner" } as const;
+    expect(resolveBothOrders(observerTier, ownerTier)).toEqual(["b-observer", "b-observer"]);
+
+    const broadcastKind = {
+      id: "b-broadcast",
+      surface: "discord",
+      kind: "broadcast_channel",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    const trustedEvidence = {
+      id: "a-trusted",
+      surface: "discord",
+      kind: "trusted_channel",
+      inboundTreatment: "evidence_only",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    expect(resolveBothOrders(broadcastKind, trustedEvidence)).toEqual([
+      "b-broadcast",
+      "b-broadcast",
+    ]);
+
+    const firstId = {
+      id: "a-first",
+      surface: "discord",
+      kind: "trusted_channel",
+      createdBy: "act_owner",
+    } as const satisfies ChannelGrantStore.Grant;
+    expect(resolveBothOrders(firstId, { ...firstId, id: "b-second" })).toEqual([
+      "a-first",
+      "a-first",
+    ]);
+  });
+
+  test("normalizes an explicit treatment against the grant kind exactly once", () => {
+    ChannelGrantStore.put({
+      id: "grant-override",
+      surface: "discord",
+      kind: "broadcast_channel",
+      inboundTreatment: "full_access",
+      createdBy: "act_owner",
+    });
+
+    expect(resolveChannelGrant({ surface: "discord" })?.inboundTreatment).toBe("evidence_only");
+  });
+
+  test("returns no resolution when no raw fact matches", () => {
+    ChannelGrantStore.put({
+      id: "grant-discord",
+      surface: "discord",
+      kind: "trusted_channel",
+      createdBy: "act_owner",
+    });
+
+    expect(resolveChannelGrant({ surface: "telegram" })).toBeUndefined();
+  });
+});

--- a/packages/channels/test/router/kernel-routing.test.ts
+++ b/packages/channels/test/router/kernel-routing.test.ts
@@ -78,8 +78,8 @@ describe("GatewayRouter kernel routing", () => {
     // Given
     registerOwnerDm();
     createMappedOwnerSession();
-    const blacklistRead = spyOn(BlacklistStore, "match");
-    const channelRead = spyOn(ChannelGrantStore, "resolve");
+    const blacklistRead = spyOn(BlacklistStore, "list");
+    const channelRead = spyOn(ChannelGrantStore, "list");
     let blacklistReads = 0;
     let channelReads = 0;
 

--- a/packages/channels/test/router/messaging/send.test.ts
+++ b/packages/channels/test/router/messaging/send.test.ts
@@ -331,10 +331,10 @@ describe("delivery receipt", () => {
     expect(stored?.correlation.replyToMessageId).toBe("platform:msg-77");
     // Correlation now answers the platform id, not the internal message id.
     expect(
-      WaitStore.findByCorrelation({ replyToMessageId: "platform:msg-77" }, messagingNow),
+      WaitStore.findByCorrelation({ replyToMessageId: "platform:msg-77" }),
     ).toHaveLength(1);
     expect(
-      WaitStore.findByCorrelation({ replyToMessageId: "message:test-awaited" }, messagingNow),
+      WaitStore.findByCorrelation({ replyToMessageId: "message:test-awaited" }),
     ).toHaveLength(0);
   });
 

--- a/packages/channels/test/router/wait/correlation.test.ts
+++ b/packages/channels/test/router/wait/correlation.test.ts
@@ -125,6 +125,25 @@ describe("findWaitCandidates", () => {
     });
   });
 
+  test("keeps resolved waits visible through the inclusive follow-up boundary only", () => {
+    const resolved = buildWaitRecord("wait-resolved", {
+      status: "resolved",
+      resolvedAt: 1_000,
+      followUpWindow: 1_000,
+    });
+    spyOn(WaitStore, "findByCorrelation").mockReturnValue([resolved]);
+
+    expect(findWaitCandidates(correlation, 2_000).kind).toBe("match");
+    expect(findWaitCandidates(correlation, 2_001)).toEqual({ kind: "none" });
+  });
+
+  test("keeps expired-open waits visible for a typed deadline rejection", () => {
+    const open = buildWaitRecord("wait-expired-open", { expiresAt: 1_000 });
+    spyOn(WaitStore, "findByCorrelation").mockReturnValue([open]);
+
+    expect(findWaitCandidates(correlation, 1_001).kind).toBe("match");
+  });
+
   test("deduplicates duplicate records within the winning precedence level", () => {
     const record = buildWaitRecord("same-wait");
     spyOn(WaitStore, "findByCorrelation").mockImplementation((query) =>

--- a/packages/ledger/AGENTS.md
+++ b/packages/ledger/AGENTS.md
@@ -35,13 +35,13 @@ src/
 ├── ledger-core/          # Ledger append core (#510 A): serialized CAS append, adoptStream, headFact/factsByType, verifyTail over the hash-chained ledger_event table (schema.ts = drizzle DDL source)
 ├── bus-persistence/      # Observational hash-chained bus journal + BusQuery; payload status/diagnostic preserves invalid raw values
 ├── actor/                # ActorIdentity / ActorEndpoint registry stores
-├── blacklist/            # Blacklist entry store (absolute deny gate data)
-├── channel-grant/        # ChannelGrant store (surface/workspace/channel ceilings)
+├── blacklist/            # Raw Blacklist entry CRUD; channels owns active/pattern matching
+├── channel-grant/        # Raw ChannelGrant CRUD; channels owns ranking/default treatment
 ├── artifact/             # Artifact.store / get; reads normalize legacy invalid metadata into the current schema
 ├── app-connector/        # Installed-app lifecycle; installation and connector actor identity/endpoint change transactionally
 ├── surface-key/          # SurfaceKey — N:1 mapping from external surface keys to session IDs
 ├── engagement/           # EngagementStore — durable delegation machine (#709, gateway-design §5): fact-before-projection appends on engagement:<id> streams via the shared commit coordinator (no adoption path — the stream class was born with the table), typed Engagement.StoreError fail-closed, lazy deadline expiry at hydration (listActive). Brain-domain surface: the brain is its sole writer
-├── wait/                 # WaitStore — durable Wait contract (#215/#510 B): fact-before-projection appends on wait:<id> streams via the shared commit coordinator, typed Wait.StoreError fail-closed, lazy pre-cutover adoption (identity-only genesis)
+├── wait/                 # WaitStore — raw correlation reads plus durable channels-produced Wait outcomes (#215/#510 B): fact-before-projection CAS via the shared commit coordinator, typed Wait.StoreError fail-closed, lazy pre-cutover adoption
 ├── egress/               # EgressBudgetStore — durable perimeter social-budget debit records
 ├── work-item/            # WorkItemStore — universal work state engine
 │   ├── index.ts          # WorkItemStore namespace barrel: public WorkItemStore.* API
@@ -79,8 +79,9 @@ src/
 
 Stores may provide CRUD and indexed queries:
 
-- `WaitStore.findByCorrelation(...)` may return candidate records.
-- `ChannelGrantStore` / `BlacklistStore` may persist and retrieve records.
+- `WaitStore.findByCorrelation(...)` returns raw indexed candidate records; it does not filter follow-up eligibility.
+- `WaitStore.commit(...)` persists a channels-produced outcome under revision CAS; it does not invoke a domain fold.
+- `ChannelGrantStore` / `BlacklistStore` persist and retrieve raw records only.
 
 Stores must not own kernel decisions:
 

--- a/packages/ledger/src/blacklist/index.ts
+++ b/packages/ledger/src/blacklist/index.ts
@@ -2,48 +2,11 @@ import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
-interface BlacklistMatchInput {
-  readonly actorId?: string;
-  readonly endpointId?: string;
-  readonly channel?: string;
-  readonly candidates?: readonly string[];
-}
-
 function requireAdapter(): NonNullable<Storage.Adapter["blacklist"]> {
   return requireSubAdapter(Storage.get().blacklist, "Storage adapter does not implement blacklist");
 }
 
-function isActive(entry: Actor.BlacklistEntry, now: number): boolean {
-  return entry.expiresAt === undefined || entry.expiresAt > now;
-}
-
-function wildcardMatches(pattern: string, candidate: string): boolean {
-  if (pattern === "*") return true;
-  const parts = pattern.split("*");
-  if (parts.length === 1) return pattern === candidate;
-
-  let offset = 0;
-  for (const [index, part] of parts.entries()) {
-    if (part === "") continue;
-    const found = candidate.indexOf(part, offset);
-    if (found === -1) return false;
-    if (index === 0 && found !== 0) return false;
-    offset = found + part.length;
-  }
-
-  const last = parts[parts.length - 1];
-  return last === "" || candidate.endsWith(last ?? "");
-}
-
-function entryMatches(entry: Actor.BlacklistEntry, input: BlacklistMatchInput): boolean {
-  const candidates = input.candidates ?? [];
-  if (entry.kind === "actor") return entry.value === input.actorId;
-  if (entry.kind === "endpoint") return entry.value === input.endpointId;
-  if (entry.kind === "channel")
-    return entry.value === input.channel || candidates.includes(entry.value);
-  return candidates.some((candidate) => wildcardMatches(entry.value, candidate));
-}
-
+/** Raw blacklist fact storage. Active-pattern matching belongs to channels. */
 export namespace BlacklistStore {
   export function put(input: Actor.BlacklistEntry): Actor.BlacklistEntry {
     const store = requireAdapter();
@@ -52,14 +15,15 @@ export namespace BlacklistStore {
     return entry;
   }
 
-  export function match(
-    input: BlacklistMatchInput,
-    now = Date.now(),
-  ): Actor.BlacklistEntry | undefined {
-    // Fail closed like put(): this feeds an absolute deny gate, so an absent
-    // adapter must never read as "not blacklisted".
-    return requireAdapter()
-      .list()
-      .find((entry) => isActive(entry, now) && entryMatches(entry, input));
+  export function get(id: string): Actor.BlacklistEntry | undefined {
+    return requireAdapter().get(id);
+  }
+
+  export function list(): Actor.BlacklistEntry[] {
+    return requireAdapter().list();
+  }
+
+  export function remove(id: string): boolean {
+    return requireAdapter().remove(id);
   }
 }

--- a/packages/ledger/src/channel-grant/index.ts
+++ b/packages/ledger/src/channel-grant/index.ts
@@ -2,17 +2,6 @@ import { Actor } from "@openomni/protocol";
 import { Storage } from "../storage/storage";
 import { requireSubAdapter, withStoreTimestamps } from "../storage/timestamped-store";
 
-interface ChannelGrantMatchInput {
-  readonly surface: string;
-  readonly workspace?: string;
-  readonly channel?: string;
-}
-
-interface ChannelGrantResolution {
-  readonly grant: Actor.ChannelGrant;
-  readonly inboundTreatment: Actor.InboundTreatment;
-}
-
 function requireAdapter(): NonNullable<Storage.Adapter["channelGrant"]> {
   return requireSubAdapter(
     Storage.get().channelGrant,
@@ -20,83 +9,7 @@ function requireAdapter(): NonNullable<Storage.Adapter["channelGrant"]> {
   );
 }
 
-function defaultTreatment(kind: Actor.ChannelGrantKind): Actor.InboundTreatment {
-  if (kind === "trusted_channel") return "full_access";
-  if (kind === "broadcast_channel") return "evidence_only";
-  return "drop";
-}
-
-function matches(grant: Actor.ChannelGrant, input: ChannelGrantMatchInput): boolean {
-  if (grant.surface !== input.surface) return false;
-  if (grant.workspace !== undefined && grant.workspace !== input.workspace) return false;
-  if (grant.channel !== undefined && grant.channel !== input.channel) return false;
-  return true;
-}
-
-function specificity(grant: Actor.ChannelGrant): number {
-  return (grant.workspace === undefined ? 0 : 1) + (grant.channel === undefined ? 0 : 1);
-}
-
-const treatmentRestriction: Record<Actor.InboundTreatment, number> = {
-  drop: 0,
-  evidence_only: 1,
-  full_access: 2,
-};
-
-const defaultTierRestriction: Record<Actor.TrustTier, number> = {
-  assigned_worker: 1,
-  observer: 2,
-  collaborator: 3,
-  manager: 4,
-  co_owner: 5,
-  owner: 6,
-};
-
-const kindRestriction: Record<Actor.ChannelGrantKind, number> = {
-  blocked_channel: 0,
-  broadcast_channel: 1,
-  trusted_channel: 2,
-};
-
-function effectiveTreatment(grant: Actor.ChannelGrant): Actor.InboundTreatment {
-  const treatment = grant.inboundTreatment ?? defaultTreatment(grant.kind);
-  if (grant.kind === "blocked_channel" || treatment === "drop") return "drop";
-  if (grant.kind === "broadcast_channel") return "evidence_only";
-  return treatment;
-}
-
-function compareStableText(a: string, b: string): number {
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
-}
-
-/**
- * Resolution keeps the existing specificity lattice, then orders equal-score
- * grants fail-closed: effective treatment (drop → evidence → full), absent or
- * lower-authority default tier, intrinsically restrictive kind, then grant ID
- * by code-unit order. IDs are unique stable identities, so the final key makes
- * this a backend- and insertion-independent total order.
- */
-function compareResolutionOrder(a: Actor.ChannelGrant, b: Actor.ChannelGrant): number {
-  const specificityOrder = specificity(b) - specificity(a);
-  if (specificityOrder !== 0) return specificityOrder;
-
-  const treatmentOrder =
-    treatmentRestriction[effectiveTreatment(a)] - treatmentRestriction[effectiveTreatment(b)];
-  if (treatmentOrder !== 0) return treatmentOrder;
-
-  const defaultTierOrder =
-    (a.defaultTier === undefined ? 0 : defaultTierRestriction[a.defaultTier]) -
-    (b.defaultTier === undefined ? 0 : defaultTierRestriction[b.defaultTier]);
-  if (defaultTierOrder !== 0) return defaultTierOrder;
-
-  const kindOrder = kindRestriction[a.kind] - kindRestriction[b.kind];
-  if (kindOrder !== 0) return kindOrder;
-
-  return compareStableText(a.id, b.id);
-}
-
+/** Raw channel-grant fact storage. Resolution and treatment belong to channels. */
 export namespace ChannelGrantStore {
   export type Grant = Actor.ChannelGrant;
 
@@ -107,22 +20,15 @@ export namespace ChannelGrantStore {
     return grant;
   }
 
-  export function remove(id: string): boolean {
-    return requireAdapter().remove(id);
+  export function get(id: string): Grant | undefined {
+    return requireAdapter().get(id);
   }
 
-  export function resolve(input: ChannelGrantMatchInput): ChannelGrantResolution | undefined {
-    // Absent adapter previously read as "no grant" (deny — benign), but reads
-    // and writes follow ONE rule here: the adapter is required (like put()).
-    const grants = requireAdapter()
-      .list()
-      .filter((grant) => matches(grant, input))
-      .sort(compareResolutionOrder);
-    const grant = grants[0];
-    if (!grant) return undefined;
-    return {
-      grant,
-      inboundTreatment: grant.inboundTreatment ?? defaultTreatment(grant.kind),
-    };
+  export function list(): Grant[] {
+    return requireAdapter().list();
+  }
+
+  export function remove(id: string): boolean {
+    return requireAdapter().remove(id);
   }
 }

--- a/packages/ledger/src/wait/index.ts
+++ b/packages/ledger/src/wait/index.ts
@@ -139,19 +139,6 @@ function eventBase(record: Wait.Record, time: number, traceId: string) {
   };
 }
 
-function stillCorrelatable(record: Wait.Record, now: number): boolean {
-  // Open rows surface even past their deadline: pre-filtering expired-open
-  // waits here would silently drop late replies into surface routing. The
-  // deadline rule is owned by the fold (deadline_passed) plus the kernel's
-  // lazy expiry; only resolved rows age out of correlation here (follow-up
-  // window), because a resolved wait has already been delivered.
-  if (record.status === "open") return true;
-  if (record.status === "resolved" && record.resolvedAt !== undefined) {
-    return now <= record.resolvedAt + record.followUpWindow;
-  }
-  return false;
-}
-
 // Bus stays observe-only for the wait decision class (#510): these publishes
 // are lossy projections of the appended facts and fire only AFTER the
 // append+projection transaction committed — a subscriber can never write the
@@ -257,10 +244,9 @@ export namespace WaitStore {
     return requireAdapter().list(status);
   }
 
-  export function findByCorrelation(query: Wait.CorrelationQuery, now = Date.now()): Wait.Record[] {
-    return requireAdapter()
-      .findByCorrelation(Wait.CorrelationQuery.parse(query))
-      .filter((record) => stillCorrelatable(record, now));
+  /** Raw indexed facts; channels owns correlation visibility and precedence. */
+  export function findByCorrelation(query: Wait.CorrelationQuery): Wait.Record[] {
+    return requireAdapter().findByCorrelation(Wait.CorrelationQuery.parse(query));
   }
 
   /**
@@ -273,13 +259,14 @@ export namespace WaitStore {
    * ledger head equal to the projected revision either way. Retrying from
    * the fresh head is the caller's decision.
    */
-  export function transition(
-    id: string,
-    step: (record: Wait.Record) => Wait.Outcome,
+  export function commit(
+    outcome: Wait.Outcome,
     traceId: string,
+    rejectionReplyKey?: string,
   ): Wait.Outcome {
     const adapter = requireAdapter();
     const ledger = requireLedger();
+    const id = outcome.record.id;
     const current = adapter.get(id);
     if (!current) {
       throw new Wait.StoreError({
@@ -288,11 +275,22 @@ export namespace WaitStore {
         waitId: id,
       });
     }
-    const outcome = step(current);
     // No-write outcomes: rejections never persist; already_resolved returns
     // the recorded resolution unchanged (redelivery short-circuit — no state
-    // change, no revision bump, no event).
-    if (outcome.kind === "rejected" || outcome.kind === "already_resolved") return outcome;
+    // change, no revision bump, no event). The optional reply key preserves
+    // the existing lossy rejection observation without asking storage to
+    // decide the rejection.
+    if (outcome.kind === "rejected") {
+      Bus.publish(Wait.Events.ReplyRejected, {
+        ...eventBase(outcome.record, outcome.at, traceId),
+        code: outcome.code,
+        ...(rejectionReplyKey === undefined ? {} : { replyKey: rejectionReplyKey }),
+      });
+      return outcome;
+    }
+    if (outcome.kind === "already_resolved") return outcome;
+    const expectedRevision = outcome.record.revision - 1;
+    if (current.revision !== expectedRevision) throw revisionConflict(id, expectedRevision);
     const fact = factOf(outcome);
     runWaitTransaction(id, () => {
       // Lazy adoption (#510 review fix F3): a pre-cutover wait row exists at
@@ -309,7 +307,7 @@ export namespace WaitStore {
         ledger,
         {
           streamId: waitStreamId(id),
-          expectedHead: current.revision,
+          expectedHead: expectedRevision,
           fact,
           adoption: {
             genesis: {
@@ -329,47 +327,12 @@ export namespace WaitStore {
         // guard the same head == revision); it stays as the explosive
         // backstop — the rollback discards the appended fact so head and
         // revision still agree.
-        () => adapter.compareAndSet(id, current.revision, outcome.record) || false,
+        () => adapter.compareAndSet(id, expectedRevision, outcome.record) || false,
       );
-      if (committed.kind !== "committed") throw revisionConflict(id, current.revision);
+      if (committed.kind !== "committed") throw revisionConflict(id, expectedRevision);
     });
     publishChange(outcome, traceId);
     return outcome;
   }
 
-  export function attachReply(id: string, input: Wait.ReplyInput, traceId: string): Wait.Outcome {
-    const parsed = Wait.ReplyInput.parse(input);
-    const outcome = transition(id, (record) => Wait.attachReply(record, parsed), traceId);
-    if (outcome.kind === "rejected") {
-      Bus.publish(Wait.Events.ReplyRejected, {
-        ...eventBase(outcome.record, outcome.at, traceId),
-        code: outcome.code,
-        replyKey: parsed.replyKey,
-      });
-    }
-    return outcome;
-  }
-
-  /**
-   * Records the platform message id of the awaited outbound delivery on an
-   * open wait (fold recordDeliveryReceipt): correlation.replyToMessageId
-   * re-keys to the platform id under the same revision CAS as every other
-   * transition.
-   */
-  export function recordDeliveryReceipt(
-    id: string,
-    input: Wait.DeliveryReceiptInput,
-    traceId: string,
-  ): Wait.Outcome {
-    const parsed = Wait.DeliveryReceiptInput.parse(input);
-    return transition(id, (record) => Wait.recordDeliveryReceipt(record, parsed), traceId);
-  }
-
-  export function expire(id: string, traceId: string, at = Date.now()): Wait.Outcome {
-    return transition(id, (record) => Wait.expire(record, { at }), traceId);
-  }
-
-  export function cancel(id: string, traceId: string, at = Date.now()): Wait.Outcome {
-    return transition(id, (record) => Wait.cancel(record, { at }), traceId);
-  }
 }

--- a/packages/ledger/test/blacklist/persistence.test.ts
+++ b/packages/ledger/test/blacklist/persistence.test.ts
@@ -20,47 +20,37 @@ describe("BlacklistStore SQLite persistence", () => {
     await rm(tmpDir, { recursive: true });
   });
 
-  test("persists and matches active blacklist entries across storage re-init", () => {
-    BlacklistStore.put({
+  test("round-trips raw blacklist facts across storage reconfiguration", () => {
+    const stored = BlacklistStore.put({
       id: "bl-actor",
       kind: "actor",
       value: "act_bad",
       reason: "abuse",
       createdBy: "act_owner",
+      createdAt: 100,
+      updatedAt: 200,
     });
 
     Storage.configure(new SqliteStorageAdapter(dbPath));
 
-    const matched = BlacklistStore.match({ actorId: "act_bad" });
-    expect(matched?.id).toBe("bl-actor");
-    expect(matched?.reason).toBe("abuse");
+    expect(BlacklistStore.get(stored.id)).toEqual(stored);
+    expect(BlacklistStore.list()).toEqual([stored]);
   });
 
-  test("ignores expired blacklist entries", () => {
+  test("removes exactly one stored fact", () => {
     BlacklistStore.put({
-      id: "bl-expired",
-      kind: "endpoint",
-      value: "ep_old",
-      expiresAt: 1,
+      id: "bl-actor",
+      kind: "actor",
+      value: "act_bad",
       createdBy: "act_owner",
     });
 
-    expect(BlacklistStore.match({ endpointId: "ep_old" }, 2)).toBeUndefined();
+    expect(BlacklistStore.remove("bl-actor")).toBe(true);
+    expect(BlacklistStore.get("bl-actor")).toBeUndefined();
+    expect(BlacklistStore.remove("bl-actor")).toBe(false);
   });
 
-  test("matches wildcard pattern entries against candidates", () => {
-    BlacklistStore.put({
-      id: "bl-pattern",
-      kind: "pattern",
-      value: "discord:guild:*",
-      createdBy: "act_owner",
-    });
-
-    expect(BlacklistStore.match({ candidates: ["discord:guild:dev"] })?.id).toBe("bl-pattern");
-    expect(BlacklistStore.match({ candidates: ["discord:other:dev"] })).toBeUndefined();
-  });
-
-  test("match fails closed when the blacklist sub-adapter is absent", () => {
+  test("raw reads fail closed when the blacklist sub-adapter is absent", () => {
     const bare = Storage.get();
     Storage.configure({
       transaction: bare.transaction.bind(bare),
@@ -69,10 +59,6 @@ describe("BlacklistStore SQLite persistence", () => {
       part: bare.part,
     });
 
-    // Pre-fix behavior returned undefined ("not blacklisted") on an absent
-    // adapter — a fail-open read of absolute-deny-gate data.
-    expect(() => BlacklistStore.match({ actorId: "act_bad" })).toThrow(
-      "does not implement blacklist",
-    );
+    expect(() => BlacklistStore.list()).toThrow("does not implement blacklist");
   });
 });

--- a/packages/ledger/test/channel-grant/persistence.test.ts
+++ b/packages/ledger/test/channel-grant/persistence.test.ts
@@ -5,55 +5,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ChannelGrantStore, SqliteStorageAdapter, Storage } from "../../src/index.js";
 
-function createInsertionOrderedChannelGrantAdapter(): NonNullable<Storage.Adapter["channelGrant"]> {
-  const grants = new Map<string, ChannelGrantStore.Grant>();
-  return {
-    get: (id) => grants.get(id),
-    set: (grant) => grants.set(grant.id, grant),
-    list: () => [...grants.values()],
-    remove: (id) => grants.delete(id),
-  };
-}
-
-function configureChannelGrantAdapter(
-  channelGrant: NonNullable<Storage.Adapter["channelGrant"]>,
-): void {
-  const base = Storage.get();
-  Storage.configure({
-    transaction: base.transaction.bind(base),
-    close: base.close?.bind(base),
-    session: base.session,
-    message: base.message,
-    part: base.part,
-    channelGrant,
-  });
-}
-
-const restrictiveGrant = {
-  id: "z-restrictive",
-  surface: "discord",
-  workspace: "guild",
-  kind: "blocked_channel",
-  createdBy: "act_owner",
-  createdAt: 200,
-} as const satisfies ChannelGrantStore.Grant;
-
-const permissiveGrant = {
-  id: "a-permissive",
-  surface: "discord",
-  channel: "design",
-  kind: "trusted_channel",
-  defaultTier: "owner",
-  createdBy: "act_owner",
-  createdAt: 100,
-} as const satisfies ChannelGrantStore.Grant;
-
-const equalSpecificityInput = {
-  surface: "discord",
-  workspace: "guild",
-  channel: "design",
-} as const;
-
 describe("ChannelGrantStore SQLite persistence", () => {
   let tmpDir: string;
   let dbPath: string;
@@ -95,14 +46,8 @@ describe("ChannelGrantStore SQLite persistence", () => {
     );
   });
 
-  test("persists and resolves the most specific matching grant", () => {
-    ChannelGrantStore.put({
-      id: "grant-surface",
-      surface: "discord",
-      kind: "trusted_channel",
-      createdBy: "act_owner",
-    });
-    ChannelGrantStore.put({
+  test("round-trips raw grant facts across adapter reconfiguration", () => {
+    const stored = ChannelGrantStore.put({
       id: "grant-channel",
       surface: "discord",
       workspace: "guild",
@@ -110,121 +55,17 @@ describe("ChannelGrantStore SQLite persistence", () => {
       kind: "broadcast_channel",
       defaultTier: "observer",
       createdBy: "act_owner",
+      createdAt: 100,
+      updatedAt: 200,
     });
 
     Storage.configure(new SqliteStorageAdapter(dbPath));
 
-    const resolved = ChannelGrantStore.resolve({
-      surface: "discord",
-      workspace: "guild",
-      channel: "design",
-    });
-    expect(resolved?.grant.id).toBe("grant-channel");
-    expect(resolved?.inboundTreatment).toBe("evidence_only");
+    expect(ChannelGrantStore.get(stored.id)).toEqual(stored);
+    expect(ChannelGrantStore.list()).toEqual([stored]);
   });
 
-  test("equal-specificity conflicts choose the restrictive grant regardless of insertion order", () => {
-    const winners = [
-      [permissiveGrant, restrictiveGrant],
-      [restrictiveGrant, permissiveGrant],
-    ].map((grants) => {
-      configureChannelGrantAdapter(createInsertionOrderedChannelGrantAdapter());
-      for (const grant of grants) ChannelGrantStore.put(grant);
-      return ChannelGrantStore.resolve(equalSpecificityInput)?.grant.id;
-    });
-
-    expect(winners).toEqual([restrictiveGrant.id, restrictiveGrant.id]);
-  });
-
-  test("insertion-ordered and SQLite backends agree on equal-specificity conflicts", () => {
-    configureChannelGrantAdapter(createInsertionOrderedChannelGrantAdapter());
-    ChannelGrantStore.put(restrictiveGrant);
-    ChannelGrantStore.put(permissiveGrant);
-    const insertionOrderedWinner = ChannelGrantStore.resolve(equalSpecificityInput)?.grant.id;
-
-    Storage.reset();
-    Storage.configure(new SqliteStorageAdapter(dbPath));
-    ChannelGrantStore.put(restrictiveGrant);
-    ChannelGrantStore.put(permissiveGrant);
-    const sqliteWinner = ChannelGrantStore.resolve(equalSpecificityInput)?.grant.id;
-
-    expect([insertionOrderedWinner, sqliteWinner]).toEqual([
-      restrictiveGrant.id,
-      restrictiveGrant.id,
-    ]);
-  });
-
-  test("equal-treatment conflicts fall through tier, kind, then id tie-breaks", () => {
-    const surfaceInput = { surface: "discord" } as const;
-    const resolveBothOrders = (
-      first: ChannelGrantStore.Grant,
-      second: ChannelGrantStore.Grant,
-    ): (string | undefined)[] =>
-      [
-        [first, second],
-        [second, first],
-      ].map((grants) => {
-        configureChannelGrantAdapter(createInsertionOrderedChannelGrantAdapter());
-        for (const grant of grants) ChannelGrantStore.put(grant);
-        return ChannelGrantStore.resolve(surfaceInput)?.grant.id;
-      });
-
-    // Same effective treatment (full_access): the lower default tier wins,
-    // even though its id sorts later.
-    const observerTier = {
-      id: "b-observer",
-      surface: "discord",
-      kind: "trusted_channel",
-      defaultTier: "observer",
-      createdBy: "act_owner",
-    } as const satisfies ChannelGrantStore.Grant;
-    const ownerTier = { ...observerTier, id: "a-owner", defaultTier: "owner" } as const;
-    expect(resolveBothOrders(observerTier, ownerTier)).toEqual(["b-observer", "b-observer"]);
-
-    // Same treatment and no tiers: the intrinsically more restrictive kind
-    // wins, again against id order.
-    const broadcastKind = {
-      id: "b-broadcast",
-      surface: "discord",
-      kind: "broadcast_channel",
-      createdBy: "act_owner",
-    } as const satisfies ChannelGrantStore.Grant;
-    const trustedEvidence = {
-      id: "a-trusted",
-      surface: "discord",
-      kind: "trusted_channel",
-      inboundTreatment: "evidence_only",
-      createdBy: "act_owner",
-    } as const satisfies ChannelGrantStore.Grant;
-    expect(resolveBothOrders(broadcastKind, trustedEvidence)).toEqual([
-      "b-broadcast",
-      "b-broadcast",
-    ]);
-
-    // Fully tied grants resolve by grant id code-unit order as the stable key.
-    const firstId = {
-      id: "a-first",
-      surface: "discord",
-      kind: "trusted_channel",
-      createdBy: "act_owner",
-    } as const satisfies ChannelGrantStore.Grant;
-    const secondId = { ...firstId, id: "b-second" } as const;
-    expect(resolveBothOrders(firstId, secondId)).toEqual(["a-first", "a-first"]);
-  });
-
-  test("explicit inbound treatment overrides kind default", () => {
-    ChannelGrantStore.put({
-      id: "grant-override",
-      surface: "discord",
-      kind: "broadcast_channel",
-      inboundTreatment: "full_access",
-      createdBy: "act_owner",
-    });
-
-    expect(ChannelGrantStore.resolve({ surface: "discord" })?.inboundTreatment).toBe("full_access");
-  });
-
-  test("returns no resolution when no grant matches", () => {
+  test("removes exactly one stored fact", () => {
     ChannelGrantStore.put({
       id: "grant-discord",
       surface: "discord",
@@ -232,10 +73,12 @@ describe("ChannelGrantStore SQLite persistence", () => {
       createdBy: "act_owner",
     });
 
-    expect(ChannelGrantStore.resolve({ surface: "telegram" })).toBeUndefined();
+    expect(ChannelGrantStore.remove("grant-discord")).toBe(true);
+    expect(ChannelGrantStore.get("grant-discord")).toBeUndefined();
+    expect(ChannelGrantStore.remove("grant-discord")).toBe(false);
   });
 
-  test("resolve fails closed when the channelGrant sub-adapter is absent", () => {
+  test("raw reads fail closed when the channelGrant sub-adapter is absent", () => {
     const bare = Storage.get();
     Storage.configure({
       transaction: bare.transaction.bind(bare),
@@ -244,8 +87,6 @@ describe("ChannelGrantStore SQLite persistence", () => {
       part: bare.part,
     });
 
-    expect(() => ChannelGrantStore.resolve({ surface: "discord" })).toThrow(
-      "does not implement channel grants",
-    );
+    expect(() => ChannelGrantStore.list()).toThrow("does not implement channel grants");
   });
 });

--- a/packages/ledger/test/channel-grant/persistence.test.ts
+++ b/packages/ledger/test/channel-grant/persistence.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -67,6 +68,31 @@ describe("ChannelGrantStore SQLite persistence", () => {
   afterEach(async () => {
     Storage.reset();
     await rm(tmpDir, { recursive: true });
+  });
+
+  test("persists grant JSON bytes without resolution-derived normalization", () => {
+    ChannelGrantStore.put({
+      id: "grant-byte-fixture",
+      surface: "discord",
+      workspace: "guild",
+      channel: "design",
+      kind: "broadcast_channel",
+      defaultTier: "observer",
+      inboundTreatment: "full_access",
+      createdBy: "act_owner",
+      createdAt: 100,
+      updatedAt: 200,
+    });
+
+    const reader = new Database(dbPath, { readonly: true });
+    const row = reader
+      .query("SELECT data FROM channel_grant WHERE id = ?")
+      .get("grant-byte-fixture") as { data: string };
+    reader.close();
+
+    expect(row.data).toBe(
+      '{"id":"grant-byte-fixture","surface":"discord","workspace":"guild","channel":"design","kind":"broadcast_channel","defaultTier":"observer","inboundTreatment":"full_access","createdBy":"act_owner","createdAt":100,"updatedAt":200}',
+    );
   });
 
   test("persists and resolves the most specific matching grant", () => {

--- a/packages/ledger/test/helpers/wait.ts
+++ b/packages/ledger/test/helpers/wait.ts
@@ -1,5 +1,5 @@
 import { Wait } from "@openomni/protocol";
-import type { Storage } from "../../src/index";
+import { type Storage, WaitStore } from "../../src/index";
 
 /**
  * Shared Wait fixture builder for session tests. Default input opens a
@@ -26,6 +26,36 @@ export function buildWaitCreate(overrides: Partial<Wait.Create> = {}): Wait.Crea
     updatedAt: 100,
     ...overrides,
   };
+}
+
+function requiredWait(id: string): Wait.Record {
+  const record = WaitStore.get(id);
+  if (record === undefined) {
+    throw new Wait.StoreError({ message: `Wait not found: ${id}`, code: "not_found", waitId: id });
+  }
+  return record;
+}
+
+export function commitReply(id: string, input: Wait.ReplyInput, traceId: string): Wait.Outcome {
+  const parsed = Wait.ReplyInput.parse(input);
+  return WaitStore.commit(Wait.attachReply(requiredWait(id), parsed), traceId, parsed.replyKey);
+}
+
+export function commitCancel(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+  return WaitStore.commit(Wait.cancel(requiredWait(id), { at }), traceId);
+}
+
+export function commitExpiry(id: string, traceId: string, at = Date.now()): Wait.Outcome {
+  return WaitStore.commit(Wait.expire(requiredWait(id), { at }), traceId);
+}
+
+export function commitDeliveryReceipt(
+  id: string,
+  input: Wait.DeliveryReceiptInput,
+  traceId: string,
+): Wait.Outcome {
+  const parsed = Wait.DeliveryReceiptInput.parse(input);
+  return WaitStore.commit(Wait.recordDeliveryReceipt(requiredWait(id), parsed), traceId);
 }
 
 /** Runs fn and returns the WaitStoreError it throws; fails when none is thrown. */

--- a/packages/ledger/test/storage/commit-sequencing.test.ts
+++ b/packages/ledger/test/storage/commit-sequencing.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Engagement, Wait, WorkItem } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { EngagementStore, Storage, WaitStore, WorkItemStore } from "../../src/index";
-import { buildWaitCreate } from "../helpers/wait";
+import { buildWaitCreate, commitCancel, commitReply } from "../helpers/wait";
 
 /**
  * Characterization of the ONE durable write-ordering contract every
@@ -69,7 +69,7 @@ describe("decision-class commit sequencing (shared contract)", () => {
     const wait = WaitStore.create(buildWaitCreate(), "trace-w");
     expect(wait.revision).toBe(1);
 
-    const outcome = WaitStore.attachReply(
+    const outcome = commitReply(
       wait.id,
       { replyKey: "rk-1", responderCandidates: ["actor-a"], messageId: "in-1", at: 1_000 },
       "trace-attach",
@@ -110,7 +110,7 @@ describe("decision-class commit sequencing (shared contract)", () => {
 
     let thrown: unknown;
     try {
-      WaitStore.cancel(wait.id, "trace-cancel");
+      commitCancel(wait.id, "trace-cancel");
     } catch (error) {
       thrown = error;
     }
@@ -215,12 +215,12 @@ describe("decision-class commit sequencing (shared contract)", () => {
 
   test("a rejected fold writes no fact and leaves head at the projected revision", () => {
     const wait = WaitStore.create(buildWaitCreate(), "trace-w");
-    WaitStore.cancel(wait.id, "trace-cancel");
+    commitCancel(wait.id, "trace-cancel");
     const headAfterCancel = ledger().headFact(`wait:${wait.id}`);
     expect(headAfterCancel?.type).toBe("wait.cancelled");
 
     // Cancelling a cancelled wait is a rejected fold: no fact, no revision bump.
-    const rejected = WaitStore.cancel(wait.id, "trace-cancel-2");
+    const rejected = commitCancel(wait.id, "trace-cancel-2");
     expect(rejected.kind).toBe("rejected");
     expect(ledger().headFact(`wait:${wait.id}`)?.seq).toBe(headAfterCancel?.seq);
     expect(WaitStore.get(wait.id)?.revision).toBe(headAfterCancel?.seq);

--- a/packages/ledger/test/wait/store.test.ts
+++ b/packages/ledger/test/wait/store.test.ts
@@ -2,7 +2,15 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Wait } from "@openomni/protocol";
 import { Storage, WaitStore } from "../../src/index";
 import { Bus } from "@openomni/telemetry";
-import { bareStorageAdapter, buildWaitCreate, captureStoreError } from "../helpers/wait";
+import {
+  bareStorageAdapter,
+  buildWaitCreate,
+  captureStoreError,
+  commitCancel,
+  commitDeliveryReceipt,
+  commitExpiry,
+  commitReply,
+} from "../helpers/wait";
 
 beforeEach(() => {
   Bus.reset();
@@ -27,7 +35,7 @@ describe("WaitStore", () => {
     });
 
     const record = WaitStore.create(buildWaitCreate(), "trace-open");
-    WaitStore.attachReply(
+    commitReply(
       record.id,
       {
         replyKey: "reply-key-1",
@@ -41,7 +49,7 @@ describe("WaitStore", () => {
       buildWaitCreate({ id: "wait-cancel", originMessageId: "message-cancel" }),
       "trace-open-2",
     );
-    WaitStore.cancel(second.id, "trace-cancel");
+    commitCancel(second.id, "trace-cancel");
 
     await flushBus();
     expect(traced).toEqual([
@@ -67,7 +75,7 @@ describe("WaitStore", () => {
       buildWaitCreate({ resolutionPolicy: "first_reply", quorum: undefined }),
       "trace-wait-store",
     );
-    const resolved = WaitStore.attachReply(
+    const resolved = commitReply(
       created.id,
       {
         replyKey: "reply-key-1",
@@ -150,24 +158,18 @@ describe("WaitStore", () => {
     WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
     expect(
-      WaitStore.findByCorrelation(
-        {
-          endpointId: "telegram:seller-1",
-          channelId: "telegram:dm",
-          replyToMessageId: "reply-1",
-        },
-        1_000,
-      ),
+      WaitStore.findByCorrelation({
+        endpointId: "telegram:seller-1",
+        channelId: "telegram:dm",
+        replyToMessageId: "reply-1",
+      }),
     ).toHaveLength(1);
     expect(
-      WaitStore.findByCorrelation(
-        {
-          endpointId: "telegram:seller-1",
-          channelId: "telegram:other",
-          replyToMessageId: "reply-1",
-        },
-        1_000,
-      ),
+      WaitStore.findByCorrelation({
+        endpointId: "telegram:seller-1",
+        channelId: "telegram:other",
+        replyToMessageId: "reply-1",
+      }),
     ).toHaveLength(0);
   });
 
@@ -178,18 +180,18 @@ describe("WaitStore", () => {
     // expiresAt still correlates, the fold rejects the reply as
     // deadline_passed, and the kernel folds the wait to expired. Silently
     // dropping it here would leak late replies into surface routing.
-    const matches = WaitStore.findByCorrelation({ tokenHash: "tok-1" }, 10_001);
+    const matches = WaitStore.findByCorrelation({ tokenHash: "tok-1" });
 
     expect(matches).toHaveLength(1);
     expect(matches[0]).toMatchObject({ id: "wait-1", status: "open" });
   });
 
-  test("keeps resolved waits correlatable only inside the follow-up window", () => {
+  test("returns resolved rows raw without judging follow-up eligibility", () => {
     WaitStore.create(
       buildWaitCreate({ resolutionPolicy: "first_reply", quorum: undefined }),
       "trace-wait-store",
     );
-    const outcome = WaitStore.attachReply(
+    const outcome = commitReply(
       "wait-1",
       {
         replyKey: "reply-key-1",
@@ -201,8 +203,7 @@ describe("WaitStore", () => {
     );
     expect(outcome.kind).toBe("resolved");
 
-    expect(WaitStore.findByCorrelation({ tokenHash: "tok-1" }, 2_000)).toHaveLength(1);
-    expect(WaitStore.findByCorrelation({ tokenHash: "tok-1" }, 2_001)).toHaveLength(0);
+    expect(WaitStore.findByCorrelation({ tokenHash: "tok-1" })).toHaveLength(1);
   });
 
   test("adopts a pre-cutover row (revision >= 1, empty stream) at ITS revision before the first transition", () => {
@@ -220,7 +221,7 @@ describe("WaitStore", () => {
     });
     expect(adapter.create(record)).toBe(true);
 
-    const outcome = WaitStore.attachReply(
+    const outcome = commitReply(
       "wait-1",
       {
         replyKey: "reply-key-1",
@@ -249,7 +250,7 @@ describe("WaitStore", () => {
     Bus.observe((event) => events.push(event.name));
     WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
-    const attached = WaitStore.attachReply(
+    const attached = commitReply(
       "wait-1",
       {
         replyKey: "reply-key-1",
@@ -259,7 +260,7 @@ describe("WaitStore", () => {
       },
       "trace-wait-store",
     );
-    const resolved = WaitStore.attachReply(
+    const resolved = commitReply(
       "wait-1",
       {
         replyKey: "reply-key-2",
@@ -286,7 +287,7 @@ describe("WaitStore", () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
     WaitStore.create(buildWaitCreate(), "trace-wait-store");
-    WaitStore.attachReply(
+    commitReply(
       "wait-1",
       {
         replyKey: "reply-key-1",
@@ -297,7 +298,7 @@ describe("WaitStore", () => {
       "trace-wait-store",
     );
 
-    const duplicate = WaitStore.attachReply(
+    const duplicate = commitReply(
       "wait-1",
       {
         replyKey: "reply-key-1",
@@ -307,7 +308,7 @@ describe("WaitStore", () => {
       },
       "trace-wait-store",
     );
-    const ambiguous = WaitStore.attachReply(
+    const ambiguous = commitReply(
       "wait-1",
       {
         replyKey: "reply-key-3",
@@ -337,7 +338,7 @@ describe("WaitStore", () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
     WaitStore.create(buildWaitCreate(), "trace-wait-store");
-    WaitStore.attachReply(
+    commitReply(
       "wait-1",
       {
         replyKey: "reply-key-1",
@@ -348,7 +349,7 @@ describe("WaitStore", () => {
       "trace-wait-store",
     );
 
-    const outcome = WaitStore.expire("wait-1", "trace-wait-store", 10_001);
+    const outcome = commitExpiry("wait-1", "trace-wait-store", 10_001);
     const persisted = WaitStore.get("wait-1");
 
     expect(outcome.kind).toBe("expired");
@@ -366,7 +367,7 @@ describe("WaitStore", () => {
     Bus.observe((event) => events.push(event.name));
     WaitStore.create(buildWaitCreate(), "trace-wait-store");
 
-    const outcome = WaitStore.recordDeliveryReceipt(
+    const outcome = commitDeliveryReceipt(
       "wait-1",
       {
         externalMessageId: "platform:msg-1",
@@ -381,10 +382,8 @@ describe("WaitStore", () => {
     expect(persisted?.revision).toBe(2);
     // The adapter's correlation projection columns moved with the record:
     // lookups answer the platform id and no longer the internal one.
-    expect(WaitStore.findByCorrelation({ replyToMessageId: "platform:msg-1" }, 1_000)).toHaveLength(
-      1,
-    );
-    expect(WaitStore.findByCorrelation({ replyToMessageId: "reply-1" }, 1_000)).toHaveLength(0);
+    expect(WaitStore.findByCorrelation({ replyToMessageId: "platform:msg-1" })).toHaveLength(1);
+    expect(WaitStore.findByCorrelation({ replyToMessageId: "reply-1" })).toHaveLength(0);
     await flushBus();
     // No Bus projection for this transition: the durable
     // wait.delivery_recorded fact lives on the owner stream only.
@@ -393,9 +392,9 @@ describe("WaitStore", () => {
 
   test("a delivery receipt on a terminal wait rejects wait_terminal and writes nothing", () => {
     WaitStore.create(buildWaitCreate(), "trace-wait-store");
-    WaitStore.cancel("wait-1", "trace-wait-store", 400);
+    commitCancel("wait-1", "trace-wait-store", 400);
 
-    const outcome = WaitStore.recordDeliveryReceipt(
+    const outcome = commitDeliveryReceipt(
       "wait-1",
       {
         externalMessageId: "platform:msg-late",
@@ -415,16 +414,14 @@ describe("WaitStore", () => {
     const events: string[] = [];
     Bus.observe((event) => events.push(event.name));
 
+    const current = WaitStore.get("wait-1");
+    if (current === undefined) throw new Error("wait fixture missing");
+    const staleOutcome = Wait.expire(current, { at: 20_000 });
+    // Concurrent writer advances the revision after channels decided from
+    // the prior raw row but before storage commits that produced outcome.
+    commitCancel("wait-1", "trace-wait-store", 500);
     const error = captureStoreError(() =>
-      WaitStore.transition(
-        "wait-1",
-        (record) => {
-          // Concurrent writer advances the revision after this step read it.
-          WaitStore.cancel("wait-1", "trace-wait-store", 500);
-          return Wait.expire(record, { at: 20_000 });
-        },
-        "trace-wait-store",
-      ),
+      WaitStore.commit(staleOutcome, "trace-wait-store"),
     );
 
     expect(error.data.code).toBe("revision_conflict");
@@ -441,13 +438,16 @@ describe("WaitStore", () => {
     expect(events).not.toContain("wait.expired");
   });
 
-  test("transition on a missing wait raises a typed not_found error", () => {
+  test("commit on a missing wait raises a typed not_found error", () => {
+    const missing = Wait.Record.parse({
+      ...buildWaitCreate({ id: "wait-missing", originMessageId: "out-missing" }),
+      status: "open",
+      partial: false,
+      replies: [],
+      revision: 1,
+    });
     const error = captureStoreError(() =>
-      WaitStore.transition(
-        "wait-missing",
-        (record) => Wait.cancel(record, { at: 1 }),
-        "trace-wait-store",
-      ),
+      WaitStore.commit(Wait.cancel(missing, { at: 1 }), "trace-wait-store"),
     );
 
     expect(error.data.code).toBe("not_found");


### PR DESCRIPTION
## Summary

Consolidates runtime wait admission and channel-fact authority in `@openomni/channels` while leaving protocol as pure vocabulary/folds and ledger as raw facts + durable CAS storage.

## Current-HEAD five-site map

Re-verified against `693e6e8b` (the audit was written against `8401b583`):

1. `packages/protocol/src/wait/correlation-fold.ts` — pure tier ordering and channel/endpoint pin fold. Retained as protocol-pure input calculation; channels is its only runtime admission caller.
2. `packages/protocol/src/wait/matcher.ts` — pure sender evidence / responder candidate fold. Retained as protocol-pure input calculation; channels composes the ActorRegistry evidence and invokes it.
3. `packages/protocol/src/wait/fold.ts` — pure duplicate, terminal/follow-up, deadline, responder, attach, and quorum transition fold. Retained per the protocol vocabulary/fold boundary; invocation moved out of ledger into `WaitService` in channels.
4. `packages/ledger/src/wait/index.ts` — previously judged resolved follow-up visibility and invoked all transition folds through `attachReply` / receipt / expire / cancel wrappers. It now returns raw correlation rows and only commits channels-produced outcomes under the existing revision CAS/fact transaction.
5. `packages/channels/src/router/{wait,resolve-route,routing-execution}.ts` — candidate reduction, action/owner gate, blacklist/conversation/wait precedence, responder evidence, and execution. This is now the sole runtime admission/control owner, including follow-up visibility and fold invocation.

## Grant and blacklist authority

- `ChannelGrantStore` is raw get/list/put/remove storage only.
- Channels owns matching, specificity, restrictive tie-breaking, defaults, and the final kind treatment ceiling in one resolver.
- `BlacklistStore` is raw get/list/put/remove storage only; active/wildcard matching moved to channels.
- Existing grant ranking and blacklist matrices moved to channel-level tests.

## Behavior and byte-identity evidence

- RED pin landed first as commit `d9933da1`: exact SQLite `channel_grant.data` JSON bytes for an explicit broadcast/full-access row.
- The exact persisted fixture remains:
  `{"id":"grant-byte-fixture","surface":"discord","workspace":"guild","channel":"design","kind":"broadcast_channel","defaultTier":"observer","inboundTreatment":"full_access","createdBy":"act_owner","createdAt":100,"updatedAt":200}`
- No migration, schema, frozen hash, route fact, wait row, or message-send kernel serialization changed.
- Channel behavior tests pin restrictive order, kind normalization, blacklist matching, inclusive follow-up boundary, expired-open correlation, duplicate/late/responder/quorum behavior, route precedence, and CAS conflicts.

## Verification

Focused:
- channels: 320 pass / 0 fail
- ledger: 495 pass / 0 fail
- affected workspace type checks: green

Coverage:
- channels: 96.49% (floor 96.19%)
- ledger: 97.81% (baseline 96.78%)
- `bun run script/check-coverage-ratchet.ts`: green

Full required chain (all green):
- `bun run build`
- `bunx turbo run check-types`
- `bun run script/check-deps.ts`
- `bun run script/check-import-cycles.ts`
- `bun run lint`
- `bun run lint:tools`
- `bunx ultracite check --formatter-enabled=false .`
- `bun run script/check-dead-exports.ts`
- `bun test --timeout 15000` — 2,829 pass / 0 fail

## Explicitly not changed

- Message-send kernel behavior and persisted send facts.
- Universal/domain terminal vocabulary.
- Frozen hashes or persisted row framing.
- Engagement transitions or machine enrollment.
- Broader ingress target/route-replay ownership from the synthesis ladder; the numbered PR8 task here was limited to wait admission, channel-grant normalization, and the adjacent ledger blacklist judgment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates runtime wait admission and channel-fact normalization into `@openomni/channels`, leaving `@openomni/ledger` as raw fact storage with durable CAS commits and protocol as pure vocabulary/folds. No schema, migration, or persisted serialization changes.

**Refactors**
- `ChannelGrantStore` and `BlacklistStore` are now raw get/list/put/remove storage; channels owns grant ranking, treatment normalization, and blacklist matching via new `resolveChannelGrant` and `matchBlacklist`.
- `WaitStore.findByCorrelation` returns raw rows and no longer filters follow-up eligibility; `findWaitCandidates` in channels owns visibility and precedence.
- `WaitStore` transition wrappers (`attachReply`, `recordDeliveryReceipt`, `expire`, `cancel`) are replaced by a single `commit(outcome, traceId, rejectionReplyKey?)` that persists channels-produced outcomes.

**Migration**
- Callers of `ChannelGrantStore.resolve` and `BlacklistStore.match` must use `resolveChannelGrant` and `matchBlacklist` from `@openomni/channels`.
- Callers of `WaitStore.attachReply`, `recordDeliveryReceipt`, `expire`, `cancel`, or `transition` must run the protocol fold themselves and pass the outcome to `WaitStore.commit`.

<sup>Written for commit bdcdde936fc0f9edf4cb492d3eea3376f3a5ac00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

