### PR TITLE
refactor: injected clock/id entropy and atomic-write single owner (slop PR7)

### DIFF
--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -1,4 +1,5 @@
-import { Deadline, Delegation, NamedError, newTraceId, Operational, type BusEvent } from "@openomni/protocol";
+import { newTraceId } from "@openomni/telemetry";
+import { Deadline, Delegation, NamedError, Operational, type BusEvent } from "@openomni/protocol";
 import { DelegationStore } from "@openomni/ledger";
 import type { WorkItemLinkage } from "./work-item-linkage";
 import { delegationTraceId } from "./trace";

--- a/apps/openomni/src/delegation/work-item-linkage.ts
+++ b/apps/openomni/src/delegation/work-item-linkage.ts
@@ -1,5 +1,6 @@
+import { newTraceId } from "@openomni/telemetry";
 import { WorkItemAttemptRun, WorkItemStore } from "@openomni/ledger";
-import { Delegation, WorkItem, newTraceId } from "@openomni/protocol";
+import { Delegation, WorkItem } from "@openomni/protocol";
 
 /**
  * The bridge between the delegation kernel and the WorkItem contract: every

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -1,5 +1,6 @@
+import { newTraceId } from "@openomni/telemetry";
 import { ChatAgent, type ChatAgentConfig } from "@openomni/agent";
-import { newTraceId, type Model } from "@openomni/protocol";
+import { type Model } from "@openomni/protocol";
 import { observeComponent } from "../observation/component";
 import { buildAgentPrompt } from "../prompt/build";
 import { WORKER_PRESET } from "../prompt/roles";

--- a/apps/openomni/src/delegation/worker-loop.ts
+++ b/apps/openomni/src/delegation/worker-loop.ts
@@ -1,6 +1,6 @@
 import { newTraceId } from "@openomni/telemetry";
 import { ChatAgent, type ChatAgentConfig } from "@openomni/agent";
-import { type Model } from "@openomni/protocol";
+import type { Model } from "@openomni/protocol";
 import { observeComponent } from "../observation/component";
 import { buildAgentPrompt } from "../prompt/build";
 import { WORKER_PRESET } from "../prompt/roles";

--- a/apps/openomni/src/index.ts
+++ b/apps/openomni/src/index.ts
@@ -26,9 +26,8 @@ import {
   Gateway,
   type Ingress,
   type Machine,
-  newTraceId,
 } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { Bus, newTraceId } from "@openomni/telemetry";
 import { type BuiltChannel, channelProfile } from "./channels";
 import {
   assertWsExposure,

--- a/apps/openomni/src/memory/store.ts
+++ b/apps/openomni/src/memory/store.ts
@@ -1,5 +1,7 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { replaceFileAtomically } from "@openomni/ledger";
+import type { IdSource } from "@openomni/protocol";
 import { z } from "zod";
 
 /**
@@ -89,13 +91,14 @@ function renderSnapshot(file: MemoryFile): string {
  * write that silently skipped persistence would be a lie the next session
  * acts on.
  */
-export function openCuratedMemory(path: string): CuratedMemory {
+export function openCuratedMemory(
+  path: string,
+  idSource: IdSource = () => crypto.randomUUID(),
+): CuratedMemory {
   mkdirSync(dirname(path), { recursive: true });
 
   function persist(file: MemoryFile): void {
-    const tmp = join(dirname(path), `.memory-${process.pid}.tmp`);
-    writeFileSync(tmp, JSON.stringify(file, null, 2), "utf8");
-    renameSync(tmp, path);
+    replaceFileAtomically(path, JSON.stringify(file, null, 2));
   }
 
   function assertBudget(store: MemoryStoreName, nextChars: number): void {
@@ -129,9 +132,9 @@ export function openCuratedMemory(path: string): CuratedMemory {
   }
 
   function mintId(file: MemoryFile): string {
-    let id = crypto.randomUUID().slice(0, 8);
+    let id = idSource().slice(0, 8);
     while (MEMORY_STORES.some((store) => file[store].some((entry) => entry.id === id))) {
-      id = crypto.randomUUID().slice(0, 8);
+      id = idSource().slice(0, 8);
     }
     return id;
   }

--- a/apps/openomni/src/tools/approval.ts
+++ b/apps/openomni/src/tools/approval.ts
@@ -1,5 +1,6 @@
+import { newTraceId } from "@openomni/telemetry";
 import type { ActorRegistry, ApprovalStore } from "@openomni/ledger";
-import { type Approval, newTraceId, type Tool } from "@openomni/protocol";
+import { type Approval, type Tool } from "@openomni/protocol";
 import { z } from "zod";
 
 /**

--- a/apps/openomni/src/tools/approval.ts
+++ b/apps/openomni/src/tools/approval.ts
@@ -1,6 +1,6 @@
 import { newTraceId } from "@openomni/telemetry";
 import type { ActorRegistry, ApprovalStore } from "@openomni/ledger";
-import { type Approval, type Tool } from "@openomni/protocol";
+import type { Approval, Tool } from "@openomni/protocol";
 import { z } from "zod";
 
 /**

--- a/apps/openomni/src/tools/converse.ts
+++ b/apps/openomni/src/tools/converse.ts
@@ -1,6 +1,6 @@
 import { newTraceId } from "@openomni/telemetry";
 import type { ConversationStore, LeaseStore } from "@openomni/ledger";
-import { type Tool } from "@openomni/protocol";
+import type { Tool } from "@openomni/protocol";
 import { z } from "zod";
 import type { DelegationOrigin } from "../delegation/admission";
 

--- a/apps/openomni/src/tools/converse.ts
+++ b/apps/openomni/src/tools/converse.ts
@@ -1,5 +1,6 @@
+import { newTraceId } from "@openomni/telemetry";
 import type { ConversationStore, LeaseStore } from "@openomni/ledger";
-import { newTraceId, type Tool } from "@openomni/protocol";
+import { type Tool } from "@openomni/protocol";
 import { z } from "zod";
 import type { DelegationOrigin } from "../delegation/admission";
 

--- a/apps/openomni/src/tools/lease.ts
+++ b/apps/openomni/src/tools/lease.ts
@@ -1,6 +1,6 @@
 import { newTraceId } from "@openomni/telemetry";
 import type { LeaseStore } from "@openomni/ledger";
-import { type Delegation, type Tool } from "@openomni/protocol";
+import type { Delegation, Tool } from "@openomni/protocol";
 import { z } from "zod";
 
 /**

--- a/apps/openomni/src/tools/lease.ts
+++ b/apps/openomni/src/tools/lease.ts
@@ -1,5 +1,6 @@
+import { newTraceId } from "@openomni/telemetry";
 import type { LeaseStore } from "@openomni/ledger";
-import { type Delegation, newTraceId, type Tool } from "@openomni/protocol";
+import { type Delegation, type Tool } from "@openomni/protocol";
 import { z } from "zod";
 
 /**

--- a/apps/openomni/src/tools/llm.ts
+++ b/apps/openomni/src/tools/llm.ts
@@ -1,5 +1,5 @@
 import { ModelsDev, Provider, run as llmRun, type RunInput, type Sink } from "@openomni/llm";
-import { type Message, type Model, type Tool } from "@openomni/protocol";
+import type { Message, Model, Tool } from "@openomni/protocol";
 import { Bus, newTraceId } from "@openomni/telemetry";
 import { z } from "zod";
 

--- a/apps/openomni/src/tools/llm.ts
+++ b/apps/openomni/src/tools/llm.ts
@@ -1,6 +1,6 @@
 import { ModelsDev, Provider, run as llmRun, type RunInput, type Sink } from "@openomni/llm";
-import { type Message, type Model, newTraceId, type Tool } from "@openomni/protocol";
-import { Bus } from "@openomni/telemetry";
+import { type Message, type Model, type Tool } from "@openomni/protocol";
+import { Bus, newTraceId } from "@openomni/telemetry";
 import { z } from "zod";
 
 /**

--- a/apps/openomni/src/work-item/completion.ts
+++ b/apps/openomni/src/work-item/completion.ts
@@ -1,6 +1,7 @@
+import { newTraceId } from "@openomni/telemetry";
 import type { Storage } from "@openomni/ledger";
 import { WorkItemStore } from "@openomni/ledger";
-import { newTraceId, WorkItem } from "@openomni/protocol";
+import { WorkItem } from "@openomni/protocol";
 import { validateCompletionTerminalLinkage } from "./terminal-linkage";
 
 /**

--- a/apps/openomni/test/gateway-contracts.test.ts
+++ b/apps/openomni/test/gateway-contracts.test.ts
@@ -1,10 +1,11 @@
+import { newTraceId } from "@openomni/telemetry";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RunInput } from "@openomni/llm";
 import { ActorRegistry, ChannelGrantStore, Session, Storage } from "@openomni/ledger";
-import { Gateway, type Message, newTraceId } from "@openomni/protocol";
+import { Gateway, type Message } from "@openomni/protocol";
 import { createResidentGateway, registerTrustedChannelGrant } from "../src/gateway";
 import { openCuratedMemory } from "../src/memory/store";
 import { createPolicyRegistry } from "../src/composition/policy-registry";

--- a/apps/openomni/test/memory.test.ts
+++ b/apps/openomni/test/memory.test.ts
@@ -25,6 +25,15 @@ describe("the curated memory store", () => {
     expect(second.render()).toContain(`- [${id}] prefers worktrees`);
   });
 
+  it("keeps the curated-memory persisted bytes unchanged", () => {
+    const path = join(directory, "memory.json");
+    const memory = openCuratedMemory(path, () => "12345678-aaaa-bbbb-cccc-dddddddddddd");
+    memory.add("system", "prefers worktrees");
+    expect(readFileSync(path, "utf8")).toBe(
+      '{\n  "system": [\n    {\n      "id": "12345678",\n      "content": "prefers worktrees"\n    }\n  ],\n  "owner": []\n}',
+    );
+  });
+
   it("renders both stores under one # Memory heading, empty stores omitted", () => {
     const memory = open();
     expect(memory.render()).toBe("");

--- a/packages/agent/src/core/execution/run.ts
+++ b/packages/agent/src/core/execution/run.ts
@@ -336,6 +336,7 @@ export function buildPolicyEngine(
   agentBase: AgentRunBase,
 ): RunPolicyEngine {
   const engine = PolicyEngine.create({
+    clock: Date.now,
     traceContext: {
       traceId: agentBase.traceId,
       sessionId: agentBase.sessionId,

--- a/packages/agent/src/core/policy/index.ts
+++ b/packages/agent/src/core/policy/index.ts
@@ -28,5 +28,5 @@ export type PolicyEngineInstance = PolicyEngineInstanceGeneric<PolicyContext>;
  * registration boundary rejects timing-based (legacy) shapes fail-closed.
  */
 export const PolicyEngine: {
-  readonly create: (options?: PolicyEngineConfig) => PolicyEngineInstance;
+  readonly create: (options: PolicyEngineConfig) => PolicyEngineInstance;
 } = GenericPolicyEngine;

--- a/packages/agent/test/compaction/measure.test.ts
+++ b/packages/agent/test/compaction/measure.test.ts
@@ -78,7 +78,7 @@ describe("the run measures the final call", () => {
     const turn = await buildTurn(
       state,
       makeConfig(),
-      PolicyEngine.create(),
+      PolicyEngine.create({ clock: Date.now }),
       testProviderModel,
       undefined,
       makeTrace(),

--- a/packages/agent/test/core/execution/execution-verdicts-model.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts-model.test.ts
@@ -18,7 +18,7 @@ describe("model execution deny verdicts", () => {
   it("fail-closes model.request deny before provider execution", async () => {
     Bus.reset();
     const fn = mock(() => deny("test.deny", "provider-blocked"));
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "connection.llm.pre", {
       name: "deny-model-request",
       effects: ["audit.annotate"],
@@ -66,7 +66,7 @@ describe("model execution deny verdicts", () => {
 });
 
 function responseDenyEngine(): ReturnType<typeof PolicyEngine.create> {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(
     atPoint("connection.llm.post", {
       name: "deny-model-response",

--- a/packages/agent/test/core/execution/execution-verdicts.test.ts
+++ b/packages/agent/test/core/execution/execution-verdicts.test.ts
@@ -48,7 +48,7 @@ describe("execution helper deny verdicts", () => {
   });
   it("fail-closes run.start deny before execution", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.lifecycle.pre",
@@ -68,7 +68,7 @@ describe("execution helper deny verdicts", () => {
 
   it("fail-closes turn.start deny before building a turn", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.turn.pre", "deny-turn-start", 100, () => deny("test.deny", "blocked"), [
       "audit.annotate",
     ]);
@@ -90,7 +90,7 @@ describe("execution helper deny verdicts", () => {
 
   it("fail-closes resources.prepare deny before exposing tools", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "tool.catalog.pre",
@@ -121,7 +121,7 @@ describe("execution helper deny verdicts", () => {
     const unsubscribe = Bus.observe((event, payload) => {
       if (event.name === Operational.Events.Info.name) diagnostics.push(payload);
     });
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",

--- a/packages/agent/test/core/execution/lifecycle-budget.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-budget.test.ts
@@ -24,7 +24,7 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
     try {
       await dispatchBudgetCheck(
         state,
-        PolicyEngine.create(),
+        PolicyEngine.create({ clock: Date.now }),
         makeConfig({ budget: { maxTurns: 24 } }),
         agentBase,
       );
@@ -42,7 +42,7 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
   it("dispatches a truthful max-steps lifecycle outcome when budget is exceeded", async () => {
     const observedOutcomes: unknown[] = [];
     const state = makeState();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.lifecycle.post",
@@ -83,7 +83,7 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
     state.budgetState = { ...state.budgetState, startTime: Date.now() - 10_000 };
     const config = makeConfig({ events: collected, budget: { maxWallTimeMs: 1000 } });
 
-    const result = await dispatchBudgetCheck(state, PolicyEngine.create(), config, makeAgentBase());
+    const result = await dispatchBudgetCheck(state, PolicyEngine.create({ clock: Date.now }), config, makeAgentBase());
     await Bun.sleep(0);
 
     expect(result).not.toBeNull();
@@ -97,7 +97,7 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
   });
 
   it("returns null when budget is not exceeded", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const state = makeState();
     const config = makeConfig({ budget: { maxTurns: 100 } });
 
@@ -121,7 +121,7 @@ describe("dispatchBudgetCheck (budget exhaustion)", () => {
     try {
       await dispatchBudgetCheck(
         state,
-        PolicyEngine.create(),
+        PolicyEngine.create({ clock: Date.now }),
         makeConfig({ events: collected, budget: { maxTurns: 24 } }),
         agentBase,
       );

--- a/packages/agent/test/core/execution/lifecycle-error.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-error.test.ts
@@ -11,7 +11,7 @@ describe("handleError (error)", () => {
   it("dispatches error and respects abort verdict", async () => {
     Bus.reset();
     const fn = mock((_ctx: PolicyContext) => abortRun("test.error-abort", "error-abort"));
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.error.error", {
       name: "test-on-error",
       effects: ["run.abort"],
@@ -49,7 +49,7 @@ describe("handleError (error)", () => {
 
   it("error continue verdict allows retry when retry policy permits", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.error.error", "test-on-error-continue", 100, () => allow());
 
     const state = makeState();
@@ -79,7 +79,7 @@ describe("handleError (error)", () => {
    */
   it("reports the run.retry_after delay as the backoff", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.error.error",
@@ -114,7 +114,7 @@ describe("handleError (error)", () => {
 
   it("applies run.retry_after maxRetries as a stricter retry ceiling", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.error.error",
@@ -158,7 +158,7 @@ describe("handleError (error)", () => {
     const unsubscribe = Bus.subscribe(RunEvents.ErrorRetry, (event) => {
       retries.push(event as unknown as Record<string, unknown>);
     });
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const agentBase = makeAgentBase();
 
     try {
@@ -200,7 +200,7 @@ describe("handleError (error)", () => {
    * throw always produces one, is `run-terminal-record.test.ts`.
    */
   it("reports the decision on the terminal failure, with the narrowed ceiling", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.error.error",
@@ -244,7 +244,7 @@ describe("handleError (error)", () => {
     const unsubscribe = Bus.subscribe(RunEvents.ErrorRetry, (event) => {
       retries.push(event as unknown as { maxAttempts: number });
     });
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.error.error",

--- a/packages/agent/test/core/execution/lifecycle-model.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-model.test.ts
@@ -13,7 +13,7 @@ describe("model dispatch points", () => {
   it("dispatches model.request before provider execution", async () => {
     Bus.reset();
     const fn = mock((_ctx: PolicyContext) => allow());
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "connection.llm.pre", {
       name: "test-model-request",
       priority: 100,
@@ -38,7 +38,7 @@ describe("model dispatch points", () => {
   it("dispatches model.response after provider execution and exposes outcome type", async () => {
     Bus.reset();
     const fn = mock((_ctx: PolicyContext) => allow("test.model-response", "observe-response"));
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "connection.llm.post", {
       name: "test-model-response",
       priority: 100,
@@ -66,7 +66,7 @@ describe("model dispatch points", () => {
 
   it("applies model.request prompt injection before provider execution", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "connection.llm.pre",
@@ -97,7 +97,7 @@ describe("model dispatch points", () => {
     Bus.reset();
     const { createUserMessage } = await import("../../../src/core/message-factory");
     const replacement = [createUserMessage("replacement", "test")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "connection.llm.post",
@@ -123,7 +123,7 @@ describe("model dispatch points", () => {
 
   it("blocks model.response malformed replacement messages", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "connection.llm.post",

--- a/packages/agent/test/core/execution/lifecycle-prompt-context.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-prompt-context.test.ts
@@ -14,7 +14,7 @@ describe("buildTurn (prompt.context.pre)", () => {
       expect(ctx.pointId).toBe("prompt.context.pre");
       return appendContext("extra-context", "test.sp", "system-prompt-extend");
     });
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "prompt.context.pre", {
       name: "test-sp",
       effects: ["prompt.append_context"],
@@ -43,7 +43,7 @@ describe("buildTurn (prompt.context.pre)", () => {
 
   it("prompt.context.pre replace effect replaces an existing system prompt", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "prompt.context.pre",
@@ -71,7 +71,7 @@ describe("buildTurn (prompt.context.pre)", () => {
 
   it("prompt.context.pre replace effect creates a system prompt when none exists", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "prompt.context.pre",

--- a/packages/agent/test/core/execution/lifecycle-run-start.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-run-start.test.ts
@@ -18,7 +18,7 @@ describe("dispatchPreRun (run.start)", () => {
   it("dispatches run.start and allows continuation on continue verdict", async () => {
     Bus.reset();
     const fn = mock((_ctx: PolicyContext) => allow());
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.lifecycle.pre", {
       name: "test-pre-run",
       priority: 100,
@@ -36,7 +36,7 @@ describe("dispatchPreRun (run.start)", () => {
 
   it("returns abort event when run.start policy returns abort", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.lifecycle.pre",
@@ -56,7 +56,7 @@ describe("dispatchPreRun (run.start)", () => {
 
   it("injects user message when run.start policy returns inject", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.lifecycle.pre",
@@ -85,7 +85,7 @@ describe("dispatchPreRun (run.start)", () => {
 
 it("appends run.start context as a user message", async () => {
   Bus.reset();
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(
     atPoint("run.lifecycle.pre", {
       name: "test-pre-run-context",

--- a/packages/agent/test/core/execution/lifecycle-stop.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-stop.test.ts
@@ -25,7 +25,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
       expect(ctx.pointId).toBe("run.turn.post");
       return allow();
     });
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.turn.post", {
       name: "test-post-turn",
       priority: 100,
@@ -50,7 +50,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
 
   it("turn.finish inject verdict causes continuation", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",
@@ -76,7 +76,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
     Bus.reset();
     const { createUserMessage } = await import("../../../src/core/message-factory");
     const replacement = [createUserMessage("turn replacement", "test")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",
@@ -102,7 +102,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
 
   it("turn.finish abort verdict yields complete event with guardAborted", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",
@@ -124,7 +124,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
 
   it("turn.finish abort with reason 'stalled' sets finishReason to stalled", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",
@@ -147,7 +147,7 @@ describe("handleStop (turn.finish + run.finish)", () => {
 
   it("dispatches run.finish without modifying final text", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.lifecycle.post", "test-post-run-transform", 100, () =>
       allow("test.post-run", "observe-final"),
     );

--- a/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
+++ b/packages/agent/test/core/execution/lifecycle-turn-pre.test.ts
@@ -33,7 +33,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
   it("dispatches turn.start and returns ready on continue", async () => {
     Bus.reset();
     const fn = mock((_ctx: PolicyContext) => allow());
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.turn.pre", {
       name: "test-pre-turn",
       priority: 100,
@@ -61,7 +61,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
   it("buildTurn publishes budget reassurance when the verdict carries that reason code", async () => {
     Bus.reset();
     const budget = collectBudgetNames();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.pre",
@@ -93,7 +93,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
   it("buildTurn publishes a budget warning when the verdict carries that reason code", async () => {
     Bus.reset();
     const budget = collectBudgetNames();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.pre",
@@ -125,7 +125,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
   it("buildTurn publishes no budget event for an unrelated inject message", async () => {
     Bus.reset();
     const budget = collectBudgetNames();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.pre",
@@ -159,7 +159,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
 
   it("returns complete when turn.start policy returns abort", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.pre",
@@ -185,7 +185,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
 
   it("appends turn.start context as a user message", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.pre",
@@ -215,7 +215,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
   it("dispatches skill-backed MCP tools with the descriptor server id", async () => {
     // Given
     const seen: Array<{ readonly pointId: string; readonly serverId: unknown }> = [];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "skill-mcp-observer",
@@ -288,7 +288,7 @@ describe("buildTurn (turn.start + context.prepare + resources.prepare)", () => {
     // live invariant — an mcp-labelled tool routes fail-closed by its dotted
     // name.
     const seen: string[] = [];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "mcp-route-observer",

--- a/packages/agent/test/core/execution/overflow-recovery.test.ts
+++ b/packages/agent/test/core/execution/overflow-recovery.test.ts
@@ -63,7 +63,7 @@ function bulkyToolMessage(index: number): Message.WithParts {
 }
 
 function engineWithCompaction() {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(
     createCompactionPolicy({
       contextWindowTokens: 100,

--- a/packages/agent/test/core/execution/tool-policy-context.test.ts
+++ b/packages/agent/test/core/execution/tool-policy-context.test.ts
@@ -37,7 +37,7 @@ function engineRegistration(seen: Array<Record<string, unknown>>) {
 }
 
 function observingEngine(seen: Array<Record<string, unknown>>) {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(engineRegistration(seen));
   return engine;
 }

--- a/packages/agent/test/core/execution/tool-selection.test.ts
+++ b/packages/agent/test/core/execution/tool-selection.test.ts
@@ -50,7 +50,7 @@ function abortSelectionPolicy(reason: string): PolicyRegistration {
 describe("resources.prepare dispatch", () => {
   it("passes all tools through when no policy is registered", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const tools = makeTools("bash", "read", "write");
     const state = makeState();
     const config = makeConfig({ tools, systemPrompt: "test system prompt" });
@@ -73,7 +73,7 @@ describe("resources.prepare dispatch", () => {
 
   it("filters out tools when policy returns tool.filter patterns", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(filterPolicy(["read"]));
 
     const tools = makeTools("bash", "read", "write");
@@ -98,7 +98,7 @@ describe("resources.prepare dispatch", () => {
 
   it("filters out wildcard-prefixed tool patterns", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(filterPolicy(["dangerous.*"]));
 
     const tools = makeTools("dangerous.exec", "safe.read", "dangerous.write");
@@ -122,7 +122,7 @@ describe("resources.prepare dispatch", () => {
 
   it("returns complete result when abort verdict is returned", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(abortSelectionPolicy("tools-restricted"));
 
     const tools = makeTools("bash", "read");
@@ -149,7 +149,7 @@ describe("resources.prepare dispatch", () => {
   it("dispatches with tool catalog labels in context", async () => {
     Bus.reset();
     let capturedCtx: Record<string, unknown> | undefined;
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "tool.catalog.pre", "capture-ctx", 0, (ctx) => {
       capturedCtx = ctx as unknown as Record<string, unknown>;
       return allow();
@@ -182,7 +182,7 @@ describe("resources.prepare dispatch", () => {
 
   it("keeps all tools when transform verdict has no tools property", async () => {
     Bus.reset();
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "tool.catalog.pre", "transform-no-tools", 0, () => allow("test", "test"));
 
     const tools = makeTools("bash", "read", "write");

--- a/packages/agent/test/core/execution/tools-context.test.ts
+++ b/packages/agent/test/core/execution/tools-context.test.ts
@@ -19,7 +19,7 @@ describe("createToolExecutor execution context", () => {
     let capturedContext: Tool.ExecutionContext | undefined;
     const executor = createToolExecutor({
       events: Bus,
-      engine: PolicyEngine.create(),
+      engine: PolicyEngine.create({ clock: Date.now }),
       signal: fallbackController.signal,
       traceContext,
       toolExecutor: async (call, context) => {
@@ -53,7 +53,7 @@ describe("createToolExecutor execution context", () => {
     let capturedContext: Tool.ExecutionContext | undefined;
     const executor = createToolExecutor({
       events: Bus,
-      engine: PolicyEngine.create(),
+      engine: PolicyEngine.create({ clock: Date.now }),
       signal: fallbackController.signal,
       traceContext: fallbackTrace,
       toolExecutor: async (call, context) => {

--- a/packages/agent/test/core/execution/tools-sole-emitter.test.ts
+++ b/packages/agent/test/core/execution/tools-sole-emitter.test.ts
@@ -62,7 +62,7 @@ describe("sole emitter — worker executor owns Tool.Events events", () => {
     const executor = createToolExecutor({
       events: Bus,
       toolExecutor: emittingBaseExecutor({ output: "ok" }),
-      engine: PolicyEngine.create(),
+      engine: PolicyEngine.create({ clock: Date.now }),
       traceContext: { traceId: "trace-sole", sessionId: "sess-sole", runId: "run-1" },
     });
 
@@ -81,7 +81,7 @@ describe("sole emitter — worker executor owns Tool.Events events", () => {
     const executor = createToolExecutor({
       events: Bus,
       toolExecutor: emittingBaseExecutor({ output: "err", isError: true }),
-      engine: PolicyEngine.create(),
+      engine: PolicyEngine.create({ clock: Date.now }),
       traceContext: { traceId: "trace-sole-err", sessionId: "sess-sole-err", runId: "run-1" },
     });
 
@@ -100,7 +100,7 @@ describe("sole emitter — worker executor owns Tool.Events events", () => {
     const executor = createToolExecutor({
       events: Bus,
       toolExecutor: emittingBaseExecutor({ output: "boom", throws: new Error("boom") }),
-      engine: PolicyEngine.create(),
+      engine: PolicyEngine.create({ clock: Date.now }),
       traceContext: { traceId: "trace-sole-throw", sessionId: "sess-sole-throw", runId: "run-1" },
     });
 

--- a/packages/agent/test/core/execution/tools-verdicts.test.ts
+++ b/packages/agent/test/core/execution/tools-verdicts.test.ts
@@ -23,13 +23,13 @@ function verdictPolicy(decision: Policy.PolicyDecision): PolicyRegistration {
 }
 
 function engineWith(decision: Policy.PolicyDecision) {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(verdictPolicy(decision));
   return engine;
 }
 
 function engineWithRegistrations(registrations: PolicyRegistration[]) {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   for (const registration of registrations) engine.register(registration);
   return engine;
 }
@@ -477,7 +477,7 @@ describe("createToolExecutor effect application", () => {
     const executor = createToolExecutor({
       events: Bus,
       traceContext: { traceId: "trace-1", sessionId: "sess-1", runId: "run-1" },
-      engine: PolicyEngine.create(),
+      engine: PolicyEngine.create({ clock: Date.now }),
       getToolLabels: () => ["source:mcp"],
       toolExecutor: async (call) => {
         invoked += 1;

--- a/packages/agent/test/core/execution/tools.test.ts
+++ b/packages/agent/test/core/execution/tools.test.ts
@@ -7,7 +7,7 @@ import type { PolicyRegistration } from "../../../src/core/policy/types";
 import { abortRun } from "../../helpers/policy-decision";
 
 function makeEngine() {
-  return PolicyEngine.create();
+  return PolicyEngine.create({ clock: Date.now });
 }
 
 function makeCall(id = "call-1", tool = "bash"): Tool.Call {
@@ -192,7 +192,7 @@ describe("createToolExecutor bus events", () => {
       createToolExecutor({
         events: Bus,
         toolExecutor: async () => ({ id: "r", toolCallId: "c", output: "" }),
-        engine: PolicyEngine.create(),
+        engine: PolicyEngine.create({ clock: Date.now }),
       }),
     ).toThrow("tool executor requires a trace context with traceId, sessionId, runId");
   });

--- a/packages/agent/test/core/execution/turn-provenance.test.ts
+++ b/packages/agent/test/core/execution/turn-provenance.test.ts
@@ -9,7 +9,7 @@ import { makeAgentBase, makeTurnArtifacts } from "./lifecycle-dispatch-fixture";
 
 describe("handleStop prompt injection provenance", () => {
   it("preserves assistant role through turn.finish continuation", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",

--- a/packages/agent/test/core/execution/turn-yield.test.ts
+++ b/packages/agent/test/core/execution/turn-yield.test.ts
@@ -63,7 +63,7 @@ function userMessage(text: string): Message.WithParts {
 }
 
 function seamEngine(decision: () => ReturnType<typeof allow>) {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(
     atPoint("run.completion.pre", {
       name: "test-compaction-seam",
@@ -115,7 +115,7 @@ describe("window yield (#649 reachability fix)", () => {
   it("ends honestly at the step cap instead of pretending completion", async () => {
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const turn = makeTurnArtifacts({
       windowYieldArmed: true,
       stepCap: 2,
@@ -132,7 +132,7 @@ describe("window yield (#649 reachability fix)", () => {
   it("treats a model's own stop exactly as before", async () => {
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const turn = makeTurnArtifacts({
       windowYieldArmed: true,
       stepCap: 24,
@@ -151,7 +151,7 @@ describe("window yield (#649 reachability fix)", () => {
     // continuation application would eat a child's completion notification.
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.turn.post", "test-drain", 100, () => inject("child finished"), [
       "prompt.inject_message",
     ]);
@@ -191,7 +191,7 @@ describe("window yield (#649 reachability fix)", () => {
   it("continues on a steering yield with no drained continuation — never max-steps (#751)", async () => {
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const turn = makeTurnArtifacts({
       windowYieldArmed: false,
       stepCap: 24,
@@ -210,7 +210,7 @@ describe("window yield (#649 reachability fix)", () => {
   it("routes a steering yield's drained injection through the continuation path (#751)", async () => {
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.turn.post", "test-steer-drain", 100, () => inject("steer me"), [
       "prompt.inject_message",
     ]);
@@ -233,7 +233,7 @@ describe("window yield (#649 reachability fix)", () => {
   it("keeps the step cap's honest terminal even when steering also fired (#751)", async () => {
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const turn = makeTurnArtifacts({
       windowYieldArmed: false,
       stepCap: 2,
@@ -272,7 +272,7 @@ describe("window yield (#649 reachability fix)", () => {
     // keep terminating first — that precedence is the pin.
     const state = makeState();
     state.messages = [userMessage("u0")];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(
       engine,
       "run.turn.post",

--- a/packages/agent/test/core/policy/audit-emission.test.ts
+++ b/packages/agent/test/core/policy/audit-emission.test.ts
@@ -33,6 +33,7 @@ describe("PolicyEngine audit emission", () => {
 
     try {
       const engine = PolicyEngine.create({
+        clock: Date.now,
         traceContext: {
           traceId: "trace-config",
           sessionId: "sess-config",
@@ -107,7 +108,7 @@ describe("PolicyEngine audit emission", () => {
     });
 
     try {
-      const engine = PolicyEngine.create({ auditEmit: Bus.publish });
+      const engine = PolicyEngine.create({ clock: Date.now, auditEmit: Bus.publish });
       engine.register(
         atPoint("tool.native.pre", {
           name: "deny-shell",

--- a/packages/agent/test/core/policy/conformance/no-bypass.test.ts
+++ b/packages/agent/test/core/policy/conformance/no-bypass.test.ts
@@ -72,7 +72,7 @@ describe("policy no-bypass conformance — agent governed paths", () => {
         isError: false,
       }),
     );
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(denyAllInvokePre("native tool denied by conformance policy"));
 
     const executor = createToolExecutor({
@@ -98,7 +98,7 @@ describe("policy no-bypass conformance — agent governed paths", () => {
       }),
     );
     const capturedLabels: string[][] = [];
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       ...denyAllInvokePre("mcp tool denied by conformance policy"),
       fn: (ctx) => {
@@ -127,7 +127,7 @@ describe("policy no-bypass conformance — agent governed paths", () => {
   });
 
   it("blocks system prompt composition before prompt content is returned", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(denyAllContextPre("system prompt denied by conformance policy"));
 
     const decision = await engine.dispatchPoint("prompt.context.pre", {

--- a/packages/agent/test/core/policy/dispatch-completion.test.ts
+++ b/packages/agent/test/core/policy/dispatch-completion.test.ts
@@ -22,7 +22,7 @@ function toolHarness(options: {
   execute?: (call: Tool.Call) => Promise<Tool.Result>;
   getContext?: () => Pick<PolicyContext, "steps" | "turnCount" | "elapsedMs" | "usage">;
 }) {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   registerAt(engine, options.point, "test:policy", 100, options.fn, options.effects);
   const execute =
     options.execute ??

--- a/packages/agent/test/core/policy/engine.test.ts
+++ b/packages/agent/test/core/policy/engine.test.ts
@@ -31,6 +31,7 @@ describe("agent policy Bus integration", () => {
     const warning = nextWarning();
     try {
       const engine = PolicyEngine.create({
+        clock: Date.now,
         onDecision: () => {
           throw new Error("observer failed");
         },
@@ -75,6 +76,7 @@ describe("agent policy Bus integration", () => {
     const warning = nextWarning();
     try {
       const engine = PolicyEngine.create({
+        clock: Date.now,
         traceContext: { traceId: "trace-async", sessionId: "session-async" },
         onDecision: async () => {
           throw new Error("async observer failed");
@@ -116,6 +118,7 @@ describe("agent policy Bus integration", () => {
     });
     try {
       const engine = PolicyEngine.create({
+        clock: Date.now,
         traceContext: {
           traceId: "trace-policy",
           sessionId: "sess-policy",

--- a/packages/agent/test/core/policy/native-tool-post-dispatch.test.ts
+++ b/packages/agent/test/core/policy/native-tool-post-dispatch.test.ts
@@ -13,7 +13,7 @@ import { PolicyEngine } from "../../../src/core/policy";
  */
 it("dispatches at the canonical native tool result point", async () => {
   let observed = 0;
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   engine.register(
     atPoint("tool.native.post", {
       name: "test:native-post-observer",

--- a/packages/channels/src/authn/websocket.ts
+++ b/packages/channels/src/authn/websocket.ts
@@ -1,7 +1,7 @@
+import { newTraceId } from "../support/trace";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { Operational } from "@openomni/protocol";
 import type { Policy } from "@openomni/protocol";
-import { newTraceId } from "@openomni/protocol";
 import { evaluateChannelPermission, recordDecision } from "./decision";
 import type { ChannelAuthnDecisionObserver, WebSocketAuthResult } from "./types";
 import type { PublishPort } from "../types";

--- a/packages/channels/src/discord/gateway.ts
+++ b/packages/channels/src/discord/gateway.ts
@@ -1,5 +1,5 @@
+import { newTraceId } from "../support/trace";
 import { Operational } from "@openomni/protocol";
-import { newTraceId } from "@openomni/protocol";
 import { sleep } from "../support/fetch-retry";
 import type { PublishPort } from "../types";
 import { GatewayOp, Intents, type DiscordUser, type GatewayPayload } from "./types";

--- a/packages/channels/src/discord/surface.ts
+++ b/packages/channels/src/discord/surface.ts
@@ -1,5 +1,5 @@
+import { newTraceId } from "../support/trace";
 import { type Channel, Operational, PolicyDecision } from "@openomni/protocol";
-import { newTraceId } from "@openomni/protocol";
 import { Dedupe, DedupeWindow } from "../support/dedupe";
 import { DiscordClient } from "./client";
 import { DiscordHandlerMissingError } from "./error";

--- a/packages/channels/src/github/surface.ts
+++ b/packages/channels/src/github/surface.ts
@@ -1,5 +1,5 @@
+import { newTraceId } from "../support/trace";
 import { type Channel, Operational, PolicyDecision } from "@openomni/protocol";
-import { newTraceId } from "@openomni/protocol";
 import { Dedupe } from "../support/dedupe";
 import { GitHubClient } from "./client";
 import { GitHubNormalizer } from "./normalizer";

--- a/packages/channels/src/router/index.ts
+++ b/packages/channels/src/router/index.ts
@@ -1,10 +1,10 @@
+import { newTraceId } from "../support/trace";
 import {
   Gateway,
   Ingress,
   Operational,
   Wait,
   extractSurfaceKey,
-  newTraceId,
   type BusEvent,
   type Ledger,
   type Policy,

--- a/packages/channels/src/support/trace.ts
+++ b/packages/channels/src/support/trace.ts
@@ -1,0 +1,6 @@
+import { traceIdFromUuid } from "@openomni/protocol";
+
+/** Channel-driver trace origin; entropy stays in the consuming runtime package. */
+export function newTraceId(): string {
+  return traceIdFromUuid(crypto.randomUUID());
+}

--- a/packages/channels/src/telegram/poller.ts
+++ b/packages/channels/src/telegram/poller.ts
@@ -1,4 +1,4 @@
-import { newTraceId } from "@openomni/protocol";
+import { newTraceId } from "../support/trace";
 import { Operational } from "@openomni/protocol";
 import { sleep } from "../support/fetch-retry";
 import type { PublishPort } from "../types";

--- a/packages/channels/src/telegram/surface.ts
+++ b/packages/channels/src/telegram/surface.ts
@@ -1,5 +1,5 @@
+import { newTraceId } from "../support/trace";
 import { type Channel, Operational, PolicyDecision } from "@openomni/protocol";
-import { newTraceId } from "@openomni/protocol";
 import { Dedupe, DedupeWindow } from "../support/dedupe";
 import { chunkMarkdown } from "../support/format/chunk";
 import { renderTelegramMarkdown } from "../support/format/telegram";

--- a/packages/channels/src/websocket.ts
+++ b/packages/channels/src/websocket.ts
@@ -1,4 +1,5 @@
-import { Channel, newTraceId, Operational } from "@openomni/protocol";
+import { newTraceId } from "./support/trace";
+import { Channel, Operational } from "@openomni/protocol";
 import { ChannelAuthnMiddleware, type ChannelAuthnDecisionObserver } from "./channel-authn";
 import type { PublishPort } from "./types";
 

--- a/packages/ipc/src/peer-request-table.ts
+++ b/packages/ipc/src/peer-request-table.ts
@@ -1,4 +1,4 @@
-import { Ipc } from "@openomni/protocol";
+import { Ipc, type IdSource } from "@openomni/protocol";
 
 import { IpcRemoteError, IpcTimeoutError } from "./errors";
 
@@ -27,6 +27,7 @@ type NotificationHandler<TPeer> = (
 
 type PeerRequestTableOptions<TPeer> = {
   readonly send: SendFrame<TPeer>;
+  readonly idSource?: IdSource;
   readonly onRequest?: RequestHandler<TPeer>;
   readonly onNotification?: NotificationHandler<TPeer>;
   readonly missingRequestHandlerMessage?: (method: string) => string;
@@ -52,7 +53,11 @@ export class PeerRequestTable<TPeer = undefined> {
     params: Record<string, unknown> | undefined,
     timeoutMs: number,
   ): Promise<unknown> {
-    const request = Ipc.createRequest(method, params);
+    const request = Ipc.createRequest(
+      (this.options.idSource ?? (() => crypto.randomUUID()))(),
+      method,
+      params,
+    );
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(request.id);

--- a/packages/ipc/test/backpressure.test.ts
+++ b/packages/ipc/test/backpressure.test.ts
@@ -42,7 +42,7 @@ describe("server write backpressure (Bun partial writes)", () => {
       if (frames.length > 0) frameReceived.resolve(frames[0]);
     });
     socket.pause();
-    const request = Ipc.createRequest("get-big", {});
+    const request = Ipc.createRequest("request-big-1", "get-big", {});
     socket.write(`${JSON.stringify(request)}\n`);
     await within(responseIssued.promise, "server issuing queued large response");
     socket.resume();
@@ -77,7 +77,7 @@ describe("server write backpressure (Bun partial writes)", () => {
       if (frames.length >= 2) bothFramesReceived.resolve();
     });
     socket.pause();
-    const request = Ipc.createRequest("get-big", {});
+    const request = Ipc.createRequest("request-big-2", "get-big", {});
     socket.write(`${JSON.stringify(request)}\n`);
     await within(responseIssued.promise, "server queuing first large frame");
 

--- a/packages/ipc/test/peer-request-table.test.ts
+++ b/packages/ipc/test/peer-request-table.test.ts
@@ -15,11 +15,14 @@ function requestFrom(frames: Frame[], index = 0): Ipc.Request {
 describe("PeerRequestTable", () => {
   test("call issues an id and correlates the matching response", async () => {
     const sent: Frame[] = [];
-    const table = new PeerRequestTable<string>({ send: (_peer, frame) => sent.push(frame) });
+    const table = new PeerRequestTable<string>({
+      send: (_peer, frame) => sent.push(frame),
+      idSource: () => "request-injected",
+    });
 
     const call = table.call("peer-a", "compute", { n: 21 }, 1_000);
     const request = requestFrom(sent);
-    expect(request.id.length).toBeGreaterThan(0);
+    expect(request.id).toBe("request-injected");
     expect(request.method).toBe("compute");
     expect(table.dispatch(Ipc.createResponse(request.id, { answer: 42 }), "peer-a")).toBe(true);
     expect(await call).toEqual({ answer: 42 });
@@ -95,7 +98,7 @@ describe("PeerRequestTable", () => {
       },
     });
 
-    expect(table.dispatch(Ipc.createRequest("echo", { value: 1 }), "peer-a")).toBe(true);
+    expect(table.dispatch(Ipc.createRequest("inbound-echo", "echo", { value: 1 }), "peer-a")).toBe(true);
     expect(sent).toHaveLength(2);
     expect(Ipc.Response.parse(sent[0]).result).toEqual({ method: "echo", params: { value: 1 } });
     expect(Ipc.Notification.parse(sent[1])).toMatchObject({
@@ -110,7 +113,7 @@ describe("PeerRequestTable", () => {
       send: (_peer, frame) => missingFrames.push(frame),
       missingRequestHandlerMessage: (method) => `missing ${method}`,
     });
-    missing.dispatch(Ipc.createRequest("none"), "peer-a");
+    missing.dispatch(Ipc.createRequest("inbound-none", "none"), "peer-a");
     expect(Ipc.Response.parse(missingFrames[0]).error).toEqual({
       code: 1000,
       message: "missing none",
@@ -123,7 +126,7 @@ describe("PeerRequestTable", () => {
         throw new TypeError("handler failed");
       },
     });
-    throwing.dispatch(Ipc.createRequest("boom"), "peer-a");
+    throwing.dispatch(Ipc.createRequest("inbound-boom", "boom"), "peer-a");
     expect(Ipc.Response.parse(failureFrames[0]).error).toEqual({
       code: 1000,
       message: "handler failed",

--- a/packages/ipc/test/server-edges.test.ts
+++ b/packages/ipc/test/server-edges.test.ts
@@ -134,7 +134,7 @@ describe("server edge branches", () => {
     const reply = new Promise<string>((resolve) => {
       second.once("data", (chunk) => resolve(String(chunk)));
     });
-    second.write(`${JSON.stringify(Ipc.createRequest("machine.run_cell", {}))}\n`);
+    second.write(`${JSON.stringify(Ipc.createRequest("request-run-cell", "machine.run_cell", {}))}\n`);
     const frame = JSON.parse(await reply);
     expect(frame.type).toBe("response");
     expect(frame.result).toEqual({ ok: true });

--- a/packages/ledger/AGENTS.md
+++ b/packages/ledger/AGENTS.md
@@ -29,6 +29,7 @@ src/
 │   ├── sqlite-*-adapter.ts # SQLite sub-adapters by storage seam
 │   ├── sqlite-schema-lifecycle.ts # PRAGMAs, migrations, and clear ordering
 │   ├── commit-coordinator.ts # SOLE owner of decision-class commit MECHANICS: append at expectedHead → adopt an empty pre-cutover stream → caller's projection CAS, with SQLITE_BUSY mapped to the caller's typed error. A refused projection is ATOMIC via a nested transaction (savepoint), so head never outruns revision even when the caller reports the refusal by RETURNING (completion-writer) rather than throwing. Domains keep their folds, fact payloads, adoption genesis, and conflict taxonomy
+│   ├── atomic-file.ts # sole temp-write/rename owner for durable file replacement (optional fsync durability)
 │   ├── migration-runner.ts / sqlite-busy.ts / sqlite-json-data.ts / timestamped-store.ts # shared SQLite helpers (requireSubAdapter lives in timestamped-store)
 │   └── initialize.ts     # initialize({ dbPath }) — bootstraps the default SQLite adapter
 ├── ledger-core/          # Ledger append core (#510 A): serialized CAS append, adoptStream, headFact/factsByType, verifyTail over the hash-chained ledger_event table (schema.ts = drizzle DDL source)

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -1,6 +1,12 @@
 export { BusPersistence } from "./bus-persistence/index.js";
 export { BusQuery } from "./bus-persistence/query";
-export { Storage, SqliteStorageAdapter, initialize } from "./storage";
+export {
+  type AtomicFileOptions,
+  initialize,
+  replaceFileAtomically,
+  SqliteStorageAdapter,
+  Storage,
+} from "./storage";
 export { StorageUnavailableError } from "./storage/sqlite-busy.js";
 export { LedgerAppend } from "./storage/append-port";
 export { Session } from "./session";

--- a/packages/ledger/src/storage/atomic-file.ts
+++ b/packages/ledger/src/storage/atomic-file.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { IdSource } from "@openomni/protocol";
+
+export interface AtomicFileOptions {
+  readonly mode?: number;
+  readonly durable?: boolean;
+  readonly temporaryId?: IdSource;
+  readonly replace?: (temporaryPath: string, finalPath: string) => void;
+}
+
+/**
+ * Makes complete bytes visible in one rename, cleaning the exclusive temporary
+ * file on every failure. Durable writes additionally sync the file and parent
+ * directory around the rename.
+ */
+export function replaceFileAtomically(
+  path: string,
+  contents: string | Uint8Array,
+  options: AtomicFileOptions = {},
+): void {
+  const directory = dirname(path);
+  const temporaryId = options.temporaryId ?? (() => randomUUID());
+  const temporaryPath = join(
+    directory,
+    `.${basename(path)}.${process.pid}.${temporaryId()}.tmp`,
+  );
+
+  try {
+    const descriptor = openSync(temporaryPath, "wx", options.mode);
+    try {
+      writeFileSync(descriptor, contents);
+      if (options.durable) fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+
+    (options.replace ?? renameSync)(temporaryPath, path);
+
+    if (options.durable) {
+      const directoryDescriptor = openSync(directory, "r");
+      try {
+        fsyncSync(directoryDescriptor);
+      } finally {
+        closeSync(directoryDescriptor);
+      }
+    }
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}

--- a/packages/ledger/src/storage/index.ts
+++ b/packages/ledger/src/storage/index.ts
@@ -1,3 +1,4 @@
+export { replaceFileAtomically, type AtomicFileOptions } from "./atomic-file";
 export { Storage } from "./storage";
 export { SqliteStorageAdapter } from "./sqlite-storage";
 export { initialize } from "./initialize";

--- a/packages/ledger/src/work-item/builder.ts
+++ b/packages/ledger/src/work-item/builder.ts
@@ -1,9 +1,10 @@
 import { WorkItem } from "@openomni/protocol";
+import { newWorkItemId } from "./identity.js";
 import type { CreateWorkItemInput } from "./types.js";
 
 export function buildWorkItem(input: CreateWorkItemInput, now: number): WorkItem.Info {
   const maxAttempts = input.maxAttempts;
-  const hash = WorkItem.generateHash();
+  const hash = newWorkItemId();
   const criteria = input.acceptanceCriteria.map((statement, index) => ({
     id: WorkItem.criterionId(hash, index, statement),
     revision: 1,

--- a/packages/ledger/src/work-item/identity.ts
+++ b/packages/ledger/src/work-item/identity.ts
@@ -1,0 +1,13 @@
+import { WorkItem } from "@openomni/protocol";
+
+function entropy(byteLength: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(byteLength));
+}
+
+export function newWorkItemId(): string {
+  return WorkItem.generateHash(entropy(8));
+}
+
+export function newAttemptId(): string {
+  return WorkItem.generateAttemptId(entropy(16));
+}

--- a/packages/ledger/src/work-item/lifecycle.ts
+++ b/packages/ledger/src/work-item/lifecycle.ts
@@ -1,4 +1,5 @@
 import { WorkItem } from "@openomni/protocol";
+import { newAttemptId } from "./identity.js";
 import { Bus } from "@openomni/telemetry";
 import { Storage } from "../storage/storage.js";
 import { attemptAllocatedFact } from "./facts.js";
@@ -120,7 +121,7 @@ export async function allocateWorkItemAttempt(
       throw new Error(`Cannot allocate an attempt on a ${status} work item`);
     }
     const attempt = WorkItem.Attempt.parse({
-      attemptId: WorkItem.generateAttemptId(),
+      attemptId: newAttemptId(),
       attemptSeq: existing.lastAttemptSeq + 1,
       retryOf: existing.currentAttemptId ?? null,
       contentFingerprint: identity.contentFingerprint,

--- a/packages/ledger/test/storage/atomic-file.test.ts
+++ b/packages/ledger/test/storage/atomic-file.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { replaceFileAtomically } from "../../src/index";
+
+describe("replaceFileAtomically", () => {
+  test("publishes exact bytes and removes its temporary file after replacement failure", () => {
+    const directory = mkdtempSync(join(tmpdir(), "openomni-atomic-file-"));
+    const path = join(directory, "state.json");
+    try {
+      writeFileSync(path, "previous\n");
+      replaceFileAtomically(path, "replacement\n", { temporaryId: () => "success" });
+      expect(readFileSync(path, "utf8")).toBe("replacement\n");
+      expect(readdirSync(directory)).toEqual(["state.json"]);
+
+      expect(() =>
+        replaceFileAtomically(path, "partial\n", {
+          temporaryId: () => "failure",
+          replace: () => {
+            throw new Error("injected replacement failure");
+          },
+        }),
+      ).toThrow("injected replacement failure");
+      expect(readFileSync(path, "utf8")).toBe("replacement\n");
+      expect(readdirSync(directory)).toEqual(["state.json"]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/policy/src/engine/audit.ts
+++ b/packages/policy/src/engine/audit.ts
@@ -48,7 +48,7 @@ function resolveAuditPoint(ctx: Readonly<AuditDispatchContextGeneric<GenericPoli
 
 /**
  * Whether anything will read an audit context. Not every engine binds one:
- * the completion-admission engine is built as `PolicyEngine.create()` with no
+ * the completion-admission engine is built as `PolicyEngine.create({ clock: Date.now })` with no
  * options at product composition, so building a
  * correlation context for its dispatches is pure waste.
  */
@@ -115,7 +115,7 @@ function publishAuditRecord(
     if (traceId) {
       options.auditEmit?.(Operational.Events.Warn, {
         traceId,
-        time: Date.now(),
+        time: options.clock(),
         component: "agent.policy",
         msg: "audit record dropped: missing sessionId",
         context: {
@@ -133,7 +133,7 @@ function publishAuditRecord(
     traceId,
     sessionId,
     ...(traceContext?.runId !== undefined && { runId: traceContext.runId }),
-    time: Date.now(),
+    time: options.clock(),
     ...(record.policyId !== undefined && { policyId: record.policyId }),
     actor: buildActor(traceContext),
     action: record.action,
@@ -161,7 +161,7 @@ export function publishDecisionObserverError(
   if (traceId === undefined || traceId.length === 0) return;
   options.auditEmit?.(Operational.Events.Warn, {
     traceId,
-    time: Date.now(),
+    time: options.clock(),
     ...(traceContext?.sessionId !== undefined && { sessionId: traceContext.sessionId }),
     component: "agent.policy",
     msg: "onDecision observer error",

--- a/packages/policy/src/engine/dispatch.ts
+++ b/packages/policy/src/engine/dispatch.ts
@@ -24,7 +24,7 @@ import type {
 const CONTRACT_REGISTRATION = { name: "policy.point.contract" } as const;
 
 export function createPolicyEngine<TCtx extends GenericPolicyContext>(
-  options: PolicyEngineConfig = {},
+  options: PolicyEngineConfig,
 ): PolicyEngineInstanceGeneric<TCtx> {
   const registrations = createPolicyRegistrationStore<TCtx>();
 
@@ -126,13 +126,13 @@ export function createPolicyEngine<TCtx extends GenericPolicyContext>(
   ): Promise<Policy.PolicyDecision | undefined> {
     const contract = Policy.PolicyPoint.Registry[pointId];
     const timing = timingForPolicyPoint(pointId);
-    const startTime = Date.now();
+    const startTime = options.clock();
     let middlewareDecision: unknown;
     let engineDecision: Policy.PolicyDecision | undefined;
     try {
       middlewareDecision = await invoke();
     } catch (err) {
-      const durationMs = Date.now() - startTime;
+      const durationMs = options.clock() - startTime;
       const failPolicy = reg.failPolicy ?? contract.defaultFailPolicy;
       const error = err instanceof Error ? err : new Error(String(err));
       publishMiddlewareError(
@@ -153,7 +153,7 @@ export function createPolicyEngine<TCtx extends GenericPolicyContext>(
           : pointMiddlewareErrorDecision(reg, pointId, durationMs);
     }
 
-    const durationMs = Date.now() - startTime;
+    const durationMs = options.clock() - startTime;
     const normalized =
       engineDecision === undefined
         ? normalizePointDecision(middlewareDecision, reg, pointId, durationMs)

--- a/packages/policy/src/engine/telemetry.ts
+++ b/packages/policy/src/engine/telemetry.ts
@@ -57,7 +57,7 @@ export function publishMiddlewareError(
   if (traceId === undefined) return;
   options.auditEmit?.(Operational.Events.Warn, {
     traceId,
-    time: Date.now(),
+    time: options.clock(),
     component: "agent.policy",
     msg: "middleware error",
     context: { timing, name, error: String(err), failPolicy, durationMs },
@@ -76,7 +76,7 @@ export function publishMiddlewareDebug(
   if (traceId === undefined) return;
   options.auditEmit?.(Operational.Events.Debug, {
     traceId,
-    time: Date.now(),
+    time: options.clock(),
     component: "agent.policy",
     msg: "middleware dispatch",
     context: { timing, name, verdict, durationMs },

--- a/packages/policy/src/engine/types.ts
+++ b/packages/policy/src/engine/types.ts
@@ -1,4 +1,4 @@
-import type { BusEvent, Message, Policy, TraceContext } from "@openomni/protocol";
+import type { BusEvent, Clock, Message, Policy, TraceContext } from "@openomni/protocol";
 
 export type PolicyPointId = keyof typeof Policy.PolicyPoint.Registry;
 
@@ -41,6 +41,7 @@ export type PolicyDecision = Policy.PolicyDecision;
 type AuditEmit = <T>(event: BusEvent.Descriptor<T>, data: T) => void;
 
 export interface PolicyEngineConfig {
+  readonly clock: Clock;
   readonly onDecision?: (decision: Policy.PolicyDecision) => void | Promise<void>;
   readonly traceContext?: TraceContext.Type;
   /**

--- a/packages/policy/test/canonical-registration-boundary.test.ts
+++ b/packages/policy/test/canonical-registration-boundary.test.ts
@@ -9,7 +9,7 @@ const allow = () => PolicyDecision.allow({ policyId: "canonical.boundary.test" }
 function registrationErrorFor(
   registration: Readonly<Record<string, unknown>>,
 ): PolicyRegistrationError {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   try {
     Reflect.apply(engine.register, engine, [registration]);
   } catch (error) {
@@ -22,7 +22,7 @@ function registrationErrorFor(
 
 describe("PolicyEngine canonical registration boundary", () => {
   test("accepts complete canonical metadata", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     expect(() =>
       engine.register({
@@ -181,7 +181,7 @@ test("rejects a legacy-shaped proxy fail-closed without reclassifying its later 
       },
     },
   );
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
 
   let rejection: unknown;
   try {

--- a/packages/policy/test/canonical-registration.test.ts
+++ b/packages/policy/test/canonical-registration.test.ts
@@ -28,7 +28,7 @@ function expectRegistrationError(
 
 describe("PolicyEngine canonical registration", () => {
   test("accepts explicit effect-free and multi-point capabilities", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     expect(() =>
       engine.register({
@@ -52,7 +52,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("exposes no legacy timing dispatch entry point around canonical registrations", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let invocationCount = 0;
 
     engine.register({
@@ -154,7 +154,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("rejects non-point kind and malformed canonical boundaries with typed errors", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const base = { ...registrationDefaults, name: "malformed" };
 
     expectRegistrationError(engine, {
@@ -185,7 +185,7 @@ describe("PolicyEngine canonical registration", () => {
     // scope: { agentType: [] } is the config-filter footgun: it used to mean
     // "unscoped" and silently applied the policy to every agent. Fail-closed
     // at the boundary — unscoped is spelled by omitting agentType.
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     const error = expectRegistrationError(engine, {
       ...registrationDefaults,
@@ -200,7 +200,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("rejects empty and duplicate point bindings with typed errors", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const base = {
       ...registrationDefaults,
       name: "invalid-points",
@@ -215,7 +215,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("rejects empty, missing, unknown, and unbound capability entries with typed errors", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const base = {
       ...registrationDefaults,
       name: "invalid-capabilities",
@@ -243,7 +243,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("rejects effects outside a point contract's allowed maximum", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     expectRegistrationError(engine, {
       ...registrationDefaults,
@@ -254,7 +254,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("rejects duplicate effects with a typed error", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     expectRegistrationError(engine, {
       ...registrationDefaults,
@@ -265,7 +265,7 @@ describe("PolicyEngine canonical registration", () => {
   });
 
   test("rejects disallowed effects after attempted catalog mutation", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const allowedEffects = Policy.PolicyPoint.Registry["run.lifecycle.post"].allowedEffects;
     const mutated = Reflect.set(allowedEffects, allowedEffects.length, "run.abort");
 
@@ -288,7 +288,7 @@ describe("PolicyEngine canonical registration", () => {
 });
 
 test("accepts union-typed registrations through the public engine overload", () => {
-  const engine = PolicyEngine.create<GenericPolicyContext>();
+  const engine = PolicyEngine.create<GenericPolicyContext>({ clock: Date.now });
   const registerUnion = (registration: CanonicalPolicyRegistrationGeneric<GenericPolicyContext>) =>
     engine.register(registration);
 

--- a/packages/policy/test/engine-behavior.test.ts
+++ b/packages/policy/test/engine-behavior.test.ts
@@ -37,6 +37,7 @@ function systemToolDescriptor(name: string): Policy.Resource.Descriptor {
 function auditedObserver(onDecision: (decision: Policy.PolicyDecision) => void | Promise<void>) {
   const events: Array<{ name: string; data: unknown }> = [];
   const engine = PolicyEngine.create({
+    clock: Date.now,
     traceContext: { traceId: "trace-observer", sessionId: "session-observer" },
     onDecision,
     auditEmit: (event, data) => events.push({ name: event.name, data }),
@@ -52,7 +53,7 @@ function auditedObserver(onDecision: (decision: Policy.PolicyDecision) => void |
 describe("PolicyEngine behavior", () => {
   it("dispatches one registration at every declared point", async () => {
     const fn = mock(() => allow("multi"));
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "multi",
@@ -74,7 +75,7 @@ describe("PolicyEngine behavior", () => {
   });
 
   it("merges and preserves prompt effects in policy order", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "prompt.context.pre", {
       name: "prompt-a",
       priority: 100,
@@ -114,7 +115,7 @@ describe("PolicyEngine behavior", () => {
   });
 
   it("allows deny decisions without reason codes", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.turn.pre", {
       name: "missing-reason",
       priority: 0,
@@ -148,6 +149,7 @@ describe("PolicyEngine behavior", () => {
       resolveWarning = resolve;
     });
     const engine = PolicyEngine.create({
+      clock: Date.now,
       traceContext: { traceId: "trace-async", sessionId: "session-async" },
       onDecision: async () => {
         throw new Error("async observer failed");
@@ -190,7 +192,7 @@ describe("PolicyEngine behavior", () => {
   });
 
   it("does not add run.abort to a post-boundary denial", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "run.lifecycle.post", {
       name: "deny-finish",
       priority: 0,
@@ -215,7 +217,7 @@ describe("PolicyEngine behavior", () => {
   it("passes the exact resource descriptor snapshot to middleware", async () => {
     const descriptor = systemToolDescriptor("shell");
     let received: unknown;
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     registerAt(engine, "tool.native.pre", {
       name: "resource-observer",
       priority: 0,
@@ -242,7 +244,7 @@ describe("PolicyEngine behavior", () => {
 
   it("continues after an allow without middleware policy metadata", async () => {
     const after = mock(() => allow("after"));
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(
       atPoint("tool.native.pre", {
         name: "missing-policy-id",
@@ -262,6 +264,7 @@ describe("PolicyEngine behavior", () => {
     const events: string[] = [];
     const after = mock(() => allow("after"));
     const engine = PolicyEngine.create({
+      clock: Date.now,
       traceContext: { traceId: "trace-deny", sessionId: "session-deny" },
       auditEmit: (event) => events.push(event.name),
     });

--- a/packages/policy/test/engine-determinism.test.ts
+++ b/packages/policy/test/engine-determinism.test.ts
@@ -117,7 +117,7 @@ function policySet(): PolicyRegistration[] {
 }
 
 function registerPolicies(registrations: PolicyRegistration[]) {
-  const engine = PolicyEngine.create();
+  const engine = PolicyEngine.create({ clock: Date.now });
   for (const registration of registrations) engine.register(registration);
   return engine;
 }

--- a/packages/policy/test/engine-portability.test.ts
+++ b/packages/policy/test/engine-portability.test.ts
@@ -27,6 +27,7 @@ function createDispatchContext() {
 function createAuditedEngine() {
   const events: Array<{ name: string; data: unknown }> = [];
   const engine = PolicyEngine.create({
+    clock: Date.now,
     traceContext: { traceId: "trace-portability", sessionId: "session-portability" },
     auditEmit: (event, data) => {
       events.push({ name: event.name, data });
@@ -54,7 +55,7 @@ function capturedRegistrationError(register: () => void): PolicyRegistrationErro
 
 describe("PolicyEngine portability", () => {
   it("does not match a scoped canonical registration when agentType is empty", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let invocationCount = 0;
 
     engine.register({
@@ -80,7 +81,7 @@ describe("PolicyEngine portability", () => {
   });
 
   it("rejects legacy timing registrations fail-closed at the trusted boundary", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     const error = capturedRegistrationError(() =>
       Reflect.apply(engine.register, engine, [

--- a/packages/policy/test/engine-scope-and-points.test.ts
+++ b/packages/policy/test/engine-scope-and-points.test.ts
@@ -74,7 +74,7 @@ describe("deny-wins point matrix", () => {
     ] as const;
 
     for (const { pointId, ctx } of pointCases) {
-      const engine = PolicyEngine.create();
+      const engine = PolicyEngine.create({ clock: Date.now });
       engine.register({
         kind: "point",
         name: "allow",
@@ -101,7 +101,7 @@ describe("deny-wins point matrix", () => {
 
 describe("scope filtering with 100 policies", () => {
   it("dispatches only policies matching specific agentType out of 100", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const executed: string[] = [];
 
     const agentTypes = [
@@ -146,7 +146,7 @@ describe("scope filtering with 100 policies", () => {
   });
 
   it("unscoped policies always execute alongside scoped matches", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const executed: string[] = [];
 
     for (let i = 0; i < 50; i++) {
@@ -188,7 +188,7 @@ describe("scope filtering with 100 policies", () => {
   });
 
   it("no agentType in context skips all scoped policies", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const executed: string[] = [];
     let scopedInvocations = 0;
 
@@ -233,7 +233,7 @@ describe("scope filtering with 100 policies", () => {
   });
 
   it("scope filtering with multi-agent scope arrays", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const executed: string[] = [];
 
     for (let i = 0; i < 100; i++) {

--- a/packages/policy/test/invariant-smoke.test.ts
+++ b/packages/policy/test/invariant-smoke.test.ts
@@ -43,7 +43,7 @@ describe("engine invariants hold under the package's own suite", () => {
   ] as const) {
     test(name, async () => {
       const calls: string[] = [];
-      const engine = PolicyEngine.create({ audit: false });
+      const engine = PolicyEngine.create({ clock: Date.now, audit: false });
       for (const [id, priority, result] of entries) engine.register(registration(id, priority, calls, result));
       const decision = await engine.dispatchPoint(POINT, context);
       expect(decision.verdict).toBe(verdict);
@@ -52,7 +52,7 @@ describe("engine invariants hold under the package's own suite", () => {
   }
 
   test("a deny at a side-effect boundary escalates to run.abort", async () => {
-    const engine = PolicyEngine.create({ audit: false });
+    const engine = PolicyEngine.create({ clock: Date.now, audit: false });
     engine.register({
       kind: "point", name: "denier-without-abort", pointIds: [POINT], effectCapabilities: { [POINT]: [] }, priority: 0,
       fn: () => PolicyDecision.deny({ policyId: "denier-without-abort", reasonCodes: ["invariant.deny_reason"] }),

--- a/packages/policy/test/point-audit.test.ts
+++ b/packages/policy/test/point-audit.test.ts
@@ -13,6 +13,7 @@ describe("PolicyEngine canonical point audit", () => {
     } as const;
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
+      clock: () => 1_234,
       traceContext,
       auditEmit: (event, data) => events.push({ name: event.name, data }),
     });
@@ -44,12 +45,25 @@ describe("PolicyEngine canonical point audit", () => {
     );
     const pointVersion = Policy.PolicyPoint.Registry[pointId].version;
 
-    expect(evaluated).toMatchObject({ ...traceContext, pointId, pointVersion });
-    expect(composed).toMatchObject({ ...traceContext, pointId, pointVersion });
+    expect(evaluated).toMatchObject({
+      ...traceContext,
+      pointId,
+      pointVersion,
+      time: 1_234,
+      durationMs: 0,
+    });
+    expect(composed).toMatchObject({
+      ...traceContext,
+      pointId,
+      pointVersion,
+      time: 1_234,
+      durationMs: 0,
+    });
   });
   test("warns under the trace instead of silently dropping audit records without a sessionId", async () => {
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
+      clock: Date.now,
       // A trace but no session: the audit record cannot be filed (an audit
       // row without its session names nothing queryable), but the drop must
       // be visible as an Operational.Events.Warn under the real trace.
@@ -99,6 +113,7 @@ describe("PolicyEngine canonical point audit", () => {
   test("preserves safe correlation when canonical context snapshot fails", async () => {
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
+      clock: Date.now,
       auditEmit: (event, data) => events.push({ name: event.name, data }),
     });
     // The snapshot exists to protect a policy from a mutable context, so it is

--- a/packages/policy/test/point-context-immutability.test.ts
+++ b/packages/policy/test/point-context-immutability.test.ts
@@ -8,7 +8,7 @@ cyclic.self = cyclic;
 
 describe("PolicyEngine canonical point context immutability", () => {
   test("rejects Map context before it can mutate across middleware", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const invocations: string[] = [];
     for (const name of ["first-map-policy", "second-map-policy"] as const) {
       engine.register({
@@ -37,7 +37,7 @@ describe("PolicyEngine canonical point context immutability", () => {
   });
 
   test("deeply freezes plain structured records and arrays", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let deeplyFrozen = false;
     engine.register({
       kind: "point",
@@ -77,7 +77,7 @@ describe("PolicyEngine canonical point context immutability", () => {
     { name: "non-plain object", value: new Date(0) },
   ]) {
     test(`returns input-invalid for ${testCase.name} context`, async () => {
-      const engine = PolicyEngine.create();
+      const engine = PolicyEngine.create({ clock: Date.now });
       let invoked = false;
       engine.register({
         kind: "point",
@@ -110,7 +110,7 @@ describe("PolicyEngine canonical point context immutability", () => {
    * `unsupported`, so an emitter under any other key was always refused.
    */
   test("returns input-invalid for an eventEmitter-keyed emitter", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let invoked = false;
     engine.register({
       kind: "point",

--- a/packages/policy/test/point-dispatch.test.ts
+++ b/packages/policy/test/point-dispatch.test.ts
@@ -8,7 +8,7 @@ import { atPoint, dispatchContext } from "./point-test-fixtures";
 
 describe("PolicyEngine dispatchPoint selection", () => {
   test("passes an immutable canonical context to matching registrations", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let observedPointId: string | undefined;
     let observedTiming: Policy.Timing | undefined;
     let observedMarker: string | undefined;
@@ -44,7 +44,7 @@ describe("PolicyEngine dispatchPoint selection", () => {
 
   test("keeps generic run completion and canonical WorkItem completion independent", async () => {
     const timing = Policy.Timing.COMPLETION_PREPARE;
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let observedPointId: string | undefined;
     let observedTiming: Policy.Timing | undefined;
     engine.register({
@@ -76,7 +76,7 @@ describe("PolicyEngine dispatchPoint selection", () => {
   });
 
   test("selects only the requested point and preserves stable priority order", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const order: string[] = [];
     for (const [name, priority] of [
       ["first", 10],
@@ -113,7 +113,7 @@ describe("PolicyEngine dispatchPoint selection", () => {
   });
 
   test("pins the agent type that selected a scoped registration into its context", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let agentTypeReads = 0;
     let observedAgentType: unknown;
     engine.register({
@@ -144,7 +144,7 @@ describe("PolicyEngine dispatchPoint selection", () => {
   });
 
   test("keeps point selection isolated with no legacy dispatch member", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const invocations: string[] = [];
     engine.register({
       kind: "point",
@@ -182,7 +182,7 @@ describe("PolicyEngine dispatchPoint selection", () => {
   });
 
   test("allows valid canonical dispatches with no matching registrations", async () => {
-    const decision = await PolicyEngine.create().dispatchPoint(
+    const decision = await PolicyEngine.create({ clock: Date.now }).dispatchPoint(
       "dispatch.action.pre",
       dispatchContext,
     );
@@ -200,7 +200,7 @@ describe("PolicyEngine dispatchPoint selection", () => {
         effects: [{ type: "run.abort", reason: "test-error-abort" }],
       }),
     );
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register(
       atPoint("run.error.error", {
         name: "test:error",

--- a/packages/policy/test/point-enforcement.test.ts
+++ b/packages/policy/test/point-enforcement.test.ts
@@ -33,7 +33,7 @@ void assertPolicyRegistrationRejectsAsync;
 
 describe("direct-lane runtime async refusal", () => {
   test("an async function smuggled past the type surface is refused at registration", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     expect(() =>
       engine.register({
         kind: "point",
@@ -68,7 +68,7 @@ describe("direct-lane runtime async refusal", () => {
   });
 
   test("a sync callback returning a thenable is thrown, never awaited", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "thenable-smuggler",
@@ -108,7 +108,7 @@ const workCompletionContext = {
 
 describe("PolicyEngine dispatchPoint", () => {
   test("rejects an invalid policy point ID with PolicyPointTimingError", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     await expect(
       Reflect.apply(engine.dispatchPoint, engine, ["unknown.point.pre", {}]),
@@ -119,7 +119,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("denies missing pre-boundary context before middleware runs", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let invoked = false;
     engine.register({
       kind: "point",
@@ -145,7 +145,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("allows malformed post-boundary context with audit evidence before middleware runs", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let invoked = false;
     engine.register({
       kind: "point",
@@ -183,7 +183,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("rejects effects not declared by the canonical registration", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "undeclared-rewrite",
@@ -210,7 +210,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("parses middleware decisions once before enforcing declared effects", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     let effectReads = 0;
     const middlewareDecision = {
       policyId: "single-parse-policy",
@@ -256,7 +256,7 @@ describe("PolicyEngine dispatchPoint", () => {
         reason: "policy.middleware_failed.fail_open:throwing-policy",
       },
     ] as const) {
-      const engine = PolicyEngine.create();
+      const engine = PolicyEngine.create({ clock: Date.now });
       let invocationCount = 0;
       engine.register({
         kind: "point",
@@ -280,7 +280,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("records a fail-open middleware crash in the composed allow without auditEmit", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "crashing-guard",
@@ -323,7 +323,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("applies the contract default fail-open to a post-boundary middleware crash", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "post-crasher",
@@ -377,6 +377,7 @@ describe("PolicyEngine dispatchPoint", () => {
   test("re-attributes a spoofed middleware policyId to the invoked registration", async () => {
     const recorded: Policy.PolicyDecision[] = [];
     const engine = PolicyEngine.create({
+      clock: Date.now,
       onDecision: (decision) => {
         recorded.push(decision);
       },
@@ -399,7 +400,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("keeps same-priority divergent writes fail-closed when one policy spoofs the other's id", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "spoofer",
@@ -450,7 +451,7 @@ describe("PolicyEngine dispatchPoint", () => {
       type: "work.allow_asserted",
       criterionIds: ["criterion:publish"],
     } satisfies Policy.PolicyEffect;
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const evaluated: string[] = [];
     engine.register({
       kind: "point",
@@ -490,7 +491,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("denies invalid canonical middleware decisions deterministically", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     Reflect.apply(engine.register, engine, [
       {
         kind: "point",
@@ -511,7 +512,7 @@ describe("PolicyEngine dispatchPoint", () => {
   });
 
   test("normalizes decision parser exceptions to invalid-decision denial", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const throwingDecision = Object.defineProperty({}, "verdict", {
       enumerable: true,
       get() {

--- a/packages/policy/test/registration-factory.test.ts
+++ b/packages/policy/test/registration-factory.test.ts
@@ -44,8 +44,8 @@ describe("per-engine registration factories", () => {
 
   test("each engine registering the same factory gets independent state", async () => {
     const shared = onceFactory();
-    const engineOne = PolicyEngine.create();
-    const engineTwo = PolicyEngine.create();
+    const engineOne = PolicyEngine.create({ clock: Date.now });
+    const engineTwo = PolicyEngine.create({ clock: Date.now });
     engineOne.register(shared);
     engineTwo.register(shared);
     expect(shared.instances()).toBe(2);
@@ -62,14 +62,14 @@ describe("per-engine registration factories", () => {
   });
 
   test("a factory whose create is not a function is rejected fail-closed", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     expect(() =>
       Reflect.apply(engine.register, engine, [{ kind: "factory", name: "test:bad", create: 1 }]),
     ).toThrow(PolicyRegistrationError);
   });
 
   test("a factory producing a non-registration is rejected fail-closed", () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     expect(() =>
       Reflect.apply(engine.register, engine, [
         { kind: "factory", name: "test:bad-product", create: () => null },

--- a/packages/policy/test/unguarded-point.test.ts
+++ b/packages/policy/test/unguarded-point.test.ts
@@ -32,7 +32,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
   }
 
   test("does not descend into the context when no policy is registered", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const probe = contextWithProbe();
 
     const decision = await engine.dispatchPoint(
@@ -45,7 +45,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
   });
 
   test("descends into the context once a policy is registered at the point", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     engine.register({
       kind: "point",
       name: "context-consumer",
@@ -66,7 +66,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
   });
 
   test("still enforces the point contract with no registration", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     const decision = await engine.dispatchPoint("dispatch.action.pre", {
       actor: { kind: "system", actorId: "system:test" },
@@ -82,6 +82,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
   test("publishes a composed audit event carrying correlation", async () => {
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
+      clock: Date.now,
       auditEmit: (event, data) => events.push({ name: event.name, data }),
     });
     const traceContext = {
@@ -104,6 +105,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
   test("captures accessor-defined correlation into the audit record", async () => {
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
+      clock: Date.now,
       auditEmit: (event, data) => events.push({ name: event.name, data }),
     });
     const traceContext = {
@@ -131,6 +133,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
   test("keeps every capturable field when one cannot be captured", async () => {
     const events: Array<{ readonly name: string; readonly data: unknown }> = [];
     const engine = PolicyEngine.create({
+      clock: Date.now,
       auditEmit: (event, data) => events.push({ name: event.name, data }),
     });
     const traceContext = {
@@ -168,7 +171,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
     ["a correlation key", "traceContext"],
     ["an unrelated key", "unrelated"],
   ])("resolves to a verdict when %s throws on read", async (_label, key) => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
     const context: Record<string, unknown> = { sessionId: "s", runId: "r", turnIndex: 0 };
     Object.defineProperty(context, key, {
       enumerable: true,
@@ -193,7 +196,7 @@ describe("PolicyEngine unguarded point dispatch", () => {
    * through rather than denied.
    */
   test("allows a context that could not be snapshotted", async () => {
-    const engine = PolicyEngine.create();
+    const engine = PolicyEngine.create({ clock: Date.now });
 
     const decision = await engine.dispatchPoint("run.turn.pre", {
       sessionId: "session-1",

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -29,7 +29,7 @@ src/
 ├── storage/              # Storage namespace: sub-adapter interface contracts (single file)
 ├── token/                # Token usage contracts
 ├── tool/                 # Tool.Spec / Call / Result / State
-├── trace/                # TraceContext schema and newTraceId()
+├── trace/                # TraceContext contract and pure UUID-to-trace-id codec
 ├── transcript/           # Transcript facts and pure fold
 ├── wait/                 # Wait schemas, events, matching, and pure folds
 └── work-item/            # WorkItem schemas, attempt identity, completion admission, events, status, and linkage
@@ -48,7 +48,7 @@ Namespace additions are gated: `script/lint-tools.ts` (#467) enforces a grandfat
 - **WorkItem namespace**: `work-item/index.ts` is the public facade. `work-item/schemas.ts` defines `WorkItem.Info`; `attempt.ts` owns attempt and environment-fingerprint contracts; `completion-admission.ts` defines stable criteria, claims, observations, requests, admissions, and terminal receipts. Rows parse through `WorkItem.Info` directly. `work-item/events.ts` preserves the shipped `Completed` meaning and carries distinct request/admission/CompletedV2 descriptors; `status.ts`, `hash.ts`, and `terminal-linkage.ts` own pure lifecycle derivation and linkage validation.
 - **IPC contracts**: `ipc/` describes the generic wire envelopes and the machine wire method schemas only. Process delegation lifecycle lives in the product app.
 - **AppConnector namespace**: `app-connector/index.ts` defines installed-app connector schema contracts. Runtime install, consent, and process execution live above protocol.
-- **Trace contract**: `trace/index.ts` defines `TraceContext` and the shared `newTraceId()` origin helper.
+- **Trace contract**: `trace/index.ts` defines `TraceContext` and the pure `traceIdFromUuid()` format codec. Runtime entropy belongs to telemetry or the consuming driver package.
 
 ## CONTRACT BOUNDARY
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./error/index.js";
 export { canonicalKey, isPlainValue, PlainValueSchema } from "./json.js";
 export type { PlainObject, PlainValue } from "./json.js";
+export type { Clock, EntropySource, IdSource } from "./platform.js";
 export * from "./tool/index.js";
 export * from "./token/index.js";
 export * from "./message/index.js";

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -79,8 +79,12 @@ export namespace Ipc {
 
   const version = 2;
 
-  export function createRequest(method: string, params?: Record<string, unknown>): Request {
-    return { v: version, type: "request", id: crypto.randomUUID(), method, params };
+  export function createRequest(
+    id: string,
+    method: string,
+    params?: Record<string, unknown>,
+  ): Request {
+    return { v: version, type: "request", id, method, params };
   }
 
   export function createResponse(id: string, result: unknown): Response {

--- a/packages/protocol/src/platform.ts
+++ b/packages/protocol/src/platform.ts
@@ -1,0 +1,10 @@
+import type { EpochMs } from "./time.js";
+
+/** Wall-clock epoch milliseconds supplied by a runtime owner. */
+export type Clock = () => EpochMs;
+
+/** Opaque identity supplied by the package that owns its runtime lifecycle. */
+export type IdSource = () => string;
+
+/** Random bytes supplied by a runtime owner to a pure format-bearing codec. */
+export type EntropySource = (byteLength: number) => Uint8Array;

--- a/packages/protocol/src/trace/index.ts
+++ b/packages/protocol/src/trace/index.ts
@@ -2,14 +2,9 @@
 /** 32 lowercase hex characters (W3C trace id). */
 type TraceId = string;
 
-/**
- * Side-effect-free trace-id mint (W3C shape, nondeterministic by nature): `crypto.randomUUID()` is already 32 hex
- * once the dashes go. Lives in protocol so channel drivers can mint at the
- * first frame (D11 origin) without a telemetry import — gateway stage-1 seam
- * prep (#551); `@openomni/telemetry` re-exports it for its own consumers.
- */
-export function newTraceId(): TraceId {
-  return crypto.randomUUID().split("-").join("");
+/** Pure codec from the caller's UUID entropy into the existing W3C wire shape. */
+export function traceIdFromUuid(uuid: string): TraceId {
+  return uuid.split("-").join("");
 }
 
 /**

--- a/packages/protocol/src/work-item/attempt.ts
+++ b/packages/protocol/src/work-item/attempt.ts
@@ -30,10 +30,9 @@ export { canonicalDigest };
 export const AttemptId = z.string().min(1).max(128);
 export type AttemptId = z.infer<typeof AttemptId>;
 
-/** Mints a fresh opaque attemptId (128 random bits, base36). */
-export function generateAttemptId(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
+/** Encodes exactly 128 caller-supplied entropy bits in the persisted base36 grammar. */
+export function generateAttemptId(bytes: Uint8Array): string {
+  if (bytes.byteLength !== 16) throw new RangeError("attempt ids require exactly 16 entropy bytes");
   let n = 0n;
   for (const byte of bytes) n = (n << 8n) | BigInt(byte);
   return `attempt_${n.toString(36)}`;

--- a/packages/protocol/src/work-item/hash.ts
+++ b/packages/protocol/src/work-item/hash.ts
@@ -10,9 +10,8 @@ function stableToken(input: string): string {
   return (hash >>> 0).toString(36);
 }
 
-export function generateHash(): string {
-  const bytes = new Uint8Array(8);
-  crypto.getRandomValues(bytes);
+export function generateHash(bytes: Uint8Array): string {
+  if (bytes.byteLength !== 8) throw new RangeError("WorkItem ids require exactly 8 entropy bytes");
   let n = 0n;
   for (const b of bytes) n = (n << 8n) | BigInt(b);
   // Cap at 36^12 so toString(36) yields at most 12 chars; padStart below

--- a/packages/protocol/test/ipc/schema.test.ts
+++ b/packages/protocol/test/ipc/schema.test.ts
@@ -44,17 +44,16 @@ describe("Ipc.Notification", () => {
 });
 
 describe("Ipc helpers", () => {
-  test("createRequest produces valid request", () => {
-    const req = Ipc.createRequest("machine.attach", { machineId: "m-1" });
+  test("createRequest preserves the caller-supplied id byte-exact", () => {
+    const req = Ipc.createRequest("request-0001", "machine.attach", { machineId: "m-1" });
     expect(Ipc.Request.safeParse(req).success).toBe(true);
-    expect(req.type).toBe("request");
-    expect(req.v).toBe(2);
-    expect(typeof req.id).toBe("string");
-    expect(req.method).toBe("machine.attach");
+    expect(JSON.stringify(req)).toBe(
+      '{"v":2,"type":"request","id":"request-0001","method":"machine.attach","params":{"machineId":"m-1"}}',
+    );
   });
 
   test("createRequest without params", () => {
-    const req = Ipc.createRequest("machine.run_cell");
+    const req = Ipc.createRequest("request-0002", "machine.run_cell");
     expect(Ipc.Request.safeParse(req).success).toBe(true);
     expect(req.params).toBe(undefined);
   });

--- a/packages/protocol/test/work-item/attempt.test.ts
+++ b/packages/protocol/test/work-item/attempt.test.ts
@@ -159,10 +159,9 @@ describe("WorkItem.Attempt", () => {
     expect(WorkItem.Attempt.safeParse(attemptOf({ attemptSeq: 1.5 })).success).toBe(false);
   });
 
-  test("generateAttemptId mints distinct opaque ids", () => {
-    const first = WorkItem.generateAttemptId();
-    const second = WorkItem.generateAttemptId();
-    expect(first).not.toBe(second);
-    expect(WorkItem.AttemptId.safeParse(first).success).toBe(true);
+  test("generateAttemptId encodes caller-supplied entropy without changing its grammar", () => {
+    const id = WorkItem.generateAttemptId(Uint8Array.from({ length: 16 }, (_, index) => index));
+    expect(id).toBe("attempt_avh9he7dy896m08s18udxr");
+    expect(WorkItem.AttemptId.safeParse(id).success).toBe(true);
   });
 });

--- a/packages/protocol/test/work-item/work-item.test.ts
+++ b/packages/protocol/test/work-item/work-item.test.ts
@@ -598,10 +598,10 @@ describe("WorkItem.deriveStatus", () => {
 });
 
 describe("WorkItem.generateHash", () => {
-  test("produces wi_ hashes with 12 base36 characters", () => {
-    for (let index = 0; index < 100; index += 1) {
-      expect(WorkItem.generateHash()).toMatch(/^wi_[0-9a-z]{12}$/);
-    }
+  test("encodes caller-supplied entropy into the unchanged wire grammar", () => {
+    expect(WorkItem.generateHash(Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7]))).toBe(
+      "wi_002sk3zitmo7",
+    );
   });
 });
 

--- a/packages/telemetry/src/trace.ts
+++ b/packages/telemetry/src/trace.ts
@@ -40,8 +40,12 @@ const INVALID_SPAN_ID = "0".repeat(16);
 const TRACEPARENT_PATTERN = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(-.*)?$/;
 const FORBIDDEN_TRACEPARENT_VERSION = "ff";
 
-import { newTraceId } from "@openomni/protocol";
-export { newTraceId };
+import { traceIdFromUuid } from "@openomni/protocol";
+
+/** Runtime trace-id owner; protocol only retains the pure format codec. */
+export function newTraceId(): TraceId {
+  return traceIdFromUuid(crypto.randomUUID());
+}
 
 export function newSpanId(): SpanId {
   for (;;) {

--- a/script/generate-ledger-archive-manifest.test.ts
+++ b/script/generate-ledger-archive-manifest.test.ts
@@ -27,7 +27,7 @@ describe("ledger archive manifest", () => {
       expect(await readdir(directory)).toEqual(["ledger-archive-manifest.json"]);
 
       await expect(
-        writeArchiveManifestAtomically(outPath, "partial\n", async () => {
+        writeArchiveManifestAtomically(outPath, "partial\n", () => {
           throw new Error("injected replacement failure");
         }),
       ).rejects.toThrow("injected replacement failure");

--- a/script/generate-ledger-archive-manifest.ts
+++ b/script/generate-ledger-archive-manifest.ts
@@ -27,10 +27,9 @@
 //   bun run script/generate-ledger-archive-manifest.ts [--db <path>] [--out <path>]
 
 import { Database } from "bun:sqlite";
-import { randomUUID } from "node:crypto";
-import { open, rename, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
+import { replaceFileAtomically } from "../packages/ledger/src/index";
 import { WorkItem } from "../packages/protocol/src/index";
 
 /** Frozen legacy tables enumerated by the manifest (grows as writers freeze). */
@@ -100,45 +99,19 @@ export function buildLedgerArchiveManifest(db: Database): LedgerArchiveManifest 
   };
 }
 
-type ReplaceFile = (temporaryPath: string, finalPath: string) => Promise<void>;
+type ReplaceFile = (temporaryPath: string, finalPath: string) => void;
 
 /** Replaces a durable manifest without exposing a partial final file. */
 export async function writeArchiveManifestAtomically(
   outPath: string,
   contents: string,
-  replaceFile: ReplaceFile = rename,
+  replace?: ReplaceFile,
 ): Promise<void> {
-  const directory = dirname(outPath);
-  const temporaryPath = join(
-    directory,
-    `.${basename(outPath)}.${process.pid}.${randomUUID()}.tmp`,
-  );
-  let temporaryExists = false;
-
-  try {
-    const temporary = await open(temporaryPath, "wx", 0o600);
-    temporaryExists = true;
-    try {
-      await temporary.writeFile(contents, "utf8");
-      await temporary.sync();
-    } finally {
-      await temporary.close();
-    }
-
-    await replaceFile(temporaryPath, outPath);
-    temporaryExists = false;
-
-    const directoryHandle = await open(directory, "r");
-    try {
-      await directoryHandle.sync();
-    } finally {
-      await directoryHandle.close();
-    }
-  } finally {
-    if (temporaryExists) {
-      await unlink(temporaryPath).catch(() => undefined);
-    }
-  }
+  replaceFileAtomically(outPath, contents, {
+    durable: true,
+    mode: 0o600,
+    ...(replace === undefined ? {} : { replace }),
+  });
 }
 
 function parseArgs(argv: readonly string[]): { dbPath: string; outPath: string } {


### PR DESCRIPTION
## Summary

Implements rung 7 of the remediation ladder:

- makes protocol ID/trace codecs pure by taking caller-owned IDs or entropy while preserving the existing wire grammars
- injects a protocol-owned `Clock` into the policy engine and routes policy timestamps/durations through it
- moves runtime entropy ownership to IPC, ledger, telemetry, channels, and app composition boundaries
- consolidates the in-scope curated-memory and ledger-archive atomic replacement paths under ledger's topology-valid `replaceFileAtomically`

## Audit findings

- Protocol production sources now contain no runtime random/UUID minting calls.
- Policy production sources now contain no `Date.now()` calls (the remaining text occurrence is documentation showing composition injection).
- The atomic-write finding narrowed to curated memory plus the ledger archive generator. Secret/auth writers have different security semantics and topology, so they were intentionally not folded into this owner.
- The shared writer uses exclusive temp creation, optional mode/fsync durability, atomic rename, and failure cleanup.

## Regression and byte-identity pins

Tests distinguish the previous behavior by requiring:

- exact caller-provided IPC request IDs
- exact caller-provided WorkItem hash/attempt entropy with unchanged ID grammar
- deterministic policy timestamps and elapsed durations from a fake clock
- atomic replacement cleanup after rename failure
- exact published bytes for the shared writer
- unchanged curated-memory persisted JSON bytes
- deterministic UUID-to-trace conversion and valid runtime-minted trace IDs

## Verification

Passed the full repository gate chain from a clean build-output state:

- `bun run build`
- `bunx turbo run check-types`
- `bun run check-deps`
- `bun run check-import-cycles`
- `bun run lint`
- `bun run lint:tools`
- `bun run ultracite`
- `bun run check-dead-exports`
- `bun test`

Coverage suites passed for every touched package (`protocol`, `telemetry`, `ipc`, `ledger`, `policy`, `agent`, `channels`) and the touched app. The app report was then removed because topology explicitly marks apps as non-ratchet lanes. Coverage was also generated for the remaining ratchet lanes (`llm`, `placement`).

Coverage ratchet passed:

- agent 98.2%
- channels 96.44%
- ipc 95.51% (+3.01pp)
- ledger 97.68% (+0.90pp)
- llm 97.04%
- placement 100%
- policy 96.56%
- protocol 97.67%
- telemetry 98.99%

Dependency and cycle checks retain only the repository's pre-existing stale-AGENTS notices for `llm`/`placement`; there are no new violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes protocol ID and trace codecs pure by accepting caller-provided IDs and entropy, and routes policy engine time through an injected clock. Production sources no longer mint UUIDs or call `Date.now()`, and atomic file replacement now has a single owner in ledger.

**Refactors**
- Runtime entropy moves to ledger, telemetry, ipc, and channel drivers.
- Ledger owns atomic file replacement; curated memory and archive manifests now share it.
- Policy timestamps, durations, and audit times come from the injected clock.

**Migration**
- `Ipc.createRequest(id, method, params)` now takes the request id as its first argument.
- `WorkItem.generateHash()` and `generateAttemptId()` require caller-supplied entropy bytes.
- `PolicyEngine.create` now requires a `clock` option.
- `newTraceId` moved from `@openomni/protocol` to `@openomni/telemetry`; channels mint it via their own `support/trace`.

<sup>Written for commit bd888b37cf6a9b737ca5da4ebe9c496cb3df982d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable time sources for policy evaluation and audit timestamps.
  - Added caller-controlled request IDs for IPC requests.
  - Added configurable ID generation for memory, work items, and attempts.
  - Added atomic file replacement with optional durability controls.

- **Bug Fixes**
  - Improved cleanup and preservation of existing files when replacements fail.
  - Standardized trace ID generation across runtime components.

- **Tests**
  - Expanded coverage for deterministic IDs, audit timing, request propagation, and atomic file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->