### PR TITLE
refactor: extract high-complexity orchestration kernels (slop PR11)

### DIFF
--- a/apps/openomni/src/delegation/kernel.ts
+++ b/apps/openomni/src/delegation/kernel.ts
@@ -43,7 +43,10 @@ export interface DriverReport {
 
 export interface DelegationDriver {
   /** Optional prepare phase; channel uses it to allocate a durable waitId. */
-  prepare?(admitted: Admitted, handle: Delegation.Handle): DriverPreparation | Promise<DriverPreparation>;
+  prepare?(
+    admitted: Admitted,
+    handle: Delegation.Handle,
+  ): DriverPreparation | Promise<DriverPreparation>;
   run(
     admitted: Admitted,
     handle: Delegation.Handle,
@@ -128,6 +131,8 @@ function leaseClosedBy(status: Delegation.Settled["status"]): "settled" | "cance
 type DelegationResult =
   | { readonly refused: string; readonly error: AdmissionRefusal }
   | { readonly handle: Delegation.Handle; readonly settled?: Delegation.Settled };
+
+type DelegationRefusal = Extract<DelegationResult, { readonly refused: string }>;
 
 type DelegationAwaitResult =
   | { readonly kind: "settled"; readonly settlement: Delegation.Settled }
@@ -254,7 +259,10 @@ function controlError(code: "not_found" | "not_open", delegationId: string): Nam
   return new DelegationControlError({
     code,
     delegationId,
-    message: code === "not_found" ? `delegation ${delegationId} was not found` : `delegation ${delegationId} is not open`,
+    message:
+      code === "not_found"
+        ? `delegation ${delegationId} was not found`
+        : `delegation ${delegationId} is not open`,
   });
 }
 
@@ -333,7 +341,10 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
    * waiter notification, timer cleanup, and wake delivery happen only after
    * that CAS has recorded the settlement.
    */
-  function settle(delegationId: string, candidate: Delegation.Settled): Delegation.Settled | undefined {
+  function settle(
+    delegationId: string,
+    candidate: Delegation.Settled,
+  ): Delegation.Settled | undefined {
     const current = store.get(delegationId);
     if (current === undefined) return undefined;
     if (current.status === "settled") return current.settled;
@@ -387,11 +398,13 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     // synchronous, so the ledger write runs behind it and reports its own
     // failure instead of blocking settlement.
     const workItems = options.workItems;
-    if (persisted.operation === "assign" && persisted.workItemId !== undefined && workItems !== undefined) {
+    if (
+      persisted.operation === "assign" &&
+      persisted.workItemId !== undefined &&
+      workItems !== undefined
+    ) {
       void Promise.resolve()
-        .then(() =>
-          workItems.closeAttempt({ record: persisted, settlement: winner }),
-        )
+        .then(() => workItems.closeAttempt({ record: persisted, settlement: winner }))
         .catch((error: unknown) => {
           events.publish(Operational.Events.Error, {
             traceId: delegationTraceId(delegationId),
@@ -444,22 +457,25 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
 
   function arm(record: Delegation.Record): void {
     if (record.status !== "open" || timers.has(record.delegationId)) return;
-    const timer = setTimeout(() => {
-      timers.delete(record.delegationId);
-      const current = store.get(record.delegationId);
-      if (current?.status !== "open") return;
-      const now = options.now();
-      if (!Deadline.isExpired(now, current.deadline)) {
-        arm(current);
-        return;
-      }
-      settle(current.delegationId, {
-        status: "no_response",
-        delegationId: current.delegationId,
-        deadline: current.deadline,
-        at: Math.max(now, current.deadline),
-      });
-    }, nextTimerDelay(options.now(), record.deadline));
+    const timer = setTimeout(
+      () => {
+        timers.delete(record.delegationId);
+        const current = store.get(record.delegationId);
+        if (current?.status !== "open") return;
+        const now = options.now();
+        if (!Deadline.isExpired(now, current.deadline)) {
+          arm(current);
+          return;
+        }
+        settle(current.delegationId, {
+          status: "no_response",
+          delegationId: current.delegationId,
+          deadline: current.deadline,
+          at: Math.max(now, current.deadline),
+        });
+      },
+      nextTimerDelay(options.now(), record.deadline),
+    );
     // Timers are lifecycle guards, not process-liveness handles.
     const unref = (timer as unknown as { unref?: () => void }).unref;
     unref?.call(timer);
@@ -473,8 +489,9 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     if (workItems !== undefined) {
       // Re-close attempts whose settlement committed but whose ledger write
       // was lost before the restart (closeAttempt is idempotent).
-      void workItems.recoverAttempts((delegationId) => store.get(delegationId)).catch(
-        (error: unknown) => {
+      void workItems
+        .recoverAttempts((delegationId) => store.get(delegationId))
+        .catch((error: unknown) => {
           events.publish(Operational.Events.Error, {
             traceId: newTraceId(),
             time: options.now(),
@@ -483,8 +500,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
             error: error instanceof Error ? error.message : String(error),
             context: {},
           });
-        },
-      );
+        });
     }
     for (const record of store.listSettledUnwoken()) {
       if (record.transport !== "inline" && record.settled !== undefined) {
@@ -553,17 +569,22 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     return completion;
   }
 
-  async function delegate(candidate: unknown, origin: DelegationOrigin): Promise<DelegationResult> {
-    if (stopped) {
-      throw stoppedKernelError();
-    }
-    const now = options.now();
-    const delegationId = options.newDelegationId();
+  function refuseDelegation(
+    code: ConstructorParameters<typeof AdmissionRefusal>[0]["code"],
+    message: string,
+  ): DelegationRefusal {
+    return { refused: message, error: new AdmissionRefusal({ code, message }) };
+  }
+
+  function admitCandidate(
+    candidate: unknown,
+    origin: DelegationOrigin,
+    now: number,
+    delegationId: string,
+  ): Admitted | DelegationRefusal {
     const parentDelegationId = origin.parentDelegationId;
     const parent = parentDelegationId === undefined ? undefined : store.get(parentDelegationId);
     const rootDelegationId = parent?.rootDelegationId ?? delegationId;
-    // Live-lease facts are read only for a worker origin with a durable
-    // parent — the only origin the §3.5 relaxation can ever admit.
     const liveLeases =
       origin.role === "worker" && parentDelegationId !== undefined
         ? options.leases?.listLiveByHolder(parentDelegationId, now)
@@ -577,15 +598,12 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       ...(liveLeases === undefined ? {} : { leases: liveLeases }),
     });
     if (!admitted.ok) return { refused: admitted.reason, error: admitted.error };
-    // Only an internal process worker has a worker loop that can consume this
-    // identity. Channel assignments must never persist a fabricated UUID.
     const workerRunId = admitted.transport === "process" ? crypto.randomUUID() : undefined;
-    const decision: Admitted = {
-      ...admitted,
-      ...(workerRunId === undefined ? {} : { workerRunId }),
-    };
+    return { ...admitted, ...(workerRunId === undefined ? {} : { workerRunId }) };
+  }
 
-    const baseHandle: Delegation.Handle = {
+  function baseHandleFor(decision: Admitted, delegationId: string): Delegation.Handle {
+    return {
       delegationId,
       operation: decision.request.operation,
       address: decision.request.address,
@@ -596,49 +614,64 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
         : { parentDelegationId: decision.parentDelegationId }),
       rootDelegationId: decision.rootDelegationId,
     };
+  }
 
+  async function prepareTransport(
+    decision: Admitted,
+    baseHandle: Delegation.Handle,
+  ): Promise<Delegation.Handle | DelegationRefusal> {
     const driver = options.drivers[decision.transport];
-    let handle = baseHandle;
-    if (driver?.prepare !== undefined) {
-      try {
-        const prepared = await driver.prepare(decision, baseHandle);
-        handle = Delegation.Handle.parse({
-          ...baseHandle,
-          ...(prepared.waitId === undefined ? {} : { waitId: prepared.waitId }),
-        });
-      } catch (error) {
-        const message = `transport preparation failed: ${error instanceof Error ? error.message : String(error)}`;
-        return {
-          refused: message,
-          error: new AdmissionRefusal({ code: "prepare_failed", message }),
-        };
-      }
+    if (driver?.prepare === undefined) return baseHandle;
+    try {
+      const prepared = await driver.prepare(decision, baseHandle);
+      return Delegation.Handle.parse({
+        ...baseHandle,
+        ...(prepared.waitId === undefined ? {} : { waitId: prepared.waitId }),
+      });
+    } catch (error) {
+      const message = `transport preparation failed: ${error instanceof Error ? error.message : String(error)}`;
+      return refuseDelegation("prepare_failed", message);
     }
+  }
 
-    let workItemId: string | undefined;
-    if (decision.request.operation === "assign") {
-      if (options.workItems === undefined) {
-        const message = "assign requires the WorkItem linkage and this kernel carries none";
-        return { refused: message, error: new AdmissionRefusal({ code: "work_item_failed", message }) };
-      }
-      try {
-        workItemId = await options.workItems.openAssign({
-          delegationId,
-          ...(decision.workerRunId === undefined && handle.waitId === undefined
-            ? {}
-            : { workerRunId: decision.workerRunId ?? handle.waitId }),
-          transport: decision.transport,
-          instruction: decision.request.payload.text,
-          acceptanceCriteria: decision.request.acceptanceCriteria ?? [],
-          sessionId:
-            decision.transport === "process" ? `delegation-${delegationId}` : origin.sessionId,
-        });
-      } catch (error) {
-        const message = `WorkItem commissioning failed: ${error instanceof Error ? error.message : String(error)}`;
-        return { refused: message, error: new AdmissionRefusal({ code: "work_item_failed", message }) };
-      }
+  async function commissionWorkItem(
+    decision: Admitted,
+    handle: Delegation.Handle,
+    origin: DelegationOrigin,
+  ): Promise<{ readonly workItemId?: string } | DelegationRefusal> {
+    if (decision.request.operation !== "assign") return {};
+    if (options.workItems === undefined) {
+      return refuseDelegation(
+        "work_item_failed",
+        "assign requires the WorkItem linkage and this kernel carries none",
+      );
     }
+    try {
+      const workItemId = await options.workItems.openAssign({
+        delegationId: handle.delegationId,
+        ...(decision.workerRunId === undefined && handle.waitId === undefined
+          ? {}
+          : { workerRunId: decision.workerRunId ?? handle.waitId }),
+        transport: decision.transport,
+        instruction: decision.request.payload.text,
+        acceptanceCriteria: decision.request.acceptanceCriteria ?? [],
+        sessionId:
+          decision.transport === "process" ? `delegation-${handle.delegationId}` : origin.sessionId,
+      });
+      return { workItemId };
+    } catch (error) {
+      const message = `WorkItem commissioning failed: ${error instanceof Error ? error.message : String(error)}`;
+      return refuseDelegation("work_item_failed", message);
+    }
+  }
 
+  function delegationRecord(
+    decision: Admitted,
+    handle: Delegation.Handle,
+    origin: DelegationOrigin,
+    now: number,
+    workItemId: string | undefined,
+  ): Delegation.Record {
     const recordOrigin: DelegationOrigin = {
       role: origin.role,
       depth: origin.depth,
@@ -650,7 +683,7 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
             rootDelegationId: decision.rootDelegationId,
           }),
     };
-    const record = Delegation.Record.parse({
+    return Delegation.Record.parse({
       ...handle,
       origin: Delegation.Origin.parse(recordOrigin),
       instruction: decision.request.payload.text,
@@ -658,62 +691,76 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       createdAt: now,
       ...(workItemId === undefined ? {} : { workItemId }),
     });
+  }
+
+  async function claimDelegationRecord(
+    record: Delegation.Record,
+    workItemId: string | undefined,
+  ): Promise<DelegationRefusal | undefined> {
     const claim = store.claimOpenWithinRoot(record, limits.maxFanout, {
       ...(record.parentDelegationId === undefined
         ? {}
         : { requireOpenParent: record.parentDelegationId }),
     });
-    if (!claim.claimed) {
-      if (workItemId !== undefined) {
-        try {
-          await options.workItems?.cancelAssign(workItemId);
-        } catch (error) {
-          events.publish(Operational.Events.Error, {
-            traceId: delegationTraceId(record.delegationId),
-            sessionId: record.origin.sessionId,
-            time: options.now(),
-            component: "delegation",
-            msg: `WorkItem rollback failed for ${record.delegationId}`,
-            error: error instanceof Error ? error.message : String(error),
-            context: {
-              delegationId: record.delegationId,
-              workItemId,
-              refusal: claim.reason,
-            },
-          });
-        }
+    if (claim.claimed) return undefined;
+    if (workItemId !== undefined) {
+      try {
+        await options.workItems?.cancelAssign(workItemId);
+      } catch (error) {
+        events.publish(Operational.Events.Error, {
+          traceId: delegationTraceId(record.delegationId),
+          sessionId: record.origin.sessionId,
+          time: options.now(),
+          component: "delegation",
+          msg: `WorkItem rollback failed for ${record.delegationId}`,
+          error: error instanceof Error ? error.message : String(error),
+          context: {
+            delegationId: record.delegationId,
+            workItemId,
+            refusal: claim.reason,
+          },
+        });
       }
-      const message =
-        claim.reason === "parent_settled"
-          ? `parent delegation ${record.parentDelegationId ?? ""} is already settled`
-          : `delegation fanout is capped at ${limits.maxFanout} open records for root ${record.rootDelegationId}`;
-      return {
-        refused: message,
-        error: new AdmissionRefusal({ code: claim.reason, message }),
-      };
     }
+    const message =
+      claim.reason === "parent_settled"
+        ? `parent delegation ${record.parentDelegationId ?? ""} is already settled`
+        : `delegation fanout is capped at ${limits.maxFanout} open records for root ${record.rootDelegationId}`;
+    return refuseDelegation(claim.reason, message);
+  }
+
+  async function awaitImmediate(handle: Delegation.Handle): Promise<DelegationResult> {
+    const settled = await awaitDelegation(handle.delegationId);
+    if (settled.kind === "timeout") {
+      throw new Error(`delegation ${handle.delegationId} remained open at its deadline`);
+    }
+    return { handle, settled: settled.settlement };
+  }
+
+  async function delegate(candidate: unknown, origin: DelegationOrigin): Promise<DelegationResult> {
+    if (stopped) throw stoppedKernelError();
+    const now = options.now();
+    const delegationId = options.newDelegationId();
+    const admission = admitCandidate(candidate, origin, now, delegationId);
+    if ("refused" in admission) return admission;
+
+    const prepared = await prepareTransport(admission, baseHandleFor(admission, delegationId));
+    if ("refused" in prepared) return prepared;
+    const handle = prepared;
+    const commission = await commissionWorkItem(admission, handle, origin);
+    if ("refused" in commission) return commission;
+    const record = delegationRecord(admission, handle, origin, now, commission.workItemId);
+    const refusal = await claimDelegationRecord(record, commission.workItemId);
+    if (refusal !== undefined) return refusal;
+
     publishAdmitted(record);
     arm(record);
-
     const controller = new AbortController();
     controllers.set(handle.delegationId, controller);
-    const completion = dispatch(decision, handle, controller);
-
-    // Inline is intentionally volatile and awaited. Await the durable fold,
-    // rather than the driver promise alone, so an uncooperative worker still
-    // returns the timer's no_response settlement at the effective deadline.
-    // Notify likewise waits only until transport acceptance (or its deadline).
+    const completion = dispatch(admission, handle, controller);
     if (handle.transport === "inline" || handle.operation === "notify") {
-      const settled = await awaitDelegation(handle.delegationId);
-      if (settled.kind === "timeout") {
-        throw new Error(`delegation ${handle.delegationId} remained open at its deadline`);
-      }
-      return { handle, settled: settled.settlement };
+      return awaitImmediate(handle);
     }
-
-    // Process/channel ask|assign are durable background work. The handle is
-    // returned without waiting for a result; the settlement fold will wake the
-    // owner session later.
     void completion;
     return { handle };
   }
@@ -726,7 +773,8 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
     const record = store.get(delegationId);
     if (record === undefined) return Promise.reject(controlError("not_found", delegationId));
     if (record.status === "settled") {
-      if (record.settled === undefined) return Promise.reject(controlError("not_open", delegationId));
+      if (record.settled === undefined)
+        return Promise.reject(controlError("not_open", delegationId));
       return Promise.resolve({ kind: "settled", settlement: record.settled });
     }
 
@@ -783,27 +831,30 @@ export function createDelegationKernel(options: DelegationKernelOptions): Delega
       }
       const deadlineBound = end === record.deadline;
       const scheduleAwaitTimeout = (): void => {
-        timer = setTimeout(() => {
-          const currentNow = options.now();
-          if (!Deadline.isExpired(currentNow, end)) {
-            scheduleAwaitTimeout();
-            return;
-          }
-          removeWaiter();
-          if (deadlineBound) {
-            const settled = settle(delegationId, {
-              status: "no_response",
-              delegationId,
-              deadline: record.deadline,
-              at: Math.max(currentNow, record.deadline),
-            });
-            if (settled !== undefined) {
-              resolve({ kind: "settled", settlement: settled });
+        timer = setTimeout(
+          () => {
+            const currentNow = options.now();
+            if (!Deadline.isExpired(currentNow, end)) {
+              scheduleAwaitTimeout();
               return;
             }
-          }
-          resolve({ kind: "timeout", delegationId, deadline: record.deadline });
-        }, nextTimerDelay(options.now(), end));
+            removeWaiter();
+            if (deadlineBound) {
+              const settled = settle(delegationId, {
+                status: "no_response",
+                delegationId,
+                deadline: record.deadline,
+                at: Math.max(currentNow, record.deadline),
+              });
+              if (settled !== undefined) {
+                resolve({ kind: "settled", settlement: settled });
+                return;
+              }
+            }
+            resolve({ kind: "timeout", delegationId, deadline: record.deadline });
+          },
+          nextTimerDelay(options.now(), end),
+        );
         const unref = (timer as unknown as { unref?: () => void }).unref;
         unref?.call(timer);
       };

--- a/packages/agent/src/core/execution/run.ts
+++ b/packages/agent/src/core/execution/run.ts
@@ -6,7 +6,7 @@ import {
   handleError,
   handleStop,
 } from "./turn";
-import { ModelsDev, Provider, Retry as LlmRetry, run as llmRun } from "@openomni/llm";
+import { ModelsDev, Provider, Retry as LlmRetry, type Run, run as llmRun } from "@openomni/llm";
 import type { Sink } from "@openomni/llm";
 import { Placement } from "@openomni/placement";
 import { DEFAULT_THRESHOLD_RATIO } from "../../compaction/compact";
@@ -29,6 +29,9 @@ import {
   requireTrace,
   type AgentRunBase,
   type RunFailureFacts,
+  type RunState,
+  type RunTrace,
+  type TurnArtifacts,
 } from "./state";
 
 /**
@@ -39,264 +42,317 @@ import {
  * The `AgentEvent` generator that used to carry all three had no consumer
  * outside this package's own tests.
  */
+type RetryPolicy = Parameters<typeof handleError>[6];
+
+type AttemptModel = ChatAgentConfig["model"];
+
+interface RunProgress {
+  attempt: number;
+  thrownFailure?: RunFailureFacts;
+  terminalLlmError?: Error;
+  readonly failureReasons: string[];
+  lastModelKey?: string;
+}
+
+/** Runs an agent to a result. */
 export async function runAgent(
   input: ChatAgentInput,
   config: ChatAgentConfig,
   sink?: Sink,
 ): Promise<AgentResult> {
-  // With a fallback chain configured, validation_error joins the retryable
-  // set (#752 review F1): a refusal/unusable shape is model-specific, so a
-  // DIFFERENT candidate can plausibly succeed. Without a chain it stays
-  // terminal (blind same-model retry). Once a chain is spent, placement
-  // clamps to the last candidate, so the remaining attempts DO re-ask the
-  // same model — bounded by maxAttempts, and the retry policy stays the
-  // termination owner.
-  const retryPolicy =
-    (config.modelFallbacks?.length ?? 0) > 0
-      ? {
-          ...Retry.DEFAULT_RETRY_POLICY,
-          retryOn: [...(Retry.DEFAULT_RETRY_POLICY.retryOn ?? []), "validation_error" as const],
-        }
-      : Retry.DEFAULT_RETRY_POLICY;
-  let attempt = 1;
-  let thrownFailure: RunFailureFacts | undefined;
-  // Set only at the llm.run boundary. A later policy/configuration failure
-  // must not inherit public-facing provenance from an earlier model error.
-  let terminalLlmError: Error | undefined;
-  // The decided reason of every finished attempt, oldest first — the input
-  // to the placement fold below. Decided facts only (the retry decision's
-  // own record), never re-derived from the thrown error (#752).
-  const failureReasons: string[] = [];
-  // The previous attempt's model, for invalidating model-scoped window
-  // guards on a fallback switch (#752 review F3).
-  let lastModelKey: string | undefined;
-
+  const retryPolicy = retryPolicyFor(config);
+  const progress: RunProgress = { attempt: 1, failureReasons: [] };
   const trace = requireTrace("agent run", input.traceContext);
   const { traceId, sessionId, runId } = trace;
-  // The actor defaults to the run identity: no production caller threads a
-  // real actor principal yet (none supplies `agentName` either), so today
-  // actor ≡ runId. A validated principal lane replaces this when one exists
-  // (#606). The former `input.metadata?.actorId` leg was an unvalidated
-  // side-channel with zero producers and is gone.
   const actorId = nonEmptyString(trace.agentName) ?? runId;
   const agentBase = { traceId, sessionId, runId, actorId };
-  // All validators run before the run is opened: `buildPolicyEngine`
-  // rejects a malformed middleware registration, and a configuration error
-  // must not open a run it cannot close.
+
+  // Configuration is validated before opening the run.
   assertToolExecutor(config);
   assertUnambiguousToolMetadata(config);
   const engine = buildPolicyEngine(config, agentBase);
   emitRunStarted(config.events, trace, config.model.id);
-
-  // #546: run state and pre-run dispatch are run-scoped, living across
-  // attempts — an agent-level retry regenerates only the attempt (turn
-  // artifacts), never the history, budget/usage (no double-billing reset),
-  // or run.lifecycle.pre effects (prompt injections apply exactly once).
   const state = createRunState({ ...input, traceContext: trace });
 
-  /**
-   * The run's two terminals. Both live here because the run is opened here:
-   * a branch that records its own end can only be relied on for the ends it
-   * knows about, and the ends it does not know about are exactly the ones
-   * that go unrecorded. `handleError` used to emit the failure, so anything
-   * raised from inside it — an abort from `Retry.sleep`, a non-`Error` throw
-   * — escaped past its own record.
-   */
   const finish = (result: AgentResult): AgentResult => {
     engine.endRun();
     emitRunCompleted(config.events, state, agentBase, result.finishReason);
     return result;
   };
 
-  /**
-   * A throw that never reached a retry decision — nothing decided a reason or
-   * a ceiling for it, so the record says what the throw itself can support.
-   * Every path that *did* reach one carries the decided facts instead.
-   * Aborts are recognized by identity, never by message substrings (M4).
-   */
-  const undecidedFacts = (error: unknown): RunFailureFacts => ({
-    reason:
-      error instanceof Error && Retry.isAbort(error, config.signal)
-        ? "aborted"
-        : Retry.classifyRetryReason(error instanceof Error ? error.message : String(error)),
-    attempt,
-    maxAttempts: retryPolicy.maxAttempts,
-  });
-
   try {
     const preRunResult = await dispatchPreRun(state, engine, config, agentBase);
     if (preRunResult) return finish(preRunResult);
-
-    for (;;) {
-      try {
-        // Attempt identity for lifecycle policies (#694 observation material):
-        // stamped before any dispatch of this attempt, so run.turn.pre can
-        // pair it with turnIndex to tell a retry re-entry from progress.
-        recordRunAttempt(state, attempt);
-        // Fallback chain (#752): THIS attempt's model is a pure placement
-        // selection over the decided failure history — the primary when no
-        // fallbacks are configured. Resolution stays per-attempt, so a
-        // fallback switch also re-records the window fact below and the
-        // per-call assistant records carry the model actually used.
-        const attemptModel = Placement.selectModel(
-          [config.model, ...(config.modelFallbacks ?? [])],
-          failureReasons,
-        ).model;
-        // A model SWITCH invalidates the model-scoped window guards (#752
-        // review F3): "the remaining headroom is real" (windowYieldDisarmed)
-        // and the spent L5 overflow recovery were judgments about the
-        // PREVIOUS model's window — carried over, a smaller fallback window
-        // would run blind with its one recovery already consumed.
-        const modelKey = `${attemptModel.provider}/${attemptModel.id}`;
-        if (lastModelKey !== undefined && modelKey !== lastModelKey) {
-          resetModelWindowGuards(state);
-        }
-        lastModelKey = modelKey;
-        const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
-          attemptModel,
-        );
-        recordRunWindow(state, providerModel.limit?.context ?? 0);
-        const configuredToolChoice = config.toolChoice;
-
-        for (;;) {
-          const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
-          if (budgetResult) return finish(budgetResult);
-
-          emitTurnStart(config.events, state, agentBase);
-          const turnResult = await buildTurn(
-            state,
-            config,
-            engine,
-            providerModel,
-            configuredToolChoice,
-            trace,
-            agentBase,
-            sink,
-          );
-          if (turnResult.type === "complete") return finish(turnResult.result);
-
-          const runLlm = config.llm?.run ?? llmRun;
-          const gate = await dispatchModelRequest(
-            state,
-            engine,
-            config,
-            agentBase,
-            providerModel.id,
-          );
-          if (gate.blocked) return finish(gate.blocked);
-          // model.override (#753): a connection.llm.pre policy reroutes THIS
-          // connection to a different model — connection-scoped: the next
-          // call re-resolves from the per-attempt selection. The window-yield
-          // arm point is recomputed from the OVERRIDE's window locally; run
-          // state keeps the attempt model's window fact (the next connection
-          // reverts to it), so nothing is re-recorded.
-          let callModel = providerModel;
-          let callRunInput = turnResult.turn.runInput;
-          if (
-            gate.overrideModel !== undefined &&
-            (gate.overrideModel.provider !== attemptModel.provider ||
-              gate.overrideModel.id !== attemptModel.id)
-          ) {
-            callModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
-              gate.overrideModel,
-            );
-            const overrideWindow = callModel.limit?.context ?? 0;
-            const yieldAt =
-              overrideWindow > 0 && state.windowYieldDisarmed !== true
-                ? Math.floor(overrideWindow * DEFAULT_THRESHOLD_RATIO)
-                : undefined;
-            const { yieldAtInputTokens: _priorYield, ...restInput } = turnResult.turn.runInput;
-            callRunInput = {
-              ...restInput,
-              model: callModel,
-              auth: callModel.providerID === config.model.provider ? config.auth : undefined,
-              ...(yieldAt === undefined ? {} : { yieldAtInputTokens: yieldAt }),
-            };
-            // turnYield reads this to classify the stop — it must describe
-            // the call that actually ran, not the one buildTurn planned.
-            turnResult.turn.windowYieldArmed = yieldAt !== undefined;
-          }
-          const outcome = await runLlm(callRunInput, turnResult.turn.trackingSink);
-          const modelResponseResult = await dispatchModelResponse(
-            state,
-            engine,
-            config,
-            {
-              outcome,
-              responseTokens: turnResult.turn.turnUsage.outputTokens,
-            },
-            agentBase,
-            callModel.id,
-          );
-          if (modelResponseResult) return finish(modelResponseResult);
-
-          if (outcome.type === "stop") {
-            const stopOutcome = await handleStop(state, config, engine, agentBase, turnResult.turn);
-            if (stopOutcome !== "continue") return finish(stopOutcome);
-            continue;
-          }
-
-          if (outcome.type === "continue") {
-            handleContinue(config.events, state, agentBase, turnResult.turn.turnUsage);
-            continue;
-          }
-
-          if (outcome.type === "aborted") throw outcome.error ?? Retry.abortError();
-          if (outcome.type === "error") {
-            const error =
-              outcome.error instanceof Error ? outcome.error : new Error(outcome.error.message);
-            terminalLlmError = error;
-            throw error;
-          }
-          const _exhaustive: never = outcome;
-          throw new Error(`Unknown outcome type: ${unknownOutcomeType(_exhaustive)}`);
-        }
-      } catch (error) {
-        if (!(error instanceof Error)) throw error;
-        const decision = await handleError(
-          state,
-          engine,
-          config,
-          agentBase,
-          error,
-          attempt,
-          retryPolicy,
-        );
-        if (decision.action === "retry") {
-          // Carried across the wait, not after it: an abort raises from inside
-          // `Retry.sleep`, and the reason and ceiling it has to report are the
-          // ones decided here — re-deriving them from the abort would make the
-          // terminal record contradict this run's own retry record.
-          failureReasons.push(decision.failure.reason);
-          thrownFailure = decision.failure;
-          await LlmRetry.sleep(decision.backoffMs, config.signal);
-          thrownFailure = undefined;
-          attempt += 1;
-          continue;
-        }
-        if (decision.action === "complete") return finish(decision.result);
-        thrownFailure = decision.failure;
-        throw decision.error;
-      }
-    }
+    return finish(
+      await runAttempts(state, config, sink, engine, trace, agentBase, retryPolicy, progress),
+    );
   } catch (error) {
     engine.endRun();
-    const facts = thrownFailure ?? undecidedFacts(error);
+    const facts =
+      progress.thrownFailure ?? undecidedFailureFacts(error, config, retryPolicy, progress);
     emitRunFailed(
       config.events,
       agentBase,
       error instanceof Error ? error.message : String(error),
       facts,
     );
-    // Only a failure raised by llm.run carries public-facing provenance. The
-    // same retry machinery also observes policy, catalog, host, and telemetry
-    // faults; stamping those would let a host misrepresent an internal defect
-    // as a provider terminal.
-    if (error instanceof Error && error === terminalLlmError) {
+    if (error instanceof Error && error === progress.terminalLlmError) {
       Retry.attachFailureFacts(error, { ...facts, llm: true });
     }
     throw error;
   }
+}
+
+/** Fallbacks make validation failures retryable on a different candidate. */
+function retryPolicyFor(config: ChatAgentConfig): RetryPolicy {
+  if ((config.modelFallbacks?.length ?? 0) === 0) return Retry.DEFAULT_RETRY_POLICY;
+  return {
+    ...Retry.DEFAULT_RETRY_POLICY,
+    retryOn: [...(Retry.DEFAULT_RETRY_POLICY.retryOn ?? []), "validation_error"],
+  };
+}
+
+function undecidedFailureFacts(
+  error: unknown,
+  config: ChatAgentConfig,
+  retryPolicy: RetryPolicy,
+  progress: RunProgress,
+): RunFailureFacts {
+  return {
+    reason:
+      error instanceof Error && Retry.isAbort(error, config.signal)
+        ? "aborted"
+        : Retry.classifyRetryReason(error instanceof Error ? error.message : String(error)),
+    attempt: progress.attempt,
+    maxAttempts: retryPolicy.maxAttempts,
+  };
+}
+
+async function runAttempts(
+  state: RunState,
+  config: ChatAgentConfig,
+  sink: Sink | undefined,
+  engine: RunPolicyEngine,
+  trace: RunTrace,
+  agentBase: AgentRunBase,
+  retryPolicy: RetryPolicy,
+  progress: RunProgress,
+): Promise<AgentResult> {
+  for (;;) {
+    try {
+      return await runAttempt(state, config, sink, engine, trace, agentBase, progress);
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      const decision = await handleError(
+        state,
+        engine,
+        config,
+        agentBase,
+        error,
+        progress.attempt,
+        retryPolicy,
+      );
+      if (decision.action === "complete") return decision.result;
+      if (decision.action === "throw") {
+        progress.thrownFailure = decision.failure;
+        throw decision.error;
+      }
+      // Preserve the decided failure across an abort raised by the backoff.
+      progress.failureReasons.push(decision.failure.reason);
+      progress.thrownFailure = decision.failure;
+      await LlmRetry.sleep(decision.backoffMs, config.signal);
+      progress.thrownFailure = undefined;
+      progress.attempt += 1;
+    }
+  }
+}
+
+async function runAttempt(
+  state: RunState,
+  config: ChatAgentConfig,
+  sink: Sink | undefined,
+  engine: RunPolicyEngine,
+  trace: RunTrace,
+  agentBase: AgentRunBase,
+  progress: RunProgress,
+): Promise<AgentResult> {
+  recordRunAttempt(state, progress.attempt);
+  const attemptModel = selectAttemptModel(config, state, progress);
+  const providerModel = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(
+    attemptModel,
+  );
+  recordRunWindow(state, providerModel.limit?.context ?? 0);
+  return runTurns(
+    state,
+    config,
+    sink,
+    engine,
+    trace,
+    agentBase,
+    attemptModel,
+    providerModel,
+    progress,
+  );
+}
+
+function selectAttemptModel(
+  config: ChatAgentConfig,
+  state: RunState,
+  progress: RunProgress,
+): AttemptModel {
+  const attemptModel = Placement.selectModel(
+    [config.model, ...(config.modelFallbacks ?? [])],
+    progress.failureReasons,
+  ).model;
+  const modelKey = `${attemptModel.provider}/${attemptModel.id}`;
+  if (progress.lastModelKey !== undefined && modelKey !== progress.lastModelKey) {
+    resetModelWindowGuards(state);
+  }
+  progress.lastModelKey = modelKey;
+  return attemptModel;
+}
+
+async function runTurns(
+  state: RunState,
+  config: ChatAgentConfig,
+  sink: Sink | undefined,
+  engine: RunPolicyEngine,
+  trace: RunTrace,
+  agentBase: AgentRunBase,
+  attemptModel: AttemptModel,
+  providerModel: Provider.Model,
+  progress: RunProgress,
+): Promise<AgentResult> {
+  for (;;) {
+    const budgetResult = await dispatchBudgetCheck(state, engine, config, agentBase);
+    if (budgetResult) return budgetResult;
+    emitTurnStart(config.events, state, agentBase);
+    const turnResult = await buildTurn(
+      state,
+      config,
+      engine,
+      providerModel,
+      config.toolChoice,
+      trace,
+      agentBase,
+      sink,
+    );
+    if (turnResult.type === "complete") return turnResult.result;
+    const connectionResult = await runConnection(
+      state,
+      config,
+      engine,
+      agentBase,
+      attemptModel,
+      providerModel,
+      turnResult.turn,
+      progress,
+    );
+    if (connectionResult !== undefined) return connectionResult;
+  }
+}
+
+async function runConnection(
+  state: RunState,
+  config: ChatAgentConfig,
+  engine: RunPolicyEngine,
+  agentBase: AgentRunBase,
+  attemptModel: AttemptModel,
+  providerModel: Provider.Model,
+  turn: TurnArtifacts,
+  progress: RunProgress,
+): Promise<AgentResult | undefined> {
+  const gate = await dispatchModelRequest(state, engine, config, agentBase, providerModel.id);
+  if (gate.blocked) return gate.blocked;
+  const call = await resolveConnectionModel(
+    state,
+    config,
+    attemptModel,
+    providerModel,
+    turn,
+    gate.overrideModel,
+  );
+  const outcome = await (config.llm?.run ?? llmRun)(call.runInput, turn.trackingSink);
+  const responseResult = await dispatchModelResponse(
+    state,
+    engine,
+    config,
+    { outcome, responseTokens: turn.turnUsage.outputTokens },
+    agentBase,
+    call.model.id,
+  );
+  if (responseResult) return responseResult;
+  return handleModelOutcome(outcome, state, config, engine, agentBase, turn, progress);
+}
+
+async function resolveConnectionModel(
+  state: RunState,
+  config: ChatAgentConfig,
+  attemptModel: AttemptModel,
+  providerModel: Provider.Model,
+  turn: TurnArtifacts,
+  overrideModel: AttemptModel | undefined,
+): Promise<{ model: Provider.Model; runInput: TurnArtifacts["runInput"] }> {
+  if (
+    overrideModel === undefined ||
+    (overrideModel.provider === attemptModel.provider && overrideModel.id === attemptModel.id)
+  ) {
+    return { model: providerModel, runInput: turn.runInput };
+  }
+  const model = await (config.llm?.resolveProviderModel ?? resolveProviderModel)(overrideModel);
+  const overrideWindow = model.limit?.context ?? 0;
+  const yieldAt =
+    overrideWindow > 0 && state.windowYieldDisarmed !== true
+      ? Math.floor(overrideWindow * DEFAULT_THRESHOLD_RATIO)
+      : undefined;
+  const { yieldAtInputTokens: _priorYield, ...restInput } = turn.runInput;
+  turn.windowYieldArmed = yieldAt !== undefined;
+  return {
+    model,
+    runInput: {
+      ...restInput,
+      model,
+      auth: model.providerID === config.model.provider ? config.auth : undefined,
+      ...(yieldAt === undefined ? {} : { yieldAtInputTokens: yieldAt }),
+    },
+  };
+}
+
+async function handleModelOutcome(
+  outcome: Run.Outcome,
+  state: RunState,
+  config: ChatAgentConfig,
+  engine: RunPolicyEngine,
+  agentBase: AgentRunBase,
+  turn: TurnArtifacts,
+  progress: RunProgress,
+): Promise<AgentResult | undefined> {
+  if (outcome.type === "stop") {
+    const stopOutcome = await handleStop(state, config, engine, agentBase, turn);
+    return stopOutcome === "continue" ? undefined : stopOutcome;
+  }
+  if (outcome.type === "continue") {
+    handleContinue(config.events, state, agentBase, turn.turnUsage);
+    return undefined;
+  }
+  if (outcome.type === "aborted") throw outcome.error ?? Retry.abortError();
+  if (outcome.type === "error") {
+    const source = outcome.error;
+    const error =
+      source instanceof Error
+        ? source
+        : new Error(
+            typeof source === "object" &&
+              source !== null &&
+              "message" in source &&
+              typeof source.message === "string"
+              ? source.message
+              : String(source),
+          );
+    progress.terminalLlmError = error;
+    throw error;
+  }
+  throw new Error(`Unknown outcome type: ${unknownOutcomeType(outcome)}`);
 }
 
 function unknownOutcomeType(value: unknown): string {

--- a/packages/channels/src/router/messaging/send.ts
+++ b/packages/channels/src/router/messaging/send.ts
@@ -329,6 +329,329 @@ function debitRow(input: SendInput, sendClass: MessageClass): Gateway.EgressDebi
   };
 }
 
+type DenySend = (input: SendInput, code: MessageDenialCode, reason: string) => SendReceipt;
+
+interface AuthorizedSend {
+  readonly input: SendInput;
+  readonly target: DeliveryTarget;
+  readonly grant: SenderTargetGrant;
+  readonly conversationPinned: boolean;
+  readonly leasePinned: boolean;
+  readonly conversation: Conversation.Record | undefined;
+  readonly lease: Lease.Record | undefined;
+}
+
+/** Resolves sender authority and its exact allocated endpoint without mutating durable state. */
+function authorizeSend(
+  input: SendInput,
+  ports: MessagingPorts,
+  deny: DenySend,
+): AuthorizedSend | SendReceipt {
+  const grants = ports.grants();
+  const claim = {
+    senderId: input.senderId,
+    targetActorId: input.target.actorId,
+    operation: input.operation,
+    at: input.at,
+  };
+  const conversationPinned = input.conversationId !== undefined;
+  const leasePinned = input.leaseId !== undefined;
+  const conversation = conversationForSend(input);
+  const lease = leaseForSend(input);
+  let grant: SenderTargetGrant | undefined;
+  if (!conversationPinned && !leasePinned) {
+    grant = resolveSenderTargetGrant(grants, claim);
+    if (grant === undefined && !hasScopedSenderTargetCandidate(grants, claim)) {
+      return deny(
+        input,
+        "ungranted",
+        `no active sender-target grant covers ${input.senderId} -> ${input.target.actorId} (${input.operation})`,
+      );
+    }
+  }
+  const resolution = resolveExistingTarget(input.target);
+  if (!resolution.ok) return deny(input, resolution.code, resolution.reason);
+
+  if (leasePinned) {
+    const leaseResult = authorizeLeaseSend(
+      input,
+      resolution.target,
+      lease,
+      conversationPinned,
+      deny,
+    );
+    if ("kind" in leaseResult) return leaseResult;
+    grant = leaseResult;
+  } else if (conversationPinned) {
+    const conversationDenial = conversationGate(
+      input.conversationId ?? "",
+      conversation,
+      resolution.target,
+    );
+    if (conversationDenial !== undefined) {
+      return deny(input, "conversation_denied", conversationDenial);
+    }
+    grant = pinnedGrant(input, `conversation:${input.conversationId ?? ""}`);
+  } else if (grant === undefined) {
+    const surfaceKey = deliverySurfaceKey(resolution.target);
+    grant = resolveScopedSenderTargetGrant(grants, { ...claim, surfaceKey });
+    if (grant === undefined) {
+      return deny(
+        input,
+        "ungranted",
+        `reply-scoped grant does not cover surface ${surfaceKey} — replies stay inside the initiating container`,
+      );
+    }
+  }
+
+  return {
+    input,
+    target: resolution.target,
+    grant,
+    conversationPinned,
+    leasePinned,
+    conversation,
+    lease,
+  };
+}
+
+function authorizeLeaseSend(
+  input: SendInput,
+  target: DeliveryTarget,
+  lease: Lease.Record | undefined,
+  conversationPinned: boolean,
+  deny: DenySend,
+): SenderTargetGrant | SendReceipt {
+  const leaseId = input.leaseId ?? "";
+  if (lease === undefined) return deny(input, "lease_denied", `lease ${leaseId} does not exist`);
+  if (conversationPinned && input.conversationId !== lease.conversationId) {
+    return deny(
+      input,
+      "lease_denied",
+      `lease ${leaseId} scopes conversation ${lease.conversationId}, not ${input.conversationId ?? ""}`,
+    );
+  }
+  const conversationDenial = conversationGate(
+    lease.conversationId,
+    ConversationStore.get(lease.conversationId),
+    target,
+  );
+  if (conversationDenial !== undefined) {
+    return deny(input, "conversation_denied", conversationDenial);
+  }
+  return pinnedGrant(input, `lease:${leaseId}`);
+}
+
+/** Records all admission debits before the delivery effect. */
+function admitSend(
+  authorization: AuthorizedSend,
+  ports: MessagingPorts,
+  deny: DenySend,
+): SendAdmission | SendReceipt {
+  const { input, target, grant, conversationPinned, leasePinned } = authorization;
+  const sendClass = sendClassOf(input);
+  let admission: SendAdmission | undefined;
+  try {
+    admission = existingAdmission(input, target);
+  } catch (error) {
+    if (error instanceof SendAdmissionConflict && input.operation === "awaited") {
+      return deny(input, "wait_duplicate", error.message);
+    }
+    throw error;
+  }
+  if (admission !== undefined) {
+    repairBudgetDebit(input, admission);
+    return admission;
+  }
+
+  const budgeted =
+    !conversationPinned &&
+    !leasePinned &&
+    ports.budgets !== undefined &&
+    grant.replyScope === undefined;
+  const pinnedDenial = debitPinnedAuthority(authorization, deny);
+  if (pinnedDenial !== undefined) return pinnedDenial;
+  if (budgeted) {
+    const budget = ports
+      .budgets?.()
+      .find((candidate) => candidate.targetActorId === input.target.actorId);
+    const budgetClaim = EgressBudgetStore.claim(
+      debitRow(input, sendClass),
+      input.at - (budget?.windowMs ?? 0),
+      (state) => evaluateSocialBudget(budget, state, { class: sendClass, at: input.at }),
+    );
+    if (budgetClaim.kind === "refused") {
+      return deny(
+        input,
+        budgetClaim.reason.suppress,
+        `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${budgetClaim.reason.suppress})`,
+      );
+    }
+  }
+  admission = recordAdmission(input, target, budgeted, sendClass);
+  repairBudgetDebit(input, admission);
+  return admission;
+}
+
+function debitPinnedAuthority(
+  authorization: AuthorizedSend,
+  deny: DenySend,
+): SendReceipt | undefined {
+  const { input, leasePinned, conversationPinned, lease, conversation } = authorization;
+  if (leasePinned && lease !== undefined) {
+    const debit = LeaseStore.sendDebit(lease.id, input.at);
+    if (debit.kind === "refused") {
+      return deny(
+        input,
+        "lease_denied",
+        `lease ${lease.id} refused the outbound send (${debit.reason})`,
+      );
+    }
+  } else if (conversationPinned && conversation !== undefined) {
+    const debit = ConversationStore.admitOutbound(conversation.id, input.traceId, input.at);
+    if (debit.kind === "refused") {
+      return deny(
+        input,
+        "conversation_denied",
+        `conversation ${conversation.id} refused the outbound send (${debit.reason})`,
+      );
+    }
+  }
+  return undefined;
+}
+
+function repairBudgetDebit(input: SendInput, admission: SendAdmission): void {
+  if (!admission.budgeted) return;
+  EgressBudgetStore.claim(debitRow(input, admission.sendClass), input.at, () => "allow");
+}
+
+type WaitOpening =
+  | { readonly ok: true; readonly wait: Wait.Record | undefined }
+  | { readonly ok: false; readonly receipt: SendReceipt };
+
+/** Opens or resumes the awaited-send record before delivery. */
+function openSendWait(input: SendInput, target: DeliveryTarget, deny: DenySend): WaitOpening {
+  if (input.operation !== "awaited") return { ok: true, wait: undefined };
+  const spec = input.waitSpec;
+  if (spec === undefined) {
+    throw new Error("awaited send without waitSpec — schema layer regressed");
+  }
+  try {
+    const wait = WaitService.open(
+      {
+        id: spec.waitId,
+        ownerRef: spec.ownerRef,
+        originMessageId: input.messageId,
+        correlation: {
+          ...spec.correlation,
+          endpointId: target.endpointId,
+          replyToMessageId: input.messageId,
+        },
+        allowedActions: spec.allowedActions,
+        expectedResponders: spec.expectedResponders,
+        resolutionPolicy: spec.resolutionPolicy,
+        ...(spec.quorum === undefined ? {} : { quorum: spec.quorum }),
+        expiresAt: spec.expiresAt,
+        followUpWindow: spec.followUpWindow,
+        createdAt: input.at,
+        updatedAt: input.at,
+      },
+      input.traceId,
+    );
+    return { ok: true, wait };
+  } catch (error) {
+    if (WaitProtocol.StoreError.isInstance(error)) {
+      if (error.data.code !== "duplicate") throw error;
+      const recorded = WaitStore.get(spec.waitId);
+      if (recorded?.originMessageId === input.messageId) return { ok: true, wait: recorded };
+      return {
+        ok: false,
+        receipt: deny(
+          input,
+          "wait_duplicate",
+          `a different Wait already exists for message ${input.messageId} or wait ${spec.waitId}`,
+        ),
+      };
+    }
+    throw error;
+  }
+}
+
+/** Delivers under the stable idempotency key and records external correlation when present. */
+async function deliverSend(
+  input: SendInput,
+  target: DeliveryTarget,
+  wait: Wait.Record | undefined,
+  ports: MessagingPorts,
+): Promise<Wait.Record | undefined> {
+  const recordedExternalId =
+    wait !== undefined && wait.correlation.replyToMessageId !== input.messageId
+      ? wait.correlation.replyToMessageId
+      : undefined;
+  const delivery =
+    recordedExternalId === undefined
+      ? await ports.deliver({
+          messageId: input.messageId,
+          idempotencyKey: input.messageId,
+          senderId: input.senderId,
+          operation: input.operation,
+          body: input.body,
+          target,
+          ...(wait === undefined ? {} : { waitId: wait.id }),
+        })
+      : { externalMessageId: recordedExternalId };
+  if (wait === undefined || delivery?.externalMessageId === undefined) return wait;
+  const receipt = WaitService.recordDeliveryReceipt(
+    wait.id,
+    { externalMessageId: delivery.externalMessageId, at: input.at },
+    input.traceId,
+  );
+  return receipt.kind === "delivery_recorded" ? receipt.record : wait;
+}
+
+function recordSent(
+  authorization: AuthorizedSend,
+  wait: Wait.Record | undefined,
+  ports: MessagingPorts,
+): SendReceipt {
+  const { input, target, grant, leasePinned, lease } = authorization;
+  ports.publish(MessagingEvents.Sent, {
+    messageId: input.messageId,
+    traceId: input.traceId,
+    senderId: input.senderId,
+    targetActorId: input.target.actorId,
+    operation: input.operation,
+    grantId: grant.id,
+    endpointId: target.endpointId,
+    ...(wait === undefined ? {} : { waitId: wait.id }),
+    ...(leasePinned && lease !== undefined
+      ? { onBehalfOf: lease.holderDelegationId, via: `lease:${lease.id}` }
+      : {}),
+    time: input.at,
+  });
+  if (wait !== undefined) {
+    return {
+      kind: "sent",
+      operation: "awaited",
+      messageId: input.messageId,
+      senderId: input.senderId,
+      grantId: grant.id,
+      target,
+      wait,
+      at: input.at,
+    };
+  }
+  return {
+    kind: "sent",
+    operation: "fire_and_forget",
+    messageId: input.messageId,
+    senderId: input.senderId,
+    grantId: grant.id,
+    target,
+    at: input.at,
+  };
+}
+
 export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAgentMessaging {
   function deny(input: SendInput, code: MessageDenialCode, reason: string): SendReceipt {
     ports.publish(MessagingEvents.Denied, {
@@ -352,292 +675,17 @@ export function createExistingAgentMessaging(ports: MessagingPorts): ExistingAge
 
   async function send(rawInput: SendInput): Promise<SendReceipt> {
     const input = SendInput.parse(rawInput);
-    const grants = ports.grants();
-    const claim = {
-      senderId: input.senderId,
-      targetActorId: input.target.actorId,
-      operation: input.operation,
-      at: input.at,
-    };
-    // #P1 conversational arm / #P2 lease arm (§3.4/§3.5): a pinned send
-    // derives its authority from the open window or the live lease, not
-    // from grants — but the target still resolves and the absolute
-    // blacklist deny still binds BEFORE any window/lease fact is consulted,
-    // so an unauthorized sender learns nothing from either.
-    const conversationPinned = input.conversationId !== undefined;
-    const leasePinned = input.leaseId !== undefined;
-    const conversation = conversationForSend(input);
-    const lease = leaseForSend(input);
-    let grant: SenderTargetGrant | undefined;
-    if (!conversationPinned && !leasePinned) {
-      // Scope-aware arm (#708): a rule-materialized instance carries a
-      // replyScope that can only be checked against the RESOLVED delivery
-      // endpoint, so with a candidate present the target resolves first and
-      // the scope check follows. With no candidate the denial stays
-      // `ungranted` BEFORE any registry lookup — an ungranted sender learns
-      // nothing from the registry (pinned by the send suite).
-      grant = resolveSenderTargetGrant(grants, claim);
-      if (grant === undefined && !hasScopedSenderTargetCandidate(grants, claim)) {
-        return deny(
-          input,
-          "ungranted",
-          `no active sender-target grant covers ${input.senderId} -> ${input.target.actorId} (${input.operation})`,
-        );
-      }
-    }
-    const resolution = resolveExistingTarget(input.target);
-    if (!resolution.ok) {
-      return deny(input, resolution.code, resolution.reason);
-    }
-    if (leasePinned) {
-      const leaseId = input.leaseId ?? "";
-      if (lease === undefined) {
-        return deny(input, "lease_denied", `lease ${leaseId} does not exist`);
-      }
-      if (conversationPinned && input.conversationId !== lease.conversationId) {
-        return deny(
-          input,
-          "lease_denied",
-          `lease ${leaseId} scopes conversation ${lease.conversationId}, not ${input.conversationId ?? ""}`,
-        );
-      }
-      // The lease scopes exactly one conversation; the window's own pin and
-      // the absolute DNC deny bind the send the same way (§3.5, §8.8).
-      const scopedConversation = ConversationStore.get(lease.conversationId);
-      const conversationDenial = conversationGate(
-        lease.conversationId,
-        scopedConversation,
-        resolution.target,
-      );
-      if (conversationDenial !== undefined) {
-        return deny(input, "conversation_denied", conversationDenial);
-      }
-      grant = pinnedGrant(input, `lease:${leaseId}`);
-    } else if (conversationPinned) {
-      const conversationDenial = conversationGate(
-        input.conversationId ?? "",
-        conversation,
-        resolution.target,
-      );
-      if (conversationDenial !== undefined) {
-        return deny(input, "conversation_denied", conversationDenial);
-      }
-      grant = pinnedGrant(input, `conversation:${input.conversationId ?? ""}`);
-    } else if (grant === undefined) {
-      const surfaceKey = deliverySurfaceKey(resolution.target);
-      grant = resolveScopedSenderTargetGrant(grants, { ...claim, surfaceKey });
-      if (grant === undefined) {
-        // Cross-surface use of a reply-scoped instance fails closed: the
-        // instance authorizes replies INTO the initiating container only.
-        return deny(
-          input,
-          "ungranted",
-          `reply-scoped grant does not cover surface ${surfaceKey} — replies stay inside the initiating container`,
-        );
-      }
-    }
+    const authorization = authorizeSend(input, ports, deny);
+    if ("kind" in authorization) return authorization;
+    const { target } = authorization;
 
-    // A durable admission marker distinguishes a retry from a new send before
-    // any mutable budget/Wait state is revisited. It is also the immutable
-    // binding from messageId to content + resolved endpoint: reusing a key for
-    // different bytes fails closed.
-    const sendClass = sendClassOf(input);
-    let admission: SendAdmission | undefined;
-    try {
-      admission = existingAdmission(input, resolution.target);
-    } catch (error) {
-      if (error instanceof SendAdmissionConflict && input.operation === "awaited") {
-        return deny(input, "wait_duplicate", error.message);
-      }
-      throw error;
-    }
-    if (admission === undefined) {
-      // #219 active-egress gate: evaluate only for a NEW admission. A resumed
-      // send already passed this judgment and must not consume capacity twice.
-      // A conversation-pinned send debits the WINDOW instead — the egress
-      // budget never double-counts it.
-      const budgeted =
-        !conversationPinned &&
-        !leasePinned &&
-        ports.budgets !== undefined &&
-        grant.replyScope === undefined;
-      if (leasePinned && lease !== undefined) {
-        // Record-before-act: THE lease-send debit (LeaseStore.sendDebit)
-        // folds the carved allocation AND the scoped conversation's outbound
-        // cap in one transaction — a refusal at either fold writes nothing.
-        const debit = LeaseStore.sendDebit(lease.id, input.at);
-        if (debit.kind === "refused") {
-          return deny(
-            input,
-            "lease_denied",
-            `lease ${lease.id} refused the outbound send (${debit.reason})`,
-          );
-        }
-      } else if (conversationPinned && conversation !== undefined) {
-        // Record-before-act: the durable outbound debit lands before the
-        // delivery effect. A refusal here (closed/expired/cap/quiet-hours
-        // raced past the read above) is the same typed denial.
-        const debit = ConversationStore.admitOutbound(conversation.id, input.traceId, input.at);
-        if (debit.kind === "refused") {
-          return deny(
-            input,
-            "conversation_denied",
-            `conversation ${conversation.id} refused the outbound send (${debit.reason})`,
-          );
-        }
-      }
-      if (budgeted) {
-        const budget = ports
-          .budgets?.()
-          .find((candidate) => candidate.targetActorId === input.target.actorId);
-        const budgetClaim = EgressBudgetStore.claim(
-          debitRow(input, sendClass),
-          input.at - (budget?.windowMs ?? 0),
-          (state) => evaluateSocialBudget(budget, state, { class: sendClass, at: input.at }),
-        );
-        if (budgetClaim.kind === "refused") {
-          return deny(
-            input,
-            budgetClaim.reason.suppress,
-            `active-egress budget suppressed a ${sendClass} send ${input.senderId} -> ${input.target.actorId} (${budgetClaim.reason.suppress})`,
-          );
-        }
-      }
-      admission = recordAdmission(input, resolution.target, budgeted, sendClass);
-    }
-    if (admission.budgeted) {
-      // Repair admissions written by an older process (or a crash between its
-      // admission and debit). Deterministic claim identity makes this a no-op
-      // for the normal claim-before-admission path.
-      EgressBudgetStore.claim(debitRow(input, admission.sendClass), input.at, () => "allow");
-    }
-    // #219 escalation seam (DEFERRED, out of this PR): the autonomous
-    // timer-fired 봉수 rung-advance would attach its counting coordinate HERE —
-    // blocked by the #469 accumulator + a missing periodic-timeout firing
-    // source. The synchronous suppression gate above ships without it.
+    const admission = admitSend(authorization, ports, deny);
+    if ("kind" in admission) return admission;
 
-    let wait: Wait.Record | undefined;
-    if (input.operation === "awaited") {
-      const spec = input.waitSpec;
-      // Presence is guaranteed by the SendInput refinement; this narrows the
-      // optional type without a silent fallback.
-      if (spec === undefined) {
-        throw new Error("awaited send without waitSpec — schema layer regressed");
-      }
-      // Record-before-act: the durable Wait lands before the delivery effect.
-      // A delivery failure then leaves an open Wait that expires on schedule;
-      // the reverse order could deliver a message the ledger never awaits.
-      try {
-        wait = WaitService.open(
-          {
-            id: spec.waitId,
-            ownerRef: spec.ownerRef,
-            originMessageId: input.messageId,
-            correlation: {
-              ...spec.correlation,
-              endpointId: resolution.target.endpointId,
-              replyToMessageId: input.messageId,
-            },
-            allowedActions: spec.allowedActions,
-            expectedResponders: spec.expectedResponders,
-            resolutionPolicy: spec.resolutionPolicy,
-            ...(spec.quorum === undefined ? {} : { quorum: spec.quorum }),
-            expiresAt: spec.expiresAt,
-            followUpWindow: spec.followUpWindow,
-            createdAt: input.at,
-            updatedAt: input.at,
-          },
-          input.traceId,
-        );
-      } catch (error) {
-        if (WaitProtocol.StoreError.isInstance(error) && error.data.code === "duplicate") {
-          const recorded = WaitStore.get(spec.waitId);
-          if (recorded?.originMessageId === input.messageId) {
-            wait = recorded;
-          } else {
-            return deny(
-              input,
-              "wait_duplicate",
-              `a different Wait already exists for message ${input.messageId} or wait ${spec.waitId}`,
-            );
-          }
-        } else {
-          throw error;
-        }
-      }
-    }
-
-    // A recorded external correlation is durable proof that the effect and
-    // receipt CAS completed. Otherwise call the owner under the stable key;
-    // its contract requires API idempotency/read-back reconciliation.
-    const recordedExternalId =
-      wait !== undefined && wait.correlation.replyToMessageId !== input.messageId
-        ? wait.correlation.replyToMessageId
-        : undefined;
-    const delivery =
-      recordedExternalId === undefined
-        ? await ports.deliver({
-            messageId: input.messageId,
-            idempotencyKey: input.messageId,
-            senderId: input.senderId,
-            operation: input.operation,
-            body: input.body,
-            target: resolution.target,
-            ...(wait === undefined ? {} : { waitId: wait.id }),
-          })
-        : { externalMessageId: recordedExternalId };
-    if (wait !== undefined && delivery !== undefined && delivery.externalMessageId !== undefined) {
-      // The channel returned the platform message id: re-key the wait's
-      // correlation.replyToMessageId to it so real platform replies (which
-      // reference the platform id, not our internal one) correlate. A wait
-      // that turned terminal while the delivery was in flight rejects the
-      // receipt (wait_terminal) and keeps its recorded correlation.
-      const receipt = WaitService.recordDeliveryReceipt(
-        wait.id,
-        { externalMessageId: delivery.externalMessageId, at: input.at },
-        input.traceId,
-      );
-      if (receipt.kind === "delivery_recorded") wait = receipt.record;
-    }
-    ports.publish(MessagingEvents.Sent, {
-      messageId: input.messageId,
-      traceId: input.traceId,
-      senderId: input.senderId,
-      targetActorId: input.target.actorId,
-      operation: input.operation,
-      grantId: grant.id,
-      endpointId: resolution.target.endpointId,
-      ...(wait === undefined ? {} : { waitId: wait.id }),
-      // §3.5 egress stamping: a lease send records whose work it speaks for
-      // (the holder delegation) and which lease carried it. Owner sends
-      // carry neither; the external identity is always the Resident's.
-      ...(leasePinned && lease !== undefined
-        ? { onBehalfOf: lease.holderDelegationId, via: `lease:${lease.id}` }
-        : {}),
-      time: input.at,
-    });
-
-    if (wait !== undefined) {
-      return {
-        kind: "sent",
-        operation: "awaited",
-        messageId: input.messageId,
-        senderId: input.senderId,
-        grantId: grant.id,
-        target: resolution.target,
-        wait,
-        at: input.at,
-      };
-    }
-    return {
-      kind: "sent",
-      operation: "fire_and_forget",
-      messageId: input.messageId,
-      senderId: input.senderId,
-      grantId: grant.id,
-      target: resolution.target,
-      at: input.at,
-    };
+    const waitOpening = openSendWait(input, target, deny);
+    if (!waitOpening.ok) return waitOpening.receipt;
+    const wait = await deliverSend(input, target, waitOpening.wait, ports);
+    return recordSent(authorization, wait, ports);
   }
 
   return { send };

--- a/packages/policy/src/effects/merge/rules.ts
+++ b/packages/policy/src/effects/merge/rules.ts
@@ -1,4 +1,4 @@
-import type { PlainObject } from "@openomni/protocol";
+import type { PlainObject, Policy } from "@openomni/protocol";
 import type {
   ApprovalAccumulator,
   EffectEntry,
@@ -16,151 +16,268 @@ import {
 import { appendMergedEffects } from "./output";
 import { assertNever, deepMergeRecords } from "../records";
 
+type PolicyEffect = Policy.PolicyEffect;
+type EffectFamily<Prefix extends string> = Extract<
+  PolicyEffect,
+  { readonly type: `${Prefix}.${string}` }
+>;
+type Family =
+  | "prompt"
+  | "model"
+  | "tool"
+  | "run"
+  | "delegation"
+  | "writeback"
+  | "runtime"
+  | "work"
+  | "audit";
+
+const EFFECT_FAMILY = {
+  "prompt.append_context": "prompt",
+  "prompt.inject_message": "prompt",
+  "prompt.replace": "prompt",
+  "model.override": "model",
+  "tool.filter": "tool",
+  "tool.rewrite_input": "tool",
+  "tool.rewrite_output": "tool",
+  "tool.skip_invocation": "tool",
+  "tool.require_approval": "tool",
+  "run.abort": "run",
+  "run.continue_with_prompt": "run",
+  "run.retry_after": "run",
+  "run.replace_messages": "run",
+  "delegation.set_constraints": "delegation",
+  "delegation.require_approval": "delegation",
+  "writeback.rewrite": "writeback",
+  "writeback.suppress": "writeback",
+  "runtime.workspace_lock": "runtime",
+  "work.allow_asserted": "work",
+  "audit.annotate": "audit",
+} as const satisfies Record<PolicyEffect["type"], Family>;
+
+interface MergeAccumulators {
+  readonly merged: MergedEffect[];
+  readonly toolFilters: Map<string, number>;
+  toolRewrite?: { readonly input: PlainObject; readonly order: number };
+  toolOutputRewrite?: MergedEffect;
+  toolSkip?: MergedEffect;
+  toolApproval?: ApprovalAccumulator;
+  runAbort?: MergedEffect;
+  continueWithPrompt?: MergedEffect;
+  retryAfter?: RetryAccumulator;
+  runReplaceMessages?: MergedEffect;
+  delegationConstraints?: { readonly constraints: PlainObject; readonly order: number };
+  delegationApproval?: ApprovalAccumulator;
+  promptReplace?: MergedEffect;
+  modelOverride?: MergedEffect;
+  writebackRewrite?: MergedEffect;
+  writebackSuppress?: PriorityApprovalAccumulator;
+  workspaceLock?: { readonly required: boolean; readonly order: number };
+  allowAsserted?: {
+    readonly criterionIds: string[];
+    readonly order: number;
+    readonly priority: number;
+  };
+}
+
 export function mergeEntries(entries: readonly EffectEntry[]): MergeResult {
-  const merged: MergedEffect[] = [];
-  const toolFilters = new Map<string, number>();
-  let toolRewrite: { readonly input: PlainObject; readonly order: number } | undefined;
-  let toolOutputRewrite: MergedEffect | undefined;
-  let toolSkip: MergedEffect | undefined;
-  let toolApproval: ApprovalAccumulator | undefined;
-  let runAbort: MergedEffect | undefined;
-  let continueWithPrompt: MergedEffect | undefined;
-  let retryAfter: RetryAccumulator | undefined;
-  let runReplaceMessages: MergedEffect | undefined;
-  let delegationConstraints:
-    | { readonly constraints: PlainObject; readonly order: number }
-    | undefined;
-  let delegationApproval: ApprovalAccumulator | undefined;
-  let promptReplace: MergedEffect | undefined;
-  // Single-winner like prompt.replace: two policies overriding the same
-  // connection's model cannot compose — the higher-priority one wins (#753).
-  let modelOverride: MergedEffect | undefined;
-  let writebackRewrite: MergedEffect | undefined;
-  let writebackSuppress: PriorityApprovalAccumulator | undefined;
-  let workspaceLock: { readonly required: boolean; readonly order: number } | undefined;
-  let allowAsserted:
-    | { readonly criterionIds: string[]; readonly order: number; readonly priority: number }
-    | undefined;
+  const state: MergeAccumulators = { merged: [], toolFilters: new Map() };
+  for (const entry of entries) mergeEntry(state, entry);
+  appendAllowAsserted(state);
+  appendMergedEffects(state.merged, state);
+  return {
+    effects: state.merged
+      .sort((left, right) => left.order - right.order)
+      .map(({ effect }) => effect),
+  };
+}
 
-  for (const entry of entries) {
-    const { effect } = entry;
+/** Routes an effect to the fold that owns its policy domain. */
+function mergeEntry(state: MergeAccumulators, entry: EffectEntry): void {
+  const family: Family = EFFECT_FAMILY[entry.effect.type];
+  switch (family) {
+    case "prompt":
+      mergePromptEffect(state, entry as EffectEntry & { effect: EffectFamily<"prompt"> });
+      return;
+    case "model":
+      state.modelOverride = selectPriorityEffect(state.modelOverride, entry);
+      return;
+    case "tool":
+      mergeToolEffect(state, entry as EffectEntry & { effect: EffectFamily<"tool"> });
+      return;
+    case "run":
+      mergeRunEffect(state, entry as EffectEntry & { effect: EffectFamily<"run"> });
+      return;
+    case "delegation":
+      mergeDelegationEffect(state, entry as EffectEntry & { effect: EffectFamily<"delegation"> });
+      return;
+    case "writeback":
+      mergeWritebackEffect(state, entry as EffectEntry & { effect: EffectFamily<"writeback"> });
+      return;
+    case "runtime":
+      mergeRuntimeEffect(state, entry as EffectEntry & { effect: EffectFamily<"runtime"> });
+      return;
+    case "work":
+      mergeWorkEffect(state, entry as EffectEntry & { effect: EffectFamily<"work"> });
+      return;
+    case "audit":
+      appendImmediate(state, entry);
+      return;
+    default:
+      assertNever(family);
+  }
+}
 
-    switch (effect.type) {
-      case "prompt.append_context":
-      case "prompt.inject_message":
-      case "audit.annotate":
-        merged.push({ effect, order: entry.order, priority: entry.priority });
-        break;
-      case "prompt.replace":
-        promptReplace = selectPriorityEffect(promptReplace, entry);
-        break;
-      case "model.override":
-        modelOverride = selectPriorityEffect(modelOverride, entry);
-        break;
-      case "tool.filter":
-        if (!toolFilters.has(effect.toolPattern)) toolFilters.set(effect.toolPattern, entry.order);
-        break;
-      case "tool.rewrite_input":
-        toolRewrite = {
-          input: deepMergeRecords(toolRewrite?.input ?? {}, effect.input),
-          order: Math.min(toolRewrite?.order ?? entry.order, entry.order),
-        };
-        break;
-      case "tool.rewrite_output":
-        toolOutputRewrite = selectPriorityEffect(toolOutputRewrite, entry);
-        break;
-      case "tool.skip_invocation":
-        toolSkip ??= { effect, order: entry.order, priority: entry.priority };
-        break;
-      case "tool.require_approval":
-        toolApproval = appendReason(toolApproval, effect.reason, entry.order);
-        break;
-      case "run.abort":
-        runAbort ??= { effect, order: entry.order, priority: entry.priority };
-        break;
-      case "run.continue_with_prompt":
-        continueWithPrompt = selectPriorityEffect(continueWithPrompt, entry);
-        break;
-      case "run.retry_after":
-        retryAfter = mergeRetry(retryAfter, effect, entry.order);
-        break;
-      case "run.replace_messages":
-        runReplaceMessages = selectPriorityEffect(runReplaceMessages, entry);
-        break;
-      case "delegation.set_constraints":
-        delegationConstraints = {
-          constraints: deepMergeRecords(
-            delegationConstraints?.constraints ?? {},
-            effect.constraints,
-          ),
-          order: Math.min(delegationConstraints?.order ?? entry.order, entry.order),
-        };
-        break;
-      case "delegation.require_approval":
-        delegationApproval = appendReason(delegationApproval, effect.reason, entry.order);
-        break;
-      case "writeback.rewrite":
-        writebackRewrite = selectPriorityEffect(writebackRewrite, entry);
-        break;
-      case "writeback.suppress":
-        writebackSuppress = appendPriorityReason(
-          writebackSuppress,
-          effect.reason,
-          entry.order,
-          entry.priority,
-        );
-        break;
-      case "runtime.workspace_lock":
-        workspaceLock = {
-          required: (workspaceLock?.required ?? false) || effect.required,
-          order: Math.min(workspaceLock?.order ?? entry.order, entry.order),
-        };
-        break;
-      case "work.allow_asserted":
-        allowAsserted = {
-          ...(allowAsserted ?? { criterionIds: [], order: entry.order, priority: entry.priority }),
-          order: Math.min(allowAsserted?.order ?? entry.order, entry.order),
-          priority: Math.max(allowAsserted?.priority ?? entry.priority, entry.priority),
-        };
-        for (const criterionId of effect.criterionIds) {
-          if (!allowAsserted.criterionIds.includes(criterionId)) {
-            allowAsserted.criterionIds.push(criterionId);
-          }
-        }
-        break;
-      default:
-        assertNever(effect);
+function appendImmediate(state: MergeAccumulators, entry: EffectEntry): void {
+  state.merged.push({ effect: entry.effect, order: entry.order, priority: entry.priority });
+}
+
+function mergePromptEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"prompt"> },
+): void {
+  switch (entry.effect.type) {
+    case "prompt.append_context":
+    case "prompt.inject_message":
+      appendImmediate(state, entry);
+      return;
+    case "prompt.replace":
+      state.promptReplace = selectPriorityEffect(state.promptReplace, entry);
+      return;
+  }
+}
+
+function mergeToolEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"tool"> },
+): void {
+  const { effect } = entry;
+  switch (effect.type) {
+    case "tool.filter":
+      if (!state.toolFilters.has(effect.toolPattern)) {
+        state.toolFilters.set(effect.toolPattern, entry.order);
+      }
+      return;
+    case "tool.rewrite_input":
+      state.toolRewrite = {
+        input: deepMergeRecords(state.toolRewrite?.input ?? {}, effect.input),
+        order: Math.min(state.toolRewrite?.order ?? entry.order, entry.order),
+      };
+      return;
+    case "tool.rewrite_output":
+      state.toolOutputRewrite = selectPriorityEffect(state.toolOutputRewrite, entry);
+      return;
+    case "tool.skip_invocation":
+      state.toolSkip ??= { effect, order: entry.order, priority: entry.priority };
+      return;
+    case "tool.require_approval":
+      state.toolApproval = appendReason(state.toolApproval, effect.reason, entry.order);
+      return;
+  }
+}
+
+function mergeRunEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"run"> },
+): void {
+  const { effect } = entry;
+  switch (effect.type) {
+    case "run.abort":
+      state.runAbort ??= { effect, order: entry.order, priority: entry.priority };
+      return;
+    case "run.continue_with_prompt":
+      state.continueWithPrompt = selectPriorityEffect(state.continueWithPrompt, entry);
+      return;
+    case "run.retry_after":
+      state.retryAfter = mergeRetry(state.retryAfter, effect, entry.order);
+      return;
+    case "run.replace_messages":
+      state.runReplaceMessages = selectPriorityEffect(state.runReplaceMessages, entry);
+      return;
+  }
+}
+
+function mergeDelegationEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"delegation"> },
+): void {
+  const { effect } = entry;
+  switch (effect.type) {
+    case "delegation.set_constraints":
+      state.delegationConstraints = {
+        constraints: deepMergeRecords(
+          state.delegationConstraints?.constraints ?? {},
+          effect.constraints,
+        ),
+        order: Math.min(state.delegationConstraints?.order ?? entry.order, entry.order),
+      };
+      return;
+    case "delegation.require_approval":
+      state.delegationApproval = appendReason(state.delegationApproval, effect.reason, entry.order);
+      return;
+  }
+}
+
+function mergeWritebackEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"writeback"> },
+): void {
+  const { effect } = entry;
+  switch (effect.type) {
+    case "writeback.rewrite":
+      state.writebackRewrite = selectPriorityEffect(state.writebackRewrite, entry);
+      return;
+    case "writeback.suppress":
+      state.writebackSuppress = appendPriorityReason(
+        state.writebackSuppress,
+        effect.reason,
+        entry.order,
+        entry.priority,
+      );
+      return;
+  }
+}
+
+function mergeRuntimeEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"runtime"> },
+): void {
+  const { effect } = entry;
+  state.workspaceLock = {
+    required: (state.workspaceLock?.required ?? false) || effect.required,
+    order: Math.min(state.workspaceLock?.order ?? entry.order, entry.order),
+  };
+}
+
+function mergeWorkEffect(
+  state: MergeAccumulators,
+  entry: EffectEntry & { effect: EffectFamily<"work"> },
+): void {
+  const { effect } = entry;
+  state.allowAsserted = {
+    ...(state.allowAsserted ?? {
+      criterionIds: [],
+      order: entry.order,
+      priority: entry.priority,
+    }),
+    order: Math.min(state.allowAsserted?.order ?? entry.order, entry.order),
+    priority: Math.max(state.allowAsserted?.priority ?? entry.priority, entry.priority),
+  };
+  for (const criterionId of effect.criterionIds) {
+    if (!state.allowAsserted.criterionIds.includes(criterionId)) {
+      state.allowAsserted.criterionIds.push(criterionId);
     }
   }
+}
 
-  if (allowAsserted !== undefined) {
-    merged.push({
-      effect: { type: "work.allow_asserted", criterionIds: allowAsserted.criterionIds },
-      order: allowAsserted.order,
-      priority: allowAsserted.priority,
-    });
-  }
-
-  appendMergedEffects(merged, {
-    promptReplace,
-    modelOverride,
-    toolFilters,
-    toolRewrite,
-    toolOutputRewrite,
-    toolSkip,
-    toolApproval,
-    runAbort,
-    continueWithPrompt,
-    retryAfter,
-    runReplaceMessages,
-    delegationConstraints,
-    delegationApproval,
-    writebackRewrite,
-    writebackSuppress,
-    workspaceLock,
+function appendAllowAsserted(state: MergeAccumulators): void {
+  if (state.allowAsserted === undefined) return;
+  state.merged.push({
+    effect: {
+      type: "work.allow_asserted",
+      criterionIds: state.allowAsserted.criterionIds,
+    },
+    order: state.allowAsserted.order,
+    priority: state.allowAsserted.priority,
   });
-
-  return {
-    effects: merged.sort((left, right) => left.order - right.order).map(({ effect }) => effect),
-  };
 }

--- a/packages/protocol/src/work-item/terminal-linkage.ts
+++ b/packages/protocol/src/work-item/terminal-linkage.ts
@@ -12,27 +12,82 @@ import type { Info as TerminalLinkageItem } from "./schemas.js";
  * accept. Protocol schema parsing deliberately does not invoke this fold.
  */
 function validateTerminalLinkage(item: TerminalLinkageItem, ctx: RefinementCtx): void {
-  const evidenceIds = new Set<string>();
-  for (const [index, evidence] of item.evidence.entries()) {
-    if (evidenceIds.has(evidence.id)) {
-      addIssue(ctx, ["evidence", index, "id"]);
-    }
-    evidenceIds.add(evidence.id);
-  }
-  const foreignAdmissionIndex = item.completionFacts.admissions.findIndex(
-    ({ workItemHash }) => workItemHash !== item.workItemId,
-  );
-  if (foreignAdmissionIndex !== -1) {
-    addIssue(ctx, ["completionFacts", "admissions", foreignAdmissionIndex, "workItemHash"]);
-  }
+  validateEvidenceIdentities(item, ctx);
+  validateAdmissionOwnership(item, ctx);
   const receipt = item.completionTerminalReceipt;
-  const completedAt = item.timestamps.completed;
-  if (completedAt !== undefined && receipt === undefined) {
+  if (item.timestamps.completed !== undefined && receipt === undefined) {
     addIssue(ctx, ["completionTerminalReceipt"], "completed WorkItem requires receipt");
     return;
   }
   if (receipt === undefined) return;
-  if (completedAt === undefined) {
+
+  validateReceiptHeader(item, receipt, ctx);
+  const admissionIndex = item.completionFacts.admissions.findIndex(
+    ({ id }) => id === receipt.admissionId,
+  );
+  const admission = item.completionFacts.admissions[admissionIndex];
+  if (admissionIndex === -1 || admission === undefined) {
+    addIssue(ctx, ["completionTerminalReceipt", "admissionId"]);
+    return;
+  }
+
+  validateProposedFactIds(item, admission, admissionIndex, ctx);
+  const indexes = completionFactIndexes(item);
+  validateUnresolvedCriteria(admission, admissionIndex, indexes.criteriaById, ctx);
+  const effectiveCriterionIds = validateEffectiveResults(
+    item,
+    admission,
+    admissionIndex,
+    indexes,
+    ctx,
+  );
+  if (admission.requestId !== receipt.requestId) {
+    addIssue(ctx, ["completionTerminalReceipt", "requestId"]);
+  }
+  const report = validateCompletionReportLinkage(item, admission, receipt, ctx);
+  if (report === undefined) return;
+  validateCompletionReportEvidence(item, admission, report, effectiveCriterionIds, ctx);
+  validateReceiptContinuity(item, admission, admissionIndex, receipt, ctx);
+}
+
+type TerminalReceipt = NonNullable<TerminalLinkageItem["completionTerminalReceipt"]>;
+type CompletionCriterion = TerminalLinkageItem["completionFacts"]["criteria"][number];
+type CompletionResult = TerminalLinkageItem["completionFacts"]["results"][number];
+type CompletionObservation = TerminalLinkageItem["completionFacts"]["observations"][number];
+
+interface CompletionFactIndexes {
+  readonly criteriaById: ReadonlyMap<string, CompletionCriterion>;
+  readonly resultsById: ReadonlyMap<
+    string,
+    { readonly index: number; readonly result: CompletionResult }
+  >;
+  readonly observationsById: ReadonlyMap<
+    string,
+    { readonly index: number; readonly observation: CompletionObservation }
+  >;
+}
+
+function validateEvidenceIdentities(item: TerminalLinkageItem, ctx: RefinementCtx): void {
+  const evidenceIds = new Set<string>();
+  for (const [index, evidence] of item.evidence.entries()) {
+    if (evidenceIds.has(evidence.id)) addIssue(ctx, ["evidence", index, "id"]);
+    evidenceIds.add(evidence.id);
+  }
+}
+
+function validateAdmissionOwnership(item: TerminalLinkageItem, ctx: RefinementCtx): void {
+  const index = item.completionFacts.admissions.findIndex(
+    ({ workItemHash }) => workItemHash !== item.workItemId,
+  );
+  if (index !== -1) addIssue(ctx, ["completionFacts", "admissions", index, "workItemHash"]);
+}
+
+function validateReceiptHeader(
+  item: TerminalLinkageItem,
+  receipt: TerminalReceipt,
+  ctx: RefinementCtx,
+): void {
+  if (item.timestamps.completed === undefined) {
     addIssue(ctx, ["timestamps", "completed"], "receipt requires completed timestamp");
   }
   if (receipt.hash !== item.workItemId) addIssue(ctx, ["completionTerminalReceipt", "hash"]);
@@ -45,33 +100,31 @@ function validateTerminalLinkage(item: TerminalLinkageItem, ctx: RefinementCtx):
   if (receipt.recordedHead > item.revision) {
     addIssue(ctx, ["completionTerminalReceipt", "recordedHead"]);
   }
+}
 
-  const admissionIndex = item.completionFacts.admissions.findIndex(
-    ({ id }) => id === receipt.admissionId,
-  );
-  if (admissionIndex === -1) {
-    addIssue(ctx, ["completionTerminalReceipt", "admissionId"]);
-    return;
-  }
-  const admission = item.completionFacts.admissions[admissionIndex];
-  if (admission === undefined) {
-    addIssue(ctx, ["completionTerminalReceipt", "admissionId"]);
-    return;
-  }
-  validateProposedFactIds(item, admission, admissionIndex, ctx);
-  const criteriaById = new Map(
-    item.completionFacts.criteria.map((criterion) => [criterion.id, criterion]),
-  );
-  const resultsById = new Map(
-    item.completionFacts.results.map((result, index) => [result.id, { index, result }]),
-  );
-  const observationsById = new Map(
-    item.completionFacts.observations.map((observation, index) => [
-      observation.id,
-      { index, observation },
-    ]),
-  );
-  const effectiveCriterionIds = new Set<string>();
+function completionFactIndexes(item: TerminalLinkageItem): CompletionFactIndexes {
+  return {
+    criteriaById: new Map(
+      item.completionFacts.criteria.map((criterion) => [criterion.id, criterion]),
+    ),
+    resultsById: new Map(
+      item.completionFacts.results.map((result, index) => [result.id, { index, result }]),
+    ),
+    observationsById: new Map(
+      item.completionFacts.observations.map((observation, index) => [
+        observation.id,
+        { index, observation },
+      ]),
+    ),
+  };
+}
+
+function validateUnresolvedCriteria(
+  admission: CompletionAdmission,
+  admissionIndex: number,
+  criteriaById: ReadonlyMap<string, CompletionCriterion>,
+  ctx: RefinementCtx,
+): void {
   for (const [index, criterionId] of admission.unresolvedCriterionIds.entries()) {
     if (!criteriaById.has(criterionId)) {
       addIssue(
@@ -81,9 +134,19 @@ function validateTerminalLinkage(item: TerminalLinkageItem, ctx: RefinementCtx):
       );
     }
   }
+}
+
+function validateEffectiveResults(
+  item: TerminalLinkageItem,
+  admission: CompletionAdmission,
+  admissionIndex: number,
+  indexes: CompletionFactIndexes,
+  ctx: RefinementCtx,
+): ReadonlySet<string> {
+  const effectiveCriterionIds = new Set<string>();
   for (const [index, resultId] of admission.effectiveResultIds.entries()) {
-    const effective = resultsById.get(resultId);
-    if (!effective) {
+    const effective = indexes.resultsById.get(resultId);
+    if (effective === undefined) {
       addIssue(
         ctx,
         ["completionFacts", "admissions", admissionIndex, "effectiveResultIds", index],
@@ -91,47 +154,64 @@ function validateTerminalLinkage(item: TerminalLinkageItem, ctx: RefinementCtx):
       );
       continue;
     }
-    const { result } = effective;
-    if (!criteriaById.has(result.criterionId)) {
-      addIssue(
-        ctx,
-        ["completionFacts", "results", effective.index, "criterionId"],
-        "terminal admission effective result references an unknown criterion",
-      );
-    }
-    if (result.basisRef !== admission.basisRef) {
-      addIssue(
-        ctx,
-        ["completionFacts", "results", effective.index, "basisRef"],
-        "terminal admission effective result uses a different basis",
-      );
-    }
-    for (const [observationIndex, observationId] of result.observationIds.entries()) {
-      const resolved = observationsById.get(observationId);
-      if (!resolved) {
-        addIssue(ctx, [
-          "completionFacts",
-          "results",
-          effective.index,
-          "observationIds",
-          observationIndex,
-        ]);
-        continue;
-      }
-      if (resolved.observation.subjectRef !== item.workItemId) {
-        addIssue(ctx, ["completionFacts", "observations", resolved.index, "subjectRef"]);
-      }
-      if (resolved.observation.basisRef !== result.basisRef) {
-        addIssue(ctx, ["completionFacts", "observations", resolved.index, "basisRef"]);
-      }
-    }
-    effectiveCriterionIds.add(result.criterionId);
+    validateEffectiveResult(item, admission, effective, indexes, ctx);
+    effectiveCriterionIds.add(effective.result.criterionId);
   }
-  if (admission.requestId !== receipt.requestId) {
-    addIssue(ctx, ["completionTerminalReceipt", "requestId"]);
+  return effectiveCriterionIds;
+}
+
+function validateEffectiveResult(
+  item: TerminalLinkageItem,
+  admission: CompletionAdmission,
+  effective: { readonly index: number; readonly result: CompletionResult },
+  indexes: CompletionFactIndexes,
+  ctx: RefinementCtx,
+): void {
+  const { result } = effective;
+  if (!indexes.criteriaById.has(result.criterionId)) {
+    addIssue(
+      ctx,
+      ["completionFacts", "results", effective.index, "criterionId"],
+      "terminal admission effective result references an unknown criterion",
+    );
   }
+  if (result.basisRef !== admission.basisRef) {
+    addIssue(
+      ctx,
+      ["completionFacts", "results", effective.index, "basisRef"],
+      "terminal admission effective result uses a different basis",
+    );
+  }
+  for (const [observationIndex, observationId] of result.observationIds.entries()) {
+    const resolved = indexes.observationsById.get(observationId);
+    if (resolved === undefined) {
+      addIssue(ctx, [
+        "completionFacts",
+        "results",
+        effective.index,
+        "observationIds",
+        observationIndex,
+      ]);
+      continue;
+    }
+    if (resolved.observation.subjectRef !== item.workItemId) {
+      addIssue(ctx, ["completionFacts", "observations", resolved.index, "subjectRef"]);
+    }
+    if (resolved.observation.basisRef !== result.basisRef) {
+      addIssue(ctx, ["completionFacts", "observations", resolved.index, "basisRef"]);
+    }
+  }
+}
+
+function validateCompletionReportLinkage(
+  item: TerminalLinkageItem,
+  admission: CompletionAdmission,
+  receipt: TerminalReceipt,
+  ctx: RefinementCtx,
+): CompletionReport | undefined {
+  const report = item.completionReport;
   if (
-    item.completionReport === undefined ||
+    report === undefined ||
     admission.completionReportSnapshot === undefined ||
     admission.completionReportRef === undefined ||
     receipt.completionReportRef === undefined
@@ -141,23 +221,26 @@ function validateTerminalLinkage(item: TerminalLinkageItem, ctx: RefinementCtx):
       ["completionTerminalReceipt", "completionReportRef"],
       "terminal receipt requires canonical completion report linkage",
     );
-    return;
+    return undefined;
   }
   if (
     admission.completionReportRef !== receipt.completionReportRef ||
     admission.completionReportRef !==
       completionReportReference(admission.completionReportSnapshot) ||
-    JSON.stringify(admission.completionReportSnapshot) !== JSON.stringify(item.completionReport)
+    JSON.stringify(admission.completionReportSnapshot) !== JSON.stringify(report)
   ) {
     addIssue(ctx, ["completionTerminalReceipt", "completionReportRef"]);
   }
-  validateCompletionReportEvidence(
-    item,
-    admission,
-    item.completionReport,
-    effectiveCriterionIds,
-    ctx,
-  );
+  return report;
+}
+
+function validateReceiptContinuity(
+  item: TerminalLinkageItem,
+  admission: CompletionAdmission,
+  admissionIndex: number,
+  receipt: TerminalReceipt,
+  ctx: RefinementCtx,
+): void {
   const hasReservationBridge = hasContiguousReservationBridge(
     item.completionFacts.requestReservations,
     admission.requestId,


### PR DESCRIPTION
## Summary

Behavior-preserving complexity extraction for the five remaining orchestration kernels named by the slop audit:

- `runAgent`
- terminal WorkItem linkage validation
- policy `mergeEntries`
- delegation `delegate`
- channels messaging `send`

No schemas, public APIs, event ordering, durable admission ordering, or denial behavior changed. The work stays within the five owning files and adds no dependencies.

## Complexity measurements

Measured with ESLint cyclomatic `complexity` and SonarJS `cognitive-complexity` against `origin/main` and this formatted head. The required ceiling is strictly below 22.

| Entry point | Cyclomatic before | Cyclomatic after | Cognitive before | Cognitive after |
|---|---:|---:|---:|---:|
| `runAgent` | 43 | 8 | 59 | 7 |
| `validateTerminalLinkage` | 36 | 8 | 38 | 6 |
| `mergeEntries` | 38 | 2 | 14 | 1 |
| delegation `delegate` | 39 | 8 | 42 | 6 |
| messaging `send` | 55 | 4 | 73 | 3 |

Post-extraction worst helper by touched file:

| File/domain | Max cyclomatic | Max cognitive |
|---|---:|---:|
| agent execution | 12 | 12 |
| terminal linkage | 13 | 12 |
| policy merge | 10 | 3 |
| delegation kernel | 16 | 12 |
| messaging send | 14 | 15 |

Every function in the measured files is below both ceilings.

## Extraction map

- **Agent execution:** retry policy and undecided facts -> attempt loop -> per-attempt model selection -> turn loop -> connection/model override -> terminal model outcome.
- **Terminal linkage:** evidence identity and admission ownership -> receipt header -> indexed completion facts -> unresolved/effective result validation -> canonical report linkage/evidence -> reservation continuity.
- **Policy merge:** exhaustive effect-family routing -> prompt/tool/run/delegation/writeback/runtime/work folds -> final accumulator emission.
- **Delegation:** candidate admission -> transport preparation -> WorkItem commissioning -> durable delegation-record claim -> immediate await.
- **Messaging:** sender/pinned authority -> lease authority -> durable admission and debits -> Wait open/resume -> idempotent delivery/correlation -> sent receipt.

The extraction boundaries follow existing record-before-act and fail-closed seams rather than introducing generic helpers.

## Coverage

Touched package coverage reports and the repository ratchet pass:

- `packages/agent`: 98.17% lines
- `packages/channels`: 96.53% lines
- `packages/policy`: 96.62% lines
- `packages/protocol`: 97.68% lines

The complete ratchet also passed for all baselined packages. `ipc` and `ledger` improved over their baselines.

## Verification

Passed on commit `cef9abd8`:

- `bun run build`
- `bunx turbo run check-types`
- `bun run script/check-deps.ts`
- `bun run script/check-import-cycles.ts` (364 modules, 0 value-import cycles)
- `bun run lint`
- `bun run lint:tools`
- `bunx ultracite check --formatter-enabled=false .`
- `bun run script/check-dead-exports.ts` (0 known issues, none new)
- touched-package tests and coverage runs
- `bun run script/check-coverage-ratchet.ts`
- `bun test --timeout 15000` (2,935 pass, 0 fail across 343 files)
- language-server diagnostics on all five changed files (clean)
- `git diff --check`

`check-deps` emitted only the pre-existing informational stale-doc notice for untouched `packages/placement/AGENTS.md`; it reported no violations and exited successfully.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the five highest-complexity orchestration kernels — `runAgent`, terminal WorkItem linkage validation, policy `mergeEntries`, delegation `delegate`, and messaging `send` — into smaller helpers so every measured function lands below the required complexity ceiling. The work is behavior-preserving: no schemas, public APIs, event ordering, admission ordering, or denial behavior changed, and it stays within the five owning files with no new dependencies.

**Verification**
- Entry-point cyclomatic complexity drops from 36–55 to 2–8 and cognitive complexity from 14–73 to 1–7 across the five kernels.
- Build, type checks, lint, import-cycle, dependency, and dead-export checks pass.
- Touched packages hold 96.5–98.2% line coverage; the coverage ratchet and the full test suite (2,935 tests across 343 files) pass.

<sup>Written for commit cef9abd8b99acd536eb72f6e6de7b6269036e771. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/INONONO66/openomni/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

