### PR TITLE
test: coverage/mutation hardening + pin ultracite in CI (slop PR12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       # script/, qa/, and every test file. Lint
       # the WHOLE repo so the ~420 test files + tooling are actually covered.
       - if: matrix.task == 'lint'
-        run: bunx ultracite check --formatter-enabled=false .
+        run: bunx ultracite@7.8.3 check --formatter-enabled=false .
 
   deps:
     name: Dependency Rules

--- a/apps/openomni/src/cli/main.ts
+++ b/apps/openomni/src/cli/main.ts
@@ -140,18 +140,22 @@ function follow(argv: readonly string[]): Promise<number> {
   });
 }
 
-const code = await runCli(process.argv.slice(2), {
-  stdout: (line) => console.log(line),
-  stderr: (line) => console.error(line),
-  target,
-  io,
-  envPath,
-  startApp,
-  ask,
-  writeEnv: (entries) => writeEnvFile(envPath, entries),
-  doctorPorts,
-  follow,
-});
-if (code !== 0) {
-  process.exit(code);
+export function main(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
+  return runCli(argv, {
+    stdout: (line) => console.log(line),
+    stderr: (line) => console.error(line),
+    target,
+    io,
+    envPath,
+    startApp,
+    ask,
+    writeEnv: (entries) => writeEnvFile(envPath, entries),
+    doctorPorts,
+    follow,
+  });
+}
+
+if (import.meta.main) {
+  const code = await main();
+  if (code !== 0) process.exit(code);
 }

--- a/apps/openomni/test/cli.test.ts
+++ b/apps/openomni/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
   lstatSync,
   mkdirSync,
@@ -30,6 +30,7 @@ import { applyEnvFile, parseEnvFile, renderEnvFile, writeEnvFile } from "../src/
 import { runDoctor } from "../src/cli/doctor";
 import { processEntryPath } from "../src/process-entry-path";
 import type { DoctorPorts } from "../src/cli/doctor";
+import { main } from "../src/cli/main";
 import { gatherOnboarding } from "../src/cli/onboard";
 
 const directories: string[] = [];
@@ -500,6 +501,19 @@ describe("doctor", () => {
     const byName = new Map(report.checks.map((check) => [check.name, check.status]));
     expect(byName.get("model config")).toBe("fail");
     expect(byName.get("health")).toBe("fail");
+  });
+});
+
+describe("cli entry point", () => {
+  test("returns the dispatch exit status without terminating an importer", async () => {
+    const stdout = spyOn(console, "log").mockImplementation(() => undefined);
+    const stderr = spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      expect(await main(["not-a-command"])).toBe(1);
+    } finally {
+      stdout.mockRestore();
+      stderr.mockRestore();
+    }
   });
 });
 

--- a/packages/agent/test/runtime/mcp/descriptor.test.ts
+++ b/packages/agent/test/runtime/mcp/descriptor.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { Operational } from "@openomni/protocol";
 import { Bus } from "@openomni/telemetry";
 import { McpClient, type McpClientHandle } from "../../../src/runtime/mcp/client";
+import { createTransport } from "../../../src/runtime/mcp/client-transport";
 
 const TRACE_ID = "trace-mcp-lifecycle";
 const stdio = (name = "filesystem") => ({
@@ -148,6 +150,24 @@ function observeError(serverName: string) {
   });
   return { seen, next, unsubscribe };
 }
+
+describe("MCP transport construction", () => {
+  test("preserves the stdio command and argument vector", () => {
+    const transport = createTransport({
+      name: "filesystem",
+      transport: "stdio",
+      command: "mcp-server-filesystem",
+      args: ["--root", "/workspace"],
+    });
+
+    expect(transport).toBeInstanceOf(StdioClientTransport);
+    expect(
+      (transport as unknown as {
+        readonly _serverParams: { readonly command: string; readonly args?: string[] };
+      })._serverParams,
+    ).toEqual({ command: "mcp-server-filesystem", args: ["--root", "/workspace"] });
+  });
+});
 
 describe("McpClient listed tools", () => {
   test("namespaces listed MCP tools", async () => {

--- a/packages/channels/test/router/routing-precedence.test.ts
+++ b/packages/channels/test/router/routing-precedence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Ingress } from "@openomni/protocol";
 import { resolveRoute, type RouteInbound, type RouteState } from "../../src/router/index.js";
+import { requireRoutedDecision } from "../../src/router/routing-execution.js";
 
 const inbound = Object.freeze({
   traceId: "trace-precedence",
@@ -184,6 +185,49 @@ describe("resolveRoute precedence", () => {
     expect(decisions.map((decision) => decision.outcome)).toEqual(["block", "block"]);
     expect(decisions.every((decision) => decision.target === undefined)).toBe(true);
     expect(decisions.every((decision) => decision.sessionId === undefined)).toBe(true);
+  });
+
+  it("classifies blacklist drops as accepted while block and ambiguity stay typed failures", () => {
+    const decisions = [
+      resolveRoute(inbound, {
+        blacklist: { id: "blacklist-actor", kind: "actor", reason: "revoked" },
+        wait: matchedWait,
+        channel: trustedChannel,
+        actor: registeredActor,
+      }),
+      resolveRoute(inbound, {
+        wait: { kind: "none" },
+        actor: registeredActor,
+      }),
+      resolveRoute(inbound, {
+        wait: {
+          kind: "ambiguous",
+          candidateInteractionIds: ["wait:wait-a", "wait:wait-b"],
+        },
+        channel: trustedChannel,
+        actor: registeredActor,
+      }),
+    ].map((decision) => Ingress.Events.RoutingDecision.schema.parse(decision));
+
+    const accepted = decisions[0];
+    expect(accepted).toBeDefined();
+    if (
+      accepted === undefined ||
+      accepted.stage !== "blacklist" ||
+      accepted.outcome !== "drop"
+    ) {
+      throw new TypeError("missing accepted decision fixture");
+    }
+    expect(requireRoutedDecision(accepted)).toBe(accepted);
+    const codes = decisions.slice(1).map((decision) => {
+      try {
+        requireRoutedDecision(decision);
+        return "accepted";
+      } catch (error) {
+        return (error as { readonly code?: string }).code;
+      }
+    });
+    expect(codes).toEqual(["route_blocked", "route_ambiguous"]);
   });
 
   it("preserves evidence_only treatment while routing a broadcast channel", () => {

--- a/packages/ledger/test/work-item/dependency.test.ts
+++ b/packages/ledger/test/work-item/dependency.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { detectCycles } from "../../src/work-item/dependency.js";
+import type { WorkItemAdapter } from "../../src/work-item/types.js";
+
+function adapterFor(graph: Readonly<Record<string, readonly string[]>>): WorkItemAdapter {
+  return {
+    get: (hash: string) => {
+      const dependsOn = graph[hash];
+      if (dependsOn === undefined) return undefined;
+      return { relations: { dependsOn } };
+    },
+  } as unknown as WorkItemAdapter;
+}
+
+describe("detectCycles", () => {
+  test("walks transitive dependencies and rejects a back-edge", () => {
+    const adapter = adapterFor({ child: ["grandchild"], grandchild: ["root"] });
+    let thrown: unknown;
+
+    try {
+      detectCycles(adapter, ["child"], new Set(["root"]));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+  });
+
+  test("keeps sibling branches independent and ignores missing leaves", () => {
+    const adapter = adapterFor({ left: ["shared"], right: ["shared", "missing"], shared: [] });
+
+    expect(() => detectCycles(adapter, ["left", "right"], new Set(["root"]))).not.toThrow();
+  });
+});

--- a/packages/protocol/test/policy/resource-descriptor.test.ts
+++ b/packages/protocol/test/policy/resource-descriptor.test.ts
@@ -48,17 +48,72 @@ describe("Policy.Resource descriptors", () => {
       ).toBe(false);
     });
 
-    test("rejects mismatched id segments", () => {
+    test("enforces id arity, non-empty segments, and the kind prefix independently", () => {
+      const descriptor = {
+        labels: [],
+        capabilities: [],
+        effects: [],
+      };
+
       expect(
         Policy.Resource.Descriptor.safeParse({
-          id: "tool:project",
-          kind: "tool",
-          labels: [],
-          capabilities: [],
-          effects: [],
+          ...descriptor,
+          id: "worker:one:two:three",
+          kind: "worker",
+        }).success,
+      ).toBe(false);
+      expect(
+        Policy.Resource.Descriptor.safeParse({
+          ...descriptor,
+          id: "worker:",
+          kind: "worker",
+        }).success,
+      ).toBe(false);
+      expect(
+        Policy.Resource.Descriptor.safeParse({
+          ...descriptor,
+          id: "session:primary",
+          kind: "worker",
+        }).success,
+      ).toBe(false);
+    });
+
+    test("binds tool source presence and type to the corresponding id segments", () => {
+      const descriptor = {
+        kind: "tool" as const,
+        labels: [],
+        capabilities: [],
+        effects: [],
+      };
+
+      expect(
+        Policy.Resource.Descriptor.safeParse({
+          ...descriptor,
+          id: "tool:project:bash",
+        }).success,
+      ).toBe(false);
+      expect(
+        Policy.Resource.Descriptor.safeParse({
+          ...descriptor,
+          id: "tool:bash",
           source: { type: "project" },
         }).success,
       ).toBe(false);
+      expect(
+        Policy.Resource.Descriptor.safeParse({
+          ...descriptor,
+          id: "tool:server:bash",
+          source: { type: "project" },
+        }).success,
+      ).toBe(false);
+
+      const parsed = Policy.Resource.Descriptor.parse({
+        ...descriptor,
+        id: "tool:skill-mcp:filesystem:read_file",
+        source: { type: "skill-mcp", serverId: "filesystem" },
+      });
+      expect(parsed.id).toBe("tool:skill-mcp:filesystem:read_file");
+      expect(parsed.source).toEqual({ type: "skill-mcp", serverId: "filesystem" });
     });
 
     test("rejects descriptors with invalid source type", () => {

--- a/script/conformance/coverage-baseline.json
+++ b/script/conformance/coverage-baseline.json
@@ -17,7 +17,7 @@
   "packages/ledger": {
     "linesFound": 5341,
     "linesHit": 5169,
-    "pct": 96.78
+    "pct": 97.12
   },
   "packages/llm": {
     "linesFound": 2022,


### PR DESCRIPTION
## Summary

- add behavioral and mutation-sensitive coverage for weak or previously uninstrumented runtime seams
- make the CLI entry importable without process termination so its real dispatch behavior is covered
- pin CI's Ultracite invocation to the repo's exact `7.8.3` devDependency, preventing latest-version rule drift
- raise the ledger package coverage floor from 96.78% to 97.12%, leaving 0.70pp below the local 97.82% result

## Per-package coverage

Raw per-package LCOV totals (Bun also reports loaded workspace dependencies):

| Package | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `packages/protocol` | 97.64% | 98.05% | +0.41pp |
| `packages/channels` | 63.63% | 63.63% | +0.00pp |
| `packages/agent` | 71.51% | 71.54% | +0.03pp |
| `packages/ledger` | 82.81% | 82.83% | +0.02pp |
| `apps/openomni` | 65.18% | 65.03% | -0.14pp* |

\* `cli/main.ts` previously had no LCOV row. Instrumenting its 130 lines adds it to the denominator at 35.38%, replacing a silent zero-coverage omission with measured coverage.

## Newly hardened modules

| Module | Before | After | Behavioral defect pinned |
| --- | ---: | ---: | --- |
| `packages/protocol/src/policy/resource.ts` | 80.3% | 100% | inverted/dropped ID arity, empty-segment, kind, and tool-source refinements |
| `packages/channels/src/router/routing-execution.ts` | 73.0% | 73.6% | blacklist-drop acceptance confused with blocked/ambiguous typed failures |
| `packages/agent/src/runtime/mcp/client-transport.ts` | 93.4% | 100% | stdio command or argument vector dropped during transport construction |
| `packages/ledger/src/work-item/dependency.ts` | 75.0% | 100% | recursive back-edge missed or sibling branches incorrectly share visited state |
| `apps/openomni/src/cli/main.ts` | no row | 35.4% | imported entry terminates the host or fails to forward dispatch exit status |

## Verification

- `bun run build`
- `bunx turbo run check-types`
- `bun run script/check-deps.ts`
- `bun run script/check-import-cycles.ts`
- `bun run lint`
- `bun run lint:tools`
- `bunx ultracite@7.8.3 check --formatter-enabled=false .`
- `bun run script/check-dead-exports.ts`
- `bun test --timeout 15000` (2,941 pass)
- per-package coverage suites and `bun run script/check-coverage-ratchet.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the CLI entry point importable without terminating the host and pins Ultracite in CI to the repo's `7.8.3` devDependency, so real dispatch behavior is covered and linting no longer floats with `latest`.

- `main()` now returns the dispatch exit status; `process.exit` runs only when the module is executed directly.
- CI runs `bunx ultracite@7.8.3` instead of unpinned `ultracite`.
- Adds tests pinning resource descriptor ID rules, MCP stdio transport construction, routing decision error classification, and work-item cycle detection.
- Raises the `packages/ledger` coverage floor from 96.78% to 97.12%.

<sup>Written for commit 3a3b2b806a2244060b2472ff2428d50308a03043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI behavior when invoked as an imported module, including reliable exit codes for unknown commands.
  * Clarified routing outcomes, dependency-cycle detection, transport construction, and resource descriptor validation.

* **Tests**
  * Added coverage for CLI entry points, MCP stdio transports, routing precedence, dependency graphs, and descriptor validation.

* **Chores**
  * Pinned the code-formatting tool version in continuous integration.
  * Updated the ledger coverage baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->